### PR TITLE
Fix issue #5591 - HTML 5 structural elements in IE

### DIFF
--- a/source/aria.py
+++ b/source/aria.py
@@ -83,3 +83,10 @@ landmarkRoles = {
 	# Translators: Reported for a significant region, normally found on web pages.
 	"region": _("region"),
 }
+
+htmlNodeNameToAriaLandmarkRoles = {
+	"header": "banner",
+	"nav": "navigation",
+	"main": "main",
+	"footer": "contentinfo",
+}

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -122,6 +122,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			# MSHTML puts the unavailable state on all graphics when the showing of graphics is disabled.
 			# This is rather annoying and irrelevant to our users, so discard it.
 			states.discard(controlTypes.STATE_UNAVAILABLE)
+		ariaRoles.append(aria.htmlNodeNameToAriaLandmarkRoles.get(nodeName.lower()))
 		# Get the first landmark role, if any.
 		landmark=next((ar for ar in ariaRoles if ar in aria.landmarkRoles),None)
 		ariaLevel=attrs.get('HTMLAttrib::aria-level',None)
@@ -292,7 +293,8 @@ class MSHTML(VirtualBuffer):
 			attrs = [
 				{"HTMLAttrib::role": [VBufStorage_findMatch_word(lr) for lr in aria.landmarkRoles if lr != "region"]},
 				{"HTMLAttrib::role": [VBufStorage_findMatch_word("region")],
-					"name": [VBufStorage_findMatch_notEmpty]}
+					"name": [VBufStorage_findMatch_notEmpty]},
+				{"IHTMLDOMNode::nodeName": [VBufStorage_findMatch_word(lr.upper()) for lr in aria.htmlNodeNameToAriaLandmarkRoles]}
 				]
 		elif nodeType == "embeddedObject":
 			attrs = {"IHTMLDOMNode::nodeName": ["OBJECT","EMBED","APPLET"]}

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -122,7 +122,9 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			# MSHTML puts the unavailable state on all graphics when the showing of graphics is disabled.
 			# This is rather annoying and irrelevant to our users, so discard it.
 			states.discard(controlTypes.STATE_UNAVAILABLE)
-		ariaRoles.append(aria.htmlNodeNameToAriaLandmarkRoles.get(nodeName.lower()))
+		lRole = aria.htmlNodeNameToAriaLandmarkRoles.get(nodeName.lower())
+		if lRole:
+			ariaRoles.append(lRole)
 		# Get the first landmark role, if any.
 		landmark=next((ar for ar in ariaRoles if ar in aria.landmarkRoles),None)
 		ariaLevel=attrs.get('HTMLAttrib::aria-level',None)


### PR DESCRIPTION
Issue: NVDA does not recognise HTML 5 structural elements in IE
See https://github.com/nvaccess/nvda/issues/5591

Added a mapping for HTML elemetns to ARIA landmark roles which
is now considered when looking for landmarks.
