### PR TITLE
I6312 fix mouse interaction symbol list

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1637,12 +1637,14 @@ class SpeechSymbolsDialog(SettingsDialog):
 
 		# Translators: The label for the edit field in symbol pronunciation dialog to change the pronunciation of a symbol.
 		changeSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Change symbol")), wx.VERTICAL)
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Replacement")))
 		self.replacementEdit = wx.TextCtrl(self, wx.ID_ANY)
 		self.replacementEdit.Bind(wx.EVT_KILL_FOCUS, self.onSymbolEdited)
 		sizer.Add(self.replacementEdit)
 		changeSizer.Add(sizer)
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for the combo box in symbol pronunciation dialog to change the speech level of a symbol.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Level")))
@@ -1652,6 +1654,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.levelList.Bind(wx.EVT_KILL_FOCUS, self.onSymbolEdited)
 		sizer.Add(self.levelList)
 		changeSizer.Add(sizer)
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for the combo box in symbol pronunciation dialog to change when a symbol is sent to the synthesizer.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Send actual symbol to synthesizer")))
@@ -1661,6 +1664,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.preserveList.Bind(wx.EVT_KILL_FOCUS, self.onSymbolEdited)
 		sizer.Add(self.preserveList)
 		changeSizer.Add(sizer)
+
 		settingsSizer.Add(changeSizer)
 		entryButtonsSizer=wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for a button in the Symbol Pronunciation dialog to add a new symbol.
@@ -1685,15 +1689,15 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.symbolsList.SetStringItem(item, 3, characterProcessing.SPEECH_SYMBOL_PRESERVE_LABELS[symbol.preserve])
 
 	def onSymbolEdited(self, evt):
-		if self.editingItem is None:
-			return
-		# Update the symbol the user was just editing.
-		item = self.editingItem
-		symbol = self.symbols[item]
-		symbol.replacement = self.replacementEdit.Value
-		symbol.level = characterProcessing.SPEECH_SYMBOL_LEVELS[self.levelList.Selection]
-		symbol.preserve = characterProcessing.SPEECH_SYMBOL_PRESERVES[self.preserveList.Selection]
-		self.updateListItem(item, symbol)
+		if self.editingItem is not None:
+			# Update the symbol the user was just editing.
+			item = self.editingItem
+			symbol = self.symbols[item]
+			symbol.replacement = self.replacementEdit.Value
+			symbol.level = characterProcessing.SPEECH_SYMBOL_LEVELS[self.levelList.Selection]
+			symbol.preserve = characterProcessing.SPEECH_SYMBOL_PRESERVES[self.preserveList.Selection]
+			self.updateListItem(item, symbol)
+		evt.Skip()
 
 	def onListItemFocused(self, evt):
 		# Update the editing controls to reflect the newly selected symbol.
@@ -1704,6 +1708,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.levelList.Selection = characterProcessing.SPEECH_SYMBOL_LEVELS.index(symbol.level)
 		self.preserveList.Selection = characterProcessing.SPEECH_SYMBOL_PRESERVES.index(symbol.preserve)
 		self.removeButton.Enabled = not self.symbolProcessor.isBuiltin(symbol.identifier)
+		evt.Skip()
 
 	def onListChar(self, evt):
 		if evt.KeyCode == wx.WXK_RETURN:
@@ -1712,7 +1717,6 @@ class SpeechSymbolsDialog(SettingsDialog):
 			# Therefore, we must catch the enter key here.
 			# Activate the OK button.
 			self.ProcessEvent(wx.CommandEvent(wx.wxEVT_COMMAND_BUTTON_CLICKED, wx.ID_OK))
-
 		else:
 			evt.Skip()
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1635,26 +1635,25 @@ class SpeechSymbolsDialog(SettingsDialog):
 		sizer.Add(self.symbolsList)
 		settingsSizer.Add(sizer)
 
-		# Translators: The label for the edit field in symbol pronunciation dialog to change the pronunciation of a symbol.
+		# Translators: The label for the group of controls in symbol pronunciation dialog to change the pronunciation of a symbol.
 		changeSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Change selected symbol")), wx.VERTICAL)
 
-		# Used to ensure that event handlers call Skip(). In the case of handling EVT_KILL_FOCUS, not calling skip can 
-		# cause focus problems for controls. More generally the advice on the wx documentation is: "In general, it is 
-		# recommended to skip all non-command events to allow the default handling to take place. The command events are,
-		# however, normally not skipped as usually a single command such as a button click or menu item selection must 
-		# only be processed by one handler."
-		def SkipEventAndCall(some_func):
-			def WrapWithEventSkip(event):
+		# Used to ensure that event handlers call Skip(). Not calling skip can cause focus problems for controls. More 
+		# generally the advice on the wx documentation is: "In general, it is recommended to skip all non-command events
+		# to allow the default handling to take place. The command events are, however, normally not skipped as usually 
+		# a single command such as a button click or menu item selection must only be processed by one handler."
+		def skipEventAndCall(handler):
+			def wrapWithEventSkip(event):
 				if event:
 					event.Skip()
-				return some_func()
-			return WrapWithEventSkip
+				return handler()
+			return wrapWithEventSkip
 
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label for the edit field in symbol pronunciation dialog to change the replacement text of a symbol.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Replacement")))
 		self.replacementEdit = wx.TextCtrl(self, wx.ID_ANY)
-		self.replacementEdit.Bind(wx.EVT_TEXT, SkipEventAndCall(self.onSymbolEdited))
+		self.replacementEdit.Bind(wx.EVT_TEXT, skipEventAndCall(self.onSymbolEdited))
 		sizer.Add(self.replacementEdit)
 		changeSizer.Add(sizer)
 
@@ -1664,7 +1663,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		symbolLevelLabels = characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS
 		self.levelList = wx.Choice(self, wx.ID_ANY,choices=[
 			symbolLevelLabels[level] for level in characterProcessing.SPEECH_SYMBOL_LEVELS])
-		self.levelList.Bind(wx.EVT_CHOICE, SkipEventAndCall(self.onSymbolEdited))
+		self.levelList.Bind(wx.EVT_CHOICE, skipEventAndCall(self.onSymbolEdited))
 		sizer.Add(self.levelList)
 		changeSizer.Add(sizer)
 
@@ -1674,7 +1673,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		symbolPreserveLabels = characterProcessing.SPEECH_SYMBOL_PRESERVE_LABELS
 		self.preserveList = wx.Choice(self, wx.ID_ANY,choices=[
 			symbolPreserveLabels[mode] for mode in characterProcessing.SPEECH_SYMBOL_PRESERVES])
-		self.preserveList.Bind(wx.EVT_CHOICE, SkipEventAndCall(self.onSymbolEdited))
+		self.preserveList.Bind(wx.EVT_CHOICE, skipEventAndCall(self.onSymbolEdited))
 		sizer.Add(self.preserveList)
 		changeSizer.Add(sizer)
 


### PR DESCRIPTION
Calling Skip() on the focus events fixes the "unable to type in the replacement field when using the mouse to focus it" issue.

Updating the symbol list items as the "change symbol" fields are
changed fixes an issue where the values for the items in the list were
not updated when the mouse was used to select a new item in the list.
When the already selected (and now changed) item was reselected, then
the item in the list WAS updated.
This issue seemed to be caused by the EVT_KILL_FOCUS and the
EVT_LIST_ITEM_FOCUSED being received out of order.

Disables "change symbol" fields when no item is selected (when dialog is
first opened. Seeing the fields disabled helps to indicate that an item
must be selected first. When this happens its clear that the fields
relate to the selected item, as they can be seen to update.

Fixes #6312
