### PR TITLE
It is now possible to assign gestures to commands for the Handy Tech braille display driver in the NVDA Input Gestures dialog. (#6461)

### DIFF
--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -14,6 +14,7 @@ import speech
 import inputCore
 import os
 from baseObject import ScriptableObject
+from globalCommands import SCRCAT_BRAILLE
 
 COM_CLASS = "HtBrailleDriverServer.HtBrailleDriver"
 HT_KEYS = {}
@@ -80,6 +81,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def display(self, cells):
 		self._server.displayText(cells)
+
+	scriptCategory = SCRCAT_BRAILLE
 
 	def script_showConfig(self, gesture):
 		self._server.startConfigDialog(False)

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -553,6 +553,8 @@ class _AllGestureMappingsRetriever(object):
 		gmap = braille.handler.display.gestureMap
 		if gmap:
 			self.addGlobalMap(gmap)
+		if isinstance(braille.handler.display, baseObject.ScriptableObject):
+			self.addObj(braille.handler.display)
 
 		# Global plugins.
 		import globalPluginHandler


### PR DESCRIPTION
- Scripts on braille display drivers are now considered when building the list of all input gesture mappings.
- The Handy Tech driver now specifies a script category of braille instead of defaulting to miscellaneous.

Fixes #6461.
