### PR TITLE
Make it easier for add-ons to supply custom braille tables

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1434,17 +1434,29 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def _getTableList(self, table):
 		return [self._getTablePath(table), PATTERNS_TABLE]
 
-	def setTranslationTable(self, table):
+	def setTranslationTable(self, table, isFallback=False):
 		tableList = self._getTableList(table)
-		# TODO: Use louis.checkTable() to verify if tableList can actually be compiled.
-		config.conf["braille"]["translationTable"] = table
+		if not isFallback:
+			try:
+				louis.checkTable(tables)
+			except:
+				log.error("Error compiling translation tables", exc_info=True)
+				self.setTranslationTable("en-us-comp8.ctb", isFallback=True)
+				return False
+			config.conf["braille"]["translationTable"] = table
 		self.translationTableList = tableList
 		return True
 
-	def setInputTable(self, table):
+	def setInputTable(self, table, isFallback=False):
 		tableList = self._getTableList(table)
-		# TODO: Use louis.checkTable() to verify if tableList can actually be compiled.
-		config.conf["braille"]["inputTable"] = table
+		if not isFallback:
+			try:
+				louis.checkTable(tables)
+			except:
+				log.error("Error compiling input tables", exc_info=True)
+				self.setInputTable("en-us-comp8.ctb", isFallback=True)
+				return False
+			config.conf["braille"]["inputTable"] = table
 		self.inputTableList = tableList
 		return True
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -1642,8 +1642,8 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		display = config.conf["braille"]["display"]
 		if display != self.display.name:
 			self.setDisplayByName(display)
-		setTranslationTable(config.conf["braille"]["translationTable"])
-		setInputTable(config.conf["braille"]["inputTable"])
+		self.setTranslationTable(config.conf["braille"]["translationTable"])
+		self.setInputTable(config.conf["braille"]["inputTable"])
 
 def initialize():
 	global handler

--- a/source/braille.py
+++ b/source/braille.py
@@ -21,7 +21,7 @@ import inputCore
 
 #: The directory in which liblouis braille tables are located.
 TABLES_DIR = r"louis\tables"
-UNICODe_BRAILLE_TABLE = os.path.join(TABLES_DIR, "braille-patterns.cti")
+UNICODE_BRAILLE_TABLE = os.path.join(TABLES_DIR, "braille-patterns.cti")
 
 #: The braille table file names and information.
 tables = [

--- a/source/braille.py
+++ b/source/braille.py
@@ -1438,7 +1438,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		tableList = self._getTableList(table)
 		if not isFallback:
 			try:
-				louis.checkTable(tables)
+				louis.checkTable(tableList)
 			except:
 				log.error("Error compiling translation tables", exc_info=True)
 				self.setTranslationTable("en-us-comp8.ctb", isFallback=True)
@@ -1451,7 +1451,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		tableList = self._getTableList(table)
 		if not isFallback:
 			try:
-				louis.checkTable(tables)
+				louis.checkTable(tableList)
 			except:
 				log.error("Error compiling input tables", exc_info=True)
 				self.setInputTable("en-us-comp8.ctb", isFallback=True)

--- a/source/braille.py
+++ b/source/braille.py
@@ -21,9 +21,10 @@ import inputCore
 
 #: The directory in which liblouis braille tables are located.
 TABLES_DIR = r"louis\tables"
+PATTERNS_TABLE = os.path.join(TABLES_DIR, "braille-patterns.cti")
 
-#: The table file names and information.
-TABLES = (
+#: The braille table file names and information.
+tables = [
 	# (fileName, displayName, supportsInput),
 	# Translators: The name of a braille table displayed in the
 	# braille settings dialog.
@@ -277,10 +278,7 @@ TABLES = (
 	# Translators: The name of a braille table displayed in the
 	# braille settings dialog.
 	("zh-tw.ctb", _("Chinese (Taiwan, Mandarin)"), False),
-)
-
-#: Braille tables that support input (only computer braille tables yet).
-INPUT_TABLES = tuple(t for t in TABLES if t[2])
+]
 
 roleLabels = {
 	# Translators: Displayed in braille for an object which is an
@@ -447,7 +445,7 @@ class Region(object):
 		text=unicode(self.rawText).replace('\0','')
 		braille, self.brailleToRawPos, self.rawToBraillePos, brailleCursorPos = louis.translate(
 			[os.path.join(TABLES_DIR, config.conf["braille"]["translationTable"]),
-				"braille-patterns.cti"],
+				PATTERNS_TABLE],
 			text,
 			# liblouis mutates typeform if it is a list.
 			typeform=tuple(self.rawTextTypeforms) if isinstance(self.rawTextTypeforms, list) else self.rawTextTypeforms,

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -42,7 +42,7 @@ class BrailleInputHandler(object):
 		char = unichr(dots | 0x8000)
 		text = louis.backTranslate(
 			[os.path.join(braille.TABLES_DIR, config.conf["braille"]["inputTable"]),
-			"braille-patterns.cti"],
+				braille.PATTERNS_TABLE],
 			char, mode=louis.dotsIO)
 		chars = text[0]
 		if len(chars) > 0:

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -41,9 +41,7 @@ class BrailleInputHandler(object):
 		# liblouis requires us to set the highest bit for proper use of dotsIO.
 		char = unichr(dots | 0x8000)
 		text = louis.backTranslate(
-			[os.path.join(braille.TABLES_DIR, config.conf["braille"]["inputTable"]),
-				braille.PATTERNS_TABLE],
-			char, mode=louis.dotsIO)
+			braille.handler.inputTableList, char, mode=louis.dotsIO)
 		chars = text[0]
 		if len(chars) > 0:
 			self.sendChars(chars)

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -508,7 +508,9 @@ class ConfigManager(object):
 		import synthDriverHandler
 		synthDriverHandler.handleConfigProfileSwitch()
 		import braille
+		import brailleInput
 		braille.handler.handleConfigProfileSwitch()
+		brailleInput.handler.handleConfigProfileSwitch()
 
 	def _initBaseConf(self, factoryDefaults=False):
 		fn = os.path.join(globalVars.appArgs.configPath, "nvda.ini")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1457,8 +1457,14 @@ class BrailleSettingsDialog(SettingsDialog):
 		if not braille.handler.setDisplayByName(display):
 			gui.messageBox(_("Could not load the %s display.")%display, _("Braille Display Error"), wx.OK|wx.ICON_WARNING, self)
 			return 
-		config.conf["braille"]["translationTable"] = self.tableNames[self.tableList.GetSelection()]
-		config.conf["braille"]["inputTable"] = self.inputTableNames[self.inputTableList.GetSelection()]
+		table = self.tableNames[self.tableList.GetSelection()]
+		if not braille.handler.setTranslationTable(table):
+			gui.messageBox(_("Could not load the %s translation table.")%table, _("Braille Table Error"), wx.OK|wx.ICON_WARNING, self)
+			return
+		table = self.inputTableNames[self.inputTableList.GetSelection()]
+		if not braille.handler.setInputTable(table):
+			gui.messageBox(_("Could not load the %s input table.")%table, _("Braille Table Error"), wx.OK|wx.ICON_WARNING, self)
+			return
 		config.conf["braille"]["expandAtCursor"] = self.expandAtCursorCheckBox.GetValue()
 		try:
 			val = int(self.cursorBlinkRateEdit.GetValue())

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1370,8 +1370,9 @@ class BrailleSettingsDialog(SettingsDialog):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the output table (the braille table used to read braille text on the braille display).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("&Output table:"))
-		self.tableNames = [table[0] for table in braille.tables]
-		self.tableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in braille.tables])
+		tables = sorted(braille.tables, key=lambda table: table[1])
+		self.tableNames = [table[0] for table in tables]
+		self.tableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in tables])
 		try:
 			selection = self.tableNames.index(config.conf["braille"]["translationTable"])
 			self.tableList.SetSelection(selection)
