### PR TITLE
Fix build failures when building with nvdaHelperLogLevel set to debug (<= 10).

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -357,7 +357,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 	VARIANT varState;
 	VariantInit(&varState);
 	if(pacc->get_accState(varChild,&varState)!=S_OK) {
-		LOG_DEBUG(L"pacc->get_accState returned "<<res);
+		LOG_DEBUG(L"pacc->get_accState failed");
 		varState.vt=VT_I4;
 		varState.lVal=0;
 	}

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -897,7 +897,7 @@ VBufStorage_fieldNode_t* VBufStorage_buffer_t::findNodeByAttributes(int offset, 
 		LOG_DEBUGWARNING(L" offset "<<offset<<L" is past end of buffer, returning NULL");
 		return NULL;
 	}
-	LOG_DEBUG(L"find node starting at offset "<<offset<<L", with attributes: "<<attribsString);
+	LOG_DEBUG(L"find node starting at offset "<<offset<<L", with attribute regexp: "<<regexp);
 	int bufferStart, bufferEnd, tempRelativeStart=0;
 	VBufStorage_fieldNode_t* node=NULL;
 	if(offset==-1) {


### PR DESCRIPTION
It seems a couple of bits of code got updated, but the debug logging wasn't.
