### PR TITLE
Fix gui alignment issues

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -689,32 +689,30 @@ class ElementsListDialog(wx.Dialog):
 		contentsSizer.Add(self.tree,flag=wx.EXPAND)
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of an editable text field to filter the elements
 		# in the browse mode Elements List dialog.
-		label = wx.StaticText(self, wx.ID_ANY, _("&Filter by:"))
-		self.filterEdit = wx.TextCtrl(self, wx.ID_ANY)
+		filterText = _("&Filter by:")
+		labeledCtrl = gui.guiHelper.LabeledControlHelper(self, filterText, wx.TextCtrl)
+		self.filterEdit = labeledCtrl.control
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)
-		gui.guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.filterEdit)
-		contentsSizer.Add(sizer)
+		contentsSizer.Add(labeledCtrl.sizer)
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		bHelper = gui.guiHelper.ButtonHelper(wx.HORIZONTAL)
 		# Translators: The label of a button to activate an element
 		# in the browse mode Elements List dialog.
-		self.activateButton = wx.Button(self, wx.ID_ANY, _("&Activate"))
+		self.activateButton = bHelper.addButton(self, label=_("&Activate"))
 		self.activateButton.Bind(wx.EVT_BUTTON, lambda evt: self.onAction(True))
-		buttonsToAdd = [self.activateButton,]
+		
 		# Translators: The label of a button to move to an element
 		# in the browse mode Elements List dialog.
-		self.moveButton = wx.Button(self, wx.ID_ANY, _("&Move to"))
+		self.moveButton = bHelper.addButton(self, label=_("&Move to"))
 		self.moveButton.Bind(wx.EVT_BUTTON, lambda evt: self.onAction(False))
-		buttonsToAdd.append(self.moveButton)
-		buttonsToAdd.append(wx.Button(self, wx.ID_CANCEL))
-		gui.guiHelper.addItemsToSizer(sizer, buttonsToAdd, gui.guiHelper.SPACE_BETWEEN_BUTTONS)
-		gui.guiHelper.addButtonsSizerToMainSizer(contentsSizer, sizer)
+		bHelper.addButton(self, id=wx.ID_CANCEL)
 
-		gui.guiHelper.addAllContentSizerToMainSizer(mainSizer, contentsSizer)
+		contentsSizer.Add(bHelper.sizer)
+
+		mainSizer.Add(contentsSizer, border=gui.guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -29,6 +29,7 @@ import sayAllHandler
 import treeInterceptorHandler
 import inputCore
 import api
+import gui.guiHelper
 from NVDAObjects import NVDAObject
 
 REASON_QUICKNAV = "quickNav"
@@ -669,46 +670,51 @@ class ElementsListDialog(wx.Dialog):
 		# Translators: The title of the browse mode Elements List dialog.
 		super(ElementsListDialog, self).__init__(gui.mainFrame, wx.ID_ANY, _("Elements List"))
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		contentsSizer = wx.BoxSizer(wx.VERTICAL)
 
 		# Translators: The label of a group of radio buttons to select the type of element
 		# in the browse mode Elements List dialog.
 		child = wx.RadioBox(self, wx.ID_ANY, label=_("Type:"), choices=tuple(et[1] for et in self.ELEMENT_TYPES))
 		child.SetSelection(self.lastSelectedElementType)
 		child.Bind(wx.EVT_RADIOBOX, self.onElementTypeChange)
-		mainSizer.Add(child,proportion=1)
+		contentsSizer.Add(child, flag=wx.EXPAND)
+		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
-		self.tree = wx.TreeCtrl(self, wx.ID_ANY, style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE | wx.TR_EDIT_LABELS)
+		self.tree = wx.TreeCtrl(self, size=wx.Size(500, 600), style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE | wx.TR_EDIT_LABELS)
 		self.tree.Bind(wx.EVT_SET_FOCUS, self.onTreeSetFocus)
 		self.tree.Bind(wx.EVT_CHAR, self.onTreeChar)
 		self.tree.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.onTreeLabelEditBegin)
 		self.tree.Bind(wx.EVT_TREE_END_LABEL_EDIT, self.onTreeLabelEditEnd)
 		self.treeRoot = self.tree.AddRoot("root")
-		mainSizer.Add(self.tree,proportion=7,flag=wx.EXPAND)
+		contentsSizer.Add(self.tree,flag=wx.EXPAND)
+		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of an editable text field to filter the elements
 		# in the browse mode Elements List dialog.
 		label = wx.StaticText(self, wx.ID_ANY, _("&Filter by:"))
-		sizer.Add(label)
 		self.filterEdit = wx.TextCtrl(self, wx.ID_ANY)
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)
-		sizer.Add(self.filterEdit)
-		mainSizer.Add(sizer,proportion=1)
+		gui.guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.filterEdit)
+		contentsSizer.Add(sizer)
+		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a button to activate an element
 		# in the browse mode Elements List dialog.
 		self.activateButton = wx.Button(self, wx.ID_ANY, _("&Activate"))
 		self.activateButton.Bind(wx.EVT_BUTTON, lambda evt: self.onAction(True))
-		sizer.Add(self.activateButton)
+		buttonsToAdd = [self.activateButton,]
 		# Translators: The label of a button to move to an element
 		# in the browse mode Elements List dialog.
 		self.moveButton = wx.Button(self, wx.ID_ANY, _("&Move to"))
 		self.moveButton.Bind(wx.EVT_BUTTON, lambda evt: self.onAction(False))
-		sizer.Add(self.moveButton)
-		sizer.Add(wx.Button(self, wx.ID_CANCEL))
-		mainSizer.Add(sizer,proportion=1)
+		buttonsToAdd.append(self.moveButton)
+		buttonsToAdd.append(wx.Button(self, wx.ID_CANCEL))
+		gui.guiHelper.addItemsToSizer(sizer, buttonsToAdd, gui.guiHelper.SPACE_BETWEEN_BUTTONS)
+		gui.guiHelper.addButtonsSizerToMainSizer(contentsSizer, sizer)
 
+		gui.guiHelper.addAllContentSizerToMainSizer(mainSizer, contentsSizer)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -677,7 +677,7 @@ class ElementsListDialog(wx.Dialog):
 		child.Bind(wx.EVT_RADIOBOX, self.onElementTypeChange)
 		mainSizer.Add(child,proportion=1)
 
-		self.tree = wx.TreeCtrl(self, wx.ID_ANY, style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_SINGLE | wx.TR_EDIT_LABELS)
+		self.tree = wx.TreeCtrl(self, wx.ID_ANY, style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE | wx.TR_EDIT_LABELS)
 		self.tree.Bind(wx.EVT_SET_FOCUS, self.onTreeSetFocus)
 		self.tree.Bind(wx.EVT_CHAR, self.onTreeChar)
 		self.tree.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.onTreeLabelEditBegin)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -718,7 +718,7 @@ class ExitDialog(wx.Dialog):
 		actionSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for actions list in the Exit dialog.
 		actionsLabel=wx.StaticText(self,-1,label=_("What would you like to &do?"))
-		actionSizer.Add(actionsLabel)
+		actionSizer.Add(actionsLabel,border=10,flag=wx.RIGHT|wx.ALIGN_CENTER_VERTICAL)
 		actionsListID=wx.NewId()
 		self.actions = [
 		# Translators: An option in the combo box to choose exit action.
@@ -730,9 +730,9 @@ class ExitDialog(wx.Dialog):
 		self.actionsList=wx.Choice(self,actionsListID,choices=self.actions)
 		self.actionsList.SetSelection(0)
 		actionSizer.Add(self.actionsList)
-		mainSizer.Add(actionSizer,border=10,flag=wx.CENTER)
+		mainSizer.Add(actionSizer,border=10,flag=wx.ALL)
 
-		mainSizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		mainSizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), border=5, flag=wx.ALL)
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
 		mainSizer.Fit(self)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -626,20 +626,22 @@ class LauncherDialog(wx.Dialog):
 	def __init__(self, parent):
 		super(LauncherDialog, self).__init__(parent, title=versionInfo.name)
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		# Translators: The label of the license text which will be shown when NVDA installation program starts.
-		sizer = wx.StaticBoxSizer(wx.StaticBox(self, label=_("License Agreement")), wx.VERTICAL)
-		ctrl = wx.TextCtrl(self, size=(500, 400), style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH)
-		ctrl.Value = codecs.open(getDocFilePath("copying.txt", False), "r", encoding="UTF-8").read()
-		sizer.Add(ctrl)
-		# Translators: The label for a checkbox in NvDA installation program to agree to the license agreement.
-		ctrl = self.licenseAgreeCheckbox = wx.CheckBox(self, label=_("I &agree"))
-		ctrl.Value = False
-		sizer.Add(ctrl)
-		ctrl.Bind(wx.EVT_CHECKBOX, self.onLicenseAgree)
-		mainSizer.Add(sizer)
+		groupLabel = _("License Agreement")
+		sizer = sHelper.addItem(wx.StaticBoxSizer(wx.StaticBox(self, label=groupLabel), wx.VERTICAL))
+		licenseTextCtrl = wx.TextCtrl(self, size=(500, 400), style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH)
+		licenseTextCtrl.Value = codecs.open(getDocFilePath("copying.txt", False), "r", encoding="UTF-8").read()
+		sizer.Add(licenseTextCtrl)
 
-		sizer = wx.GridSizer(rows=2, cols=2)
+		# Translators: The label for a checkbox in NvDA installation program to agree to the license agreement.
+		agreeText = _("I &agree")
+		self.licenseAgreeCheckbox = sHelper.addItem(wx.CheckBox(self, label=agreeText))
+		self.licenseAgreeCheckbox.Value = False
+		self.licenseAgreeCheckbox.Bind(wx.EVT_CHECKBOX, self.onLicenseAgree)
+
+		sizer = sHelper.addItem(wx.GridSizer(rows=2, cols=2))
 		self.actionButtons = []
 		# Translators: The label of the button in NVDA installation program to install NvDA on the user's computer.
 		ctrl = wx.Button(self, label=_("&Install NVDA on this computer"))
@@ -659,10 +661,11 @@ class LauncherDialog(wx.Dialog):
 		sizer.Add(wx.Button(self, label=_("E&xit"), id=wx.ID_CANCEL))
 		# If we bind this on the button, it fails to trigger when the dialog is closed.
 		self.Bind(wx.EVT_BUTTON, self.onExit, id=wx.ID_CANCEL)
-		mainSizer.Add(sizer)
+
 		for ctrl in self.actionButtons:
 			ctrl.Disable()
 
+		mainSizer.Add(sHelper.sizer, border = guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -713,12 +713,13 @@ class ExitDialog(wx.Dialog):
 		dialog = self
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 
-		contentSizerHelper = guiHelper.BoxSizerHelper(wx.VERTICAL)
+		contentSizerHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		if globalVars.appArgs.disableAddons:
 			# Translators: A message in the exit Dialog shown when all add-ons are disabled.
 			addonsDisabledText = _("All add-ons are now disabled. They will be re-enabled on the next restart unless you choose to disable them again.")
 			addonsDisabledLabel=wx.StaticText(self, wx.ID_ANY, label=addonsDisabledText)
+			# RTU test here....
 			mainSizer.Add(addonsDisabledLabel)
 
 		# Translators: The label for actions list in the Exit dialog.
@@ -730,12 +731,10 @@ class ExitDialog(wx.Dialog):
 		_("Restart"),
 		# Translators: An option in the combo box to choose exit action.
 		_("Restart with add-ons disabled")]
-		labeledActionList = guiHelper.LabeledControlHelper(dialog, labelText, wx.Choice, choices=self.actions)
-		self.actionsList=labeledActionList.control
+		self.actionsList = contentSizerHelper.addLabeledControl(labelText, wx.Choice, choices=self.actions)
 		self.actionsList.SetSelection(0)
-		contentSizerHelper.addAutoSpacedItem(labeledActionList)
 
-		contentSizerHelper.addAutoSpacedItem( self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		contentSizerHelper.addItem( self.CreateButtonSizer(wx.OK | wx.CANCEL))
 
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -710,7 +710,10 @@ class ExitDialog(wx.Dialog):
 		ExitDialog._instance = weakref.ref(self)
 		# Translators: The title of the dialog to exit NVDA
 		super(ExitDialog, self).__init__(parent, title=_("Exit NVDA"))
+		dialog = self
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
+
+		contentSizerHelper = guiHelper.BoxSizerHelper(wx.VERTICAL)
 
 		if globalVars.appArgs.disableAddons:
 			# Translators: A message in the exit Dialog shown when all add-ons are disabled.
@@ -718,10 +721,8 @@ class ExitDialog(wx.Dialog):
 			addonsDisabledLabel=wx.StaticText(self, wx.ID_ANY, label=addonsDisabledText)
 			mainSizer.Add(addonsDisabledLabel)
 
-		actionSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for actions list in the Exit dialog.
-		actionsLabel=wx.StaticText(self,wx.ID_ANY,label=_("What would you like to &do?"))
-		actionsListID=wx.NewId()
+		labelText=_("What would you like to &do?")
 		self.actions = [
 		# Translators: An option in the combo box to choose exit action.
 		_("Exit"),
@@ -729,15 +730,17 @@ class ExitDialog(wx.Dialog):
 		_("Restart"),
 		# Translators: An option in the combo box to choose exit action.
 		_("Restart with add-ons disabled")]
-		self.actionsList=wx.Choice(self,actionsListID,choices=self.actions)
+		labeledActionList = guiHelper.LabeledControlHelper(dialog, labelText, wx.Choice, choices=self.actions)
+		self.actionsList=labeledActionList.control
 		self.actionsList.SetSelection(0)
+		contentSizerHelper.addAutoSpacedItem(labeledActionList)
 
-		guiHelper.addLabelAndControlToHorizontalSizer(actionSizer, actionsLabel, self.actionsList)
-		guiHelper.addAllContentSizerToMainSizer(mainSizer, actionSizer)
-		guiHelper.addButtonsSizerToMainSizer(mainSizer, self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		contentSizerHelper.addAutoSpacedItem( self.CreateButtonSizer(wx.OK | wx.CANCEL))
 
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
+
+		mainSizer.Add(contentSizerHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.Sizer = mainSizer
 		self.actionsList.SetFocus()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -29,6 +29,8 @@ import logViewer
 import speechViewer
 import winUser
 import api
+import guiHelper
+
 try:
 	import updateCheck
 except RuntimeError:
@@ -712,13 +714,13 @@ class ExitDialog(wx.Dialog):
 
 		if globalVars.appArgs.disableAddons:
 			# Translators: A message in the exit Dialog shown when all add-ons are disabled.
-			addonsDisabledLabel=wx.StaticText(self,-1,label=_("All add-ons are now disabled. They will be re-enabled on the next restart unless you choose to disable them again."))
+			addonsDisabledText = _("All add-ons are now disabled. They will be re-enabled on the next restart unless you choose to disable them again.")
+			addonsDisabledLabel=wx.StaticText(self, wx.ID_ANY, label=addonsDisabledText)
 			mainSizer.Add(addonsDisabledLabel)
 
 		actionSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for actions list in the Exit dialog.
-		actionsLabel=wx.StaticText(self,-1,label=_("What would you like to &do?"))
-		actionSizer.Add(actionsLabel,border=10,flag=wx.RIGHT|wx.ALIGN_CENTER_VERTICAL)
+		actionsLabel=wx.StaticText(self,wx.ID_ANY,label=_("What would you like to &do?"))
 		actionsListID=wx.NewId()
 		self.actions = [
 		# Translators: An option in the combo box to choose exit action.
@@ -729,10 +731,11 @@ class ExitDialog(wx.Dialog):
 		_("Restart with add-ons disabled")]
 		self.actionsList=wx.Choice(self,actionsListID,choices=self.actions)
 		self.actionsList.SetSelection(0)
-		actionSizer.Add(self.actionsList)
-		mainSizer.Add(actionSizer,border=10,flag=wx.ALL)
 
-		mainSizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), border=5, flag=wx.ALL)
+		guiHelper.addLabelAndControlToHorizontalSizer(actionSizer, actionsLabel, self.actionsList)
+		guiHelper.addAllContentSizerToMainSizer(mainSizer, actionSizer)
+		guiHelper.addButtonsSizerToMainSizer(mainSizer, self.CreateButtonSizer(wx.OK | wx.CANCEL))
+
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
 		mainSizer.Fit(self)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -718,9 +718,7 @@ class ExitDialog(wx.Dialog):
 		if globalVars.appArgs.disableAddons:
 			# Translators: A message in the exit Dialog shown when all add-ons are disabled.
 			addonsDisabledText = _("All add-ons are now disabled. They will be re-enabled on the next restart unless you choose to disable them again.")
-			addonsDisabledLabel=wx.StaticText(self, wx.ID_ANY, label=addonsDisabledText)
-			# RTU test here....
-			mainSizer.Add(addonsDisabledLabel)
+			contentSizerHelper.addItem(wx.StaticText(self, wx.ID_ANY, label=addonsDisabledText))
 
 		# Translators: The label for actions list in the Exit dialog.
 		labelText=_("What would you like to &do?")

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -378,10 +378,11 @@ class NewProfileDialog(wx.Dialog):
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a field to enter the name of a new configuration profile.
-		sizer.Add(wx.StaticText(self, label=_("Profile name:")))
+		sizer.Add(wx.StaticText(self, label=_("Profile name:")), flag=wx.ALIGN_CENTER_VERTICAL)
+		sizer.AddSpacer(5)
 		item = self.profileName = wx.TextCtrl(self)
 		sizer.Add(item)
-		mainSizer.Add(sizer)
+		mainSizer.Add(sizer, border=10, flag=wx.ALL)
 
 		# Translators: The label of a radio button to specify that a profile will be used for manual activation
 		# in the new configuration profile dialog.
@@ -392,9 +393,9 @@ class NewProfileDialog(wx.Dialog):
 		item.Bind(wx.EVT_RADIOBOX, self.onTriggerChoice)
 		self.autoProfileName = ""
 		self.onTriggerChoice(None)
-		mainSizer.Add(item)
+		mainSizer.Add(item, border=5, flag=wx.ALL)
 
-		mainSizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		mainSizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), border=5, flag=wx.ALL)
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
 		mainSizer.Fit(self)

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -34,35 +34,45 @@ class ProfilesDialog(wx.Dialog):
 		self.profileNames = [None]
 		self.profileNames.extend(config.conf.listProfiles())
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
-		# Translators: The label of the profile list in the Configuration Profiles dialog.
-		sizer.Add(wx.StaticText(self, label=_("&Profile")))
+		# Translators: The label of the profiles group in the Configuration Profiles dialog.
+		profilesListGroupSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("&Profiles")), wx.HORIZONTAL)
+
+		sizer = wx.BoxSizer(wx.VERTICAL)
 		item = self.profileList = wx.ListBox(self,
 			choices=[self.getProfileDisplay(name, includeStates=True) for name in self.profileNames])
 		item.Bind(wx.EVT_LISTBOX, self.onProfileListChoice)
 		item.Selection = self.profileNames.index(config.conf.profiles[-1].name)
-		sizer.Add(item)
-		mainSizer.Add(sizer)
+		sizer.Add(item, proportion=1.0)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		spaceBetweenButtons = 3
 		item = self.changeStateButton = wx.Button(self)
 		item.Bind(wx.EVT_BUTTON, self.onChangeState)
-		sizer.Add(item)
 		self.AffirmativeId = item.Id
 		item.SetDefault()
+		sizer.AddSpacer(spaceBetweenButtons)
+		sizer.Add(item)
+
+		profilesListGroupSizer.Add(sizer, flag = wx.EXPAND)
+		profilesListGroupSizer.AddSpacer(5)
+
+		sizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: The label of a button to create a new configuration profile.
 		item = newButton = wx.Button(self, label=_("&New"))
 		item.Bind(wx.EVT_BUTTON, self.onNew)
 		sizer.Add(item)
+		sizer.AddSpacer(spaceBetweenButtons)
 		# Translators: The label of a button to rename a configuration profile.
 		item = self.renameButton = wx.Button(self, label=_("&Rename"))
 		item.Bind(wx.EVT_BUTTON, self.onRename)
 		sizer.Add(item)
+		sizer.AddSpacer(spaceBetweenButtons)
 		# Translators: The label of a button to delete a configuration profile.
 		item = self.deleteButton = wx.Button(self, label=_("&Delete"))
 		item.Bind(wx.EVT_BUTTON, self.onDelete)
 		sizer.Add(item)
-		mainSizer.Add(sizer)
+		profilesListGroupSizer.Add(sizer)
+
+		mainSizer.Add(profilesListGroupSizer, flag=wx.ALL, border=5)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a button to manage triggers
@@ -71,16 +81,17 @@ class ProfilesDialog(wx.Dialog):
 		triggersButton = wx.Button(self, label=_("&Triggers..."))
 		triggersButton.Bind(wx.EVT_BUTTON, self.onTriggers)
 		sizer.Add(triggersButton)
+		sizer.AddSpacer(5)
 		# Translators: The label of a checkbox in the Configuration Profiles dialog.
 		item = self.disableTriggersToggle = wx.CheckBox(self, label=_("Temporarily d&isable all triggers"))
 		item.Value = not config.conf.profileTriggersEnabled
-		sizer.Add(item)
-		mainSizer.Add(sizer)
+		sizer.Add(item, flag=wx.ALIGN_CENTER_VERTICAL)
+		mainSizer.Add(sizer, flag=wx.ALL, border=10)
 
 		# Translators: The label of a button to close a dialog.
 		item = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
 		item.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		mainSizer.Add(item)
+		mainSizer.Add(item, flag=wx.ALL, border=10)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.EscapeId = wx.ID_CLOSE
 

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -47,7 +47,7 @@ class ProfilesDialog(wx.Dialog):
 		item.Selection = self.profileNames.index(config.conf.profiles[-1].name)
 		changeProfilesSizer.Add(item, proportion=1.0)
 