@@ -1384,9 +1385,9 @@ class BrailleSettingsDialog(SettingsDialog):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the input table (the braille table used to type braille characters on a braille keyboard).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("&Input table:"))
-		inputTables = [table for table in braille.tables if table[2]]
-		self.inputTableNames = [table[0] for table in inputTables]
-		self.inputTableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in inputTables])
+		tables = [table for table in tables if table[2]]
+		self.inputTableNames = [table[0] for table in tables]
+		self.inputTableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in tables])
 		try:
 			selection = self.inputTableNames.index(config.conf["braille"]["inputTable"])
 			self.inputTableList.SetSelection(selection)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1370,8 +1370,8 @@ class BrailleSettingsDialog(SettingsDialog):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the output table (the braille table used to read braille text on the braille display).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("&Output table:"))
-		self.tableNames = [table[0] for table in braille.TABLES]
-		self.tableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in braille.TABLES])
+		self.tableNames = [table[0] for table in braille.tables]
+		self.tableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in braille.tables])
 		try:
 			selection = self.tableNames.index(config.conf["braille"]["translationTable"])
 			self.tableList.SetSelection(selection)
@@ -1384,8 +1384,9 @@ class BrailleSettingsDialog(SettingsDialog):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the input table (the braille table used to type braille characters on a braille keyboard).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("&Input table:"))
-		self.inputTableNames = [table[0] for table in braille.INPUT_TABLES]
-		self.inputTableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in braille.INPUT_TABLES])
+		inputTables = [table for table in braille.tables if table[2]]
+		self.inputTableNames = [table[0] for table in inputTables]
+		self.inputTableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in inputTables])
 		try:
 			selection = self.inputTableNames.index(config.conf["braille"]["inputTable"])
 			self.inputTableList.SetSelection(selection)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -25,6 +25,7 @@ import speechDictHandler
 import appModuleHandler
 import queueHandler
 import braille
+import brailleInput
 import core
 import keyboardHandler
 import characterProcessing
@@ -1463,7 +1464,7 @@ class BrailleSettingsDialog(SettingsDialog):
 			gui.messageBox(_("Could not load the %s translation table.")%table, _("Braille Table Error"), wx.OK|wx.ICON_WARNING, self)
 			return
 		table = self.inputTableNames[self.inputTableList.GetSelection()]
-		if not braille.handler.setInputTable(table):
+		if not brailleInput.handler.setInputTable(table):
 			gui.messageBox(_("Could not load the %s input table.")%table, _("Braille Table Error"), wx.OK|wx.ICON_WARNING, self)
 			return
 		config.conf["braille"]["expandAtCursor"] = self.expandAtCursorCheckBox.GetValue()


### PR DESCRIPTION
Related issue: #3304
- Make braille.TABLES a list so add-on code can append to it.
- Detect if a table is one of the stock tables or a custom table based on its path.
- Fall back to the US 8-dot computer braille table if a table can't be found, both for custom tables and stock tables.
- In the GUI, show an error if a table is selected that can't be found. This is also logged.
- In the GUI, sort translation and input tables alphabetically.
