### PR TITLE
Support language switching in wordpad

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -17,6 +17,7 @@ import globalVars
 import eventHandler
 import comInterfaces.tom
 from logHandler import log
+import languageHandler
 import config
 import speech
 import winKernel
@@ -473,6 +474,14 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError
 
+	def _getLanguageFromLcid(self, lcid):
+		"""
+		gets a normalized locale from a lcid
+		"""
+		lang = locale.windows_locale[lcid]
+		if lang:
+			return languageHandler.normalizeLanguage(lang)
+
 	def _getFormatFieldAtRange(self,range,formatConfig):
 		formatField=textInfos.FormatField()
 		fontObj=None
@@ -532,6 +541,16 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 				formatField['background-color']=_("Unknown color")
 			else:
 				formatField["background-color"]=colors.RGB.fromCOLORREF(bkColor)
+		if True:
+			if not fontObj: fontObj=range.font
+			try:
+				langId = fontObj.languageID
+			except:
+				log.debugWarning("language error",exc_info=True)
+				pass
+			else:
+				if langId:
+					formatField['language']=self._getLanguageFromLcid(langId)
 		return formatField
 
 	def _expandFormatRange(self,range,formatConfig):

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -474,14 +474,6 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError
 
-	def _getLanguageFromLcid(self, lcid):
-		"""
-		gets a normalized locale from a lcid
-		"""
-		lang = locale.windows_locale[lcid]
-		if lang:
-			return languageHandler.normalizeLanguage(lang)
-
 	def _getFormatFieldAtRange(self,range,formatConfig):
 		formatField=textInfos.FormatField()
 		fontObj=None
@@ -541,16 +533,15 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 				formatField['background-color']=_("Unknown color")
 			else:
 				formatField["background-color"]=colors.RGB.fromCOLORREF(bkColor)
-		if True:
-			if not fontObj: fontObj=range.font
-			try:
-				langId = fontObj.languageID
-			except:
-				log.debugWarning("language error",exc_info=True)
-				pass
-			else:
-				if langId:
-					formatField['language']=self._getLanguageFromLcid(langId)
+		if not fontObj: fontObj=range.font
+		try:
+			langId = fontObj.languageID
+		except:
+			log.debugWarning("language error",exc_info=True)
+			pass
+		else:
+			if langId:
+				formatField['language']=languageHandler.windowsLCIDToLocaleName(langId)
 		return formatField
 
 	def _expandFormatRange(self,range,formatConfig):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -761,7 +761,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		try:
 			languageId = int(field.pop('wdLanguageId',0))
 			if languageId:
-				field['language']=self._getLanguageFromLcid(languageId)
+				field['language']=languageHandler.windowsLCIDToLocaleName(languageId)
 		except:
 			log.debugWarning("language error",exc_info=True)
 			pass
@@ -775,14 +775,6 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 				v=self.obj.getLocalizedMeasurementTextForPointSize(v)
 			field[x]=v
 		return field
-
-	def _getLanguageFromLcid(self, lcid):
-		"""
-		gets a normalized locale from a lcid
-		"""
-		lang = locale.windows_locale[lcid]
-		if lang:
-			return languageHandler.normalizeLanguage(lang)
 
 	def expand(self,unit):
 		if unit==textInfos.UNIT_LINE: 

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -40,6 +40,14 @@ def localeNameToWindowsLCID(localeName):
 			LCID=0
 	return LCID
 
+def windowsLCIDToLocaleName(lcid):
+	"""
+	gets a normalized locale from a lcid
+	"""
+	lang = locale.windows_locale[lcid]
+	if lang:
+		return normalizeLanguage(lang)
+
 def getLanguageDescription(language):
 	"""Finds out the description (localized full name) of a given local name"""
 	desc=None


### PR DESCRIPTION
Fix for #6555

One concern is to ensure that we dont re-introduce #2047: don't expose language for whitespace as its incorrect for east-asian languages. I'm not sure how to test for that specifically.
				