### PR TITLE
Kindle 1.19 support

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -52,7 +52,7 @@ class OrderedWinEventLimiter(object):
 	Only allow one event for one specific object at a time, though push it further forward in time if a duplicate tries to get added. This is true for both generic and focus events.
  	"""
 
-	def __init__(self,maxFocusItems=3):
+	def __init__(self,maxFocusItems=4):
 		"""
 		@param maxFocusItems: the amount of focus changed events allowed to be queued.
 		@type maxFocusItems: integer
@@ -82,9 +82,6 @@ class OrderedWinEventLimiter(object):
 		if eventID==winUser.EVENT_OBJECT_FOCUS:
 			if objectID in (winUser.OBJID_SYSMENU,winUser.OBJID_MENU) and childID==0:
 				# This is a focus event on a menu bar itself, which is just silly. Ignore it.
-				return False
-			#We do not need a focus event on an object if we already got a foreground event for it
-			if (winUser.EVENT_SYSTEM_FOREGROUND,window,objectID,childID,threadID) in self._focusEventCache:
 				return False
 			self._focusEventCache[(eventID,window,objectID,childID,threadID)]=next(self._eventCounter)
 			return True

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -199,7 +199,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			log.debugWarning("could not get attributes",exc_info=True)
 			return textInfos.FormatField(),(self._startOffset,self._endOffset)
 		formatField=textInfos.FormatField()
-		if not attribsString and offset>0:
+		if attribsString is None and offset>0:
 			try:
 				attribsString=self.obj.IAccessibleTextObject.attributes(offset-1)[2]
 			except COMError:

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -201,14 +201,17 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 				yield item
 			elif isinstance(item, int): # Embedded object.
 				embedded = _getEmbedded(ti.obj, item)
+				notText = _getRawTextInfo(embedded) is NVDAObjectTextInfo
 				if controlStack is not None:
 					controlField = self._getControlFieldForObject(embedded)
 					controlStack.append(controlField)
 					if controlField:
+						if notText:
+							controlField["content"] = embedded.name
 						controlField["_startOfNode"] = True
 						yield textInfos.FieldCommand("controlStart", controlField)
-				if _getRawTextInfo(embedded) is NVDAObjectTextInfo: # No text
-					yield embedded.basicText
+				if notText:
+					yield u" "
 				else:
 					for subItem in self._iterRecursiveText(self._makeRawTextInfo(embedded, textInfos.POSITION_ALL), controlStack, formatConfig):
 						yield subItem

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -546,7 +546,10 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			# Find the edge of the current unit in the requested direction.
 			moveTi, moveObj = self._findUnitEndpoints(moveTi, unit, findStart=moveBack, findEnd=not moveBack)
 
-			if not moveBack:
+			if moveBack:
+				# Collapse to the start of the previous unit.
+				moveTi.collapse()
+			else:
 				# Collapse to the start of the next unit.
 				moveTi.collapse(end=True)
 				if moveTi.compareEndPoints(self._makeRawTextInfo(moveObj, textInfos.POSITION_ALL), "endToEnd") == 0:

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016 NV Access Limited
+#Copyright (C) 2016-2017 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -26,8 +26,13 @@ import winUser
 from logHandler import log
 import ui
 
-class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,BrowseModeDocumentTreeInterceptor):
+class ElementsListDialog(browseMode.ElementsListDialog):
+	ELEMENT_TYPES = (
+		browseMode.ElementsListDialog.ELEMENT_TYPES[0], # Links
+	)
 
+class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,BrowseModeDocumentTreeInterceptor):
+	ElementsListDialog = ElementsListDialog
 	TextInfo=treeInterceptorHandler.RootProxyTextInfo
 	pageChangeAlreadyHandled = False
 

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -4,6 +4,7 @@
 #See the file COPYING for more details.
 
 import time
+from comtypes.hresult import S_OK
 import appModuleHandler
 import speech
 import sayAllHandler
