### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/nvdaHelper/common/ia2utils.cpp
+++ b/nvdaHelper/common/ia2utils.cpp
@@ -21,7 +21,7 @@ void IA2AttribsToMap(const wstring &attribsString, map<wstring, wstring> &attrib
 	wstring str, key;
 	bool inEscape = false;
 
-	for (wstring::const_iterator it = attribsString.begin(); it != attribsString.end(); it++) {
+	for (wstring::const_iterator it = attribsString.begin(); it != attribsString.end(); ++it) {
 		if (inEscape) {
 			str.push_back(*it);
 			inEscape = false;

--- a/nvdaHelper/local/dllImportTableHooks.cpp
+++ b/nvdaHelper/local/dllImportTableHooks.cpp
@@ -99,7 +99,7 @@ BOOL DllImportTableHooks::unhookFunctions() {
 		return TRUE;
 	}
 	LOG_DEBUG(L"apiHook_unhookFunctions: unhooking functions on module at address 0X" << targetModule << L"\n");
-	for(funcToThunk_t::iterator i=this->hookedFunctions.begin();i!=this->hookedFunctions.end();i++) {
+	for(funcToThunk_t::iterator i=this->hookedFunctions.begin();i!=this->hookedFunctions.end();++i) {
 		LOG_DEBUG(L"apiHook_unhookFunctions: restoring thunk at address 0X" << i->second << L" back to original function at address 0X" << i->first << L"\n");
 		DWORD oldProtect;
 		VirtualProtect(i->second,sizeof(IMAGE_THUNK_DATA),PAGE_READWRITE,&oldProtect);

--- a/nvdaHelper/remote/displayModel.cpp
+++ b/nvdaHelper/remote/displayModel.cpp
@@ -287,7 +287,7 @@ void displayModel_t::copyRectangle(const RECT& srcRect, BOOL removeFromSource, B
 				destModel->setFocusRect(&newFocusRect);
 			}
 		}
-		free(srcFocusRect);
+		delete srcFocusRect;
 	}
 }
 


### PR DESCRIPTION
[nvdaHelper/common/ia2utils.cpp:24]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[nvdaHelper/local/dllImportTableHooks.cpp:102]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[nvdaHelper/remote/displayModel.cpp:290]: (error) Mismatching allocation and deallocation: srcFocusRect
