### PR TITLE
In the Outlook 2016 message list, no longer report associated draft information

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -418,6 +418,11 @@ class UIAGridRow(RowWithFakeNavigation,UIA):
 		cachedChildren=self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
 		for index in xrange(cachedChildren.length):
 			e=cachedChildren.getElement(index)
+			# Outlook 2016 started exposing the draft column as a text node.
+			# Users reportedly find this extremely annoying.
+			# Thus we filter it out.
+			if self.appModule.outlookVersion>=16 and e.cachedClassName=="DraftFlagField":
+				continue
 			name=e.cachedName
 			columnHeaderTextList=[]
 			if name and config.conf['documentFormatting']['reportTableHeaders']:

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -418,7 +418,7 @@ class UIAGridRow(RowWithFakeNavigation,UIA):
 		cachedChildren=self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
 		for index in xrange(cachedChildren.length):
 			e=cachedChildren.getElement(index)
-			# Outlook 2016 started exposing the draft column as a text node.
+			# #6219: Outlook 2016 started exposing the draft column as a text node.
 			# Users reportedly find this extremely annoying.
 			# Thus we filter it out.
 			if self.appModule.outlookVersion>=16 and e.cachedClassName=="DraftFlagField":


### PR DESCRIPTION
Fixes #6219 
