### PR TITLE
Iframes now reported as frame

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -86,7 +86,7 @@ class HTMLAttribCache(object):
 
 nodeNamesToNVDARoles={
 	"FRAME":controlTypes.ROLE_FRAME,
-	"IFRAME":controlTypes.ROLE_FRAME,
+	"IFRAME":controlTypes.ROLE_INTERNALFRAME,
 	"FRAMESET":controlTypes.ROLE_DOCUMENT,
 	"BODY":controlTypes.ROLE_DOCUMENT,
 	"TH":controlTypes.ROLE_TABLECELL,

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -426,7 +426,7 @@ roleLabels={
 	ROLE_DESKTOPICON:_("desktop icon"),
 	# Translators: Identifies an alert message such as file download alert in Internet explorer 9 and above.
 	ROLE_ALERT:_("alert"),
-	# Translators: Identifies an internal frame (commonly called iframe; usually seen when browsing some sites with Internet Explorer).
+	# Translators: Identifies an internal frame. This is usually a frame on a web page; i.e. a web page embedded within a web page.
 	ROLE_INTERNALFRAME:_("frame"),
 	# Translators: Identifies desktop pane (the desktop window).
 	ROLE_DESKTOPPANE:_("desktop pane"),

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -427,7 +427,7 @@ roleLabels={
 	# Translators: Identifies an alert message such as file download alert in Internet explorer 9 and above.
 	ROLE_ALERT:_("alert"),
 	# Translators: Identifies an internal frame (commonly called iframe; usually seen when browsing some sites with Internet Explorer).
-	ROLE_INTERNALFRAME:_("IFrame"),
+	ROLE_INTERNALFRAME:_("frame"),
 	# Translators: Identifies desktop pane (the desktop window).
 	ROLE_DESKTOPPANE:_("desktop pane"),
 	# Translators: Identifies an option pane.


### PR DESCRIPTION
Fixes #6047
In IE IFrames were being reported as "frame" and in Chrome as "IFrame".
Since "frame" is a more user friendly name, now both browsers report as
"frame".