@@ -13,23 +14,42 @@ from scriptHandler import willSayAllResume, isScriptWaiting
 import controlTypes
 import treeInterceptorHandler
 from cursorManager import ReviewCursorManager
+import browseMode
 from browseMode import BrowseModeDocumentTreeInterceptor
 import textInfos
 from textInfos import DocumentWithPageTurns
-from NVDAObjects.IAccessible import IAccessible, IA2TextTextInfo
+from NVDAObjects.IAccessible import IAccessible
+from globalCommands import SCRCAT_SYSTEMCARET
+from NVDAObjects.IAccessible.ia2TextMozilla import MozillaCompoundTextInfo
+import IAccessibleHandler
+import winUser
+from logHandler import log
+import ui
 
 class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,BrowseModeDocumentTreeInterceptor):
 
 	TextInfo=treeInterceptorHandler.RootProxyTextInfo
+	pageChangeAlreadyHandled = False
 
 	def turnPage(self,previous=False):
-		# When in a page turn, Kindle  fires focus on the new page in the table of contents treeview.
-		# We must ignore this focus event as it is a hinderance to a screen reader user while reading the book.
-		try:
-			self.rootNVDAObject.appModule.inPageTurn=True
-			return self.rootNVDAObject.turnPage(previous=previous)
-		finally:
-			self.rootNVDAObject.appModule.inPageTurn=False
+		self.rootNVDAObject.turnPage(previous=previous)
+		# turnPage waits for a pageChange event before returning,
+		# but the pageChange event will still get fired.
+		# We need to know that we've already handled it.
+		self.pageChangeAlreadyHandled=True
+
+	def event_pageChange(self, obj, nextHandler):
+		if self.pageChangeAlreadyHandled:
+			# This page change has already been handled.
+			self.pageChangeAlreadyHandled = False
+			return
+		info = self.makeTextInfo(textInfos.POSITION_FIRST)
+		self.selection = info
+		if not self.rootNVDAObject.hasFocus:
+			# Don't report anything if the book area isn't focused.
+			return
+		info.expand(textInfos.UNIT_LINE)
+		speech.speakTextInfo(info, unit=textInfos.UNIT_LINE, reason=controlTypes.REASON_CARET)
 
 	def isAlive(self):
 		return winUser.isWindow(self.rootNVDAObject.windowHandle)
@@ -60,7 +80,127 @@ class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,Brow
 	def _tabOverride(self,direction):
 		return False
 
