### PR TITLE
Add the ClientToScreen function from user32.dll to the winUser module

### DIFF
--- a/source/winUser.py
+++ b/source/winUser.py
@@ -1,6 +1,6 @@
 #winUser.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2016 NV Access Limited, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -514,6 +514,12 @@ def ScreenToClient(hwnd, x, y):
 	point = POINT(x, y)
 	user32.ScreenToClient(hwnd, byref(point))
 	return point.x, point.y
+
+def ClientToScreen(hwnd, x, y):
+	point = POINT(x, y)
+	user32.ClientToScreen(hwnd, byref(point))
+	return point.x, point.y
+
 
 class STICKYKEYS(Structure):
 	_fields_ = (


### PR DESCRIPTION
For a @BabbageCom project, I needed the ClientToScreen function from user32.dll which wasn't yet available in the winUser module. So, I decided to at it to winUser for ease of use. Might be handy for #4703 as well, cc @dkager
