### PR TITLE
Support all existing (and hopefully future) versions of SecureCRT

### DIFF
--- a/source/appModules/securecrt.py
+++ b/source/appModules/securecrt.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2017 NV Access Limited, , Noel Romey
+#Copyright (C) 2010-2017 NV Access Limited, Noel Romey
 
 """App module for SecureCRT
 """
@@ -15,7 +15,8 @@ import appModuleHandler
 
 # Regexp which matches the terminal window class in all existing versions
 # (and hopefully future ones).
-RE_TERMINAL_WINCLASS = re.compile ("AfxFrameOrView\d{2,}u")
+# For example, it matches "AfxFrameOrView80u", "AfxFrameOrView90u" and "AfxFrameOrView100u".
+RE_TERMINAL_WINCLASS = re.compile (r"AfxFrameOrView\d{2,}u")
 
 class AppModule(appModuleHandler.AppModule):
 

--- a/source/appModules/securecrt.py
+++ b/source/appModules/securecrt.py
@@ -2,20 +2,25 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2012 NV Access Limited
+#Copyright (C) 2010-2017 NV Access Limited, , Noel Romey
 
 """App module for SecureCRT
 """
 
+import re
 import oleacc
 from NVDAObjects.behaviors import Terminal
 from NVDAObjects.window import DisplayModelEditableText, DisplayModelLiveText
 import appModuleHandler
 
+# Regexp which matches the terminal window class in all existing versions
+# (and hopefully future ones).
+RE_TERMINAL_WINCLASS = re.compile ("AfxFrameOrView\d{2,}u")
+
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if obj.windowClassName in ("AfxFrameOrView80u", "AfxFrameOrView90u", "AfxFrameOrView100u") and obj.IAccessibleRole == oleacc.ROLE_SYSTEM_CLIENT:
+		if RE_TERMINAL_WINCLASS.match (obj.windowClassName) and obj.IAccessibleRole == oleacc.ROLE_SYSTEM_CLIENT: 
 			try:
 				clsList.remove(DisplayModelEditableText)
 			except ValueError:


### PR DESCRIPTION
Uses a regexp rather than hard-coding a list of class names.
Supersedes #6303. Fixes #6302.
CC @nromey.