### PR TITLE
In Microsoft Excel, pressing enter or numpadEnter when navigating a spreadsheet now correctly reports navigation to the next row.

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -869,6 +869,8 @@ class ExcelWorksheet(ExcelBase):
 	__changeSelectionGestures = (
 		"kb:tab",
 		"kb:shift+tab",
+		"kb:enter",
+		"kb:numpadEnter",
 		"kb:upArrow",
 		"kb:downArrow",
 		"kb:leftArrow",


### PR DESCRIPTION
Fixes #6500.
