### PR TITLE
Adjust the symbols list

### DIFF
--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -1,0 +1,22 @@
+# -*- coding: UTF-8 -*-
+#settingsDialogs.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2016 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+import wx
+from wx.lib.mixins import listctrl as listmix
+
+class AutoWidthColumnListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
+	"""
+	A list control that allows you to specify a column to resize to take up the remaining width of a wx.ListCtrl
+	"""
+	def __init__(self, parent, ID, autoSizeColumnIndex="LAST", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0):
+		""" initialiser
+			Takes the same parameter as a wx.ListCtrl with the following additions:
+			autoSizeColumnIndex - defaults to "LAST" which results in the last column being resized. Pass the index of 
+			the column to be resized.
+		"""
+		wx.ListCtrl.__init__(self, parent, ID, pos, size, style)
+		listmix.ListCtrlAutoWidthMixin.__init__(self)
+		self.setResizeColumn(autoSizeColumnIndex)

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#settingsDialogs.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2016 NV Access Limited
+#Copyright (C) 2016 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+
 import wx
 from wx.lib.mixins import listctrl as listmix
 
@@ -11,12 +11,12 @@ class AutoWidthColumnListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
 	"""
 	A list control that allows you to specify a column to resize to take up the remaining width of a wx.ListCtrl
 	"""
-	def __init__(self, parent, ID, autoSizeColumnIndex="LAST", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0):
+	def __init__(self, parent, id=wx.ID_ANY, autoSizeColumnIndex="LAST", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0):
 		""" initialiser
 			Takes the same parameter as a wx.ListCtrl with the following additions:
 			autoSizeColumnIndex - defaults to "LAST" which results in the last column being resized. Pass the index of 
 			the column to be resized.
 		"""
-		wx.ListCtrl.__init__(self, parent, ID, pos, size, style)
+		wx.ListCtrl.__init__(self, parent, id, pos, size, style)
 		listmix.ListCtrlAutoWidthMixin.__init__(self)
 		self.setResizeColumn(autoSizeColumnIndex)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1598,25 +1598,25 @@ class SpeechSymbolsDialog(SettingsDialog):
 		symbols = self.symbols = [copy.copy(symbol) for symbol in self.symbolProcessor.computedSymbols.itervalues()]
 		self.pendingRemovals = {}
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: The label for symbols list in symbol pronunciation dialog.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Symbols")))
-		self.symbolsList = wx.ListCtrl(self, wx.ID_ANY, style=wx.LC_REPORT | wx.LC_SINGLE_SEL, size=(360, 350))
+		self.symbolsList = wx.ListCtrl(self, wx.ID_ANY, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
 		# Translators: The label for a column in symbols list used to identify a symbol.
-		self.symbolsList.InsertColumn(0, _("Symbol"), width=150)
-		self.symbolsList.InsertColumn(1, _("Replacement"), width=150)
+		self.symbolsList.InsertColumn(0, _("Symbol"))
+		self.symbolsList.InsertColumn(1, _("Replacement"))
 		# Translators: The label for a column in symbols list used to identify a symbol's speech level (either none, some, most, all or character).
-		self.symbolsList.InsertColumn(2, _("Level"), width=60)
+		self.symbolsList.InsertColumn(2, _("Level"))
 		# Translators: The label for a column in symbols list which specifies when the actual symbol will be sent to the synthesizer (preserved).
 		# See the "Punctuation/Symbol Pronunciation" section of the User Guide for details.
-		self.symbolsList.InsertColumn(3, _("Preserve"), width=60)
+		self.symbolsList.InsertColumn(3, _("Preserve"))
 		for symbol in symbols:
 			item = self.symbolsList.Append((symbol.displayName,))
 			self.updateListItem(item, symbol)
 		self.symbolsList.Bind(wx.EVT_LIST_ITEM_FOCUSED, self.onListItemFocused)
 		self.symbolsList.Bind(wx.EVT_CHAR, self.onListChar)
-		sizer.Add(self.symbolsList)
-		settingsSizer.Add(sizer)
+		sizer.Add(self.symbolsList, flag=wx.EXPAND)
+		settingsSizer.Add(sizer, flag=wx.EXPAND)
 
 		# Translators: The label for the edit field in symbol pronunciation dialog to change the pronunciation of a symbol.
 		changeSizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Change symbol")), wx.VERTICAL)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -34,6 +34,7 @@ try:
 except RuntimeError:
 	updateCheck = None
 import inputCore
+import nvdaControls
 
 class SettingsDialog(wx.Dialog):
 	"""A settings dialog.
@@ -1600,8 +1601,8 @@ class SpeechSymbolsDialog(SettingsDialog):
 
 		sizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: The label for symbols list in symbol pronunciation dialog.
-		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Symbols")))
-		self.symbolsList = wx.ListCtrl(self, wx.ID_ANY, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+		sizer.Add(wx.StaticText(self, wx.ID_ANY, _("&Symbols:")))
+		self.symbolsList = nvdaControls.AutoWidthColumnListCtrl(self, wx.ID_ANY, autoSizeColumnIndex=0, style=wx.LC_REPORT | wx.LC_SINGLE_SEL )
 		# Translators: The label for a column in symbols list used to identify a symbol.
 		self.symbolsList.InsertColumn(0, _("Symbol"))
 		self.symbolsList.InsertColumn(1, _("Replacement"))


### PR DESCRIPTION
Fixes #6101
Extends PR #6178 

Put the 'symbol' label above the list and have the list itself take up the full width of the dialog. Columns are spaced automatically, with one nominated to take up any extra available room.

The first column was selected to expand more, as the information in the other columns can be viewed in the "change symbol" group.
