### PR TITLE
iTunes no longer intermittently freezes forever when using browse mode for the iTunes Store, Apple Music, etc.

### DIFF
--- a/nvdaHelper/interfaces/vbuf/vbuf.idl
+++ b/nvdaHelper/interfaces/vbuf/vbuf.idl
@@ -181,25 +181,4 @@ interface VBuf {
  */ 
 	int getLineOffsets([in] VBufRemote_bufferHandle_t buffer, [in] int offset, [in] int maxLineLength, [in] boolean useScreenLayout, [out] int *startOffset, [out] int *endOffset);
 
-/**
- * Retrieve the native handle for the object underlying a node.
- * This handle is used to retrieve the object out-of-process.
- * The way in which it is used is implementation specific.
- * @param buffer the virtual buffer to use
- * @param node the node in question.
- * @return the handle or 0 on error.
- */
-	int getNativeHandleForNode([in] VBufRemote_bufferHandle_t buffer, [in] VBufRemote_nodeHandle_t node);
-
-/**
- * Retrieve a node given the native handle for its underlying object.
- * This handle identifies the object out-of-process.
- * The way in which it is used is implementation specific.
- * @param buffer the virtual buffer to use
- * @param handle the handle in question.
- * @param node the node
- * @return non-zero if a node could be found.
- */
-	int getNodeForNativeHandle([in] VBufRemote_bufferHandle_t buffer, [in] int handle, [out] VBufRemote_nodeHandle_t* node);
-
 }

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -22,8 +22,6 @@ EXPORTS
 	VBuf_getFieldNodeOffsets
 	VBuf_getIdentifierFromControlFieldNode
 	VBuf_getLineOffsets
-	VBuf_getNativeHandleForNode
-	VBuf_getNodeForNativeHandle
 	VBuf_getSelectionOffsets
 	VBuf_getTextInRange
 	VBuf_getTextLength

--- a/nvdaHelper/remote/vbufRemote.cpp
+++ b/nvdaHelper/remote/vbufRemote.cpp
@@ -162,23 +162,6 @@ int VBufRemote_getLineOffsets(VBufRemote_bufferHandle_t buffer, int offset, int 
 	return res;
 }
 
