### PR TITLE
Support for Microsoft Edge from Windows build 15002 and up

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -567,7 +567,7 @@ class UIA(Window):
 			import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
 				clsList.append(edge.EdgeHTMLRootContainer)
-			elif self.UIATextPattern and isinstance(self.parent,edge.EdgeHTMLRootContainer):
+			elif self.UIATextPattern and self.role==controlTypes.ROLE_PANE and self.parent and (isinstance(self.parent,edge.EdgeHTMLRootContainer) or not isinstance(self.parent,edge.EdgeNode)): 
 				clsList.append(edge.EdgeHTMLRoot)
 			elif self.role==controlTypes.ROLE_LIST:
 				clsList.append(edge.EdgeList)

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -208,6 +208,10 @@ class EdgeTextInfo(UIATextInfo):
 		startRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,enclosingRange,UIAHandler.TextPatternRangeEndpoint_End)
 		if startRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)>0:
 			startRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)
+		# Ensure we don't now have a collapsed range
+		if startRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,startRange,UIAHandler.TextPatternRangeEndpoint_Start)<=0:
+			log.debug("Collapsed range. Returning")
+			return
 		# check for an embedded child
 		childElements=startRange.getChildren()
 		if childElements.length==1 and UIAHandler.handler.clientObject.compareElements(rootElement,childElements.getElement(0)):

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -258,9 +258,10 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 
 	# #6713: Edge (and soon all UWP apps) will no longer have windows as descendants of the foreground window.
 	# However, it does look like they are always  equal to or descendants of the "active" window of the input thread. 
-	gi=winUser.getGUIThreadInfo(0)
-	if winUser.isDescendantWindow(gi.hwndActive,windowHandle) and wClass.startswith('Windows.UI.Core'):
-		return True
+	if wClass.startswith('Windows.UI.Core'):
+		gi=winUser.getGUIThreadInfo(0)
+		if winUser.isDescendantWindow(gi.hwndActive,windowHandle):
+			return True
 
 	fg = winUser.getForegroundWindow()
 	if wClass == "NetUIHWND" and winUser.getClassName(fg) == "Net UI Tool Window Layered":

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -256,6 +256,10 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 		# #5595: Events for the cursor get mapped to the desktop window.
 		return True
 
+	# #6713: Edge (and soon all UWP apps) will no longer have windows as descendants of the foreground window
+	if wClass.startswith('Windows.UI.Core'):
+		return True
+
 	fg = winUser.getForegroundWindow()
 	if wClass == "NetUIHWND" and winUser.getClassName(fg) == "Net UI Tool Window Layered":
 		# #5504: In Office >= 2013 with the ribbon showing only tabs,

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -256,8 +256,10 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 		# #5595: Events for the cursor get mapped to the desktop window.
 		return True
 
-	# #6713: Edge (and soon all UWP apps) will no longer have windows as descendants of the foreground window
-	if wClass.startswith('Windows.UI.Core'):
+	# #6713: Edge (and soon all UWP apps) will no longer have windows as descendants of the foreground window.
+	# However, it does look like they are always  equal to or descendants of the "active" window of the input thread. 
+	gi=winUser.getGUIThreadInfo(0)
+	if winUser.isDescendantWindow(gi.hwndActive,windowHandle) and wClass.startswith('Windows.UI.Core'):
 		return True
 
 	fg = winUser.getForegroundWindow()


### PR DESCRIPTION
Handle the change to the Edge document container UIAElement, and explicitly allow events for Windows.UI.Core windows as foreground checks will no longer work for UWP. 
Fixes #6713