### PR TITLE
No longer set the language before restarting

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -253,13 +253,6 @@ class GeneralSettingsDialog(SettingsDialog):
 
 	def onOk(self,evt):
 		newLanguage=[x[0] for x in self.languageNames][self.languageList.GetSelection()]
-		if newLanguage!=self.oldLanguage:
-			try:
-				languageHandler.setLanguage(newLanguage)
-			except:
-				log.error("languageHandler.setLanguage", exc_info=True)
-				gui.messageBox(_("Error in %s language file")%newLanguage,_("Language Error"),wx.OK|wx.ICON_WARNING,self)
-				return
 		config.conf["general"]["language"]=newLanguage
 		config.conf["general"]["saveConfigurationOnExit"]=self.saveOnExitCheckBox.IsChecked()
 		config.conf["general"]["askToExit"]=self.askToExitCheckBox.IsChecked()


### PR DESCRIPTION
See issue #4561
When a new language is selected (on the general settings dialog) and the ok
button is pushed, the language is not changed until until NVDA is restarted.

This fixes an issue where some parts of the UI are translated and some
are not.

Note there is now a change in behaviour, the dialog asking for a restart is no longer translated.
**Good:** If you know the existing language and accidentally change it, you are given a warning can understand, hit cancel, and set it back to the existing language.
**Bad:** If you dont know the existing language you are presented with a dialog you can not understand. However you have managed to get to this point in a language you dont know.
