### PR TITLE
Fix issue #5490 - lock keys double announce

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -389,8 +389,8 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			return False
 		if self.vkCode in self.TOGGLE_KEYS:
 			# #5490: Dont report for keys that toggle on off.
-			# This is to avoid them from reported twice: once by the 'speak command keys' feature,
-			# and once by the 'speak typed characters' feature
+			# This is to avoid them from being reported twice: once by the 'speak command keys' feature,
+			# and once to announce that the state has changed.
 			return False
 		return not self.isCharacter
 

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -387,6 +387,11 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			# This could be for an event such as gyroscope movement,
 			# so don't report it.
 			return False
+		if self.vkCode in self.TOGGLE_KEYS:
+			# #5490: Dont report for keys that toggle on off.
+			# This is to avoid them from reported twice: once by the 'speak command keys' feature,
+			# and once by the 'speak typed characters' feature
+			return False
 		return not self.isCharacter
 
 	def _get_isCharacter(self):


### PR DESCRIPTION
Issue: Lock keys double announce when Speak command keys is on
https://github.com/nvaccess/nvda/issues/5490

Added a special case to _get_shouldReportAsCommand if the key
is in the TOGGLE_KEYS list.
