### PR TITLE
Fix scons.bat failure when the NVDA source tree resides in a path containing spaces

### DIFF
--- a/scons.bat
+++ b/scons.bat
@@ -2,4 +2,4 @@
 rem We need this script because .py probably isn't in pathext.
 rem We can't just call python -c because it may not be in the path.
 rem Python registers itself with the .py extension, so call scons.py.
-%~dp0\scons.py %*
+"%~dp0\scons.py" %*


### PR DESCRIPTION
When the NVDA source tree is cloned into a path containing spaces, scons.bat fails to find scons.py. This pull request fixes this issue by adding double quotes around %~dp0\scons.py
