### PR TITLE
Enable wx assertions and fix known assertion trigger.

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -206,10 +206,6 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 	import wx
 	log.info("Using wx version %s"%wx.version())
 	app = wx.App(redirect=False)
-	# HACK: wx currently raises spurious assertion failures when a timer is stopped but there is already an event in the queue for that timer.
-	# Unfortunately, these assertion exceptions are raised in the middle of other code, which causes problems.
-	# Therefore, disable assertions for now.
-	app.SetAssertMode(wx.PYAPP_ASSERT_SUPPRESS)
 	# We do support QueryEndSession events, but we don't want to do anything for them.
 	app.Bind(wx.EVT_QUERY_END_SESSION, lambda evt: None)
 	def onEndSession(evt):

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -418,8 +418,9 @@ class KeyboardInputGesture(inputCore.InputGesture):
 		return self.SPEECHEFFECT_CANCEL
 
 	def reportExtra(self):
+		import core
 		if self.vkCode in self.TOGGLE_KEYS:
-			wx.CallLater(30, self._reportToggleKey)
+			core.callLater(30, self._reportToggleKey)
 
 	def _reportToggleKey(self):
 		toggleState = winUser.getKeyState(self.vkCode) & 1


### PR DESCRIPTION
See #6127 

I have enabled assertions and confirmed that replacing wx.CallLater with core.callLater in keyboardHandler.KeyboardInputGesture.reportExtra runs cleanly. I exercised this code path by toggling caps-lock.

Also successfully smoke tested in a few applications looking for other assertions triggered by wx. This was done while running from source.

There are about 16 other places that use wx.CallLater directly, do you think we are likely to run into a problem with these?
