### PR TITLE
fixes to JAB toggle button and trees

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -89,6 +89,27 @@ class AccessibleContextInfo(Structure):
 		('accessibleText',BOOL),
 		('accessibleValue',BOOL),
 	]
+	
+	def __eq__(self,other):
+		return (\
+		self.name == other.name and\
+		self.description ==other.description and\
+		self.role == other.role and\
+		self.role_en_US == other.role_en_US and\
+		self.states == other.states and\
+		self.states_en_US == other.states_en_US and\
+		self.indexInParent == other.indexInParent and\
+		self.childrenCount == other.childrenCount and\
+		self.x == other.x and\
+		self.y == other.y and\
+		self.width == other.width and\
+		self.height == other.height and\
+		self.accessibleComponent == other.accessibleComponent and\
+		self.accessibleAction == other.accessibleAction and\
+		self.accessibleSelection == other.accessibleSelection and\
+		self.accessibleText == other.accessibleText and\
+		self.accessibleValue == other.accessibleValue\
+		)
 
 class AccessibleTextInfo(Structure):
 	_fields_=[
@@ -342,14 +363,18 @@ class JABContext(object):
 	def __eq__(self,jabContext):
 		if self.vmID==jabContext.vmID and bridgeDll.isSameObject(self.vmID,self.accContext,jabContext.accContext):
 			return True
-		else:
-			return False
+		#try to compare using accessibleContextInfo
+		if self.getAccessibleContextInfo() and jabContext.getAccessibleContextInfo():
+			if self.getAccessibleContextInfo() == jabContext.getAccessibleContextInfo():
+				return True
+		return False
 
 	def __ne__(self,jabContext):
-		if self.vmID!=jabContext.vmID or not bridgeDll.isSameObject(self.vmID,self.accContext,jabContext.accContext):
+		if self.vmID!=jabContext.vmID:
 			return True
-		else:
-			return False
+		elif self.getAccessibleContextInfo() != jabContext.getAccessibleContextInfo():
+			return Treu
+		return False
 
 	def getVersionInfo(self):
 		info=AccessBridgeVersionInfo()
@@ -559,7 +584,7 @@ def event_gainFocus(vmID,accContext,hwnd):
 def internal_event_activeDescendantChange(vmID, event,source,oldDescendant,newDescendant):
 	hwnd=getWindowHandleFromAccContext(vmID,source)
 	internalQueueFunction(event_gainFocus,vmID,newDescendant,hwnd)
-	for accContext in [event,oldDescendant]:
+	for accContext in [event,oldDescendant,source]:
 		bridgeDll.releaseJavaObject(vmID,accContext)
 
 @AccessBridge_PropertyNameChangeFP

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -291,10 +291,14 @@ class JAB(Window):
 			stateSet.add(controlTypes.STATE_OFFSCREEN)
 		if "expandable" not in stateStrings:
 			stateSet.discard(controlTypes.STATE_COLLAPSED)
+		#fix toggle buttun: checked means pressed
+		if self.role == controlTypes.ROLE_TOGGLEBUTTON and controlTypes.STATE_CHECKED in stateSet:
+			stateSet.remove(controlTypes.STATE_CHECKED)
+			stateSet.add(controlTypes.STATE_PRESSED)
 		return stateSet
 
 	def _get_value(self):
-		if self.role not in [controlTypes.ROLE_CHECKBOX,controlTypes.ROLE_MENU,controlTypes.ROLE_MENUITEM,controlTypes.ROLE_RADIOBUTTON,controlTypes.ROLE_BUTTON] and self._JABAccContextInfo.accessibleValue and not self._JABAccContextInfo.accessibleText:
+		if self.role not in [controlTypes.ROLE_CHECKBOX,controlTypes.ROLE_MENU,controlTypes.ROLE_MENUITEM,controlTypes.ROLE_RADIOBUTTON,controlTypes.ROLE_BUTTON,controlTypes.ROLE_TOGGLEBUTTON] and self._JABAccContextInfo.accessibleValue and not self._JABAccContextInfo.accessibleText:
 			return self.jabContext.getCurrentAccessibleValueFromContext()
 
 	def _get_description(self):


### PR DESCRIPTION
this is a fix for java toggle buttons and trees:
- the states of toggle button are now announced currectly
- collapsed and expanded are now reported with tree views.
  **eq** was added to accessibleContextInfo, and eq and ne of JABContext were updated

notes:
- don't know if this solution is efficient enough, for eq the new way of comparison is only used when the previous way of comparing fails. the real problem with ne, now instead of one call to the DLL, 2 are performed. however, I couldn't think of other solution
- I remove the code of node levels, because it has been committed already.
- a call for releaseJavaObject was added in internal_event_activeDescendantChange.