-class BookPageViewTextInfo(IA2TextTextInfo):
+	def script_showSelectionOptions(self, gesture):
+		fakeSel = self.selection
+		if fakeSel.isCollapsed:
+			# Double click to access the toolbar; e.g. for annotations.
+			try:
+				p = fakeSel.pointAtStart
+			except NotImplementedError:
+				log.debugWarning("Couldn't get point to click")
+				return
+			log.debug("Double clicking")
+			winUser.setCursorPos(p.x, p.y)
+			winUser.mouse_event(winUser.MOUSEEVENTF_LEFTDOWN, 0, 0, None, None)
+			winUser.mouse_event(winUser.MOUSEEVENTF_LEFTUP, 0, 0, None, None)
+			winUser.mouse_event(winUser.MOUSEEVENTF_LEFTDOWN, 0, 0, None, None)
+			winUser.mouse_event(winUser.MOUSEEVENTF_LEFTUP, 0, 0, None, None)
+			return
+
+		# The user makes a selection using browse mode virtual selection.
+		# Update the selection in Kindle.
+		# This will cause the options to appear.
+		fakeSel.innerTextInfo.updateSelection()
+		# The selection might have been adjusted to meet word boundaries,
+		# so retrieve and report the selection from Kindle.
+		# we can't just use self.makeTextInfo, as that will use our fake selection.
+		realSel = self.rootNVDAObject.makeTextInfo(textInfos.POSITION_SELECTION)
+		# Translators: Announces selected text. %s is replaced with the text.
+		speech.speakSelectionMessage(_("selected %s"), realSel.text)
+		# Remove our virtual selection and move the caret to the active end.
+		fakeSel.innerTextInfo = realSel
+		fakeSel.collapse(end=not self._lastSelectionMovedStart)
+		self.selection = fakeSel
+	# Translators: Describes a command.
+	script_showSelectionOptions.__doc__ = _("Shows options related to selected text or text at the cursor")
+	script_showSelectionOptions.category = SCRCAT_SYSTEMCARET
+
+	__gestures = {
+		"kb:control+c": "showSelectionOptions",
+		"kb:applications": "showSelectionOptions",
+		"kb:shift+f10": "showSelectionOptions",
+	}
+
+	def _iterEmbeddedObjs(self, hypertext, startIndex, direction):
+		"""Recursively iterate through all embedded objects in a given direction starting at a given hyperlink index.
+		"""
+		log.debug("Starting at hyperlink index %d" % startIndex)
+		for index in xrange(startIndex, hypertext.nHyperlinks if direction == "next" else -1, 1 if direction == "next" else -1):
+			hl = hypertext.hyperlink(index)
+			obj = IAccessible(IAccessibleObject=hl.QueryInterface(IAccessibleHandler.IAccessible2), IAccessibleChildID=0)
+			log.debug("Yielding object at index %d" % index)
+			yield obj
+			try:
+				objHt = obj.iaHypertext
+			except:
+				# This is a graphic, etc. which doesn't support text.
+				continue
+			log.debug("Object has hypertext. Recursing")
+			for subObj in self._iterEmbeddedObjs(objHt, 0 if direction == "next" else objHt.nHyperlinks - 1, direction):
+				yield subObj
+
+	NODE_TYPES_TO_ROLES = {
+		"link": {controlTypes.ROLE_LINK, controlTypes.ROLE_FOOTNOTE},
+		"graphic": {controlTypes.ROLE_GRAPHIC},
+	}
+
+	def _iterNodesByType(self, nodeType, direction="next", pos=None):
+		roles = self.NODE_TYPES_TO_ROLES.get(nodeType)
+		if not roles:
+			raise NotImplementedError
+		if not pos:
+			pos = self.makeTextInfo(textInfos.POSITION_FIRST if direction == "next" else textInfos.POSITION_LAST)
+		obj = pos.innerTextInfo._startObj
+		# Find the first embedded object in the requested direction.
+		# Use the text, as enumerating IAccessibleHypertext means more cross-process calls.
+		offset = pos.innerTextInfo._start._startOffset
+		if direction == "next":
+			text = obj.IAccessibleTextObject.text(offset + 1, obj.IAccessibleTextObject.nCharacters)
+			embed = text.find(u"\uFFFC")
+			if embed != -1:
+				embed += offset + 1
+		else:
+			if offset > 0:
+				text = obj.IAccessibleTextObject.text(0, offset)
+				embed = text.rfind(u"\uFFFC")
+			else:
+				# We're at the start; we can't go back any further.
+				embed = -1
+		log.debug("%s embedded object from offset %d: %d" % (direction, offset, embed))
+		hli = -1 if embed == -1 else obj.iaHypertext.hyperlinkIndex(embed)
+		while True:
+			if hli != -1:
+				for embObj in self._iterEmbeddedObjs(obj.iaHypertext, hli, direction):
+					if embObj.role in roles:
+						ti = self.makeTextInfo(embObj)
+						yield browseMode.TextInfoQuickNavItem(nodeType, self, ti)
+			# No more embedded objects here.
+			# We started in an embedded object, so continue in the parent.
+			if obj == self.rootNVDAObject:
+				log.debug("At root, stopping")
+				break # Can't go any further.
+			log.debug("Continuing in parent")
+			# Get the index of the embedded object we just came from.
+			hl = obj.IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleHyperlink)
+			offset = hl.startIndex
+			obj = obj.parent
+			hli = obj.iaHypertext.hyperlinkIndex(offset)
+			# Continue the walk from the next embedded object.
+			hli += 1 if direction == "next" else -1
+
+	def script_find(self, gesture):
+		# Translators: Reported when a user tries to use a find command when it isn't supported.
+		ui.message(_("Not supported in this document"))
+
+	def script_findNext(self, gesture):
+		# Translators: Reported when a user tries to use a find command when it isn't supported.
+		ui.message(_("Not supported in this document"))
+
+	def script_findPrevious(self, gesture):
+		# Translators: Reported when a user tries to use a find command when it isn't supported.
+		ui.message(_("Not supported in this document"))
+
+class BookPageViewTextInfo(MozillaCompoundTextInfo):
 
 	def _get_locationText(self):
 		curLocation=self.obj.IA2Attributes.get('kindle-first-visible-location-number')
