### PR TITLE
Abbreviate landmark names in braille

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -381,17 +381,17 @@ landmarkLabels = {
 	# Translators: Displayed in braille for the banner landmark, normally found on web pages.
 	"banner": _("bnnr"),
 	# Translators: Displayed in braille for the complementary landmark, normally found on web pages.
-	"complementary": _("comp"),
+	"complementary": _("cmpl"),
 	# Translators: Displayed in braille for the contentinfo landmark, normally found on web pages.
 	"contentinfo": _("cinf"),
 	# Translators: Displayed in braille for the main landmark, normally found on web pages.
 	"main": _("main"),
 	# Translators: Displayed in braille for the navigation landmark, normally found on web pages.
-	"navigation": _("nav"),
+	"navigation": _("navi"),
 	# Translators: Displayed in braille for the search landmark, normally found on web pages.
 	"search": _("srch"),
 	# Translators: Displayed in braille for the form landmark, normally found on web pages.
-	"form": _("frm"),
+	"form": _("form"),
 	# Strictly speaking, region isn't a landmark, but it is very similar.
 	# Translators: Displayed in braille for a significant region, normally found on web pages.
 	"region": _("rgn"),

--- a/source/braille.py
+++ b/source/braille.py
@@ -377,6 +377,26 @@ negativeStateLabels = {
 	controlTypes.STATE_CHECKED: _("( )"),
 }
 
+landmarkLabels = {
+	# Translators: Displayed in braille for the banner landmark, normally found on web pages.
+	"banner": _("bnnr"),
+	# Translators: Displayed in braille for the complementary landmark, normally found on web pages.
+	"complementary": _("comp"),
+	# Translators: Displayed in braille for the contentinfo landmark, normally found on web pages.
+	"contentinfo": _("cinf"),
+	# Translators: Displayed in braille for the main landmark, normally found on web pages.
+	"main": _("main"),
+	# Translators: Displayed in braille for the navigation landmark, normally found on web pages.
+	"navigation": _("nav"),
+	# Translators: Displayed in braille for the search landmark, normally found on web pages.
+	"search": _("srch"),
+	# Translators: Displayed in braille for the form landmark, normally found on web pages.
+	"form": _("frm"),
+	# Strictly speaking, region isn't a landmark, but it is very similar.
+	# Translators: Displayed in braille for a significant region, normally found on web pages.
+	"region": _("rgn"),
+}
+
 #: Cursor shapes
 CURSOR_SHAPES = (
 	# Translators: The description of a braille cursor shape.

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -975,8 +975,8 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 				# The word landmark is superfluous for regions.
 				textList.append(braille.landmarkLabels[landmark])
 			else:
-				# Translators: This is brailled to indicate a landmark (example output: main lmk).
-				textList.append(_("%s lmk") % braille.landmarkLabels[landmark])
+				# Translators: This is brailled to indicate a landmark (example output: lmk main).
+				textList.append(_("lmk %s") % braille.landmarkLabels[landmark])
 		text = super(BrowseModeDocumentTextInfo, self).getControlFieldBraille(field, ancestors, reportStart, formatConfig)
 		if text:
 			textList.append(text)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -973,10 +973,10 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 				pass
 			if landmark == "region":
 				# The word landmark is superfluous for regions.
-				textList.append(aria.landmarkRoles[landmark])
+				textList.append(braille.landmarkLabels[landmark])
 			else:
 				# Translators: This is spoken and brailled to indicate a landmark (example output: main landmark).
-				textList.append(_("%s landmark") % aria.landmarkRoles[landmark])
+				textList.append(_("%s landmark") % braille.landmarkLabels[landmark])
 		text = super(BrowseModeDocumentTextInfo, self).getControlFieldBraille(field, ancestors, reportStart, formatConfig)
 		if text:
 			textList.append(text)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -975,8 +975,8 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 				# The word landmark is superfluous for regions.
 				textList.append(braille.landmarkLabels[landmark])
 			else:
-				# Translators: This is spoken and brailled to indicate a landmark (example output: main landmark).
-				textList.append(_("%s landmark") % braille.landmarkLabels[landmark])
+				# Translators: This is brailled to indicate a landmark (example output: main lmk).
+				textList.append(_("%s lmk") % braille.landmarkLabels[landmark])
 		text = super(BrowseModeDocumentTextInfo, self).getControlFieldBraille(field, ancestors, reportStart, formatConfig)
 		if text:
 			textList.append(text)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2223,8 +2223,8 @@ Please see the [BRLTTY key binding lists http://mielke.cc/brltty/doc/KeyBindings
 | Route to braille cell | route (bring cursor to character) |
 %kc:endInclude
 
-+ Braille control type and state abbreviations +
-In order to fit as much information as possible on a braille display, The folowing abbreviations have been defined to indicate control type and state.
++ Braille control type, state and landmark abbreviations +
+In order to fit as much information as possible on a braille display, the following abbreviations have been defined to indicate control type and state as well as landmarks.
 
 || Abbreviation | Control type |
 | btn | button |
@@ -2259,6 +2259,17 @@ The following state indicators are also defined:
 | ro | displayed when an object (e.g. an editable text field) is read-only |
 | sel | displayed when an object is selected |
 | submnu | displayed when an object has a popup (usually a sub-menu) |
+
+Finally, the following abbreviations for landmarks are defined:
+|| Abbreviation | Landmark |
+| bnnr | banner |
+| cinf | content info |
+| cmpl | complementary |
+| form | form |
+| main | main |
+| navi | navigation |
+| srch | search |
+| rgn | region |
 
 + Advanced Topics +
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2237,8 +2237,9 @@ In order to fit as much information as possible on a braille display, the follow
 | rN | table row number n, e.g. r1, r2. |
 | hN | heading at level n, e.g. h1, h2. |
 | lnk | link |
-| lst | list |
 | vlnk | visited link |
+| lst | list |
+| lmk | landmark |
 | mnu | menu |
 | mnubar | menu bar |
 | rbtn | radio button |


### PR DESCRIPTION
Re #3975 

Summary of proposed changes:
The order of the word landmark and the type of landmark is swapped. Landmark becomes "lmk". The names of each of the landmarks are altered as follows:
```
"banner": "bnnr"
"complementary": "comp"
"contentinfo": "cinf"
"main": "main"
"navigation": "nav"
"search": "srch"
"form": "frm"
"region": "rgn"
```

Example: "navigation landmark" becomes "lmk nav".