-int VBufRemote_getNativeHandleForNode(VBufRemote_bufferHandle_t buffer, VBufRemote_nodeHandle_t node) {
-	VBufBackend_t* backend=(VBufBackend_t*)buffer;
-	VBufStorage_controlFieldNode_t* realNode=(VBufStorage_controlFieldNode_t*)node;
-	backend->lock.acquire();
-	int res=backend->getNativeHandleForNode(realNode);
-	backend->lock.release();
-	return res;
-}
-
-int VBufRemote_getNodeForNativeHandle(VBufRemote_bufferHandle_t buffer, int nativeHandle, VBufRemote_nodeHandle_t* node) {
-	VBufBackend_t* backend=(VBufBackend_t*)buffer;
-	backend->lock.acquire();
-	*node=(VBufRemote_nodeHandle_t)(backend->getNodeForNativeHandle(nativeHandle));
-	backend->lock.release();
-	return (*node)!=0;
-}
-
 //Special cleanup method for VBufRemote when client is lost
 void __RPC_USER VBufRemote_bufferHandle_t_rundown(VBufRemote_bufferHandle_t buffer) {
 	VBufRemote_destroyBuffer(&buffer);

--- a/nvdaHelper/vbufBackends/webKit/sconscript
+++ b/nvdaHelper/vbufBackends/webKit/sconscript
@@ -1,7 +1,7 @@
 ###
 #This file is a part of the NVDA project.
 #URL: http://www.nvda-project.org/
-#Copyright 2011 NV Access Inc
+#Copyright 2011-2016 NV Access Limited
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
 #the Free Software Foundation.
@@ -15,6 +15,7 @@
 Import([
 	'env',
 	'vbufBaseStaticLib',
+	'ia2RPCStubs',
 ])
 
 webKitBackendLib=env.SharedLibrary(
@@ -22,6 +23,7 @@ webKitBackendLib=env.SharedLibrary(
 	source=[
 		env['projectResFile'],
 		"webKit.cpp",
+		env.Object('_ia2_i',ia2RPCStubs[3]),
 	],
 	LIBS=[
 		vbufBaseStaticLib,

--- a/nvdaHelper/vbufBackends/webKit/webKit.cpp
+++ b/nvdaHelper/vbufBackends/webKit/webKit.cpp
@@ -15,6 +15,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <sstream>
 #include <comdef.h>
 #include <comip.h>
+#include <comutil.h>
 #include <windows.h>
 #include <oleacc.h>
 #include <ia2.h>
@@ -61,8 +62,7 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 	varChild.lVal=0;
 
 	// Get role with accRole
-	VARIANT varRole;
-	VariantInit(&varRole);
+	_variant_t varRole;
 	pacc->get_accRole(varChild, &varRole);
 
 	if (varRole.vt == VT_I4 && varRole.lVal == ROLE_SYSTEM_COLUMN) {
@@ -71,7 +71,6 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 		// We never want the column representation.
 		return NULL;
 	}
-	// varRole is still needed. It will be cleaned up later.
 
 	int id;
 	if(pacc->get_uniqueID((long*)&id) != S_OK)
@@ -79,7 +78,6 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 
 	//Make sure that we don't already know about this object -- protect from loops
 	if(buffer->getControlFieldNodeWithIdentifier(docHandle,id)!=NULL) {
-		VariantClear(&varRole);
 		pacc->Release();
 		return NULL;
 	}
@@ -103,7 +101,6 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 		role = varRole.lVal;
 	}
 	parentNode->addAttribute(L"IAccessible::role",s.str());
-	VariantClear(&varRole);
 
 	// Get states with accState
 	varChild.lVal=0;

--- a/nvdaHelper/vbufBackends/webKit/webKit.cpp
+++ b/nvdaHelper/vbufBackends/webKit/webKit.cpp
@@ -44,7 +44,7 @@ IAccessible2* IAccessible2FromIdentifier(int docHandle, int id) {
 	}
 	VariantClear(&varChild);
 	IServiceProviderPtr serv = NULL;
-	if (acc.QueryInterface(IID_IServiceProvider, (void**)&serv) != S_OK)
+	if (acc.QueryInterface(IID_IServiceProvider, &serv) != S_OK)
 		return NULL;
 	IAccessible2* pacc2 = NULL;
 	serv->QueryService(IID_IAccessible, IID_IAccessible2, (void**)&pacc2);

--- a/nvdaHelper/vbufBackends/webKit/webKit.cpp
+++ b/nvdaHelper/vbufBackends/webKit/webKit.cpp
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2011-2015 NV Access Limited
+Copyright 2011-2016 NV Access Limited
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -13,8 +13,11 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
 #include <sstream>
+#include <comdef.h>
+#include <comip.h>
 #include <windows.h>
 #include <oleacc.h>
+#include <ia2.h>
 #include <remote/nvdaHelperRemote.h>
 #include <common/log.h>
 #include <vbufBase/backend.h>
@@ -22,56 +25,32 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 using namespace std;
 
-const UINT WM_LRESULT_FROM_IACCESSIBLE = RegisterWindowMessage(L"VBufBackend_lresultFromIAccessible");
-const UINT WM_IACCESSIBLE_FROM_CHILDID = RegisterWindowMessage(L"VBufBackend_IAccessibleFromChildID");
+_COM_SMARTPTR_TYPEDEF(IAccessible, __uuidof(IAccessible));
+_COM_SMARTPTR_TYPEDEF(IServiceProvider, __uuidof(IServiceProvider));
 
-IAccessible* IAccessibleFromIdentifier(int docHandle, int ID) {
-	// We want to bypass oleacc proxying,
-	// so retrieve the IAccessible directly rather than using AccessibleObjectFromEvent.
-	LRESULT lres;
-	if (!(lres = SendMessage((HWND)UlongToHandle(docHandle), WM_GETOBJECT, 0, OBJID_CLIENT)))
-		return NULL;
-	IAccessible* root = NULL;
-	if (ObjectFromLresult(lres, IID_IAccessible, 0, (void**)&root) != S_OK)
-		return NULL;
+IAccessible2* IAccessible2FromIdentifier(int docHandle, int id) {
+	IAccessiblePtr acc = NULL;
 	VARIANT varChild;
-	varChild.vt = VT_I4;
-	varChild.lVal = ID;
-	IDispatch* childDisp;
-	HRESULT hres = root->get_accChild(varChild, &childDisp);
-	root->Release();
-	if (hres != S_OK)
+	// WebKit returns a positive value for uniqueID,
+	// but we need to pass a negative value when retrieving objects.
+	id = -id;
+	if (AccessibleObjectFromEvent((HWND)UlongToHandle(docHandle), OBJID_CLIENT, id, &acc, &varChild) != S_OK)
 		return NULL;
-	IAccessible* childAcc;
-	hres = childDisp->QueryInterface(IID_IAccessible, (void**)&childAcc);
-	childDisp->Release();
-	if (hres != S_OK)
+	if (varChild.lVal != CHILDID_SELF) {
+		// IAccessible2 can't be implemented on a simple child,
+		// so this object is invalid.
 		return NULL;
-	return childAcc;
+	}
+	VariantClear(&varChild);
+	IServiceProviderPtr serv = NULL;
+	if (acc.QueryInterface(IID_IServiceProvider, (void**)&serv) != S_OK)
+		return NULL;
+	IAccessible2* pacc2 = NULL;
+	serv->QueryService(IID_IAccessible, IID_IAccessible2, (void**)&pacc2);
+	return pacc2;
 }
 
-class WebKitVBufStorage_controlFieldNode_t: public VBufStorage_controlFieldNode_t {
-	public:
-	WebKitVBufStorage_controlFieldNode_t(int docHandle, int ID, bool isBlock, IAccessible* accessibleObj, WebKitVBufBackend_t* backend): VBufStorage_controlFieldNode_t(docHandle, ID, isBlock) {
-		this->accessibleObj = accessibleObj;
-		this->backend = backend;
-		backend->accessiblesToNodes[accessibleObj] = this;
-	}
-
-	~WebKitVBufStorage_controlFieldNode_t() {
-		if (accessibleObj) {
-			backend->accessiblesToNodes.erase(accessibleObj);
-			accessibleObj->Release();
-		}
-	}
-
-	protected:
-	IAccessible* accessibleObj;
-	WebKitVBufBackend_t* backend;
-	friend class WebKitVBufBackend_t;
-};
-
-VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessible* pacc, VBufStorage_buffer_t* buffer,
+VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessible2* pacc, VBufStorage_buffer_t* buffer,
 	VBufStorage_controlFieldNode_t* parentNode, VBufStorage_fieldNode_t* previousNode
 ) {
 	nhAssert(buffer);
@@ -94,7 +73,10 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 	}
 	// varRole is still needed. It will be cleaned up later.
 
-	int id = ++idCounter;
+	int id;
+	if(pacc->get_uniqueID((long*)&id) != S_OK)
+		return NULL;
+
 	//Make sure that we don't already know about this object -- protect from loops
 	if(buffer->getControlFieldNodeWithIdentifier(docHandle,id)!=NULL) {
 		VariantClear(&varRole);
@@ -103,8 +85,8 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 	}
 
 	//Add this node to the buffer
-	parentNode = buffer->addControlFieldNode(parentNode, previousNode, 
-		new WebKitVBufStorage_controlFieldNode_t(docHandle, id, true, pacc, this));
+	parentNode = buffer->addControlFieldNode(parentNode, previousNode,
+		docHandle, id, true);
 	nhAssert(parentNode); //new node must have been created
 	previousNode=NULL;
 	VBufStorage_fieldNode_t* tempNode;
@@ -166,8 +148,8 @@ VBufStorage_fieldNode_t* WebKitVBufBackend_t::fillVBuf(int docHandle, IAccessibl
 		}
 		for(int i=0;i<childCount;i++) {
 			if(varChildren[i].vt==VT_DISPATCH) {
-				IAccessible* childPacc=NULL;
-				if(varChildren[i].pdispVal->QueryInterface(IID_IAccessible,(void**)(&childPacc))!=S_OK) {
+				IAccessible2* childPacc=NULL;
+				if(varChildren[i].pdispVal->QueryInterface(IID_IAccessible2,(void**)(&childPacc))!=S_OK) {
 					childPacc=NULL;
 				}
 				if(childPacc) {
@@ -235,15 +217,13 @@ void CALLBACK WebKitVBufBackend_t::renderThread_winEventProcHook(HWINEVENTHOOK h
 	}
 	if (!backend)
 		return;
-
-	IAccessible* acc = IAccessibleFromIdentifier(HandleToUlong(hwnd), childID);
-	if (!acc)
+	int docHandle = HandleToUlong(hwnd);
+	// WebKit returns positive values for uniqueID, but fires events with negative ids.
+	// Therefore, flip the sign on childID.
+	VBufStorage_controlFieldNode_t* node = backend->getControlFieldNodeWithIdentifier(docHandle, -childID);
+	if (!node)
 		return;
-	acc->Release();
-	map<IAccessible*, WebKitVBufStorage_controlFieldNode_t*>::const_iterator it;
-	if ((it = backend->accessiblesToNodes.find(acc)) == backend->accessiblesToNodes.end())
-		return;
-	backend->invalidateSubtree(it->second);
+	backend->invalidateSubtree(node);
 }
 
 void WebKitVBufBackend_t::renderThread_initialize() {
@@ -257,67 +237,14 @@ void WebKitVBufBackend_t::renderThread_terminate() {
 }
 
 void WebKitVBufBackend_t::render(VBufStorage_buffer_t* buffer, int docHandle, int ID, VBufStorage_controlFieldNode_t* oldNode) {
-	IAccessible* pacc = NULL;
-	if (oldNode) {
-		pacc = static_cast<WebKitVBufStorage_controlFieldNode_t*>(oldNode)->accessibleObj;
-		// This accessible will now be used by a new node,
-		// so make sure the old node doesn't clean it up.
-		static_cast<WebKitVBufStorage_controlFieldNode_t*>(oldNode)->accessibleObj = NULL;
-	} else
-		pacc = IAccessibleFromIdentifier(docHandle,ID);
+	IAccessible2* pacc = NULL;
+	pacc = IAccessible2FromIdentifier(docHandle,ID);
 	nhAssert(pacc); //must get a valid IAccessible object
 	this->fillVBuf(docHandle, pacc, buffer, NULL, NULL);
 	// pacc will be released later.
 }
 
-WebKitVBufBackend_t::WebKitVBufBackend_t(int docHandle, int ID): VBufBackend_t(docHandle,ID), idCounter(-1) {
-}
-
-LRESULT CALLBACK callWndProcHook(int code, WPARAM wParam,LPARAM lParam) {
-	CWPSTRUCT* pcwp = (CWPSTRUCT*)lParam;
-	if (pcwp->message == WM_LRESULT_FROM_IACCESSIBLE) {
-		*(LRESULT*)pcwp->lParam = LresultFromObject(IID_IAccessible, 0,
-			(IUnknown*)pcwp->wParam);
-	} else if (pcwp->message == WM_IACCESSIBLE_FROM_CHILDID) {
-		IAccessible* acc = IAccessibleFromIdentifier(HandleToUlong(pcwp->hwnd), (int)pcwp->wParam);
-		if (acc) {
-			acc->Release();
-		}
-		*(IAccessible**) pcwp->lParam = acc;
-	}
-	return 0;
-}
-
-int WebKitVBufBackend_t::getNativeHandleForNode(VBufStorage_controlFieldNode_t* node) {
-	if (!this->isNodeInBuffer(node))
-		return 0;
-	LRESULT res = 0;
-	// This method will be called in an RPC thread.
-	// LresultFromObject must be called in the thread in which the object was created.
-	registerWindowsHook(WH_CALLWNDPROC, callWndProcHook);
-	SendMessage((HWND)UlongToHandle(rootDocHandle), WM_LRESULT_FROM_IACCESSIBLE,
-		(WPARAM)static_cast<WebKitVBufStorage_controlFieldNode_t*>(node)->accessibleObj, (LPARAM)&res);
-	unregisterWindowsHook(WH_CALLWNDPROC, callWndProcHook);
-	if (res <= 0)
-		return 0;
-	// LResultFromObject always returns a 32 bit value.
-	return (int)res;
-}
-
-VBufStorage_controlFieldNode_t* WebKitVBufBackend_t::getNodeForNativeHandle(int nativeHandle) {
-	IAccessible* acc;
-	// This method will be called in an RPC thread.
-	// IAccessibleFromIdentifier must be called in the thread in which the object was created.
-	registerWindowsHook(WH_CALLWNDPROC, callWndProcHook);
-	SendMessage((HWND)UlongToHandle(rootDocHandle), WM_IACCESSIBLE_FROM_CHILDID,
-		(WPARAM)nativeHandle, (LPARAM)&acc);
-	unregisterWindowsHook(WH_CALLWNDPROC, callWndProcHook);
-	if (!acc)
-		return NULL;
-	map<IAccessible*, WebKitVBufStorage_controlFieldNode_t*>::const_iterator it;
-	if ((it = accessiblesToNodes.find(acc)) == accessiblesToNodes.end())
-		return NULL;
-	return it->second;
+WebKitVBufBackend_t::WebKitVBufBackend_t(int docHandle, int ID): VBufBackend_t(docHandle,ID) {
 }
 
 extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {

--- a/nvdaHelper/vbufBackends/webKit/webKit.h
+++ b/nvdaHelper/vbufBackends/webKit/webKit.h
@@ -18,16 +18,12 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <map>
 #include <vbufBase/backend.h>
 
-class WebKitVBufStorage_controlFieldNode_t;
-
 class WebKitVBufBackend_t: public VBufBackend_t {
 	private:
 
-	VBufStorage_fieldNode_t* fillVBuf(int docHandle, IAccessible* pacc, VBufStorage_buffer_t* buffer,
+	VBufStorage_fieldNode_t* fillVBuf(int docHandle, IAccessible2* pacc, VBufStorage_buffer_t* buffer,
 		VBufStorage_controlFieldNode_t* parentNode, VBufStorage_fieldNode_t* previousNode
 	);
-
-	int idCounter;
 
 	protected:
 
@@ -39,19 +35,9 @@ class WebKitVBufBackend_t: public VBufBackend_t {
 
 	virtual void render(VBufStorage_buffer_t* buffer, int docHandle, int ID, VBufStorage_controlFieldNode_t* oldNode);
 
-	//virtual ~WebKitVBufBackend_t();
-
-	std::map<IAccessible*, WebKitVBufStorage_controlFieldNode_t*> accessiblesToNodes;
-
-	friend class WebKitVBufStorage_controlFieldNode_t;
-
 	public:
 
 	WebKitVBufBackend_t(int docHandle, int ID);
-
-	virtual int getNativeHandleForNode(VBufStorage_controlFieldNode_t* node);
-
-	virtual VBufStorage_controlFieldNode_t* getNodeForNativeHandle(int nativeHandle);
 
 };
 

--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -229,14 +229,6 @@ void VBufBackend_t::update() {
 	LOG_DEBUG(L"Update complete");
 }
 
-int VBufBackend_t::getNativeHandleForNode(VBufStorage_controlFieldNode_t* node) {
-	return 0;
-}
-
-VBufStorage_controlFieldNode_t* VBufBackend_t::getNodeForNativeHandle(int nativeHandle) {
-	return NULL;
-}
-
 void VBufBackend_t::terminate() {
 	if(runningBackends.count(this)>0) {
 		LOG_DEBUG(L"Render thread not terminated yet");

--- a/nvdaHelper/vbufBase/backend.h
+++ b/nvdaHelper/vbufBase/backend.h
@@ -151,25 +151,6 @@ static LRESULT CALLBACK destroy_callWndProcHook(int code, WPARAM wParam, LPARAM 
 	virtual void forceUpdate();
 
 /**
- * Retrieve the native handle for the object underlying a node.
- * This handle is used to retrieve the object out-of-process.
- * The way in which it is used is implementation specific.
- * @param node The node in question.
- * @return the handle or 0 on error.
- */
-	virtual int getNativeHandleForNode(VBufStorage_controlFieldNode_t*);
-
-/**
- * Retrieve a node given the native handle for its underlying object.
- * This handle identifies the object out-of-process.
- * The way in which it is used is implementation specific.
- * @param buffer the virtual buffer to use
- * @param handle the handle in question.
- * @return the node or 0 on error.
- */
-	virtual VBufStorage_controlFieldNode_t* getNodeForNativeHandle(int);
-
-/**
  * Clears the content of the backend and terminates any code used for rendering.
  */
 	virtual void terminate();

--- a/source/virtualBuffers/webKit.py
+++ b/source/virtualBuffers/webKit.py
@@ -1,6 +1,6 @@
 #virtualBuffers/webKit.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2011 NV Access Inc
+#Copyright (C) 2011-2016 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -60,29 +60,16 @@ class WebKit(VirtualBuffer):
 		return True
 
 	def getNVDAObjectFromIdentifier(self, docHandle, ID):
-		node=VBufRemote_nodeHandle_t()
-		NVDAHelper.localLib.VBuf_getControlFieldNodeWithIdentifier(self.VBufHandle, docHandle, ID,ctypes.byref(node))
-		if not node:
-			return None
-		lresult = NVDAHelper.localLib.VBuf_getNativeHandleForNode(self.VBufHandle, node)
-		if not lresult:
-			return None
-		return NVDAObjects.IAccessible.IAccessible(
-			IAccessibleObject=oleacc.ObjectFromLresult(lresult, 0, oleacc.IAccessible),
-			IAccessibleChildID=0, windowHandle=self.rootDocHandle)
+		if ID > 0:
+			# WebKit returns a positive value for uniqueID,
+			# but we need to pass a negative value when retrieving objects.
+			ID = -ID
+		return NVDAObjects.IAccessible.getNVDAObjectFromEvent(docHandle, winUser.OBJID_CLIENT, ID)
 
-	def getIdentifierFromNVDAObject(self,obj):
-		if obj == self.rootNVDAObject:
-			return obj.windowHandle, 0
-		if not self.isReady or not obj.event_childID:
-			# We can only retrieve the node for objects obtained from events.
-			raise LookupError
-		node=VBufRemote_nodeHandle_t()
-		NVDAHelper.localLib.VBuf_getNodeForNativeHandle(self.VBufHandle, obj.event_childID,ctypes.byref(node))
-		docHandle=ctypes.c_int()
-		ID=ctypes.c_int()
-		NVDAHelper.localLib.VBuf_getIdentifierFromControlFieldNode(self.VBufHandle, node, ctypes.byref(docHandle), ctypes.byref(ID))
-		return docHandle.value, ID.value
+	def getIdentifierFromNVDAObject(self, obj):
+		docHandle = obj.windowHandle
+		ID = obj.IA2UniqueID
+		return docHandle, ID
 
 	def _searchableAttribsForNodeType(self,nodeType):
 		if nodeType=="formField":


### PR DESCRIPTION
This was due to a deadlock between an RPC thread and the main thread when NVDA called getNativeHandleForNode and the main thread was attempting to render at the same time.
WebKit now supports IAccessible2 uniqueID. We now use this instead of our getNativeHandleForNode hack, as it's a much cleaner, safer and more reliable way to marshal objects between processes. This does mean we no longer support iTunes versions from a few years ago, but I doubt Apple does either and iTunes is free anyway.
getNativeHandleForNode and getNodeForNativeHandle have been removed from vbuf backend. They suffer from this deadlock, they're extremely ugly, and they were only introduced to support WebKit before it got IA2 anyway.
Fixes #6502.
