### PR TITLE
Remove incorrect vmIDsToWindowHandles cache

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -665,6 +665,7 @@ def enterJavaWindow_helper(hwnd):
 		except:
 			return
 	vmID=vmID.value
+	vmIDsToWindowHandles[vmID]=hwnd
 	lastFocus=eventHandler.lastQueuedFocusObject
 	if isinstance(lastFocus,NVDAObjects.JAB.JAB) and lastFocus.windowHandle==hwnd:
 		return

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -282,12 +282,38 @@ if bridgeDll:
 #NVDA specific code
 
 isRunning=False
+# Cache of the last active window handle for a given JVM ID. In theory, this
+# cache should not be needed, as it should always be possible to retrieve the
+# window handle of a given accessible context by calling getTopLevelObject then
+# getHWNDFromAccessibleContext. However, getTopLevelObject sometimes returns 
+# accessible contexts that make getHWNDFromAccessibleContext fail. To workaround
+# the issue, we use this cache as a fallback when either getTopLevelObject or
+# getHWNDFromAccessibleContext fails.
+vmIDsToWindowHandles={}
 internalFunctionQueue=Queue.Queue(1000)
 internalFunctionQueue.__name__="JABHandler.internalFunctionQueue"
 
 def internalQueueFunction(func,*args,**kwargs):
 	internalFunctionQueue.put_nowait((func,args,kwargs))
 	core.requestPump()
+
+def internal_getWindowHandleFromAccContext(vmID,accContext):
+	try:
+		topAC=bridgeDll.getTopLevelObject(vmID,accContext)
+		try:
+			return bridgeDll.getHWNDFromAccessibleContext(vmID,topAC)
+		finally:
+			bridgeDll.releaseJavaObject(vmID,topAC)
+	except:
+		return None
+
+def getWindowHandleFromAccContext(vmID,accContext):
+	hwnd=internal_getWindowHandleFromAccContext(vmID,accContext)
+	if hwnd:
+		vmIDsToWindowHandles[vmID]=hwnd
+		return hwnd
+	else:
+		return vmIDsToWindowHandles.get(vmID)
 
 class JABContext(object):
 
@@ -296,10 +322,11 @@ class JABContext(object):
 			vmID=c_long()
 			accContext=JOBJECT64()
 			bridgeDll.getAccessibleContextFromHWND(hwnd,byref(vmID),byref(accContext))
+			#Record  this vm ID and window handle for later use with other objects
+			vmID=vmID.value
+			vmIDsToWindowHandles[vmID]=hwnd
 		elif vmID and not hwnd:
-			topAC=bridgeDll.getTopLevelObject(vmID,accContext)
-			hwnd=bridgeDll.getHWNDFromAccessibleContext(vmID,topAC)
-			bridgeDll.releaseJavaObject(vmID,topAC)
+			hwnd = getWindowHandleFromAccContext(vmID,accContext)
 		self.hwnd=hwnd
 		self.vmID=vmID
 		self.accContext=accContext
@@ -512,11 +539,12 @@ class JABContext(object):
 
 @AccessBridge_FocusGainedFP
 def internal_event_focusGained(vmID, event,source):
-	internalQueueFunction(event_gainFocus,vmID,source)
+	hwnd=getWindowHandleFromAccContext(vmID,source)
+	internalQueueFunction(event_gainFocus,vmID,source,hwnd)
 	bridgeDll.releaseJavaObject(vmID,event)
 
-def event_gainFocus(vmID,accContext):
-	jabContext=JABContext(vmID=vmID,accContext=accContext)
+def event_gainFocus(vmID,accContext,hwnd):
+	jabContext=JABContext(hwnd=hwnd,vmID=vmID,accContext=accContext)
 	if not winUser.isDescendantWindow(winUser.getForegroundWindow(),jabContext.hwnd):
 		return
 	focus=eventHandler.lastQueuedFocusObject
@@ -529,7 +557,8 @@ def event_gainFocus(vmID,accContext):
 
 @AccessBridge_PropertyActiveDescendentChangeFP
 def internal_event_activeDescendantChange(vmID, event,source,oldDescendant,newDescendant):
-	internalQueueFunction(event_gainFocus,vmID,newDescendant)
+	hwnd=getWindowHandleFromAccContext(vmID,source)
+	internalQueueFunction(event_gainFocus,vmID,newDescendant,hwnd)
 	for accContext in [event,oldDescendant]:
 		bridgeDll.releaseJavaObject(vmID,accContext)
 
@@ -596,14 +625,15 @@ def event_stateChange(vmID,accContext,oldState,newState):
 
 @AccessBridge_PropertyCaretChangeFP
 def internal_event_caretChange(vmID, event,source,oldPos,newPos):
+	hwnd=getWindowHandleFromAccContext(vmID,source)
 	if oldPos<0 and newPos>=0:
-		internalQueueFunction(event_gainFocus,vmID,source)
+		internalQueueFunction(event_gainFocus,vmID,source,hwnd)
 	else:
