### PR TITLE
Upload appropriate debug symbols to Mozilla crash-stats for non-try builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
  PY_PYTHON: 2.7-32
  encFileKey:
   secure: ekOvuyywHuDdGZmRmoj+b3jfrq39A2xlx4RD5ZUGd/8=
+ mozillaSymsAuthToken:
+  secure: Dz24ukUM3Ho0soTDwJEYaw0fNY3yzfVp3Vf+y8I+Uh4wiSYibWJxOANacceGmfIU
  symstore: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\symstore.exe
 
 init:
@@ -93,6 +95,7 @@ deploy_script:
  - ps: |
      if ($env:versionType) {
       # Not a try build.
+      # Notify our server.
       $exe = Get-ChildItem -Name output\*.exe
       $hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
       $data = @{
@@ -105,4 +108,8 @@ deploy_script:
        artifacts=$artifacts
       }
       ConvertTo-Json -InputObject $data -Compress | ssh nvaccess@exbi.nvaccess.org nvdaAppveyorHook
+      # Upload symbols to Mozilla.
+      Start-FileDownload https://github.com/mozilla/gecko-dev/raw/master/toolkit/crashreporter/tools/win32/dump_syms_vc1800.exe -FileName appveyor\dump_syms.exe
+      py -m pip install requests
+      py appveyor\mozillaSyms.py
      }

--- a/appveyor/mozillaSyms.py
+++ b/appveyor/mozillaSyms.py
@@ -1,0 +1,102 @@
+# Based on code from https://gist.github.com/luser/2ad32d290f224782fcfc
+
+"""Script to convert and upload appropriate NVDA debug symbols to Mozilla crash-stats.
+This should just be run as a script with no arguments.
+It expects the crash-stats auth token to be placed in the mozillaSymsAuthToken environment variable.
+To update the list of symbols uploaded to Mozilla, see the DLL_NAMES constant below.
+"""
+
+from __future__ import print_function
+import argparse
+import os
+import subprocess
+import sys
+import zipfile
+import requests
+
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+DUMP_SYMS = os.path.join(SCRIPT_DIR, "dump_syms.exe")
+NVDA_SOURCE = os.path.join(os.path.dirname(SCRIPT_DIR), "source")
+NVDA_LIB = os.path.join(NVDA_SOURCE, "lib")
+NVDA_LIB64 = NVDA_LIB + "64"
+ZIP_FILE = os.path.join(SCRIPT_DIR, "mozillaSyms.zip")
+URL = 'https://crash-stats.mozilla.com/symbols/upload'
+
+# The dlls for which symbols are to be uploaded to Mozilla.
+# This only needs to include dlls injected into Mozilla products.
+DLL_NAMES = [
+	"IAccessible2Proxy.dll",
+	"minHook.dll",
+	"nvdaHelperRemote.dll",
+	"VBufBackend_adobeFlash.dll",
+	"VBufBackend_gecko_ia2.dll",
+]
+DLL_FILES = [f
+	for dll in DLL_NAMES
+	# We need both the 32 bit and 64 bit symbols.
+	for f in (os.path.join(NVDA_LIB, dll), os.path.join(NVDA_LIB64, dll))]
+
+class ProcError(Exception):
+	def __init__(self, returncode, stderr):
+		self.returncode = returncode
+		self.stderr = stderr
+
+def check_output(command):
+	proc = subprocess.Popen(command,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE)
+	stdout, stderr = proc.communicate()
+	if proc.returncode != 0:
+		raise ProcError(proc.returncode, stderr)
+	return stdout
+
+def processFile(path):
+	try:
+		stdout = check_output([DUMP_SYMS, path])
+	except ProcError as e:
+		print('Error: running "%s %s": %s' % (DUMP_SYMS, path, e.stderr))
+		return None, None, None
+	bits = stdout.splitlines()[0].split(' ', 4)
+	if len(bits) != 5:
+		return None, None, None
+	_, platform, cpu_arch, debug_id, debug_file = bits
+	sym_file = debug_file[:-4] + '.sym'
+	filename = os.path.join(debug_file, debug_id, sym_file)
+	debug_filename = os.path.join(debug_file, debug_id, debug_file)
+	return filename, stdout, debug_filename
+
+def generate():
+	count = 0
+	with zipfile.ZipFile(ZIP_FILE, 'w', zipfile.ZIP_DEFLATED) as zf:
+		for f in DLL_FILES:
+			filename, contents, debug_filename = processFile(f)
+			if not (filename and contents):
+				print('Error dumping symbols')
+				raise RuntimeError
+			zf.writestr(filename, contents)
+			count += 1
+	print('Added %d files to %s' % (count, ZIP_FILE))
+
+def upload():
+	r = requests.post(URL,
+		files={'symbols.zip': open(ZIP_FILE, 'rb')},
+		headers={'Auth-Token': os.getenv('mozillaSymsAuthToken')},
+		allow_redirects=False
+	)
+	if r.status_code >= 200 and r.status_code < 300:
+		print('Uploaded successfully!')
+	elif r.status_code < 400:
+		print('Error: bad auth token? (%d)' % r.status_code)
+		raise RuntimeError
+	else:
+		print('Error: %d' % r.status_code)
+		print(r.text)
+		raise RuntimeError
+	return 0
+
+if __name__ == '__main__':
+	try:
+		generate()
+		upload()
+	except RuntimeError:
+		sys.exit(1)

--- a/appveyor/mozillaSyms.py
+++ b/appveyor/mozillaSyms.py
@@ -60,6 +60,9 @@ def processFile(path):
 	if len(bits) != 5:
 		return None, None, None
 	_, platform, cpu_arch, debug_id, debug_file = bits
+	# debug_file will have a .pdb extension; e.g. nvdaHelperRemote.dll.pdb.
+	# The output file format should have a .sym extension instead.
+	# Strip .pdb and add .sym.
 	sym_file = debug_file[:-4] + '.sym'
 	filename = os.path.join(debug_file, debug_id, sym_file)
 	debug_filename = os.path.join(debug_file, debug_id, debug_file)


### PR DESCRIPTION
Tested by making a try build with appveyor.yml changed slightly so that this code also runs for try builds. I manually verified with crash-stats that the symbols were uploaded correctly. Note that we don't want to run this for try builds normally.

I'd like to merge this to next briefly just to verify that it works without modification, but then merge it to master immediately once that's confirmed. There is nothing for users to test here; we just need to verify that it uploads the symbols and doesn't break the deploy process.

Fixes #6646.