-		changeProfilesSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICALLY)
+		changeProfilesSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICAL)
 
 		self.changeStateButton = wx.Button(self)
 		self.changeStateButton.Bind(wx.EVT_BUTTON, self.onChangeState)
@@ -371,29 +371,28 @@ class NewProfileDialog(wx.Dialog):
 		# Translators: The title of the dialog to create a new configuration profile.
 		super(NewProfileDialog, self).__init__(parent, title=_("New Profile"))
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a field to enter the name of a new configuration profile.
-		sizer.Add(wx.StaticText(self, label=_("Profile name:")), flag=wx.ALIGN_CENTER_VERTICAL)
-		sizer.AddSpacer(5)
-		item = self.profileName = wx.TextCtrl(self)
-		sizer.Add(item)
-		mainSizer.Add(sizer, border=10, flag=wx.ALL)
+		profileNameText = _("Profile name:")
+		self.profileName = sHelper.addLabeledControl(profileNameText, wx.TextCtrl)
 
 		# Translators: The label of a radio button to specify that a profile will be used for manual activation
 		# in the new configuration profile dialog.
 		self.triggers = triggers = [(None, _("Manual activation"), True)]
 		triggers.extend(parent.getSimpleTriggers())
-		item = self.triggerChoice = wx.RadioBox(self, label=_("Use this profile for:"),
-			choices=[trig[1] for trig in triggers])
-		item.Bind(wx.EVT_RADIOBOX, self.onTriggerChoice)
+		self.triggerChoice = sHelper.addItem(wx.RadioBox(self, label=_("Use this profile for:"),
+			choices=[trig[1] for trig in triggers]))
+		self.triggerChoice.Bind(wx.EVT_RADIOBOX, self.onTriggerChoice)
 		self.autoProfileName = ""
 		self.onTriggerChoice(None)
-		mainSizer.Add(item, border=5, flag=wx.ALL)
 
-		mainSizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), border=5, flag=wx.ALL)
+		sHelper.addItem(self.CreateButtonSizer(wx.OK | wx.CANCEL))
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
+
+		mainSizer.Add(sHelper.sizer, border = guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.Sizer = mainSizer
 		self.profileName.SetFocus()

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -11,6 +11,7 @@ import gui
 from logHandler import log
 import appModuleHandler
 import globalVars
+import guiHelper
 
 class ProfilesDialog(wx.Dialog):
 	shouldSuspendConfigProfileTriggers = True
@@ -34,8 +35,7 @@ class ProfilesDialog(wx.Dialog):
 		self.profileNames = [None]
 		self.profileNames.extend(config.conf.listProfiles())
 
-		# Translators: The label of the profiles group in the Configuration Profiles dialog.
-		profilesListGroupSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("&Profiles")), wx.HORIZONTAL)
+		profilesListGroupSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY), wx.HORIZONTAL)
 
 		sizer = wx.BoxSizer(wx.VERTICAL)
 		item = self.profileList = wx.ListBox(self,
@@ -44,33 +44,35 @@ class ProfilesDialog(wx.Dialog):
 		item.Selection = self.profileNames.index(config.conf.profiles[-1].name)
 		sizer.Add(item, proportion=1.0)
 
-		spaceBetweenButtons = 3
+		spaceBetweenItemsInGroupSizer = 5
+		profilesListGroupSizer.Add(sizer, border=spaceBetweenItemsInGroupSizer, flag = wx.EXPAND | wx.ALL)
+
 		item = self.changeStateButton = wx.Button(self)
 		item.Bind(wx.EVT_BUTTON, self.onChangeState)
 		self.AffirmativeId = item.Id
 		item.SetDefault()
-		sizer.AddSpacer(spaceBetweenButtons)
+		sizer.AddSpacer(spaceBetweenItemsInGroupSizer)	
 		sizer.Add(item)
-
-		profilesListGroupSizer.Add(sizer, flag = wx.EXPAND)
-		profilesListGroupSizer.AddSpacer(5)
 
 		sizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: The label of a button to create a new configuration profile.
 		item = newButton = wx.Button(self, label=_("&New"))
 		item.Bind(wx.EVT_BUTTON, self.onNew)
-		sizer.Add(item)
-		sizer.AddSpacer(spaceBetweenButtons)
+		buttonsToAdd = [item,]
+
 		# Translators: The label of a button to rename a configuration profile.
 		item = self.renameButton = wx.Button(self, label=_("&Rename"))
 		item.Bind(wx.EVT_BUTTON, self.onRename)
-		sizer.Add(item)
-		sizer.AddSpacer(spaceBetweenButtons)
+		buttonsToAdd.append(item)
+
 		# Translators: The label of a button to delete a configuration profile.
 		item = self.deleteButton = wx.Button(self, label=_("&Delete"))
 		item.Bind(wx.EVT_BUTTON, self.onDelete)
-		sizer.Add(item)
-		profilesListGroupSizer.Add(sizer)
+		buttonsToAdd.append(item)
+		# these buttons are closely related, and are stacked vertically. They look better closer together
+		spaceBetweenButtons = 3
+		guiHelper.addItemsToSizer(sizer, buttonsToAdd, spaceBetweenButtons)
+		profilesListGroupSizer.Add(sizer, border=spaceBetweenItemsInGroupSizer, flag = wx.ALL)
 
 		mainSizer.Add(profilesListGroupSizer, flag=wx.ALL, border=5)
 

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -29,71 +29,67 @@ class ProfilesDialog(wx.Dialog):
 		ProfilesDialog._instance = self
 		# Translators: The title of the Configuration Profiles dialog.
 		super(ProfilesDialog, self).__init__(parent, title=_("Configuration Profiles"))
-		mainSizer = wx.BoxSizer(wx.VERTICAL)
 
 		self.currentAppName = (gui.mainFrame.prevFocus or api.getFocusObject()).appModule.appName
 		self.profileNames = [None]
 		self.profileNames.extend(config.conf.listProfiles())
 
-		profilesListGroupSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY), wx.HORIZONTAL)
+		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self,orientation=wx.VERTICAL)
+		profilesListGroupSizer = wx.StaticBoxSizer(wx.StaticBox(self), wx.HORIZONTAL)
+		profilesListGroupContents = wx.BoxSizer(wx.HORIZONTAL)
 
-		sizer = wx.BoxSizer(wx.VERTICAL)
+		#contains the profile list and activation button in vertical arrangement.
+		changeProfilesSizer = wx.BoxSizer(wx.VERTICAL)
 		item = self.profileList = wx.ListBox(self,
 			choices=[self.getProfileDisplay(name, includeStates=True) for name in self.profileNames])
 		item.Bind(wx.EVT_LISTBOX, self.onProfileListChoice)
 		item.Selection = self.profileNames.index(config.conf.profiles[-1].name)
-		sizer.Add(item, proportion=1.0)
+		changeProfilesSizer.Add(item, proportion=1.0)
 
-		spaceBetweenItemsInGroupSizer = 5
-		profilesListGroupSizer.Add(sizer, border=spaceBetweenItemsInGroupSizer, flag = wx.EXPAND | wx.ALL)
+		changeProfilesSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICALLY)
 
