### PR TITLE
Fix validation errors for some Excel background pattern strings in Poedit, xgettext, etc.

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -112,18 +112,23 @@ backgroundPatternLabels={
 		xlPatternDown:_("reverse diagonal stripe"),
 		# Translators: A type of background pattern in Microsoft Excel. 
 		# 12.5% gray
+		# xgettext:no-python-format
 		xlPatternGray16:_("12.5% gray"),
 		# Translators: A type of background pattern in Microsoft Excel. 
 		# 25% gray
+		# xgettext:no-python-format
 		xlPatternGray25:_("25% gray"),
 		# Translators: A type of background pattern in Microsoft Excel. 
+		# xgettext:no-python-format
 		# 50% gray
 		xlPatternGray50:_("50% gray"),
 		# Translators: A type of background pattern in Microsoft Excel. 
 		# 75% gray
+		# xgettext:no-python-format
 		xlPatternGray75:_("75% gray"),
 		# Translators: A type of background pattern in Microsoft Excel. 
 		# 6.25% gray
+		# xgettext:no-python-format
 		xlPatternGray8:_("6.25% gray"),
 		# Translators: A type of background pattern in Microsoft Excel. 
 		# Grid


### PR DESCRIPTION
These strings contain a % sign, so xgettext thinks they are Python % formatted (python-format). However, these are actually just literal, unformatted strings. Add xgettext:no-python-format comments to prevent these from being interpreted/validated incorrectly.
Fixes #6229. Closes #6092.
