### PR TITLE
Report current worksheet in excel

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -966,6 +966,9 @@ class ExcelCellTextInfo(NVDAObjectTextInfo):
 				pass
 		return formatField,(self._startOffset,self._endOffset)
 
+	def _get_locationText(self):
+		return self.obj.getCellPosition()
+
 class ExcelCell(ExcelBase):
 
 	def doAction(self):
@@ -1105,6 +1108,11 @@ class ExcelCell(ExcelBase):
 		return self._rowAndColumnNumber[1]
 
 	colSpan=1
+
+	def getCellPosition(self):
+		rowAndColumn = self.cellCoordsText
+		sheet = self.excelWindowObject.ActiveSheet.name
+		return "Sheet {0}, {1}".format(sheet, rowAndColumn)
 
 	def _get_tableID(self):
 		address=self.excelCellObject.address(1,1,0,1)


### PR DESCRIPTION
Provide a command to report the name of the worksheet and the cell
location while in MS excel. This can be triggered with `NVDA+numpadDelete` or for laptop layout `NVDA+delete`

Fixes #6613