### PR TITLE
When disabling and then immediately re-enabling an add-on or vice versa, the add-on status now correctly reverts to what it was previously.

### DIFF
--- a/source/addonHandler.py
+++ b/source/addonHandler.py
@@ -291,11 +291,17 @@ class Addon(object):
 	def enable(self, shouldEnable):
 		"""Sets this add-on to be disabled or enabled when NVDA restarts."""
 		if shouldEnable:
-			state["pendingEnableSet"].add(self.name)
-			state["pendingDisableSet"].discard(self.name)
+			if self.name in state["pendingDisableSet"]:
+				# Undoing a pending disable.
+				state["pendingDisableSet"].discard(self.name)
+			else:
+				state["pendingEnableSet"].add(self.name)
 		else:
-			state["pendingDisableSet"].add(self.name)
-			state["pendingEnableSet"].discard(self.name)
+			if self.name in state["pendingEnableSet"]:
+				# Undoing a pending enable.
+				state["pendingEnableSet"].discard(self.name)
+			else:
+				state["pendingDisableSet"].add(self.name)
 		# Record enable/disable flags as a way of preparing for disaster such as sudden NVDA crash.
 		saveState()
 


### PR DESCRIPTION
When an add-on is in the pending disable set and the user enables it, the user is just undoing the disable; i.e. there is nothing to do. Therefore, just remove it from the pending disable set; don't also add it to the pending enable set. Make a similar change for undoing an enable.
