### PR TITLE
NVDA+F9 then NVDA+F10 attempts to select first, then copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ uninstaller/UAC.nsh
 *.pyc
 *.pyo
 *.dmp
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ uninstaller/UAC.nsh
 *.pyc
 *.pyo
 *.dmp
+*.swp

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -556,5 +556,5 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 
 	def _setSelectionOffsets(self,start,end):
 		if start!=end:
-			raise TypeError("Expanded selections not supported")
+			raise NotImplementedError("Expanded selections not supported")
 		self._setCaretOffset(start)

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -259,6 +259,12 @@ class EditableTextWithoutAutoSelectDetection(EditableText):
 	This should be used when an object does not notify of selection changes.
 	"""
 
+	def waitForAndSpeakSelectionChange(self, oldTextInfo):
+		api.processPendingEvents(processEventQueue=False)
+		newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
+		speech.speakSelectionChange(oldTextInfo,newInfo)
+		braille.handler.handleCaretMove(self)
+
 	def script_caret_changeSelection(self,gesture):
 		try:
 			oldInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
@@ -268,13 +274,10 @@ class EditableTextWithoutAutoSelectDetection(EditableText):
 		gesture.send()
 		if isScriptWaiting() or eventHandler.isPendingEvents("gainFocus"):
 			return
-		api.processPendingEvents(processEventQueue=False)
 		try:
-			newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
+			waitForAndSpeakSelectionChange(oldInfo)
 		except:
 			return
-		speech.speakSelectionChange(oldInfo,newInfo)
-		braille.handler.handleCaretMove(self)
 
 	__changeSelectionGestures = (
 		"kb:shift+upArrow",

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -259,7 +259,7 @@ class EditableTextWithoutAutoSelectDetection(EditableText):
 	This should be used when an object does not notify of selection changes.
 	"""
 
-	def waitForAndSpeakSelectionChange(self, oldTextInfo):
+	def waitForAndReportSelectionChange(self, oldTextInfo):
 		api.processPendingEvents(processEventQueue=False)
 		newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
 		speech.speakSelectionChange(oldTextInfo,newInfo)
@@ -275,7 +275,7 @@ class EditableTextWithoutAutoSelectDetection(EditableText):
 		if isScriptWaiting() or eventHandler.isPendingEvents("gainFocus"):
 			return
 		try:
-			waitForAndSpeakSelectionChange(oldInfo)
+			self.waitForAndReportSelectionChange(oldInfo)
 		except:
 			return
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -17,6 +17,7 @@ import review
 import controlTypes
 import api
 import textInfos
+import editableText
 import speech
 import sayAllHandler
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
@@ -1704,8 +1705,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_markStartForCopy(self, gesture):
 		reviewPos = api.getReviewPosition()
-		startMark = reviewPos.copy()
-		reviewPos.obj._copyStartMarker = startMark # represents the start location
+		# attach the marker to obj so that the marker is cleaned up when obj is cleaned up.
+		reviewPos.obj._copyStartMarker = reviewPos.copy() # represents the start location
 		reviewPos.obj._selectThenCopyRange = None # we may be part way through a select, reset the copy range.
 		# Translators: Indicates start of review cursor text to be copied to clipboard.
 		ui.message(_("Start marked"))
@@ -1725,7 +1726,7 @@ class GlobalCommands(ScriptableObject):
 			if getattr(pos.obj, "_selectThenCopyRange", None):
 				# we have already tried selecting the text, dont try again. For now selections can not be ammended.
 				# Translators: Presented when text has already been marked for selection, but not yet copied.
-				ui.message(_("Press twice to copy, or reset the start marker"))
+				ui.message(_("Press twice to copy or reset the start marker"))
 				return
 			copyMarker = startMarker.copy()
 			# Check if the end position has moved
@@ -1735,19 +1736,17 @@ class GlobalCommands(ScriptableObject):
 				# end needs to be updated to the current cursor position.
 				copyMarker.setEndPoint(pos, "endToEnd")
 				copyMarker.move(textInfos.UNIT_CHARACTER, 1, endPoint="end")
-			elif pos.compareEndPoints(startMarker, "endToEnd") <= 0: # user has moved the cursor 'backwards'
+			else:# user has moved the cursor 'backwards' or not at all.
+				# when the cursor is not moved at all we still want to select the character have under the cursor
 				# start becomes the current cursor position position
 				copyMarker.setEndPoint(pos, "startToStart")
 				# end becomes the original start position plus 1
 				copyMarker.setEndPoint(startMarker, "endToEnd")
 				copyMarker.move(textInfos.UNIT_CHARACTER, 1, endPoint="end")
-			else:
-				# the cursor has not moved
-				pass
 			if copyMarker.compareEndPoints(copyMarker, "startToEnd") == 0:
 				# Translators: Presented when there is no text selection to copy from review cursor.
 				ui.message(_("No text to copy"))
-				api.getReviewPosition().obj._copyStartMarker = None;
+				api.getReviewPosition().obj._copyStartMarker = None
 				return
 			api.getReviewPosition().obj._selectThenCopyRange = copyMarker
 			# for applications such as word, where the selected text is not automatically spoken we must monitor it ourself
@@ -1759,15 +1758,12 @@ class GlobalCommands(ScriptableObject):
 				pass
 			try:
 				copyMarker.updateSelection()
-				if hasattr(pos.obj, "waitForAndSpeakSelectionChange"):
+				if isinstance(pos.obj, editableText.EditableTextWithoutAutoSelectDetection):
 					# wait for applications such as word to update their selection so that we can detect it
 					try:
-						pos.obj.waitForAndSpeakSelectionChange(oldInfo)
+						pos.obj.waitForAndReportSelectionChange(oldInfo)
 					except Exception as e:
 						log.debug("Error trying to wait for the selection to update and then speak the selection %s" % e)
-						pass
-				# Translators: Presented when some review text has been selected
-				ui.message(_("Selection made"))
 			except NotImplementedError:
 				# we are unable to select the text, leave the _copyStartMarker in place in case the user wishes to copy the text.
 				# Translators: Presented when unable to select the marked text.
@@ -1784,11 +1780,9 @@ class GlobalCommands(ScriptableObject):
 			# on the second call always clean up the start marker
 			api.getReviewPosition().obj._selectThenCopyRange = None
 			api.getReviewPosition().obj._copyStartMarker = None
-		else: # an unknown number of getLastScriptRepeatCount() calls
-			return
 		return
 	# Translators: Input help mode message for the select then copy command. The select then copy command first selects the review cursor text, then copies it to the clipboard.
-	script_review_copy.__doc__ = _("On first trigger, the text from the previously set start marker up to and including the current position of the review cursor is selected. On second trigger, the text is copied to the clipboard")
+	script_review_copy.__doc__ = _("If pressed once, the text from the previously set start marker up to and including the current position of the review cursor is selected. If pressed twice, the text is copied to the clipboard")
 	script_review_copy.category=SCRCAT_TEXTREVIEW
 
 	def script_braille_scrollBack(self, gesture):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1763,11 +1763,12 @@ class GlobalCommands(ScriptableObject):
 					try:
 						pos.obj.waitForAndReportSelectionChange(oldInfo)
 					except Exception as e:
-						log.debug("Error trying to wait for the selection to update and then speak the selection %s" % e)
-			except NotImplementedError:
+						log.debug("Error trying to wait for the selection to update and then speak the selection: %s" % e)
+			except NotImplementedError as e:
 				# we are unable to select the text, leave the _copyStartMarker in place in case the user wishes to copy the text.
 				# Translators: Presented when unable to select the marked text.
 				ui.message(_("Can't select text, press twice to copy"))
+				log.debug("Error trying to update selection: %s" % e)
 				return
 		elif scriptHandler.getLastScriptRepeatCount()==1: # the second call, try to copy the text
 			copyMarker = pos.obj._selectThenCopyRange

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -370,8 +370,8 @@ The following commands are available for reviewing text:
 | Move to next character in review | numpad3 | NVDA+rightArrow | flick right (text mode) | Move the review cursor to the next character on the current line of text |
 | Move to end of line in review | shift+numpad3 | NVDA+end | none | Moves the review cursor to the end of the current line of text |
 | Say all with review | numpadPlus | NVDA+shift+a | 3-finger flick down (text mode) | Reads from the current position of the review cursor, moving it as it goes |
-| Copy from review cursor | NVDA+f9 | NVDA+f9 | none | starts copying text from the current position of the review cursor. The actual copy is not performed until you tell NVDA where to copy to |
-| Copy to review cursor | NVDA+f10 | NVDA+f10 | none | Copies from the position previously set with Copy from review cursor up to and including the review cursor's current position. After pressing this key, the text will be copied to the Windows clipboard |
+| Select then Copy from review cursor | NVDA+f9 | NVDA+f9 | none | Starts the select then copy process from the current position of the review cursor. The actual action is not performed until you tell NVDA where the end of the text range is |
+| Select then Copy to review cursor | NVDA+f10 | NVDA+f10 | none | On the first press, text is selected from the position previously set start marker up to and including the review cursor's current position. After pressing this key a second time, the text will be copied to the Windows clipboard |
 | Report text formatting | NVDA+f | NVDA+f | none | Reports the formatting of the text where the review cursor is currently situated. Pressing twice shows the information in browse mode |
 %kc:endInclude
 


### PR DESCRIPTION
The existing NVDA+F9 then NVDA+F10 behaviour has been modified to select
text on the first press of F10. When F10 is presed twice (in quick
succession) the text is copied to the clipboard.

See issue: https://github.com/nvaccess/nvda/issues/4636

**Basic functionality**
In an application where text can be selected eg Notepad++ or Google Chrome:
- Navigate using the review cursor or caret.
- Press NVDA+F9, "Start marker set" should be output.
- Navigate using the review cursor or caret.
- Press NVDA+F10, "Selection made" should be output along with the changes to the current selection.
- Press NVDA+F10 twice quickly, "Selection copied to clipboard" should be output.

In an application where text can not be selected eg System dialogs, application menus and dialogs:
- When Pressing NVDA+F10 , "Cant select, press twice to copy" should be output

**Testing the edge cases:**

| Input | Result |
| --- | --- |
| NVDA+F9, move, NVDA+F9 | Start marker set |
| NVDA+F9, move, NVDA+F10, move, NVDA+F9 | Start marker set |
| NVDA+F9, move, NVDA+F10, wait, NVDA+F10 | Press twice to copy, or reset the start marker |
| In word, try select | Selection is spoken |
| NVDA+F10 | No start marker |

**Note:**
- The behaviour should ideally be the same whether the review cursor or caret is moved, however the review cursor has been considered to be the main use case.
- The selection should make sense regardless of the direction the caret was moved in.
- An attempt was made at allowing the selection range to be modified by pressing moving the review cursor / caret and pressing F10 again. This was more complicated than expected, since the act of selecting text the first time actually modifies the caret (and therefore the review cursor), this can also happen in a deferred manner. Given the behaviour of other software that allows this kind of selection this was deprioritied for this feature.