@@ -74,18 +214,63 @@ class BookPageViewTextInfo(IA2TextTextInfo):
 			text+=", "+_("Page {pageNumber}").format(pageNumber=pageNumber)
 		return text
 
-	def _getFormatFieldAndOffsets(self,offset,formatConfig,calculateOffsets=True):
-		formatField,offsets=super(BookPageViewTextInfo,self)._getFormatFieldAndOffsets(offset,formatConfig,calculateOffsets=calculateOffsets)
-		if formatConfig['reportPage']:
-			formatField['page-number']=self.obj.pageNumber
-		return formatField,offsets
+	def getTextWithFields(self, formatConfig=None):
+		items = super(BookPageViewTextInfo, self).getTextWithFields(formatConfig=formatConfig)
+		for item in items:
+			if isinstance(item, textInfos.FieldCommand) and item.command == "formatChange":
+				if formatConfig['reportPage']:
+					item.field['page-number'] = self.obj.pageNumber
+		return items
+
+	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
+		out = ""
+		comment = attrs.get("kindle-user-note")
+		if comment:
+			# For now, we report this the same way we do comments.
+			attrs["comment"] = comment
+		highlight = attrs.get("kindle-highlight")
+		oldHighlight = attrsCache.get("kindle-highlight") if attrsCache is not None else None
+		if oldHighlight != highlight:
+			# Translators: Reported when text is highlighted.
+			out += (_("highlight") if highlight
+				# Translators: Reported when text is not highlighted.
+				else _("no highlight")) + separator
+		popular = attrs.get("kindle-popular-highlight-count")
+		oldPopular = attrsCache.get("kindle-popular-highlight-count") if attrsCache is not None else None
+		if oldPopular != popular:
+			# Translators: Reported in Kindle when text has been identified as a popular highlight;
+			# i.e. it has been highlighted by several people.
+			# %s is replaced with the number of people who have highlighted this text.
+			out += (_("%s highlighted") % popular if popular
+				# Translators: Reported when moving out of a popular highlight.
+				else _("out of popular highlight")) + separator
+		out += super(BookPageViewTextInfo, self).getFormatFieldSpeech(attrs, attrsCache=attrsCache, formatConfig=formatConfig, reason=reason, unit=unit, extraDetail=extraDetail , initialFormat=initialFormat, separator=separator)
+		return out
+
+	def updateSelection(self):
+		# hack: For now, we need to do all selection on the root.
+		# This means only entire embedded objects can be selected.
+		if self._startObj == self.obj:
+			sel = self._start.copy()
+		else:
+			log.debug("Start object isn't root, getting embedding")
+			sel = self._getEmbedding(self._startObj)
+			assert sel.obj == self.obj
+		if self._endObj == self.obj:
+			end = self._end
+		else:
+			log.debug("End object isn't root, getting embedding")
+			end = self._getEmbedding(self._endObj)
+			assert end.obj == self.obj
+		sel.setEndPoint(end, "endToEnd")
+		log.debug("Setting selection to (%d, %d)" % (sel._startOffset, sel._endOffset))
+		sel.updateSelection()
 
 class BookPageView(DocumentWithPageTurns,IAccessible):
 	"""Allows navigating page text content with the arrow keys."""
 
 	treeInterceptorClass=BookPageViewTreeInterceptor
 	TextInfo=BookPageViewTextInfo
