### PR TITLE
Add isSpeaking attribute to stock synthesizers

### DIFF
--- a/source/synthDrivers/audiologic.py
+++ b/source/synthDrivers/audiologic.py
@@ -82,3 +82,7 @@ class SynthDriver(SynthDriver):
 			_audiologic.TtsPause()
 		else:
 			_audiologic.TtsRestart()
+
+	def _get_isSpeaking(self):
+		_audiologic.TtsGetStatus()
+		return _audiologic.Tts3Status().SynthStatus != _audiologic.SYNTH_IDLE

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -237,3 +237,6 @@ class SynthDriver(SynthDriver):
 
 	def _getAvailableVariants(self):
 		return OrderedDict((ID,VoiceInfo(ID, name)) for ID, name in self._variantDict.iteritems())
+
+	def _get_isSpeaking(self):
+		return _espeak.isSpeaking

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -24,6 +24,9 @@ class SynthDriverBufSink(COMObject):
 		self._allowDelete = True
 		super(SynthDriverBufSink,self).__init__()
 
+	def ITTSBufNotifySink_TextDataDone(self, this, qTimeStamp, dwFlags):
+		self._synthDriver._isSpeaking=False
+
 	def ITTSBufNotifySink_BookMark(self, this, qTimeStamp, dwMarkNum):
 		self._synthDriver.lastIndex=dwMarkNum
 
@@ -75,6 +78,7 @@ class SynthDriver(SynthDriver):
 		if len(self._enginesList)==0:
 			raise RuntimeError("No Sapi4 engines available")
 		self.voice=str(self._enginesList[0].gModeID)
+		self._isSpeaking=False
 
 	def terminate(self):
 		self._bufSink._allowDelete = True
@@ -99,11 +103,13 @@ class SynthDriver(SynthDriver):
 			textList.append("\\RmS=0\\")
 		text="".join(textList)
 		flags=TTSDATAFLAG_TAGGED
+		self._isSpeaking=True
 		self._ttsCentral.TextData(VOICECHARSET.CHARSET_TEXT, flags,TextSDATA(text),self._bufSinkPtr,ITTSBufNotifySink._iid_)
 
 	def cancel(self):
 		self._ttsCentral.AudioReset()
 		self.lastIndex=None
+		self._isSpeaking=False
 
 	def pause(self,switch):
 		if switch:
@@ -251,3 +257,6 @@ class SynthDriver(SynthDriver):
 		val=self._percentToParam(val,self._minVolume&0xffff,self._maxVolume&0xffff)
 		val+=val<<16
 		self._ttsAttrs.VolumeSet(val)
+
+	def _get_isSpeaking(self):
+		return self._isSpeaking

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -304,3 +304,6 @@ class SynthDriver(SynthDriver):
 	def pause(self,switch):
 		if switch:
 			self.cancel()
+
+	def _get_isSpeaking(self):
+		return self.tts.Status.RunningState != 1


### PR DESCRIPTION
This is a continuation of #6175.

Turns out using the bookmark approach to determining end-of-speech results in overlapping speech for SAPI and MSSP drivers.  This patch adds the isSpeaking attribute to the stock synthesizers to allow smoother transition when multiple speech synthesizers are used.
