### PR TITLE
Restart NVDA with a single gesture

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2016 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee, Leonard de Ruijter, Derek Riemer
+#Copyright (C) 2006-2016 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee, Leonard de Ruijter, Derek Riemer, Babbage B.V.
 
 import time
 import itertools
@@ -39,6 +39,7 @@ import inputCore
 import virtualBuffers
 import characterProcessing
 from baseObject import ScriptableObject
+import core
 
 #: Script category for text review commands.
 # Translators: The name of a category of NVDA commands.
@@ -1232,6 +1233,11 @@ class GlobalCommands(ScriptableObject):
 		gui.quit()
 	# Translators: Input help mode message for quit NVDA command.
 	script_quit.__doc__=_("Quits NVDA!")
+
+	def script_restart(self,gesture):
+		core.restart()
+	# Translators: Input help mode message for restart NVDA command.
+	script_restart.__doc__=_("Restarts NVDA!")
 
 	def script_showGui(self,gesture):
 		gui.showGui()


### PR DESCRIPTION
By default, ctrl+nvda+f4 is assigned, but we can consider removing this as well as change it to the current gesture for reloading plugins (ctrl+NVDA+f3).
Even though it is possible to restart NVDA using its desktop shortcut, this way of restarting appears to be much quicker and is a nice alternative for reloading plugins, which would allow for deprecating this as @jcsteh suggested in #6389. Furthermore, it works with portable copies.

The only thing I'm not sure about, do we just want to call core.restart, or use queueHandler.queueFunction(queueHandler.eventQueue,core.restart) as in gui.ExitDialog? I'm sure it's used there for a reason.
