### PR TITLE
Optimize elements list filtering to retrieve an element label only once

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -706,13 +706,14 @@ class ElementsListDialog(wx.Dialog):
 		#Do case-insensitive matching by lowering both filterText and each element's text.
 		filterText=filterText.lower()
 		for element in self._elements:
-			if filterText and filterText not in element.item.label.lower():
+			label=element.item.label
+			if filterText and filterText not in label.lower():
 				continue
 			matched = True
 			parent = element.parent
 			if parent:
 				parent = elementsToTreeItems.get(parent)
-			item = self.tree.AppendItem(parent or self.treeRoot, element.item.label)
+			item = self.tree.AppendItem(parent or self.treeRoot, label)
 			self.tree.SetItemPyData(item, element)
 			elementsToTreeItems[element] = item
 			if element == defaultElement:


### PR DESCRIPTION
As discussed in [this thread on nvda-devel](http://nabble.nvda-project.org/Building-NVDA-from-source-nvda-exe-is-missing-tp40536p40547.html):

> What do you think about the following though, related to the elements list? IN browseMode.ElementsListDialog.filter, label is called twice in every for element in self._elements loop, namely:
> - if filterText and filterText not in element.item.label.lower():
> - item = self.tree.AppendItem(parent or self.treeRoot, element.item.label)
> 
> I'd like to suggest create a local label variable which contains element.item.label, and than do the returning and filtering with that variable. This will, if I understand it correctly, call element.item.label only once instead of twice, which can improve performance on complex label generation as in virtualBuffers.VirtualBufferQuickNavItem.label.