-		item = self.changeStateButton = wx.Button(self)
-		item.Bind(wx.EVT_BUTTON, self.onChangeState)
-		self.AffirmativeId = item.Id
-		item.SetDefault()
-		sizer.AddSpacer(spaceBetweenItemsInGroupSizer)	
-		sizer.Add(item)
+		self.changeStateButton = wx.Button(self)
+		self.changeStateButton.Bind(wx.EVT_BUTTON, self.onChangeState)
+		self.AffirmativeId = self.changeStateButton.Id
+		self.changeStateButton.SetDefault()
+		changeProfilesSizer.Add(self.changeStateButton)
+		
+		profilesListGroupContents.Add(changeProfilesSizer, flag = wx.EXPAND)
+		profilesListGroupContents.AddSpacer(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
 
-		sizer = wx.BoxSizer(wx.VERTICAL)
+		buttonHelper = guiHelper.ButtonHelper(wx.VERTICAL)
 		# Translators: The label of a button to create a new configuration profile.
-		item = newButton = wx.Button(self, label=_("&New"))
-		item.Bind(wx.EVT_BUTTON, self.onNew)
-		buttonsToAdd = [item,]
+		newButton = buttonHelper.addButton(self, label=_("&New"))
+		newButton.Bind(wx.EVT_BUTTON, self.onNew)
 
 		# Translators: The label of a button to rename a configuration profile.
-		item = self.renameButton = wx.Button(self, label=_("&Rename"))
-		item.Bind(wx.EVT_BUTTON, self.onRename)
-		buttonsToAdd.append(item)
+		self.renameButton = buttonHelper.addButton(self, label=_("&Rename"))
+		self.renameButton.Bind(wx.EVT_BUTTON, self.onRename)
 
 		# Translators: The label of a button to delete a configuration profile.
-		item = self.deleteButton = wx.Button(self, label=_("&Delete"))
-		item.Bind(wx.EVT_BUTTON, self.onDelete)
-		buttonsToAdd.append(item)
-		# these buttons are closely related, and are stacked vertically. They look better closer together
-		spaceBetweenButtons = 3
-		guiHelper.addItemsToSizer(sizer, buttonsToAdd, spaceBetweenButtons)
-		profilesListGroupSizer.Add(sizer, border=spaceBetweenItemsInGroupSizer, flag = wx.ALL)
+		self.deleteButton = buttonHelper.addButton(self, label=_("&Delete"))
+		self.deleteButton.Bind(wx.EVT_BUTTON, self.onDelete)
 
-		mainSizer.Add(profilesListGroupSizer, flag=wx.ALL, border=5)
+		profilesListGroupContents.Add(buttonHelper.sizer)
+		profilesListGroupSizer.Add(profilesListGroupContents, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
+		sHelper.addItem(profilesListGroupSizer)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a button to manage triggers
 		# in the Configuration Profiles dialog.
 		# See the Configuration Profiles section of the User Guide for details.
 		triggersButton = wx.Button(self, label=_("&Triggers..."))
 		triggersButton.Bind(wx.EVT_BUTTON, self.onTriggers)
-		sizer.Add(triggersButton)
-		sizer.AddSpacer(5)
+
 		# Translators: The label of a checkbox in the Configuration Profiles dialog.
-		item = self.disableTriggersToggle = wx.CheckBox(self, label=_("Temporarily d&isable all triggers"))
-		item.Value = not config.conf.profileTriggersEnabled
-		sizer.Add(item, flag=wx.ALIGN_CENTER_VERTICAL)
-		mainSizer.Add(sizer, flag=wx.ALL, border=10)
+		self.disableTriggersToggle = wx.CheckBox(self, label=_("Temporarily d&isable all triggers"))
+		self.disableTriggersToggle.Value = not config.conf.profileTriggersEnabled
+		sHelper.addItem(guiHelper.associateElements(triggersButton,self.disableTriggersToggle))
 
 		# Translators: The label of a button to close a dialog.
-		item = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
-		item.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		mainSizer.Add(item, flag=wx.ALL, border=10)
+		closeButton = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
+		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
+		sHelper.addItem(closeButton)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.EscapeId = wx.ID_CLOSE
 
@@ -102,6 +98,7 @@ class ProfilesDialog(wx.Dialog):
 				item.Disable()
 		self.onProfileListChoice(None)
 
+		mainSizer.Add(sHelper.sizer, flag=wx.ALL, border=guiHelper.BORDER_FOR_DIALOGS)
 		mainSizer.Fit(self)
 		self.Sizer = mainSizer
 		self.profileList.SetFocus()
@@ -287,6 +284,7 @@ class TriggersDialog(wx.Dialog):
 		# Translators: The title of the configuration profile triggers dialog.
 		super(TriggersDialog, self).__init__(parent, title=_("Profile Triggers"))
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		processed = set()
 		triggers = self.triggers = []
@@ -311,34 +309,29 @@ class TriggersDialog(wx.Dialog):
 				continue
 			triggers.append(TriggerInfo(spec, disp, profile))
 
-		sizer = wx.BoxSizer(wx.VERTICAL)
+		
 		# Translators: The label of the triggers list in the Configuration Profile Triggers dialog.
-		sizer.Add(wx.StaticText(self, label=_("Triggers")))
-		item = self.triggerList = wx.ListBox(self, choices=[trig.display for trig in triggers])
-		item.Bind(wx.EVT_LISTBOX, self.onTriggerListChoice)
-		item.Selection = 0
-		sizer.Add(item, flag=wx.EXPAND)
-		mainSizer.Add(sizer, border=10, flag=wx.ALL|wx.EXPAND)
+		triggersText = _("Triggers")
+		triggerChoices = [trig.display for trig in triggers]
+		self.triggerList = sHelper.addLabeledControl(triggersText, wx.ListBox, choices=triggerChoices)
+		self.triggerList.Bind(wx.EVT_LISTBOX, self.onTriggerListChoice)
+		self.triggerList.Selection = 0
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of the profile list in the Configuration Profile Triggers dialog.
-		sizer.Add(wx.StaticText(self, label=_("Profile")), flag=wx.ALIGN_CENTER_VERTICAL)
-		sizer.AddSpacer(5)
-		item = self.profileList = wx.Choice(self,
-			choices=[parent.getProfileDisplay(name) for name in parent.profileNames])
-		item.Bind(wx.EVT_CHOICE, self.onProfileListChoice)
-		sizer.Add(item, proportion=1.0)
-		mainSizer.Add(sizer, border=10, flag=wx.ALL|wx.EXPAND)
+		profileText = _("Profile")
+		profileChoices = [parent.getProfileDisplay(name) for name in parent.profileNames]
+		self.profileList = sHelper.addLabeledControl(profileText, wx.Choice, choices=profileChoices)
+		self.profileList.Bind(wx.EVT_CHOICE, self.onProfileListChoice)
 
-		item = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
-		item.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		mainSizer.Add(item, border=10, flag=wx.ALL)
+		closeButton = sHelper.addItem(wx.Button(self, wx.ID_CLOSE, label=_("&Close")))
+		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.AffirmativeId = wx.ID_CLOSE
-		item.SetDefault()
+		closeButton.SetDefault()
 		self.EscapeId = wx.ID_CLOSE
 
 		self.onTriggerListChoice(None)
+		mainSizer.Add(sHelper.sizer, border = guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.Sizer = mainSizer
 		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -309,27 +309,28 @@ class TriggersDialog(wx.Dialog):
 				continue
 			triggers.append(TriggerInfo(spec, disp, profile))
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: The label of the triggers list in the Configuration Profile Triggers dialog.
 		sizer.Add(wx.StaticText(self, label=_("Triggers")))
 		item = self.triggerList = wx.ListBox(self, choices=[trig.display for trig in triggers])
 		item.Bind(wx.EVT_LISTBOX, self.onTriggerListChoice)
 		item.Selection = 0
-		sizer.Add(item)
-		mainSizer.Add(sizer)
+		sizer.Add(item, flag=wx.EXPAND)
+		mainSizer.Add(sizer, border=10, flag=wx.ALL|wx.EXPAND)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of the profile list in the Configuration Profile Triggers dialog.
-		sizer.Add(wx.StaticText(self, label=_("Profile")))
+		sizer.Add(wx.StaticText(self, label=_("Profile")), flag=wx.ALIGN_CENTER_VERTICAL)
+		sizer.AddSpacer(5)
 		item = self.profileList = wx.Choice(self,
 			choices=[parent.getProfileDisplay(name) for name in parent.profileNames])
 		item.Bind(wx.EVT_CHOICE, self.onProfileListChoice)
-		sizer.Add(item)
-		mainSizer.Add(sizer)
+		sizer.Add(item, proportion=1.0)
+		mainSizer.Add(sizer, border=10, flag=wx.ALL|wx.EXPAND)
 
 		item = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
 		item.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		mainSizer.Add(item)
+		mainSizer.Add(item, border=10, flag=wx.ALL)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.AffirmativeId = wx.ID_CLOSE
 		item.SetDefault()

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -1,18 +1,17 @@
 # -*- coding: UTF-8 -*-
 #guiHelper.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2015 NV Access Limited
+#Copyright (C) 2016 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-import wx
-
 """ Example usage
+Utilities to simplify the creation of wx GUIs, including automatic management of spacing.
 
 class myDialog(class wx.Dialog):
 
 	def __init__(self,parent):
-		super(SettingsDialog, self).__init__(parent, wx.ID_ANY, self.title)
+		super(SettingsDialog, self).__init__(parent, title=self.title)
 		dialog = self
 
 		mainSizer=wx.BoxSizer(wx.VERTICAL)
@@ -42,38 +41,40 @@ class myDialog(class wx.Dialog):
 		self.SetSizer(mainSizer)
 	...
 """
-# border space to be used around all controls in dialogs
+
+import wx
+
+#: border space to be used around all controls in dialogs
 BORDER_FOR_DIALOGS=10
 
-# when dialog items are laid out vertically use this much space between them
+#: when dialog items are laid out vertically use this much space between them
 SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS = 10
 
-# put this much space between buttons  next to each other horizontally.
+#: put this much space between buttons  next to each other horizontally.
 SPACE_BETWEEN_BUTTONS_HORIZONTAL = 7
 
-# put this much space between buttons next to each other vertically
-SPACE_BETWEEN_BUTTONS_VERTICALLY = 5
+#: put this much space between buttons next to each other vertically
+SPACE_BETWEEN_BUTTONS_VERTICAL = 5
 
-# put this much space between two horizontally associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
+#: put this much space between two horizontally associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
 SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL = 10
 
-# put this much space between two vertically associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
+#: put this much space between two vertically associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
 SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL = 3
 
 class ButtonHelper(object):
 	""" Class used to ensure that the appropriate space is added between each button, whether in horizontal or vertical
-	arrangement. This class should be used for groups of buttons. While it wont cause problems to use this class with a
+	arrangement. This class should be used for groups of buttons. While it won't cause problems to use this class with a
 	single button there is little benefit. Individual buttons can be added directly to a sizer / sizer helper.
 	"""
 	def __init__(self, orientation):
 		"""
 		@param orientation: the orientation for the buttons, either wx.HORIZONTAL or wx.VERTICAL
-		@type itemType: wx.HORIZONTAL or wx.VERTICAL
 		"""
 		object.__init__(self)
 		self._firstButton = True
 		self._sizer = wx.BoxSizer(orientation)
-		self._space = SPACE_BETWEEN_BUTTONS_HORIZONTAL if orientation is wx.HORIZONTAL else SPACE_BETWEEN_BUTTONS_VERTICALLY
+		self._space = SPACE_BETWEEN_BUTTONS_HORIZONTAL if orientation is wx.HORIZONTAL else SPACE_BETWEEN_BUTTONS_VERTICAL
 
 	@property
 	def sizer(self):
@@ -112,9 +113,7 @@ def associateElements( firstElement, secondElement):
 	# staticText and (choice or textCtrl)
 	if isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (wx.Choice, wx.TextCtrl)):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
-		kwargs = {}
-		kwargs.update( {'flag':wx.ALIGN_CENTER_VERTICAL} )
-		sizer.Add(firstElement, **kwargs)
+		sizer.Add(firstElement, flag=wx.ALIGN_CENTER_VERTICAL)
 		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
 		sizer.Add(secondElement)
 	# staticText and (ListCtrl, ListBox or TreeCtrl)
@@ -146,11 +145,11 @@ class LabeledControlHelper(object):
 	Relies on guiHelper.associateElements(), any limitations in guiHelper.associateElements() also apply here.
 	"""
 	def __init__(self, parent, labelText, wxCtrlClass, **kwargs):
-		""" @param parent - An instance of the parent wx window. EG wx.Dialog
-			@param labelText - The text to associate with a wx control.
-			@type labelText - string
-			@param wxCtrlClass - The class to associate with the label, eg: wx.TextCtrl
-			@param kwargs - The keyword arguments used to instantiate the wxCtrlClass
+		""" @param parent: An instance of the parent wx window. EG wx.Dialog
+			@param labelText: The text to associate with a wx control.
+			@type labelText: string
+			@param wxCtrlClass: The class to associate with the label, eg: wx.TextCtrl
+			@param kwargs: The keyword arguments used to instantiate the wxCtrlClass
 		"""
 		object.__init__(self)
 		self._label = wx.StaticText(parent, label=labelText)
@@ -168,14 +167,15 @@ class LabeledControlHelper(object):
 class PathSelectionHelper(object):
 	"""
 	Abstracts away details for creating a path selection helper. The path selection helper is a textCtrl with a
-	button in horizontal layout. The Button launches a directory explorer. Its recommended that the 
+	button in horizontal layout. The Button launches a directory explorer. To get the path selected by the user, use the
+	`pathControl` property which exposes a wx.TextCtrl.
 	"""
 	def __init__(self, parent, buttonText, browseForDirectoryTitle):
-		""" @param parent - An instance of the parent wx window. EG wx.Dialog
-			@param buttonText - The text for the button to launch a directory dialog (wx.DirDialog). This is typically 'Browse'
-			@type buttonText - string
-			@param browseForDirectoryTitle - The text for the title of the directory dialog (wx.DirDialog)
-			@type browseForDirectoryTitle - string
+		""" @param parent: An instance of the parent wx window. EG wx.Dialog
+			@param buttonText: The text for the button to launch a directory dialog (wx.DirDialog). This is typically 'Browse'
+			@type buttonText: string
+			@param browseForDirectoryTitle: The text for the title of the directory dialog (wx.DirDialog)
+			@type browseForDirectoryTitle: string
 		"""
 		object.__init__(self)
 		self._textCtrl = wx.TextCtrl(parent)
@@ -193,13 +193,11 @@ class PathSelectionHelper(object):
 	def sizer(self):
 		return self._sizer
 
-	def getDefulatBrowseForDirectoryPath(self):
+	def getDefaultBrowseForDirectoryPath(self):
 		return self._textCtrl.Value or "c:\\"
 
 	def onBrowseForDirectory(self, evt):
-		# Translators: The title of the dialog presented when browsing for the
-		# destination directory when creating a portable copy of NVDA.
-		startPath = self.getDefulatBrowseForDirectoryPath()
+		startPath = self.getDefaultBrowseForDirectoryPath()
 		with wx.DirDialog(self._parent, self._browseForDirectoryTitle, defaultPath=startPath) as d:
 			if d.ShowModal() == wx.ID_OK:
 				self._textCtrl.Value = d.Path
@@ -209,7 +207,7 @@ class BoxSizerHelper(object):
 	"""
 	def __init__(self, parent, orientation=None, sizer=None):
 		""" Init. Pass in either orientation OR sizer.
-			@param parent - An instance of the parent wx window. EG wx.Dialog
+			@param parent: An instance of the parent wx window. EG wx.Dialog
 			@param orientation: the orientation to use when constructing the sizer, either wx.HORIZONTAL or wx.VERTICAL
 			@type itemType: wx.HORIZONTAL or wx.VERTICAL
 			@param sizer: the sizer to use rather than constructing one.
@@ -225,11 +223,11 @@ class BoxSizerHelper(object):
 		elif sizer and isinstance(sizer, wx.BoxSizer):
 			self.sizer = sizer
 		else:
-			ValueError("Orientation OR Sizer must be supplied.")
+			raise ValueError("Orientation OR Sizer must be supplied.")
 
 	def addItem(self, item):
 		""" Adds an item with space between it and the previous item.
-			Does not handle adding LabledControlHelper, use the convenience method instead.
+			Does not handle adding LabledControlHelper; use L{addlabelledControl} instead.
 		"""
 		toAdd = item
 		keywordArgs = {}
@@ -240,22 +238,20 @@ class BoxSizerHelper(object):
 			buttonBorderAmount = 5
 			keywordArgs.update({'border':buttonBorderAmount, 'flag':wx.ALL})
 			shouldAddSpacer = False # no need to add a spacer, since the button border has been added.
-
-		if isinstance(item, BoxSizerHelper):
+		elif isinstance(item, BoxSizerHelper):
 			toAdd = item.sizer
-
-		if isinstance(item, PathSelectionHelper):
+		elif isinstance(item, PathSelectionHelper):
 			toAdd = item.sizer
 			if self.sizer.GetOrientation() == wx.VERTICAL:
-				keywordArgs.update({'flag':wx.EXPAND,})
+				keywordArgs['flag'] = wx.EXPAND
 			else:
 				raise NotImplementedError("Adding PathSelectionHelper to a horizontal BoxSizerHelper is not implemented")
-
-		if isinstance(item, LabeledControlHelper):
+		elif isinstance(item, LabeledControlHelper):
 			raise NotImplementedError("Use addLabeledControl instead")
 
+		# a boxSizerHelper could contain a wx.StaticBoxSizer
 		if isinstance(toAdd, wx.StaticBoxSizer):
-			keywordArgs.update({'flag':wx.EXPAND,})
+			keywordArgs['flag'] = wx.EXPAND
 
 		if shouldAddSpacer:
 			self.sizer.AddSpacer(SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
@@ -265,11 +261,11 @@ class BoxSizerHelper(object):
 
 	def addLabeledControl(self, labelText, wxCtrlClass, **kwargs):
 		""" Convenience method to create a labeled control
-			@param labelText - Text to use when constructing the wx.StaticText to label the control.
-			@type LabelText - String
-			@param wxCtrlClass - Control class to construct and associate with the label
-			@type wxCtrlClass - Some wx control type EG wx.TextCtrl
-			@param kwargs - keyword arguments used to construct the wxCtrlClass. As taken by guiHelper.LabeledControlHelper
+			@param labelText: Text to use when constructing the wx.StaticText to label the control.
+			@type LabelText: String
+			@param wxCtrlClass: Control class to construct and associate with the label
+			@type wxCtrlClass: Some wx control type EG wx.TextCtrl
+			@param kwargs: keyword arguments used to construct the wxCtrlClass. As taken by guiHelper.LabeledControlHelper
 
 			Relies on guiHelper.LabeledControlHelper and thus guiHelper.associateElements, and therefore inherits any
 			limitations from there.

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -10,42 +10,111 @@ import wx
 # when dialog items are laid out vertically use this much space between them
 SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS = 10
 
-# put this much space between buttons, vertical or horizontal
-SPACE_BETWEEN_BUTTONS = 7
+# put this much space between buttons  next to each other horizontally.
+SPACE_BETWEEN_BUTTONS_HORIZONTAL = 7
 
-# put this much space between a label and a control (such as a wx.Choice or wx.TextCtrl) when in a horizontal layout.
-SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL = 10
+# put this much space between buttons next to each other vertically
+SPACE_BETWEEN_BUTTONS_VERTICALLY = 5
 
-def addLabelAndControlToHorizontalSizer(wxSizer, wxLabel, wxControl):
-	''' Add a label and a control (such as a wx.Choice or wx.TextCtrl) to a horizontal layout sizer, with spacers and 
-		alignment set to cater for a horizontal layout.
-	'''
-	wxSizer.Add(wxLabel,flag=wx.ALIGN_CENTER_VERTICAL)
-	wxSizer.AddSpacer(SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL)
-	wxSizer.Add(wxControl)
+# put this much space between two horizontally associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
+SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL = 10
 
+# put this much space between two vertically associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
+SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL = 3
 
-def addAllContentSizerToMainSizer(wxMainSizer, wxContentSizer):
-	''' Add a sizer containing all the content to the main sizer for the dialog. This ensures that the appropriate 
-		border is added around the content
-	'''
-	Content_BorderSpace = 10
-	wxMainSizer.Add(wxContentSizer,border=Content_BorderSpace,flag=wx.ALL)
+class buttonHelper:
+	def __init__(self, orientation):
+		self.buttonSizer = wx.BoxSizer(orientation)
+		self.space = SPACE_BETWEEN_BUTTONS_HORIZONTAL if orientation is wx.HORIZONTAL else SPACE_BETWEEN_BUTTONS_VERTICALLY
 
-def addButtonsSizerToMainSizer(wxMainSizer, wxButtonsSizer):
-	''' Add the given buttons sizer (commonly for OK & Cancel, created with Dialog.CreateButtonSizer) to the main sizer
-		for the dialog. This ensures that the appropriate border is added around the content. The Buttons seem to have a
-		1px border and 4px spacers inserted before and after each button. 
-	'''
-	wxMainSizer.Add(wxButtonsSizer, border=5, flag=wx.ALL)
+	def AddButton(self, *args, **kwargs):
+		wxButton = wx.Button(*args, **kwargs)
+		if is not firstButton:
+			self.buttonSizer.AddSpacer(self.space)
+		self.buttonSizer.Add(wxButton)
+		return wxButton
 
-def addItemsToSizer(wxSizer, itemArray, spaceBetween=SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS):
-	''' Add the array of items to the sizer putting a spacer between each one.
-	'''
-	lastIndex = len(itemArray)-1
-	for i in xrange(0, lastIndex):
-		wxSizer.Add(itemArray[i])
-		wxSizer.AddSpacer(spaceBetween)
-	# don't add a spacer after the last element
-	wxSizer.Add(itemArray[lastIndex])
+""" Example usage
 
+class myDialog(class wx.Dialog):
+
+	def __init__(self,parent):
+		super(SettingsDialog, self).__init__(parent, wx.ID_ANY, self.title)
+		mainSizer=wx.BoxSizer(wx.VERTICAL)
+
+		# Use factory method to create a sizer type specific helper
+		sHelper = guiHelper.sizerHelper(dialog, wx.BoxSizer(wx.VERTICAL))
+
+		filterElement = guiHelper.labeledControlHelper(dialog, "Filter:", wx.TextCtrl)
+		symbols = wx.ListCtrl()
+		sHelper.AddAutoSpacedItem(associateElement(filterElement, symbols)
+
+		sHelper.AddAutoSpacedItem(guiHelper.labeledControlHelper(dialog, "Choose option", wx.Choice, choices=[1,2,3]))
+
+		button = sHelper.AddAutoSpacedItem( wx.Button("Does stuff"))
+
+		# for general items
+		checkbox = sHelper.AddAutoSpacedItem(wx.CheckBox("always do something"))
+
+		# for groups of buttons
+		buttonGroup = guiHelper.buttonHelper(wx.VERTICAL)
+		oneButton = buttonHelper.AddButton(wx.Button("one"))
+		twoButton = buttonHelper.AddButton(wx.Button("one"))
+		threeButton = buttonHelper.AddButton(wx.Button("three")
+		sHelper.AddItem(buttonGroup)
+
+		mainSizer.Add(sHelper.sizer, border=10, flag=wx.ALL)
+		mainSizer.Fit(self)
+		self.SetSizer(mainSizer)
+	...
+"""
+
+def AssociateElements( firstElement, secondElement):
+		# check if horizontal / vertical
+		# check type of control
+		# handle different combinations eg:
+		if isinstance(firstElement, buttonHelper) or isinstance(secondElement, buttonHelper):
+			raise NotImplemented("AssociateElements has no implementation for buttonHelper elements")
+
+		if isinstance(firstElement, labeledControlHelper):
+			firstElement = firstElement.sizer
+
+		if isinstance(secondElement, [wx.Choice, wx.TextCtrl]):
+			sizer = wx.BoxSizer(wx.HORIZONTAL)
+			sizer.Add(firstElement)
+			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
+			sizer.Add(secondElement)
+
+		if isinstance(secondElement, [wx.ListCtrl, wx.TextCtrl])
+			sizer = wx.BoxSizer(wx.VERTICAL)
+			sizer.Add(firstElement)
+			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
+			sizer.Add(secondElement)
+
+		return sizer
+
+class labeledControlHelper:
+	def __init__(self, dialog, labelText, wxCtrlClass, **kwargs):
+		self.label = wx.StaticText(dialog, labelText)
+		self.ctrl = ctlClass(dialog, **kwargs)
+		self.sizer = AssociateElements(self.label, self.ctrl)
+
+class sizerHelper:
+	def __init__(self, wxSizer):
+		self.sizer = wxSizer
+		self.hasFirstItemBeenAdded = False
+
+	def AddAutoSpacedItem(item):
+		toAdd = item
+		if isinstance(item, ButtonHelper):
+			self.Sizer.Add(item.sizer, border=buttonBorderAmount, flags=wx.ALL)
+			return item # no need to add a spacer, since the button border has been added.
+
+		if self.hasFirstItemBeenAdded:
+			self.sizer.AddSpacer(betweenItemsAmount)
+
+		if isinstance(item, labeledControlHelper):
+			toAdd = item.sizer
+
+		self.Sizer.Add(toAdd)
+		return item

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -104,36 +104,35 @@ def associateElements( firstElement, secondElement):
 			wx.StaticText and (wx.ListCtrl or wx.ListBox or wx.TreeCtrl ) - Vertical layout
 			wx.Button and wx.CheckBox - Horizontal layout
 	"""
-		if isinstance(firstElement, ButtonHelper) or isinstance(secondElement, ButtonHelper):
-			raise NotImplementedError("AssociateElements has no implementation for ButtonHelper elements")
-		if isinstance(firstElement, LabeledControlHelper) or isinstance(secondElement, LabeledControlHelper)
-			raise NotImplementedError("AssociateElements as no implementation for LabeledControlHelper elements")
+	if isinstance(firstElement, ButtonHelper) or isinstance(secondElement, ButtonHelper):
+		raise NotImplementedError("AssociateElements has no implementation for ButtonHelper elements")
+	if isinstance(firstElement, LabeledControlHelper) or isinstance(secondElement, LabeledControlHelper):
+		raise NotImplementedError("AssociateElements as no implementation for LabeledControlHelper elements")
 
-		# staticText and (choice or textCtrl)
-		if isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (wx.Choice, wx.TextCtrl)):
-			sizer = wx.BoxSizer(wx.HORIZONTAL)
-			kwargs = {}
-			kwargs.update( {'flag':wx.ALIGN_CENTER_VERTICAL} )
-			else: raise NotImplementedError("firstElement not supported with secondElement type.")
-			sizer.Add(firstElement, **kwargs)
-			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
-			sizer.Add(secondElement)
-		# staticText and (ListCtrl, ListBox or TreeCtrl)
-		elif isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (wx.ListCtrl,wx.ListBox,wx.TreeCtrl)):
-			sizer = wx.BoxSizer(wx.VERTICAL)
-			sizer.Add(firstElement)
-			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
-			sizer.Add(secondElement)
-		# button and checkBox
-		elif isinstance(firstElement, wx.Button) and isinstance(secondElement, wx.CheckBox):
-			sizer = wx.BoxSizer(wx.HORIZONTAL)
-			sizer.Add(firstElement)
-			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
-			sizer.Add(secondElement, flag=wx.ALIGN_CENTER_VERTICAL)
-		else:
-			raise NotImplementedError("The firstElement and secondElement argument combination has no implementation")
+	# staticText and (choice or textCtrl)
+	if isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (wx.Choice, wx.TextCtrl)):
+		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		kwargs = {}
+		kwargs.update( {'flag':wx.ALIGN_CENTER_VERTICAL} )
+		sizer.Add(firstElement, **kwargs)
+		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
+		sizer.Add(secondElement)
+	# staticText and (ListCtrl, ListBox or TreeCtrl)
+	elif isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (wx.ListCtrl,wx.ListBox,wx.TreeCtrl)):
+		sizer = wx.BoxSizer(wx.VERTICAL)
+		sizer.Add(firstElement)
+		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
+		sizer.Add(secondElement)
+	# button and checkBox
+	elif isinstance(firstElement, wx.Button) and isinstance(secondElement, wx.CheckBox):
+		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sizer.Add(firstElement)
+		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
+		sizer.Add(secondElement, flag=wx.ALIGN_CENTER_VERTICAL)
+	else:
+		raise NotImplementedError("The firstElement and secondElement argument combination has no implementation")
 
-		return sizer
+	return sizer
 
 class LabeledControlHelper(object):
 	""" Represents a Labeled Control. Provides a class to create and hold on to the objects and automatically associate
@@ -164,13 +163,13 @@ class BoxSizerHelper(object):
 	""" Used to abstract away spacing logic for a wx.BoxSizer
 	"""
 	def __init__(self, parent, orientation=None, sizer=None):
-	""" Init. Pass in either orientation OR sizer.
-		@param parent - An instance of the parent wx window. EG wx.Dialog
-		@param orientation: the orientation to use when constructing the sizer, either wx.HORIZONTAL or wx.VERTICAL
-		@type itemType: wx.HORIZONTAL or wx.VERTICAL
-		@param sizer: the sizer to use rather than constructing one.
-		@type sizer: wx.BoxSizer
-	"""
+		""" Init. Pass in either orientation OR sizer.
+			@param parent - An instance of the parent wx window. EG wx.Dialog
+			@param orientation: the orientation to use when constructing the sizer, either wx.HORIZONTAL or wx.VERTICAL
+			@type itemType: wx.HORIZONTAL or wx.VERTICAL
+			@param sizer: the sizer to use rather than constructing one.
+			@type sizer: wx.BoxSizer
+		"""
 		object.__init__(self)
 		self._parent = parent
 		self.hasFirstItemBeenAdded = False

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -5,8 +5,8 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-""" Example usage
-Utilities to simplify the creation of wx GUIs, including automatic management of spacing.
+""" Utilities to simplify the creation of wx GUIs, including automatic management of spacing.
+Example usage:
 
 class myDialog(class wx.Dialog):
 

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -9,6 +9,85 @@ import wx
 
 # when dialog items are laid out vertically use this much space between them
 SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS = 10
+# put this much space between buttons, vertical or horizontal
+SPACE_BETWEEN_BUTTONS = 7
+
+# put this much space between a label and a control (such as a wx.Choice or wx.TextCtrl) when in a horizontal layout.
+SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL = 10
+
+def addLabelAndControlToHorizontalSizer(wxSizer, wxLabel, wxControl):
+	''' Add a label and a control (such as a wx.Choice or wx.TextCtrl) to a horizontal layout sizer, with spacers and 
+		alignment set to cater for a horizontal layout.
+	'''
+	wxSizer.Add(wxLabel,flag=wx.ALIGN_CENTER_VERTICAL)
+	wxSizer.AddSpacer(SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL)
+	wxSizer.Add(wxControl)
+
+
+def addAllContentSizerToMainSizer(wxMainSizer, wxContentSizer):
+	''' Add a sizer containing all the content to the main sizer for the dialog. This ensures that the appropriate 
+		border is added around the content
+	'''
+	Content_BorderSpace = 10
+	wxMainSizer.Add(wxContentSizer,border=Content_BorderSpace,flag=wx.ALL)
+
+def addButtonsSizerToMainSizer(wxMainSizer, wxButtonsSizer):
+	''' Add the given buttons sizer (commonly for OK & Cancel, created with Dialog.CreateButtonSizer) to the main sizer
+		for the dialog. This ensures that the appropriate border is added around the content. The Buttons seem to have a
+		1px border and 4px spacers inserted before and after each button. 
+	'''
+	wxMainSizer.Add(wxButtonsSizer, border=5, flag=wx.ALL)
+
+def addItemsToSizer(wxSizer, itemArray, spaceBetween=SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS):
+	''' Add the array of items to the sizer putting a spacer between each one.
+	'''
+	lastIndex = len(itemArray)-1
+	for i in xrange(0, lastIndex):
+		wxSizer.Add(itemArray[i])
+		wxSizer.AddSpacer(spaceBetween)
+	# don't add a spacer after the last element
+	wxSizer.Add(itemArray[lastIndex])
+
+""" Example usage
+
+class myDialog(class wx.Dialog):
+
+	def __init__(self,parent):
+		super(SettingsDialog, self).__init__(parent, wx.ID_ANY, self.title)
+		dialog = self
+
+		mainSizer=wx.BoxSizer(wx.VERTICAL)
+
+		sHelper = guiHelper.SizerHelper( wx.VERTICAL)
+
+		filterElement = guiHelper.LabeledControlHelper(dialog, "Filter:", wx.TextCtrl)
+		symbols = wx.ListCtrl()
+		sHelper.addAutoSpacedItem(guiHelper.associateElement(filterElement, symbols)
+
+		sHelper.addAutoSpacedItem(guiHelper.LabeledControlHelper(dialog, "Choose option", wx.Choice, choices=[1,2,3]))
+
+		button = sHelper.addAutoSpacedItem( wx.Button("Does stuff"))
+
+		# for general items
+		checkbox = sHelper.addAutoSpacedItem(wx.CheckBox("always do something"))
+
+		# for groups of buttons
+		buttonGroup = guiHelper.ButtonHelper(wx.VERTICAL)
+		oneButton = buttonHelper.addButton(wx.Button("one"))
+		twoButton = buttonHelper.addButton(wx.Button("one"))
+		threeButton = buttonHelper.addButton(wx.Button("three")
+		sHelper.addAutoSpacedItem(buttonGroup)
+
+		mainSizer.Add(sHelper.sizer, border=10, flag=wx.ALL)
+		mainSizer.Fit(self)
+		self.SetSizer(mainSizer)
+	...
+"""
+# border space to be used around all controls in dialogs
+BORDER_FOR_DIALOGS=10
+
+# when dialog items are laid out vertically use this much space between them
+SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS = 10
 
 # put this much space between buttons  next to each other horizontally.
 SPACE_BETWEEN_BUTTONS_HORIZONTAL = 7
@@ -22,70 +101,35 @@ SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL = 10
 # put this much space between two vertically associated elements (such as a wx.StaticText and a wx.Choice or wx.TextCtrl)
 SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL = 3
 
-class buttonHelper:
+class ButtonHelper:
 	def __init__(self, orientation):
 		self.buttonSizer = wx.BoxSizer(orientation)
 		self.space = SPACE_BETWEEN_BUTTONS_HORIZONTAL if orientation is wx.HORIZONTAL else SPACE_BETWEEN_BUTTONS_VERTICALLY
 
-	def AddButton(self, *args, **kwargs):
+	def addButton(self, *args, **kwargs):
 		wxButton = wx.Button(*args, **kwargs)
-		if is not firstButton:
+		if not firstButton:
 			self.buttonSizer.AddSpacer(self.space)
 		self.buttonSizer.Add(wxButton)
 		return wxButton
 
-""" Example usage
-
-class myDialog(class wx.Dialog):
-
-	def __init__(self,parent):
-		super(SettingsDialog, self).__init__(parent, wx.ID_ANY, self.title)
-		mainSizer=wx.BoxSizer(wx.VERTICAL)
-
-		# Use factory method to create a sizer type specific helper
-		sHelper = guiHelper.sizerHelper(dialog, wx.BoxSizer(wx.VERTICAL))
-
-		filterElement = guiHelper.labeledControlHelper(dialog, "Filter:", wx.TextCtrl)
-		symbols = wx.ListCtrl()
-		sHelper.AddAutoSpacedItem(associateElement(filterElement, symbols)
-
-		sHelper.AddAutoSpacedItem(guiHelper.labeledControlHelper(dialog, "Choose option", wx.Choice, choices=[1,2,3]))
-
-		button = sHelper.AddAutoSpacedItem( wx.Button("Does stuff"))
-
-		# for general items
-		checkbox = sHelper.AddAutoSpacedItem(wx.CheckBox("always do something"))
-
-		# for groups of buttons
-		buttonGroup = guiHelper.buttonHelper(wx.VERTICAL)
-		oneButton = buttonHelper.AddButton(wx.Button("one"))
-		twoButton = buttonHelper.AddButton(wx.Button("one"))
-		threeButton = buttonHelper.AddButton(wx.Button("three")
-		sHelper.AddItem(buttonGroup)
-
-		mainSizer.Add(sHelper.sizer, border=10, flag=wx.ALL)
-		mainSizer.Fit(self)
-		self.SetSizer(mainSizer)
-	...
-"""
-
-def AssociateElements( firstElement, secondElement):
-		# check if horizontal / vertical
-		# check type of control
-		# handle different combinations eg:
-		if isinstance(firstElement, buttonHelper) or isinstance(secondElement, buttonHelper):
+def associateElements( firstElement, secondElement):
+		if isinstance(firstElement, ButtonHelper) or isinstance(secondElement, ButtonHelper):
 			raise NotImplemented("AssociateElements has no implementation for buttonHelper elements")
 
-		if isinstance(firstElement, labeledControlHelper):
+		if isinstance(firstElement, LabeledControlHelper):
 			firstElement = firstElement.sizer
 
-		if isinstance(secondElement, [wx.Choice, wx.TextCtrl]):
+		if isinstance(secondElement, (wx.Choice, wx.TextCtrl)):
 			sizer = wx.BoxSizer(wx.HORIZONTAL)
-			sizer.Add(firstElement)
+			kwargs = {}
+			if isinstance(firstElement, wx.StaticText):
+				kwargs.update( {'flag':wx.ALIGN_CENTER_VERTICAL} )
+			sizer.Add(firstElement, **kwargs)
 			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
 			sizer.Add(secondElement)
 
-		if isinstance(secondElement, [wx.ListCtrl, wx.TextCtrl])
+		if isinstance(secondElement, (wx.ListCtrl, wx.TextCtrl)):
 			sizer = wx.BoxSizer(wx.VERTICAL)
 			sizer.Add(firstElement)
 			sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
@@ -93,28 +137,36 @@ def AssociateElements( firstElement, secondElement):
 
 		return sizer
 
-class labeledControlHelper:
+class LabeledControlHelper:
 	def __init__(self, dialog, labelText, wxCtrlClass, **kwargs):
-		self.label = wx.StaticText(dialog, labelText)
-		self.ctrl = ctlClass(dialog, **kwargs)
-		self.sizer = AssociateElements(self.label, self.ctrl)
+		self.label = wx.StaticText(dialog, label=labelText)
+		self._ctrl = wxCtrlClass(dialog, **kwargs)
+		self.sizer = associateElements(self.label, self._ctrl)
 
-class sizerHelper:
-	def __init__(self, wxSizer):
-		self.sizer = wxSizer
+	@property
+	def control(self):
+		return self._ctrl
+
+class BoxSizerHelper:
+	def __init__(self, orientation):
+		self.sizer = wx.BoxSizer(orientation)
 		self.hasFirstItemBeenAdded = False
 
-	def AddAutoSpacedItem(item):
+	def addAutoSpacedItem(self, item):
 		toAdd = item
+		keywordArgs = {}
+		shouldAddSpacer = self.hasFirstItemBeenAdded
+
 		if isinstance(item, ButtonHelper):
-			self.Sizer.Add(item.sizer, border=buttonBorderAmount, flags=wx.ALL)
-			return item # no need to add a spacer, since the button border has been added.
+			toAdd = item.sizer
+			keywordArgs.update({'border':buttonBorderAmount, 'flags':wx.ALL})
+			shouldAddSpacer = False # no need to add a spacer, since the button border has been added.
 
-		if self.hasFirstItemBeenAdded:
-			self.sizer.AddSpacer(betweenItemsAmount)
-
-		if isinstance(item, labeledControlHelper):
+		if isinstance(item, LabeledControlHelper):
 			toAdd = item.sizer
 
-		self.Sizer.Add(toAdd)
+		if shouldAddSpacer:
+			self.sizer.AddSpacer(SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
+		self.sizer.Add(toAdd, **keywordArgs)
+		self.hasFirstItemBeenAdded = True
 		return item

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -1,0 +1,51 @@
+# -*- coding: UTF-8 -*-
+#guiHelper.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2015 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import wx
+
+# when dialog items are laid out vertically use this much space between them
+SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS = 10
+
+# put this much space between buttons, vertical or horizontal
+SPACE_BETWEEN_BUTTONS = 7
+
+# put this much space between a label and a control (such as a wx.Choice or wx.TextCtrl) when in a horizontal layout.
+SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL = 10
+
+def addLabelAndControlToHorizontalSizer(wxSizer, wxLabel, wxControl):
+	''' Add a label and a control (such as a wx.Choice or wx.TextCtrl) to a horizontal layout sizer, with spacers and 
+		alignment set to cater for a horizontal layout.
+	'''
+	wxSizer.Add(wxLabel,flag=wx.ALIGN_CENTER_VERTICAL)
+	wxSizer.AddSpacer(SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL)
+	wxSizer.Add(wxControl)
+
+
+def addAllContentSizerToMainSizer(wxMainSizer, wxContentSizer):
+	''' Add a sizer containing all the content to the main sizer for the dialog. This ensures that the appropriate 
+		border is added around the content
+	'''
+	Content_BorderSpace = 10
+	wxMainSizer.Add(wxContentSizer,border=Content_BorderSpace,flag=wx.ALL)
+
+def addButtonsSizerToMainSizer(wxMainSizer, wxButtonsSizer):
+	''' Add the given buttons sizer (commonly for OK & Cancel, created with Dialog.CreateButtonSizer) to the main sizer
+		for the dialog. This ensures that the appropriate border is added around the content. The Buttons seem to have a
+		1px border and 4px spacers inserted before and after each button. 
+	'''
+	wxMainSizer.Add(wxButtonsSizer, border=5, flag=wx.ALL)
+
+def addItemsToSizer(wxSizer, itemArray, spaceBetween=SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS):
+	''' Add the array of items to the sizer putting a spacer between each one.
+	'''
+	lastIndex = len(itemArray)-1
+	for i in xrange(0, lastIndex):
+		wxSizer.Add(itemArray[i])
+		wxSizer.AddSpacer(spaceBetween)
+	# don't add a spacer after the last element
+	wxSizer.Add(itemArray[lastIndex])
+

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -182,48 +182,45 @@ class PortableCreaterDialog(wx.Dialog):
 		# Translators: The title of the Create Portable NVDA dialog.
 		super(PortableCreaterDialog, self).__init__(parent, title=_("Create Portable NVDA"))
 		mainSizer = self.mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+
 		# Translators: An informational message displayed in the Create Portable NVDA dialog.
-		dialogCaption=wx.StaticText(self,label=_("To create a portable copy of NVDA, please select the path and other options and then press Continue")) 
-		mainSizer.Add(dialogCaption)
-		optionsSizer = wx.BoxSizer(wx.VERTICAL)
+		dialogCaption=_("To create a portable copy of NVDA, please select the path and other options and then press Continue")
+		sHelper.addItem(wx.StaticText(self, label=dialogCaption))
+
 		# Translators: The label of a grouping containing controls to select the destination directory
 		# in the Create Portable NVDA dialog.
-		sizer = wx.StaticBoxSizer(wx.StaticBox(self, label=_("Portable &directory:")), wx.HORIZONTAL)
-		ctrl = self.portableDirectoryEdit = wx.TextCtrl(self)
-		sizer.Add(ctrl)
+		directoryGroupText = _("Portable &directory:")
+		groupHelper = sHelper.addItem(gui.guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=directoryGroupText), wx.VERTICAL)))
 		# Translators: The label of a button to browse for a directory.
