### PR TITLE
Align ok and cancel buttons to right

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -710,7 +710,7 @@ class ElementsListDialog(wx.Dialog):
 		self.moveButton.Bind(wx.EVT_BUTTON, lambda evt: self.onAction(False))
 		bHelper.addButton(self, id=wx.ID_CANCEL)
 
-		contentsSizer.Add(bHelper.sizer)
+		contentsSizer.Add(bHelper.sizer, flag=wx.ALIGN_RIGHT)
 
 		mainSizer.Add(contentsSizer, border=gui.guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -49,7 +49,7 @@ class FindDialog(wx.Dialog):
 		self.caseSensitiveCheckBox.SetValue(caseSensitivity)
 		mainSizer.Add(self.caseSensitiveCheckBox,border=10,flag=wx.BOTTOM)
 
-		mainSizer.AddSizer(self.CreateButtonSizer(wx.OK|wx.CANCEL))
+		mainSizer.AddSizer(self.CreateButtonSizer(wx.OK|wx.CANCEL), flag=wx.ALIGN_RIGHT)
 		self.Bind(wx.EVT_BUTTON,self.onOk,id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON,self.onCancel,id=wx.ID_CANCEL)
 		mainSizer.Fit(self)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -84,7 +84,7 @@ class AddonsDialog(wx.Dialog):
 		# Translators: The label of a button to close the Addons dialog.
 		closeButton = wx.Button(self, label=_("&Close"), id=wx.ID_CLOSE)
 		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		mainSizer.Add(closeButton,border=20,flag=wx.LEFT|wx.RIGHT|wx.BOTTOM|wx.CENTER)
+		mainSizer.Add(closeButton,border=20,flag=wx.LEFT|wx.RIGHT|wx.BOTTOM|wx.CENTER|wx.ALIGN_RIGHT)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.EscapeId = wx.ID_CLOSE
 		mainSizer.Fit(self)

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -89,7 +89,7 @@ class ProfilesDialog(wx.Dialog):
 		# Translators: The label of a button to close a dialog.
 		closeButton = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
 		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
-		sHelper.addItem(closeButton)
+		sHelper.addDialogDismissButtons(closeButton)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.EscapeId = wx.ID_CLOSE
 
@@ -323,7 +323,7 @@ class TriggersDialog(wx.Dialog):
 		self.profileList = sHelper.addLabeledControl(profileText, wx.Choice, choices=profileChoices)
 		self.profileList.Bind(wx.EVT_CHOICE, self.onProfileListChoice)
 
-		closeButton = sHelper.addItem(wx.Button(self, wx.ID_CLOSE, label=_("&Close")))
+		closeButton = sHelper.addDialogDismissButtons(wx.Button(self, wx.ID_CLOSE, label=_("&Close")))
 		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.AffirmativeId = wx.ID_CLOSE
@@ -388,7 +388,7 @@ class NewProfileDialog(wx.Dialog):
 		self.autoProfileName = ""
 		self.onTriggerChoice(None)
 
-		sHelper.addItem(self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		sHelper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK | wx.CANCEL))
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
 

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -210,7 +210,7 @@ class BoxSizerHelper(object):
 		""" Init. Pass in either orientation OR sizer.
 			@param parent: An instance of the parent wx window. EG wx.Dialog
 			@param orientation: the orientation to use when constructing the sizer, either wx.HORIZONTAL or wx.VERTICAL
-			@type itemType: wx.HORIZONTAL or wx.VERTICAL
+			@type itemType: wx.HORIZNOTAL or wx.VERTICAL
 			@param sizer: the sizer to use rather than constructing one.
 			@type sizer: wx.BoxSizer
 		"""
@@ -225,13 +225,18 @@ class BoxSizerHelper(object):
 			self.sizer = sizer
 		else:
 			raise ValueError("Orientation OR Sizer must be supplied.")
+		self.dialogDismissButtonsAdded = False
 
-	def addItem(self, item):
+	def addItem(self, item, **keywordArgs):
 		""" Adds an item with space between it and the previous item.
 			Does not handle adding LabledControlHelper; use L{addlabelledControl} instead.
+			@param item: the item to add to the sizer
+			@param **keywordArgs: the extra args to pass when adding the item to the wx.Sizer. This parameter is 
+				normally not necessary.
 		"""
+		assert not self.dialogDismissButtonsAdded, "Buttons to dismiss the dialog already added, they should be the last item added."
+
 		toAdd = item
-		keywordArgs = {}
 		shouldAddSpacer = self.hasFirstItemBeenAdded
 
 		if isinstance(item, ButtonHelper):
@@ -274,3 +279,21 @@ class BoxSizerHelper(object):
 		labeledControl = LabeledControlHelper(self._parent, labelText, wxCtrlClass, **kwargs)
 		self.addItem(labeledControl.sizer)
 		return labeledControl.control
