### PR TITLE
fix UIA build issue on windows 7

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -155,7 +155,7 @@ class UIAHandler(COMObject):
 			try:
 				self.clientObject=CoCreateInstance(CUIAutomation8._reg_clsid_,interface=IUIAutomation,clsctx=CLSCTX_INPROC_SERVER)
 				isUIA8=True
-			except (COMError,WindowsError):
+			except (COMError,WindowsError,NameError):
 				self.clientObject=CoCreateInstance(CUIAutomation._reg_clsid_,interface=IUIAutomation,clsctx=CLSCTX_INPROC_SERVER)
 			if isUIA8:
 				try:


### PR DESCRIPTION
as discussed on NVDA development list, NVDA won't be able to use UIA on windows 7 if built from source. this pull request aims to fix this by catching "NameError" exception as well when trying to initialize UIA 3.
I didn't want to ad if condition which checks the winVersion because the code will be ugly then.
not sure this is the best way to fix that. this is at least a place holder to track the mentioned issue.
