### PR TITLE
I6102 ms word cross ref links

### DIFF
--- a/nvdaHelper/remote/WinWord/Constants.h
+++ b/nvdaHelper/remote/WinWord/Constants.h
@@ -1,0 +1,165 @@
+/*
+This file is a part of the NVDA project.
+URL: http://www.nvda-project.org/
+Copyright 2006-2010 NVDA contributers.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2.0, as published by
+    the Free Software Foundation.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+This license can be found at:
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
+// See https://github.com/nvaccess/nvda/wiki/Using-COM-with-NVDA-and-Microsoft-Word
+constexpr int wdDISPID_APPLICATION_ISSANDBOX = 492;
+constexpr int wdDISPID_APPLICATION_SCREENUPDATING = 26;
+constexpr int wdDISPID_BORDERS_ENABLE = 2;
+constexpr int wdDISPID_CELL_COLUMNINDEX = 5;
+constexpr int wdDISPID_CELL_RANGE = 0;
+constexpr int wdDISPID_CELL_ROWINDEX = 4;
+constexpr int wdDISPID_CELLS_ITEM = 0;
+constexpr int wdDISPID_COLUMNS_COUNT = 2;
+constexpr int wdDISPID_COMMENT_SCOPE = 1005;
+constexpr int wdDISPID_COMMENTS_COUNT = 2;
+constexpr int wdDISPID_COMMENTS_ITEM = 0;
+constexpr int wdDISPID_CONTENTCONTROL_CHECKED = 28;
+constexpr int wdDISPID_CONTENTCONTROL_RANGE = 1;
+constexpr int wdDISPID_CONTENTCONTROL_TITLE = 12;
+constexpr int wdDISPID_CONTENTCONTROL_TYPE = 5;
+constexpr int wdDISPID_CONTENTCONTROLS_ITEM = 0;
+constexpr int wdDISPID_DOCUMENT_RANGE = 2000;
+constexpr int wdDISPID_DOCUMENT_STYLES = 22;
+constexpr int wdDISPID_ENDNOTE_INDEX = 6;
+constexpr int wdDISPID_ENDNOTES_COUNT = 2;
+constexpr int wdDISPID_ENDNOTES_ITEM = 0;
+constexpr int wdDISPID_FIELDS_COUNT = 1;
+constexpr int wdDISPID_FIELDS_ITEM = 0;
+constexpr int wdDISPID_FIELDS_ITEM_RESULT = 4;
+constexpr int wdDISPID_FIELDS_ITEM_TYPE = 1;
+constexpr int wdDISPID_FONT_BOLD = 130;
+constexpr int wdDISPID_FONT_COLOR = 159;
+constexpr int wdDISPID_FONT_DOUBLESTRIKETHROUGH = 136;
+constexpr int wdDISPID_FONT_ITALIC = 131;
+constexpr int wdDISPID_FONT_NAME = 142;
+constexpr int wdDISPID_FONT_SIZE = 141;
+constexpr int wdDISPID_FONT_STRIKETHROUGH = 135;
+constexpr int wdDISPID_FONT_SUBSCRIPT = 138;
+constexpr int wdDISPID_FONT_SUPERSCRIPT = 139;
+constexpr int wdDISPID_FONT_UNDERLINE = 140;
+constexpr int wdDISPID_FOOTNOTE_INDEX = 6;
+constexpr int wdDISPID_FOOTNOTES_COUNT = 2;
+constexpr int wdDISPID_FOOTNOTES_ITEM = 0;
+constexpr int wdDISPID_FORMFIELD_RANGE = 17;
+constexpr int wdDISPID_FORMFIELD_RESULT = 10;
+constexpr int wdDISPID_FORMFIELD_STATUSTEXT = 8;
+constexpr int wdDISPID_FORMFIELD_TYPE = 0;
+constexpr int wdDISPID_FORMFIELDS_ITEM = 0;
+constexpr int wdDISPID_HYPERLINKS_COUNT = 1;
+constexpr int wdDISPID_INLINESHAPE_ALTERNATIVETEXT = 131;
+constexpr int wdDISPID_INLINESHAPE_OLEFORMAT = 5;
+constexpr int wdDISPID_INLINESHAPE_TITLE = 158;
+constexpr int wdDISPID_INLINESHAPE_TYPE = 6;
+constexpr int wdDISPID_INLINESHAPES_COUNT = 1;
+constexpr int wdDISPID_INLINESHAPES_ITEM = 0;
+constexpr int wdDISPID_LISTFORMAT_LISTSTRING = 75;
+constexpr int wdDISPID_OLEFORMAT_PROGID = 22;
+constexpr int wdDISPID_PARAGRAPH_OUTLINELEVEL = 202;
+constexpr int wdDISPID_PARAGRAPH_RANGE = 0;
+constexpr int wdDISPID_PARAGRAPH_STYLE = 100;
+constexpr int wdDISPID_PARAGRAPHFORMAT_ALIGNMENT = 101;
+constexpr int wdDISPID_PARAGRAPHFORMAT_FIRSTLINEINDENT = 108;
+constexpr int wdDISPID_PARAGRAPHFORMAT_LEFTINDENT = 107;
+constexpr int wdDISPID_PARAGRAPHFORMAT_LINESPACING = 109;
+constexpr int wdDISPID_PARAGRAPHFORMAT_LINESPACINGRULE = 110;
+constexpr int wdDISPID_PARAGRAPHFORMAT_RIGHTINDENT = 106;
+constexpr int wdDISPID_PARAGRAPHS_ITEM = 0;
+constexpr int wdDISPID_RANGE_APPLICATION = 1000;
+constexpr int wdDISPID_RANGE_CELLS = 57;
+constexpr int wdDISPID_RANGE_COLLAPSE = 101;
+constexpr int wdDISPID_RANGE_COMMENTS = 56;
+constexpr int wdDISPID_RANGE_CONTENTCONTROLS = 424;
+constexpr int wdDISPID_RANGE_DUPLICATE = 6;
+constexpr int wdDISPID_RANGE_END = 4;
+constexpr int wdDISPID_RANGE_ENDNOTES = 55;
+constexpr int wdDISPID_RANGE_EXPAND = 129;
+constexpr int wdDISPID_RANGE_FIELDS = 64;
+constexpr int wdDISPID_RANGE_FONT = 5;
+constexpr int wdDISPID_RANGE_FOOTNOTES = 54;
+constexpr int wdDISPID_RANGE_FORMFIELDS = 65;
+constexpr int wdDISPID_RANGE_HYPERLINKS = 156;
+constexpr int wdDISPID_RANGE_INFORMATION = 313;
+constexpr int wdDISPID_RANGE_INLINESHAPES = 319;
+constexpr int wdDISPID_RANGE_INRANGE = 126;
+constexpr int wdDISPID_RANGE_LANGUAGEID = 153;
+constexpr int wdDISPID_RANGE_LISTFORMAT = 68;
+constexpr int wdDISPID_RANGE_MOVE = 109;
+constexpr int wdDISPID_RANGE_MOVEEND = 111;
+constexpr int wdDISPID_RANGE_PARAGRAPHFORMAT = 1102;
+constexpr int wdDISPID_RANGE_PARAGRAPHS = 59;
+constexpr int wdDISPID_RANGE_REVISIONS = 150;
+constexpr int wdDISPID_RANGE_SELECT = 65535;
+constexpr int wdDISPID_RANGE_SETRANGE = 100;
+constexpr int wdDISPID_RANGE_SPELLINGERRORS = 316;
+constexpr int wdDISPID_RANGE_START = 3;
+constexpr int wdDISPID_RANGE_STORYTYPE = 7;
+constexpr int wdDISPID_RANGE_STYLE = 151;
+constexpr int wdDISPID_RANGE_TABLES = 50;
+constexpr int wdDISPID_RANGE_TEXT = 0;
+constexpr int wdDISPID_REVISION_TYPE = 4;
+constexpr int wdDISPID_REVISIONS_ITEM = 0;
+constexpr int wdDISPID_ROWS_COUNT = 2;
+constexpr int wdDISPID_SELECTION_ENDOF = 108;
+constexpr int wdDISPID_SELECTION_RANGE = 400;
+constexpr int wdDISPID_SELECTION_SETRANGE = 100;
+constexpr int wdDISPID_SELECTION_STARTISACTIVE = 404;
+constexpr int wdDISPID_SELECTION_STARTOF = 107;
+constexpr int wdDISPID_SPELLINGERRORS_COUNT = 1;
+constexpr int wdDISPID_SPELLINGERRORS_ITEM = 0;
+constexpr int wdDISPID_STYLE_NAMELOCAL = 0;
+constexpr int wdDISPID_STYLE_PARENT = 1002;
+constexpr int wdDISPID_STYLES_ITEM = 0;
+constexpr int wdDISPID_TABLE_BORDERS = 1100;
+constexpr int wdDISPID_TABLE_COLUMNS = 100;
+constexpr int wdDISPID_TABLE_DESCR = 210;
+constexpr int wdDISPID_TABLE_NESTINGLEVEL = 108;
+constexpr int wdDISPID_TABLE_RANGE = 0;
+constexpr int wdDISPID_TABLE_ROWS = 101;
+constexpr int wdDISPID_TABLE_TITLE = 209;
+constexpr int wdDISPID_TABLES_ITEM = 0;
+constexpr int wdDISPID_WINDOW_APPLICATION = 1000;
+constexpr int wdDISPID_WINDOW_DOCUMENT = 2;
+constexpr int wdDISPID_WINDOW_SELECTION = 4;
+
+constexpr int wdCommentsStory = 4;
+
+constexpr int wdCharacter = 1;
+constexpr int wdWord = 2;
+constexpr int wdParagraph = 4;
+constexpr int wdLine = 5;
+constexpr int wdStory = 6;
+constexpr int wdCharacterFormatting = 13;
+
+constexpr int wdCollapseEnd = 0;
+constexpr int wdCollapseStart = 1;
+
+constexpr int wdActiveEndAdjustedPageNumber = 1;
+constexpr int wdFirstCharacterLineNumber = 10;
+constexpr int wdWithInTable = 12;
+constexpr int wdStartOfRangeRowNumber = 13;
+constexpr int wdMaximumNumberOfRows = 15;
+constexpr int wdStartOfRangeColumnNumber = 16;
+constexpr int wdMaximumNumberOfColumns = 18;
+
+constexpr int wdAlignParagraphLeft = 0;
+constexpr int wdAlignParagraphCenter = 1;
+constexpr int wdAlignParagraphRight = 2;
+constexpr int wdAlignParagraphJustify = 3;
+constexpr int wdLanguageNone = 0;  //&H0
+constexpr int wdNoProofing = 1024;  //&H400
+constexpr int wdLanguageUnknown = 9999999;
+
+constexpr int wdInlineShapeEmbeddedOLEObject = 1;
+constexpr int wdInlineShapePicture = 3;
+constexpr int wdInlineShapeLinkedPicture = 4;

--- a/nvdaHelper/remote/WinWord/Links.cpp
+++ b/nvdaHelper/remote/WinWord/Links.cpp
@@ -1,0 +1,116 @@
+/*
+This file is a part of the NVDA project.
+URL: http://www.nvda-project.org/
+Copyright 2006-2010 NVDA contributers.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2.0, as published by
+    the Free Software Foundation.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+This license can be found at:
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
+#define WIN32_LEAN_AND_MEAN 
+
+#include <sstream>
+#include <vector>
+#include <utility>
+#include <comdef.h>
+#include <windows.h>
+#include <common/log.h>
+#include <remote/nvdaInProcUtils.h>
+#include <remote/nvdaInProcUtils.h>
+
+
+#include "Links.h"
+#include <remote/WinWord/Constants.h>
+
+namespace WinWord {
+
+/* Overview of the structures being accessed:
+	pRange.Fields property
+	pRange.Fields.Count property
+	pRange.Fields.Item method - takes an int (starting at 1) to give item 1 up to item Count. Returns a Field
+	Field.Type property
+	Field.Result property - the range for the ref / hyperlink object. This is the displayed range.
+	Field.Code property - Not used, but gives the hidden part of the ref / hyperlink.
+	Field.Result.Start property
+	Field.Result.End property
+*/
+Links::Links(IDispatch* pRange) {
+	IDispatchPtr pDispatchFields = nullptr;
+	auto res = _com_dispatch_raw_propget( pRange, wdDISPID_RANGE_FIELDS, VT_DISPATCH, &pDispatchFields);
+	if( res != S_OK || !pDispatchFields ) {
+		LOG_DEBUGWARNING(L"error getting fields from range");
+		return;
+	}
+
+	int count = 0;
+	res = _com_dispatch_raw_propget( pDispatchFields, wdDISPID_FIELDS_COUNT, VT_I4, &count);
+	if( res != S_OK || count <= 0 ) {
+		return;
+	}
+
+	for(int i = 1; i <= count; ++i) {
+		IDispatchPtr pDispatchItem = nullptr;
+		res = _com_dispatch_raw_method( pDispatchFields, wdDISPID_FIELDS_ITEM, DISPATCH_METHOD, VT_DISPATCH, &pDispatchItem, L"\x0003", i);
+		if( res != S_OK || !pDispatchItem){
+			LOG_DEBUGWARNING(L"error getting field item");
+			continue;
+		}
+		/*
+		Fields can be of many types, to get this we look at Type property. We care about:
+		  Ref - a Reference to some other part of the file
+		  Hyperlink - a link to another part of the file or to an external URL
+		
+		The following are defined on msdn (WdFieldType Enumeration - https://msdn.microsoft.com/en-us/library/office/ff192211.aspx)
+		*/
+		const int CROSS_REFERENCE_TYPE_VALUE = 3; // wdFieldRef 
+		const int HYPERLINK_TYPE_VALUE = 88; // wdFieldHyperlink
+		int type = -1;
+		res = _com_dispatch_raw_propget( pDispatchItem, wdDISPID_FIELDS_ITEM_TYPE, VT_I4, &type);
+		if( res != S_OK || !(type == CROSS_REFERENCE_TYPE_VALUE || type == HYPERLINK_TYPE_VALUE) ){
+			continue;
+		}
+
+		IDispatchPtr pDispatchFieldResult = nullptr;
+		res = _com_dispatch_raw_propget( pDispatchItem, wdDISPID_FIELDS_ITEM_RESULT, VT_DISPATCH, &pDispatchFieldResult);
+		if( res != S_OK || !pDispatchFieldResult){
+			LOG_DEBUGWARNING(L"error getting the result from the field item.");
+			continue;
+		}
+
+		long resultStart = 0, resultEnd = 0;
+		auto ok = S_OK == _com_dispatch_raw_propget( pDispatchFieldResult, wdDISPID_RANGE_START, VT_I4, &resultStart)
+		       && S_OK == _com_dispatch_raw_propget( pDispatchFieldResult, wdDISPID_RANGE_END, VT_I4, &resultEnd);
+		if(!ok){
+			LOG_DEBUGWARNING(L"error getting range start and end points");
+			continue;
+		}
+		m_links.push_back(std::make_pair(resultStart, resultEnd));
+	}
+}
+
+bool inRange (long index, long start, long end) {
+		return index >= start && index <= end;
+	};
+
+bool Links::hasLinks(const int rangeStart, const int rangeEnd){
+	for( auto&& link : m_links) {
+		if( inRange(link.first, rangeStart, rangeStart) ||
+			inRange(link.second, rangeStart, rangeStart) ||
+			inRange(rangeStart, link.first, link.second) ||
+			inRange(rangeStart, link.first, link.second) ){
+			return true;
+		}
+	}
+	return false;
+}
+
+bool Links::hasLinks(){
+	return false == m_links.empty();
+}
+
+} // end namespace WinWord

