### PR TITLE
Fix issue where selecting text with NVDA+f9 and NVDA+f10 in browse mode did not report the selected text.

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -313,6 +313,11 @@ class CursorManager(baseObject.ScriptableObject):
 			# Translators: Message presented when text has been copied to clipboard.
 			ui.message(_("Copied to clipboard"))
 
+	def waitForAndReportSelectionChange(self, oldTextInfo):
+		newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
+		speech.speakSelectionChange(oldTextInfo,newInfo)
+		braille.handler.handleCaretMove(self)
+
 	__gestures = {
 		"kb:pageUp": "moveByPage_back",
 		"kb:pageDown": "moveByPage_forward",

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -313,7 +313,7 @@ class CursorManager(baseObject.ScriptableObject):
 			# Translators: Message presented when text has been copied to clipboard.
 			ui.message(_("Copied to clipboard"))
 
-	def waitForAndReportSelectionChange(self, oldTextInfo):
+	def reportSelectionChange(self, oldTextInfo):
 		newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
 		speech.speakSelectionChange(oldTextInfo,newInfo)
 		braille.handler.handleCaretMove(self)

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -259,7 +259,7 @@ class EditableTextWithoutAutoSelectDetection(EditableText):
 	This should be used when an object does not notify of selection changes.
 	"""
 
-	def waitForAndReportSelectionChange(self, oldTextInfo):
+	def reportSelectionChange(self, oldTextInfo):
 		api.processPendingEvents(processEventQueue=False)
 		newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
 		speech.speakSelectionChange(oldTextInfo,newInfo)
@@ -275,7 +275,7 @@ class EditableTextWithoutAutoSelectDetection(EditableText):
 		if isScriptWaiting() or eventHandler.isPendingEvents("gainFocus"):
 			return
 		try:
-			self.waitForAndReportSelectionChange(oldInfo)
+			self.reportSelectionChange(oldInfo)
 		except:
 			return
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1785,12 +1785,12 @@ class GlobalCommands(ScriptableObject):
 				pass
 			try:
 				copyMarker.updateSelection()
-				if hasattr(pos.obj, "waitForAndReportSelectionChange"):
+				if hasattr(pos.obj, "reportSelectionChange"):
 					# wait for applications such as word to update their selection so that we can detect it
 					try:
-						pos.obj.waitForAndReportSelectionChange(oldInfo)
+						pos.obj.reportSelectionChange(oldInfo)
 					except Exception as e:
-						log.debug("Error trying to wait for the selection to update and then speak the selection: %s" % e)
+						log.debug("Error trying to report the updated selection: %s" % e)
 			except NotImplementedError as e:
 				# we are unable to select the text, leave the _copyStartMarker in place in case the user wishes to copy the text.
 				# Translators: Presented when unable to select the marked text.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -17,7 +17,6 @@ import review
 import controlTypes
 import api
 import textInfos
-import editableText
 import speech
 import sayAllHandler
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
@@ -1786,7 +1785,7 @@ class GlobalCommands(ScriptableObject):
 				pass
 			try:
 				copyMarker.updateSelection()
-				if isinstance(pos.obj, editableText.EditableTextWithoutAutoSelectDetection):
+				if hasattr(pos.obj, "waitForAndReportSelectionChange"):
 					# wait for applications such as word to update their selection so that we can detect it
 					try:
 						pos.obj.waitForAndReportSelectionChange(oldInfo)


### PR DESCRIPTION
Browse mode documents can't automatically report selection changes, so we need to treat them the same way we treat EditableTextWithoutAutoSelectDetection.