-	shouldAllowIAccessibleFocusEvent=True
 
 	def _get_pageNumber(self):
 		try:
@@ -103,34 +288,22 @@ class BookPageView(DocumentWithPageTurns,IAccessible):
 			return first
 
 	def turnPage(self,previous=False):
-		try:
-			self.IAccessibleActionObject.doAction(1 if previous else 0)
-		except COMError:
+		if self.IAccessibleActionObject.doAction(1 if previous else 0) != S_OK:
 			raise RuntimeError("no more pages")
-		startTime=curTime=time.time()
-		while (curTime-startTime)<0.5:
-			api.processPendingEvents(processEventQueue=False)
-			# should  only check for pending pageChange for this object specifically, but object equality seems to fail sometimes?
-			if eventHandler.isPendingEvents("pageChange"):
-				self.invalidateCache()
-				break
-			time.sleep(0.05)
-			curTime=time.time()
-		else:
-			raise RuntimeError("no more pages")
+		self.invalidateCache()
 
 class PageTurnFocusIgnorer(IAccessible):
 
 	def _get_shouldAllowIAccessibleFocusEvent(self):
-		# When in a page turn, Kindle  fires focus on the new page in the table of contents treeview.
+		# hack: When turning pages to a new section, Kindle  fires focus on the new section in the table of contents treeview.
 		# We must ignore this focus event as it is a hinderance to a screen reader user while reading the book.
-		if self.appModule.inPageTurn:
+		focus = api.getFocusObject()
+		if isinstance(focus, BookPageView) and focus.hasFocus:
+			# The book area reports that it still has the focus, so this event is bogus.
 			return False
 		return super(PageTurnFocusIgnorer,self).shouldAllowIAccessibleFocusEvent
 
 class AppModule(appModuleHandler.AppModule):
-
-	inPageTurn=False
 
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
 		if isinstance(obj,IAccessible):
@@ -138,3 +311,9 @@ class AppModule(appModuleHandler.AppModule):
 			if hasattr(obj,'IAccessibleTextObject') and obj.name=="Book Page View":
 				clsList.insert(0,BookPageView)
 		return clsList
+
+	def event_NVDAObject_init(self, obj):
+		if isinstance(obj, IAccessible) and isinstance(obj.IAccessibleObject, IAccessibleHandler.IAccessible2) and obj.role == controlTypes.ROLE_LINK:
+			xRoles = obj.IA2Attributes.get("xml-roles", "").split(" ")
+			if "kindle-footnoteref" in xRoles:
+				obj.role = controlTypes.ROLE_FOOTNOTE

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -41,7 +41,9 @@ class CompoundTextInfo(textInfos.TextInfo):
 			# Aside from being pointless, we don't want a collapsed end object, as this will cause bogus control fields to be emitted.
 			try:
 				self._end, self._endObj = self._findNextContent(self._endObj, moveBack=True)
-				self._end.move(textInfos.UNIT_OFFSET, 1)
+				# _end is now on the last character, but we want it collapsed after this.
+				self._end.move(textInfos.UNIT_OFFSET, 1, endPoint="end")
+				self._end.collapse(end=True)
 			except LookupError:
 				pass
 
@@ -152,6 +154,10 @@ class CompoundTextInfo(textInfos.TextInfo):
 		return field
 
 	def __eq__(self, other):
