### PR TITLE
UIA.Toast: handle window open event from Windows 10 Insider build 14366 and later, now powered by NVDAObjects.behaviors.Notification

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -330,7 +330,7 @@ class UIA(Window):
 		# #5136: Windows 8.x and Windows 10 uses different window class and other attributes for toast notifications.
 		elif UIAClassName=="ToastContentHost" and UIAControlType==UIAHandler.UIA_ToolTipControlTypeId: #Windows 8.x
 			clsList.append(Toast_win8)
-		elif self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and self.UIAElement.cachedAutomationId=="NormalToastView": # Windows 10
+		elif self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and "ToastView" in self.UIAElement.cachedAutomationId: # Windows 10
 			clsList.append(Toast_win10)
 		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
 			import edge

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -8,6 +8,7 @@ from ctypes import byref
 from ctypes.wintypes import POINT, RECT
 from comtypes import COMError
 import weakref
+import sys
 import UIAHandler
 import globalVars
 import eventHandler
@@ -19,7 +20,7 @@ import textInfos
 from logHandler import log
 from NVDAObjects.window import Window
 from NVDAObjects import NVDAObjectTextInfo, InvalidNVDAObject
-from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDetection, Dialog
+from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDetection, Dialog, Notification
 import braille
 
 class UIATextInfo(textInfos.TextInfo):
@@ -973,20 +974,17 @@ class ListItem(UIA):
 class Dialog(Dialog):
 	role=controlTypes.ROLE_DIALOG
 
-class Toast(UIA):
+class Toast_win8(Notification, UIA):
 
-	def event_alert(self):
-		if not config.conf["presentation"]["reportHelpBalloons"]:
-			return
-		speech.speakObject(self,reason=controlTypes.REASON_FOCUS)
-		# TODO: Don't use getBrailleTextForProperties directly.
-		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
+	event_UIA_toolTipOpened=Notification.event_alert
 
-class Toast_win8(Toast):
-	event_UIA_toolTipOpened=Toast.event_alert
+class Toast_win10(Notification, UIA):
 
-class Toast_win10(Toast):
-	event_UIA_window_windowOpen=Toast.event_alert
+	# #6096: Windows 10 Redstone build 14366 and later does not fire tooltip event when toasts appear.
+	if sys.getwindowsversion().build > 10586:
+		event_UIA_window_windowOpen=Notification.event_alert
+	else:
+		event_UIA_toolTipOpened=Notification.event_alert
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
 #This causes major lags when using this control with Braille in NVDA. (#2759) 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -327,9 +327,10 @@ class UIA(Window):
 		if UIAClassName=="WpfTextView":
 			clsList.append(WpfTextView)
 		# #5136: Windows 8.x and Windows 10 uses different window class and other attributes for toast notifications.
-		elif ((UIAClassName=="ToastContentHost" and UIAControlType==UIAHandler.UIA_ToolTipControlTypeId) #Windows 8.x
-		or (self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and self.UIAElement.cachedAutomationId=="NormalToastView")): # Windows 10
-			clsList.append(Toast)
+		elif UIAClassName=="ToastContentHost" and UIAControlType==UIAHandler.UIA_ToolTipControlTypeId: #Windows 8.x
+			clsList.append(Toast_win8)
+		elif self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and self.UIAElement.cachedAutomationId=="NormalToastView": # Windows 10
+			clsList.append(Toast_win10)
 		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
 			import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
@@ -980,6 +981,12 @@ class Toast(UIA):
 		speech.speakObject(self,reason=controlTypes.REASON_FOCUS)
 		# TODO: Don't use getBrailleTextForProperties directly.
 		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
+
+class Toast_win8(Toast):
+	event_UIA_toolTipOpened=Toast.event_alert
+
+class Toast_win10(Toast):
+	event_UIA_window_windowOpen=Toast.event_alert
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
 #This causes major lags when using this control with Braille in NVDA. (#2759) 

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -621,7 +621,7 @@ class ToolTip(NVDAObject):
 
 class Notification(NVDAObject):
 	"""Informs the user of non-critical information that does not require immediate action.
-	This is primarily for notifications displayed in the system notification area.
+	This is primarily for notifications displayed in the system notification area, and for Windows 8 and later, toasts.
 	The object should fire a alert or show event when the user should be notified.
 	"""
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -119,9 +119,10 @@ UIAEventIdsToNVDAEventNames={
 	UIA_SelectionItem_ElementRemovedFromSelectionEventId:"stateChange",
 	#UIA_MenuModeEndEventId:"menuModeEnd",
 	#UIA_Text_TextSelectionChangedEventId:"caret",
-	UIA_ToolTipOpenedEventId:"alert",
+	UIA_ToolTipOpenedEventId:"UIA_toolTipOpened",
 	#UIA_AsyncContentLoadedEventId:"documentLoadComplete",
 	#UIA_ToolTipClosedEventId:"hide",
+	UIA_Window_WindowOpenedEventId:"UIA_window_windowOpen",
 }
 
 class UIAHandler(COMObject):


### PR DESCRIPTION
Hi,

Addresses the following issues:
- #6096: Toasts from Insider build 14366 and later are now announced. This requires adding event handling routine for window open UIA event (a big concern is performance).
- #6163: Toasts are now powered by NVDAObjects.behaviors.Notification to reduce code duplication.

Thanks.
