### PR TITLE
Various fixes for 2016.4 what's new and user guide. re #6517, #6519, #6520

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,9 +29,8 @@
 
 
 == Bug Fixes ==
-- Fixed a rare issue when exiting NVDA while the speech viewer is open which caused an error. (#5050)
+- Fixed a rare error when exiting NVDA while the speech viewer is open. (#5050)
 - Image maps now render as expected in browse mode in Mozilla Firefox. (#6051)
-- Fixed an issue causing a warning in the NVDA log file when caps lock is toggled. (#6127)
 - While in the dictionary dialog, pressing the enter key now saves changes such as adding new entries and exits. (#6206)
 - Messages are now displayed in braille when changing input modes for an input method (native input/alphanumeric, full shaped/half shaped, etc.). (#5892, #5893)
 - When disabling and then immediately re-enabling an add-on or vice versa, the add-on status now correctly reverts to what it was previously. (#6299)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,7 +6,7 @@
 = 2016.4 =
 
 == New Features ==
-- NVDA can now indicate line indentation using tones. This can be configured using the "Report line indentation with" combo box in NVDA's Document Formatting preferences dialog. (#5906)
+- NVDA can now indicate line indentation using tones. This can be configured using the "Line indentation reporting" combo box in NVDA's Document Formatting preferences dialog. (#5906)
 - Support for the Orbit Reader 20 braille display. (#6007)
 - An option to open the speech viewer window on startup has been added. This can be enabled via a check box in the speech viewer window. (#5050)
 - When re-opening the speech viewer window, the location and dimensions will now be restored. (#5050)
@@ -21,23 +21,23 @@
 - Various padding and alignment issues in NVDA's dialogs have been resolved. (#6317, #5548, #6342, #6343, #6349)
 - The document formatting dialog has been adjusted so that the contents scrolls. (#6348)
 - Adjusted the layout of the symbols pronunciation dialog so the full width of the dialog is used for the symbols list. (#6101)
-- In browse mode in web browsers, the edit field (e and shift+e) and form field (f and shift+f) single letter navigation commands now move to read-only edit fields. (#4164)
+- In browse mode in web browsers, the edit field (e and shift+e) and form field (f and shift+f) single letter navigation commands can be used to move to read-only edit fields. (#4164)
 - In NVDA's Document Formatting settings, "Announce formatting changes after the cursor" has been renamed to "Report formatting changes after the cursor", as it affects braille as well as speech. (#6336)
 - Adjusted the appearance of the NVDA "Welcome dialog". (#6350)
 - NVDA dialog boxes now have their "ok" and "cancel" buttons aligned to the right of the dialog. (#6333)
-- Spin Controls are now used for numerical input fields. (#6099)
+- Spin Controls are now used for numeric input fields such as "Capital pitch change percentage" setting  in voice settings dialog. Enter the desired setting or use up or down arrow keys to change values. (#6099)
 
 
 == Bug Fixes ==
-- Fixed a rare issue when exiting NVDA while the speech viewer is open causing an error. (#5050)
+- Fixed a rare issue when exiting NVDA while the speech viewer is open which caused an error. (#5050)
 - Image maps now render as expected in browse mode in Mozilla Firefox. (#6051)
-- Fixed an issue causing a warning in the NVDA log file when caps-lock is toggled. (#6127)
-- While in the dictionary dialog, pressing the enter key now saves changes and exits. (#6206)
+- Fixed an issue causing a warning in the NVDA log file when caps lock is toggled. (#6127)
+- While in the dictionary dialog, pressing the enter key now saves changes such as adding new entries and exits. (#6206)
 - Messages are now displayed in braille when changing input modes for an input method (native input/alphanumeric, full shaped/half shaped, etc.). (#5892, #5893)
 - When disabling and then immediately re-enabling an add-on or vice versa, the add-on status now correctly reverts to what it was previously. (#6299)
 - When using Microsoft Word, page-number fields in headers can now be read. (#6004)
 - The mouse can now be used to move focus between the symbol list and the edit fields in the symbol pronunciation dialog. (#6312)
-- Fixed an issue that stops the the elements list from appearing when Microsoft Word contains an invalid hyperlink. (#5886)
+- In browse mode in Microsoft Word, Fixed an issue that stops the elements list from appearing when a document contains an invalid hyperlink. (#5886)
 - After being closed via the task bar or the alt+F4 shortcut, the speech viewer checkbox status in the NVDA menu will now reflect the actual visibility of the window. (#6340)
 - The reload plugins command no longer causes problems for triggered configuration profiles, new documents in web browsers and screen review. (#2892, #5380)
 - In the list of languages in NVDA's General Settings dialog, languages such as Aragonese are now displayed correctly on Windows 10. (#6259)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -91,6 +91,7 @@ Apart from the  inability to automatically start during and/or after log-on, the
 - The inability to read User Account Control (UAC) screens when trying to start an application with administrative privileges.
 - Windows 8 and later: the inability to support input from a touch screen.
 - Windows 8 and later: the inability to provide features such as browse mode and speaking of typed characters in Windows Store apps.
+- Windows 8 and later: audio ducking and ways to configure it is unsupported.
 -
 
 ++ Installing NVDA ++


### PR DESCRIPTION
Linguistic fixes and clarifications:
- #6517: entries clarified, grammar fixes, linguistic fixes.
- #6519: document the fact that audio ducking isn't supported on temporary copies nad on portable ones on Windows 8 and later.
- #6520: changed label for indentation reporting combo box.

Thanks.
