### PR TITLE
Add missing capitals to messages and GUI dialogs

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -316,254 +316,254 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 qn = BrowseModeTreeInterceptor.addQuickNav
 qn("heading", key="h",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading"),
+	nextDoc=_("Moves to the next heading"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading"),
+	nextError=_("No next heading"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading"),
+	prevDoc=_("Moves to the previous heading"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading"))
+	prevError=_("No previous heading"))
 qn("heading1", key="1",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading at level 1"),
+	nextDoc=_("Moves to the next heading at level 1"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading at level 1"),
+	nextError=_("No next heading at level 1"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading at level 1"),
+	prevDoc=_("Moves to the previous heading at level 1"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading at level 1"))
+	prevError=_("No previous heading at level 1"))
 qn("heading2", key="2",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading at level 2"),
+	nextDoc=_("Moves to the next heading at level 2"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading at level 2"),
+	nextError=_("No next heading at level 2"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading at level 2"),
+	prevDoc=_("Moves to the previous heading at level 2"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading at level 2"))
+	prevError=_("No previous heading at level 2"))
 qn("heading3", key="3",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading at level 3"),
+	nextDoc=_("Moves to the next heading at level 3"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading at level 3"),
+	nextError=_("No next heading at level 3"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading at level 3"),
+	prevDoc=_("Moves to the previous heading at level 3"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading at level 3"))
+	prevError=_("No previous heading at level 3"))
 qn("heading4", key="4",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading at level 4"),
+	nextDoc=_("Moves to the next heading at level 4"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading at level 4"),
+	nextError=_("No next heading at level 4"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading at level 4"),
+	prevDoc=_("Moves to the previous heading at level 4"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading at level 4"))
+	prevError=_("No previous heading at level 4"))
 qn("heading5", key="5",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading at level 5"),
+	nextDoc=_("Moves to the next heading at level 5"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading at level 5"),
+	nextError=_("No next heading at level 5"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading at level 5"),
+	prevDoc=_("Moves to the previous heading at level 5"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading at level 5"))
+	prevError=_("No previous heading at level 5"))
 qn("heading6", key="6",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next heading at level 6"),
+	nextDoc=_("Moves to the next heading at level 6"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next heading at level 6"),
+	nextError=_("No next heading at level 6"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous heading at level 6"),
+	prevDoc=_("Moves to the previous heading at level 6"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous heading at level 6"))
+	prevError=_("No previous heading at level 6"))
 qn("table", key="t",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next table"),
+	nextDoc=_("Moves to the next table"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next table"),
+	nextError=_("No next table"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous table"),
+	prevDoc=_("Moves to the previous table"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous table"),
+	prevError=_("No previous table"),
 	readUnit=textInfos.UNIT_LINE)
 qn("link", key="k",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next link"),
+	nextDoc=_("Moves to the next link"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next link"),
+	nextError=_("No next link"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous link"),
+	prevDoc=_("Moves to the previous link"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous link"))
+	prevError=_("No previous link"))
 qn("visitedLink", key="v",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next visited link"),
+	nextDoc=_("Moves to the next visited link"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next visited link"),
+	nextError=_("No next visited link"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous visited link"),
+	prevDoc=_("Moves to the previous visited link"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous visited link"))
+	prevError=_("No previous visited link"))
 qn("unvisitedLink", key="u",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next unvisited link"),
+	nextDoc=_("Moves to the next unvisited link"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next unvisited link"),
+	nextError=_("No next unvisited link"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous unvisited link"), 
+	prevDoc=_("Moves to the previous unvisited link"), 
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous unvisited link"))
+	prevError=_("No previous unvisited link"))
 qn("formField", key="f",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next form field"),
+	nextDoc=_("Moves to the next form field"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next form field"),
+	nextError=_("No next form field"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous form field"),
+	prevDoc=_("Moves to the previous form field"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous form field"),
+	prevError=_("No previous form field"),
 	readUnit=textInfos.UNIT_LINE)
 qn("list", key="l",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next list"),
+	nextDoc=_("Moves to the next list"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next list"),
+	nextError=_("No next list"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous list"),
+	prevDoc=_("Moves to the previous list"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous list"),
+	prevError=_("No previous list"),
 	readUnit=textInfos.UNIT_LINE)
 qn("listItem", key="i",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next list item"),
+	nextDoc=_("Moves to the next list item"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next list item"),
+	nextError=_("No next list item"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous list item"),
+	prevDoc=_("Moves to the previous list item"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous list item"))
+	prevError=_("No previous list item"))
 qn("button", key="b",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next button"),
+	nextDoc=_("Moves to the next button"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next button"),
+	nextError=_("No next button"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous button"),
+	prevDoc=_("Moves to the previous button"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous button"))
+	prevError=_("No previous button"))
 qn("edit", key="e",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next edit field"),
+	nextDoc=_("Moves to the next edit field"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next edit field"),
+	nextError=_("No next edit field"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous edit field"),
+	prevDoc=_("Moves to the previous edit field"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous edit field"),
+	prevError=_("No previous edit field"),
 	readUnit=textInfos.UNIT_LINE)
 qn("frame", key="m",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next frame"),
+	nextDoc=_("Moves to the next frame"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next frame"),
+	nextError=_("No next frame"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous frame"),
+	prevDoc=_("Moves to the previous frame"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous frame"),
+	prevError=_("No previous frame"),
 	readUnit=textInfos.UNIT_LINE)
 qn("separator", key="s",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next separator"),
+	nextDoc=_("Moves to the next separator"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next separator"),
+	nextError=_("No next separator"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous separator"),
+	prevDoc=_("Moves to the previous separator"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous separator"))
+	prevError=_("No previous separator"))
 qn("radioButton", key="r",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next radio button"),
+	nextDoc=_("Moves to the next radio button"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next radio button"),
+	nextError=_("No next radio button"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous radio button"),
+	prevDoc=_("Moves to the previous radio button"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous radio button"))
+	prevError=_("No previous radio button"))
 qn("comboBox", key="c",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next combo box"),
+	nextDoc=_("Moves to the next combo box"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next combo box"),
+	nextError=_("No next combo box"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous combo box"),
+	prevDoc=_("Moves to the previous combo box"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous combo box"))
+	prevError=_("No previous combo box"))
 qn("checkBox", key="x",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next check box"),
+	nextDoc=_("Moves to the next check box"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next check box"),
+	nextError=_("No next check box"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous check box"),
+	prevDoc=_("Moves to the previous check box"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous check box"))
+	prevError=_("No previous check box"))
 qn("graphic", key="g",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next graphic"),
+	nextDoc=_("Moves to the next graphic"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next graphic"),
+	nextError=_("No next graphic"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous graphic"),
+	prevDoc=_("Moves to the previous graphic"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous graphic"))
+	prevError=_("No previous graphic"))
 qn("blockQuote", key="q",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next block quote"),
+	nextDoc=_("Moves to the next block quote"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next block quote"),
+	nextError=_("No next block quote"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous block quote"), 
+	prevDoc=_("Moves to the previous block quote"), 
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous block quote"))
+	prevError=_("No previous block quote"))
 qn("notLinkBlock", key="n",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("skips forward past a block of links"),
+	nextDoc=_("Skips forward past a block of links"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no more text after a block of links"),
+	nextError=_("No more text after a block of links"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("skips backward past a block of links"),
+	prevDoc=_("Skips backward past a block of links"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no more text before a block of links"),
+	prevError=_("No more text before a block of links"),
 	readUnit=textInfos.UNIT_LINE)
 qn("landmark", key="d",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next landmark"),
+	nextDoc=_("Moves to the next landmark"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next landmark"),
+	nextError=_("No next landmark"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous landmark"),
+	prevDoc=_("Moves to the previous landmark"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous landmark"),
+	prevError=_("No previous landmark"),
 	readUnit=textInfos.UNIT_LINE)
 qn("embeddedObject", key="o",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next embedded object"),
+	nextDoc=_("Moves to the next embedded object"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next embedded object"),
+	nextError=_("No next embedded object"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous embedded object"),
+	prevDoc=_("Moves to the previous embedded object"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous embedded object"))
+	prevError=_("No previous embedded object"))
 qn("annotation", key="a",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next annotation"),
+	nextDoc=_("Moves to the next annotation"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next annotation"),
+	nextError=_("No next annotation"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous annotation"),
+	prevDoc=_("Moves to the previous annotation"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous annotation"))
+	prevError=_("No previous annotation"))
 del qn
 
 class ElementsListDialog(wx.Dialog):

--- a/source/core.py
+++ b/source/core.py
@@ -58,7 +58,7 @@ def doStartupDialogs():
 		import wx
 		gui.messageBox(_("Your gesture map file contains errors.\n"
 				"More details about the errors can be found in the log file."),
-			_("gesture map File Error"), wx.OK|wx.ICON_EXCLAMATION)
+			_("Gesture Map File Error"), wx.OK|wx.ICON_EXCLAMATION)
 
 def restart(disableAddons=False):
 	"""Restarts NVDA by starting a new copy with -r."""

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -147,7 +147,7 @@ class CursorManager(baseObject.ScriptableObject):
 		d.Show()
 		gui.mainFrame.postPopup()
 	# Translators: Input help message for NVDA's find command.
-	script_find.__doc__ = _("find a text string from the current cursor position")
+	script_find.__doc__ = _("Find a text string from the current cursor position")
 
 	def script_findNext(self,gesture):
 		if not self._lastFindText:
@@ -155,7 +155,7 @@ class CursorManager(baseObject.ScriptableObject):
 			return
 		self.doFindText(self._lastFindText)
 	# Translators: Input help message for find next command.
-	script_findNext.__doc__ = _("find the next occurrence of the previously entered text string from the current cursor's position")
+	script_findNext.__doc__ = _("Find the next occurrence of the previously entered text string from the current cursor's position")
 
 	def script_findPrevious(self,gesture):
 		if not self._lastFindText:
@@ -163,7 +163,7 @@ class CursorManager(baseObject.ScriptableObject):
 			return
 		self.doFindText(self._lastFindText,reverse=True)
 	# Translators: Input help message for find previous command.
-	script_findPrevious.__doc__ = _("find the previous occurrence of the previously entered text string from the current cursor's position")
+	script_findPrevious.__doc__ = _("Find the previous occurrence of the previously entered text string from the current cursor's position")
 
 	def script_moveByPage_back(self,gesture):
 		self._caretMovementScriptHelper(gesture,textInfos.UNIT_LINE,-config.conf["virtualBuffers"]["linesPerPage"],extraDetail=False)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -433,11 +433,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportGrammarErrors(self,gesture):
 		if config.conf["documentFormatting"]["reportGrammarErrors"]:
 			# Translators: The message announced when toggling the report grammar errors document formatting setting.
-			state = _("report grammar errors off")
+			state = _("Report grammar errors off")
 			config.conf["documentFormatting"]["reportGrammarErrors"]=False
 		else:
 			# Translators: The message announced when toggling the report grammar errors document formatting setting.
-			state = _("report grammar errors on")
+			state = _("Report grammar errors on")
 			config.conf["documentFormatting"]["reportGrammarErrors"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report grammar errors command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -102,9 +102,9 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleInputHelp(self,gesture):
 		inputCore.manager.isInputHelpActive = not inputCore.manager.isInputHelpActive
 		# Translators: This will be presented when the input help is toggled.
-		stateOn = _("input help on")
+		stateOn = _("Input help on")
 		# Translators: This will be presented when the input help is toggled.
-		stateOff = _("input help off")
+		stateOff = _("Input help off")
 		state = stateOn if inputCore.manager.isInputHelpActive else stateOff
 		ui.message(state)
 	# Translators: Input help mode message for toggle input help command.
@@ -125,7 +125,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: This is presented when sleep mode is activated, the focused application is self voicing, such as klango or openbook.
 			ui.message(_("Sleep mode on"))
 	# Translators: Input help mode message for toggle sleep mode command.
-	script_toggleCurrentAppSleepMode.__doc__=_("Toggles  sleep mode on and off for  the active application.")
+	script_toggleCurrentAppSleepMode.__doc__=_("Toggles sleep mode on and off for the active application")
 	script_toggleCurrentAppSleepMode.allowInSleepMode=True
 
 	def script_reportCurrentLine(self,gesture):
@@ -265,11 +265,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleSpeakTypedCharacters(self,gesture):
 		if config.conf["keyboard"]["speakTypedCharacters"]:
 			# Translators: The message announced when toggling the speak typed characters keyboard setting.
-			state = _("speak typed characters off")
+			state = _("Speak typed characters off")
 			config.conf["keyboard"]["speakTypedCharacters"]=False
 		else:
 			# Translators: The message announced when toggling the speak typed characters keyboard setting.
-			state = _("speak typed characters on")
+			state = _("Speak typed characters on")
 			config.conf["keyboard"]["speakTypedCharacters"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle speaked typed characters command.
@@ -279,11 +279,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleSpeakTypedWords(self,gesture):
 		if config.conf["keyboard"]["speakTypedWords"]:
 			# Translators: The message announced when toggling the speak typed words keyboard setting.
-			state = _("speak typed words off")
+			state = _("Speak typed words off")
 			config.conf["keyboard"]["speakTypedWords"]=False
 		else:
 			# Translators: The message announced when toggling the speak typed words keyboard setting.
-			state = _("speak typed words on")
+			state = _("Speak typed words on")
 			config.conf["keyboard"]["speakTypedWords"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle speak typed words command.
@@ -293,11 +293,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleSpeakCommandKeys(self,gesture):
 		if config.conf["keyboard"]["speakCommandKeys"]:
 			# Translators: The message announced when toggling the speak typed command keyboard setting.
-			state = _("speak command keys off")
+			state = _("Speak command keys off")
 			config.conf["keyboard"]["speakCommandKeys"]=False
 		else:
 			# Translators: The message announced when toggling the speak typed command keyboard setting.
-			state = _("speak command keys on")
+			state = _("Speak command keys on")
 			config.conf["keyboard"]["speakCommandKeys"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle speak command keys command.
@@ -307,11 +307,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportFontName(self,gesture):
 		if config.conf["documentFormatting"]["reportFontName"]:
 			# Translators: The message announced when toggling the report font name document formatting setting.
-			state = _("report font name off")
+			state = _("Report font name off")
 			config.conf["documentFormatting"]["reportFontName"]=False
 		else:
 			# Translators: The message announced when toggling the report font name document formatting setting.
-			state = _("report font name on")
+			state = _("Report font name on")
 			config.conf["documentFormatting"]["reportFontName"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report font name command.
@@ -321,11 +321,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportFontSize(self,gesture):
 		if config.conf["documentFormatting"]["reportFontSize"]:
 			# Translators: The message announced when toggling the report font size document formatting setting.
-			state = _("report font size off")
+			state = _("Report font size off")
 			config.conf["documentFormatting"]["reportFontSize"]=False
 		else:
 			# Translators: The message announced when toggling the report font size document formatting setting.
-			state = _("report font size on")
+			state = _("Report font size on")
 			config.conf["documentFormatting"]["reportFontSize"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report font size command.
@@ -335,11 +335,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportFontAttributes(self,gesture):
 		if config.conf["documentFormatting"]["reportFontAttributes"]:
 			# Translators: The message announced when toggling the report font attributes document formatting setting.
-			state = _("report font attributes off")
+			state = _("Report font attributes off")
 			config.conf["documentFormatting"]["reportFontAttributes"]=False
 		else:
 			# Translators: The message announced when toggling the report font attributes document formatting setting.
-			state = _("report font attributes on")
+			state = _("Report font attributes on")
 			config.conf["documentFormatting"]["reportFontAttributes"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report font attributes command.
@@ -349,11 +349,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportRevisions(self,gesture):
 		if config.conf["documentFormatting"]["reportRevisions"]:
 			# Translators: The message announced when toggling the report revisions document formatting setting.
-			state = _("report revisions off")
+			state = _("Report revisions off")
 			config.conf["documentFormatting"]["reportRevisions"]=False
 		else:
 			# Translators: The message announced when toggling the report revisions document formatting setting.
-			state = _("report revisions on")
+			state = _("Report revisions on")
 			config.conf["documentFormatting"]["reportRevisions"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report revisions command.
@@ -363,11 +363,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportEmphasis(self,gesture):
 		if config.conf["documentFormatting"]["reportEmphasis"]:
 			# Translators: The message announced when toggling the report emphasis document formatting setting.
-			state = _("report emphasis off")
+			state = _("Report emphasis off")
 			config.conf["documentFormatting"]["reportEmphasis"]=False
 		else:
 			# Translators: The message announced when toggling the report emphasis document formatting setting.
-			state = _("report emphasis on")
+			state = _("Report emphasis on")
 			config.conf["documentFormatting"]["reportEmphasis"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report emphasis command.
@@ -377,11 +377,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportColor(self,gesture):
 		if config.conf["documentFormatting"]["reportColor"]:
 			# Translators: The message announced when toggling the report colors document formatting setting.
-			state = _("report colors off")
+			state = _("Report colors off")
 			config.conf["documentFormatting"]["reportColor"]=False
 		else:
 			# Translators: The message announced when toggling the report colors document formatting setting.
-			state = _("report colors on")
+			state = _("Report colors on")
 			config.conf["documentFormatting"]["reportColor"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report colors command.
@@ -391,11 +391,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportAlignment(self,gesture):
 		if config.conf["documentFormatting"]["reportAlignment"]:
 			# Translators: The message announced when toggling the report alignment document formatting setting.
-			state = _("report alignment off")
+			state = _("Report alignment off")
 			config.conf["documentFormatting"]["reportAlignment"]=False
 		else:
 			# Translators: The message announced when toggling the report alignment document formatting setting.
-			state = _("report alignment on")
+			state = _("Report alignment on")
 			config.conf["documentFormatting"]["reportAlignment"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report alignment command.
@@ -405,11 +405,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportStyle(self,gesture):
 		if config.conf["documentFormatting"]["reportStyle"]:
 			# Translators: The message announced when toggling the report style document formatting setting.
-			state = _("report style off")
+			state = _("Report style off")
 			config.conf["documentFormatting"]["reportStyle"]=False
 		else:
 			# Translators: The message announced when toggling the report style document formatting setting.
-			state = _("report style on")
+			state = _("Report style on")
 			config.conf["documentFormatting"]["reportStyle"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report style command.
@@ -419,11 +419,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportSpellingErrors(self,gesture):
 		if config.conf["documentFormatting"]["reportSpellingErrors"]:
 			# Translators: The message announced when toggling the report spelling errors document formatting setting.
-			state = _("report spelling errors off")
+			state = _("Report spelling errors off")
 			config.conf["documentFormatting"]["reportSpellingErrors"]=False
 		else:
 			# Translators: The message announced when toggling the report spelling errors document formatting setting.
-			state = _("report spelling errors on")
+			state = _("Report spelling errors on")
 			config.conf["documentFormatting"]["reportSpellingErrors"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report spelling errors command.
@@ -447,11 +447,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportPage(self,gesture):
 		if config.conf["documentFormatting"]["reportPage"]:
 			# Translators: The message announced when toggling the report pages document formatting setting.
-			state = _("report pages off")
+			state = _("Report pages off")
 			config.conf["documentFormatting"]["reportPage"]=False
 		else:
 			# Translators: The message announced when toggling the report pages document formatting setting.
-			state = _("report pages on")
+			state = _("Report pages on")
 			config.conf["documentFormatting"]["reportPage"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report pages command.
@@ -461,11 +461,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportLineNumber(self,gesture):
 		if config.conf["documentFormatting"]["reportLineNumber"]:
 			# Translators: The message announced when toggling the report line numbers document formatting setting.
-			state = _("report line numbers off")
+			state = _("Report line numbers off")
 			config.conf["documentFormatting"]["reportLineNumber"]=False
 		else:
 			# Translators: The message announced when toggling the report line numbers document formatting setting.
-			state = _("report line numbers on")
+			state = _("Report line numbers on")
 			config.conf["documentFormatting"]["reportLineNumber"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report line numbers command.
@@ -475,11 +475,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportLineIndentation(self,gesture):
 		if config.conf["documentFormatting"]["reportLineIndentation"]:
 			# Translators: The message announced when toggling the report line indentation document formatting setting.
-			state = _("report line indentation off")
+			state = _("Report line indentation off")
 			config.conf["documentFormatting"]["reportLineIndentation"]=False
 		else:
 			# Translators: The message announced when toggling the report line indentation document formatting setting.
-			state = _("report line indentation on")
+			state = _("Report line indentation on")
 			config.conf["documentFormatting"]["reportLineIndentation"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report line indentation command.
@@ -489,11 +489,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportParagraphIndentation(self,gesture):
 		if config.conf["documentFormatting"]["reportParagraphIndentation"]:
 			# Translators: The message announced when toggling the report paragraph indentation document formatting setting.
-			state = _("report paragraph indentation off")
+			state = _("Report paragraph indentation off")
 			config.conf["documentFormatting"]["reportParagraphIndentation"]=False
 		else:
 			# Translators: The message announced when toggling the report paragraph indentation document formatting setting.
-			state = _("report paragraph indentation on")
+			state = _("Report paragraph indentation on")
 			config.conf["documentFormatting"]["reportParagraphIndentation"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report paragraph indentation command.
@@ -503,11 +503,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportTables(self,gesture):
 		if config.conf["documentFormatting"]["reportTables"]:
 			# Translators: The message announced when toggling the report tables document formatting setting.
-			state = _("report tables off")
+			state = _("Report tables off")
 			config.conf["documentFormatting"]["reportTables"]=False
 		else:
 			# Translators: The message announced when toggling the report tables document formatting setting.
-			state = _("report tables on")
+			state = _("Report tables on")
 			config.conf["documentFormatting"]["reportTables"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report tables command.
@@ -517,11 +517,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportTableHeaders(self,gesture):
 		if config.conf["documentFormatting"]["reportTableHeaders"]:
 			# Translators: The message announced when toggling the report table row/column headers document formatting setting.
-			state = _("report table row and column headers off")
+			state = _("Report table row and column headers off")
 			config.conf["documentFormatting"]["reportTableHeaders"]=False
 		else:
 			# Translators: The message announced when toggling the report table row/column headers document formatting setting.
-			state = _("report table row and column headers on")
+			state = _("Report table row and column headers on")
 			config.conf["documentFormatting"]["reportTableHeaders"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report table row/column headers command.
@@ -531,11 +531,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportTableCellCoords(self,gesture):
 		if config.conf["documentFormatting"]["reportTableCellCoords"]:
 			# Translators: The message announced when toggling the report table cell coordinates document formatting setting.
-			state = _("report table cell coordinates off")
+			state = _("Report table cell coordinates off")
 			config.conf["documentFormatting"]["reportTableCellCoords"]=False
 		else:
 			# Translators: The message announced when toggling the report table cell coordinates document formatting setting.
-			state = _("report table cell coordinates on")
+			state = _("Report table cell coordinates on")
 			config.conf["documentFormatting"]["reportTableCellCoords"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report table cell coordinates command.
@@ -545,11 +545,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportLinks(self,gesture):
 		if config.conf["documentFormatting"]["reportLinks"]:
 			# Translators: The message announced when toggling the report links document formatting setting.
-			state = _("report links off")
+			state = _("Report links off")
 			config.conf["documentFormatting"]["reportLinks"]=False
 		else:
 			# Translators: The message announced when toggling the report links document formatting setting.
-			state = _("report links on")
+			state = _("Report links on")
 			config.conf["documentFormatting"]["reportLinks"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report links command.
@@ -559,11 +559,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportComments(self,gesture):
 		if config.conf["documentFormatting"]["reportComments"]:
 			# Translators: The message announced when toggling the report comments document formatting setting.
-			state = _("report comments off")
+			state = _("Report comments off")
 			config.conf["documentFormatting"]["reportComments"]=False
 		else:
 			# Translators: The message announced when toggling the report comments document formatting setting.
-			state = _("report comments on")
+			state = _("Report comments on")
 			config.conf["documentFormatting"]["reportComments"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report comments command.
@@ -573,11 +573,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportLists(self,gesture):
 		if config.conf["documentFormatting"]["reportLists"]:
 			# Translators: The message announced when toggling the report lists document formatting setting.
-			state = _("report lists off")
+			state = _("Report lists off")
 			config.conf["documentFormatting"]["reportLists"]=False
 		else:
 			# Translators: The message announced when toggling the report lists document formatting setting.
-			state = _("report lists on")
+			state = _("Report lists on")
 			config.conf["documentFormatting"]["reportLists"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report lists command.
@@ -587,11 +587,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportHeadings(self,gesture):
 		if config.conf["documentFormatting"]["reportHeadings"]:
 			# Translators: The message announced when toggling the report headings document formatting setting.
-			state = _("report headings off")
+			state = _("Report headings off")
 			config.conf["documentFormatting"]["reportHeadings"]=False
 		else:
 			# Translators: The message announced when toggling the report headings document formatting setting.
-			state = _("report headings on")
+			state = _("Report headings on")
 			config.conf["documentFormatting"]["reportHeadings"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report headings command.
@@ -601,11 +601,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportBlockQuotes(self,gesture):
 		if config.conf["documentFormatting"]["reportBlockQuotes"]:
 			# Translators: The message announced when toggling the report block quotes document formatting setting.
-			state = _("report block quotes off")
+			state = _("Report block quotes off")
 			config.conf["documentFormatting"]["reportBlockQuotes"]=False
 		else:
 			# Translators: The message announced when toggling the report block quotes document formatting setting.
-			state = _("report block quotes on")
+			state = _("Report block quotes on")
 			config.conf["documentFormatting"]["reportBlockQuotes"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report block quotes command.
@@ -615,11 +615,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportLandmarks(self,gesture):
 		if config.conf["documentFormatting"]["reportLandmarks"]:
 			# Translators: The message announced when toggling the report landmarks document formatting setting.
-			state = _("report landmarks off")
+			state = _("Report landmarks off")
 			config.conf["documentFormatting"]["reportLandmarks"]=False
 		else:
 			# Translators: The message announced when toggling the report landmarks document formatting setting.
-			state = _("report landmarks on")
+			state = _("Report landmarks on")
 			config.conf["documentFormatting"]["reportLandmarks"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report landmarks command.
@@ -629,11 +629,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportFrames(self,gesture):
 		if config.conf["documentFormatting"]["reportFrames"]:
 			# Translators: The message announced when toggling the report frames document formatting setting.
-			state = _("report frames off")
+			state = _("Report frames off")
 			config.conf["documentFormatting"]["reportFrames"]=False
 		else:
 			# Translators: The message announced when toggling the report frames document formatting setting.
-			state = _("report frames on")
+			state = _("Report frames on")
 			config.conf["documentFormatting"]["reportFrames"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report frames command.
@@ -643,11 +643,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportClickable(self,gesture):
 		if config.conf["documentFormatting"]["reportClickable"]:
 			# Translators: The message announced when toggling the report if clickable document formatting setting.
-			state = _("report if clickable off")
+			state = _("Report if clickable off")
 			config.conf["documentFormatting"]["reportClickable"]=False
 		else:
 			# Translators: The message announced when toggling the report if clickable document formatting setting.
-			state = _("report if clickable on")
+			state = _("Report if clickable on")
 			config.conf["documentFormatting"]["reportClickable"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report if clickable command.
@@ -769,7 +769,7 @@ class GlobalCommands(ScriptableObject):
 		else:
 			speech.speakObject(curObject,reason=controlTypes.REASON_QUERY)
 	# Translators: Input help mode message for report current navigator object command.
-	script_navigatorObject_current.__doc__=_("Reports the current navigator object. Pressing twice spells this information, and pressing three times Copies name and value of this  object to the clipboard")
+	script_navigatorObject_current.__doc__=_("Reports the current navigator object. Pressing twice spells this information, and pressing three times copies name and value of this object to the clipboard")
 	script_navigatorObject_current.category=SCRCAT_OBJECTNAVIGATION
 
 	def script_navigatorObject_currentDimensions(self,gesture):
@@ -1412,11 +1412,11 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleReportDynamicContentChanges(self,gesture):
 		if config.conf["presentation"]["reportDynamicContentChanges"]:
 			# Translators: presented when the present dynamic changes is toggled.
-			state = _("report dynamic content changes off")
+			state = _("Report dynamic content changes off")
 			config.conf["presentation"]["reportDynamicContentChanges"]=False
 		else:
 			# Translators: presented when the present dynamic changes is toggled.
-			state = _("report dynamic content changes on")
+			state = _("Report dynamic content changes on")
 			config.conf["presentation"]["reportDynamicContentChanges"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle dynamic content changes command.
@@ -1426,25 +1426,25 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleCaretMovesReviewCursor(self,gesture):
 		if config.conf["reviewCursor"]["followCaret"]:
 			# Translators: presented when toggled.
-			state = _("caret moves review cursor off")
+			state = _("Caret moves review cursor off")
 			config.conf["reviewCursor"]["followCaret"]=False
 		else:
 			# Translators: presented when toggled.
-			state = _("caret moves review cursor on")
+			state = _("Caret moves review cursor on")
 			config.conf["reviewCursor"]["followCaret"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle caret moves review cursor command.
-	script_toggleCaretMovesReviewCursor.__doc__=_("Toggles on and off the movement of the review cursor due to the caret moving.")
+	script_toggleCaretMovesReviewCursor.__doc__=_("Toggles on and off the movement of the review cursor due to the caret moving")
 	script_toggleCaretMovesReviewCursor.category=SCRCAT_TEXTREVIEW
 
 	def script_toggleFocusMovesNavigatorObject(self,gesture):
 		if config.conf["reviewCursor"]["followFocus"]:
 			# Translators: presented when toggled.
-			state = _("focus moves navigator object off")
+			state = _("Focus moves navigator object off")
 			config.conf["reviewCursor"]["followFocus"]=False
 		else:
 			# Translators: presented when toggled.
-			state = _("focus moves navigator object on")
+			state = _("Focus moves navigator object on")
 			config.conf["reviewCursor"]["followFocus"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle focus moves navigator object command.
@@ -1635,12 +1635,12 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleSpeechViewer(self,gesture):
 		if gui.speechViewer.isActive:
 			# Translators: The message announced when disabling speech viewer.
-			state = _("speech viewer disabled")
+			state = _("Speech viewer disabled")
 			gui.speechViewer.deactivate()
 			gui.mainFrame.sysTrayIcon.menu_tools_toggleSpeechViewer.Check(False)
 		else:
 			# Translators: The message announced when enabling speech viewer.
-			state = _("speech viewer enabled")
+			state = _("Speech viewer enabled")
 			gui.speechViewer.activate()
 			gui.mainFrame.sysTrayIcon.menu_tools_toggleSpeechViewer.Check(True)
 		ui.message(state)
@@ -1796,7 +1796,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Presented when plugins (app modules and global plugins) are reloaded.
 		ui.message(_("Plugins reloaded"))
 	# Translators: Input help mode message for reload plugins command.
-	script_reloadPlugins.__doc__=_("Reloads app modules and global plugins without restarting NVDA, which can be Useful for developers")
+	script_reloadPlugins.__doc__=_("Reloads app modules and global plugins without restarting NVDA, which can be useful for developers")
 	script_reloadPlugins.category=SCRCAT_TOOLS
 
 	def script_navigatorObject_nextInFlow(self,gesture):

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -175,16 +175,16 @@ class AddonsDialog(wx.Dialog):
 	def getAddonStatus(self,addon):
 		if addon.isPendingInstall:
 			# Translators: The status shown for a newly installed addon before NVDA is restarted.
-			return _("install")
+			return _("Install")
 		elif addon.isPendingRemove:
 			# Translators: The status shown for an addon that has been marked as removed, before NVDA has been restarted.
-			return _("remove")
+			return _("Remove")
 		elif globalVars.appArgs.disableAddons:
 			# Translators: The status shown for an addon when its currently suspended do to addons been disabled.
-			return _("suspended")
+			return _("Suspended")
 		else:
 			# Translators: The status shown for an addon when its currently running in NVDA.
-			return _("running")
+			return _("Running")
 
 	def refreshAddonsList(self,activeIndex=0):
 		self.addonsList.DeleteAllItems()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -119,13 +119,13 @@ class GeneralSettingsDialog(SettingsDialog):
 	title = _("General Settings")
 	LOG_LEVELS = (
 		# Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
-		(log.INFO, _("info")),
+		(log.INFO, _("Info")),
 		# Translators: One of the log levels of NVDA (the debug warning shows debugging messages and warnings as NVDA runs).
-		(log.DEBUGWARNING, _("debug warning")),
+		(log.DEBUGWARNING, _("Debug warning")),
 		# Translators: One of the log levels of NVDA (the input/output shows keyboard commands and/or braille commands as well as speech and/or braille output of NVDA).
-		(log.IO, _("input/output")),
+		(log.IO, _("Input/Output")),
 		# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
-		(log.DEBUG, _("debug"))
+		(log.DEBUG, _("Debug"))
 	)
 
 	def makeSettings(self, settingsSizer):
@@ -750,7 +750,7 @@ class MouseSettingsDialog(SettingsDialog):
 		import textInfos
 		self.textUnits=[textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD,textInfos.UNIT_LINE,textInfos.UNIT_PARAGRAPH]
 		# Translators: This is the name of a combobox in the mouse settings dialog.
-		self.textUnitComboBox=wx.Choice(self,wx.ID_ANY,name=_("text reporting unit"),choices=[textInfos.unitLabels[x] for x in self.textUnits])
+		self.textUnitComboBox=wx.Choice(self,wx.ID_ANY,name=_("Text reporting unit"),choices=[textInfos.unitLabels[x] for x in self.textUnits])
 		try:
 			index=self.textUnits.index(config.conf["mouse"]["mouseTextUnit"])
 		except:
@@ -872,7 +872,7 @@ class ObjectPresentationDialog(SettingsDialog):
 		# Translators: An option for progress bar output in the Object Presentation dialog
 		# which disables reporting of progress bars.
 		# See Progress bar output in the Object Presentation Settings section of the User Guide.
-		("off", _("off")),
+		("off", _("Off")),
 		# Translators: An option for progress bar output in the Object Presentation dialog
 		# which reports progress bar updates by speaking.
 		# See Progress bar output in the Object Presentation Settings section of the User Guide.
@@ -1281,10 +1281,10 @@ class DictionaryDialog(SettingsDialog):
 		# Translators: The label for a column in dictionary entries list and in a list of symbols from symbol pronunciation dialog used to identify replacement for a pattern or a symbol
 		self.dictList.InsertColumn(2,_("Replacement"),width=150)
 		# Translators: The label for a column in dictionary entries list used to identify whether the entry is case sensitive or not.
-		self.dictList.InsertColumn(3,_("case"),width=50)
+		self.dictList.InsertColumn(3,_("Case"),width=50)
 		# Translators: The label for a column in dictionary entries list used to identify whether the entry is a regular expression, matches whole words, or matches anywhere.
 		self.dictList.InsertColumn(4,_("Type"),width=50)
-		self.offOn = (_("off"),_("on"))
+		self.offOn = (_("Off"),_("On"))
 		for entry in self.tempSpeechDict:
 			self.dictList.Append((entry.comment,entry.pattern,entry.replacement,self.offOn[int(entry.caseSensitive)],DictionaryDialog.TYPE_LABELS[entry.type]))
 		self.editingIndex=-1
@@ -1476,7 +1476,7 @@ class BrailleSettingsDialog(SettingsDialog):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to set whether braille should be tethered to focus or review cursor.
 		label = wx.StaticText(self, wx.ID_ANY, label=_("Braille tethered to:"))
-		self.tetherValues=[("focus",_("focus")),("review",_("review"))]
+		self.tetherValues=[("focus",_("Focus")),("review",_("Review"))]
 		self.tetherList = wx.Choice(self, wx.ID_ANY, choices=[x[1] for x in self.tetherValues])
 		tetherConfig=braille.handler.tether
 		selection = (x for x,y in enumerate(self.tetherValues) if y[0]==tetherConfig).next()  

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -620,23 +620,23 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 	def script_nextRow(self, gesture):
 		self._tableMovementScriptHelper(axis="row", movement="next")
 	# Translators: the description for the next table row script on virtualBuffers.
-	script_nextRow.__doc__ = _("moves to the next table row")
+	script_nextRow.__doc__ = _("Moves to the next table row")
 
 
 	def script_previousRow(self, gesture):
 		self._tableMovementScriptHelper(axis="row", movement="previous")
 	# Translators: the description for the previous table row script on virtualBuffers.
-	script_previousRow.__doc__ = _("moves to the previous table row")
+	script_previousRow.__doc__ = _("Moves to the previous table row")
 
 	def script_nextColumn(self, gesture):
 		self._tableMovementScriptHelper(axis="column", movement="next")
 	# Translators: the description for the next table column script on virtualBuffers.
-	script_nextColumn.__doc__ = _("moves to the next table column")
+	script_nextColumn.__doc__ = _("Moves to the next table column")
 
 	def script_previousColumn(self, gesture):
 		self._tableMovementScriptHelper(axis="column", movement="previous")
 	# Translators: the description for the previous table column script on virtualBuffers.
-	script_previousColumn.__doc__ = _("moves to the previous table column")
+	script_previousColumn.__doc__ = _("Moves to the previous table column")
 
 	def _isSuitableNotLinkBlock(self,range):
 		return (range._endOffset-range._startOffset)>=self.NOT_LINK_BLOCK_MIN_LEN


### PR DESCRIPTION
This will cause a ton of fuzzy strings for translators. Initially posted as a comment in #5557. Opening a new PR now to separate the discussion about the use of ui.message from the discussion on capitalization and punctuation.

The commits in this PR try to make the use of capitalization and punctuation more consistent. But there are still some points for debate:
- Should this even be attempted? Can it be made into a simple policy (that code reviewers can follow)?
- Should we sift through the messages that are only spoken, e.g. through the speak\* functions? There should be no audible difference, but these messages could be shown in the speech viewer. I left them alone for now.
- It'll never be perfect. Some strings are used in multiple contexts so you can't capitalize them.

@josephsl and @derekriemer: any thoughts?
