### PR TITLE
handle DescribedBy in iframe and multiple DescribedBy IDs

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -165,7 +165,7 @@ def locateHTMLElementByID(document,ID):
 		elements=document.getElementsByName(ID)
 		if elements is not None:
 			element=elements.item(0)
-		else : #probably IE 10 in standards mode (#3151)
+		else: #probably IE 10 in standards mode (#3151)
 			try:
 				element=document.all.item(ID)
 			except:

--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -165,10 +165,16 @@ def locateHTMLElementByID(document,ID):
 		elements=document.getElementsByName(ID)
 		if elements is not None:
 			element=elements.item(0)
-		else: #probably IE 10 in standards mode (#3151)
+		else : #probably IE 10 in standards mode (#3151)
 			try:
 				element=document.all.item(ID)
 			except:
+				element=None
+		if element is None: #getElementsByName doesn't return element with specified ID in IE11 (#5784)
+			try:
+				element=document.getElementByID(ID)
+			except COMError as e:
+				log.debugWarning("document.getElementByID failed with COMError %s"%e)
 				element=None
 	except COMError as e:
 		log.debugWarning("document.getElementsByName failed with COMError %s"%e)

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -82,11 +82,11 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 				descNode=None
 				try:
 					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedById)
-				except (COMError, NameError):
+				except (COMError,NameError):
 					descNode=None
 				if not descNode:
 					try:
-						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document, ariaDescribedById)
+						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document,ariaDescribedById)
 					except (COMError,NameError):
 						descNode=None
 				if descNode:

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -76,15 +76,24 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 		description=None
 		ariaDescribedBy=attrs.get('HTMLAttrib::aria-describedby')
 		if ariaDescribedBy:
-			try:
-				descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedBy)
-			except (COMError,NameError):
+			ariaDescribedByIds=ariaDescribedBy.split()
+			description=""
+			for ariaDescribedById in ariaDescribedByIds:
 				descNode=None
-			if descNode:
 				try:
-					description=self.obj.makeTextInfo(NVDAObjects.IAccessible.MSHTML.MSHTML(HTMLNode=descNode)).text
-				except:
-					pass
+					descNode=self.obj.rootNVDAObject.HTMLNode.document.getElementById(ariaDescribedById)
+				except (COMError, NameError):
+					descNode=None
+				if not descNode:
+					try:
+						descNode=NVDAObjects.IAccessible.MSHTML.locateHTMLElementByID(self.obj.rootNVDAObject.HTMLNode.document, ariaDescribedById)
+					except (COMError,NameError):
+						descNode=None
+				if descNode:
+					try:
+						description=description+" "+self.obj.makeTextInfo(NVDAObjects.IAccessible.MSHTML.MSHTML(HTMLNode=descNode)).text
+					except:
+						pass
 		ariaSort=attrs.get('HTMLAttrib::aria-sort')
 		state=aria.ariaSortValuesToNVDAStates.get(ariaSort)
 		if state is not None:


### PR DESCRIPTION
Added to yalingliu2's [fix](https://github.com/nvaccess/nvda/pull/5988). locateHTMLElementByID was not working properly because getElementsByName does not return an element with specified ID in IE11. The fix to locateHTMLElementByID in addition to yalingliu2's changes to _normalizeControlField should now allow NVDA to properly handle multiple DescribedBy IDs & DescribedBy IDs in iframes in IE11.