### PR TITLE
Save configuration profiles and gesture maps as an atomic operation (…

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -6,6 +6,7 @@ import _winreg
 import ctypes
 import ctypes.wintypes
 import os
+import osreplace
 import sys
 from cStringIO import StringIO
 import itertools
@@ -17,6 +18,7 @@ from logHandler import log
 import shlobj
 import baseObject
 import easeOfAccess
+from fileUtils import FaultTolerantFile
 import winKernel
 
 def validateConfig(configObj,validator,validationResult=None,keyList=None):
@@ -641,10 +643,12 @@ class ConfigManager(object):
 			# Never save the config if running securely.
 			return
 		try:
-			self.profiles[0].write()
+			with FaultTolerantFile(self.profiles[0].filename) as f:
+				self.profiles[0].write(f)
 			log.info("Base configuration saved")
 			for name in self._dirtyProfiles:
-				self._profileCache[name].write()
+				with FaultTolerantFile(self._profileCache[name].filename) as f:
+					self._profileCache[name].write(f)
 				log.info("Saved configuration profile %s" % name)
 			self._dirtyProfiles.clear()
 		except Exception as e:
@@ -741,7 +745,7 @@ class ConfigManager(object):
 		if oldName.lower() != newName.lower() and os.path.isfile(newFn):
 			raise ValueError("A profile with the same name already exists: %s" % newName)
 
-		os.rename(oldFn, newFn)
+		osreplace.replace(oldFn, newFn)
 		# Update any associated triggers.
 		allTriggers = self.triggersToProfiles
 		saveTrigs = False

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -6,7 +6,6 @@ import _winreg
 import ctypes
 import ctypes.wintypes
 import os
-import osreplace
 import sys
 from cStringIO import StringIO
 import itertools
@@ -745,7 +744,7 @@ class ConfigManager(object):
 		if oldName.lower() != newName.lower() and os.path.isfile(newFn):
 			raise ValueError("A profile with the same name already exists: %s" % newName)
 
-		osreplace.replace(oldFn, newFn)
+		os.rename(oldFn, newFn)
 		# Update any associated triggers.
 		allTriggers = self.triggersToProfiles
 		saveTrigs = False

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,3 +1,8 @@
+#fileUtils.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2016 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
 import os
 import osreplace
 from contextlib import contextmanager

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,0 +1,16 @@
+import os
+import osreplace
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from logHandler import log
+
+@contextmanager
+def FaultTolerantFile(name):
+	dirpath, filename = os.path.split(name)
+	with NamedTemporaryFile(dir=dirpath, prefix=filename, suffix='.tmp', delete=False) as f:
+		log.debug(f.name)
+		yield f
+		f.flush()
+		os.fsync(f)
+		f.close()
+		osreplace.replace(f.name, name)

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -23,6 +23,7 @@ import api
 import speech
 import characterProcessing
 import config
+from fileUtils import FaultTolerantFile
 import watchdog
 from logHandler import log
 import globalVars
@@ -359,7 +360,8 @@ class GlobalGestureMap(object):
 					else:
 						outSect[script] = [outVal, gesture]
 
-		out.write()
+		with FaultTolerantFile(out.filename) as f:
+			out.write(f)
 
 class InputManager(baseObject.AutoPropertyObject):
 	"""Manages functionality related to input from the user.


### PR DESCRIPTION
…refs issue #3165)

Instead of directly writing the file, a temporary file is created and
moved to the final location. This prevents corrupt configuration files
being written.
Added a fileUtils module with just a FaultTolerantFile context manager for
now to facilitate this pattern.
Please update miscDependencies submodule to a revision that includes the
osmove module.
