### PR TITLE
Use translated key labels when identifying emulated system keyboard keys #6212

### DIFF
--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010 James Teh <jamie@jantrid.net>
+#Copyright (C) 2010-2016 NV Access Limited, Babbage B.V.
 
 """Core framework for handling input from the user.
 Every piece of input from the user (e.g. a key press) is represented by an L{InputGesture}.
@@ -28,6 +28,7 @@ from logHandler import log
 import globalVars
 import languageHandler
 import controlTypes
+import keyLabels
 
 #: Script category for emulated keyboard keys.
 # Translators: The name of a category of NVDA commands.
@@ -613,7 +614,7 @@ class _AllGestureMappingsRetriever(object):
 	def makeKbEmuScriptInfo(self, cls, scriptName):
 		info = AllGesturesScriptInfo(cls, scriptName)
 		info.category = SCRCAT_KBEMU
-		info.displayName = scriptName[3:]
+		info.displayName = keyLabels.getKeyCombinationLabel(scriptName[3:])
 		return info
 
 	def makeNormalScriptInfo(self, cls, scriptName, script):

--- a/source/keyLabels.py
+++ b/source/keyLabels.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2010 James Teh <jamie@jantrid.net>, Aleksey Sadovoy <lex@onm.su>
+#Copyright (C) 2008-2016 NV Access Limited, Aleksey Sadovoy, Babbage B.v.
 
 localizedKeyLabels = {
 	# Translators: This is the name of the back key found on multimedia keyboards for controlling the web-browser.
@@ -162,3 +162,6 @@ localizedKeyLabels = {
 	# Translators: This is the name of a key on the keyboard.
 	'tab': pgettext("keyLabel", "tab"),
 }
+
+def getKeyCombinationLabel(keyCombination):
+	return "+".join(localizedKeyLabels[key.lower()] for key in keyCombination.split("+"))

--- a/source/keyLabels.py
+++ b/source/keyLabels.py
@@ -171,4 +171,5 @@ def getKeyCombinationLabel(keyCombination):
 	@returns: A localized key combination
 	@rtype: string
 	"""
-	return "+".join(localizedKeyLabels[key.lower()] if key.lower() in localizedKeyLabels.keys() else key.lower() for key in keyCombination.split("+"))
+	keys = keyCombination.lower().split("+")
+	return "+".join(localizedKeyLabels.get(key, key) for key in keys)

--- a/source/keyLabels.py
+++ b/source/keyLabels.py
@@ -164,4 +164,11 @@ localizedKeyLabels = {
 }
 
 def getKeyCombinationLabel(keyCombination):
-	return "+".join(localizedKeyLabels[key.lower()] for key in keyCombination.split("+"))
+	"""
+	Fetches a localized label for a combination of multiple keys.
+	@param keyCombination: The key combination identifier to get the localized label for, usually plus-separated key identifiers.
+	@type keyCombination: string
+	@returns: A localized key combination
+	@rtype: string
+	"""
+	return "+".join(localizedKeyLabels[key.lower()] if key.lower() in localizedKeyLabels.keys() else key.lower() for key in keyCombination.split("+"))

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -1,6 +1,6 @@
 #scriptHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2008 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2016 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -17,6 +17,7 @@ from logHandler import log
 import inputCore
 import globalPluginHandler
 import braille
+import keyLabels
 
 _numScriptsQueued=0 #Number of scripts that are queued to be executed
 #: Number of scripts that send their gestures on that are queued to be executed or are currently being executed.
@@ -35,7 +36,7 @@ def _makeKbEmulateScript(scriptName):
 		# __name__ must be str; i.e. can't be unicode.
 		scriptName = scriptName.encode("mbcs")
 	func.__name__ = "script_%s" % scriptName
-	func.__doc__ = _("Emulates pressing %s on the system keyboard") % keyName
+	func.__doc__ = _("Emulates pressing %s on the system keyboard") % keyLabels.getKeyCombinationLabel(keyName)
 	return func
 
 def _getObjScript(obj, gesture, globalMapScripts):

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -36,7 +36,7 @@ def _makeKbEmulateScript(scriptName):
 		# __name__ must be str; i.e. can't be unicode.
 		scriptName = scriptName.encode("mbcs")
 	func.__name__ = "script_%s" % scriptName
-	func.__doc__ = _("Emulates pressing %s on the system keyboard") % keyLabels.getKeyCombinationLabel(keyName)
+	func.__doc__ = _("Emulates pressing %s on the system keyboard") % emuGesture.displayName
 	return func
 
 def _getObjScript(obj, gesture, globalMapScripts):


### PR DESCRIPTION
This pull request includes the following:

```
* In keyboard help for emulated system keyboard keys, the translated version of a key is now spoken instead of the raw, untranslated version
* Also, the script name for emulated system keyboard keys is now localized
```

Both changes are based on a new simple function in keyLabels in which you insert a raw key combination string, which is than converted to a localised key combination identifier.
Fixes #6212.

What's New entry: in Bug fixes:

```
- Emulated system keyboard keys (e.g. a button on a braille display which emulates pressing the tab key) are now presented in the configured NVDA language in input help and the Input Gestures dialog. Previously, they were always presented in English. (#6212)
```
