### PR TITLE
Add restart with debug level logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,10 @@ By default, builds also do not use any compiler optimizations.
 Please see the release keyword argument for what compiler optimizations it will enable.
 
 ## Running the Source Code
-To start NVDA from source code, run `nvda.pyw` located in the source directory. To view help on the arguments that nvda will accept use the `-h` or `--help` option. These arguments are also documented in the user guide. Since nvda is a Windows application (rather than command line) it is best to run it with `pythonw.exe`. However, if during development you encounter an error early in the startup of nvda you can use `python.exe` which is likely to give more information about the error.
+To start NVDA from source code, run `nvda.pyw` located in the source directory.
+To view help on the arguments that NVDA will accept, use the `-h` or `--help` option.
+These arguments are also documented in the user guide. Since NVDA is a Windows application (rather than command line), it is best to run it with `pythonw.exe`.
+However, if during development you encounter an error early in the startup of NVDA, you can use `python.exe` which is likely to give more information about the error.
 
 ## Building NVDA
 A binary build of NVDA can be run on a system without Python and all of NVDA's other dependencies installed (as we do for snapshots and releases).

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ By default, builds also do not use any compiler optimizations.
 Please see the release keyword argument for what compiler optimizations it will enable.
 
 ## Running the Source Code
-To start NVDA from source code, run `nvda.pyw` located in the source directory.
+To start NVDA from source code, run `nvda.pyw` located in the source directory. To view help on the arguments that nvda will accept use the `-h` or `--help` option. These arguments are also documented in the user guide. Since nvda is a Windows application (rather than command line) it is best to run it with `pythonw.exe`. However, if during development you encounter an error early in the startup of nvda you can use `python.exe` which is likely to give more information about the error.
 
 ## Building NVDA
 A binary build of NVDA can be run on a system without Python and all of NVDA's other dependencies installed (as we do for snapshots and releases).

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,8 @@ Please see the release keyword argument for what compiler optimizations it will 
 ## Running the Source Code
 To start NVDA from source code, run `nvda.pyw` located in the source directory.
 To view help on the arguments that NVDA will accept, use the `-h` or `--help` option.
-These arguments are also documented in the user guide. Since NVDA is a Windows application (rather than command line), it is best to run it with `pythonw.exe`.
+These arguments are also documented in the user guide.
+Since NVDA is a Windows application (rather than command line), it is best to run it with `pythonw.exe`.
 However, if during development you encounter an error early in the startup of NVDA, you can use `python.exe` which is likely to give more information about the error.
 
 ## Building NVDA

--- a/source/core.py
+++ b/source/core.py
@@ -79,6 +79,10 @@ def restart(disableAddons=False, debugLogging=False):
 		sys.argv.remove('--disable-addons')
 	except ValueError:
 		pass
+	try:
+		sys.argv.remove('--debug-logging')
+	except ValueError:
+		pass
 	if disableAddons:
 		options.append('--disable-addons')
 	if debugLogging:

--- a/source/core.py
+++ b/source/core.py
@@ -62,7 +62,7 @@ def doStartupDialogs():
 				"More details about the errors can be found in the log file."),
 			_("gesture map File Error"), wx.OK|wx.ICON_EXCLAMATION)
 
-def restart(disableAddons=False):
+def restart(disableAddons=False, debugLogging=False):
 	"""Restarts NVDA by starting a new copy with -r."""
 	if globalVars.appArgs.launcher:
 		import wx
@@ -81,6 +81,8 @@ def restart(disableAddons=False):
 		pass
 	if disableAddons:
 		options.append('--disable-addons')
+	if debugLogging:
+		options.append('--debug-logging')
 	try:
 		sys.argv.remove("--ease-of-access")
 	except ValueError:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -741,7 +741,9 @@ class ExitDialog(wx.Dialog):
 		# Translators: An option in the combo box to choose exit action.
 		_("Restart"),
 		# Translators: An option in the combo box to choose exit action.
