### PR TITLE
In Google Chrome and Chrome-based browsers in a language other than English, browse mode no longer fails to work in many documents. (#6249)

### DIFF
--- a/nvdaHelper/common/xml.h
+++ b/nvdaHelper/common/xml.h
@@ -37,4 +37,15 @@ inline void appendCharToXML(const wchar_t c, std::wstring& xml, bool isAttribute
 	}
 }
 
+inline void appendAttribNameToXML(const std::wstring& attribName, std::wstring& xml) {
+	// #6249: Attribute names can sometimes contain spaces,
+	// but this isn't valid in XML, so filter it out.
+	for(auto c = attribName.begin(); c != attribName.end(); ++c) {
+		if (*c == L' ')
+			xml += L'_';
+		else
+			xml += *c;
+	}
+}
+
 #endif

--- a/nvdaHelper/common/xml.h
+++ b/nvdaHelper/common/xml.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <sstream>
+#include <algorithm>
 
 inline void appendCharToXML(const wchar_t c, std::wstring& xml, bool isAttribute=false) {
 	switch(c) {
@@ -37,15 +38,11 @@ inline void appendCharToXML(const wchar_t c, std::wstring& xml, bool isAttribute
 	}
 }
 
-inline void appendAttribNameToXML(const std::wstring& attribName, std::wstring& xml) {
+inline std::wstring sanitizeXMLAttribName(std::wstring attribName) {
 	// #6249: Attribute names can sometimes contain spaces,
 	// but this isn't valid in XML, so filter it out.
-	for(auto c = attribName.begin(); c != attribName.end(); ++c) {
-		if (*c == L' ')
-			xml += L'_';
-		else
-			xml += *c;
-	}
+	std::replace(attribName.begin(), attribName.end(), L' ', L'_');
+	return attribName;
 }
 
 #endif

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -216,7 +216,7 @@ void VBufStorage_fieldNode_t::generateAttributesForMarkupOpeningTag(std::wstring
 	s<<L"_childcount=\""<<childCount<<L"\" _childcontrolcount=\""<<childControlCount<<L"\" _indexInParent=\""<<indexInParent<<L"\" _parentChildCount=\""<<parentChildCount<<L"\" ";
 	text+=s.str();
 	for(VBufStorage_attributeMap_t::iterator i=this->attributes.begin();i!=this->attributes.end();++i) {
-		appendAttribNameToXML(i->first,text);
+		text+=sanitizeXMLAttribName(i->first);
 		text+=L"=\"";
 		for(std::wstring::iterator j=i->second.begin();j!=i->second.end();++j) {
 			appendCharToXML(*j,text,true);

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -216,7 +216,7 @@ void VBufStorage_fieldNode_t::generateAttributesForMarkupOpeningTag(std::wstring
 	s<<L"_childcount=\""<<childCount<<L"\" _childcontrolcount=\""<<childControlCount<<L"\" _indexInParent=\""<<indexInParent<<L"\" _parentChildCount=\""<<parentChildCount<<L"\" ";
 	text+=s.str();
 	for(VBufStorage_attributeMap_t::iterator i=this->attributes.begin();i!=this->attributes.end();++i) {
-		text+=i->first;
+		appendAttribNameToXML(i->first,text);
 		text+=L"=\"";
 		for(std::wstring::iterator j=i->second.begin();j!=i->second.end();++j) {
 			appendCharToXML(*j,text,true);

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -52,6 +52,7 @@ Highlights of this release include the ability to disable individual add-ons; su
 - If reporting of line numbers is enabled in NVDA's Document Formatting preferences, line numbers are now shown on a braille display. (#5941)
 - When speech mode is off, reporting objects (such as pressing NVDA+tab to report the focus) now appears in the Speech Viewer as expected. (#6049)
 - In the Outlook 2016 message list,  associated draft information is no longer reported. (#6219)
+- In Google Chrome and Chrome-based browsers in a language other than English, browse mode no longer fails to work in many documents. (#6249)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
Chrome incorrectly localises the name returned by IAccessibleAction::name, but this means it contains a space for some actions in some languages; e.g. "click" is "fai clic" in Italian. This results in the buffer producing an invalid XML attribute name, which breaks reading of affected content. We now filter the XML so this doesn't happen.
Fixes #6249.