+		if self is other:
+			return True
+		if type(self) is not type(other):
+			return False
 		return self._start == other._start and self._startObj == other._startObj and self._end == other._end and self._endObj == other._endObj
 
 	def __ne__(self, other):

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -139,7 +139,6 @@ class CompoundTextInfo(textInfos.TextInfo):
 		states.discard(controlTypes.STATE_MULTILINE)
 		states.discard(controlTypes.STATE_FOCUSED)
 		field["states"] = states
-		field["name"] = obj.name
 		field["_childcount"] = obj.childCount
 		field["level"] = obj.positionInfo.get("level")
 		if role == controlTypes.ROLE_TABLE:
@@ -259,7 +258,7 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 						embedIndex += 1
 					field = ti.obj.getChild(embedIndex)
 					controlField = self._getControlFieldForObject(field, ignoreEditableText=False)
-					controlField["alwaysReportName"] = True
+					controlField["content"] = field.name
 					fields.extend((textInfos.FieldCommand("controlStart", controlField),
 						u"\uFFFC",
 						textInfos.FieldCommand("controlEnd", None)))

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1290,7 +1290,7 @@ class GlobalCommands(ScriptableObject):
 
 		repeats=scriptHandler.getLastScriptRepeatCount()
 		if repeats==0:
-			text=speech.getFormatFieldSpeech(formatField,formatConfig=formatConfig) if formatField else None
+			text=info.getFormatFieldSpeech(formatField,formatConfig=formatConfig) if formatField else None
 			if text:
 				textList.append(text)
 
@@ -1301,7 +1301,7 @@ class GlobalCommands(ScriptableObject):
 				
 			ui.message(" ".join(textList))
 		elif repeats==1:
-			text=speech.getFormatFieldSpeech(formatField,formatConfig=formatConfig , separator="\n") if formatField else None
+			text=info.getFormatFieldSpeech(formatField,formatConfig=formatConfig , separator="\n") if formatField else None
 			if text:
 				textList.append(text)
 

--- a/source/speech.py
+++ b/source/speech.py
@@ -785,7 +785,7 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 		commonFieldCount+=1
 
 	#Fetch the text for format field attributes that have changed between what was previously cached, and this textInfo's initialFormatField.
-	text=getFormatFieldSpeech(newFormatField,formatFieldAttributesCache,formatConfig,reason=reason,unit=unit,extraDetail=extraDetail,initialFormat=True)
+	text=info.getFormatFieldSpeech(newFormatField,formatFieldAttributesCache,formatConfig,reason=reason,unit=unit,extraDetail=extraDetail,initialFormat=True)
 	if text:
 		speechSequence.append(text)
 	if autoLanguageSwitching:
@@ -843,7 +843,7 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 				if commonFieldCount>len(newControlFieldStack):
 					commonFieldCount=len(newControlFieldStack)
 			elif command.command=="formatChange":
-				fieldText=getFormatFieldSpeech(command.field,formatFieldAttributesCache,formatConfig,reason=reason,unit=unit,extraDetail=extraDetail)
+				fieldText=info.getFormatFieldSpeech(command.field,formatFieldAttributesCache,formatConfig,reason=reason,unit=unit,extraDetail=extraDetail)
 				if fieldText:
 					inTextChunk=False
 				if autoLanguageSwitching:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -437,6 +437,14 @@ class TextInfo(baseObject.AutoPropertyObject):
 		import braille
 		return braille.getControlFieldBraille(self, field, ancestors, reportStart, formatConfig)
 
