### PR TITLE
handle non-breaking spaces for indentation indication

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -408,11 +408,10 @@ def splitTextIndentation(text):
 	return RE_INDENTATION_SPLIT.match(text).groups()
 
 RE_INDENTATION_CONVERT = re.compile(r"(?P<char>\s)(?P=char)*", re.UNICODE)
-RE_NBSP_CONVERT = re.compile("\xa0", re.UNICODE)
 def getIndentationSpeech(indentation):
 	"""Retrieves the phrase to be spoken for a given string of indentation.
 	@param indentation: The string of indentation.
-	@type indentation: basestring
+	@type indentation: unicode
 	@return: The phrase to be spoken.
 	@rtype: unicode
 	"""
@@ -423,7 +422,7 @@ def getIndentationSpeech(indentation):
 		return _("no indent")
 
 	#The non-breaking space is semantically a space, so we replace it here.
-	indentation = RE_NBSP_CONVERT.sub(" ", indentation)
+	indentation = indentation.replace(u"\xa0", u" ")
 	res = []
 	locale=languageHandler.getLanguage()
 	for m in RE_INDENTATION_CONVERT.finditer(indentation):

--- a/source/speech.py
+++ b/source/speech.py
@@ -408,6 +408,7 @@ def splitTextIndentation(text):
 	return RE_INDENTATION_SPLIT.match(text).groups()
 
 RE_INDENTATION_CONVERT = re.compile(r"(?P<char>\s)(?P=char)*", re.UNICODE)
+RE_NBSP_CONVERT = re.compile("\xa0", re.UNICODE)
 def getIndentationSpeech(indentation):
 	"""Retrieves the phrase to be spoken for a given string of indentation.
 	@param indentation: The string of indentation.
@@ -421,6 +422,8 @@ def getIndentationSpeech(indentation):
 		# Translators: This is spoken when the given line has no indentation.
 		return _("no indent")
 
+	#The non-breaking space is semantically a space, so we replace it here.
+	indentation = RE_NBSP_CONVERT.sub(" ", indentation)
 	res = []
 	locale=languageHandler.getLanguage()
 	for m in RE_INDENTATION_CONVERT.finditer(indentation):


### PR DESCRIPTION
I've seen this a lot, only just figured out what it is.  if you're in the web browser and indentation indication is on, non-breaking spaces cause it to blow up annoyingly.  For an example, see [this thread](http://forum.audiogames.net/viewtopic.php?pid=242924#p242924), post 6.  It causes indentation to be read in Firefox, Thunderbird, etc. as "space space space space..."
If someone says where the indentation function is, I can probably submit a PR.  I imagine this isn't hard.
