### PR TITLE
Dont report error for column count failure

### DIFF
--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -866,7 +866,7 @@ void detectAndGenerateColumnFormatXML(IDispatchPtr pDispatchRange, wostringstrea
 	res = _com_dispatch_raw_propget( pDispatchTextColumns, wdDISPID_TEXTCOLUMNS_COUNT,
 		VT_I4, &count);
 	if( res != S_OK || count < 0){
-		LOG_ERROR(L"error getting textColumn count. res: "<< res
+		LOG_DEBUG(L"Unable to get textColumn count. We may be in a 'comment'. res: "<< res
 			<< " count: " << count);
 		return;
 	}


### PR DESCRIPTION
When getting the column count in word fails, do not report it as an
error. The call to get the column count fails when in comments.

Fix for #6711

I spent a little time looking to see if we could just disable reporting of columns entirely while in a comment range, however there are probably other ranges for which this call will fail.