### PR TITLE
removed duplicate import of queueHandler and updated copyright message.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2015 NV Access Limited
+#Copyright (C) 2016 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -9,7 +9,6 @@ import winsound
 import time
 import weakref
 import wx
-import queueHandler
 from logHandler import log
 import review
 import scriptHandler


### PR DESCRIPTION
In source/browseMode.py there are duplicate imports.
import itertools
import collections
import winsound
import time
import weakref
import wx
import queueHandler
from logHandler import log
import review
import scriptHandler
import eventHandler
import nvwave
import queueHandler

removed the first import because it is a duplicate.