-		ctrl = wx.Button(self, label=_("Browse..."))
-		ctrl.Bind(wx.EVT_BUTTON, self.onBrowseForPortableDirectory)
-		sizer.Add(ctrl)
-		optionsSizer.Add(sizer)
-		# Translators: The label of a checkbox option in the Create Portable NVDA dialog.
-		ctrl = self.copyUserConfigCheckbox = wx.CheckBox(self, label=_("Copy current &user configuration"))
-		ctrl.Value = False
-		if globalVars.appArgs.launcher:
-			ctrl.Disable()
-		optionsSizer.Add(ctrl)
-		mainSizer.Add(optionsSizer)
+		browseText = _("Browse...")
+		# Translators: The title of the dialog presented when browsing for the
+		# destination directory when creating a portable copy of NVDA.
+		dirDialogTitle = _("Select portable  directory")
+		directoryEntryControl = groupHelper.addItem(gui.guiHelper.PathSelectionHelper(self, browseText, dirDialogTitle))
+		self.portableDirectoryEdit = directoryEntryControl.pathControl
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
-		ctrl = wx.Button(self, label=_("&Continue"), id=wx.ID_OK)
-		ctrl.SetDefault()
-		ctrl.Bind(wx.EVT_BUTTON, self.onCreatePortable)
-		sizer.Add(ctrl)
-		sizer.Add(wx.Button(self, id=wx.ID_CANCEL))
+		# Translators: The label of a checkbox option in the Create Portable NVDA dialog.
+		copyConfText = _("Copy current &user configuration")
+		self.copyUserConfigCheckbox = sHelper.addItem(wx.CheckBox(self, label=copyConfText))
+		self.copyUserConfigCheckbox.Value = False
+		if globalVars.appArgs.launcher:
+			self.copyUserConfigCheckbox.Disable()
+
+		bHelper = sHelper.addItem(gui.guiHelper.ButtonHelper(wx.HORIZONTAL))
+		
+		continueButton = bHelper.addButton(self, label=_("&Continue"), id=wx.ID_OK)
+		continueButton.SetDefault()
+		continueButton.Bind(wx.EVT_BUTTON, self.onCreatePortable)
+		
+		bHelper.addButton(self, id=wx.ID_CANCEL)
 		# If we bind this using button.Bind, it fails to trigger when the dialog is closed.
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
-		mainSizer.Add(sizer)
-
+		
+		mainSizer.Add(sHelper.sizer, border=gui.guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)
-
-	def onBrowseForPortableDirectory(self, evt):
-		# Translators: The title of the dialog presented when browsing for the
-		# destination directory when creating a portable copy of NVDA.
-		with wx.DirDialog(self, _("Select portable  directory"), defaultPath=self.portableDirectoryEdit.Value or "c:\\") as d:
-			if d.ShowModal() == wx.ID_OK:
-				self.portableDirectoryEdit.Value = d.Path
 
 	def onCreatePortable(self, evt):
 		if not self.portableDirectoryEdit.Value:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -15,6 +15,7 @@ import versionInfo
 import installer
 from logHandler import log
 import gui
+from gui import guiHelper
 import tones
 
 def doInstall(createDesktopShortcut,startOnLogon,copyPortableConfig,isUpdate,silent=False,startAfterInstall=True):
@@ -85,6 +86,8 @@ class InstallerDialog(wx.Dialog):
 		# Translators: The title of the Install NVDA dialog.
 		super(InstallerDialog, self).__init__(parent, title=_("Install NVDA"))
 		mainSizer = self.mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+
 		# Translators: An informational message in the Install NVDA dialog.
 		msg=_("To install NVDA to your hard drive, please press the Continue button.")
 		if self.isUpdate:
@@ -93,43 +96,44 @@ class InstallerDialog(wx.Dialog):
 			if not os.path.isdir(installer.defaultInstallPath):
 				# Translators: a message in the installer telling the user NVDA is now located in a different place.
 				msg+=" "+_("The installation path for NVDA has changed. it will now  be installed in {path}").format(path=installer.defaultInstallPath)
-		dialogCaption=wx.StaticText(self,label=msg) 
-		mainSizer.Add(dialogCaption)
-		optionsSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper.addItem(wx.StaticText(self,label=msg))
+
 		# Translators: The label of a checkbox option in the Install NVDA dialog.
-		ctrl = self.startOnLogonCheckbox = wx.CheckBox(self, label=_("Use NVDA on the Windows &logon screen"))
-		ctrl.Value = config.getStartOnLogonScreen() if self.isUpdate else True
-		optionsSizer.Add(ctrl)
+		startOnLogonText = _("Use NVDA on the Windows &logon screen")
+		self.startOnLogonCheckbox = sHelper.addItem(wx.CheckBox(self, label=startOnLogonText))
+		self.startOnLogonCheckbox.Value = config.getStartOnLogonScreen() if self.isUpdate else True
+		
 		shortcutIsPrevInstalled=installer.isDesktopShortcutInstalled()
 		if self.isUpdate and shortcutIsPrevInstalled:
 			# Translators: The label of a checkbox option in the Install NVDA dialog.
-			ctrl = self.createDesktopShortcutCheckbox = wx.CheckBox(self, label=_("&Keep existing desktop shortcut"))
+			keepShortCutText = _("&Keep existing desktop shortcut")
+			self.createDesktopShortcutCheckbox = sHelper.addItem(wx.CheckBox(self, label=keepShortCutText))
 		else:
 			# Translators: The label of the option to create a desktop shortcut in the Install NVDA dialog.
 			# If the shortcut key has been changed for this locale,
 			# this change must also be reflected here.
-			ctrl = self.createDesktopShortcutCheckbox = wx.CheckBox(self, label=_("Create &desktop icon and shortcut key (control+alt+n)"))
-		ctrl.Value = shortcutIsPrevInstalled if self.isUpdate else True 
-		optionsSizer.Add(ctrl)
+			createShortcutText = _("Create &desktop icon and shortcut key (control+alt+n)")
+			self.createDesktopShortcutCheckbox = sHelper.addItem(wx.CheckBox(self, label=createShortcutText))
+		self.createDesktopShortcutCheckbox.Value = shortcutIsPrevInstalled if self.isUpdate else True 
+		
 		# Translators: The label of a checkbox option in the Install NVDA dialog.
-		ctrl = self.copyPortableConfigCheckbox = wx.CheckBox(self, label=_("Copy &portable configuration to current user account"))
-		ctrl.Value = False
+		createPortableText = _("Copy &portable configuration to current user account")
+		self.copyPortableConfigCheckbox = sHelper.addItem(wx.CheckBox(self, label=createPortableText))
+		self.copyPortableConfigCheckbox.Value = False
 		if globalVars.appArgs.launcher:
-			ctrl.Disable()
-		optionsSizer.Add(ctrl)
-		mainSizer.Add(optionsSizer)
+			self.copyPortableConfigCheckbox.Disable()
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		bHelper = sHelper.addItem(guiHelper.ButtonHelper(wx.HORIZONTAL))
 		# Translators: The label of a button to continue with the operation.
-		ctrl = wx.Button(self, label=_("&Continue"), id=wx.ID_OK)
-		ctrl.SetDefault()
-		ctrl.Bind(wx.EVT_BUTTON, self.onInstall)
-		sizer.Add(ctrl)
-		sizer.Add(wx.Button(self, id=wx.ID_CANCEL))
+		continueButton = bHelper.addButton(self, label=_("&Continue"), id=wx.ID_OK)
+		continueButton.SetDefault()
+		continueButton.Bind(wx.EVT_BUTTON, self.onInstall)
+		
+		bHelper.addButton(self, id=wx.ID_CANCEL)
 		# If we bind this using button.Bind, it fails to trigger when the dialog is closed.
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
-		mainSizer.Add(sizer)
-
+		
+		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1842,7 +1842,8 @@ class InputGesturesDialog(SettingsDialog):
 		settingsSizer.Add(filterSizer, flag=wx.EXPAND)
 		settingsSizer.AddSpacer(5)
 		
-		tree = self.tree = wx.TreeCtrl(self, style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_SINGLE)
+		tree = self.tree = wx.TreeCtrl(self, size=wx.Size(600, 400), style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE )
+		
 		self.treeRoot = tree.AddRoot("root")
 		tree.Bind(wx.EVT_TREE_SEL_CHANGED, self.onTreeSelect)
 		settingsSizer.Add(tree, proportion=1, flag=wx.EXPAND)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -905,6 +905,9 @@ class ObjectPresentationDialog(SettingsDialog):
 	)
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
 		self.tooltipCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report &tooltips"))
@@ -939,7 +942,7 @@ class ObjectPresentationDialog(SettingsDialog):
 		# Translators: This is the label for a combobox in the
 		# object presentation settings dialog.
 		progressLabel=wx.StaticText(self,-1,label=_("Progress &bar output:"))
