### PR TITLE
Include Python wrapper for the Handy Tech braille driver com server type lib in NVDA builds by default #6546

### DIFF
--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -45,6 +45,7 @@ COM_INTERFACES = {
 	"SpeechLib.py": ('{C866CA3A-32F7-11D2-9602-00C04F8EE628}',5,0),
 	"AcrobatAccessLib.py": "typelibs/AcrobatAccess.tlb",
 	"FlashAccessibility.py": "typelibs/FlashAccessibility.tlb",
+	"HTBRAILLEDRIVERSERVERLib.py": "brailleDisplayDrivers/handyTech/HtBrailleDriverServer.tlb",
 }
 
 for k,v in COM_INTERFACES.iteritems():


### PR DESCRIPTION
As proposed in #6546, this adds building of the ht braille driver typelib python wrapper to the comInterfaces_sconscript. Closes #6546 when this has been merged.