### PR TITLE
Minor speech viewer tweaks

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -260,7 +260,7 @@ class MainFrame(wx.Frame):
 
 	def onToggleSpeechViewerCommand(self, evt):
 		if not speechViewer.isActive:
-			speechViewer.activate(onActiveChanged = lambda nowActive: self.onSpeechViewerEnabled(nowActive))
+			speechViewer.activate()
 		else:
 			speechViewer.deactivate()
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -253,13 +253,16 @@ class MainFrame(wx.Frame):
 	def onViewLogCommand(self, evt):
 		logViewer.activate()
 
+	def onSpeechViewerEnabled(self, isEnabled):
+		# its possible for this to be called after the sysTrayIcon is destroyed if we are exiting NVDA
+		if self.sysTrayIcon and self.sysTrayIcon.menu_tools_toggleSpeechViewer:
+			self.sysTrayIcon.menu_tools_toggleSpeechViewer.Check(isEnabled)
+
 	def onToggleSpeechViewerCommand(self, evt):
 		if not speechViewer.isActive:
-			speechViewer.activate()
-			self.sysTrayIcon.menu_tools_toggleSpeechViewer.Check(True)
+			speechViewer.activate(onActiveChanged = lambda nowActive: self.onSpeechViewerEnabled(nowActive))
 		else:
 			speechViewer.deactivate()
-			self.sysTrayIcon.menu_tools_toggleSpeechViewer.Check(False)
 
 	def onPythonConsoleCommand(self, evt):
 		import pythonConsole

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -79,7 +79,6 @@ isActive=False
 def activate():
 	"""
 		Function to call to trigger the speech viewer window to open.
-		onActiveChanged - function object that takes a boolean which is true if the speechviewer is active or false if it is no longer active.
 	"""
 	_setActive(True, SpeechViewerFrame(_cleanup) )
 

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -74,12 +74,19 @@ class SpeechViewerFrame(wx.Dialog):
 		config.conf["speechViewer"]["autoPositionWindow"] = False
 
 _guiFrame=None
+_onActiveChanged = lambda isNowActive: None
 isActive=False
 
-def activate():
-	global _guiFrame, isActive
+def activate(onActiveChanged = lambda isNowActive: None):
+	"""
+		Function to call to trigger the speech viewer window to open.
+		onActiveChanged - function object that takes a boolean which is true if the speechviewer is active or false if it is no longer active.
+	"""
+	global _guiFrame, _onActiveChanged, isActive
+	_onActiveChanged = onActiveChanged
 	_guiFrame = SpeechViewerFrame(_cleanup)
 	isActive=True
+	_onActiveChanged(isActive)
 
 def appendText(text):
 	if not isActive:
@@ -93,10 +100,11 @@ def appendText(text):
 	_guiFrame.textCtrl.AppendText(text + "\n")
 
 def _cleanup():
-	global _guiFrame, isActive
+	global _guiFrame, _onActiveChanged, isActive
 	if not isActive:
 		return
 	isActive=False
+	_onActiveChanged(isActive)
 	_guiFrame = None
 
 def deactivate():

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -74,19 +74,21 @@ class SpeechViewerFrame(wx.Dialog):
 		config.conf["speechViewer"]["autoPositionWindow"] = False
 
 _guiFrame=None
-_onActiveChanged = lambda isNowActive: None
 isActive=False
 
-def activate(onActiveChanged = lambda isNowActive: None):
+def activate():
 	"""
 		Function to call to trigger the speech viewer window to open.
 		onActiveChanged - function object that takes a boolean which is true if the speechviewer is active or false if it is no longer active.
 	"""
-	global _guiFrame, _onActiveChanged, isActive
-	_onActiveChanged = onActiveChanged
-	_guiFrame = SpeechViewerFrame(_cleanup)
-	isActive=True
-	_onActiveChanged(isActive)
+	_setActive(True, SpeechViewerFrame(_cleanup) )
+
+def _setActive(isNowActive, speechViewerFrame=None):
+	global _guiFrame, isActive
+	isActive = isNowActive
+	_guiFrame = speechViewerFrame
+	if gui and gui.mainFrame:
+		gui.mainFrame.onSpeechViewerEnabled(isNowActive)
 
 def appendText(text):
 	if not isActive:
@@ -100,12 +102,10 @@ def appendText(text):
 	_guiFrame.textCtrl.AppendText(text + "\n")
 
 def _cleanup():
-	global _guiFrame, _onActiveChanged, isActive
+	global isActive
 	if not isActive:
 		return
-	isActive=False
-	_onActiveChanged(isActive)
-	_guiFrame = None
+	_setActive(False)
 
 def deactivate():
 	global _guiFrame, isActive

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,7 +8,7 @@
 == New Features ==
 - NVDA can now indicate line indentation using tones. This can be configured using the "Report line indentation with" combo box in NVDA's Document Formatting preferences dialog. (#5906)
 - Support for the Orbit Reader 20 braille display. (#6007)
-- An option to open the speech viewer window on startup has been added. (#5050)
+- An option to open the speech viewer window on startup has been added. This can be enabled via a check box in the speech viewer window. (#5050)
 - When re-opening the speech viewer window, the location and dimensions will now be restored. (#5050)
 - Cross Reference fields in Microsoft Word are now treated like hyperlinks. They are reported as links, and can be activated. (#6102)
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1437,7 +1437,7 @@ These actions are available under the viewer's Log menu.
 For sighted software developers or people demoing NVDA to sighted audiences, a floating window is available that allows you to view all the text that NVDA is currently speaking.
 
 To enable the speech viewer, check the "Speech Viewer" menu item under Tools in the NVDA menu.
-Uncheck the menu item to disable it.
+Uncheck the menu item to disable it. The speech viewer window contains a check box labeled "Show Speech Viewer on Startup". If this is checked, will result in the speech viewer opening when NVDA is started. The speech viewer window will always attempt to re-open with the same dimensions and location as when it was closed.
 
 While the speech viewer is enabled, it constantly updates to show you the most current text being spoken.
 However, if you click or focus inside the viewer, NVDA will temporarily stop updating the text, so that you are able to easily select or copy the existing content.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1437,7 +1437,11 @@ These actions are available under the viewer's Log menu.
 For sighted software developers or people demoing NVDA to sighted audiences, a floating window is available that allows you to view all the text that NVDA is currently speaking.
 
 To enable the speech viewer, check the "Speech Viewer" menu item under Tools in the NVDA menu.
-Uncheck the menu item to disable it. The speech viewer window contains a check box labeled "Show Speech Viewer on Startup". If this is checked, will result in the speech viewer opening when NVDA is started. The speech viewer window will always attempt to re-open with the same dimensions and location as when it was closed.
+Uncheck the menu item to disable it.
+
+The speech viewer window contains a check box labeled "Show speech viewer on startup".
+If this is checked, the speech viewer will open when NVDA is started.
+The speech viewer window will always attempt to re-open with the same dimensions and location as when it was closed.
 
 While the speech viewer is enabled, it constantly updates to show you the most current text being spoken.
 However, if you click or focus inside the viewer, NVDA will temporarily stop updating the text, so that you are able to easily select or copy the existing content.


### PR DESCRIPTION
Fixes an issue where the NVDA menu speechviewer checkbox status does not reflect the actual visibility of the window:
Steps to reproduce:
- Open speechviewer via menu
- close via taskbar (or alt+F4)
- look at nvda menu again, notice that speechviewer is still checked

Modified the change log for the "speech viewer on startup" feature to include information on how to use this feature.

User guide changes, include information about:
- the speech viewer checkbox
- the speech viewer position and size