-		progressSizer.Add(progressLabel)
+		progressSizer.Add(progressLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		progressListID=wx.NewId()
 		# Translators: This is the name of a combobox in the
 		# object presentation settings dialog.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1812,21 +1812,22 @@ class InputGesturesDialog(SettingsDialog):
 
 		settingsSizer.AddSpacer(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
 
-		buttonSizer = wx.BoxSizer(wx.HORIZONTAL)
+		bHelper = guiHelper.ButtonHelper(wx.HORIZONTAL)
+
 		# Translators: The label of a button to add a gesture in the Input Gestures dialog.
-		item = self.addButton = wx.Button(self, label=_("&Add"))
-		item.Bind(wx.EVT_BUTTON, self.onAdd)
-		item.Disable()
-		buttonSizer.Add(item)
-		buttonSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_HORIZONTAL)
+		self.addButton = bHelper.addButton(self, label=_("&Add"))
+		self.addButton.Bind(wx.EVT_BUTTON, self.onAdd)
+		self.addButton.Disable()
+
 		# Translators: The label of a button to remove a gesture in the Input Gestures dialog.
-		item = self.removeButton = wx.Button(self, label=_("&Remove"))
-		item.Bind(wx.EVT_BUTTON, self.onRemove)
-		item.Disable()
+		self.removeButton = bHelper.addButton(self, label=_("&Remove"))
+		self.removeButton.Bind(wx.EVT_BUTTON, self.onRemove)
+		self.removeButton.Disable()
+
 		self.pendingAdds = set()
 		self.pendingRemoves = set()
-		buttonSizer.Add(item)
-		settingsSizer.Add(buttonSizer)
+
+		settingsSizer.Add(bHelper.sizer)
 
 	def postInit(self):
 		self.tree.SetFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -72,9 +72,8 @@ class SettingsDialog(wx.Dialog):
 		"""
 		super(SettingsDialog, self).__init__(parent, wx.ID_ANY, self.title)
 		mainSizer=wx.BoxSizer(wx.VERTICAL)
-		self.settingsSizerHelper = guiHelper.BoxSizerHelper(wx.VERTICAL)
-		self.settingsSizer=self.settingsSizerHelper.sizer
-		self.makeSettings(self.settingsSizerHelper)
+		self.settingsSizer=wx.BoxSizer(wx.VERTICAL)
+		self.makeSettings(self.settingsSizer)
 
 		mainSizer.Add(self.settingsSizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Add(wx.StaticLine(self), flag=wx.EXPAND)
@@ -91,11 +90,11 @@ class SettingsDialog(wx.Dialog):
 	def __del__(self):
 		SettingsDialog._hasInstance=False
 
-	def makeSettings(self, sizerHelper):
+	def makeSettings(self, sizer):
 		"""Populate the dialog with settings controls.
 		Subclasses must override this method.
-		@param sizerHelper: The sizerHelper to which to add the settings controls.
-		@type sizerHelper: guiHelper.BoxSizerHelper
+		@param sizer: The sizer to which to add the settings controls.
+		@type sizer: wx.Sizer
 		"""
 		raise NotImplementedError
 
@@ -133,15 +132,15 @@ class GeneralSettingsDialog(SettingsDialog):
 		(log.DEBUG, _("debug"))
 	)
 
-	def makeSettings(self, settingsSizerHelper):
+	def makeSettings(self, settingsSizer):
+		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		self.languageNames = languageHandler.getAvailableLanguages()
 		languageChoices = [x[1] for x in self.languageNames]
 		# Translators: The label for a setting in general settings to select NVDA's interface language (once selected, NVDA must be restarted; the option user default means the user's Windows language will be used).
 		languageLabelText = _("&Language (requires restart to fully take effect):")
 		# Translators: The list of languages for NVDA.
 		languageCtrlName = _("Language")
-		labeledControl=guiHelper.LabeledControlHelper(self, languageLabelText, wx.Choice, name=languageCtrlName, choices=languageChoices)
-		self.languageList = labeledControl.control
+		self.languageList=settingsSizerHelper.addLabeledControl(languageLabelText, wx.Choice, name=languageCtrlName, choices=languageChoices)
 		self.languageList.SetToolTip(wx.ToolTip("Choose the language NVDA's messages and user interface should be presented in."))
 		try:
 			self.oldLanguage=config.conf["general"]["language"]
@@ -151,32 +150,30 @@ class GeneralSettingsDialog(SettingsDialog):
 			pass
 		if globalVars.appArgs.secure:
 			self.languageList.Disable()
-		settingsSizerHelper.addAutoSpacedItem(labeledControl)
 
 		# Translators: The label for a setting in general settings to save current configuration when NVDA exits (if it is not checked, user needs to save configuration before quitting NVDA).
 		self.saveOnExitCheckBox=wx.CheckBox(self,label=_("&Save configuration on exit"))
 		self.saveOnExitCheckBox.SetValue(config.conf["general"]["saveConfigurationOnExit"])
 		if globalVars.appArgs.secure:
 			self.saveOnExitCheckBox.Disable()
-		settingsSizerHelper.addAutoSpacedItem(self.saveOnExitCheckBox)
+		settingsSizerHelper.addItem(self.saveOnExitCheckBox)
 
 		# Translators: The label for a setting in general settings to ask before quitting NVDA (if not checked, NVDA will exit without asking the user for action).
 		self.askToExitCheckBox=wx.CheckBox(self,label=_("Sho&w exit options when exiting NVDA"))
 		self.askToExitCheckBox.SetValue(config.conf["general"]["askToExit"])
-		settingsSizerHelper.addAutoSpacedItem(self.askToExitCheckBox)
+		settingsSizerHelper.addItem(self.askToExitCheckBox)
 
 		# Translators: The label for a setting in general settings to play sounds when NVDA starts or exits.
 		self.playStartAndExitSoundsCheckBox=wx.CheckBox(self,label=_("&Play sounds when starting or exiting NVDA"))
 		self.playStartAndExitSoundsCheckBox.SetValue(config.conf["general"]["playStartAndExitSounds"])
-		settingsSizerHelper.addAutoSpacedItem(self.playStartAndExitSoundsCheckBox)
+		settingsSizerHelper.addItem(self.playStartAndExitSoundsCheckBox)
 
 		# Translators: The label for a setting in general settings to select logging level of NVDA as it runs (available options and what they are logged are found under comments for the logging level messages themselves).
 		logLevelLabelText=_("L&ogging level:")
 		# Translators: A combo box to choose log level (possible options are info, debug warning, input/output and debug).
 		logLevelChoicesName=_("Log level")
 		logLevelChoices = [name for level, name in self.LOG_LEVELS]
-		labeledControl = guiHelper.LabeledControlHelper(self, logLevelLabelText, wx.Choice, name=logLevelChoicesName, choices=logLevelChoices)
-		self.logLevelList=labeledControl.control
+		self.logLevelList = settingsSizerHelper.addLabeledControl(logLevelLabelText, wx.Choice, name=logLevelChoicesName, choices=logLevelChoices)
 		curLevel = log.getEffectiveLevel()
 		for index, (level, name) in enumerate(self.LOG_LEVELS):
 			if level == curLevel:
@@ -184,35 +181,34 @@ class GeneralSettingsDialog(SettingsDialog):
 				break
 		else:
 			log.debugWarning("Could not set log level list to current log level")
-		settingsSizerHelper.addAutoSpacedItem(labeledControl)
 
 		# Translators: The label for a setting in general settings to allow NVDA to start after logging onto Windows (if checked, NvDA will start automatically after loggin into Windows; if not, user must start NVDA by pressing the shortcut key (CTRL+Alt+N by default).
 		self.startAfterLogonCheckBox = wx.CheckBox(self, label=_("&Automatically start NVDA after I log on to Windows"))
 		self.startAfterLogonCheckBox.SetValue(config.getStartAfterLogon())
 		if globalVars.appArgs.secure or not config.isInstalledCopy():
 			self.startAfterLogonCheckBox.Disable()
-		settingsSizerHelper.addAutoSpacedItem(self.startAfterLogonCheckBox)
+		settingsSizerHelper.addItem(self.startAfterLogonCheckBox)
 
 		# Translators: The label for a setting in general settings to allow NVDA to come up in Windows login screen (useful if user needs to enter passwords or if multiple user accounts are present to allow user to choose the correct account).
 		self.startOnLogonScreenCheckBox = wx.CheckBox(self, label=_("Use NVDA on the Windows logon screen (requires administrator privileges)"))
 		self.startOnLogonScreenCheckBox.SetValue(config.getStartOnLogonScreen())
 		if globalVars.appArgs.secure or not config.canStartOnSecureScreens():
 			self.startOnLogonScreenCheckBox.Disable()
-		settingsSizerHelper.addAutoSpacedItem(self.startOnLogonScreenCheckBox)
+		settingsSizerHelper.addItem(self.startOnLogonScreenCheckBox)
 
 		# Translators: The label for a button in general settings to copy current user settings to system settings (to allow current settings to be used in secure screens such as User Account Control (UAC) dialog).
 		self.copySettingsButton= wx.Button(self, label=_("Use currently saved settings on the logon and other secure screens (requires administrator privileges)"))
 		self.copySettingsButton.Bind(wx.EVT_BUTTON,self.onCopySettings)
 		if globalVars.appArgs.secure or not config.canStartOnSecureScreens():
 			self.copySettingsButton.Disable()
-		settingsSizerHelper.addAutoSpacedItem(self.copySettingsButton)
+		settingsSizerHelper.addItem(self.copySettingsButton)
 		if updateCheck:
 			# Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA (if not checked, user must check for updates manually).
 			item=self.autoCheckForUpdatesCheckBox=wx.CheckBox(self,label=_("Automatically check for &updates to NVDA"))
 			item.Value=config.conf["update"]["autoCheck"]
 			if globalVars.appArgs.secure:
 				item.Disable()
-			settingsSizerHelper.addAutoSpacedItem(item)
+			settingsSizerHelper.addItem(item)
 
 	def postInit(self):
 		self.languageList.SetFocus()
@@ -304,50 +300,42 @@ class SynthesizerDialog(SettingsDialog):
 	title = _("Synthesizer")
 
 	def makeSettings(self, settingsSizer):
-
-		synthListSizer=wx.BoxSizer(wx.HORIZONTAL)
+		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is a label for the select
 		# synthesizer combobox in the synthesizer dialog.
-		synthListLabel=wx.StaticText(self,label=_("&Synthesizer:"))
+		synthListLabelText=_("&Synthesizer:")
 		driverList=getSynthList()
 		self.synthNames=[x[0] for x in driverList]
 		options=[x[1] for x in driverList]
-		self.synthList=wx.Choice(self,choices=options)
+		self.synthList = settingsSizerHelper.addLabeledControl(synthListLabelText, wx.Choice, choices=options)
+
 		try:
 			index=self.synthNames.index(getSynth().name)
 			self.synthList.SetSelection(index)
 		except:
 			pass
-		guiHelper.addLabelAndControlToHorizontalSizer(synthListSizer, synthListLabel, self.synthList)
-		itemsToAdd = [synthListSizer,]
 
-		deviceListSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is the label for the select output
 		# device combo in the synthesizer dialog. Examples of
 		# of an output device are default soundcard, usb
 		# headphones, etc.
-		deviceListLabel=wx.StaticText(self,label=_("Output &device:"))
+		deviceListLabelText = _("Output &device:")
 		deviceNames=nvwave.getOutputDeviceNames()
-		self.deviceList=wx.Choice(self,choices=deviceNames)
+		self.deviceList = settingsSizerHelper.addLabeledControl(deviceListLabelText, wx.Choice, choices=deviceNames)
+
 		try:
 			selection = deviceNames.index(config.conf["speech"]["outputDevice"])
 		except ValueError:
 			selection = 0
 		self.deviceList.SetSelection(selection)
-		guiHelper.addLabelAndControlToHorizontalSizer(deviceListSizer, deviceListLabel, self.deviceList)
-		itemsToAdd.append(deviceListSizer)
 
-		duckingListSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is a label for the audio ducking combo box in the Audio Settings dialog 
-		duckingListLabel=wx.StaticText(self,label=_("Audio &ducking mode:"))
-		self.duckingList=wx.Choice(self,choices=audioDucking.audioDuckingModes)
+		duckingListLabelText=_("Audio &ducking mode:")
+		self.duckingList=settingsSizerHelper.addLabeledControl(duckingListLabelText, wx.Choice, choices=audioDucking.audioDuckingModes)
 		index=config.conf['audio']['audioDuckingMode']
 		self.duckingList.SetSelection(index)
-		guiHelper.addLabelAndControlToHorizontalSizer(duckingListSizer, duckingListLabel, self.duckingList)
 		if not audioDucking.isAudioDuckingSupported():
 			self.duckingList.Disable()
-		itemsToAdd.append(duckingListSizer)
-		guiHelper.addItemsToSizer(settingsSizer, itemsToAdd)
 
 	def postInit(self):
 		self.synthList.SetFocus()
@@ -459,12 +447,13 @@ class VoiceSettingsDialog(SettingsDialog):
 
 	def makeStringSettingControl(self,setting):
 		"""Same as L{makeSettingControl} but for string settings. Returns sizer with label and combobox."""
-		sizer=wx.BoxSizer(wx.HORIZONTAL)
-		label=wx.StaticText(self,wx.ID_ANY,label="%s:"%setting.displayNameWithAccelerator)
+
+		labelText="%s:"%setting.displayNameWithAccelerator
 		synth=getSynth()
 		setattr(self,"_%ss"%setting.name,getattr(synth,"available%ss"%setting.name.capitalize()).values())
 		l=getattr(self,"_%ss"%setting.name)###
-		lCombo=wx.Choice(self,wx.ID_ANY,name="%s:"%setting.i18nName,choices=[x.name for x in l])
+		labeledControl=guiHelper.LabeledControlHelper(self, labelText, wx.Choice, name="%s:"%setting.i18nName, choices=[x.name for x in l])
+		lCombo = labeledControl.control
 		setattr(self,"%sList"%setting.name,lCombo)
 		try:
 			cur=getattr(synth,setting.name)
@@ -473,11 +462,10 @@ class VoiceSettingsDialog(SettingsDialog):
 		except ValueError:
 			pass
 		lCombo.Bind(wx.EVT_CHOICE,StringSynthSettingChanger(setting,self))
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, lCombo)
 		if self.lastControl:
 			lCombo.MoveAfterInTabOrder(self.lastControl)
 		self.lastControl=lCombo
-		return sizer
+		return labeledControl.sizer
 
 	def makeBooleanSettingControl(self,setting):
 		"""Same as L{makeSettingControl} but for boolean settings. Returns checkbox."""
@@ -496,64 +484,57 @@ class VoiceSettingsDialog(SettingsDialog):
 		self.lastControl=None
 		#Create controls for Synth Settings
 		self.updateVoiceSettings()
-		
+
+		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is the label for a checkbox in the
 		# voice settings dialog (if checked, text will be read using the voice for the language of the text).
-		self.autoLanguageSwitchingCheckbox=wx.CheckBox(self,label=_("Automatic language switching (when supported)"))
+		autoLanguageSwitchingText = _("Automatic language switching (when supported)")
+		self.autoLanguageSwitchingCheckbox = settingsSizerHelper.addItem(wx.CheckBox(self,label=autoLanguageSwitchingText))
 		self.autoLanguageSwitchingCheckbox.SetValue(config.conf["speech"]["autoLanguageSwitching"])
-		
-		itemsToAdd = [self.autoLanguageSwitchingCheckbox,]
 		
 		# Translators: This is the label for a checkbox in the
 		# voice settings dialog (if checked, different voices for dialects will be used to read text in that dialect).
-		self.autoDialectSwitchingCheckbox=wx.CheckBox(self,label=_("Automatic dialect switching (when supported)"))
+		autoDialectSwitchingText =_("Automatic dialect switching (when supported)")
+		self.autoDialectSwitchingCheckbox=settingsSizerHelper.addItem(wx.CheckBox(self,label=autoDialectSwitchingText))
 		self.autoDialectSwitchingCheckbox.SetValue(config.conf["speech"]["autoDialectSwitching"])
-		itemsToAdd.append(self.autoDialectSwitchingCheckbox)
 
-		sizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is the label for a combobox in the
 		# voice settings dialog (possible choices are none, some, most and all).
-		punctuationLabel = wx.StaticText(self,label=_("Punctuation/symbol &level:"))
+		punctuationLabelText = _("Punctuation/symbol &level:")
 		symbolLevelLabels=characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS
-		self.symbolLevelList=wx.Choice(self,wx.ID_ANY,choices=[symbolLevelLabels[level] for level in characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS])
+		symbolLevelChoices =[symbolLevelLabels[level] for level in characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS]
+		self.symbolLevelList = settingsSizerHelper.addLabeledControl(punctuationLabelText, wx.Choice, choices=symbolLevelChoices)
 		curLevel = config.conf["speech"]["symbolLevel"]
 		self.symbolLevelList.SetSelection(characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS.index(curLevel))
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, punctuationLabel, self.symbolLevelList)
-		itemsToAdd.append(sizer)
 
 		# Translators: This is the label for a checkbox in the
 		# voice settings dialog (if checked, text will be read using the voice for the language of the text).
-		self.trustVoiceLanguageCheckbox=wx.CheckBox(self,label=_("Trust voice's language when processing characters and symbols"))
+		trustVoiceLanguageText = _("Trust voice's language when processing characters and symbols")
+		self.trustVoiceLanguageCheckbox = settingsSizerHelper.addItem(wx.CheckBox(self,label=trustVoiceLanguageText))
 		self.trustVoiceLanguageCheckbox.SetValue(config.conf["speech"]["trustVoiceLanguage"])
-		itemsToAdd.append(self.trustVoiceLanguageCheckbox)
 		
-		sizer=wx.BoxSizer(wx.VERTICAL)
 		# Translators: This is a label for a setting in voice settings (an edit box to change voice pitch for capital letters; the higher the value, the pitch will be higher).
-		capPitchChangeLabel=wx.StaticText(self,label=_("Capital pitch change percentage"))
-		sizer.Add(capPitchChangeLabel)
-		self.capPitchChangeEdit=wx.TextCtrl(self)
+		capPitchChangeLabelText=_("Capital pitch change percentage")
+		self.capPitchChangeEdit=settingsSizerHelper.addLabeledControl(capPitchChangeLabelText,wx.TextCtrl)
 		self.capPitchChangeEdit.SetValue(str(config.conf["speech"][getSynth().name]["capPitchChange"]))
-		sizer.Add(self.capPitchChangeEdit)
-		itemsToAdd.append(sizer)
 
 		# Translators: This is the label for a checkbox in the
 		# voice settings dialog.
-		self.sayCapForCapsCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Say &cap before capitals"))
+		sayCapForCapsText = _("Say &cap before capitals")
+		self.sayCapForCapsCheckBox = settingsSizerHelper.addItem(wx.CheckBox(self,label=sayCapForCapsText))
 		self.sayCapForCapsCheckBox.SetValue(config.conf["speech"][getSynth().name]["sayCapForCapitals"])
-		itemsToAdd.append(self.sayCapForCapsCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# voice settings dialog.
-		self.beepForCapsCheckBox = wx.CheckBox(self, wx.NewId(), label = _("&Beep for capitals"))
+		beepForCapsText =_("&Beep for capitals")
+		self.beepForCapsCheckBox = settingsSizerHelper.addItem(wx.CheckBox(self, label = beepForCapsText))
 		self.beepForCapsCheckBox.SetValue(config.conf["speech"][getSynth().name]["beepForCapitals"])
-		itemsToAdd.append(self.beepForCapsCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# voice settings dialog.
-		self.useSpellingFunctionalityCheckBox = wx.CheckBox(self, wx.NewId(), label = _("Use &spelling functionality if supported"))
+		useSpellingFunctionalityText = _("Use &spelling functionality if supported")
+		self.useSpellingFunctionalityCheckBox = settingsSizerHelper.addItem(wx.CheckBox(self, label = useSpellingFunctionalityText))
 		self.useSpellingFunctionalityCheckBox.SetValue(config.conf["speech"][getSynth().name]["useSpellingFunctionality"])
-		itemsToAdd.append(self.useSpellingFunctionalityCheckBox)
-		guiHelper.addItemsToSizer(settingsSizer, itemsToAdd)
 
 	def postInit(self):
 		try:
@@ -637,97 +618,95 @@ class KeyboardSettingsDialog(SettingsDialog):
 	title = _("Keyboard Settings")
 
 	def makeSettings(self, settingsSizer):
-
-		kbdSizer=wx.BoxSizer(wx.HORIZONTAL)
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is the label for a combobox in the
 		# keyboard settings dialog.
-		kbdLabel=wx.StaticText(self,label=_("&Keyboard layout:"))
+		kbdLabelText = _("&Keyboard layout:")
+		# Translators: This is the name of a combobox in the keyboard settings dialog.
+		kbdChoicesName = _("Keyboard layout")
 		layouts=keyboardHandler.KeyboardInputGesture.LAYOUTS
 		self.kbdNames=sorted(layouts)
-		# Translators: This is the name of a combobox in the keyboard settings dialog.
-		self.kbdList=wx.Choice(self,name=_("Keyboard layout"),choices=[layouts[layout] for layout in self.kbdNames])
+		kbdChoices = [layouts[layout] for layout in self.kbdNames]
+		self.kbdList=sHelper.addLabeledControl(kbdLabelText, wx.Choice, name=kbdChoicesName, choices=kbdChoices)
 		try:
 			index=self.kbdNames.index(config.conf['keyboard']['keyboardLayout'])
 			self.kbdList.SetSelection(index)
 		except:
 			log.debugWarning("Could not set Keyboard layout list to current layout",exc_info=True) 
-		guiHelper.addLabelAndControlToHorizontalSizer(kbdSizer, kbdLabel, self.kbdList)
-		itemsToAdd = [kbdSizer,]
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.capsAsNVDAModifierCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Use CapsLock as an NVDA modifier key"))
+		capsAsNVDAText = _("Use CapsLock as an NVDA modifier key")
+		self.capsAsNVDAModifierCheckBox=sHelper.addItem(wx.CheckBox(self,label=capsAsNVDAText))
 		self.capsAsNVDAModifierCheckBox.SetValue(config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"])
-		itemsToAdd.append(self.capsAsNVDAModifierCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.numpadInsertAsNVDAModifierCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Use numpad Insert as an NVDA modifier key"))
+		numpadInsertAsModText = _("Use numpad Insert as an NVDA modifier key")
+		self.numpadInsertAsNVDAModifierCheckBox=sHelper.addItem(wx.CheckBox(self,label=numpadInsertAsModText))
 		self.numpadInsertAsNVDAModifierCheckBox.SetValue(config.conf["keyboard"]["useNumpadInsertAsNVDAModifierKey"])
-		itemsToAdd.append(self.numpadInsertAsNVDAModifierCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.extendedInsertAsNVDAModifierCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Use extended Insert as an NVDA modifier key"))
+		extendedInsertAsModText = _("Use extended Insert as an NVDA modifier key")
+		self.extendedInsertAsNVDAModifierCheckBox=sHelper.addItem(wx.CheckBox(self,label=extendedInsertAsModText))
 		self.extendedInsertAsNVDAModifierCheckBox.SetValue(config.conf["keyboard"]["useExtendedInsertAsNVDAModifierKey"])
-		itemsToAdd.append(self.extendedInsertAsNVDAModifierCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.charsCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Speak typed &characters"))
+		charsText = _("Speak typed &characters")
+		self.charsCheckBox=sHelper.addItem(wx.CheckBox(self,label=charsText))
 		self.charsCheckBox.SetValue(config.conf["keyboard"]["speakTypedCharacters"])
-		itemsToAdd.append(self.charsCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.wordsCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Speak typed &words"))
+		speakTypedWordsText = _("Speak typed &words")
+		self.wordsCheckBox=sHelper.addItem(wx.CheckBox(self,label=speakTypedWordsText))
 		self.wordsCheckBox.SetValue(config.conf["keyboard"]["speakTypedWords"])
-		itemsToAdd.append(self.wordsCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.speechInterruptForCharsCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Speech interrupt for typed characters"))
+		speechInterruptForCharText = _("Speech interrupt for typed characters")
+		self.speechInterruptForCharsCheckBox=sHelper.addItem(wx.CheckBox(self,label=speechInterruptForCharText))
 		self.speechInterruptForCharsCheckBox.SetValue(config.conf["keyboard"]["speechInterruptForCharacters"])
-		itemsToAdd.append(self.speechInterruptForCharsCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.speechInterruptForEnterCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Speech interrupt for Enter key"))
+		speechInterruptForEnterText = _("Speech interrupt for Enter key")
+		self.speechInterruptForEnterCheckBox=sHelper.addItem(wx.CheckBox(self,label=speechInterruptForEnterText))
 		self.speechInterruptForEnterCheckBox.SetValue(config.conf["keyboard"]["speechInterruptForEnter"])
-		itemsToAdd.append(self.speechInterruptForEnterCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.skimReadingInSayAllCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Allow skim &reading in Say All"))
+		allowSkimReadingInSayAllText = _("Allow skim &reading in Say All")
+		self.skimReadingInSayAllCheckBox=sHelper.addItem(wx.CheckBox(self,label=allowSkimReadingInSayAllText))
 		self.skimReadingInSayAllCheckBox.SetValue(config.conf["keyboard"]["allowSkimReadingInSayAll"])
-		itemsToAdd.append(self.skimReadingInSayAllCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.beepLowercaseCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Beep if typing lowercase letters when caps lock is on"))
+		beepForLowercaseWithCapsLockText = _("Beep if typing lowercase letters when caps lock is on")
+		self.beepLowercaseCheckBox=sHelper.addItem(wx.CheckBox(self,label=beepForLowercaseWithCapsLockText))
 		self.beepLowercaseCheckBox.SetValue(config.conf["keyboard"]["beepForLowercaseWithCapslock"])
-		itemsToAdd.append(self.beepLowercaseCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.commandKeysCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Speak command &keys"))
+		commandKeysText = _("Speak command &keys")
+		self.commandKeysCheckBox=sHelper.addItem(wx.CheckBox(self,label=commandKeysText))
 		self.commandKeysCheckBox.SetValue(config.conf["keyboard"]["speakCommandKeys"])
-		itemsToAdd.append(self.commandKeysCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.alertForSpellingErrorsCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Play sound for &spelling errors while typing"))
+		alertForSpellingErrorsText = _("Play sound for &spelling errors while typing")
+		self.alertForSpellingErrorsCheckBox=sHelper.addItem(wx.CheckBox(self,label=alertForSpellingErrorsText))
 		self.alertForSpellingErrorsCheckBox.SetValue(config.conf["keyboard"]["alertForSpellingErrors"])
 		if not config.conf["documentFormatting"]["reportSpellingErrors"]:
 			self.alertForSpellingErrorsCheckBox.Disable()
-		itemsToAdd.append(self.alertForSpellingErrorsCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# keyboard settings dialog.
-		self.handleInjectedKeysCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Handle keys from other &applications"))
+		handleInjectedKeysText = _("Handle keys from other &applications")
+		self.handleInjectedKeysCheckBox=sHelper.addItem(wx.CheckBox(self,label=handleInjectedKeysText))
 		self.handleInjectedKeysCheckBox.SetValue(config.conf["keyboard"]["handleInjectedKeys"])
-		itemsToAdd.append(self.handleInjectedKeysCheckBox)
-		guiHelper.addItemsToSizer(settingsSizer, itemsToAdd)
 
 	def postInit(self):
 		self.kbdList.SetFocus()
@@ -763,53 +742,52 @@ class MouseSettingsDialog(SettingsDialog):
 	title = _("Mouse Settings")
 
 	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 
 		# Translators: This is the label for a checkbox in the
 		# mouse settings dialog.
-		self.shapeCheckBox=wx.CheckBox(self,label=_("Report mouse &shape changes"))
+		shapeChangesText = _("Report mouse &shape changes")
+		self.shapeCheckBox=sHelper.addItem(wx.CheckBox(self,label=shapeChangesText))
 		self.shapeCheckBox.SetValue(config.conf["mouse"]["reportMouseShapeChanges"])
-		itemsToAdd = [self.shapeCheckBox,]
 
 		# Translators: This is the label for a checkbox in the
 		# mouse settings dialog.
-		self.mouseTrackingCheckBox=wx.CheckBox(self,label=_("Enable mouse &tracking"))
+		mouseTrackingText=_("Enable mouse &tracking")
+		self.mouseTrackingCheckBox=sHelper.addItem(wx.CheckBox(self,label=mouseTrackingText))
 		self.mouseTrackingCheckBox.SetValue(config.conf["mouse"]["enableMouseTracking"])
-		itemsToAdd.append(self.mouseTrackingCheckBox)
 
-		textUnitSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is the label for a combobox in the
 		# mouse settings dialog.
-		textUnitLabel=wx.StaticText(self,label=_("Text &unit resolution:"))
+		textUnitLabelText=_("Text &unit resolution:")
+		# Translators: This is the name of a combobox in the mouse settings dialog.
+		textUnitsName = _("text reporting unit")
 		import textInfos
 		self.textUnits=[textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD,textInfos.UNIT_LINE,textInfos.UNIT_PARAGRAPH]
-		# Translators: This is the name of a combobox in the mouse settings dialog.
-		self.textUnitComboBox=wx.Choice(self,name=_("text reporting unit"),choices=[textInfos.unitLabels[x] for x in self.textUnits])
+		textUnitsChoices = [textInfos.unitLabels[x] for x in self.textUnits]
+		self.textUnitComboBox=sHelper.addLabeledControl(textUnitLabelText, wx.Choice, name=textUnitsName, choices=textUnitsChoices)
 		try:
 			index=self.textUnits.index(config.conf["mouse"]["mouseTextUnit"])
 		except:
 			index=0
 		self.textUnitComboBox.SetSelection(index)
-		guiHelper.addLabelAndControlToHorizontalSizer(textUnitSizer, textUnitLabel, self.textUnitComboBox)
-		itemsToAdd.append(textUnitSizer)
 
 		# Translators: This is the label for a checkbox in the
 		# mouse settings dialog.
-		self.reportObjectRoleCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report &role when mouse enters object"))
+		reportObjectRoleText = _("Report &role when mouse enters object")
+		self.reportObjectRoleCheckBox=sHelper.addItem(wx.CheckBox(self,label=reportObjectRoleText))
 		self.reportObjectRoleCheckBox.SetValue(config.conf["mouse"]["reportObjectRoleOnMouseEnter"])
-		itemsToAdd.append(self.reportObjectRoleCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# mouse settings dialog.
-		self.audioCheckBox=wx.CheckBox(self,wx.NewId(),label=_("&Play audio coordinates when mouse moves"))
+		audioText = _("&Play audio coordinates when mouse moves")
+		self.audioCheckBox=sHelper.addItem(wx.CheckBox(self,label=audioText))
 		self.audioCheckBox.SetValue(config.conf["mouse"]["audioCoordinatesOnMouseMove"])
-		itemsToAdd.append(self.audioCheckBox)
 
 		# Translators: This is the label for a checkbox in the
 		# mouse settings dialog.
-		self.audioDetectBrightnessCheckBox=wx.CheckBox(self,wx.NewId(),label=_("&Brightness controls audio coordinates volume"))
+		audioDetectBrightnessText = _("&Brightness controls audio coordinates volume")
+		self.audioDetectBrightnessCheckBox=sHelper.addItem(wx.CheckBox(self,label=audioDetectBrightnessText))
 		self.audioDetectBrightnessCheckBox.SetValue(config.conf["mouse"]["audioCoordinates_detectBrightness"])
-		itemsToAdd.append(self.audioDetectBrightnessCheckBox)
-		guiHelper.addItemsToSizer(settingsSizer, itemsToAdd)
 
 	def postInit(self):
 		self.shapeCheckBox.SetFocus()
@@ -925,61 +903,69 @@ class ObjectPresentationDialog(SettingsDialog):
 	)
 
 	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.tooltipCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report &tooltips"))
+		reportToolTipsText = _("Report &tooltips")
+		self.tooltipCheckBox=sHelper.addItem(wx.CheckBox(self,label=reportToolTipsText))
 		self.tooltipCheckBox.SetValue(config.conf["presentation"]["reportTooltips"])
-		settingsSizer.Add(self.tooltipCheckBox,border=10,flag=wx.BOTTOM)
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.balloonCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report &help balloons"))
+		balloonText = _("Report &help balloons")
+		self.balloonCheckBox=sHelper.addItem(wx.CheckBox(self,label=balloonText))
 		self.balloonCheckBox.SetValue(config.conf["presentation"]["reportHelpBalloons"])
-		settingsSizer.Add(self.balloonCheckBox,border=10,flag=wx.BOTTOM)
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.shortcutCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report object shortcut &keys"))
+		shortcutText = _("Report object shortcut &keys")
+		self.shortcutCheckBox=sHelper.addItem(wx.CheckBox(self,label=shortcutText))
 		self.shortcutCheckBox.SetValue(config.conf["presentation"]["reportKeyboardShortcuts"])
-		settingsSizer.Add(self.shortcutCheckBox,border=10,flag=wx.BOTTOM)
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.positionInfoCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report object &position information"))
+		positionInfoText = _("Report object &position information")
+		self.positionInfoCheckBox=sHelper.addItem(wx.CheckBox(self,label=positionInfoText))
 		self.positionInfoCheckBox.SetValue(config.conf["presentation"]["reportObjectPositionInformation"])
-		settingsSizer.Add(self.positionInfoCheckBox,border=10,flag=wx.BOTTOM)
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.guessPositionInfoCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Guess object &position information when unavailable"))
+		guessPositionInfoText=_("Guess object &position information when unavailable")
+		self.guessPositionInfoCheckBox=sHelper.addItem(wx.CheckBox(self,label=guessPositionInfoText))
 		self.guessPositionInfoCheckBox.SetValue(config.conf["presentation"]["guessObjectPositionInformationWhenUnavailable"])
-		settingsSizer.Add(self.guessPositionInfoCheckBox,border=10,flag=wx.BOTTOM)
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.descriptionCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report object &descriptions"))
+		descriptionText = _("Report object &descriptions")
+		self.descriptionCheckBox=sHelper.addItem(wx.CheckBox(self,label=descriptionText))
 		self.descriptionCheckBox.SetValue(config.conf["presentation"]["reportObjectDescriptions"])
-		settingsSizer.Add(self.descriptionCheckBox,border=10,flag=wx.BOTTOM)
-		progressSizer=wx.BoxSizer(wx.HORIZONTAL)
+		
 		# Translators: This is the label for a combobox in the
 		# object presentation settings dialog.
-		progressLabel=wx.StaticText(self,label=_("Progress &bar output:"))
+		progressLabelText = _("Progress &bar output:")
 		# Translators: This is the name of a combobox in the
 		# object presentation settings dialog.
-		self.progressList=wx.Choice(self,name=_("Progress bar output"),choices=[name for setting, name in self.progressLabels])
+		progressName=_("Progress bar output")
+		progressChoices = [name for setting, name in self.progressLabels]
+		self.progressList=sHelper.addLabeledControl(progressLabelText, wx.Choice,name=progressName,choices=progressChoices)
 		for index, (setting, name) in enumerate(self.progressLabels):
 			if setting == config.conf["presentation"]["progressBarUpdates"]["progressBarOutputMode"]:
 				self.progressList.SetSelection(index)
 				break
 		else:
 			log.debugWarning("Could not set progress list to current report progress bar updates setting")
-		guiHelper.addLabelAndControlToHorizontalSizer(progressSizer, progressLabel, self.progressList)
-		settingsSizer.Add(progressSizer,border=10,flag=wx.BOTTOM)
+		
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.reportBackgroundProgressBarsCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report background progress bars"))
+		reportBackgroundProgressBarsText = _("Report background progress bars")
+		self.reportBackgroundProgressBarsCheckBox=sHelper.addItem(wx.CheckBox(self,label=reportBackgroundProgressBarsText))
 		self.reportBackgroundProgressBarsCheckBox.SetValue(config.conf["presentation"]["progressBarUpdates"]["reportBackgroundProgressBars"])
-		settingsSizer.Add(self.reportBackgroundProgressBarsCheckBox,border=10,flag=wx.BOTTOM)
+		
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings dialog.
-		self.dynamicContentCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report dynamic &content changes"))
+		dynamicContentText = _("Report dynamic &content changes")
+		self.dynamicContentCheckBox=sHelper.addItem(wx.CheckBox(self,label=dynamicContentText))
 		self.dynamicContentCheckBox.SetValue(config.conf["presentation"]["reportDynamicContentChanges"])
-		settingsSizer.Add(self.dynamicContentCheckBox,border=10,flag=wx.BOTTOM)
 
 	def postInit(self):
 		self.tooltipCheckBox.SetFocus()
@@ -1276,29 +1262,32 @@ class DictionaryEntryDialog(wx.Dialog):
 	def __init__(self, parent, title=_("Edit Dictionary Entry")):
 		super(DictionaryEntryDialog,self).__init__(parent,title=title)
 		mainSizer=wx.BoxSizer(wx.VERTICAL)
-		settingsSizer=wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+
 		# Translators: This is a label for an edit field in add dictionary entry dialog.
-		settingsSizer.Add(wx.StaticText(self,-1,label=_("&Pattern")))
-		self.patternTextCtrl=wx.TextCtrl(self,wx.NewId())
-		settingsSizer.Add(self.patternTextCtrl)
+		patternLabelText = _("&Pattern")
+		self.patternTextCtrl=sHelper.addLabeledControl(patternLabelText, wx.TextCtrl)
+
 		# Translators: This is a label for an edit field in add dictionary entry dialog and in punctuation/symbol pronunciation dialog.
-		settingsSizer.Add(wx.StaticText(self,-1,label=_("&Replacement")))
-		self.replacementTextCtrl=wx.TextCtrl(self,wx.NewId())
-		settingsSizer.Add(self.replacementTextCtrl)
+		replacementLabelText = _("&Replacement")
+		self.replacementTextCtrl=sHelper.addLabeledControl(replacementLabelText, wx.TextCtrl)
+
 		# Translators: This is a label for an edit field in add dictionary entry dialog.
-		settingsSizer.Add(wx.StaticText(self,-1,label=_("&Comment")))
-		self.commentTextCtrl=wx.TextCtrl(self,wx.NewId())
-		settingsSizer.Add(self.commentTextCtrl)
+		commentLabelText = _("&Comment")
+		self.commentTextCtrl=sHelper.addLabeledControl(commentLabelText, wx.TextCtrl)
+		
 		# Translators: This is a label for a checkbox in add dictionary entry dialog.
-		self.caseSensitiveCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Case &sensitive"))
-		settingsSizer.Add(self.caseSensitiveCheckBox)
+		caseSensitiveText = _("Case &sensitive")
+		self.caseSensitiveCheckBox=sHelper.addItem(wx.CheckBox(self,label=caseSensitiveText))
 
 		# Translators: This is a label for a set of radio buttons in add dictionary entry dialog.
-		self.typeRadioBox=wx.RadioBox(self,wx.NewId(),label=_("&Type"), choices=[DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING])
-		settingsSizer.Add(self.typeRadioBox)
-		mainSizer.Add(settingsSizer,border=20,flag=wx.LEFT|wx.RIGHT|wx.TOP)
-		buttonSizer=self.CreateButtonSizer(wx.OK|wx.CANCEL)
-		mainSizer.Add(buttonSizer,border=20,flag=wx.LEFT|wx.RIGHT|wx.BOTTOM)
+		typeText = _("&Type")
+		typeChoices = [DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING]
+		self.typeRadioBox=sHelper.addItem(wx.RadioBox(self,label=typeText, choices=typeChoices))
+		
+		sHelper.addItem(self.CreateButtonSizer(wx.OK|wx.CANCEL))
+
+		mainSizer.Add(sHelper.sizer,border=20,flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 		self.setType(speechDictHandler.ENTRY_TYPE_ANYWHERE)
@@ -1336,11 +1325,10 @@ class DictionaryDialog(SettingsDialog):
 		super(DictionaryDialog, self).__init__(parent)
 
 	def makeSettings(self, settingsSizer):
-		entriesSizer=wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: The label for the combo box of dictionary entries in speech dictionary dialog.
-		entriesLabel=wx.StaticText(self,label=_("&Dictionary entries"))
-		entriesSizer.Add(entriesLabel)
-		self.dictList=wx.ListCtrl(self,style=wx.LC_REPORT|wx.LC_SINGLE_SEL,size=(550,350))
+		entriesLabelText=_("&Dictionary entries")
+		self.dictList=sHelper.addLabeledControl(entriesLabelText, wx.ListCtrl, style=wx.LC_REPORT|wx.LC_SINGLE_SEL,size=(550,350))
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.InsertColumn(0,_("Comment"),width=150)
 		# Translators: The label for a column in dictionary entries list used to identify pattern (original word or a pattern).
@@ -1356,27 +1344,23 @@ class DictionaryDialog(SettingsDialog):
 			self.dictList.Append((entry.comment,entry.pattern,entry.replacement,self.offOn[int(entry.caseSensitive)],DictionaryDialog.TYPE_LABELS[entry.type]))
 		self.editingIndex=-1
 		self.dictList.Bind(wx.EVT_CHAR, self.onListChar)
-		entriesSizer.Add(self.dictList)
-		itemsToAdd = [entriesSizer,]
 
-		entryButtonsSizer=wx.BoxSizer(wx.HORIZONTAL)
+		bHelper = guiHelper.ButtonHelper(orientation=wx.HORIZONTAL)
 		addButtonID=wx.NewId()
 		# Translators: The label for a button in speech dictionaries dialog to add new entries.
-		buttonsToAdd=[wx.Button(self,addButtonID,_("&Add"),wx.DefaultPosition),]
+		bHelper.addButton(self, addButtonID,_("&Add"),wx.DefaultPosition)
 		
 		editButtonID=wx.NewId()
 		# Translators: The label for a button in speech dictionaries dialog to edit existing entries.
-		buttonsToAdd.append(wx.Button(self,editButtonID,_("&Edit"),wx.DefaultPosition) )
+		bHelper.addButton(self, editButtonID,_("&Edit"),wx.DefaultPosition)
 		
 		removeButtonID=wx.NewId()
-		buttonsToAdd.append(wx.Button(self,removeButtonID,_("&Remove"),wx.DefaultPosition) )
-		guiHelper.addItemsToSizer(entryButtonsSizer, buttonsToAdd, guiHelper.SPACE_BETWEEN_BUTTONS)
+		bHelper.addButton(self, removeButtonID,_("&Remove"),wx.DefaultPosition)
+		sHelper.addItem(bHelper)
 
 		self.Bind(wx.EVT_BUTTON,self.OnAddClick,id=addButtonID)
 		self.Bind(wx.EVT_BUTTON,self.OnEditClick,id=editButtonID)
 		self.Bind(wx.EVT_BUTTON,self.OnRemoveClick,id=removeButtonID)
-		itemsToAdd.append(entryButtonsSizer)
-		guiHelper.addItemsToSizer(settingsSizer, itemsToAdd)
 
 	def postInit(self):
 		self.dictList.SetFocus()
@@ -1454,81 +1438,71 @@ class BrailleSettingsDialog(SettingsDialog):
 	title = _("Braille Settings")
 
 	def makeSettings(self, settingsSizer):
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+
 		# Translators: The label for a setting in braille settings to choose a braille display.
-		label = wx.StaticText(self, wx.ID_ANY, label=_("Braille &display:"))
+		displayLabelText = _("Braille &display:")
 		driverList = braille.getDisplayList()
 		self.displayNames = [driver[0] for driver in driverList]
-		self.displayList = wx.Choice(self, wx.ID_ANY, choices=[driver[1] for driver in driverList])
+		displayChoices = [driver[1] for driver in driverList]
+		self.displayList = sHelper.addLabeledControl(displayLabelText, wx.Choice, choices=displayChoices)
 		self.Bind(wx.EVT_CHOICE, self.onDisplayNameChanged, self.displayList)
 		try:
 			selection = self.displayNames.index(braille.handler.display.name)
 			self.displayList.SetSelection(selection)
 		except:
 			pass
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.displayList)
-		itemsToAdd = [sizer,]
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to choose the connection port (if the selected braille display supports port selection).
-		label = wx.StaticText(self, wx.ID_ANY, label=_("&Port:"))
-		self.portsList = wx.Choice(self, wx.ID_ANY, choices=[])
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.portsList)
-		itemsToAdd.append(sizer)
+		portsLabelText = _("&Port:")
+		self.portsList = sHelper.addLabeledControl(portsLabelText, wx.Choice, choices=[])
 		self.updatePossiblePorts()
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the output table (the braille table used to read braille text on the braille display).
-		label = wx.StaticText(self, wx.ID_ANY, label=_("&Output table:"))
+		outputsLabelText = _("&Output table:")
 		self.tableNames = [table[0] for table in braille.TABLES]
-		self.tableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in braille.TABLES])
+		tableChoices = [table[1] for table in braille.TABLES]
+		self.tableList = sHelper.addLabeledControl(outputsLabelText, wx.Choice, choices=tableChoices)
 		try:
 			selection = self.tableNames.index(config.conf["braille"]["translationTable"])
 			self.tableList.SetSelection(selection)
 		except:
 			pass
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.tableList)
-		itemsToAdd.append(sizer)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the input table (the braille table used to type braille characters on a braille keyboard).
-		label = wx.StaticText(self, wx.ID_ANY, label=_("&Input table:"))
+		inputLabelText = _("&Input table:")
 		self.inputTableNames = [table[0] for table in braille.INPUT_TABLES]
-		self.inputTableList = wx.Choice(self, wx.ID_ANY, choices=[table[1] for table in braille.INPUT_TABLES])
+		inputChoices = [table[1] for table in braille.INPUT_TABLES]
+		self.inputTableList = sHelper.addLabeledControl(inputLabelText, wx.Choice, choices=inputChoices)
 		try:
 			selection = self.inputTableNames.index(config.conf["braille"]["inputTable"])
 			self.inputTableList.SetSelection(selection)
 		except:
 			pass
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.inputTableList)
-		itemsToAdd.append(sizer)
 
 		# Translators: The label for a setting in braille settings to expand the current word under cursor to computer braille.
-		self.expandAtCursorCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("E&xpand to computer braille for the word at the cursor"))
+		expandAtCursorText = _("E&xpand to computer braille for the word at the cursor")
+		self.expandAtCursorCheckBox = sHelper.addItem(wx.CheckBox(self, wx.ID_ANY, label=expandAtCursorText))
 		self.expandAtCursorCheckBox.SetValue(config.conf["braille"]["expandAtCursor"])
-		itemsToAdd.append(self.expandAtCursorCheckBox)
 
 		# Translators: The label for a setting in braille settings to show the cursor.
-		self.showCursorCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("&Show cursor"))
+		showCursorLabelText = _("&Show cursor")
+		self.showCursorCheckBox = sHelper.addItem(wx.CheckBox(self, label=showCursorLabelText))
 		self.showCursorCheckBox.Bind(wx.EVT_CHECKBOX, self.onShowCursorChange)
 		self.showCursorCheckBox.SetValue(config.conf["braille"]["showCursor"])
-		itemsToAdd.append(self.showCursorCheckBox)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to change cursor blink rate in milliseconds (1 second is 1000 milliseconds).
-		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor blink rate (ms)"))
-		self.cursorBlinkRateEdit = wx.TextCtrl(self, wx.ID_ANY)
+		cursorBlinkRateLabelText = _("Cursor blink rate (ms)")
+		self.cursorBlinkRateEdit = sHelper.addLabeledControl(cursorBlinkRateLabelText, wx.TextCtrl)
 		self.cursorBlinkRateEdit.SetValue(str(config.conf["braille"]["cursorBlinkRate"]))
 		if not self.showCursorCheckBox.GetValue():
 			self.cursorBlinkRateEdit.Disable()
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.cursorBlinkRateEdit)
-		itemsToAdd.append(sizer)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to select the cursor shape.
-		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor &shape:"))
+		cursorShapeLabelText = _("Cursor &shape:")
 		self.cursorShapes = [s[0] for s in braille.CURSOR_SHAPES]
-		self.shapeList = wx.Choice(self, wx.ID_ANY, choices=[s[1] for s in braille.CURSOR_SHAPES])
+		cursorShapeChoices = [s[1] for s in braille.CURSOR_SHAPES]
+		self.shapeList = sHelper.addLabeledControl(cursorShapeLabelText, wx.Choice, choices=cursorShapeChoices)
 		try:
 			selection = self.cursorShapes.index(config.conf["braille"]["cursorShape"])
 			self.shapeList.SetSelection(selection)
@@ -1536,41 +1510,34 @@ class BrailleSettingsDialog(SettingsDialog):
 			pass
 		if not self.showCursorCheckBox.GetValue():
 			self.shapeList.Disable()
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.shapeList)
-		itemsToAdd.append(sizer)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to change how long a message stays on the braille display (in seconds).
-		label = wx.StaticText(self, wx.ID_ANY, label=_("Message timeout (sec)"))
-		self.messageTimeoutEdit = wx.TextCtrl(self, wx.ID_ANY)
+		messageTimeoutText = _("Message timeout (sec)")
+		self.messageTimeoutEdit = sHelper.addLabeledControl(messageTimeoutText, wx.TextCtrl)
 		self.messageTimeoutEdit.SetValue(str(config.conf["braille"]["messageTimeout"]))
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.messageTimeoutEdit)
-		itemsToAdd.append(sizer)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to set whether braille should be tethered to focus or review cursor.
-		label = wx.StaticText(self, wx.ID_ANY, label=_("Braille tethered to:"))
+		tetherListText = _("Braille tethered to:")
+		# Translators: The value for a setting in the braille settings, to set whether braille should be tethered to focus or review cursor.
 		self.tetherValues=[("focus",_("focus")),("review",_("review"))]
-		self.tetherList = wx.Choice(self, wx.ID_ANY, choices=[x[1] for x in self.tetherValues])
+		tetherChoices = [x[1] for x in self.tetherValues]
+		self.tetherList = sHelper.addLabeledControl(tetherListText, wx.Choice, choices=tetherChoices)
 		tetherConfig=braille.handler.tether
 		selection = (x for x,y in enumerate(self.tetherValues) if y[0]==tetherConfig).next()  
 		try:
 			self.tetherList.SetSelection(selection)
 		except:
 			pass
-		guiHelper.addLabelAndControlToHorizontalSizer(sizer, label, self.tetherList)
-		itemsToAdd.append(sizer)
 
 		# Translators: The label for a setting in braille settings to read by paragraph (if it is checked, the commands to move the display by lines moves the display by paragraphs instead).
-		item = self.readByParagraphCheckBox = wx.CheckBox(self, label=_("Read by &paragraph"))
-		item.Value = config.conf["braille"]["readByParagraph"]
-		itemsToAdd.append(item)
+		readByParagraphText = _("Read by &paragraph")
+		self.readByParagraphCheckBox = sHelper.addItem(wx.CheckBox(self, label=readByParagraphText))
+		self.readByParagraphCheckBox.Value = config.conf["braille"]["readByParagraph"]
 
 		# Translators: The label for a setting in braille settings to enable word wrap (try to avoid spliting words at the end of the braille display).
-		item = self.wordWrapCheckBox = wx.CheckBox(self, label=_("Avoid splitting &words when possible"))
-		item.Value = config.conf["braille"]["wordWrap"]
-		itemsToAdd.append(item)
-		guiHelper.addItemsToSizer(settingsSizer, itemsToAdd)
+		wordWrapText = _("Avoid splitting &words when possible")
+		self.wordWrapCheckBox = sHelper.addItem(wx.CheckBox(self, label=wordWrapText))
+		self.wordWrapCheckBox.Value = config.conf["braille"]["wordWrap"]
 
 	def postInit(self):
 		self.displayList.SetFocus()
@@ -1845,12 +1812,12 @@ class InputGesturesDialog(SettingsDialog):
 		# Translators: The label of a text field to search for gestures in the Input Gestures dialog.
 		filterLabel = wx.StaticText(self, label=pgettext("inputGestures", "&Filter by:"))
 		filter = wx.TextCtrl(self)
-		filter.Bind(wx.EVT_TEXT, self.onFilterChange, filter)
 		filterSizer.Add(filterLabel, flag=wx.ALIGN_CENTER_VERTICAL)
 		filterSizer.AddSpacer(guiHelper.SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL)
 		filterSizer.Add(filter, proportion=1)
 		settingsSizer.Add(filterSizer, flag=wx.EXPAND)
 		settingsSizer.AddSpacer(5)
+		filter.Bind(wx.EVT_TEXT, self.onFilterChange, filter)
 		
 		tree = self.tree = wx.TreeCtrl(self, size=wx.Size(600, 400), style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE )
 		
@@ -1866,16 +1833,17 @@ class InputGesturesDialog(SettingsDialog):
 		item = self.addButton = wx.Button(self, label=_("&Add"))
 		item.Bind(wx.EVT_BUTTON, self.onAdd)
 		item.Disable()
-		buttonsToAdd = [item,]
+		buttonSizer.Add(item)
+		buttonSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS)
 		# Translators: The label of a button to remove a gesture in the Input Gestures dialog.
 		item = self.removeButton = wx.Button(self, label=_("&Remove"))
 		item.Bind(wx.EVT_BUTTON, self.onRemove)
 		item.Disable()
 		self.pendingAdds = set()
 		self.pendingRemoves = set()
-		buttonsToAdd.append(item)
-		guiHelper.addItemsToSizer(buttonSizer, buttonsToAdd, guiHelper.SPACE_BETWEEN_BUTTONS)
-		guiHelper.addButtonsSizerToMainSizer(settingsSizer, buttonSizer)
+		buttonSizer.Add(item)
+		buttonSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS)
+		settingsSizer.Add(buttonSizer, border=guiHelper.SPACE_BETWEEN_BUTTONS, flag=wx.ALL)
 
 	def postInit(self):
 		self.tree.SetFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -298,6 +298,9 @@ class SynthesizerDialog(SettingsDialog):
 	title = _("Synthesizer")
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
+
 		synthListSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is a label for the select
 		# synthesizer combobox in the synthesizer dialog.
@@ -312,7 +315,7 @@ class SynthesizerDialog(SettingsDialog):
 			self.synthList.SetSelection(index)
 		except:
 			pass
-		synthListSizer.Add(synthListLabel)
+		synthListSizer.Add(synthListLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		synthListSizer.Add(self.synthList)
 		settingsSizer.Add(synthListSizer,border=10,flag=wx.BOTTOM)
 		deviceListSizer=wx.BoxSizer(wx.HORIZONTAL)
@@ -329,7 +332,7 @@ class SynthesizerDialog(SettingsDialog):
 		except ValueError:
 			selection = 0
 		self.deviceList.SetSelection(selection)
-		deviceListSizer.Add(deviceListLabel)
+		deviceListSizer.Add(deviceListLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		deviceListSizer.Add(self.deviceList)
 		settingsSizer.Add(deviceListSizer,border=10,flag=wx.BOTTOM)
 		duckingListSizer=wx.BoxSizer(wx.HORIZONTAL)
@@ -339,7 +342,7 @@ class SynthesizerDialog(SettingsDialog):
 		self.duckingList=wx.Choice(self,duckingListID,choices=audioDucking.audioDuckingModes)
 		index=config.conf['audio']['audioDuckingMode']
 		self.duckingList.SetSelection(index)
-		duckingListSizer.Add(duckingListLabel)
+		duckingListSizer.Add(duckingListLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		duckingListSizer.Add(self.duckingList)
 		if not audioDucking.isAudioDuckingSupported():
 			self.duckingList.Disable()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1322,10 +1322,8 @@ class DictionaryDialog(SettingsDialog):
 
 	def makeSettings(self, settingsSizer):
 		dictListID=wx.NewId()
-		entriesSizer=wx.BoxSizer(wx.VERTICAL)
 		# Translators: The label for the combo box of dictionary entries in speech dictionary dialog.
-		entriesLabel=wx.StaticText(self,-1,label=_("&Dictionary entries"))
-		entriesSizer.Add(entriesLabel)
+		entriesSizer=wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("&Dictionary entries")), wx.VERTICAL)
 		self.dictList=wx.ListCtrl(self,dictListID,style=wx.LC_REPORT|wx.LC_SINGLE_SEL,size=(550,350))
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.InsertColumn(0,_("Comment"),width=150)
@@ -1343,23 +1341,24 @@ class DictionaryDialog(SettingsDialog):
 		self.editingIndex=-1
 		self.dictList.Bind(wx.EVT_CHAR, self.onListChar)
 		entriesSizer.Add(self.dictList,proportion=8)
-		settingsSizer.Add(entriesSizer)
 		entryButtonsSizer=wx.BoxSizer(wx.HORIZONTAL)
 		addButtonID=wx.NewId()
 		# Translators: The label for a button in speech dictionaries dialog to add new entries.
 		addButton=wx.Button(self,addButtonID,_("&Add"),wx.DefaultPosition)
 		entryButtonsSizer.Add(addButton)
 		editButtonID=wx.NewId()
+		spaceBetweenButtons = 7
 		# Translators: The label for a button in speech dictionaries dialog to edit existing entries.
 		editButton=wx.Button(self,editButtonID,_("&Edit"),wx.DefaultPosition)
-		entryButtonsSizer.Add(editButton)
+		entryButtonsSizer.Add(editButton, border=spaceBetweenButtons, flag=wx.LEFT)
 		removeButtonID=wx.NewId()
 		removeButton=wx.Button(self,removeButtonID,_("&Remove"),wx.DefaultPosition)
-		entryButtonsSizer.Add(removeButton)
+		entryButtonsSizer.Add(removeButton, border=spaceBetweenButtons, flag=wx.LEFT)
 		self.Bind(wx.EVT_BUTTON,self.OnAddClick,id=addButtonID)
 		self.Bind(wx.EVT_BUTTON,self.OnEditClick,id=editButtonID)
 		self.Bind(wx.EVT_BUTTON,self.OnRemoveClick,id=removeButtonID)
-		settingsSizer.Add(entryButtonsSizer)
+		entriesSizer.Add(entryButtonsSizer, border=5, flag=wx.BOTTOM|wx.TOP)
+		settingsSizer.Add(entriesSizer, border=10, flag=wx.BOTTOM)
 
 	def postInit(self):
 		self.dictList.SetFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -138,9 +138,7 @@ class GeneralSettingsDialog(SettingsDialog):
 		languageChoices = [x[1] for x in self.languageNames]
 		# Translators: The label for a setting in general settings to select NVDA's interface language (once selected, NVDA must be restarted; the option user default means the user's Windows language will be used).
 		languageLabelText = _("&Language (requires restart to fully take effect):")
-		# Translators: The list of languages for NVDA.
-		languageCtrlName = _("Language")
-		self.languageList=settingsSizerHelper.addLabeledControl(languageLabelText, wx.Choice, name=languageCtrlName, choices=languageChoices)
+		self.languageList=settingsSizerHelper.addLabeledControl(languageLabelText, wx.Choice, choices=languageChoices)
 		self.languageList.SetToolTip(wx.ToolTip("Choose the language NVDA's messages and user interface should be presented in."))
 		try:
 			self.oldLanguage=config.conf["general"]["language"]
@@ -170,10 +168,8 @@ class GeneralSettingsDialog(SettingsDialog):
 
 		# Translators: The label for a setting in general settings to select logging level of NVDA as it runs (available options and what they are logged are found under comments for the logging level messages themselves).
 		logLevelLabelText=_("L&ogging level:")
-		# Translators: A combo box to choose log level (possible options are info, debug warning, input/output and debug).
-		logLevelChoicesName=_("Log level")
 		logLevelChoices = [name for level, name in self.LOG_LEVELS]
-		self.logLevelList = settingsSizerHelper.addLabeledControl(logLevelLabelText, wx.Choice, name=logLevelChoicesName, choices=logLevelChoices)
+		self.logLevelList = settingsSizerHelper.addLabeledControl(logLevelLabelText, wx.Choice, choices=logLevelChoices)
 		curLevel = log.getEffectiveLevel()
 		for index, (level, name) in enumerate(self.LOG_LEVELS):
 			if level == curLevel:
@@ -433,7 +429,7 @@ class VoiceSettingsDialog(SettingsDialog):
 		"""
 		sizer=wx.BoxSizer(wx.HORIZONTAL)
 		label=wx.StaticText(self,wx.ID_ANY,label="%s:"%setting.displayNameWithAccelerator)
-		slider=VoiceSettingsSlider(self,wx.ID_ANY,minValue=0,maxValue=100,name="%s:"%setting.i18nName)
+		slider=VoiceSettingsSlider(self,wx.ID_ANY,minValue=0,maxValue=100)
 		setattr(self,"%sSlider"%setting.name,slider)
 		slider.Bind(wx.EVT_SLIDER,SynthSettingChanger(setting))
 		self._setSliderStepSizes(slider,setting)
@@ -452,7 +448,7 @@ class VoiceSettingsDialog(SettingsDialog):
 		synth=getSynth()
 		setattr(self,"_%ss"%setting.name,getattr(synth,"available%ss"%setting.name.capitalize()).values())
 		l=getattr(self,"_%ss"%setting.name)###
-		labeledControl=guiHelper.LabeledControlHelper(self, labelText, wx.Choice, name="%s:"%setting.i18nName, choices=[x.name for x in l])
+		labeledControl=guiHelper.LabeledControlHelper(self, labelText, wx.Choice, choices=[x.name for x in l])
 		lCombo = labeledControl.control
 		setattr(self,"%sList"%setting.name,lCombo)
 		try:
@@ -622,12 +618,10 @@ class KeyboardSettingsDialog(SettingsDialog):
 		# Translators: This is the label for a combobox in the
 		# keyboard settings dialog.
 		kbdLabelText = _("&Keyboard layout:")
-		# Translators: This is the name of a combobox in the keyboard settings dialog.
-		kbdChoicesName = _("Keyboard layout")
 		layouts=keyboardHandler.KeyboardInputGesture.LAYOUTS
 		self.kbdNames=sorted(layouts)
 		kbdChoices = [layouts[layout] for layout in self.kbdNames]
-		self.kbdList=sHelper.addLabeledControl(kbdLabelText, wx.Choice, name=kbdChoicesName, choices=kbdChoices)
+		self.kbdList=sHelper.addLabeledControl(kbdLabelText, wx.Choice, choices=kbdChoices)
 		try:
 			index=self.kbdNames.index(config.conf['keyboard']['keyboardLayout'])
 			self.kbdList.SetSelection(index)
@@ -759,12 +753,10 @@ class MouseSettingsDialog(SettingsDialog):
 		# Translators: This is the label for a combobox in the
 		# mouse settings dialog.
 		textUnitLabelText=_("Text &unit resolution:")
-		# Translators: This is the name of a combobox in the mouse settings dialog.
-		textUnitsName = _("text reporting unit")
 		import textInfos
 		self.textUnits=[textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD,textInfos.UNIT_LINE,textInfos.UNIT_PARAGRAPH]
 		textUnitsChoices = [textInfos.unitLabels[x] for x in self.textUnits]
-		self.textUnitComboBox=sHelper.addLabeledControl(textUnitLabelText, wx.Choice, name=textUnitsName, choices=textUnitsChoices)
+		self.textUnitComboBox=sHelper.addLabeledControl(textUnitLabelText, wx.Choice, choices=textUnitsChoices)
 		try:
 			index=self.textUnits.index(config.conf["mouse"]["mouseTextUnit"])
 		except:
@@ -943,11 +935,8 @@ class ObjectPresentationDialog(SettingsDialog):
 		# Translators: This is the label for a combobox in the
 		# object presentation settings dialog.
 		progressLabelText = _("Progress &bar output:")
-		# Translators: This is the name of a combobox in the
-		# object presentation settings dialog.
-		progressName=_("Progress bar output")
 		progressChoices = [name for setting, name in self.progressLabels]
-		self.progressList=sHelper.addLabeledControl(progressLabelText, wx.Choice,name=progressName,choices=progressChoices)
+		self.progressList=sHelper.addLabeledControl(progressLabelText, wx.Choice,choices=progressChoices)
 		for index, (setting, name) in enumerate(self.progressLabels):
 			if setting == config.conf["presentation"]["progressBarUpdates"]["progressBarOutputMode"]:
 				self.progressList.SetSelection(index)
@@ -1813,7 +1802,7 @@ class InputGesturesDialog(SettingsDialog):
 		filterLabel = wx.StaticText(self, label=pgettext("inputGestures", "&Filter by:"))
 		filter = wx.TextCtrl(self)
 		filterSizer.Add(filterLabel, flag=wx.ALIGN_CENTER_VERTICAL)
-		filterSizer.AddSpacer(guiHelper.SPACE_BETWEEN_LABEL_CONTROL_HORIZONTAL)
+		filterSizer.AddSpacer(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
 		filterSizer.Add(filter, proportion=1)
 		settingsSizer.Add(filterSizer, flag=wx.EXPAND)
 		settingsSizer.AddSpacer(5)
@@ -1828,13 +1817,15 @@ class InputGesturesDialog(SettingsDialog):
 		self.gestures = inputCore.manager.getAllGestureMappings(obj=gui.mainFrame.prevFocus, ancestors=gui.mainFrame.prevFocusAncestors)
 		self.populateTree()
 
+		settingsSizer.AddSpacer(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
+
 		buttonSizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a button to add a gesture in the Input Gestures dialog.
 		item = self.addButton = wx.Button(self, label=_("&Add"))
 		item.Bind(wx.EVT_BUTTON, self.onAdd)
 		item.Disable()
 		buttonSizer.Add(item)
-		buttonSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS)
+		buttonSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_HORIZONTAL)
 		# Translators: The label of a button to remove a gesture in the Input Gestures dialog.
 		item = self.removeButton = wx.Button(self, label=_("&Remove"))
 		item.Bind(wx.EVT_BUTTON, self.onRemove)
@@ -1842,8 +1833,7 @@ class InputGesturesDialog(SettingsDialog):
 		self.pendingAdds = set()
 		self.pendingRemoves = set()
 		buttonSizer.Add(item)
-		buttonSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS)
-		settingsSizer.Add(buttonSizer, border=guiHelper.SPACE_BETWEEN_BUTTONS, flag=wx.ALL)
+		settingsSizer.Add(buttonSizer)
 
 	def postInit(self):
 		self.tree.SetFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1598,14 +1598,15 @@ class AddSymbolDialog(wx.Dialog):
 		# Translators: This is the label for the add symbol dialog.
 		super(AddSymbolDialog,self).__init__(parent, title=_("Add Symbol"))
 		mainSizer=wx.BoxSizer(wx.VERTICAL)
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+
 		# Translators: This is the label for the edit field in the add symbol dialog.
