### PR TITLE
Fix issue where console windows launched from shortcuts were invisible in Windows 10 build 15025.

### DIFF
--- a/nvdaHelper/remote/ime.cpp
+++ b/nvdaHelper/remote/ime.cpp
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2010-2012 World Light Information Limited and Hong Kong Blind Union.
+Copyright 2010-2016 World Light Information Limited, Hong Kong Blind Union, NV Access Limited.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -14,6 +14,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 #include <windows.h>
 #include <wchar.h>
+#include <Shlwapi.h>
 #include "nvdaHelperRemote.h"
 #include "nvdaControllerInternal.h"
 #include "typedCharacter.h"
@@ -517,7 +518,28 @@ LRESULT CALLBACK IME_getMessageHook(int code, WPARAM wParam, LPARAM lParam) {
 	return 0;
 }
 
+bool isConhostBuild15025OrLater() {
+	OSVERSIONINFO ver;
+	ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+	if (!GetVersionEx(&ver))
+		return false;
+	if (ver.dwBuildNumber < 15025)
+		return false;
+	wchar_t appName[MAX_PATH];
+	if (GetModuleFileName(NULL, appName, ARRAYSIZE(appName)) == 0)
+		return false;
+	PathStripPath(appName);
+	return wcscmp(appName, L"conhost.exe") == 0;
+}
+
 void IME_inProcess_initialize() {
+	if (isConhostBuild15025OrLater()) {
+		// #6833: On Windows 10 build >= 15025, console windows launched from shortcuts
+		// are invisible if immLockIMC is called in response to WM_ACTIVATE/WM_SETFOCUS.
+		// Therefore, disable IME in this case.
+		LOG_DEBUGWARNING(L"conhost on Windows 10 >= 15025, disabling IME support");
+		return;
+	}
 	wm_candidateChange=RegisterWindowMessage(L"nvda_wm_candidateChange");
 	wm_handleIMEConversionModeUpdate=RegisterWindowMessage(L"nvda_wm_handleIMEConversionModeUpdate");
 	gImm32Module = LoadLibraryA("imm32.dll");
@@ -536,6 +558,8 @@ void IME_inProcess_initialize() {
 }
 
 void IME_inProcess_terminate() {
+	if (isConhostBuild15025OrLater())
+		return;
 	unregisterWindowsHook(WH_CALLWNDPROC, IME_callWndProcHook);
 	unregisterWindowsHook(WH_GETMESSAGE, IME_getMessageHook);
 	if (gImm32Module)  FreeLibrary(gImm32Module);


### PR DESCRIPTION
Calling immLockIMC in response to WM_ACTIVATE/WM_SETFOCUS seems to cause this, but it worked fine in earlier builds. I haven't been able to work out why, but IME probably isn't used in consoels (if it works at all). Therefore, just disable IME support in this case.
Fixes #6833.