### PR TITLE
Dont filter output when speech mode is off

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -257,8 +257,6 @@ def _speakSpellingGen(text,locale,useCharacterDescriptions):
 		if args: buf.append(args)
 
 def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allowedProperties):
-	if speechMode==speechMode_off:
-		return
 	#Fetch the values for all wanted properties
 	newPropertyValues={}
 	positionInfo=None


### PR DESCRIPTION
Fixes #6049 

No longer filters additions to the speech viewer when `speechMode==speechMode_off`.

The remaining checks for speechMode are in:
- `cancelSpeech()` - probably fine
- `speakSpelling()` - appends text to the speechViewer before the check
- `speak()` - appends text to speechViewer first, but does some other stuff after mostly related to language switching.
## Testing

Tried to perform the same actions twice before the change (with speech mode on, then off), and twice after the change (also with speech mode on, then off)
### Pre change:

```
TestDocument.rtf - WordPad  window
Rich Text Window  edit  multi line
This is a test document
-bash  row 1  column 3
-bash  terminal
blank
 { source } master »

Speech mode off
This is a test document
 { source } master »

 { source } master »
```
### Post change:

```
TestDocument.rtf - WordPad  window
Rich Text Window  edit  multi line
This is a test document
C:\Windows\System32\cmd.exe  row 1  column 2
-bash  row 1  column 3
-bash  terminal
blank
 { source } master »

Speech mode off
TestDocument.rtf - WordPad  window
Rich Text Window  edit  multi line
This is a test document
-bash  row 1  column 2
-bash  terminal
 { source } master »

 { source } master »
```