-		sizer.Add(wx.StaticText(self, label=_("Symbol:")))
-		self.identifierTextCtrl = wx.TextCtrl(self)
-		sizer.Add(self.identifierTextCtrl)
-		mainSizer.Add(sizer, border=20, flag=wx.LEFT | wx.RIGHT | wx.TOP)
-		buttonSizer=self.CreateButtonSizer(wx.OK | wx.CANCEL)
-		mainSizer.Add(buttonSizer, border=20, flag=wx.LEFT | wx.RIGHT | wx.BOTTOM)
+		symbolText = _("Symbol:")
+		self.identifierTextCtrl = sHelper.addLabeledControl(symbolText, wx.TextCtrl)
+		
+		sHelper.addItem(self.CreateButtonSizer(wx.OK | wx.CANCEL))
+
+		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 		self.identifierTextCtrl.SetFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1833,33 +1833,39 @@ class InputGesturesDialog(SettingsDialog):
 	title = _("Input Gestures")
 
 	def makeSettings(self, settingsSizer):
+		# Translators: The label of a group of controls for input gestures in the Input Gestures dialog.
+		gesturesGroupSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("&Gestures")), wx.VERTICAL)
+		filterSizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a text field to search for gestures in the Input Gestures dialog.
-		settingsSizer.Add(wx.StaticText(self, label=pgettext("inputGestures", "&Filter by:")))
+		filterLabel = wx.StaticText(self, label=pgettext("inputGestures", "&Filter by:"))
+		filterSizer.Add(filterLabel, border=10, flag=wx.RIGHT|wx.ALIGN_CENTER_VERTICAL)
 		filter = wx.TextCtrl(self)
 		filter.Bind(wx.EVT_TEXT, self.onFilterChange, filter)