+
+	def addDialogDismissButtons(self, buttons):
+		""" Adds and aligns the buttons for dismissing the dialog. These buttons may be "ok | cancel" and are expected
+		to be the last items added to the dialog. Buttons that launch an action, do not dismiss the dialog, or are not
+		the last item should be added via L{addItem}
+		@param buttons: the buttons to add
+		@type buttons: wx.Sizer or guiHelper.ButtonHelper
+		"""
+		if isinstance(buttons, ButtonHelper):
+			toAdd = buttons.sizer
+		elif isinstance(buttons, (wx.Sizer, wx.Button)):
+			toAdd = buttons
+		else:
+			raise NotImplementedError("Unknown type: {}".format(buttons))
+		self.addItem(toAdd, flag=wx.ALIGN_RIGHT)
+		self.dialogDismissButtonsAdded = True
+		return buttons
+

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -210,7 +210,7 @@ class BoxSizerHelper(object):
 		""" Init. Pass in either orientation OR sizer.
 			@param parent: An instance of the parent wx window. EG wx.Dialog
 			@param orientation: the orientation to use when constructing the sizer, either wx.HORIZONTAL or wx.VERTICAL
-			@type itemType: wx.HORIZNOTAL or wx.VERTICAL
+			@type itemType: wx.HORIZONTAL or wx.VERTICAL
 			@param sizer: the sizer to use rather than constructing one.
 			@type sizer: wx.BoxSizer
 		"""
@@ -281,11 +281,11 @@ class BoxSizerHelper(object):
 		return labeledControl.control
 
 	def addDialogDismissButtons(self, buttons):
-		""" Adds and aligns the buttons for dismissing the dialog. These buttons may be "ok | cancel" and are expected
+		""" Adds and aligns the buttons for dismissing the dialog; e.g. "ok | cancel". These buttons are expected
 		to be the last items added to the dialog. Buttons that launch an action, do not dismiss the dialog, or are not
 		the last item should be added via L{addItem}
 		@param buttons: the buttons to add
-		@type buttons: wx.Sizer or guiHelper.ButtonHelper
+		@type buttons: wx.Sizer or guiHelper.ButtonHelper or single wx.Button
 		"""
 		if isinstance(buttons, ButtonHelper):
 			toAdd = buttons.sizer

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -123,7 +123,7 @@ class InstallerDialog(wx.Dialog):
 		if globalVars.appArgs.launcher:
 			self.copyPortableConfigCheckbox.Disable()
 
-		bHelper = sHelper.addItem(guiHelper.ButtonHelper(wx.HORIZONTAL))
+		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL))
 		# Translators: The label of a button to continue with the operation.
 		continueButton = bHelper.addButton(self, label=_("&Continue"), id=wx.ID_OK)
 		continueButton.SetDefault()
@@ -211,7 +211,7 @@ class PortableCreaterDialog(wx.Dialog):
 		if globalVars.appArgs.launcher:
 			self.copyUserConfigCheckbox.Disable()
 
-		bHelper = sHelper.addItem(gui.guiHelper.ButtonHelper(wx.HORIZONTAL))
+		bHelper = sHelper.addDialogDismissButtons(gui.guiHelper.ButtonHelper(wx.HORIZONTAL))
 		
 		continueButton = bHelper.addButton(self, label=_("&Continue"), id=wx.ID_OK)
 		continueButton.SetDefault()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -78,7 +78,7 @@ class SettingsDialog(wx.Dialog):
 
 		mainSizer.Add(self.settingsSizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Add(wx.StaticLine(self), flag=wx.EXPAND)
-		mainSizer.Add(self.CreateButtonSizer(wx.OK|wx.CANCEL), border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
+		mainSizer.Add(self.CreateButtonSizer(wx.OK|wx.CANCEL), border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL|wx.ALIGN_RIGHT)
 
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
@@ -1336,7 +1336,7 @@ class DictionaryEntryDialog(wx.Dialog):
 		typeChoices = [DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING]
 		self.typeRadioBox=sHelper.addItem(wx.RadioBox(self,label=typeText, choices=typeChoices))
 		
-		sHelper.addItem(self.CreateButtonSizer(wx.OK|wx.CANCEL))
+		sHelper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK|wx.CANCEL))
 
 		mainSizer.Add(sHelper.sizer,border=20,flag=wx.ALL)
 		mainSizer.Fit(self)
@@ -1666,7 +1666,7 @@ class AddSymbolDialog(wx.Dialog):
 		symbolText = _("Symbol:")
 		self.identifierTextCtrl = sHelper.addLabeledControl(symbolText, wx.TextCtrl)
 		
-		sHelper.addItem(self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		sHelper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK | wx.CANCEL))
 
 		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -207,7 +207,7 @@ class UpdateResultDialog(wx.Dialog):
 			message = _("No update available.")
 		sHelper.addItem(wx.StaticText(self, label=message))
 
-		bHelper = sHelper.addItem(guiHelper.ButtonHelper(wx.HORIZONTAL))
+		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL))
 		if updateInfo:
 			if self.isInstalled:
 				# Translators: The label of a button to download and install an NVDA update.


### PR DESCRIPTION
fix for #6333

This change is based on both the fixGuiAlignmentIssues and i6348-documentFormattingDialog branches.
This aligns the ok / cancel buttons to the right. Extended the `guiHelper` to handle adding buttons to dismiss the dialog (which should be aligned right).

There are several dialogs that have been left:
- welcomeDialog
- donateDialog
- launcher dialog

The welcome and donate dialogs are less typical, I think they look better with the centred buttons.
Since the launcher dialog has four buttons arranged in a grid, visual this makes more sense aligned left.
