### PR TITLE
added an @script decorator for setting script metadata to the scriptH…

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -138,8 +138,6 @@ class GestureCollector(AutoPropertyType):
 			if not name.startswith('script_'):
 				continue
 			scriptName = name[7:]
-			if hasattr(script, 'gesture'):
-				gestures[script.gesture] = scriptName
 			if hasattr(script, 'gestures'):
 				for gesture in script.gestures:
 					gestures[gesture] = scriptName

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -123,6 +123,29 @@ class AutoPropertyObject(object):
 		for instance in cls.__instances.keys():
 			instance.invalidateCache()
 
+class GestureCollector(AutoPropertyType):
+	"""A metaclass used for collecting and caching gestures on a ScriptableObject"""
+
+	def __new__(meta, name, bases, dct):
+		gestures = {}
+		cls = super(GestureCollector, meta).__new__(meta, name, bases, dct)
+		for i in reversed(cls.__mro__):
+			try:
+				gestures.update(getattr(i, "_%s__gestures" % i.__name__))
+			except AttributeError:
+				pass
+		for name, script in dct.iteritems():
+			if not name.startswith('script_'):
+				continue
+			scriptName = name[7:]
+			if hasattr(script, 'gesture'):
+				gestures[script.gesture] = scriptName
+			if hasattr(script, 'gestures'):
+				for gesture in script.gestures:
+					gestures[gesture] = scriptName
+		cls._gestures = gestures
+		return cls
+
 class ScriptableObject(AutoPropertyObject):
 	"""A class that implements NVDA's scripting interface.
 	Input gestures are bound to scripts such that the script will be executed when the appropriate input gesture is received.
@@ -138,16 +161,14 @@ class ScriptableObject(AutoPropertyObject):
 	@type scriptCategory: basestring
 	"""
 
+	__metaclass__ = GestureCollector
+
 	def __init__(self):
 		#: Maps input gestures to script functions.
 		#: @type: dict
 		self._gestureMap = {}
 		# Bind gestures specified on the class.
-		for cls in reversed(self.__class__.__mro__):
-			try:
-				self.bindGestures(getattr(cls, "_%s__gestures" % cls.__name__))
-			except AttributeError:
-				pass
+		self.bindGestures(self._gestures)
 		super(ScriptableObject, self).__init__()
 
 	def bindGesture(self, gestureIdentifier, scriptName):
@@ -217,6 +238,10 @@ class ScriptableObject(AutoPropertyObject):
 				continue
 		else:
 			return None
+
+	def getScripts(self):
+		"""return a list of all scripts on this object"""
+		return self._scripts
 
 	#: A value for sleepMode which indicates that NVDA should fully sleep for this object;
 	#: i.e. braille and speech via NVDA controller client is disabled and the user cannot disable sleep mode.

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -237,10 +237,6 @@ class ScriptableObject(AutoPropertyObject):
 		else:
 			return None
 
-	def getScripts(self):
-		"""return a list of all scripts on this object"""
-		return self._scripts
-
 	#: A value for sleepMode which indicates that NVDA should fully sleep for this object;
 	#: i.e. braille and speech via NVDA controller client is disabled and the user cannot disable sleep mode.
 	SLEEP_FULL = "full"

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -230,3 +230,29 @@ def isCurrentScript(scriptFunc):
 		return False
 	return givenFunc==realFunc
 
+def script(description="", category=None, gesture=None, gestures=None):
+	"""Define metadata for a script.
+	This function is to be used as a decorator to set metadata used by the scripting system and gesture editor.
+	@param description: A short translatable description of the script to be used in the gesture editor, etc.
+	@type description: string 
+	@param category: The category of the script displayed in the gesture editor.
+	@type category: string
+	@param gesture: A gesture associated with this script
+	@type gesture: string
+	@param gestures: A list of gestures associated with this script
+@type gestures: list(string)
+	"""
+	if gestures is None:
+		gestures = []
+	def script_decorator(decoratedScript):
+		decoratedScript.__doc__ = description
+		if category is not None:
+			decoratedScript.category = category
+		if gesture is not None:
+			decoratedScript.gesture = gesture
+		if gestures:
+			decoratedScript.gestures = gestures
+		return decoratedScript
+	return script_decorator
+
+

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -249,7 +249,7 @@ def script(description="", category=None, gesture=None, gestures=None):
 		if category is not None:
 			decoratedScript.category = category
 		if gesture is not None:
-			decoratedScript.gesture = gesture
+			gestures.append(gesture)
 		if gestures:
 			decoratedScript.gestures = gestures
 		return decoratedScript


### PR DESCRIPTION
…andler module

This necessitated a change to the base ScriptableObject class, as now it has to check its methods fore defined gestures.
I added getGestures and getScripts to the ScriptableObject public API, as they are used in the constructor and seemed useful, though I can make these methods private if it is demed preferable.
Fixes #6266