-		settingsSizer.Add(filter)
+		filterSizer.Add(filter, proportion=1)
+		gesturesGroupSizer.Add(filterSizer, border = 5, flag=wx.BOTTOM|wx.EXPAND)
 		tree = self.tree = wx.TreeCtrl(self, style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_SINGLE)
 		self.treeRoot = tree.AddRoot("root")
 		tree.Bind(wx.EVT_TREE_SEL_CHANGED, self.onTreeSelect)
-		settingsSizer.Add(tree, proportion=7, flag=wx.EXPAND)
+		gesturesGroupSizer.Add(tree, proportion=1, border=5, flag=wx.EXPAND|wx.BOTTOM)
 
 		self.gestures = inputCore.manager.getAllGestureMappings(obj=gui.mainFrame.prevFocus, ancestors=gui.mainFrame.prevFocusAncestors)
 		self.populateTree()
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		buttonSizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a button to add a gesture in the Input Gestures dialog.
 		item = self.addButton = wx.Button(self, label=_("&Add"))
 		item.Bind(wx.EVT_BUTTON, self.onAdd)
 		item.Disable()
-		sizer.Add(item)
+		buttonSizer.Add(item)
 		# Translators: The label of a button to remove a gesture in the Input Gestures dialog.
 		item = self.removeButton = wx.Button(self, label=_("&Remove"))
 		item.Bind(wx.EVT_BUTTON, self.onRemove)
 		item.Disable()
 		self.pendingAdds = set()
 		self.pendingRemoves = set()
-		sizer.Add(item)
-		settingsSizer.Add(sizer)
+		buttonSizer.Add(item, border=7, flag=wx.LEFT)
+		gesturesGroupSizer.Add(buttonSizer)
+		settingsSizer.Add(gesturesGroupSizer, border=10, flag=wx.BOTTOM)
 
 	def postInit(self):
 		self.tree.SetFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1628,10 +1628,10 @@ class SpeechSymbolsDialog(SettingsDialog):
 		symbols = self.symbols = [copy.copy(symbol) for symbol in self.symbolProcessor.computedSymbols.itervalues()]
 		self.pendingRemovals = {}
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: The label for symbols list in symbol pronunciation dialog.
-		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Symbols")))
-		self.symbolsList = wx.ListCtrl(self, wx.ID_ANY, style=wx.LC_REPORT | wx.LC_SINGLE_SEL, size=(360, 350))
+		symbolsText = _("&Symbols")
+		self.symbolsList = sHelper.addLabeledControl(symbolsText, wx.ListCtrl, style=wx.LC_REPORT | wx.LC_SINGLE_SEL, size=(360, 350))
 		# Translators: The label for a column in symbols list used to identify a symbol.
 		self.symbolsList.InsertColumn(0, _("Symbol"), width=150)
 		self.symbolsList.InsertColumn(1, _("Replacement"), width=150)