+	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
+		"""Get the spoken representation for given format information.
+		The base implementation just calls L{speech.getFormatFieldSpeech}.
+		This can be extended in order to support implementation specific attributes.
+		If extended, the superclass should be called first.
+		"""
+		return speech.getFormatFieldSpeech(attrs, attrsCache=attrsCache, formatConfig=formatConfig, reason=reason, unit=unit, extraDetail=extraDetail , initialFormat=initialFormat, separator=separator)
+
 	def activate(self):
 		"""Activate this position.
 		For example, this might activate the object at this position or click the point at this position.

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -14,7 +14,6 @@ import weakref
 import re
 import baseObject
 import config
-import speech
 import controlTypes
 
 class Field(dict):
@@ -430,6 +429,8 @@ class TextInfo(baseObject.AutoPropertyObject):
 			unitInfo.collapse(end=True)
 
 	def getControlFieldSpeech(self, attrs, ancestorAttrs, fieldType, formatConfig=None, extraDetail=False, reason=None):
+		# Import late to avoid circular import.
+		import speech
 		return speech.getControlFieldSpeech(attrs, ancestorAttrs, fieldType, formatConfig, extraDetail, reason)
 
 	def getControlFieldBraille(self, field, ancestors, reportStart, formatConfig):
@@ -437,12 +438,21 @@ class TextInfo(baseObject.AutoPropertyObject):
 		import braille
 		return braille.getControlFieldBraille(self, field, ancestors, reportStart, formatConfig)
 
-	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
+	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=None):
 		"""Get the spoken representation for given format information.
 		The base implementation just calls L{speech.getFormatFieldSpeech}.
 		This can be extended in order to support implementation specific attributes.
 		If extended, the superclass should be called first.
