### PR TITLE
Excel: Disable auto passThrough mode in Excel's browse mode by default

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -428,6 +428,9 @@ class SheetsExcelCollectionQuicknavIterator(ExcelQuicknavIterator):
 
 class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 
+	# This treeInterceptor starts in focus mode, thus escape should not switch back to browse mode
+	disableAutoPassThrough=True
+
 	def __init__(self,rootNVDAObject):
 		super(ExcelBrowseModeTreeInterceptor,self).__init__(rootNVDAObject)
 		self.passThrough=True

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1232,7 +1232,7 @@ class GlobalCommands(ScriptableObject):
 			return
 		# Toggle browse mode pass-through.
 		vbuf.passThrough = not vbuf.passThrough
-		if isinstance(vbuf,browseMode.BrowseModeDocumentTreeInterceptor):
+		if isinstance(vbuf,browseMode.BrowseModeTreeInterceptor):
 			# If we are enabling pass-through, the user has explicitly chosen to do so, so disable auto-pass-through.
 			# If we're disabling pass-through, re-enable auto-pass-through.
 			vbuf.disableAutoPassThrough = vbuf.passThrough


### PR DESCRIPTION
Excel has a browse mode treeInterceptor, which starts in focus mode, so that the user can bring up the NVDA elements list without having to switch to browse mode first. However, at current, if the user presses escape, they drop into browse mode, which can be confusing and unproductive, especially when escaping too many times out of editing a cell. This pr ensures that autoPassThrough is disabled by default, meaning that focus mode is locked unless the user manually switches to browse mode.  Escape will still work if switching to focus mode when pressing enter on a form field. This brings the experience inline with all other browse mode implementations. 