@@ -1645,47 +1645,39 @@ class SpeechSymbolsDialog(SettingsDialog):
 			self.updateListItem(item, symbol)
 		self.symbolsList.Bind(wx.EVT_LIST_ITEM_FOCUSED, self.onListItemFocused)
 		self.symbolsList.Bind(wx.EVT_CHAR, self.onListChar)
-		sizer.Add(self.symbolsList)
-		settingsSizer.Add(sizer)
 
 		# Translators: The label for the edit field in symbol pronunciation dialog to change the pronunciation of a symbol.
-		changeSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Change symbol")), wx.VERTICAL)
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
-		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Replacement")))
-		self.replacementEdit = wx.TextCtrl(self, wx.ID_ANY)
+		changeSymbolText = _("Change symbol")
+		changeSymbolHelper = sHelper.addItem(guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=changeSymbolText), wx.VERTICAL)))
+		
+		replacementText = _("&Replacement")
+		self.replacementEdit = changeSymbolHelper.addLabeledControl(replacementText, wx.TextCtrl)
 		self.replacementEdit.Bind(wx.EVT_KILL_FOCUS, self.onSymbolEdited)
-		sizer.Add(self.replacementEdit)
-		changeSizer.Add(sizer)
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+
 		# Translators: The label for the combo box in symbol pronunciation dialog to change the speech level of a symbol.
-		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Level")))
+		levelText = _("&Level")
 		symbolLevelLabels = characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS
-		self.levelList = wx.Choice(self, wx.ID_ANY,choices=[
-			symbolLevelLabels[level] for level in characterProcessing.SPEECH_SYMBOL_LEVELS])
+		levelChoices = [symbolLevelLabels[level] for level in characterProcessing.SPEECH_SYMBOL_LEVELS]
+		self.levelList = changeSymbolHelper.addLabeledControl(levelText, wx.Choice, choices=levelChoices)
 		self.levelList.Bind(wx.EVT_KILL_FOCUS, self.onSymbolEdited)
-		sizer.Add(self.levelList)
-		changeSizer.Add(sizer)
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+
 		# Translators: The label for the combo box in symbol pronunciation dialog to change when a symbol is sent to the synthesizer.
-		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Send actual symbol to synthesizer")))
+		preserveText = _("&Send actual symbol to synthesizer")
 		symbolPreserveLabels = characterProcessing.SPEECH_SYMBOL_PRESERVE_LABELS
-		self.preserveList = wx.Choice(self, wx.ID_ANY,choices=[
-			symbolPreserveLabels[mode] for mode in characterProcessing.SPEECH_SYMBOL_PRESERVES])
+		preserveChoices = [symbolPreserveLabels[mode] for mode in characterProcessing.SPEECH_SYMBOL_PRESERVES]
+		self.preserveList = changeSymbolHelper.addLabeledControl(preserveText, wx.Choice, choices=preserveChoices)
 		self.preserveList.Bind(wx.EVT_KILL_FOCUS, self.onSymbolEdited)
-		sizer.Add(self.preserveList)
-		changeSizer.Add(sizer)
-		settingsSizer.Add(changeSizer)
-		entryButtonsSizer=wx.BoxSizer(wx.HORIZONTAL)
+
+		bHelper = sHelper.addItem(guiHelper.ButtonHelper(orientation=wx.HORIZONTAL))
 		# Translators: The label for a button in the Symbol Pronunciation dialog to add a new symbol.
-		addButton = wx.Button(self, label=_("&Add"))
-		entryButtonsSizer.Add(addButton)
+		addButton = bHelper.addButton(self, label=_("&Add"))
+
 		# Translators: The label for a button in the Symbol Pronunciation dialog to remove a symbol.
-		self.removeButton = wx.Button(self, label=_("Re&move"))
+		self.removeButton = bHelper.addButton(self, label=_("Re&move"))
 		self.removeButton.Disable()
-		entryButtonsSizer.Add(self.removeButton)
+
 		addButton.Bind(wx.EVT_BUTTON, self.OnAddClick)
 		self.removeButton.Bind(wx.EVT_BUTTON, self.OnRemoveClick)
-		settingsSizer.Add(entryButtonsSizer)
 
 		self.editingItem = None
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -629,11 +629,14 @@ class KeyboardSettingsDialog(SettingsDialog):
 	title = _("Keyboard Settings")
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
+
 		kbdSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is the label for a combobox in the
 		# keyboard settings dialog.
 		kbdLabel=wx.StaticText(self,-1,label=_("&Keyboard layout:"))
-		kbdSizer.Add(kbdLabel)
+		kbdSizer.Add(kbdLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		kbdListID=wx.NewId()
 		layouts=keyboardHandler.KeyboardInputGesture.LAYOUTS
 		self.kbdNames=sorted(layouts)
@@ -743,6 +746,9 @@ class MouseSettingsDialog(SettingsDialog):
 	title = _("Mouse Settings")
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
+
 		# Translators: This is the label for a checkbox in the
 		# mouse settings dialog.
 		self.shapeCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Report mouse &shape changes"))
@@ -757,7 +763,7 @@ class MouseSettingsDialog(SettingsDialog):
 		# Translators: This is the label for a combobox in the
 		# mouse settings dialog.
 		textUnitLabel=wx.StaticText(self,-1,label=_("Text &unit resolution:"))
-		textUnitSizer.Add(textUnitLabel)
+		textUnitSizer.Add(textUnitLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		import textInfos
 		self.textUnits=[textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD,textInfos.UNIT_LINE,textInfos.UNIT_PARAGRAPH]
 		# Translators: This is the name of a combobox in the mouse settings dialog.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1434,6 +1434,9 @@ class BrailleSettingsDialog(SettingsDialog):
 	title = _("Braille Settings")
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to choose a braille display.
 		label = wx.StaticText(self, wx.ID_ANY, label=_("Braille &display:"))
@@ -1446,7 +1449,7 @@ class BrailleSettingsDialog(SettingsDialog):
 			self.displayList.SetSelection(selection)
 		except:
 			pass
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags) 
 		sizer.Add(self.displayList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
@@ -1454,7 +1457,7 @@ class BrailleSettingsDialog(SettingsDialog):
 		# Translators: The label for a setting in braille settings to choose the connection port (if the selected braille display supports port selection).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("&Port:"))
 		self.portsList = wx.Choice(self, wx.ID_ANY, choices=[])
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		sizer.Add(self.portsList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 		self.updatePossiblePorts()
@@ -1469,7 +1472,7 @@ class BrailleSettingsDialog(SettingsDialog):
 			self.tableList.SetSelection(selection)
 		except:
 			pass
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		sizer.Add(self.tableList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
@@ -1483,7 +1486,7 @@ class BrailleSettingsDialog(SettingsDialog):
 			self.inputTableList.SetSelection(selection)
 		except:
 			pass
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		sizer.Add(self.inputTableList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
@@ -1501,7 +1504,7 @@ class BrailleSettingsDialog(SettingsDialog):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to change cursor blink rate in milliseconds (1 second is 1000 milliseconds).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("Cursor blink rate (ms)"))
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		self.cursorBlinkRateEdit = wx.TextCtrl(self, wx.ID_ANY)
 		self.cursorBlinkRateEdit.SetValue(str(config.conf["braille"]["cursorBlinkRate"]))
 		if not self.showCursorCheckBox.GetValue():
@@ -1521,17 +1524,17 @@ class BrailleSettingsDialog(SettingsDialog):
 			pass
 		if not self.showCursorCheckBox.GetValue():
 			self.shapeList.Disable()
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		sizer.Add(self.shapeList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in braille settings to change how long a message stays on the braille display (in seconds).
 		label = wx.StaticText(self, wx.ID_ANY, label=_("Message timeout (sec)"))
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		self.messageTimeoutEdit = wx.TextCtrl(self, wx.ID_ANY)
 		self.messageTimeoutEdit.SetValue(str(config.conf["braille"]["messageTimeout"]))
-		sizer.Add(self.messageTimeoutEdit)
+		sizer.Add(self.messageTimeoutEdit, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -1545,7 +1548,7 @@ class BrailleSettingsDialog(SettingsDialog):
 			self.tetherList.SetSelection(selection)
 		except:
 			pass
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		sizer.Add(self.tetherList)
 		settingsSizer.Add(sizer, border=10, flag=wx.BOTTOM)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -458,6 +458,8 @@ class VoiceSettingsDialog(SettingsDialog):
 
 	def makeStringSettingControl(self,setting):
 		"""Same as L{makeSettingControl} but for string settings. Returns sizer with label and combobox."""
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
 		sizer=wx.BoxSizer(wx.HORIZONTAL)
 		label=wx.StaticText(self,wx.ID_ANY,label="%s:"%setting.displayNameWithAccelerator)
 		synth=getSynth()
@@ -472,7 +474,7 @@ class VoiceSettingsDialog(SettingsDialog):
 		except ValueError:
 			pass
 		lCombo.Bind(wx.EVT_CHOICE,StringSynthSettingChanger(setting,self))
-		sizer.Add(label)
+		sizer.Add(label, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		sizer.Add(lCombo)
 		if self.lastControl:
 			lCombo.MoveAfterInTabOrder(self.lastControl)
@@ -492,6 +494,8 @@ class VoiceSettingsDialog(SettingsDialog):
 		return checkbox
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
 		self.sizerDict={}
 		self.lastControl=None
 		#Create controls for Synth Settings
@@ -509,7 +513,7 @@ class VoiceSettingsDialog(SettingsDialog):
 		sizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: This is the label for a combobox in the
 		# voice settings dialog (possible choices are none, some, most and all).
-		sizer.Add(wx.StaticText(self,wx.ID_ANY,label=_("Punctuation/symbol &level:")))
+		sizer.Add(wx.StaticText(self,wx.ID_ANY,label=_("Punctuation/symbol &level:")), border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		symbolLevelLabels=characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS
 		self.symbolLevelList=wx.Choice(self,wx.ID_ANY,choices=[symbolLevelLabels[level] for level in characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS])
 		curLevel = config.conf["speech"]["symbolLevel"]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -75,7 +75,7 @@ class SettingsDialog(wx.Dialog):
 		self.makeSettings(self.settingsSizer)
 		mainSizer.Add(self.settingsSizer,border=20,flag=wx.LEFT|wx.RIGHT|wx.TOP)
 		buttonSizer=self.CreateButtonSizer(wx.OK|wx.CANCEL)
-		mainSizer.Add(buttonSizer,border=20,flag=wx.LEFT|wx.RIGHT|wx.BOTTOM)
+		mainSizer.Add(buttonSizer,border=15,flag=wx.LEFT|wx.RIGHT|wx.BOTTOM) #Button sizer has 5 px border already.
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 		self.Bind(wx.EVT_BUTTON,self.onOk,id=wx.ID_OK)
@@ -129,10 +129,12 @@ class GeneralSettingsDialog(SettingsDialog):
 	)
 
 	def makeSettings(self, settingsSizer):
+		dropDownLabelBorder = 10
+		dropDownLabelFlags = wx.RIGHT | wx.ALIGN_CENTER_VERTICAL # border on right, center vertically.
 		languageSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in general settings to select NVDA's interface language (once selected, NVDA must be restarted; the option user default means the user's Windows language will be used).
 		languageLabel=wx.StaticText(self,-1,label=_("&Language (requires restart to fully take effect):"))
-		languageSizer.Add(languageLabel)
+		languageSizer.Add(languageLabel,border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		languageListID=wx.NewId()
 		self.languageNames=languageHandler.getAvailableLanguages()
 		# Translators: The list of languages for NVDA.
@@ -147,25 +149,27 @@ class GeneralSettingsDialog(SettingsDialog):
 		languageSizer.Add(self.languageList)
 		if globalVars.appArgs.secure:
 			self.languageList.Disable()
-		settingsSizer.Add(languageSizer,border=10,flag=wx.BOTTOM)
+		settingsItemBorder = 10
+		settingsItemFlags = wx.BOTTOM
+		settingsSizer.Add(languageSizer,border=settingsItemBorder,flag=settingsItemFlags)
 		# Translators: The label for a setting in general settings to save current configuration when NVDA exits (if it is not checked, user needs to save configuration before quitting NVDA).
 		self.saveOnExitCheckBox=wx.CheckBox(self,wx.NewId(),label=_("&Save configuration on exit"))
 		self.saveOnExitCheckBox.SetValue(config.conf["general"]["saveConfigurationOnExit"])
 		if globalVars.appArgs.secure:
 			self.saveOnExitCheckBox.Disable()
-		settingsSizer.Add(self.saveOnExitCheckBox,border=10,flag=wx.BOTTOM)
+		settingsSizer.Add(self.saveOnExitCheckBox,border=settingsItemBorder,flag=settingsItemFlags)
 		# Translators: The label for a setting in general settings to ask before quitting NVDA (if not checked, NVDA will exit without asking the user for action).
 		self.askToExitCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Sho&w exit options when exiting NVDA"))
 		self.askToExitCheckBox.SetValue(config.conf["general"]["askToExit"])
-		settingsSizer.Add(self.askToExitCheckBox,border=10,flag=wx.BOTTOM)
+		settingsSizer.Add(self.askToExitCheckBox,border=settingsItemBorder,flag=settingsItemFlags)
 		# Translators: The label for a setting in general settings to play sounds when NVDA starts or exits.
 		self.playStartAndExitSoundsCheckBox=wx.CheckBox(self,wx.NewId(),label=_("&Play sounds when starting or exiting NVDA"))
 		self.playStartAndExitSoundsCheckBox.SetValue(config.conf["general"]["playStartAndExitSounds"])
-		settingsSizer.Add(self.playStartAndExitSoundsCheckBox,border=10,flag=wx.BOTTOM)
+		settingsSizer.Add(self.playStartAndExitSoundsCheckBox,border=settingsItemBorder,flag=settingsItemFlags)
 		logLevelSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a setting in general settings to select logging level of NVDA as it runs (available options and what they are logged are found under comments for the logging level messages themselves).
 		logLevelLabel=wx.StaticText(self,-1,label=_("L&ogging level:"))
-		logLevelSizer.Add(logLevelLabel)
+		logLevelSizer.Add(logLevelLabel, border=dropDownLabelBorder, flag=dropDownLabelFlags)
 		logLevelListID=wx.NewId()
 		# Translators: A combo box to choose log level (possible options are info, debug warning, input/output and debug).
 		self.logLevelList=wx.Choice(self,logLevelListID,name=_("Log level"),choices=[name for level, name in self.LOG_LEVELS])
@@ -177,32 +181,32 @@ class GeneralSettingsDialog(SettingsDialog):
 		else:
 			log.debugWarning("Could not set log level list to current log level") 
 		logLevelSizer.Add(self.logLevelList)
-		settingsSizer.Add(logLevelSizer,border=10,flag=wx.BOTTOM)
+		settingsSizer.Add(logLevelSizer,border=settingsItemBorder,flag=settingsItemFlags)
 		# Translators: The label for a setting in general settings to allow NVDA to start after logging onto Windows (if checked, NvDA will start automatically after loggin into Windows; if not, user must start NVDA by pressing the shortcut key (CTRL+Alt+N by default).
 		self.startAfterLogonCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("&Automatically start NVDA after I log on to Windows"))
 		self.startAfterLogonCheckBox.SetValue(config.getStartAfterLogon())
 		if globalVars.appArgs.secure or not config.isInstalledCopy():
 			self.startAfterLogonCheckBox.Disable()
-		settingsSizer.Add(self.startAfterLogonCheckBox)
+		settingsSizer.Add(self.startAfterLogonCheckBox,border=settingsItemBorder,flag=settingsItemFlags)
 		# Translators: The label for a setting in general settings to allow NVDA to come up in Windows login screen (useful if user needs to enter passwords or if multiple user accounts are present to allow user to choose the correct account).
 		self.startOnLogonScreenCheckBox = wx.CheckBox(self, wx.ID_ANY, label=_("Use NVDA on the Windows logon screen (requires administrator privileges)"))
 		self.startOnLogonScreenCheckBox.SetValue(config.getStartOnLogonScreen())
 		if globalVars.appArgs.secure or not config.canStartOnSecureScreens():
 			self.startOnLogonScreenCheckBox.Disable()
-		settingsSizer.Add(self.startOnLogonScreenCheckBox)
+		settingsSizer.Add(self.startOnLogonScreenCheckBox,border=settingsItemBorder,flag=settingsItemFlags)
 		# Translators: The label for a button in general settings to copy current user settings to system settings (to allow current settings to be used in secure screens such as User Account Control (UAC) dialog).
 		self.copySettingsButton= wx.Button(self, wx.ID_ANY, label=_("Use currently saved settings on the logon and other secure screens (requires administrator privileges)"))
 		self.copySettingsButton.Bind(wx.EVT_BUTTON,self.onCopySettings)
 		if globalVars.appArgs.secure or not config.canStartOnSecureScreens():
 			self.copySettingsButton.Disable()
-		settingsSizer.Add(self.copySettingsButton)
+		settingsSizer.Add(self.copySettingsButton,border=settingsItemBorder,flag=settingsItemFlags)
 		if updateCheck:
 			# Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA (if not checked, user must check for updates manually).
 			item=self.autoCheckForUpdatesCheckBox=wx.CheckBox(self,label=_("Automatically check for &updates to NVDA"))
 			item.Value=config.conf["update"]["autoCheck"]
 			if globalVars.appArgs.secure:
 				item.Disable()
-			settingsSizer.Add(item)
+			settingsSizer.Add(item,border=settingsItemBorder,flag=settingsItemFlags)
 
 	def postInit(self):
 		self.languageList.SetFocus()

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -28,6 +28,7 @@ import ssl
 import wx
 import languageHandler
 import gui
+from gui import guiHelper
 from logHandler import log
 import config
 import shellapi
@@ -192,6 +193,7 @@ class UpdateResultDialog(wx.Dialog):
 		super(UpdateResultDialog, self).__init__(parent, title=_("NVDA Update"))
 		self.updateInfo = updateInfo
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		if updateInfo:
 			self.isInstalled = config.isInstalledCopy()
@@ -203,8 +205,9 @@ class UpdateResultDialog(wx.Dialog):
 		else:
 			# Translators: A message indicating that no update to NVDA is available.
 			message = _("No update available.")
-		mainSizer.Add(wx.StaticText(self, label=message))
+		sHelper.addItem(wx.StaticText(self, label=message))
 
+		bHelper = sHelper.addItem(guiHelper.ButtonHelper(wx.HORIZONTAL))
 		if updateInfo:
 			if self.isInstalled:
 				# Translators: The label of a button to download and install an NVDA update.
@@ -212,25 +215,22 @@ class UpdateResultDialog(wx.Dialog):
 			else:
 				# Translators: The label of a button to download an NVDA update.
 				label = _("&Download update")
-			item = wx.Button(self, label=label)
-			item.Bind(wx.EVT_BUTTON, self.onDownloadButton)
-
-			mainSizer.Add(item)
+			downloadButton = bHelper.addButton(self, label=label)
+			downloadButton.Bind(wx.EVT_BUTTON, self.onDownloadButton)
 
 			if auto:
 				# Translators: The label of a button to remind the user later about performing some action.
-				item = wx.Button(self, label=_("Remind me &later"))
-				item.Bind(wx.EVT_BUTTON, self.onLaterButton)
-				mainSizer.Add(item)
-				item.SetFocus()
+				remindMeButton = bHelper.addButton(self, label=_("Remind me &later"))
+				remindMeButton.Bind(wx.EVT_BUTTON, self.onLaterButton)
+				remindMeButton.SetFocus()
 
 		# Translators: The label of a button to close a dialog.
-		item = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
-		item.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		mainSizer.Add(item)
+		closeButton = bHelper.addButton(self, wx.ID_CLOSE, label=_("&Close"))
+		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
 		self.Bind(wx.EVT_CLOSE, lambda evt: self.Destroy())
 		self.EscapeId = wx.ID_CLOSE
 
+		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -121,11 +121,11 @@ If creating a portable copy directly from the NVDA download  package, simply pre
 If you have already closed this dialog or you are running an installed copy of NVDA, choose the Create Portable copy menu item found under Tools in the NVDA menu.
 
 The Dialog that appears allows you to choose where the portable copy should be created.
-This can be a directory on your hard drive or a location on a USB thum drive or other portable media.
+This can be a directory on your hard drive or a location on a USB thumb drive or other portable media.
 There is also an option to choose whether NVDA should copy the logged on user's current NVDA configuration for use  with the newly created portable copy.
  This option is only available when creating a portable copy from an installed copy, not when creating from the download package.
 Pressing Continue will create the portable copy.
-Once creation is complete, a message will appear telling you it was successfull.
+Once creation is complete, a message will appear telling you it was successful.
 Press OK to dismiss this dialog.
 
 + Getting started with NVDA +


### PR DESCRIPTION
Fixed alignment and made small modifications to several nvda dialogs.

Also fixes:
#6317 (Gestures treeview does not look like a treeview)
#5548 (Text control to specify the path when creating a portable copy is quite narrow)
#6342 (Spacing between labels and combo boxes)
#6343 (Inconsistency with vertical spacing between checkbox/label options)
#6349 (input gestures dialog tree view too small)