+		@param separator: The text used to separate chunks of format information;
+			defaults to L{speech.CHUNK_SEPARATOR}.
+		@type separator: basestring
 		"""
+		# Import late to avoid circular import.
+		import speech
+		if separator is None:
+			# #6749: The default for this argument is actually speech.CHUNK_SEPARATOR,
+			# but that can't be specified as a default argument because of circular import issues.
+			separator = speech.CHUNK_SEPARATOR
 		return speech.getFormatFieldSpeech(attrs, attrsCache=attrsCache, formatConfig=formatConfig, reason=reason, unit=unit, extraDetail=extraDetail , initialFormat=initialFormat, separator=separator)
 
 	def activate(self):

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -11,6 +11,7 @@ import review
 import textInfos
 import config
 import braille
+import speech
 
 runningTable=set()
 
@@ -217,3 +218,6 @@ class RootProxyTextInfo(textInfos.TextInfo):
 
 	def _get_focusableNVDAObjectAtStart(self):
 		return self.innerTextInfo.focusableNVDAObjectAtStart
+
+	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
+		return self.innerTextInfo.getFormatFieldSpeech(attrs, attrsCache=attrsCache, formatConfig=formatConfig, reason=reason, unit=unit, extraDetail=extraDetail , initialFormat=initialFormat, separator=separator)

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -11,7 +11,6 @@ import review
 import textInfos
 import config
 import braille
-import speech
 
 runningTable=set()
 
@@ -219,7 +218,12 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def _get_focusableNVDAObjectAtStart(self):
 		return self.innerTextInfo.focusableNVDAObjectAtStart
 
-	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
+	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=None):
+		if separator is None:
+			# #6749: The default for this argument is actually speech.CHUNK_SEPARATOR,
+			# but that can't be specified as a default argument because of circular import issues.
+			import speech
+			separator = speech.CHUNK_SEPARATOR
 		return self.innerTextInfo.getFormatFieldSpeech(attrs, attrsCache=attrsCache, formatConfig=formatConfig, reason=reason, unit=unit, extraDetail=extraDetail , initialFormat=initialFormat, separator=separator)
 
 	def _get_pointAtStart(self):

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -221,3 +221,6 @@ class RootProxyTextInfo(textInfos.TextInfo):
 
 	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
 		return self.innerTextInfo.getFormatFieldSpeech(attrs, attrsCache=attrsCache, formatConfig=formatConfig, reason=reason, unit=unit, extraDetail=extraDetail , initialFormat=initialFormat, separator=separator)
+
+	def _get_pointAtStart(self):
+		return self.innerTextInfo.pointAtStart

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -722,7 +722,8 @@ If you do this with no text selected, options will be shown for the word at the 
 
 +++ User Notes +++
 You can add a note regarding a word or passage of text.
-To do this, select the relevant text as described above and then choose Add Note.
+To do this, first select the relevant text and access the selection options as described above.
+Then, choose Add Note.
 
 When reading in browse mode, NVDA refers to these notes as comments.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -698,6 +698,41 @@ When in a conversation:
 | Review message | NVDA+control+1-0 | Reports and moves the review cursor to a recent message, depending on the number pressed; e.g. NVDA+control+2 reads the second most recent message. |
 %kc:endInclude
 
+++ Kindle for PC ++
+NVDA supports reading and navigating books in Amazon Kindle for PC.
+This functionality is only available in Kindle books that support "Enhanced Typesetting", which you can check on the details page for the book.
+
+Browse mode is used to read books.
+It is enabled automatically when you open a book or focus the book area.
+The page will be turned automatically as appropriate when you move the cursor or use the say all command.
+%kc:beginInclude
+You can manually turn to the next page with the pageDown key and turn to the previous page with the pageUp key.
+%kc:endInclude
+
+Single letter navigation is supported for links and graphics, but only within the current page.
+Navigating by link also includes footnotes.
+
++++ Text Selection +++
+Kindle allows you to perform various functions on selected text, including obtaining a dictionary definition, adding notes and highlights, copying the text to the clipboard and searching the web.
+To do this, first select text as you normally would in browse mode; e.g. by using shift and the cursor keys.
+%kc:beginInclude
+Once you have selected text, press the applications key or shift+f10 to show the available options for working with the selection.
+%kc:endInclude
+If you do this with no text selected, options will be shown for the word at the cursor.
+
++++ User Notes +++
+You can add a note regarding a word or passage of text.
+To do this, select the relevant text as described above and then choose Add Note.
+
+When reading in browse mode, NVDA refers to these notes as comments.
+
+To view, edit or delete a note:
+
++ Move the cursor to the text containing the note.
++ Access the options for the selection as described above.
++ Choose Edit Note.
++
+
 + Configuring NVDA +
 
 ++ Preferences ++


### PR DESCRIPTION
This adds support for new Kindle functionality introduced in Kindle 1.19, as well as other improvements to Kindle support. It also adds documentation for Kindle support to the User Guide.

Features:

* Reporting of links and graphics and activation of links. The IA2 embedded object model is used for this, so we use MozillaCompoundTextInfo.
* Reporting of notes and highlights.
* Selection of text and access to selection options (including creating highlights and notes).
* Single letter navigation to links (including footnotes) and graphics.

Fixes/improvements:

* Fix failure to detect focus change when opening a book from the Kindle library.
* Handle page changes not triggered by NVDA (e.g. using the mouse, using a keyboard command not intercepted by NVDA, via the Table of Contents, resizing the window, etc.).
* Better workaround for focus being inaccurately thrown into the Table of Contents when turning pages. Kindle still fires incorrect events, but we can now use the focused state on the book area to accurately determine whether these events are incorrect.
* The find commands aren't currently supported, so report this fact rather than just throwing an exception.
* Remove various hacks that are no longer needed: waiting in a loop for a pageChange event after turnPage (since the action is now synchronous), forcing shouldAllowIAccessibleFocusEvent for BookPageView (since Kindle now sets the focused state correctly).

This work required quite a few fixes and changes scattered throughout the code base. Because some of these changes will be hard to understand without context, I've split these into smaller commits. When it comes time to merge to master, this should be done as a standard merge, rather than our usual squash.

What's New entry: in New Features:

```
- Support for reading and navigating books in Kindle for PC version 1.19, including access to links, footnotes, graphics, highlighted text and user notes. Please see the Kindle for PC section of the NVDA User Guide for further information. (#6247, #6638)
```