### PR TITLE
Tweaks for UIA keyboard shortcut key retriever routine. re #6779, #6790

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -767,18 +767,26 @@ class UIA(Window):
 			return ""
 
 	def _get_keyboardShortcut(self):
+		# Build the keyboard shortcuts list early for readability.
+		keyboardShortcuts = []
 		try:
 			accessKey = self.UIAElement.currentAccessKey
 		except COMError:
 			# #6779: Forcefully set access key to an empty string if UIA says access key is None, resolves concatenation error in focus events, object navigation and so on.
+			# In rare cases, access key itself is None.
+			pass
+		if not accessKey:
 			accessKey = ""
+		keyboardShortcuts.append(accessKey)
 		try:
 			acceleratorKey = self.UIAElement.currentAcceleratorKey
 		except COMError:
+			pass
+		if not acceleratorKey:
 			acceleratorKey = ""
+		keyboardShortcuts.append(acceleratorKey)
 		# #6790: Do not add two spaces unless both access key and accelerator are present in order to not waste string real estate.
 		# If not, just return the longest string.
-		keyboardShortcuts = (accessKey, acceleratorKey)
 		return "  ".join(keyboardShortcuts) if accessKey and acceleratorKey else max(keyboardShortcuts)
 
 	def _get_UIACachedStatesElement(self):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -767,19 +767,17 @@ class UIA(Window):
 			return ""
 
 	def _get_keyboardShortcut(self):
-		ret = ""
 		try:
-			ret += self.UIAElement.currentAccessKey
+			accessKey = self.UIAElement.currentAccessKey
 		except COMError:
-			pass
-		if ret:
-			#add a double space to the end of the string
-			ret +="  "
+			# #6779: Forcefully set access key to an empty string if UIA says access key is None, resolves concatenation error in focus events, object navigation and so on.
+			accessKey = ""
 		try:
-			ret += self.UIAElement.currentAcceleratorKey
+			acceleratorKey = self.UIAElement.currentAcceleratorKey
 		except COMError:
-			pass
-		return ret
+			acceleratorKey = ""
+		# #6790: Do not add two spaces blindly in order to not waste string real estate.
+		return accessKey if not acceleratorKey else "  ".join([accessKey, acceleratorKey])
 
 	def _get_UIACachedStatesElement(self):
 		statesCacheRequest=UIAHandler.handler.clientObject.createCacheRequest()

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -768,26 +768,24 @@ class UIA(Window):
 
 	def _get_keyboardShortcut(self):
 		# Build the keyboard shortcuts list early for readability.
-		keyboardShortcuts = []
+		shortcuts = []
 		try:
 			accessKey = self.UIAElement.currentAccessKey
-		except COMError:
-			# #6779: Forcefully set access key to an empty string if UIA says access key is None, resolves concatenation error in focus events, object navigation and so on.
+			# #6779: Don't add access key to the shortcut list if UIA says access key is None, resolves concatenation error in focus events, object navigation and so on.
 			# In rare cases, access key itself is None.
+			if accessKey:
+				shortcuts.append(accessKey)
+		except COMError, AttributeError:
 			pass
-		if not accessKey:
-			accessKey = ""
-		keyboardShortcuts.append(accessKey)
 		try:
 			acceleratorKey = self.UIAElement.currentAcceleratorKey
-		except COMError:
+			# Same case as access key.
+			if acceleratorKey:
+				shortcuts.append(acceleratorKey)
+		except COMError, AttributeError:
 			pass
-		if not acceleratorKey:
-			acceleratorKey = ""
-		keyboardShortcuts.append(acceleratorKey)
 		# #6790: Do not add two spaces unless both access key and accelerator are present in order to not waste string real estate.
-		# If not, just return the longest string.
-		return "  ".join(keyboardShortcuts) if accessKey and acceleratorKey else max(keyboardShortcuts)
+		return "  ".join(shortcuts) if shortcuts else ""
 
 	def _get_UIACachedStatesElement(self):
 		statesCacheRequest=UIAHandler.handler.clientObject.createCacheRequest()

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -776,8 +776,10 @@ class UIA(Window):
 			acceleratorKey = self.UIAElement.currentAcceleratorKey
 		except COMError:
 			acceleratorKey = ""
-		# #6790: Do not add two spaces blindly in order to not waste string real estate.
-		return accessKey if not acceleratorKey else "  ".join([accessKey, acceleratorKey])
+		# #6790: Do not add two spaces unless both access key and accelerator are present in order to not waste string real estate.
+		# If not, just return the longest string.
+		keyboardShortcuts = (accessKey, acceleratorKey)
+		return "  ".join(keyboardShortcuts) if accessKey and acceleratorKey else max(keyboardShortcuts)
 
 	def _get_UIACachedStatesElement(self):
 		statesCacheRequest=UIAHandler.handler.clientObject.createCacheRequest()


### PR DESCRIPTION
Resolves the following issues:

* #6779: string concatenation error when focus event is fired or when attempting to access certain UIA controls via object navigation by checking if access key is None or not.
* #6790: Two spaces are no longer inserted if only access key or accelerator key is returned by UIA.

Suggested What's New entries:
Bug fixes:

* NVDA will no longer fail to navigate to or announce UIA controls where no keyboard shortcuts are defined. (#6779)
* In certain UIA controls, two empty spaces are no longer added in keyboard shortcut information if the control does not have more than one keyboard shortcut. (#6790)

Thanks.