### PR TITLE
Web conference plugin. Removes the progress bar that is used to show microphone strength.

### DIFF
--- a/source/appModules/webconferenceplugin.py
+++ b/source/appModules/webconferenceplugin.py
@@ -1,7 +1,12 @@
+#webconferenceplugin.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2016 NV Access Limited, Derek Riemer
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+""" AppModule to remove redundant progressbar announcement from the web conference plugin. """
 import appModuleHandler
 from NVDAObjects.behaviors import ProgressBar
-import controlTypes
-import ui
 
 class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):

--- a/source/appModules/webconferenceplugin.py
+++ b/source/appModules/webconferenceplugin.py
@@ -1,0 +1,12 @@
+import appModuleHandler
+from NVDAObjects.behaviors import ProgressBar
+import controlTypes
+import ui
+
+class AppModule(appModuleHandler.AppModule):
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if obj.windowClassName=="msctls_progress32":
+			try:
+				clsList.remove(ProgressBar)
+			except ValueError:
+				pass


### PR DESCRIPTION
Web conference plugin. Removes the progress bar that is used to announce the level of the microphone indicator (how strong the mic signal is). Causes NVDA to speak and beep constantly if this isn't installed.
This plugin is used in many chat rooms for various things including
http://www.out-of-sight.net/hints/install.html
