### PR TITLE
GUI/SettingsDialog: Add pneumonic for new braille cursor options

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1401,7 +1401,7 @@ class BrailleSettingsDialog(SettingsDialog):
 		settingsSizer.Add(self.expandAtCursorCheckBox, border=10, flag=wx.BOTTOM)
 
 		# Translators: The label for a setting in braille settings to show the cursor.
-		self.showCursorCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("Show cursor"))
+		self.showCursorCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("&Show cursor"))
 		self.showCursorCheckBox.Bind(wx.EVT_CHECKBOX, self.onShowCursorChange)
 		self.showCursorCheckBox.SetValue(config.conf["braille"]["showCursor"])
 		settingsSizer.Add(self.showCursorCheckBox, border=10, flag=wx.BOTTOM)
@@ -1419,7 +1419,7 @@ class BrailleSettingsDialog(SettingsDialog):
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the cursor shape.
-		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor shape:"))
+		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor &shape:"))
 		self.cursorShapes = [s[0] for s in braille.CURSOR_SHAPES]
 		self.shapeList = wx.Choice(self, wx.ID_ANY, choices=[s[1] for s in braille.CURSOR_SHAPES])
 		try:


### PR DESCRIPTION
Hi,

Follow-up to #5198:

When Davy added braille cursor options, he may have forgotten to add penumonic (hotkeys) for these dialogs. I've added Alt+S for both braille cursor and cursor shape options in braille settings. Thanks.
