### PR TITLE
Invalid regex expressions in dictionaries no longer causes crash.

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1252,9 +1252,9 @@ class DictionaryEntryDialog(wx.Dialog):
 		try:
 			self.dictEntry=speechDictHandler.SpeechDictEntry(self.patternTextCtrl.GetValue(),self.replacementTextCtrl.GetValue(),self.commentTextCtrl.GetValue(),bool(self.caseSensitiveCheckBox.GetValue()),self.getType())
 		except Exception as e:
-			log.debugWarning("Could not add dictionary entry due to: %s" % e)
+			log.debugWarning("Could not add dictionary entry due to (regex error) : %s" % e)
 			# Translators: This is an error message to let the user know that the dictionary entry is not valid.
-			gui.messageBox(_("Error in dictionary entry: %s.")%e, _("Dictionary Entry Error"), wx.OK|wx.ICON_WARNING, self)
+			gui.messageBox(_("Regular Expression error: \"%s\".")%e, _("Dictionary Entry Error"), wx.OK|wx.ICON_WARNING, self)
 			return 
 		evt.Skip()
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1240,12 +1240,23 @@ class DictionaryEntryDialog(wx.Dialog):
 		self.SetSizer(mainSizer)
 		self.setType(speechDictHandler.ENTRY_TYPE_ANYWHERE)
 		self.patternTextCtrl.SetFocus()
+		self.Bind(wx.EVT_BUTTON,self.onOk,id=wx.ID_OK)
 
 	def getType(self):
 		typeRadioValue = self.typeRadioBox.GetSelection()
 		if typeRadioValue == wx.NOT_FOUND:
 			return speechDictHandler.ENTRY_TYPE_ANYWHERE
 		return DictionaryEntryDialog.TYPE_LABELS_ORDERING[typeRadioValue]
+
+	def onOk(self,evt):
+		try:
+			self.dictEntry=speechDictHandler.SpeechDictEntry(self.patternTextCtrl.GetValue(),self.replacementTextCtrl.GetValue(),self.commentTextCtrl.GetValue(),bool(self.caseSensitiveCheckBox.GetValue()),self.getType())
+		except Exception as e:
+			log.debugWarning("Could not add dictionary entry due to: %s" % e)
+			# Translators: This is an error message to let the user know that the dictionary entry is not valid.
+			gui.messageBox(_("Error in dictionary entry: %s.")%e, _("Dictionary Entry Error"), wx.OK|wx.ICON_WARNING, self)
+			return 
+		evt.Skip()
 
 	def setType(self, type):
 		self.typeRadioBox.SetSelection(DictionaryEntryDialog.TYPE_LABELS_ORDERING.index(type))
@@ -1320,7 +1331,7 @@ class DictionaryDialog(SettingsDialog):
 		# Translators: This is the label for the add dictionary entry dialog.
 		entryDialog=DictionaryEntryDialog(self,title=_("Add Dictionary Entry"))
 		if entryDialog.ShowModal()==wx.ID_OK:
-			self.tempSpeechDict.append(speechDictHandler.SpeechDictEntry(entryDialog.patternTextCtrl.GetValue(),entryDialog.replacementTextCtrl.GetValue(),entryDialog.commentTextCtrl.GetValue(),bool(entryDialog.caseSensitiveCheckBox.GetValue()),entryDialog.getType()))
+			self.tempSpeechDict.append(entryDialog.dictEntry)
 			self.dictList.Append((entryDialog.commentTextCtrl.GetValue(),entryDialog.patternTextCtrl.GetValue(),entryDialog.replacementTextCtrl.GetValue(),self.offOn[int(entryDialog.caseSensitiveCheckBox.GetValue())],DictionaryDialog.TYPE_LABELS[entryDialog.getType()]))
 			index=self.dictList.GetFirstSelected()
 			while index>=0:
@@ -1345,7 +1356,7 @@ class DictionaryDialog(SettingsDialog):
 		entryDialog.caseSensitiveCheckBox.SetValue(self.tempSpeechDict[editIndex].caseSensitive)
 		entryDialog.setType(self.tempSpeechDict[editIndex].type)
 		if entryDialog.ShowModal()==wx.ID_OK:
