### PR TITLE
Expose jab node level

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,4 +1,4 @@
-﻿#javaAccessBridgeHandler.py
+#javaAccessBridgeHandler.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,4 +1,4 @@
-#javaAccessBridgeHandler.py
+﻿#javaAccessBridgeHandler.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.
@@ -250,6 +250,7 @@ if bridgeDll:
 	_fixBridgeFunc(BOOL,'getAccessibleContextInfo',c_long,JOBJECT64,POINTER(AccessibleContextInfo),errcheck=True)
 	_fixBridgeFunc(JOBJECT64,'getAccessibleChildFromContext',c_long,JOBJECT64,jint,errcheck=True)
 	_fixBridgeFunc(JOBJECT64,'getAccessibleParentFromContext',c_long,JOBJECT64)
+	_fixBridgeFunc(JOBJECT64,'getParentWithRole',c_long,JOBJECT64,POINTER(c_wchar))
 	_fixBridgeFunc(BOOL,'getAccessibleRelationSet',c_long,JOBJECT64,POINTER(AccessibleRelationSetInfo),errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextInfo',c_long,JOBJECT64,POINTER(AccessibleTextInfo),jint,jint,errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextItems',c_long,JOBJECT64,POINTER(AccessibleTextItemsInfo),jint,errcheck=True)
@@ -411,6 +412,13 @@ class JABContext(object):
 
 	def getAccessibleParentFromContext(self):
 		accContext=bridgeDll.getAccessibleParentFromContext(self.vmID,self.accContext)
+		if accContext:
+			return self.__class__(self.hwnd,self.vmID,accContext)
+		else:
+			return None
+
+	def getAccessibleParentWithRole(self, role):
+		accContext=bridgeDll.getParentWithRole(self.vmID,self.accContext, role)
 		if accContext:
 			return self.__class__(self.hwnd,self.vmID,accContext)
 		else:

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,4 +1,4 @@
-import ctypes
+﻿import ctypes
 import re
 import eventHandler
 import keyLabels
@@ -307,16 +307,34 @@ class JAB(Window):
 			return False
 
 	def _get_positionInfo(self):
+		info=super(JAB,self).positionInfo or {}
+
+		# If tree view item, try to retrieve the level via JAB
+		if self.role==controlTypes.ROLE_TREEVIEWITEM:
+			try:
+				tree=self.jabContext.getAccessibleParentWithRole("tree")
+				if tree:
+					treeDepth=tree.getObjectDepth()
+					selfDepth=self.jabContext.getObjectDepth()
+					if selfDepth > treeDepth:
+						info['level']=selfDepth-treeDepth
+			except:
+				pass
+
 		targets=self._getJABRelationTargets('memberOf')
 		for index,target in enumerate(targets):
 			if target==self.jabContext:
-				return {'indexInGroup':index+1,'similarItemsInGroup':len(targets)}
+				info['indexInGroup']=index+1
+				info['similarItemsInGroup']=len(targets)
+				return info;
+
 		parent=self.parent
 		if isinstance(parent,JAB) and self.role in (controlTypes.ROLE_TREEVIEWITEM,controlTypes.ROLE_LISTITEM):
 			index=self._JABAccContextInfo.indexInParent+1
 			childCount=parent._JABAccContextInfo.childrenCount
-			return {'indexInGroup':index,'similarItemsInGroup':childCount}
-		return {}
+			info['indexInGroup']=index
+			info['similarItemsInGroup']=childCount
+		return info
 
 	def _get_activeChild(self):
 		jabContext=self.jabContext.getActiveDescendent()

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,4 +1,4 @@
-﻿import ctypes
+import ctypes
 import re
 import eventHandler
 import keyLabels


### PR DESCRIPTION
Retrieve node level of tree node items for JAB objects.
Fixes #5766.

Note that this does not fix the issue where collapse/expand state
changes are not detected. That will require a separate (non-trivial)
fix.
