### PR TITLE
handle Describedby in iframe and multiple Describedby IDs

### DIFF
--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -76,15 +76,25 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 		description=None
 		ariaDescribedBy=attrs.get('HTMLAttrib::aria-describedby')
 		if ariaDescribedBy:
-			try:
-				descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedBy)
-			except (COMError,NameError):
-				descNode=None
-			if descNode:
+			ariaDescribedByIds=ariaDescribedBy.split(" ")
+			for ariaDescribedById in ariaDescribedByIds:
+				descNode=None				
 				try:
-					description=self.obj.makeTextInfo(NVDAObjects.IAccessible.MSHTML.MSHTML(HTMLNode=descNode)).text
-				except:
+					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedBy)
+				except (COMError,NameError):
+					descNode=None	
+				if descNode:
 					pass
+				elif:
+					try:
+						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document, ariaDescribedById)
+					except (COMError,NameError):
+						descNode=None
+				if descNode:
+					try:
+						description=description+" "+self.obj.makeTextInfo(NVDAObjects.IAccessible.MSHTML.MSHTML(HTMLNode=descNode)).text
+					except:
+						pass
 		ariaSort=attrs.get('HTMLAttrib::aria-sort')
 		state=aria.ariaSortValuesToNVDAStates.get(ariaSort)
 		if state is not None:

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -83,9 +83,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedBy)
 				except (COMError,NameError):
 					descNode=None	
-				if descNode:
-					pass
-				elif:
+				if !descNode:
 					try:
 						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document, ariaDescribedById)
 					except (COMError,NameError):

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -76,7 +76,8 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 		description=None
 		ariaDescribedBy=attrs.get('HTMLAttrib::aria-describedby')
 		if ariaDescribedBy:			
-			ariaDescribedByIds=ariaDescribedBy.split(" ")
+			ariaDescribedByIds=ariaDescribedBy.split()
+			description=""
 			for ariaDescribedById in ariaDescribedByIds:
 				descNode=None				
 				try:
@@ -92,7 +93,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 					try:
 						description=description+" "+self.obj.makeTextInfo(NVDAObjects.IAccessible.MSHTML.MSHTML(HTMLNode=descNode)).text
 					except:
-						pass
+						pass			
 		ariaSort=attrs.get('HTMLAttrib::aria-sort')
 		state=aria.ariaSortValuesToNVDAStates.get(ariaSort)
 		if state is not None:

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -83,9 +83,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedById)
 				except (COMError,NameError):
 					descNode=None	
-				if descNode:
-					pass
-				else:
+				if not descNode:
 					try:
 						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document, ariaDescribedById)
 					except (COMError,NameError):

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -75,15 +75,17 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			states.add(controlTypes.STATE_REQUIRED)
 		description=None
 		ariaDescribedBy=attrs.get('HTMLAttrib::aria-describedby')
-		if ariaDescribedBy:
+		if ariaDescribedBy:			
 			ariaDescribedByIds=ariaDescribedBy.split(" ")
 			for ariaDescribedById in ariaDescribedByIds:
 				descNode=None				
 				try:
-					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedBy)
+					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedById)
 				except (COMError,NameError):
 					descNode=None	
-				if !descNode:
+				if descNode:
+					pass
+				else:
 					try:
 						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document, ariaDescribedById)
 					except (COMError,NameError):


### PR DESCRIPTION
Fixed issue #5784: IE11: aria-describedby on buttons inside iFrames not respected. In addition, changed the code to support aria-describedby containing multiple ids using a space separated list.