-		internalQueueFunction(event_caret,vmID,source)
+		internalQueueFunction(event_caret,vmID,source,hwnd)
 	bridgeDll.releaseJavaObject(vmID,event)
 
-def event_caret(vmID, accContext):
-	jabContext = JABContext(vmID=vmID, accContext=accContext)
+def event_caret(vmID, accContext, hwnd):
+	jabContext = JABContext(hwnd=hwnd, vmID=vmID, accContext=accContext)
 	focus = api.getFocusObject()
 	if isinstance(focus, NVDAObjects.JAB.JAB) and focus.jabContext == jabContext:
 		obj = focus
@@ -638,7 +668,7 @@ def enterJavaWindow_helper(hwnd):
 	lastFocus=eventHandler.lastQueuedFocusObject
 	if isinstance(lastFocus,NVDAObjects.JAB.JAB) and lastFocus.windowHandle==hwnd:
 		return
-	event_gainFocus(vmID,accContext)
+	event_gainFocus(vmID,accContext,hwnd)
 
 def isJavaWindow(hwnd):
 	if not bridgeDll or not isRunning:

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,4 +1,4 @@
-﻿#javaAccessBridgeHandler.py
+#javaAccessBridgeHandler.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,4 +1,4 @@
-#javaAccessBridgeHandler.py
+﻿#javaAccessBridgeHandler.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.
@@ -282,7 +282,6 @@ if bridgeDll:
 #NVDA specific code
 
 isRunning=False
-vmIDsToWindowHandles={}
 internalFunctionQueue=Queue.Queue(1000)
 internalFunctionQueue.__name__="JABHandler.internalFunctionQueue"
 
@@ -297,16 +296,10 @@ class JABContext(object):
 			vmID=c_long()
 			accContext=JOBJECT64()
 			bridgeDll.getAccessibleContextFromHWND(hwnd,byref(vmID),byref(accContext))
-			#Record  this vm ID and window handle for later use with other objects
-			vmIDsToWindowHandles[vmID.value]=hwnd
 		elif vmID and not hwnd:
-			hwnd=vmIDsToWindowHandles.get(vmID)
-			if not hwnd:
-				topAC=bridgeDll.getTopLevelObject(vmID,accContext)
-				hwnd=bridgeDll.getHWNDFromAccessibleContext(vmID,topAC)
-				bridgeDll.releaseJavaObject(vmID,topAC)
-				#Record  this vm ID and window handle for later use with other objects
-				vmIDsToWindowHandles[vmID.value]=hwnd
+			topAC=bridgeDll.getTopLevelObject(vmID,accContext)
+			hwnd=bridgeDll.getHWNDFromAccessibleContext(vmID,topAC)
+			bridgeDll.releaseJavaObject(vmID,topAC)
 		self.hwnd=hwnd
 		self.vmID=vmID
 		self.accContext=accContext
@@ -642,7 +635,6 @@ def enterJavaWindow_helper(hwnd):
 		except:
 			return
 	vmID=vmID.value
-	vmIDsToWindowHandles[vmID]=hwnd
 	lastFocus=eventHandler.lastQueuedFocusObject
 	if isinstance(lastFocus,NVDAObjects.JAB.JAB) and lastFocus.windowHandle==hwnd:
 		return

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,4 +1,4 @@
-﻿import ctypes
+import ctypes
 import re
 import eventHandler
 import keyLabels

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,4 +1,4 @@
-import ctypes
+﻿import ctypes
 import re
 import eventHandler
 import keyLabels
@@ -229,7 +229,12 @@ class JAB(Window):
 		return super(JAB,self).TextInfo
 
 	def _isEqual(self,other):
-		return super(JAB,self)._isEqual(other) and self.jabContext==other.jabContext
+		if not isinstance(other,JAB):
+			return False
+		try:
+			return self.jabContext==other.jabContext
+		except:
+			return False
 
 	def _get_keyboardShortcut(self):
 		bindings=self.jabContext.getAccessibleKeyBindings()

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -229,8 +229,6 @@ class JAB(Window):
 		return super(JAB,self).TextInfo
 
 	def _isEqual(self,other):
-		if not isinstance(other,JAB):
-			return False
 		try:
 			return self.jabContext==other.jabContext
 		except:


### PR DESCRIPTION
The vmIDsToWindowHandles cache is base on an incorrect assumption
that there is a mapping between a jvmid to a _single_ Window Handle.
This is incorrect as a Java application can have many top level
windows (each top level frame corresponds to a unique Window Handle).

The cache was introduced in 2007:

https://github.com/nvaccess/nvda/commit/d4a74c7cf155cedcd1cf48b47604a9c5d667e83b

This code was incorrect at the time, but was good enough to make things
work with Java applications that have only one top level frame.

A commit in 2010 implemented the correct way of retrieving the window
handle from a given AccessibleContext:

https://github.com/nvaccess/nvda/commit/eddfb4bd3e193ae4145dd6a697babc4bc12582e5

This effectively removed the need of using cache, but the cache was
not removed for some reason.

The symptom of the issue is described in bug #5732.