--- a/nvdaHelper/remote/WinWord/Links.cpp
+++ b/nvdaHelper/remote/WinWord/Links.cpp
@@ -11,7 +11,6 @@ Copyright 2006-2010 NVDA contributers.
 This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-
 #define WIN32_LEAN_AND_MEAN 
 
 #include <sstream>
@@ -22,7 +21,6 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <common/log.h>
 #include <remote/nvdaInProcUtils.h>
 #include <remote/nvdaInProcUtils.h>
-
 
 #include "Links.h"
 #include <remote/WinWord/Constants.h>
@@ -99,10 +97,10 @@ bool inRange (long index, long start, long end) {
 
 bool Links::hasLinks(const int rangeStart, const int rangeEnd){
 	for( auto&& link : m_links) {
-		if( inRange(link.first, rangeStart, rangeStart) ||
-			inRange(link.second, rangeStart, rangeStart) ||
+		if( inRange(link.first, rangeStart, rangeEnd) ||
+			inRange(link.second, rangeStart, rangeEnd) ||
 			inRange(rangeStart, link.first, link.second) ||
-			inRange(rangeStart, link.first, link.second) ){
+			inRange(rangeEnd, link.first, link.second) ){
 			return true;
 		}
 	}

--- a/nvdaHelper/remote/WinWord/Links.h
+++ b/nvdaHelper/remote/WinWord/Links.h
@@ -11,6 +11,8 @@ Copyright 2006-2010 NVDA contributers.
 This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
+#ifndef WINWORD_LINKS_H
+#define WINWORD_LINKS_H
 
 #define WIN32_LEAN_AND_MEAN 
 #include <vector>
@@ -49,3 +51,5 @@ namespace WinWord {
 
 	};
 }
+
+#endif

--- a/nvdaHelper/remote/WinWord/Links.h
+++ b/nvdaHelper/remote/WinWord/Links.h
@@ -1,0 +1,51 @@
+/*
+This file is a part of the NVDA project.
+URL: http://www.nvda-project.org/
+Copyright 2006-2010 NVDA contributers.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2.0, as published by
+    the Free Software Foundation.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+This license can be found at:
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
+#define WIN32_LEAN_AND_MEAN 
+#include <vector>
+
+struct IDispatch;
+namespace WinWord {
+
+	typedef std::pair<int, int> range;
+
+	class Links {
+	public:
+		/**
+		* Ctor
+		* @param pRange the range to get link information for. All subsequent queries will be on
+		*        sub-ranges of this. Most likely, this range should be the paragraph.
+		*/
+		Links(IDispatch* pRange);
+
+		/*
+		* Are there any links that given range intersects with.
+		* @param rangeStart start of range to look for links in
+		* @param rangeEnd end of the range to look for links in
+		* @remarks should be a subset of the range given on construction, otherwise the function is likely to be inaccurate.
+		*/
+		bool hasLinks(const int rangeStart, const int rangeEnd);
+
+		/*
+		* Are there any links in the original range
+		*/
+		bool hasLinks();
+
+		Links(const Links&) = delete; // Copy constructor disabled, no implementation.
+		Links& operator=(const Links&) = delete; // Assignment disabled, no implementation.
+	private:
+		std::vector<range> m_links; ///< The links contained in the paragraph
+
+	};
+}

