### PR TITLE
Python 2.7.13: Fix unicode paths passed to ctypes.CDLL, ctypes.WINDLL, etc.

### DIFF
--- a/source/pythonMonkeyPatches.py
+++ b/source/pythonMonkeyPatches.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2013 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2013-2017 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -13,3 +13,14 @@ tempPath = ctypes.create_string_buffer(260)
 if ctypes.windll.kernel32.GetTempPathA(260, tempPath) > 0:
 	# Strip trailing backslash which is always included.
 	tempfile.tempdir = tempPath.value[:-1]
+
+# #6705: ctypes._dlopen (imported from _ctypes.LoadLibrary) doesn't support unicode paths.
+# In Python < 2.7.13, it silently converted them to str, treating them as ASCII.
+# In Python 2.7.13 (Python issue 27330), passing unicode now throws an exception.
+# Some add-ons depend on the previous behaviour, so monkey patch this to support unicode.
+old_dlopen = ctypes._dlopen
+def _dlopen(name, mode=ctypes.DEFAULT_MODE):
+	if isinstance(name, unicode):
+		name = name.encode("mbcs")
+	return old_dlopen(name, mode)
+ctypes._dlopen = _dlopen


### PR DESCRIPTION
Monkey patch ctypes._dlopen (used by the constructor for ctypes.CDLL, ctypes.WINDLL, etc.) so that it accepts unicode paths as it did prior to Python 2.7.13.
In Python 2.7.13, it raises an exception if you pass a unicode path. In Python < 2.7.13, it silently converted them to str, treating them as ASCII. Some add-ons (such as the Eurobraille driver) relied on the previous behaviour.
This monkey patch actually gives slightly better results than < 2.7.13 in that it converts paths using mbcs, so it should work with non-ASCII paths as well in most cases. Aside from restoring the previous behaviour, given that we push for unicode wherever possible, I think this is a good thing.
Fixes #6705.