### PR TITLE
New event to fire when review position changes #6383

### DIFF
--- a/source/api.py
+++ b/source/api.py
@@ -1,6 +1,6 @@
 #api.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NVDA Contributors
+#Copyright (C) 2006-2016 NV Access Limited, NVDA Contributors, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -181,6 +181,7 @@ def setReviewPosition(reviewPosition,clearNavigatorObject=True):
 	if clearNavigatorObject: globalVars.navigatorObject=None
 	import braille
 	braille.handler.handleReviewMove()
+	eventHandler.executeEvent("becomeReviewObject",globalVars.reviewPositionObj, reviewPosition=globalVars.reviewPosition)
 
 def getNavigatorObject():
 	"""Gets the current navigator object. Navigator objects can be used to navigate around the operating system (with the number pad) with out moving the focus. If the navigator object is not set, it fetches it from the review position. 

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2007-2014 NV Access Limited
+#Copyright (C) 2007-2016 NV Access Limited, Babbage b.v.
 
 import threading
 import queueHandler
@@ -16,6 +16,7 @@ from logHandler import log
 import globalPluginHandler
 import config
 import winUser
+import NVDAObjects
 
 #Some dicts to store event counts by name and or obj
 _pendingEventCountsByName={}
@@ -107,14 +108,14 @@ class _EventExecuter(object):
 				yield func, (obj, self.next)
 
 		# App module level.
-		app = obj.appModule
+		app = obj.appModule if isinstance(obj,NVDAObjects.NVDAObject) else None
 		if app:
 			func = getattr(app, funcName, None)
 			if func:
 				yield func, (obj, self.next)
 
 		# Tree interceptor level.
-		treeInterceptor = obj.treeInterceptor
+		treeInterceptor = obj.treeInterceptor if isinstance(obj,NVDAObjects.NVDAObject) else None
 		if treeInterceptor:
 			func = getattr(treeInterceptor, funcName, None)
 			if func and (getattr(func,'ignoreIsReady',False) or treeInterceptor.isReady):
@@ -134,7 +135,7 @@ def executeEvent(eventName,obj,**kwargs):
 	@param kwargs: Additional event parameters as keyword arguments.
 	"""
 	try:
-		sleepMode=obj.sleepMode
+		sleepMode=obj.sleepMode if isinstance(obj,NVDAObjects.NVDAObject) else None
 		if eventName=="gainFocus" and not doPreGainFocus(obj,sleepMode=sleepMode):
 			return
 		elif not sleepMode and eventName=="documentLoadComplete" and not doPreDocumentLoadComplete(obj):


### PR DESCRIPTION
I added an event called becomeReviewobject, which is fired on api.setReviewPosition. May be reviewPositionChange is a better name for this, which is something to discuss. Furthermore, I had to implement some checks in eventHandler to be sure that events could be fired when the object is not an instance of NVDAObjects.NVDAObject.
Fixes #6383
