### PR TITLE
added __ne__ to textInfos.TextInfo class

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -823,6 +823,9 @@ class UIA(Window):
 	def event_UIA_elementSelected(self):
 		self.event_stateChange()
 
+	def event_caret(self):
+		return
+
 	def event_valueChange(self):
 		if isinstance(self, EditableTextWithoutAutoSelectDetection):
 			return

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -62,6 +62,8 @@ class EditableText(ScriptableObject):
 			api.processPendingEvents(processEventQueue=False)
 			if eventHandler.isPendingEvents("gainFocus"):
 				return (True,None)
+			if eventHandler.isPendingEvents("caret"):
+				return (True,None)
 			#The caret may stop working as the focus jumps, we want to stay in the while loop though
 			try:
 				newInfo = self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -453,6 +453,9 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
+	def __ne__(self, other):
+		return not self.__eq__(other)
+
 RE_EOL = re.compile("\r\n|[\n\r]")
 def convertToCrlf(text):
 	"""Convert a string so that it contains only CRLF line endings.


### PR DESCRIPTION
I tested NVDA's behavior after the change: unfortunately, backspace script no longer works. no errors in the log, the char before the caret is deleted, but NVDA doesn't make any announcement
