### PR TITLE
Synth settings: no more i18n attribute

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -139,8 +139,6 @@ class SynthSetting(object):
 		"""
 		self.name=name
 		self.displayNameWithAccelerator=displayNameWithAccelerator
-		#: @deprecated: Use L{displaynameWithAccelerator} and L{displayName} instead.
-		self.i18nName=displayNameWithAccelerator
 		if not displayName:
 			# Strip accelerator from displayNameWithAccelerator.
 			displayName=displayNameWithAccelerator.replace("&","")


### PR DESCRIPTION
Resolves the following:

* #6846, #5185: i18nName for synth settings is no more, replaced by displayName and displayNameWithAccelerator.

Thanks.