### PR TITLE
Remove config.validateConfig and config.val, Config Manager directly instantiates Validator object. re #6846

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -29,39 +29,6 @@ import winKernel
 import profileUpgrader
 from .configSpec import confspec
 
-def validateConfig(configObj,validator,validationResult=None,keyList=None):
-	"""
-	@deprecated: Add-ons which need this should provide their own implementation.
-	"""
-	import warnings
-	warnings.warn("config.validateConfig deprecated. Callers should provide their own implementation.",
-		DeprecationWarning, 2)
-	if validationResult is None:
-		validationResult=configObj.validate(validator,preserve_errors=True)
-	if validationResult is True:
-		return None #No errors
-	if validationResult is False:
-		return "Badly formed configuration file"
-	errorStrings=[]
-	for k,v in validationResult.iteritems():
-		if v is True:
-			continue
-		newKeyList=list(keyList) if keyList is not None else []
-		newKeyList.append(k)
-		if isinstance(v,dict):
-			errorStrings.extend(validateConfig(configObj[k],validator,v,newKeyList))
-		else:
-			#If a key is invalid configObj does not record its default, thus we need to get and set the default manually 
-			defaultValue=validator.get_default_value(configObj.configspec[k])
-			configObj[k]=defaultValue
-			if k not in configObj.defaults:
-				configObj.defaults.append(k)
-			errorStrings.append("%s: %s, defaulting to %s"%(k,v,defaultValue))
-	return errorStrings
-
-#: @deprecated: Use C{conf.validator} instead.
-val = Validator()
-
 #: The active configuration, C{None} if it has not yet been loaded.
 #: @type: ConfigObj
 conf = None
@@ -102,7 +69,6 @@ def isInstalledCopy():
 		return os.stat(instDir)==os.stat(os.getcwdu()) 
 	except WindowsError:
 		return False
-
 
 def getInstalledUserConfigPath():
 	try:
@@ -335,7 +301,7 @@ class ConfigManager(object):
 		#: Whether profile triggers are enabled (read-only).
 		#: @type: bool
 		self.profileTriggersEnabled = True
-		self.validator = val
+		self.validator = Validator()
 		self.rootSection = None
 		self._shouldHandleProfileSwitch = True
 		self._pendingHandleProfileSwitch = False


### PR DESCRIPTION
resolves the following:

* #6846, #667: config.validateConfig is no more. Also, Config Manager instantiates Validator object directly, thus config.val is no longer required.

Thanks.