### PR TITLE
Use paragraph as unit when reading in table

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1588,7 +1588,7 @@ class WordDocument(EditableTextWithoutAutoSelectDetection, Window):
 			ui.message(_("Edge of table"))
 			return False
 		newInfo=WordDocumentTextInfo(self,textInfos.POSITION_CARET,_rangeObj=foundCell)
-		speech.speakTextInfo(newInfo,reason=controlTypes.REASON_CARET)
+		speech.speakTextInfo(newInfo,reason=controlTypes.REASON_CARET, unit=textInfos.UNIT_PARAGRAPH)
 		newInfo.collapse()
 		newInfo.updateCaret()
 		return True


### PR DESCRIPTION
When moving in a table, use a paragraph unit when reading text to ensure that the number for a numbered list item in the cell is read.

Fixes #6446.
