### PR TITLE
Change the PlaySound routine in the launcher to prevent warnings on systems without a sound card

### DIFF
--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -90,6 +90,7 @@ SectionEnd
 Function PlaySound
 ; Retrieve the file to play
 pop $9
+; The code below is derived from the code example at http://nsis.sourceforge.net/WinAPI:winmm:PlaySound
 IntOp $0 "SND_ASYNC" || 1
 System::Call 'winmm::PlaySound(t r9, i 0, i r0) b'
 FunctionEnd

--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -86,21 +86,10 @@ execWait "$PLUGINSDIR\app\nvda_noUIAccess.exe $0 -r --launcher" $1
 intcmp $1 3 exec +1
 SectionEnd
 
-var hmci
 
 Function PlaySound
 ; Retrieve the file to play
 pop $9
-System::Call 'msvfw32.dll::MCIWndCreate(i 0, i 0, i 0x0070, t "$9") i .r0'
-StrCpy $hmci $0
-; Checks format support
-SendMessage $hmci 0x0490 0 0 $0
-IntCmp $0 0 nosup
-; if you want mci window to be hidden
-ShowWindow $hmci SW_HIDE
-; you can use "STR:play" or "STR:play repeat", but I saw "repeat" problems with midi files
-SendMessage $hmci 0x0465 0 "STR:play"
-;SendMessage $hmci ${WM_CLOSE} 0 0
-
-nosup:
+IntOp $0 "SND_ASYNC" || 1
+System::Call 'winmm::PlaySound(t r9, i 0, i r0) b'
 FunctionEnd


### PR DESCRIPTION
This was initially reported as part of #6289.
In the current pr, I changed the PlaySound routine according to [this](http://nsis.sourceforge.net/mediawiki/index.php?title=WinAPI:winmm:PlaySound&oldid=13110) NSIS example. It uses windows standard [PlaySound function](https://msdn.microsoft.com/en-us/library/ms712879.aspx), which is a nicer approach anyway. I tested with with a soundless vm, and all works fine.

CC @WJdZ