--- a/nvdaHelper/remote/sconscript
+++ b/nvdaHelper/remote/sconscript
@@ -95,6 +95,7 @@ remoteLib=env.SharedLibrary(
 		controllerInternalRPCClientSource,
 		"sysListView32.cpp",
 		"winword.cpp",
+		"WinWord/Links.cpp",
 		"gdiHooks.cpp",
 		"displayModel.cpp",
 		"displayModelRemote.cpp",

--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -24,159 +24,13 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include "nvdaHelperRemote.h"
 #include "nvdaInProcUtils.h"
 #include "nvdaInProcUtils.h"
+#include <remote/WinWord/Constants.h>
+#include <remote/WinWord/Links.h>
 #include "winword.h"
 
 using namespace std;
 
 // See https://github.com/nvaccess/nvda/wiki/Using-COM-with-NVDA-and-Microsoft-Word
-constexpr int wdDISPID_STYLES_ITEM = 0;
-constexpr int wdDISPID_DOCUMENT_STYLES = 22;
-constexpr int wdDISPID_DOCUMENT_RANGE = 2000;
-constexpr int wdDISPID_WINDOW_DOCUMENT = 2;
-constexpr int wdDISPID_WINDOW_APPLICATION = 1000;
-constexpr int wdDISPID_WINDOW_SELECTION = 4;
-constexpr int wdDISPID_APPLICATION_SCREENUPDATING = 26;
-constexpr int wdDISPID_SELECTION_RANGE = 400;
-constexpr int wdDISPID_SELECTION_SETRANGE = 100;
-constexpr int wdDISPID_SELECTION_STARTISACTIVE = 404;
-constexpr int wdDISPID_SELECTION_STARTOF = 107;
-constexpr int wdDISPID_SELECTION_ENDOF = 108;
-constexpr int wdDISPID_RANGE_INRANGE = 126;
-constexpr int wdDISPID_RANGE_DUPLICATE = 6;
-constexpr int wdDISPID_RANGE_REVISIONS = 150;
-constexpr int wdDISPID_REVISIONS_ITEM = 0;
-constexpr int wdDISPID_REVISION_TYPE = 4;
-constexpr int wdDISPID_RANGE_STORYTYPE = 7;
-constexpr int wdDISPID_RANGE_MOVE = 109;
-constexpr int wdDISPID_RANGE_MOVEEND = 111;
-constexpr int wdDISPID_RANGE_COLLAPSE = 101;
-constexpr int wdDISPID_RANGE_TEXT = 0;
-constexpr int wdDISPID_RANGE_EXPAND = 129;
-constexpr int wdDISPID_RANGE_SELECT = 65535;
-constexpr int wdDISPID_RANGE_SETRANGE = 100;
-constexpr int wdDISPID_RANGE_START = 3;
-constexpr int wdDISPID_RANGE_END = 4;
-constexpr int wdDISPID_RANGE_INFORMATION = 313;
-constexpr int wdDISPID_RANGE_STYLE = 151;
-constexpr int wdDISPID_RANGE_LANGUAGEID = 153;
-constexpr int wdDISPID_RANGE_FORMFIELDS = 65;
-constexpr int wdDISPID_RANGE_CONTENTCONTROLS = 424;
-constexpr int wdDISPID_FORMFIELDS_ITEM = 0;
-constexpr int wdDISPID_FORMFIELD_RANGE = 17;
-constexpr int wdDISPID_FORMFIELD_TYPE = 0;
-constexpr int wdDISPID_FORMFIELD_RESULT = 10;
-constexpr int wdDISPID_FORMFIELD_STATUSTEXT = 8;
-constexpr int wdDISPID_CONTENTCONTROLS_ITEM = 0;
-constexpr int wdDISPID_CONTENTCONTROL_RANGE = 1;
-constexpr int wdDISPID_CONTENTCONTROL_TYPE = 5;
-constexpr int wdDISPID_CONTENTCONTROL_CHECKED = 28;
-constexpr int wdDISPID_CONTENTCONTROL_TITLE = 12;
-constexpr int wdDISPID_STYLE_NAMELOCAL = 0;
-constexpr int wdDISPID_STYLE_PARENT = 1002;
-constexpr int wdDISPID_RANGE_SPELLINGERRORS = 316;
-constexpr int wdDISPID_SPELLINGERRORS_ITEM = 0;
-constexpr int wdDISPID_SPELLINGERRORS_COUNT = 1;
-constexpr int wdDISPID_RANGE_APPLICATION = 1000;
-constexpr int wdDISPID_APPLICATION_ISSANDBOX = 492;
-
-constexpr int wdDISPID_RANGE_FONT = 5;
-constexpr int wdDISPID_FONT_COLOR = 159;
-constexpr int wdDISPID_FONT_BOLD = 130;
-constexpr int wdDISPID_FONT_ITALIC = 131;
-constexpr int wdDISPID_FONT_UNDERLINE = 140;
-constexpr int wdDISPID_FONT_STRIKETHROUGH = 135;
-constexpr int wdDISPID_FONT_DOUBLESTRIKETHROUGH = 136;
-constexpr int wdDISPID_FONT_NAME = 142;
-constexpr int wdDISPID_FONT_SIZE = 141;
-constexpr int wdDISPID_FONT_SUBSCRIPT = 138;
-constexpr int wdDISPID_FONT_SUPERSCRIPT = 139;
-constexpr int wdDISPID_RANGE_PARAGRAPHFORMAT = 1102;
-constexpr int wdDISPID_PARAGRAPHFORMAT_ALIGNMENT = 101;
-constexpr int wdDISPID_PARAGRAPHFORMAT_LINESPACING = 109;
-constexpr int wdDISPID_PARAGRAPHFORMAT_LINESPACINGRULE = 110;
-
-constexpr int wdDISPID_RANGE_LISTFORMAT = 68;
-constexpr int wdDISPID_LISTFORMAT_LISTSTRING = 75;
-constexpr int wdDISPID_RANGE_PARAGRAPHS = 59;
-constexpr int wdDISPID_PARAGRAPHS_ITEM = 0;
-constexpr int wdDISPID_PARAGRAPH_RANGE = 0;
-constexpr int wdDISPID_PARAGRAPH_STYLE = 100;
-constexpr int wdDISPID_PARAGRAPH_OUTLINELEVEL = 202;
-constexpr int wdDISPID_RANGE_FOOTNOTES = 54;
-constexpr int wdDISPID_FOOTNOTES_ITEM = 0;
-constexpr int wdDISPID_FOOTNOTES_COUNT = 2;
-constexpr int wdDISPID_FOOTNOTE_INDEX = 6;
-constexpr int wdDISPID_RANGE_ENDNOTES = 55;
-constexpr int wdDISPID_ENDNOTES_ITEM = 0;
-constexpr int wdDISPID_ENDNOTES_COUNT = 2;
-constexpr int wdDISPID_ENDNOTE_INDEX = 6;
-constexpr int wdDISPID_RANGE_INLINESHAPES = 319;
-constexpr int wdDISPID_INLINESHAPES_COUNT = 1;
-constexpr int wdDISPID_INLINESHAPES_ITEM = 0;
-constexpr int wdDISPID_INLINESHAPE_OLEFORMAT = 5;
-constexpr int wdDISPID_INLINESHAPE_TYPE = 6;
-constexpr int wdDISPID_INLINESHAPE_ALTERNATIVETEXT = 131;
-constexpr int wdDISPID_INLINESHAPE_TITLE = 158;
-constexpr int wdDISPID_RANGE_HYPERLINKS = 156;
-constexpr int wdDISPID_HYPERLINKS_COUNT = 1;
-constexpr int wdDISPID_RANGE_COMMENTS = 56;
-constexpr int wdDISPID_COMMENTS_COUNT = 2;
-constexpr int wdDISPID_COMMENTS_ITEM = 0;
-constexpr int wdDISPID_COMMENT_SCOPE = 1005;
-constexpr int wdDISPID_RANGE_TABLES = 50;
-constexpr int wdDISPID_TABLES_ITEM = 0;
-constexpr int wdDISPID_TABLE_NESTINGLEVEL = 108;
-constexpr int wdDISPID_TABLE_RANGE = 0;
-constexpr int wdDISPID_TABLE_TITLE = 209;
-constexpr int wdDISPID_TABLE_DESCR = 210;
-constexpr int wdDISPID_TABLE_BORDERS = 1100;
-constexpr int wdDISPID_BORDERS_ENABLE = 2;
-constexpr int wdDISPID_RANGE_CELLS = 57;
-constexpr int wdDISPID_CELLS_ITEM = 0;
-constexpr int wdDISPID_CELL_RANGE = 0;
-constexpr int wdDISPID_CELL_ROWINDEX = 4;
-constexpr int wdDISPID_CELL_COLUMNINDEX = 5;
-constexpr int wdDISPID_TABLE_COLUMNS = 100;
-constexpr int wdDISPID_COLUMNS_COUNT = 2;
-constexpr int wdDISPID_TABLE_ROWS = 101;
-constexpr int wdDISPID_ROWS_COUNT = 2;
-constexpr int wdDISPID_PARAGRAPHFORMAT_RIGHTINDENT = 106;
-constexpr int wdDISPID_PARAGRAPHFORMAT_LEFTINDENT = 107;
-constexpr int wdDISPID_PARAGRAPHFORMAT_FIRSTLINEINDENT = 108;
-constexpr int wdDISPID_OLEFORMAT_PROGID = 22;
-
-constexpr int wdCommentsStory = 4;
-
-constexpr int wdCharacter = 1;
-constexpr int wdWord = 2;
-constexpr int wdParagraph = 4;
-constexpr int wdLine = 5;
-constexpr int wdStory = 6;
-constexpr int wdCharacterFormatting = 13;
-
-constexpr int wdCollapseEnd = 0;
-constexpr int wdCollapseStart = 1;
-
-constexpr int wdActiveEndAdjustedPageNumber = 1;
-constexpr int wdFirstCharacterLineNumber = 10;
-constexpr int wdWithInTable = 12;
-constexpr int wdStartOfRangeRowNumber = 13;
-constexpr int wdMaximumNumberOfRows = 15;
-constexpr int wdStartOfRangeColumnNumber = 16;
-constexpr int wdMaximumNumberOfColumns = 18;
-
-constexpr int wdAlignParagraphLeft = 0;
-constexpr int wdAlignParagraphCenter = 1;
-constexpr int wdAlignParagraphRight = 2;
-constexpr int wdAlignParagraphJustify = 3;
-constexpr int wdLanguageNone = 0;  //&H0
-constexpr int wdNoProofing = 1024;  //&H400
-constexpr int wdLanguageUnknown = 9999999;
-
-constexpr int wdInlineShapeEmbeddedOLEObject = 1;
-constexpr int wdInlineShapePicture = 3;
-constexpr int wdInlineShapeLinkedPicture = 4;
-
 constexpr int formatConfig_reportFontName = 1;
 constexpr int formatConfig_reportFontSize = 2;
 constexpr int formatConfig_reportFontAttributes = 4;
@@ -272,12 +126,8 @@ void winword_expandToLine_helper(HWND hwnd, winword_expandToLine_args* args) {
 	_com_dispatch_raw_propput(pDispatchApplication,wdDISPID_APPLICATION_SCREENUPDATING,VT_BOOL,true);
 }
 
-BOOL generateFormFieldXML(IDispatch* pDispatchRange, wostringstream& XMLStream, int& chunkEnd) {
-	IDispatchPtr pDispatchRange2=NULL;
-	if(_com_dispatch_raw_propget(pDispatchRange,wdDISPID_RANGE_DUPLICATE,VT_DISPATCH,&pDispatchRange2)!=S_OK||!pDispatchRange2) {
-		return false;
-	}
-	_com_dispatch_raw_method(pDispatchRange2,wdDISPID_RANGE_EXPAND,DISPATCH_METHOD,VT_EMPTY,NULL,L"\x0003",wdParagraph);
+BOOL generateFormFieldXML(IDispatch* pDispatchRange, IDispatchPtr pDispatchRangeExpandedToParagraph, wostringstream& XMLStream, int& chunkEnd) {
+	IDispatchPtr pDispatchRange2=pDispatchRangeExpandedToParagraph;
 	BOOL foundFormField=false;
 	IDispatchPtr pDispatchFormFields=NULL;
 	_com_dispatch_raw_propget(pDispatchRange2,wdDISPID_RANGE_FORMFIELDS,VT_DISPATCH,&pDispatchFormFields);
@@ -453,91 +303,19 @@ int getRevisionType(IDispatch* pDispatchOrigRange) {
 	return revisionType;
 }
 
-bool hasHyperlink(IDispatch* pDispatchRange) {
-	IDispatchPtr pDispatchHyperlinks=NULL;
-	int count=0;
-	if(_com_dispatch_raw_propget(pDispatchRange,wdDISPID_RANGE_HYPERLINKS,VT_DISPATCH,&pDispatchHyperlinks)!=S_OK||!pDispatchHyperlinks) {
-		return false;
-	}
-	if(_com_dispatch_raw_propget(pDispatchHyperlinks,wdDISPID_HYPERLINKS_COUNT,VT_I4,&count)!=S_OK||count<=0) {
-		return false;
-	}
-	return count > 0;
-}
-
-const int wdDISPID_RANGE_FIELDS = 64;
-const int wdDISPID_FIELDS_COUNT = 1;
-const int wdDISPID_FIELDS_ITEM = 0;
-const int wdDISPID_FIELDS_ITEM_TYPE = 1;
-const int wdDISPID_FIELDS_ITEM_RESULT = 4;
-
-bool hasXRefLink(IDispatch* pDispatchRange) {
+IDispatchPtr CreateExpandedDuplicate(IDispatch* pDispatchRange, const int expandTo) {
 	IDispatchPtr pDispatchRangeDup = nullptr;
 	auto res = _com_dispatch_raw_propget( pDispatchRange, wdDISPID_RANGE_DUPLICATE, VT_DISPATCH, &pDispatchRangeDup);
 	if( res != S_OK || !pDispatchRangeDup ) {
 		LOG_DEBUGWARNING(L"error duplicating the range.");
-		return false;
 	}
-
-	res = _com_dispatch_raw_method( pDispatchRangeDup, wdDISPID_RANGE_EXPAND,DISPATCH_METHOD,VT_EMPTY,NULL,L"\x0003",wdParagraph);
-	if( res != S_OK || !pDispatchRangeDup ) {
-		LOG_DEBUGWARNING(L"error expanding the range");
-		return false;
-	}
-
-	IDispatchPtr pDispatchFields = nullptr;
-	res = _com_dispatch_raw_propget( pDispatchRangeDup, wdDISPID_RANGE_FIELDS, VT_DISPATCH, &pDispatchFields);
-	if( res != S_OK || !pDispatchFields ) {
-		LOG_DEBUGWARNING(L"error getting fields from range");
-		return false;
-	}
-
-	int count = 0;
-	res = _com_dispatch_raw_propget( pDispatchFields, wdDISPID_FIELDS_COUNT, VT_I4, &count);
-	if( res != S_OK || count <= 0 ) {
-		return 0;
-	}
-
-	for(int i = 1; i <= count; ++i) {
-		IDispatchPtr pDispatchItem = nullptr;
-		res = _com_dispatch_raw_method( pDispatchFields, wdDISPID_FIELDS_ITEM, DISPATCH_METHOD, VT_DISPATCH, &pDispatchItem, L"\x0003", i);
-		if( res != S_OK || !pDispatchItem){
-			LOG_DEBUGWARNING(L"error getting field item");
-			continue;
-		}
-		int type = -1;
-		const int CROSS_REFERENCE_TYPE_VALUE = 3; // wdFieldRef see (WdFieldType Enumeration - https://msdn.microsoft.com/en-us/library/office/ff192211.aspx)
-		res = _com_dispatch_raw_propget( pDispatchItem, wdDISPID_FIELDS_ITEM_TYPE, VT_I4, &type);
-		if( res != S_OK || type != CROSS_REFERENCE_TYPE_VALUE ){
-			continue;
-		}
-
-		IDispatchPtr pDispatchFieldResult = nullptr;
-		res = _com_dispatch_raw_propget( pDispatchItem, wdDISPID_FIELDS_ITEM_RESULT, VT_DISPATCH, &pDispatchFieldResult);
-		if( res != S_OK || !pDispatchFieldResult){
-			LOG_DEBUGWARNING(L"error getting the result from the field item.");
-			continue;
-		}
-
-		long rangeStart = 0, rangeEnd = 0, resultStart = 0, resultEnd = 0;
-		auto ok = S_OK == _com_dispatch_raw_propget( pDispatchRange, wdDISPID_RANGE_START, VT_I4, &rangeStart)
-		       && S_OK == _com_dispatch_raw_propget( pDispatchRange, wdDISPID_RANGE_END, VT_I4, &rangeEnd)
-		       && S_OK == _com_dispatch_raw_propget( pDispatchFieldResult, wdDISPID_RANGE_START, VT_I4, &resultStart)
-		       && S_OK == _com_dispatch_raw_propget( pDispatchFieldResult, wdDISPID_RANGE_END, VT_I4, &resultEnd);
-
-		auto inRange = [] (long index, long start, long end) {
-			return index >= start && index <= end;
-		};
-
-		if( ok && (
-			inRange(rangeStart, resultStart, resultEnd) ||
-			inRange(rangeEnd, resultStart, resultEnd) ||
-			inRange(resultStart, rangeStart, rangeEnd) ||
-			inRange(resultEnd, rangeStart, rangeEnd) )){
-			return true;
+	else {
+		res = _com_dispatch_raw_method( pDispatchRangeDup, wdDISPID_RANGE_EXPAND,DISPATCH_METHOD,VT_EMPTY,NULL,L"\x0003", expandTo);
+		if( res != S_OK || !pDispatchRangeDup ) {
+			LOG_DEBUGWARNING(L"error expanding the range");
 		}
 	}
-	return false;
+	return pDispatchRangeDup;
 }
 
 bool collectCommentOffsets(IDispatchPtr pDispatchRange, vector<pair<long,long>>& commentVector) {
@@ -681,7 +459,7 @@ int generateTableXML(IDispatch* pDispatchRange, bool includeLayoutTables, int st
 	return numTags;
 }
 
-void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset, int endOffset, int formatConfig, wostringstream& formatAttribsStream) {
+void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset, int endOffset, int formatConfig, wostringstream& formatAttribsStream, WinWord::Links& currentLinks) {
 	int iVal=0;
 	if((formatConfig&formatConfig_reportPage)&&(_com_dispatch_raw_method(pDispatchRange,wdDISPID_RANGE_INFORMATION,DISPATCH_PROPERTYGET,VT_I4,&iVal,L"\x0003",wdActiveEndAdjustedPageNumber)==S_OK)&&iVal>0) {
 		formatAttribsStream<<L"page-number=\""<<iVal<<L"\" ";
@@ -764,7 +542,7 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 			}
 		}
 	}
-	if( (formatConfig&formatConfig_reportLinks) && (hasHyperlink(pDispatchRange) || hasXRefLink(pDispatchRange)) ) {
+	if( (formatConfig&formatConfig_reportLinks) && currentLinks.hasLinks(startOffset, endOffset) ) {
 		formatAttribsStream<<L"link=\"1\" ";
 	}
 	if(formatConfig&formatConfig_reportRevisions) {
@@ -956,7 +734,11 @@ void winword_getTextInRange_helper(HWND hwnd, winword_getTextInRange_args* args)
 	//Collapse the range
 	int initialFormatConfig=(args->formatConfig)&formatConfig_initialFormatFlags;
 	int formatConfig=(args->formatConfig)&(~formatConfig_initialFormatFlags);
-	if((formatConfig&formatConfig_reportLinks) && !(hasHyperlink(pDispatchRange) || hasXRefLink(pDispatchRange) )) {
+
+	IDispatchPtr paragraphRange = CreateExpandedDuplicate(pDispatchRange, wdParagraph);
+	WinWord::Links currentLinks(paragraphRange);
+
+	if((formatConfig&formatConfig_reportLinks) && false == currentLinks.hasLinks() ) {
 		formatConfig&=~formatConfig_reportLinks;
 	}
 
@@ -994,7 +776,7 @@ void winword_getTextInRange_helper(HWND hwnd, winword_getTextInRange_args* args)
 	if(initialFormatConfig&formatConfig_reportHeadings) {
 		neededClosingControlTagCount+=generateHeadingXML(pDispatchParagraph,pDispatchParagraphRange,args->startOffset,args->endOffset,XMLStream);
 	}
-	generateXMLAttribsForFormatting(pDispatchRange,chunkStartOffset,chunkEndOffset,initialFormatConfig,initialFormatAttribsStream);
+	generateXMLAttribsForFormatting(pDispatchRange,chunkStartOffset,chunkEndOffset,initialFormatConfig,initialFormatAttribsStream, currentLinks);
 	bool firstLoop=true;
 	//Walk the range from the given start to end by characterFormatting or word units
 	//And grab any text and formatting and generate appropriate xml
@@ -1002,7 +784,7 @@ void winword_getTextInRange_helper(HWND hwnd, winword_getTextInRange_args* args)
 		int curDisabledFormatConfig=0;
 		//generated form field xml if in a form field
 		//Also automatically extends the range and chunkEndOffset to the end of the field
-		BOOL isFormField=generateFormFieldXML(pDispatchRange,XMLStream,chunkEndOffset);
+		BOOL isFormField=generateFormFieldXML(pDispatchRange,paragraphRange,XMLStream,chunkEndOffset);
 		if(!isFormField) {
 			//Move the end by word
 			if(_com_dispatch_raw_method(pDispatchRange,wdDISPID_RANGE_MOVEEND,DISPATCH_METHOD,VT_I4,&unitsMoved,L"\x0003\x0003",wdWord,1)!=S_OK||unitsMoved<=0) {
@@ -1065,7 +847,7 @@ void winword_getTextInRange_helper(HWND hwnd, winword_getTextInRange_args* args)
 			}
 			XMLStream<<L"<text _startOffset=\""<<chunkStartOffset<<L"\" _endOffset=\""<<chunkEndOffset<<L"\" ";
 			XMLStream<<initialFormatAttribsStream.str();
-			generateXMLAttribsForFormatting(pDispatchRange,chunkStartOffset,chunkEndOffset,formatConfig&(~curDisabledFormatConfig),XMLStream);
+			generateXMLAttribsForFormatting(pDispatchRange,chunkStartOffset,chunkEndOffset,formatConfig&(~curDisabledFormatConfig),XMLStream, currentLinks);
 			for(vector<pair<long,long>>::iterator i=errorVector.begin();i!=errorVector.end();++i) {
 				if(chunkStartOffset>=i->first&&chunkStartOffset<i->second) {
 					XMLStream<<L" invalid-spelling=\"1\" ";

--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -29,177 +29,176 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 using namespace std;
 
 // See https://github.com/nvaccess/nvda/wiki/Using-COM-with-NVDA-and-Microsoft-Word
-#define wdDISPID_STYLES_ITEM 0
-#define wdDISPID_DOCUMENT_STYLES 22
-#define wdDISPID_DOCUMENT_RANGE 2000
-#define wdDISPID_WINDOW_DOCUMENT 2
-#define wdDISPID_WINDOW_APPLICATION 1000
-#define wdDISPID_WINDOW_SELECTION 4
-#define wdDISPID_APPLICATION_SCREENUPDATING 26
-#define wdDISPID_SELECTION_RANGE 400
-#define wdDISPID_SELECTION_SETRANGE 100
-#define wdDISPID_SELECTION_STARTISACTIVE 404
-#define wdDISPID_SELECTION_STARTOF 107
-#define wdDISPID_SELECTION_ENDOF 108
-#define wdDISPID_RANGE_INRANGE 126
-#define wdDISPID_RANGE_DUPLICATE 6
-#define wdDISPID_RANGE_REVISIONS 150
-#define wdDISPID_REVISIONS_ITEM 0
-#define wdDISPID_REVISION_TYPE 4
-#define wdDISPID_RANGE_STORYTYPE 7
-#define wdDISPID_RANGE_MOVE 109
-#define wdDISPID_RANGE_MOVEEND 111
-#define wdDISPID_RANGE_COLLAPSE 101
-#define wdDISPID_RANGE_TEXT 0
-#define wdDISPID_RANGE_EXPAND 129
-#define wdDISPID_RANGE_SELECT 65535
-#define wdDISPID_RANGE_SETRANGE 100
-#define wdDISPID_RANGE_START 3
-#define wdDISPID_RANGE_END 4
-#define wdDISPID_RANGE_INFORMATION 313
-#define wdDISPID_RANGE_STYLE 151
-#define wdDISPID_RANGE_LANGUAGEID 153
-#define wdDISPID_RANGE_DUPLICATE 6
-#define wdDISPID_RANGE_FORMFIELDS 65
-#define wdDISPID_RANGE_CONTENTCONTROLS 424
-#define wdDISPID_FORMFIELDS_ITEM 0
-#define wdDISPID_FORMFIELD_RANGE 17
-#define wdDISPID_FORMFIELD_TYPE 0
-#define wdDISPID_FORMFIELD_RESULT 10
-#define wdDISPID_FORMFIELD_STATUSTEXT 8
-#define wdDISPID_CONTENTCONTROLS_ITEM 0
-#define wdDISPID_CONTENTCONTROL_RANGE 1
-#define wdDISPID_CONTENTCONTROL_TYPE 5
-#define wdDISPID_CONTENTCONTROL_CHECKED 28
-#define wdDISPID_CONTENTCONTROL_TITLE 12
-#define wdDISPID_STYLE_NAMELOCAL 0
-#define wdDISPID_STYLE_PARENT 1002
-#define wdDISPID_RANGE_SPELLINGERRORS 316
-#define wdDISPID_SPELLINGERRORS_ITEM 0
-#define wdDISPID_SPELLINGERRORS_COUNT 1
-#define wdDISPID_RANGE_APPLICATION 1000
-#define wdDISPID_APPLICATION_ISSANDBOX 492
+constexpr int wdDISPID_STYLES_ITEM = 0;
+constexpr int wdDISPID_DOCUMENT_STYLES = 22;
+constexpr int wdDISPID_DOCUMENT_RANGE = 2000;
+constexpr int wdDISPID_WINDOW_DOCUMENT = 2;
+constexpr int wdDISPID_WINDOW_APPLICATION = 1000;
+constexpr int wdDISPID_WINDOW_SELECTION = 4;
+constexpr int wdDISPID_APPLICATION_SCREENUPDATING = 26;
+constexpr int wdDISPID_SELECTION_RANGE = 400;
+constexpr int wdDISPID_SELECTION_SETRANGE = 100;
+constexpr int wdDISPID_SELECTION_STARTISACTIVE = 404;
+constexpr int wdDISPID_SELECTION_STARTOF = 107;
+constexpr int wdDISPID_SELECTION_ENDOF = 108;
+constexpr int wdDISPID_RANGE_INRANGE = 126;
+constexpr int wdDISPID_RANGE_DUPLICATE = 6;
+constexpr int wdDISPID_RANGE_REVISIONS = 150;
+constexpr int wdDISPID_REVISIONS_ITEM = 0;
+constexpr int wdDISPID_REVISION_TYPE = 4;
+constexpr int wdDISPID_RANGE_STORYTYPE = 7;
+constexpr int wdDISPID_RANGE_MOVE = 109;
+constexpr int wdDISPID_RANGE_MOVEEND = 111;
+constexpr int wdDISPID_RANGE_COLLAPSE = 101;
+constexpr int wdDISPID_RANGE_TEXT = 0;
+constexpr int wdDISPID_RANGE_EXPAND = 129;
+constexpr int wdDISPID_RANGE_SELECT = 65535;
+constexpr int wdDISPID_RANGE_SETRANGE = 100;
+constexpr int wdDISPID_RANGE_START = 3;
+constexpr int wdDISPID_RANGE_END = 4;
+constexpr int wdDISPID_RANGE_INFORMATION = 313;
+constexpr int wdDISPID_RANGE_STYLE = 151;
+constexpr int wdDISPID_RANGE_LANGUAGEID = 153;
+constexpr int wdDISPID_RANGE_FORMFIELDS = 65;
+constexpr int wdDISPID_RANGE_CONTENTCONTROLS = 424;
+constexpr int wdDISPID_FORMFIELDS_ITEM = 0;
+constexpr int wdDISPID_FORMFIELD_RANGE = 17;
+constexpr int wdDISPID_FORMFIELD_TYPE = 0;
+constexpr int wdDISPID_FORMFIELD_RESULT = 10;
+constexpr int wdDISPID_FORMFIELD_STATUSTEXT = 8;
+constexpr int wdDISPID_CONTENTCONTROLS_ITEM = 0;
+constexpr int wdDISPID_CONTENTCONTROL_RANGE = 1;
+constexpr int wdDISPID_CONTENTCONTROL_TYPE = 5;
+constexpr int wdDISPID_CONTENTCONTROL_CHECKED = 28;
+constexpr int wdDISPID_CONTENTCONTROL_TITLE = 12;
+constexpr int wdDISPID_STYLE_NAMELOCAL = 0;
+constexpr int wdDISPID_STYLE_PARENT = 1002;
+constexpr int wdDISPID_RANGE_SPELLINGERRORS = 316;
+constexpr int wdDISPID_SPELLINGERRORS_ITEM = 0;
+constexpr int wdDISPID_SPELLINGERRORS_COUNT = 1;
+constexpr int wdDISPID_RANGE_APPLICATION = 1000;
+constexpr int wdDISPID_APPLICATION_ISSANDBOX = 492;
 
-#define wdDISPID_RANGE_FONT 5
-#define wdDISPID_FONT_COLOR 159
-#define wdDISPID_FONT_BOLD 130
-#define wdDISPID_FONT_ITALIC 131
-#define wdDISPID_FONT_UNDERLINE 140
-#define wdDISPID_FONT_STRIKETHROUGH 135
-#define wdDISPID_FONT_DOUBLESTRIKETHROUGH 136
-#define wdDISPID_FONT_NAME 142
-#define wdDISPID_FONT_SIZE 141
-#define wdDISPID_FONT_SUBSCRIPT 138
-#define wdDISPID_FONT_SUPERSCRIPT 139
-#define wdDISPID_RANGE_PARAGRAPHFORMAT 1102
-#define wdDISPID_PARAGRAPHFORMAT_ALIGNMENT 101
-#define wdDISPID_PARAGRAPHFORMAT_LINESPACING 109
-#define wdDISPID_PARAGRAPHFORMAT_LINESPACINGRULE 110
+constexpr int wdDISPID_RANGE_FONT = 5;
+constexpr int wdDISPID_FONT_COLOR = 159;
+constexpr int wdDISPID_FONT_BOLD = 130;
+constexpr int wdDISPID_FONT_ITALIC = 131;
+constexpr int wdDISPID_FONT_UNDERLINE = 140;
+constexpr int wdDISPID_FONT_STRIKETHROUGH = 135;
+constexpr int wdDISPID_FONT_DOUBLESTRIKETHROUGH = 136;
+constexpr int wdDISPID_FONT_NAME = 142;
+constexpr int wdDISPID_FONT_SIZE = 141;
+constexpr int wdDISPID_FONT_SUBSCRIPT = 138;
+constexpr int wdDISPID_FONT_SUPERSCRIPT = 139;
+constexpr int wdDISPID_RANGE_PARAGRAPHFORMAT = 1102;
+constexpr int wdDISPID_PARAGRAPHFORMAT_ALIGNMENT = 101;
+constexpr int wdDISPID_PARAGRAPHFORMAT_LINESPACING = 109;
+constexpr int wdDISPID_PARAGRAPHFORMAT_LINESPACINGRULE = 110;
 
-#define wdDISPID_RANGE_LISTFORMAT 68
-#define wdDISPID_LISTFORMAT_LISTSTRING 75
-#define wdDISPID_RANGE_PARAGRAPHS 59
-#define wdDISPID_PARAGRAPHS_ITEM 0
-#define wdDISPID_PARAGRAPH_RANGE 0
-#define wdDISPID_PARAGRAPH_STYLE 100
-#define wdDISPID_PARAGRAPH_OUTLINELEVEL 202
-#define wdDISPID_RANGE_FOOTNOTES 54
-#define wdDISPID_FOOTNOTES_ITEM 0
-#define wdDISPID_FOOTNOTES_COUNT 2
-#define wdDISPID_FOOTNOTE_INDEX 6
-#define wdDISPID_RANGE_ENDNOTES 55
-#define wdDISPID_ENDNOTES_ITEM 0
-#define wdDISPID_ENDNOTES_COUNT 2
-#define wdDISPID_ENDNOTE_INDEX 6
-#define wdDISPID_RANGE_INLINESHAPES 319
-#define wdDISPID_INLINESHAPES_COUNT 1
-#define wdDISPID_INLINESHAPES_ITEM 0 
-#define wdDISPID_INLINESHAPE_OLEFORMAT 5
-#define wdDISPID_INLINESHAPE_TYPE 6
-#define wdDISPID_INLINESHAPE_ALTERNATIVETEXT 131
-#define wdDISPID_INLINESHAPE_TITLE 158
-#define wdDISPID_RANGE_HYPERLINKS 156
-#define wdDISPID_HYPERLINKS_COUNT 1
-#define wdDISPID_RANGE_COMMENTS 56
-#define wdDISPID_COMMENTS_COUNT 2
-#define wdDISPID_COMMENTS_ITEM 0
-#define wdDISPID_COMMENT_SCOPE 1005
-#define wdDISPID_RANGE_TABLES 50
-#define wdDISPID_TABLES_ITEM 0
-#define wdDISPID_TABLE_NESTINGLEVEL 108
-#define wdDISPID_TABLE_RANGE 0
-#define wdDISPID_TABLE_TITLE 209
-#define wdDISPID_TABLE_DESCR 210
-#define wdDISPID_TABLE_BORDERS 1100
-#define wdDISPID_BORDERS_ENABLE 2
-#define wdDISPID_RANGE_CELLS 57
-#define wdDISPID_CELLS_ITEM 0
-#define wdDISPID_CELL_RANGE 0
-#define wdDISPID_CELL_ROWINDEX 4
-#define wdDISPID_CELL_COLUMNINDEX 5
-#define wdDISPID_TABLE_COLUMNS 100
-#define wdDISPID_COLUMNS_COUNT 2
-#define wdDISPID_TABLE_ROWS 101
-#define wdDISPID_ROWS_COUNT 2
-#define wdDISPID_PARAGRAPHFORMAT_RIGHTINDENT 106
-#define wdDISPID_PARAGRAPHFORMAT_LEFTINDENT 107
-#define wdDISPID_PARAGRAPHFORMAT_FIRSTLINEINDENT 108
-#define wdDISPID_OLEFORMAT_PROGID 22
+constexpr int wdDISPID_RANGE_LISTFORMAT = 68;
+constexpr int wdDISPID_LISTFORMAT_LISTSTRING = 75;
+constexpr int wdDISPID_RANGE_PARAGRAPHS = 59;
+constexpr int wdDISPID_PARAGRAPHS_ITEM = 0;
+constexpr int wdDISPID_PARAGRAPH_RANGE = 0;
+constexpr int wdDISPID_PARAGRAPH_STYLE = 100;
+constexpr int wdDISPID_PARAGRAPH_OUTLINELEVEL = 202;
+constexpr int wdDISPID_RANGE_FOOTNOTES = 54;
+constexpr int wdDISPID_FOOTNOTES_ITEM = 0;
+constexpr int wdDISPID_FOOTNOTES_COUNT = 2;
+constexpr int wdDISPID_FOOTNOTE_INDEX = 6;
+constexpr int wdDISPID_RANGE_ENDNOTES = 55;
+constexpr int wdDISPID_ENDNOTES_ITEM = 0;
+constexpr int wdDISPID_ENDNOTES_COUNT = 2;
+constexpr int wdDISPID_ENDNOTE_INDEX = 6;
+constexpr int wdDISPID_RANGE_INLINESHAPES = 319;
+constexpr int wdDISPID_INLINESHAPES_COUNT = 1;
+constexpr int wdDISPID_INLINESHAPES_ITEM = 0;
+constexpr int wdDISPID_INLINESHAPE_OLEFORMAT = 5;
+constexpr int wdDISPID_INLINESHAPE_TYPE = 6;
+constexpr int wdDISPID_INLINESHAPE_ALTERNATIVETEXT = 131;
+constexpr int wdDISPID_INLINESHAPE_TITLE = 158;
+constexpr int wdDISPID_RANGE_HYPERLINKS = 156;
+constexpr int wdDISPID_HYPERLINKS_COUNT = 1;
+constexpr int wdDISPID_RANGE_COMMENTS = 56;
+constexpr int wdDISPID_COMMENTS_COUNT = 2;
+constexpr int wdDISPID_COMMENTS_ITEM = 0;
+constexpr int wdDISPID_COMMENT_SCOPE = 1005;
+constexpr int wdDISPID_RANGE_TABLES = 50;
+constexpr int wdDISPID_TABLES_ITEM = 0;
+constexpr int wdDISPID_TABLE_NESTINGLEVEL = 108;
+constexpr int wdDISPID_TABLE_RANGE = 0;
+constexpr int wdDISPID_TABLE_TITLE = 209;
+constexpr int wdDISPID_TABLE_DESCR = 210;
+constexpr int wdDISPID_TABLE_BORDERS = 1100;
+constexpr int wdDISPID_BORDERS_ENABLE = 2;
+constexpr int wdDISPID_RANGE_CELLS = 57;
+constexpr int wdDISPID_CELLS_ITEM = 0;
+constexpr int wdDISPID_CELL_RANGE = 0;
+constexpr int wdDISPID_CELL_ROWINDEX = 4;
+constexpr int wdDISPID_CELL_COLUMNINDEX = 5;
+constexpr int wdDISPID_TABLE_COLUMNS = 100;
+constexpr int wdDISPID_COLUMNS_COUNT = 2;
+constexpr int wdDISPID_TABLE_ROWS = 101;
+constexpr int wdDISPID_ROWS_COUNT = 2;
+constexpr int wdDISPID_PARAGRAPHFORMAT_RIGHTINDENT = 106;
+constexpr int wdDISPID_PARAGRAPHFORMAT_LEFTINDENT = 107;
+constexpr int wdDISPID_PARAGRAPHFORMAT_FIRSTLINEINDENT = 108;
+constexpr int wdDISPID_OLEFORMAT_PROGID = 22;
 
-#define wdCommentsStory 4
+constexpr int wdCommentsStory = 4;
 
-#define wdCharacter 1
-#define wdWord 2
-#define wdParagraph 4
-#define wdLine 5
-const int wdStory = 6;
-#define wdCharacterFormatting 13
+constexpr int wdCharacter = 1;
+constexpr int wdWord = 2;
+constexpr int wdParagraph = 4;
+constexpr int wdLine = 5;
+constexpr int wdStory = 6;
+constexpr int wdCharacterFormatting = 13;
 
-#define wdCollapseEnd 0
-#define wdCollapseStart 1
+constexpr int wdCollapseEnd = 0;
+constexpr int wdCollapseStart = 1;
 
-#define wdActiveEndAdjustedPageNumber 1
-#define wdFirstCharacterLineNumber 10
-#define wdWithInTable 12
-#define wdStartOfRangeRowNumber 13
-#define wdMaximumNumberOfRows 15
-#define wdStartOfRangeColumnNumber 16
-#define wdMaximumNumberOfColumns 18
+constexpr int wdActiveEndAdjustedPageNumber = 1;
+constexpr int wdFirstCharacterLineNumber = 10;
+constexpr int wdWithInTable = 12;
+constexpr int wdStartOfRangeRowNumber = 13;
+constexpr int wdMaximumNumberOfRows = 15;
+constexpr int wdStartOfRangeColumnNumber = 16;
+constexpr int wdMaximumNumberOfColumns = 18;
 
-#define wdAlignParagraphLeft 0
-#define wdAlignParagraphCenter 1
-#define wdAlignParagraphRight 2
-#define wdAlignParagraphJustify 3
-#define wdLanguageNone 0  //&H0
-#define wdNoProofing 1024  //&H400
-#define wdLanguageUnknown 9999999
+constexpr int wdAlignParagraphLeft = 0;
+constexpr int wdAlignParagraphCenter = 1;
+constexpr int wdAlignParagraphRight = 2;
+constexpr int wdAlignParagraphJustify = 3;
+constexpr int wdLanguageNone = 0;  //&H0
+constexpr int wdNoProofing = 1024;  //&H400
+constexpr int wdLanguageUnknown = 9999999;
 
-#define wdInlineShapeEmbeddedOLEObject 1
-#define wdInlineShapePicture 3
-#define wdInlineShapeLinkedPicture 4
+constexpr int wdInlineShapeEmbeddedOLEObject = 1;
+constexpr int wdInlineShapePicture = 3;
+constexpr int wdInlineShapeLinkedPicture = 4;
 
-#define formatConfig_reportFontName 1
-#define formatConfig_reportFontSize 2
-#define formatConfig_reportFontAttributes 4
-#define formatConfig_reportColor 8
-#define formatConfig_reportAlignment 16
-#define formatConfig_reportStyle 32
-#define formatConfig_reportSpellingErrors 64
-#define formatConfig_reportPage 128
-#define formatConfig_reportLineNumber 256
-#define formatConfig_reportTables 512
-#define formatConfig_reportLists 1024
-#define formatConfig_reportLinks 2048
-#define formatConfig_reportComments 4096
-#define formatConfig_reportHeadings 8192
-#define formatConfig_reportLanguage 16384
-#define formatConfig_reportRevisions 32768
-#define formatConfig_reportParagraphIndentation 65536
-#define formatConfig_includeLayoutTables 131072
- #define formatConfig_reportLineSpacing 262144
- 
-#define formatConfig_fontFlags (formatConfig_reportFontName|formatConfig_reportFontSize|formatConfig_reportFontAttributes|formatConfig_reportColor)
-#define formatConfig_initialFormatFlags (formatConfig_reportPage|formatConfig_reportLineNumber|formatConfig_reportTables|formatConfig_reportHeadings|formatConfig_includeLayoutTables)
+constexpr int formatConfig_reportFontName = 1;
+constexpr int formatConfig_reportFontSize = 2;
+constexpr int formatConfig_reportFontAttributes = 4;
+constexpr int formatConfig_reportColor = 8;
+constexpr int formatConfig_reportAlignment = 16;
+constexpr int formatConfig_reportStyle = 32;
+constexpr int formatConfig_reportSpellingErrors = 64;
+constexpr int formatConfig_reportPage = 128;
+constexpr int formatConfig_reportLineNumber = 256;
+constexpr int formatConfig_reportTables = 512;
+constexpr int formatConfig_reportLists = 1024;
+constexpr int formatConfig_reportLinks = 2048;
+constexpr int formatConfig_reportComments = 4096;
+constexpr int formatConfig_reportHeadings = 8192;
+constexpr int formatConfig_reportLanguage = 16384;
+constexpr int formatConfig_reportRevisions = 32768;
+constexpr int formatConfig_reportParagraphIndentation = 65536;
+constexpr int formatConfig_includeLayoutTables = 131072;
+constexpr int formatConfig_reportLineSpacing = 262144;
+
+constexpr int formatConfig_fontFlags =(formatConfig_reportFontName|formatConfig_reportFontSize|formatConfig_reportFontAttributes|formatConfig_reportColor);
+constexpr int formatConfig_initialFormatFlags =(formatConfig_reportPage|formatConfig_reportLineNumber|formatConfig_reportTables|formatConfig_reportHeadings|formatConfig_includeLayoutTables);
 
 UINT wm_winword_expandToLine=0;
 typedef struct {

--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -277,7 +277,7 @@ BOOL generateFormFieldXML(IDispatch* pDispatchRange, wostringstream& XMLStream, 
 	if(_com_dispatch_raw_propget(pDispatchRange,wdDISPID_RANGE_DUPLICATE,VT_DISPATCH,&pDispatchRange2)!=S_OK||!pDispatchRange2) {
 		return false;
 	}
-	_com_dispatch_raw_method(pDispatchRange2,wdDISPID_RANGE_EXPAND,DISPATCH_METHOD,VT_EMPTY,NULL,L"\x0003",wdParagraph,1); // is it wrong?
+	_com_dispatch_raw_method(pDispatchRange2,wdDISPID_RANGE_EXPAND,DISPATCH_METHOD,VT_EMPTY,NULL,L"\x0003",wdParagraph);
 	BOOL foundFormField=false;
 	IDispatchPtr pDispatchFormFields=NULL;
 	_com_dispatch_raw_propget(pDispatchRange2,wdDISPID_RANGE_FORMFIELDS,VT_DISPATCH,&pDispatchFormFields);

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -499,6 +499,23 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		if links.count>0:
 			links[1].follow()
 			return
+		fields=tempRange.fields
+		if fields.count>0 and fields[1].type == 3:
+			# text will be something like ' REF _Ref457210120 \\h '
+			fieldText = fields[1].code.text.split(' ')
+			log.debugWarning("fieldText: %s" % fieldText)
+			# ensure that the text has a \\h in it
+			if not any( fieldText[i] == '\\h' for i in range(2, len(fieldText)) ):
+				log.debugWarning("no \\h for field xref: %s" % fields[1].code.text)
+			bookmarkKey = fieldText[2] # we want the _Ref12345 part
+			log.debugWarning("bookmarkKey to activate: %s" % bookmarkKey)
+			# get book mark start, we need to look at the whole document to find the bookmark.
+			tempRange.Expand(wdStory)
+			log.debugWarning("range start: %s end: %s" % (tempRange.start, tempRange.end))
+			bMark = tempRange.bookmarks(bookmarkKey)
+			log.debugWarning("bMark range start: %s end: %s" % (bMark.range.start, bMark.range.end))
+			self._rangeObj.setRange(bMark.start, bMark.start)
+			self.updateCaret()
 
 	def _expandToLineAtCaret(self):
 		lineStart=ctypes.c_int()


### PR DESCRIPTION
Add support for cross references in word. Fixes #6102 

Now able to report cross references as links when reading through text in word. Can browse by link and when in browse mode a Cross ref link can be activated.

Had to expand the range to the paragraph because single words with in a `ref` dont report as refs. Only the first and the last character.

Refs that are links have the `fields.item(1).code.text` property set to something like `u' REF _Ref457210120 \\h`

For performance reasons the links are cached first, then as we traverse over the words in the range we check if the word is in the vector of known links.