-		_("Restart with add-ons disabled")]
+		_("Restart with add-ons disabled"),
+		# Translators: An option in the combo box to choose exit action.
+		_("Restart with debug logging enabled")]
 		self.actionsList = contentSizerHelper.addLabeledControl(labelText, wx.Choice, choices=self.actions)
 		self.actionsList.SetSelection(0)
 
@@ -763,7 +765,9 @@ class ExitDialog(wx.Dialog):
 		elif action == 1:
 			queueHandler.queueFunction(queueHandler.eventQueue,core.restart)
 		elif action == 2:
-			queueHandler.queueFunction(queueHandler.eventQueue,core.restart,True)
+			queueHandler.queueFunction(queueHandler.eventQueue,core.restart,disableAddons=True)
+		elif action == 3:
+			queueHandler.queueFunction(queueHandler.eventQueue,core.restart,debugLogging=True)
 		self.Destroy()
 
 	def onCancel(self, evt):

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -334,7 +334,7 @@ def initialize(shouldDoRemoteLogging=False):
 def setLogLevelFromConfig():
 	"""Set the log level based on the current configuration.
 	"""
-	if globalVars.appArgs.logLevel != 0 or globalVars.appArgs.secure:
+	if globalVars.appArgs.debugLogging or globalVars.appArgs.logLevel != 0 or globalVars.appArgs.secure:
 		# Log level was overridden on the command line or we're running in secure mode,
 		# so don't set it.
 		return

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -76,6 +76,7 @@ parser.add_option('-c','--config-path',dest='configPath',default=None,help="The 
 parser.add_option('-m','--minimal',action="store_true",dest='minimal',default=False,help="No sounds, no interface, no start message etc")
 parser.add_option('-s','--secure',action="store_true",dest='secure',default=False,help="Secure mode (disable Python console)")
 parser.add_option('--disable-addons',action="store_true",dest='disableAddons',default=False,help="Disable all add-ons")
+parser.add_option('--debug-logging',action="store_true",dest='debugLogging',default=False,help="Enable debug level logging just for this run. This setting will override any other log level (--loglevel, -l) argument given.")
 parser.add_option('--no-sr-flag',action="store_false",dest='changeScreenReaderFlag',default=True,help="Don't change the global system screen reader flag")
 parser.add_option('--install',action="store_true",dest='install',default=False,help="Installs NVDA (starting the new copy after installation)")
 parser.add_option('--install-silent',action="store_true",dest='installSilent',default=False,help="Installs NVDA silently (does not start the new copy after installation).")
@@ -168,10 +169,13 @@ if isSecureDesktop:
 logLevel=globalVars.appArgs.logLevel
 if logLevel<=0:
 	logLevel=log.INFO
+if globalVars.appArgs.debugLogging:
+	logLevel=log.DEBUG
 logHandler.initialize()
 logHandler.log.setLevel(logLevel)
 
 log.info("Starting NVDA")
+log.debug("Debug level logging enabled")
 if globalVars.appArgs.changeScreenReaderFlag:
 	winUser.setSystemScreenReaderFlag(True)
 #Accept wm_quit from other processes, even if running with higher privilages

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2258,6 +2258,7 @@ Following are the command line options for NVDA:
 | -m | --minimal | No sounds, no interface, no start message etc |
 | -s | --secure | Secure mode (disable Python console) |
 | None | --disable-addons | Addons will have no effect |
+| None | --debug-logging | Enable debug level logging just for this run. This setting will override any other log level ( ""--loglevel"", -l) argument given. |
 | None | --no-sr-flag  | Don't change the global system screen reader flag |
 | None | --install | Installs NVDA (starting the newly installed copy) |
 | None | --install-silent | Silently installs NVDA (does not start the newly installed copy) |


### PR DESCRIPTION
See issue #6689
This provides a convenience to users who wish to enable debug level logging temporarily (one run of nvda).
A start up option is added to make it easier to start nvda with debug level logging. Enabling debug logging in this way sets the log level earlier than setting it via the configuration file. In particular, this allows the debug messages that occur during the loading of the configuration file to be present in the log file.