### PR TITLE
Opening NVDA windows no longer sometimes freezes in Windows 10 build 14901 and later.

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -262,6 +262,11 @@ class UIAHandler(COMObject):
 		eventHandler.queueEvent(NVDAEventName,obj)
 
 	def _isUIAWindowHelper(self,hwnd):
+		if hwnd == winUser.getDesktopWindow():
+			# #6301: In Windows 10 build >= 14901,
+			# calling UiaHasServerSideProvider with the desktop window sometimes freezes when bringing up NVDA windows.
+			# It will always return False anyway.
+			return False
 		# UIA in NVDA's process freezes in Windows 7 and below
 		processID=winUser.getWindowThreadProcessID(hwnd)[0]
 		if windll.kernel32.GetCurrentProcessId()==processID:

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -265,7 +265,7 @@ class UIAHandler(COMObject):
 		if hwnd == winUser.getDesktopWindow():
 			# #6301: In Windows 10 build >= 14901,
 			# calling UiaHasServerSideProvider with the desktop window sometimes freezes when bringing up NVDA windows.
-			# It will always return False anyway.
+			# Return early if hwnd is the desktop window. UiaHasServerSideProvider would return False anyway.
 			return False
 		# UIA in NVDA's process freezes in Windows 7 and below
 		processID=winUser.getWindowThreadProcessID(hwnd)[0]


### PR DESCRIPTION
In these builds, calling UiaHasServerSideProvider with the desktop window sometimes freezes when bringing up NVDA windows. It will (and should) always return False anyway, so just assume False without calling it.
Fixes #6301.
