### PR TITLE
Catch exception when word contains invalid data

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -426,8 +426,16 @@ class WinWordCollectionQuicknavIterator(object):
 			if self.direction=="previous":
 				index=itemCount-(index-1)
 			collectionItem=items[index]
-			item=self.quickNavItemClass(self.itemType,self.document,collectionItem)
-			itemRange=item.rangeObj
+			try:
+				item=self.quickNavItemClass(self.itemType,self.document,collectionItem)
+				itemRange=item.rangeObj
+			except:
+				values = (self.itemType, self.direction, itemCount, index)
+				message = ("Error iterating over item with "+
+				("type: %s, iteration direction: %s, total item count: %s, item at index: %s" % values )+
+				"\nThis could be caused by an issue with some element within or a corruption of the word document.")
+				log.debugWarning(message ,exc_info=True)
+				continue
 			# Skip over the item we're already on.
 			if not self.includeCurrent and isFirst and ((self.direction=="next" and itemRange.start<=self.rangeObj.start) or (self.direction=="previous" and itemRange.end>self.rangeObj.end)):
 				continue

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -428,14 +428,14 @@ class WinWordCollectionQuicknavIterator(object):
 			collectionItem=items[index]
 			try:
 				item=self.quickNavItemClass(self.itemType,self.document,collectionItem)
-				itemRange=item.rangeObj
-			except:
-				values = (self.itemType, self.direction, itemCount, index)
-				message = ("Error iterating over item with "+
-				("type: %s, iteration direction: %s, total item count: %s, item at index: %s" % values )+
-				"\nThis could be caused by an issue with some element within or a corruption of the word document.")
+			except COMError:
+				message = ("Error iterating over item with "
+					"type: {type}, iteration direction: {dir}, total item count: {count}, item at index: {index}"
+					"\nThis could be caused by an issue with some element within or a corruption of the word document."
+					).format(type=self.itemType, dir=self.direction, count=itemCount, index=index)
 				log.debugWarning(message ,exc_info=True)
 				continue
+			itemRange=item.rangeObj
 			# Skip over the item we're already on.
 			if not self.includeCurrent and isFirst and ((self.direction=="next" and itemRange.start<=self.rangeObj.start) or (self.direction=="previous" and itemRange.end>self.rangeObj.end)):
 				continue


### PR DESCRIPTION
An example document contained some kind of hidden hyperlink, which looks
like it is an invalid element. When trying to get range information an
exception is thrown with the COM error "Object has been deleted". The
fix is to catch the exception, record information in the log, and
discard the item, continuing with iteration over the rest of the items.

Fixes #5886 
