### PR TITLE
Include our dll/exe files in the symbol store

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,11 +71,18 @@ build_script:
  - py scons.py %sconsArgs%
  # Build symbol store.
  - ps: |
-     foreach ($syms in "source\*.pdb", "source\lib\*.pdb", "source\lib64\*.pdb", "source\synthDrivers\*.pdb") {
+     foreach ($syms in
+      # We don't just include source\*.dll because that would include system dlls.
+      "source\liblouis.dll", "source\*.pdb",
+      "source\lib\*.dll", "source\lib\*.pdb",
+      # We include source\lib64\*.exe to cover nvdaHelperRemoteLoader.
+      "source\lib64\*.dll", "source\lib64\*.exe", "source\lib64\*.pdb",
+      "source\synthDrivers\*.dll", "source\synthDrivers\*.pdb"
+     ) {
       & $env:symstore add /s symbols /compress -:NOREFS /t NVDA /f $syms
      }
  - cd symbols
- - 7z a -tzip -r ..\output\symbols.zip *.pd_
+ - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
  - cd ..
 
 artifacts:


### PR DESCRIPTION
These are necessary to work with crash dumps.
Re #6482.
