### PR TITLE
Add options to change braille cursor visibility and shape

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -361,7 +361,7 @@ CURSOR_SHAPES = (
 	# Translators: The description of a cursor shape.
 	(0xFF, _("All dots")),
 )
-SELECTION_SHAPE = 0xC0
+SELECTION_SHAPE = 0xC0 #: Dots 7 and 8
 
 def NVDAObjectHasUsefulText(obj):
 	import displayModel
@@ -928,7 +928,7 @@ class TextInfoRegion(Region):
 		super(TextInfoRegion, self).update()
 
 		if self._selectionStart is not None:
-			# Mark the selection with dots 7 and 8.
+			# Mark the selection.
 			if self._selectionEnd >= len(self.rawText):
 				brailleSelEnd = len(self.brailleCells)
 			else:

--- a/source/braille.py
+++ b/source/braille.py
@@ -354,11 +354,11 @@ negativeStateLabels = {
 
 #: Cursor shapes
 CURSOR_SHAPES = (
-	# Translators: The description of a cursor shape.
+	# Translators: The description of a braille cursor shape.
 	(0xC0, _("Dots 7 and 8")),
-	# Translators: The description of a cursor shape.
+	# Translators: The description of a braille cursor shape.
 	(0x80, _("Dot 8")),
-	# Translators: The description of a cursor shape.
+	# Translators: The description of a braille cursor shape.
 	(0xFF, _("All dots")),
 )
 SELECTION_SHAPE = 0xC0 #: Dots 7 and 8

--- a/source/braille.py
+++ b/source/braille.py
@@ -1437,10 +1437,12 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		if self._cursorBlinkTimer:
 			self._cursorBlinkTimer.Stop()
 			self._cursorBlinkTimer = None
-		self._cursorBlinkUp = True
+		self._cursorBlinkUp = showCursor = config.conf["braille"]["showCursor"]
 		self._displayWithCursor()
+		if self._cursorPos is None or not showCursor:
+			return
 		blinkRate = config.conf["braille"]["cursorBlinkRate"]
-		if blinkRate and self._cursorPos is not None:
+		if blinkRate:
 			self._cursorBlinkTimer = wx.PyTimer(self._blink)
 			self._cursorBlinkTimer.Start(blinkRate)
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -352,8 +352,16 @@ negativeStateLabels = {
 	controlTypes.STATE_CHECKED: _("( )"),
 }
 
-DOT7 = 64
-DOT8 = 128
+#: Cursor shapes
+CURSOR_SHAPES = (
+	# Translators: The description of a cursor shape.
+	(0xC0, _("Dots 7 and 8")),
+	# Translators: The description of a cursor shape.
+	(0x80, _("Dot 8")),
+	# Translators: The description of a cursor shape.
+	(0xFF, _("All dots")),
+)
+SELECTION_SHAPE = 0xC0
 
 def NVDAObjectHasUsefulText(obj):
 	import displayModel
@@ -926,7 +934,7 @@ class TextInfoRegion(Region):
 			else:
 				brailleSelEnd = self.rawToBraillePos[self._selectionEnd]
 			for pos in xrange(self.rawToBraillePos[self._selectionStart], brailleSelEnd):
-				self.brailleCells[pos] |= DOT7 | DOT8
+				self.brailleCells[pos] |= SELECTION_SHAPE
 
 	def routeTo(self, braillePos):
 		if braillePos == self.brailleCursorPos:
@@ -1344,8 +1352,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	TETHER_FOCUS = "focus"
 	TETHER_REVIEW = "review"
 
-	cursorShape = 0xc0
-
 	def __init__(self):
 		self.display = None
 		self.displaySize = 0
@@ -1443,7 +1449,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			return
 		cells = list(self._cells)
 		if self._cursorPos is not None and self._cursorBlinkUp:
-			cells[self._cursorPos] |= self.cursorShape
+			cells[self._cursorPos] |= config.conf["braille"]["cursorShape"]
 		self.display.display(cells)
 
 	def _blink(self):

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -89,6 +89,7 @@ confspec = ConfigObj(StringIO(
 	translationTable = string(default=en-us-comp8.ctb)
 	inputTable = string(default=en-us-comp8.ctb)
 	expandAtCursor = boolean(default=true)
+	showCursor = boolean(default=true)
 	cursorBlinkRate = integer(default=500,min=0,max=2000)
 	cursorShape = integer(default=192,min=1,max=255)
 	messageTimeout = integer(default=4,min=0,max=20)

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -90,6 +90,7 @@ confspec = ConfigObj(StringIO(
 	inputTable = string(default=en-us-comp8.ctb)
 	expandAtCursor = boolean(default=true)
 	cursorBlinkRate = integer(default=500,min=0,max=2000)
+	cursorShape = integer(default=192,min=1,max=255)
 	messageTimeout = integer(default=4,min=0,max=20)
 	tetherTo = string(default="focus")
 	readByParagraph = boolean(default=false)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1620,6 +1620,10 @@ class GlobalCommands(ScriptableObject):
 	script_braille_toggleShowCursor.category=SCRCAT_BRAILLE
 
 	def script_braille_cycleCursorShape(self, gesture):
+		if not config.conf["braille"]["showCursor"]:
+			# Translators: A message reported when changing the braille cursor shape when the braille cursor is turned off.
+			ui.message(_("Braille cursor is turned off"))
+			return
 		shapes = [s[0] for s in braille.CURSOR_SHAPES]
 		try:
 			index = shapes.index(config.conf["braille"]["cursorShape"]) + 1

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1605,6 +1605,20 @@ class GlobalCommands(ScriptableObject):
 	script_braille_toggleTether.__doc__ = _("Toggle tethering of braille between the focus and the review position")
 	script_braille_toggleTether.category=SCRCAT_BRAILLE
 
+	def script_braille_toggleShowCursor(self, gesture):
+		if config.conf["braille"]["showCursor"]:
+			# Translators: The message announced when toggling the braille cursor.
+			state = _("Braille cursor off")
+			config.conf["braille"]["showCursor"]=False
+		else:
+			# Translators: The message announced when toggling the braille cursor.
+			state = _("Braille cursor on")
+			config.conf["braille"]["showCursor"]=True
+		ui.message(state)
+	# Translators: Input help mode message for toggle braille cursor command.
+	script_braille_toggleShowCursor.__doc__ = _("Toggle the braille cursor on and off")
+	script_braille_toggleShowCursor.category=SCRCAT_BRAILLE
+
 	def script_braille_cycleCursorShape(self, gesture):
 		shapes = [s[0] for s in braille.CURSOR_SHAPES]
 		try:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1605,6 +1605,22 @@ class GlobalCommands(ScriptableObject):
 	script_braille_toggleTether.__doc__ = _("Toggle tethering of braille between the focus and the review position")
 	script_braille_toggleTether.category=SCRCAT_BRAILLE
 
+	def script_braille_cycleCursorShape(self, gesture):
+		shapes = [s[0] for s in braille.CURSOR_SHAPES]
+		try:
+			index = shapes.index(config.conf["braille"]["cursorShape"]) + 1
+		except:
+			index = 1
+		if index >= len(braille.CURSOR_SHAPES):
+			index = 0
+		config.conf["braille"]["cursorShape"] = braille.CURSOR_SHAPES[index][0]
+		shapeMsg = braille.CURSOR_SHAPES[index][1]
+		# Translators: Reports which braille cursor shape is activated.
+		ui.message(_("Braille cursor %s") % shapeMsg)
+	# Translators: Input help mode message for cycle braille cursor shape command.
+	script_braille_cycleCursorShape.__doc__ = _("Cycle through the braille cursor shapes")
+	script_braille_cycleCursorShape.category=SCRCAT_BRAILLE
+
 	def script_reportClipboardText(self,gesture):
 		try:
 			text = api.getClipData()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1400,12 +1400,20 @@ class BrailleSettingsDialog(SettingsDialog):
 		self.expandAtCursorCheckBox.SetValue(config.conf["braille"]["expandAtCursor"])
 		settingsSizer.Add(self.expandAtCursorCheckBox, border=10, flag=wx.BOTTOM)
 
+		# Translators: The label for a setting in braille settings to show the cursor.
+		self.showCursorCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("Show cursor"))
+		self.showCursorCheckBox.Bind(wx.EVT_CHECKBOX, self.onShowCursorChange)
+		self.showCursorCheckBox.SetValue(config.conf["braille"]["showCursor"])
+		settingsSizer.Add(self.showCursorCheckBox, border=10, flag=wx.BOTTOM)
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to change cursor blink rate in milliseconds (1 second is 1000 milliseconds).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor blink rate (ms)"))
 		sizer.Add(label)
 		self.cursorBlinkRateEdit = wx.TextCtrl(self, wx.ID_ANY)
 		self.cursorBlinkRateEdit.SetValue(str(config.conf["braille"]["cursorBlinkRate"]))
+		if not self.showCursorCheckBox.GetValue():
+			self.cursorBlinkRateEdit.Disable()
 		sizer.Add(self.cursorBlinkRateEdit)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
@@ -1419,6 +1427,8 @@ class BrailleSettingsDialog(SettingsDialog):
 			self.shapeList.SetSelection(selection)
 		except:
 			pass
+		if not self.showCursorCheckBox.GetValue():
+			self.shapeList.Disable()
 		sizer.Add(label)
 		sizer.Add(self.shapeList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
@@ -1473,6 +1483,7 @@ class BrailleSettingsDialog(SettingsDialog):
 		config.conf["braille"]["translationTable"] = self.tableNames[self.tableList.GetSelection()]
 		config.conf["braille"]["inputTable"] = self.inputTableNames[self.inputTableList.GetSelection()]
 		config.conf["braille"]["expandAtCursor"] = self.expandAtCursorCheckBox.GetValue()
+		config.conf["braille"]["showCursor"] = self.showCursorCheckBox.GetValue()
 		try:
 			val = int(self.cursorBlinkRateEdit.GetValue())
 		except (ValueError, TypeError):
@@ -1515,6 +1526,10 @@ class BrailleSettingsDialog(SettingsDialog):
 		# If no port selection is possible or only automatic selection is available, disable the port selection control
 		enable = len(self.possiblePorts) > 0 and not (len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto")
 		self.portsList.Enable(enable)
+
+	def onShowCursorChange(self, evt):
+		self.cursorBlinkRateEdit.Enable(evt.IsChecked())
+		self.shapeList.Enable(evt.IsChecked())
 
 class AddSymbolDialog(wx.Dialog):
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1410,6 +1410,20 @@ class BrailleSettingsDialog(SettingsDialog):
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		# Translators: The label for a setting in braille settings to select the cursor shape.
+		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor shape:"))
+		self.cursorShapes = [s[0] for s in braille.CURSOR_SHAPES]
+		self.shapeList = wx.Choice(self, wx.ID_ANY, choices=[s[1] for s in braille.CURSOR_SHAPES])
+		try:
+			selection = self.cursorShapes.index(config.conf["braille"]["cursorShape"])
+			self.shapeList.SetSelection(selection)
+		except:
+			pass
+		sizer.Add(label)
+		sizer.Add(self.shapeList)
+		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
+
+		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to change how long a message stays on the braille display (in seconds).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("Message timeout (sec)"))
 		sizer.Add(label)
@@ -1465,6 +1479,7 @@ class BrailleSettingsDialog(SettingsDialog):
 			val = None
 		if 0 <= val <= 2000:
 			config.conf["braille"]["cursorBlinkRate"] = val
+		config.conf["braille"]["cursorShape"] = self.cursorShapes[self.shapeList.GetSelection()]
 		try:
 			val = int(self.messageTimeoutEdit.GetValue())
 		except (ValueError, TypeError):

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -888,8 +888,14 @@ If input is not supported on a display which does have a braille keyboard, this 
 ==== Expand to computer braille for the word at the cursor ====
 This option allows the word that is under the cursor to be displayed in non-contracted computer braille.
 
-==== Cursor Blink Rate ====
+==== Show Cursor ====
+This option allows the braille cursor to be turned on and off. It applies to all cursors including the selection indicator.
+
+==== Cursor Blink Rate (ms) ====
 This option is a numerical field that allows you to change the blink rate of the cursor in milliseconds.
+
+==== Cursor Shape ====
+This option allows you to choose the shape of the braille cursor. Shapes are defined as dot patterns. The selection indicator is not affected by this option.
 
 ==== Message Timeout (sec) ====
 This option is a numerical field that controls how long NVDA messages are displayed on the braille display.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -889,13 +889,15 @@ If input is not supported on a display which does have a braille keyboard, this 
 This option allows the word that is under the cursor to be displayed in non-contracted computer braille.
 
 ==== Show Cursor ====
-This option allows the braille cursor to be turned on and off. It applies to all cursors including the selection indicator.
+This option allows the braille cursor to be turned on and off.
+It applies to the focus and review cursors, the selection indicator is not affected by this option.
 
 ==== Cursor Blink Rate (ms) ====
 This option is a numerical field that allows you to change the blink rate of the cursor in milliseconds.
 
 ==== Cursor Shape ====
-This option allows you to choose the shape of the braille cursor. Shapes are defined as dot patterns. The selection indicator is not affected by this option.
+This option allows you to choose the shape (dot pattern) of the braille cursor.
+The selection indicator is not affected by this option.
 
 ==== Message Timeout (sec) ====
 This option is a numerical field that controls how long NVDA messages are displayed on the braille display.


### PR DESCRIPTION
Related issue: #5198

The option to toggle the cursor on/off is something I'd really like to have. The option to change the cursor shape was suggested by someone else but seems useful.

Also contains a minor refactor: define a constant `SELECTION_SHAPE` instead of computing it over and over again when marking the selection.
