### PR TITLE
hwPortUtils.listComPorts: Don't barf when SPDRP_FRIENDLYNAME is invalid

### DIFF
--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -196,6 +196,9 @@ def listComPorts(onlyAvailable=True):
 					# #6015: In some rare cases, this value doesn't exist.
 					log.debugWarning("No PortName value for hardware ID %s" % hwID)
 					continue
+				if not port:
+					log.debugWarning("Empty PortName value for hardware ID %s" % hwID)
+					continue
 				if hwID.startswith("BTHENUM\\"):
 					# This is a Microsoft bluetooth port.
 					try:
@@ -229,11 +232,9 @@ def listComPorts(onlyAvailable=True):
 				ctypes.byref(buf), ctypes.sizeof(buf) - 1,
 				None
 			):
-				# Ignore ERROR_INSUFFICIENT_BUFFER
-				if ctypes.GetLastError() != ERROR_INSUFFICIENT_BUFFER:
-					# #6007: SPDRP_FRIENDLYNAME sometimes doesn't exist/isn't valid.
-					log.debugWarning("Couldn't get SPDRP_FRIENDLYNAME for %s: %s" % (port, ctypes.WinError()))
-					entry["friendlyName"] = port
+				# #6007: SPDRP_FRIENDLYNAME sometimes doesn't exist/isn't valid.
+				log.debugWarning("Couldn't get SPDRP_FRIENDLYNAME for %s: %s" % (port, ctypes.WinError()))
+				entry["friendlyName"] = port
 			else:
 				entry["friendlyName"] = buf.value
 

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -231,7 +231,9 @@ def listComPorts(onlyAvailable=True):
 			):
 				# Ignore ERROR_INSUFFICIENT_BUFFER
 				if ctypes.GetLastError() != ERROR_INSUFFICIENT_BUFFER:
-					raise ctypes.WinError()
+					# #6007: SPDRP_FRIENDLYNAME sometimes doesn't exist/isn't valid.
+					log.debugWarning("Couldn't get SPDRP_FRIENDLYNAME for %s: %s" % (port, ctypes.WinError()))
+					entry["friendlyName"] = port
 			else:
 				entry["friendlyName"] = buf.value
 


### PR DESCRIPTION
Fixed another rare issue when scanning for serial ports on some systems which made some braille display drivers unusable.

hwPortUtils.listComPorts: In some rare cases, the SPDRP_FRIENDLYNAME registry property doesn't exist/isn't valid. In these cases, just use the port name as the friendly name.
Originally reported by @joshknnd1982 in https://github.com/nvaccess/nvda/issues/6007#issuecomment-253681701

While we're at it:
- Also use PortName for FriendlyName on ERROR_INSUFFICIENT_BUFFER. We haven't seen it, but callers depend on FriendlyName, so we want to fall back if it does happen.
- For extra safety, skip the port altogether if PortName is empty.
