### PR TITLE
Limit braille cursor blink rate

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1525,8 +1525,9 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self._displayWithCursor()
 		if self._cursorPos is None or not showCursor:
 			return
+		cursorShouldBlink = config.conf["braille"]["cursorBlink"]
 		blinkRate = config.conf["braille"]["cursorBlinkRate"]
-		if blinkRate:
+		if cursorShouldBlink and blinkRate:
 			self._cursorBlinkTimer = wx.PyTimer(self._blink)
 			self._cursorBlinkTimer.Start(blinkRate)
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,0 +1,197 @@
+# -*- coding: UTF-8 -*-
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2016 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+from cStringIO import StringIO
+from configobj import ConfigObj
+
+#: The version of the schema outlined in this file. Increment this when modifying the schema and 
+#: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
+#: just adding a new element to (or removing from) the schema, only when old versions of the config 
+#: (conforming to old schema versions) will not work correctly with the new schema.
+latestSchemaVersion = 0
+
+#: The configuration specification string
+#: @type: String
+configSpecString = ("""# NVDA Configuration File
+schemaVersion = integer(min=0, default={latestSchemaVersion})
+[general]
+	language = string(default="Windows")
+	saveConfigurationOnExit = boolean(default=True)
+	askToExit = boolean(default=true)
+	playStartAndExitSounds = boolean(default=true)
+	#possible log levels are DEBUG, IO, DEBUGWARNING, INFO
+	loggingLevel = string(default="INFO")
+	showWelcomeDialogAtStartup = boolean(default=true)
+
+# Speech settings
+[speech]
+	# The synthesiser to use
+	synth = string(default=auto)
+	symbolLevel = integer(default=100)
+	trustVoiceLanguage = boolean(default=true)
+	beepSpeechModePitch = integer(default=10000,min=50,max=11025)
+	outputDevice = string(default=default)
+	autoLanguageSwitching = boolean(default=true)
+	autoDialectSwitching = boolean(default=false)
+
+	[[__many__]]
+		capPitchChange = integer(default=30,min=-100,max=100)
+		sayCapForCapitals = boolean(default=false)
+		beepForCapitals = boolean(default=false)
+		useSpellingFunctionality = boolean(default=true)
+
+# Audio settings
+[audio]
+	audioDuckingMode = integer(default=0)
+
+# Braille settings
+[braille]
+	display = string(default=noBraille)
+	translationTable = string(default=en-us-comp8.ctb)
+	inputTable = string(default=en-us-comp8.ctb)
+	expandAtCursor = boolean(default=true)
+	showCursor = boolean(default=true)
+	cursorBlinkRate = integer(default=500,min=0,max=2000)
+	cursorShape = integer(default=192,min=1,max=255)
+	messageTimeout = integer(default=4,min=0,max=20)
+	tetherTo = string(default="focus")
+	readByParagraph = boolean(default=false)
+	wordWrap = boolean(default=true)
+
+	# Braille display driver settings
+	[[__many__]]
+		port = string(default="")
+
+# Presentation settings
+[presentation]
+		reportKeyboardShortcuts = boolean(default=true)
+		reportObjectPositionInformation = boolean(default=true)
+		guessObjectPositionInformationWhenUnavailable = boolean(default=false)
+		reportTooltips = boolean(default=false)
+		reportHelpBalloons = boolean(default=true)
+		reportObjectDescriptions = boolean(default=True)
+		reportDynamicContentChanges = boolean(default=True)
+	[[progressBarUpdates]]
+		reportBackgroundProgressBars = boolean(default=false)
+		#output modes are beep, speak, both, or off
+		progressBarOutputMode = string(default="beep")
+		speechPercentageInterval = integer(default=10)
+		beepPercentageInterval = integer(default=1)
+		beepMinHZ = integer(default=110)
+
+[mouse]
+	enableMouseTracking = boolean(default=True) #must be true for any of the other settings to work
+	mouseTextUnit = string(default="paragraph")
+	reportObjectRoleOnMouseEnter = boolean(default=False)
+	audioCoordinatesOnMouseMove = boolean(default=False)
+	audioCoordinates_detectBrightness = boolean(default=False)
+	audioCoordinates_blurFactor = integer(default=3)
+	audioCoordinates_minVolume = float(default=0.1)
+	audioCoordinates_maxVolume = float(default=1.0)
+	audioCoordinates_minPitch = integer(default=220)
+	audioCoordinates_maxPitch = integer(default=880)
+	reportMouseShapeChanges = boolean(default=false)
+
+[speechViewer]
+	showSpeechViewerAtStartup = boolean(default=false)
+	autoPositionWindow = boolean(default=True)
+	# values for positioning the window. Defaults are not used. They should not be read if autoPositionWindow is True
+	x = integer()
+	y = integer()
+	width = integer()
+	height = integer()
+	displays = string_list()
+
+#Keyboard settings
+[keyboard]
+	useCapsLockAsNVDAModifierKey = boolean(default=false)
+	useNumpadInsertAsNVDAModifierKey = boolean(default=true)
+	useExtendedInsertAsNVDAModifierKey = boolean(default=true)
+	keyboardLayout = string(default="desktop")
+	speakTypedCharacters = boolean(default=true)
+	speakTypedWords = boolean(default=false)
+	beepForLowercaseWithCapslock = boolean(default=true)
+	speakCommandKeys = boolean(default=false)
+	speechInterruptForCharacters = boolean(default=true)
+	speechInterruptForEnter = boolean(default=true)
+	allowSkimReadingInSayAll = boolean(default=False)
+	alertForSpellingErrors = boolean(default=True)
+	handleInjectedKeys= boolean(default=true)
+
+[virtualBuffers]
+	maxLineLength = integer(default=100)
+	linesPerPage = integer(default=25)
+	useScreenLayout = boolean(default=True)
+	autoPassThroughOnFocusChange = boolean(default=true)
+	autoPassThroughOnCaretMove = boolean(default=false)
+	passThroughAudioIndication = boolean(default=true)
+	autoSayAllOnPageLoad = boolean(default=true)
+	trapNonCommandGestures = boolean(default=true)
+
+#Settings for document reading (such as MS Word and wordpad)
+[documentFormatting]
+	#These settings affect what information is reported when you navigate to text where the formatting  or placement has changed
+	detectFormatAfterCursor = boolean(default=false)
+	reportFontName = boolean(default=false)
+	reportFontSize = boolean(default=false)
+	reportFontAttributes = boolean(default=false)
+	reportRevisions = boolean(default=true)
+	reportEmphasis = boolean(default=false)
+	reportColor = boolean(default=False)
+	reportAlignment = boolean(default=false)
+	reportLineSpacing = boolean(default=false)
+	reportStyle = boolean(default=false)
+	reportSpellingErrors = boolean(default=true)
+	reportPage = boolean(default=true)
+	reportLineNumber = boolean(default=False)
+	reportLineIndentation = boolean(default=False)
+	reportLineIndentationWithTones = boolean(default=False)
+	reportParagraphIndentation = boolean(default=False)
+	reportTables = boolean(default=true)
+	includeLayoutTables = boolean(default=False)
+	reportTableHeaders = boolean(default=True)
+	reportTableCellCoords = boolean(default=True)
+	reportLinks = boolean(default=true)
+	reportComments = boolean(default=true)
+	reportLists = boolean(default=true)
+	reportHeadings = boolean(default=true)
+	reportBlockQuotes = boolean(default=true)
+	reportLandmarks = boolean(default=true)
+	reportFrames = boolean(default=true)
+	reportClickable = boolean(default=true)
+
+[reviewCursor]
+	simpleReviewMode = boolean(default=True)
+	followFocus = boolean(default=True)
+	followCaret = boolean(default=True)
+	followMouse = boolean(default=False)
+
+[UIA]
+	minWindowsVersion = float(default=6.1)
+	enabled = boolean(default=true)
+
+[update]
+	autoCheck = boolean(default=true)
+
+[inputComposition]
+	autoReportAllCandidates = boolean(default=True)
+	announceSelectedCandidate = boolean(default=True)
+	alwaysIncludeShortCharacterDescriptionInCandidateName = boolean(default=True)
+	reportReadingStringChanges = boolean(default=True)
+	reportCompositionStringChanges = boolean(default=True)
+
+[debugLog]
+	hwIo = boolean(default=false)
+	audioDucking = boolean(default=false)
+
+[upgrade]
+	newLaptopKeyboardLayout = boolean(default=false)
+""").format(latestSchemaVersion=latestSchemaVersion)
+
+#: The configuration specification
+#: @type: ConfigObj
+confspec = ConfigObj(StringIO( configSpecString ), list_values=False, encoding="UTF-8")
+confspec.newlines = "\r\n"

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -11,7 +11,7 @@ from configobj import ConfigObj
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config 
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 0
+latestSchemaVersion = 1
 
 #: The configuration specification string
 #: @type: String