-			self.tempSpeechDict[editIndex]=speechDictHandler.SpeechDictEntry(entryDialog.patternTextCtrl.GetValue(),entryDialog.replacementTextCtrl.GetValue(),entryDialog.commentTextCtrl.GetValue(),bool(entryDialog.caseSensitiveCheckBox.GetValue()),entryDialog.getType())
+			self.tempSpeechDict[editIndex]=entryDialog.dictEntry
 			self.dictList.SetStringItem(editIndex,0,entryDialog.commentTextCtrl.GetValue())
 			self.dictList.SetStringItem(editIndex,1,entryDialog.patternTextCtrl.GetValue())
 			self.dictList.SetStringItem(editIndex,2,entryDialog.replacementTextCtrl.GetValue())

--- a/source/speechDictHandler.py
+++ b/source/speechDictHandler.py
@@ -67,7 +67,13 @@ class SpeechDict(list):
 			else:
 				temp=line.split("\t")
 				if len(temp) ==4:
-					self.append(SpeechDictEntry(temp[0].replace(r'\#','#'),temp[1].replace(r'\#','#'),comment,bool(int(temp[2])),int(temp[3])))
+					pattern = temp[0].replace(r'\#','#')
+					replace = temp[1].replace(r'\#','#')
+					try:
+						dictionaryEntry=SpeechDictEntry(pattern, replace, comment, caseSensitive=bool(int(temp[2])), type=int(temp[3]))
+						self.append(dictionaryEntry)
+					except Exception as e:
+						log.exception("Dictionary (\"%s\") entry invalid for \"%s\" error raised: \"%s\"" % (fileName, line, e))
 					comment=""
 				else:
 					log.warning("can't parse line '%s'" % line)
@@ -105,14 +111,8 @@ def processText(text):
 def initialize():
 	for type in dictTypes:
 		dictionaries[type]=SpeechDict()
-	try:
-		dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
-	except Exception as e:
-		log.exception("Error loading dictionary, default.dic: %s" % e)
-	try:
-		dictionaries["builtin"].load("builtin.dic")
-	except Exception as e:
-		log.exception("Error loading dictionary, builtin.dic: %s" % e)
+	dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
+	dictionaries["builtin"].load("builtin.dic")
 
 def loadVoiceDict(synth):
 	"""Loads appropriate dictionary for the given synthesizer.
@@ -123,7 +123,4 @@ It handles case when the synthesizer doesn't support voice setting.
 		fileName=r"%s\%s-%s.dic"%(speechDictsPath,synth.name,api.filterFileName(voiceName))
 	else:
 		fileName=r"%s\%s.dic"%(speechDictsPath,synth.name)
-	try:
-		dictionaries["voice"].load(fileName)
-	except Exception as e:
-		log.exception("Error loading voice dictionary, %s:%s" % (filename, e))
+	dictionaries["voice"].load(fileName)

--- a/source/speechDictHandler.py
+++ b/source/speechDictHandler.py
@@ -105,8 +105,14 @@ def processText(text):
 def initialize():
 	for type in dictTypes:
 		dictionaries[type]=SpeechDict()
-	dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
-	dictionaries["builtin"].load("builtin.dic")
+	try:
+		dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
+	except Exception as e:
+		log.exception("Error loading dictionary, default.dic: %s" % e)
+	try:
+		dictionaries["builtin"].load("builtin.dic")
+	except Exception as e:
+		log.exception("Error loading dictionary, builtin.dic: %s" % e)
 
 def loadVoiceDict(synth):
 	"""Loads appropriate dictionary for the given synthesizer.
@@ -117,4 +123,7 @@ It handles case when the synthesizer doesn't support voice setting.
 		fileName=r"%s\%s-%s.dic"%(speechDictsPath,synth.name,api.filterFileName(voiceName))
 	else:
 		fileName=r"%s\%s.dic"%(speechDictsPath,synth.name)
-	dictionaries["voice"].load(fileName)
+	try:
+		dictionaries["voice"].load(fileName)
+	except Exception as e:
+		log.exception("Error loading voice dictionary, %s:%s" % (filename, e))


### PR DESCRIPTION
This change introduces a safety check when loading speech dictionaries, to ensure that nvda does not crash if the dictionaries contain invalid regex. This change also catches the same situation in the UI and informs the user that the regex is invalid.

Fixes #4834
