### PR TITLE
Fix a typo in the document formatting user guide section

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1191,7 +1191,7 @@ You can configure reporting of:
 - Text alignment
 - Colors
 - Comments
-- editor revisions
+- Editor revisions
 - Emphasis
 - Text style
 - Spelling errors


### PR DESCRIPTION
'Editor revisions' did not start with an uppercase letter. This has been fixed in this request.
