### PR TITLE
Improve support for the Alva BC6 braille displays

### DIFF
--- a/source/brailleDisplayDrivers/alvaBC6.py
+++ b/source/brailleDisplayDrivers/alvaBC6.py
@@ -124,6 +124,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			"review_top": ("br(alvaBC6):t1+t2",),
 			"review_bottom": ("br(alvaBC6):t4+t5",),
 			"braille_toggleTether": ("br(alvaBC6):t1+t3",),
+			"braille_cycleCursorShape": ("br(alvaBC6):t1+t4",),
+			"braille_toggleShowCursor": ("br(alvaBC6):t2+t5",),
 			"title": ("br(alvaBC6):etouch2",),
 			"reportStatusLine": ("br(alvaBC6):etouch4",),
 			"kb:shift+tab": ("br(alvaBC6):sp1",),

--- a/source/brailleDisplayDrivers/alvaBC6.py
+++ b/source/brailleDisplayDrivers/alvaBC6.py
@@ -117,7 +117,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		"globalCommands.GlobalCommands": {
 			"braille_scrollBack": ("br(alvaBC6):t1","br(alvaBC6):etouch1"),
 			"braille_previousLine": ("br(alvaBC6):t2",),
-			"navigatorObject_toFocus": ("br(alvaBC6):t3",),
+			"braille_toFocus": ("br(alvaBC6):t3",),
 			"braille_nextLine": ("br(alvaBC6):t4",),
 			"braille_scrollForward": ("br(alvaBC6):t5","br(alvaBC6):etouch3"),
 			"braille_routeTo": ("br(alvaBC6):routing",),

--- a/source/brailleDisplayDrivers/alvaBC6.py
+++ b/source/brailleDisplayDrivers/alvaBC6.py
@@ -114,11 +114,17 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	gestureMap = inputCore.GlobalGestureMap({
 		"globalCommands.GlobalCommands": {
-			"braille_scrollBack": ("br(alvaBC6):t1",),
+			"braille_scrollBack": ("br(alvaBC6):t1","br(alvaBC6):etouch1"),
 			"braille_previousLine": ("br(alvaBC6):t2",),
+			"navigatorObject_toFocus": ("br(alvaBC6):t3",),
 			"braille_nextLine": ("br(alvaBC6):t4",),
-			"braille_scrollForward": ("br(alvaBC6):t5",),
+			"braille_scrollForward": ("br(alvaBC6):t5","br(alvaBC6):etouch3"),
 			"braille_routeTo": ("br(alvaBC6):routing",),
+			"review_top": ("br(alvaBC6):t1+t2",),
+			"review_bottom": ("br(alvaBC6):t4+t5",),
+			"braille_toggleTether": ("br(alvaBC6):t1+t3",),
+			"title": ("br(alvaBC6):etouch2",),
+			"reportStatusLine": ("br(alvaBC6):etouch4",),
 			"kb:shift+tab": ("br(alvaBC6):sp1",),
 			"kb:alt": ("br(alvaBC6):sp2",),
 			"kb:escape": ("br(alvaBC6):sp3",),
@@ -128,10 +134,16 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			"kb:leftArrow": ("br(alvaBC6):spLeft",),
 			"kb:rightArrow": ("br(alvaBC6):spRight",),
 			"kb:enter": ("br(alvaBC6):spEnter",),
+			"dateTime": ("br(alvaBC6):sp1+sp2",),
 			"showGui": ("br(alvaBC6):sp1+sp3",),
 			"kb:windows+d": ("br(alvaBC6):sp1+sp4",),
+			"kb:windows+b": ("br(alvaBC6):sp3+sp4",),
 			"kb:windows": ("br(alvaBC6):sp2+sp3",),
 			"kb:alt+tab": ("br(alvaBC6):sp2+sp4",),
+			"kb:control+home": ("br(alvaBC6):t3+spUp",),
+			"kb:control+end": ("br(alvaBC6):t3+spDown",),
+			"kb:home": ("br(alvaBC6):t3+spLeft",),
+			"kb:end": ("br(alvaBC6):t3+spRight",),
 		}
 	})
 

--- a/source/brailleDisplayDrivers/alvaBC6.py
+++ b/source/brailleDisplayDrivers/alvaBC6.py
@@ -14,6 +14,7 @@ import config
 import inputCore
 
 ALVA_RELEASE_MASK = 0x8000
+ALVA_2ND_CR_MASK = 0x80
 
 ALVA_KEYS = {
 	# Thumb keys (FRONT_GROUP)
@@ -158,8 +159,12 @@ class InputGesture(braille.BrailleDisplayGesture):
 		self.keyNames = names = set()
 		for group, number in self.keyCodes:
 			if group == ALVA_CR_GROUP:
-				names.add("routing")
-				self.routingIndex = number
+				if number & ALVA_2ND_CR_MASK:
+					names.add("routing2")
+					self.routingIndex = number & ~ALVA_2ND_CR_MASK
+				else:
+					names.add("routing")
+					self.routingIndex = number
 			else:
 				try:
 					names.add(ALVA_KEYS[group][number])

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1572,13 +1572,13 @@ Please see the display's documentation for descriptions of where these keys can 
 || Name | Key |
 | Scroll braille display back | t1 or etouch1 |
 | Move braille display to previous line | t2 |
-| Move to focus object | t3 |
+| Move to current focus | t3 |
 | Move braille display to next line | t4 |
 | Scroll braille display forward | t5 or etouch3 |
 | Route to braille cell | routing |
 | Move to top line in review | t1+t2 |
 | Move to bottom line in review | t4+t5 |
-| Braille Tethered to | t1+t3 |
+| Toggle braille tethered to | t1+t3 |
 | Report title | etouch2 |
 | Report status bar | etouch4 |
 | shift+tab key | sp1 |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1570,11 +1570,17 @@ Following are the key assignments for this display with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.
 %kc:beginInclude
 || Name | Key |
-| Scroll braille display back | t1 |
+| Scroll braille display back | t1 or etouch1 |
 | Move braille display to previous line | t2 |
+| Move to focus object | t3 |
 | Move braille display to next line | t4 |
-| Scroll braille display forward | t5 |
+| Scroll braille display forward | t5 or etouch3 |
 | Route to braille cell | routing |
+| Move to top line in review | t1+t2 |
+| Move to bottom line in review | t4+t5 |
+| Braille Tethered to | t1+t3 |
+| Report title | etouch2 |
+| Report status bar | etouch4 |
 | shift+tab key | sp1 |
 | alt key | sp2 |
 | escape key | sp3 |
@@ -1584,10 +1590,16 @@ Please see the display's documentation for descriptions of where these keys can 
 | leftArrow key | spLeft |
 | rightArrow key | spRight |
 | enter key | spEnter |
+| Report date/time | sp1+sp2 |
 | NVDA Menu | sp1+sp3 |
 | windows+d key (minimize all applications) | sp1+sp4 |
+| windows+b key (focus system tray) | sp3+sp4 |
 | windows key | sp2+sp3 |
 | alt+tab key | sp2+sp4 |
+| control+home key | t3+spUp |
+| control+end key | t3+spDown |
+| home key | t3+spLeft |
+| end key | t3+spRight |
 %kc:endInclude
 
 ++ Handy Tech Displays ++


### PR DESCRIPTION
Related issue: #5206

This adds a bunch of default key assignments for the Alva BC6 braille displays, approved by Optelec. Most commands were already in NVDA, but I added two new ones that are not merged into this branch. See the commit messages for the relevant issue numbers.