@@ -54,7 +54,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	inputTable = string(default=en-us-comp8.ctb)
 	expandAtCursor = boolean(default=true)
 	showCursor = boolean(default=true)
-	cursorBlinkRate = integer(default=500,min=0,max=2000)
+	cursorBlink = boolean(default=true)
+	cursorBlinkRate = integer(default=500,min=200,max=2000)
 	cursorShape = integer(default=192,min=1,max=255)
 	messageTimeout = integer(default=4,min=0,max=20)
 	tetherTo = string(default="focus")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -1,0 +1,19 @@
+# -*- coding: UTF-8 -*-
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2016 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""
+Contains upgrade steps for the NVDA configuration files. These steps are run to ensure that a configuration file
+complies with the latest schema (@see configSpec.py).
+
+To add a new step (after modifying the schema and incrementing the schema version number) add a new method to this
+module. The method name should be in the form "upgradeConfigFrom_X_to_Y" where X is the previous schema version, and Y
+is the current schema version. The argument profile will be a configobj.ConfigObj object. The function should ensure 
+that no information is lost, while updating the ConfigObj to meet the requirements of the new schema.
+"""
+
+from logHandler import log
+
+# add upgrade steps here.

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -16,4 +16,19 @@ that no information is lost, while updating the ConfigObj to meet the requiremen
 
 from logHandler import log
 
-# add upgrade steps here.
+def upgradeConfigFrom_0_to_1(profile):
+	# Schema has been modified to set a new minimum blink rate
+	# The blink rate could previously be set to zero to disable blinking (while still 
+	# having a cursor)
+	try:
+		blinkRate = int(profile["braille"]["cursorBlinkRate"])
+	except KeyError as e:
+		# Setting does not exist, no need for upgrade of this setting
+		log.debug("No cursorBlinkRate, no action taken.")
+		pass
+	else:
+		newMinBlinkRate = 200
+		if blinkRate < newMinBlinkRate :
+			profile["braille"]["cursorBlinkRate"] = newMinBlinkRate
+			if blinkRate < 1 :
+				profile["braille"]["cursorBlink"] = False

--- a/source/config/profileUpgrader.py
+++ b/source/config/profileUpgrader.py
@@ -1,0 +1,73 @@
+# -*- coding: UTF-8 -*-
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2016 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+from logHandler import log
+from .configSpec import latestSchemaVersion, confspec
+from configobj import flatten_errors
+from copy import deepcopy
+from . import profileUpgradeSteps
+
+SCHEMA_VERSION_KEY = "schemaVersion"
+
+def upgrade(profile, validator):
+	# when profile is none or empty we can still validate. It should at least have a version set.
+	_ensureVersionProperty(profile)
+	startSchemaVersion = int(profile[SCHEMA_VERSION_KEY])
+	log.debug("Current config schema version: {0}, latest: {1}".format(startSchemaVersion, latestSchemaVersion))
+
+	for fromVersion in xrange(startSchemaVersion, latestSchemaVersion):
+		_doConfigUpgrade(profile, fromVersion)
+	_doValidation(deepcopy(profile), validator) # copy the profile, since validating mutates the object
+	try:
+		# write out the configuration once the upgrade has been validated. This means that if NVDA crashes for some
+		# other reason the file does not need to be upgraded again.
+		profile.write()
+	except Exception as e:
+		log.warning("Error saving configuration; probably read only file system")
+		log.debugWarning("", exc_info=True)
+		pass
+
+def _doConfigUpgrade(profile, fromVersion):
+	toVersion = fromVersion+1
+	upgradeStepName = "upgradeConfigFrom_{0}_to_{1}".format(fromVersion, toVersion)
+	upgradeStepFunc = getattr(profileUpgradeSteps, upgradeStepName)
+	log.debug("Upgrading from schema version {0} to {1}".format(fromVersion, toVersion))
+	upgradeStepFunc(profile)
+	profile[SCHEMA_VERSION_KEY] = toVersion
+
+def _doValidation(profile, validator):
+	oldConfSpec = profile.configspec
+	profile.configspec = confspec
+	result = profile.validate(validator, preserve_errors=True)
+	profile.configspec = oldConfSpec
+
+	if isinstance(result, bool) and not result:
+		# empty file?
+		raise ValueError("Unable to validate config file after upgrade.")
+
+	flatResult = flatten_errors(profile, result)
+	for section_list, key, value in flatResult :
+		 # bool values don't matter
+		 #	True and the value is fine.
+		 #	False and the value is missing (which is typically fine)
+		 # dict values should be recursively checked 
+		if not isinstance(value, bool):
+			errorString=(
+				u"Unable to validate config file after upgrade: Key {0} : {1}\n" +
+				"Full result: (value of false means the key was not present)\n" +
+				"{2}"
+				).format(key, value, flatResult)
+			raise ValueError(errorString)
+
+def _ensureVersionProperty(profile):
+	isEmptyProfile = 1 > len(profile.keys())
+	if isEmptyProfile:
+		log.debug("Empty profile, triggering default schema version")
+		profile[SCHEMA_VERSION_KEY] = latestSchemaVersion
+	elif not SCHEMA_VERSION_KEY in profile:
+		# this must be a "before schema versions" config file.
+		log.debug("No schema version found, setting to zero.")
+		profile[SCHEMA_VERSION_KEY] = 0

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -916,6 +916,10 @@ This option allows the word that is under the cursor to be displayed in non-cont
 This option allows the braille cursor to be turned on and off.
 It applies to the system caret and review cursor, but not to the selection indicator.
 
+==== Blink Cursor ====
+This option allows the braille cursor to blink.
+If blinking is turned off, the braille cursor will constantly be in the "up" position.
+
 ==== Cursor Blink Rate (ms) ====
 This option is a numerical field that allows you to change the blink rate of the cursor in milliseconds.
 


### PR DESCRIPTION
Fix for #6470, limit the minimum blink rate to 200ms

This stops the blink rate from being set below 200ms. Configurations that are already set below 200ms will be modified, and set to 200ms.

There is some active discussion about being able to disable the braille cursor blinking, this was previously possible by setting the blink rate to 0.