### PR TITLE
Change wording of delete profile confirmation

### DIFF
--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -171,11 +171,11 @@ class ProfilesDialog(wx.Dialog):
 		index = self.profileList.Selection
 		if gui.messageBox(
 			# Translators: The confirmation prompt displayed when the user requests to delete a configuration profile.
-			_("Are you sure you want to delete this profile? This cannot be undone."),
+			_("This profile will be permanently deleted, this action cannot be undone."),
 			# Translators: The title of the confirmation dialog for deletion of a configuration profile.
 			_("Confirm Deletion"),
-			wx.YES | wx.NO | wx.ICON_QUESTION, self
-		) == wx.NO:
+			wx.OK | wx.CANCEL | wx.ICON_QUESTION, self
+		) != wx.OK:
 			return
 		name = self.profileNames[index]
 		try:

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -171,7 +171,7 @@ class ProfilesDialog(wx.Dialog):
 		index = self.profileList.Selection
 		if gui.messageBox(
 			# Translators: The confirmation prompt displayed when the user requests to delete a configuration profile.
-			_("This profile will be permanently deleted, this action cannot be undone."),
+			_("This profile will be permanently deleted. This action cannot be undone."),
 			# Translators: The title of the confirmation dialog for deletion of a configuration profile.
 			_("Confirm Deletion"),
 			wx.OK | wx.CANCEL | wx.ICON_QUESTION, self


### PR DESCRIPTION
Pressing escape does not exit the "confirm profile deletion" dialog. To fix this the dialog has been reworded and the buttons changed to `ok | cancel`
Fixes #6851

The [wx docs for messageBox](http://docs.wxwidgets.org/3.1.0/classwx_message_dialog.html) specifies:
>It is recommended to always use wxCANCEL with this style as otherwise the message box won't have a close button under wxMSW and the user will be forced to answer it.

Adding `wx.CANCEL` allows the dialog to be dismissed with the `esc` key. However, adding `wx.CANCEL` results in three buttons (yes, no, and cancel). Rather than do that I have re-worded the sentence, swapped to use the ok/cancel buttons. The message box will now say: 
>This profile will be permanently deleted, this action cannot be undone.