### PR TITLE
Indeterminate progress bar dialogs: only beep when progress bar output config includes beeps

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -829,7 +829,8 @@ class IndeterminateProgressDialog(wx.ProgressDialog):
 
 	def done(self):
 		self.timer.Stop()
-		if self.IsActive():
+		pbConf = config.conf["presentation"]["progressBarUpdates"]
+		if pbConf["progressBarOutputMode"] in ("beep", "both") and (pbConf["reportBackgroundProgressBars"] or self.IsActive()):
 			tones.beep(1760, 40)
 		self.Hide()
 		self.Destroy()


### PR DESCRIPTION
Fixes #6759 
In indeterminate progress bar dialogs such as the update checker, only beep when done if progress bar output is configured to include beeps.