### PR TITLE
AppModuleHandler: Handle apps where a dot is in the middle of an executable name. re #5323

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -108,10 +108,8 @@ def getAppModuleFromProcessID(processID):
 	with _getAppModuleLock:
 		mod=runningTable.get(processID)
 		if not mod:
-			appName=getAppNameFromProcessID(processID)
-			# #5323: Certain executables contain dots as part of its file name.
-			if "." in appName:
-				appName = appName.replace(".","_")
+			# #5323: Certain executables contain dots as part of their file names.
+			appName=getAppNameFromProcessID(processID).replace(".","_")
 			mod=fetchAppModule(processID,appName)
 			if not mod:
 				raise RuntimeError("error fetching default appModule")

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #appModuleHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2014 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda
+#Copyright (C) 2006-2016 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -109,6 +109,9 @@ def getAppModuleFromProcessID(processID):
 		mod=runningTable.get(processID)
 		if not mod:
 			appName=getAppNameFromProcessID(processID)
+			# #5323: Certain executables contain dots as part of its file name.
+			if "." in appName:
+				appName = appName.replace(".","_")
 			mod=fetchAppModule(processID,appName)
 			if not mod:
 				raise RuntimeError("error fetching default appModule")


### PR DESCRIPTION
To avoid module lookup issue, a 'dot' (.) is replaced by an underscore (_).

Fixes #5323.
