### PR TITLE
Add an 'analyze' flag to scons nvdaHelperDebugFlags which causes MSVC to run code analysis on all of our own nvdaHelper code, stopping on any warning.

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -35,8 +35,18 @@ signExec=env['signExec'] if env['certFile'] else None
 
 #Some defines and includes for the environment
 env.Append(CPPDEFINES=['UNICODE','_CRT_SECURE_NO_DEPRECATE',('LOGLEVEL','${nvdaHelperLogLevel}'),('_WIN32_WINNT','_WIN32_WINNT_WS03')])
-env.Append(CCFLAGS=['/W3','/WX']);
+env.Append(CCFLAGS=['/W3','/WX'])
+if 'analyze' in debug:
+	env.Append(CCFLAGS=['/analyze'])
+	# Disable: Inconsistent annotation for 'x': this instance has no annotations.
+	# Seems all MIDL-generated code from idl files don't add annotations 
+	env.Append(CCFLAGS='/wd28251')
+	# Disable: 'x': unreferenced formal parameter
+	# We use a great deal of hook functions where we have no need for various parameters 
+	env.Append(CCFLAGS='/wd4100')
+
 env.Append(CXXFLAGS=['/EHsc'])
+
 env.Append(CPPPATH=['#/include','#/miscDeps/include',Dir('.').abspath])
 env.Append(LINKFLAGS=['/incremental:no','/WX'])
 env.Append(LINKFLAGS='/release') #We always want a checksum in the header

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -35,7 +35,13 @@ env=env.Clone()
 #Therefore specifically force it off
 env.Append(CCFLAGS='/GL-')
 
+# Don't analyze the code as not our project
+if 'analyze' in env['nvdaHelperDebugFlags']:
+	env.Append(CCFLAGS='/analyze-')
+
+# Ignore all warnings as the code is not ours
 env.Append(CCFLAGS='/W0')
+
 env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir])
 
 def espeak_compilePhonemeData_buildEmitter(target,source,env):

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -35,6 +35,11 @@ def getLouisVersion():
 	return "unknown"
 
 env = env.Clone()
+
+# Don't analyze the code as not our project
+if 'analyze' in env['nvdaHelperDebugFlags']:
+	env.Append(CCFLAGS='/analyze-')
+
 env.Append(CCFLAGS="/W2")
 env.Append(CPPDEFINES=[
 	("PACKAGE_VERSION", r'\"%s\"' % getLouisVersion()),

--- a/nvdaHelper/minHook/sconscript
+++ b/nvdaHelper/minHook/sconscript
@@ -6,6 +6,10 @@ Import([
 minhookPath=Dir('#include/minhook')
 env=env.Clone(CPPPATH=minhookPath.Dir('include'))
 
+# Don't analyze the code as not our project
+if 'analyze' in env['nvdaHelperDebugFlags']:
+	env.Append(CCFLAGS='/analyze-')
+
 HDESourceFile='HDE64/src/HDE64.c' if env['TARGET_ARCH']=='x86_64' else 'HDE32/HDE32.c'
 
 sourceFiles=[

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@ If trying to debug nvdaHelper, You can control various  debugging options  with 
 
 * debugCRT: the libraries will be linked against the debug C runtime and assertions will be enabled. (By default, the normal CRT is used and assertions are disabled.)
 * RTC: runtime checks (stack corruption, uninitialized variables, etc.) will be enabled. (The default is no runtime checks.)
+* analyze: runs MSVC code analysis on all nvdaHelper code, holting on any warning. (default is no analysis).
 
 The special keywords none and all can also be used in place of the individual flags.
 

--- a/sconstruct
+++ b/sconstruct
@@ -70,7 +70,7 @@ vars.Add(PathVariable("certFile", "The certificate file with which to sign execu
 vars.Add("certPassword", "The password for the private key in the signing certificate", "")
 vars.Add("certTimestampServer", "The URL of the timestamping server to use to timestamp authenticode signatures", "")
 vars.Add(PathVariable("outputDir", "The directory where the final built archives and such will be placed", "output",PathVariable.PathIsDirCreate))
-vars.Add(ListVariable("nvdaHelperDebugFlags", "a list of debugging features you require", 'none', ["debugCRT","RTC"]))
+vars.Add(ListVariable("nvdaHelperDebugFlags", "a list of debugging features you require", 'none', ["debugCRT","RTC","analyze"]))
 vars.Add(EnumVariable('nvdaHelperLogLevel','The level of logging you wish to see, lower is more verbose','15',allowed_values=[str(x) for x in xrange(60)]))
 
 #Base environment for this and sub sconscripts
@@ -140,6 +140,10 @@ env['signExec']=signExec
 
 #architecture-specific environments
 archTools=['default','windowsSdk','midl','msrpc']
+# MSVC analysis is only available in newer Windows SDKs
+# So if required, remove the Windows SDK 7.1 (XP) tool
+if 'analyze' in env['nvdaHelperDebugFlags']:
+	archTools.remove('windowsSdk')
 env32=env.Clone(TARGET_ARCH='x86',tools=archTools)
 env64=env.Clone(TARGET_ARCH='x86_64',tools=archTools)
 # Hack around odd bug where some tool [after] msvc states that static and shared objects are different


### PR DESCRIPTION
Note that eSpeak, minHook and liblouis deliberately ignore this flag for now as they are not our projects.