### PR TITLE
Avoid error when changing the read timeout on a serial port

### DIFF
--- a/source/hwIo.py
+++ b/source/hwIo.py
@@ -15,14 +15,13 @@ import ctypes
 from ctypes import byref
 from ctypes.wintypes import DWORD, USHORT
 import serial
-from serial.win32 import OVERLAPPED, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, ERROR_IO_PENDING, CreateFile
+from serial.win32 import OVERLAPPED, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, ERROR_IO_PENDING, COMMTIMEOUTS, CreateFile, SetCommTimeouts
 import winKernel
 import braille
 from logHandler import log
 import config
 
 LPOVERLAPPED_COMPLETION_ROUTINE = ctypes.WINFUNCTYPE(None, DWORD, DWORD, serial.win32.LPOVERLAPPED)
-ERROR_OPERATION_ABORTED = 995
 
 def _isDebug():
 	return config.conf["debugLog"]["hwIo"]
@@ -155,7 +154,7 @@ class Serial(IoBase):
 			raise
 		self._origTimeout = self._ser.timeout
 		# We don't want a timeout while we're waiting for data.
-		self._ser.timeout = None
+		self._setTimeout(None)
 		self.inWaiting = self._ser.inWaiting
 		super(Serial, self).__init__(self._ser.hComPort, onReceive)
 
@@ -178,9 +177,19 @@ class Serial(IoBase):
 
 	def _notifyReceive(self, data):
 		# Set the timeout for onReceive in case it does a sync read.
-		self._ser.timeout = self._origTimeout
+		self._setTimeout(self._origTimeout)
 		super(Serial, self)._notifyReceive(data)
-		self._ser.timeout = None
+		self._setTimeout(None)
+
+	def _setTimeout(self, timeout):
+		# #6035: pyserial reconfigures all settings of the port when setting a timeout.
+		# This can cause error 'Cannot configure port, some setting was wrong.'
+		# Therefore, manually set the timeout using the Win32 API.
+		# timeout=None to clear all timeouts, else a positive number of milliseconds.
+		timeouts = COMMTIMEOUTS()
+		if timeout is not None:
+			timeouts.ReadTotalTimeoutConstant = max(int(timeout * 1000), 1)
+		SetCommTimeouts(self._ser.hComPort, ctypes.byref(timeouts))
 
 class HIDP_CAPS (ctypes.Structure):
 	_fields_ = (

--- a/source/hwIo.py
+++ b/source/hwIo.py
@@ -187,20 +187,18 @@ class Serial(IoBase):
 		# Therefore, manually set the timeouts using the Win32 API.
 		# Adapted from pyserial 3.1.1.
 		timeouts = COMMTIMEOUTS()
-		if timeout is None:
-			pass # default of all zeros is OK
-		elif timeout == 0:
-			timeouts.ReadIntervalTimeout = win32.MAXDWORD
-		else:
-			timeouts.ReadTotalTimeoutConstant = max(int(timeout * 1000), 1)
-		if timeout != 0 and self.ser._interCharTimeout is not None:
-			timeouts.ReadIntervalTimeout = max(int(self.ser._interCharTimeout * 1000), 1)
-		if self.ser._writeTimeout is None:
-			pass
-		elif self.ser._writeTimeout == 0:
-			timeouts.WriteTotalTimeoutConstant = win32.MAXDWORD
-		else:
-			timeouts.WriteTotalTimeoutConstant = max(int(self.ser._writeTimeout * 1000), 1)
+		if timeout is not None:
+			if timeout == 0:
+				timeouts.ReadIntervalTimeout = win32.MAXDWORD
+			else:
+				timeouts.ReadTotalTimeoutConstant = max(int(timeout * 1000), 1)
+		if timeout != 0 and self._ser._interCharTimeout is not None:
+			timeouts.ReadIntervalTimeout = max(int(self._ser._interCharTimeout * 1000), 1)
+		if self._ser._writeTimeout is not None:
+			if self._ser._writeTimeout == 0:
+				timeouts.WriteTotalTimeoutConstant = win32.MAXDWORD
+			else:
+				timeouts.WriteTotalTimeoutConstant = max(int(self._ser._writeTimeout * 1000), 1)
 		SetCommTimeouts(self._ser.hComPort, ctypes.byref(timeouts))
 
 class HIDP_CAPS (ctypes.Structure):


### PR DESCRIPTION
Related issue: #6035 
This explicitly uses SetCommTimeouts to change the read timeout of a serial port. In pyserial, the entire port is reconfigured, sometimes causing an error if the computer was busy. I've run this patch on the machine that was causing me the most problems for two days and didn't get the error.

Another request is to turn pyserial into a Git submodule and upgrade it to version 2.7 (tag release2_7).
