### PR TITLE
Replace execInWindow with execInThread

### DIFF
--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -291,7 +291,7 @@ bool findContentDescendant(IAccessible2* pacc2, long what, long* descendantID, l
 
 error_status_t nvdaInProcUtils_IA2Text_findContentDescendant(handle_t bindingHandle, const unsigned long windowHandle, long parentID, long what, long* descendantID, long* descendantOffset) {
 	HWND hwnd=(HWND)UlongToHandle(windowHandle);
-	auto func=[&](void* data){
+	auto func=[&] {
 		IAccessible* pacc=NULL;
 		VARIANT varChild;
 		AccessibleObjectFromEvent((HWND)hwnd,OBJID_CLIENT,parentID,&pacc,&varChild);
@@ -307,6 +307,6 @@ error_status_t nvdaInProcUtils_IA2Text_findContentDescendant(handle_t bindingHan
 		findContentDescendant(pacc2,what,descendantID,descendantOffset);
 		pacc2->Release();
 	};
-	execInWindow((HWND)hwnd,func,NULL);
+	execInWindow((HWND)hwnd,func);
 	return 0;
 }

--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -307,6 +307,8 @@ error_status_t nvdaInProcUtils_IA2Text_findContentDescendant(handle_t bindingHan
 		findContentDescendant(pacc2,what,descendantID,descendantOffset);
 		pacc2->Release();
 	};
-	execInWindow((HWND)hwnd,func);
+	if(!execInThread(GetWindowThreadProcessId(hwnd,NULL),func)) {
+			LOG_DEBUGWARNING(L"Could not execute findContentDescendant in UI thread");
+	}
 	return 0;
 }

--- a/nvdaHelper/remote/inProcess.cpp
+++ b/nvdaHelper/remote/inProcess.cpp
@@ -117,6 +117,14 @@ LRESULT CALLBACK inProcess_getMessageHook(int code, WPARAM wParam, LPARAM lParam
 	if(code<0||wParam==PM_NOREMOVE) {
 		return CallNextHookEx(0,code,wParam,lParam);
 	}
+	MSG* pmsg=(MSG*)lParam;
+	if(pmsg->message==wm_execInWindow) {
+		execInWindow_funcType* func=(execInWindow_funcType*)(pmsg->wParam);
+		if(func) (*func)();
+		// Signal completion to execInWindow.
+		SetEvent((HANDLE)pmsg->lParam);
+		return 0;
+	}
 	//Hookprocs may unregister or register hooks themselves, so we must copy the hookprocs before executing
 	windowsHookRegistry_t hookProcs=inProcess_registeredGetMessageWindowsHooks;
 	for(windowsHookRegistry_t::iterator i=hookProcs.begin();i!=hookProcs.end();++i) {
@@ -129,13 +137,6 @@ LRESULT CALLBACK inProcess_getMessageHook(int code, WPARAM wParam, LPARAM lParam
 LRESULT CALLBACK inProcess_callWndProcHook(int code, WPARAM wParam,LPARAM lParam) {
 	if(code<0) {
 		return CallNextHookEx(0,code,wParam,lParam);
-	}
-	CWPSTRUCT* pcwp=(CWPSTRUCT*)lParam;
-	if(pcwp->message==wm_execInWindow) {
-		execInWindow_funcType* func=(execInWindow_funcType*)(pcwp->wParam);
-		void* data=(void*)(pcwp->lParam);
-		if(func) (*func)(data);
-		return 0;
 	}
 	//Hookprocs may unregister or register hooks themselves, so we must copy the hookprocs before executing
 	windowsHookRegistry_t hookProcs=inProcess_registeredCallWndProcWindowsHooks;
@@ -156,18 +157,11 @@ void CALLBACK inProcess_winEventCallback(HWINEVENTHOOK hookID, DWORD eventID, HW
 	}
 }
 
-void execInWindow(HWND hwnd, execInWindow_funcType func,void* data) {
+void execInWindow(HWND hwnd, execInWindow_funcType func) {
 	// Using SendMessage here causes outgoing cross-process COM calls to fail with RPC_E_CANTCALLOUT_ININPUTSYNCCALL,
-	// which breaks us for Firefox multi-process. See Mozilla bug 1297549 comments 14 and 18.
-	// Use SendMessageCallback instead.
-	SENDASYNCPROC callback = [] (HWND hwnd, UINT msg, ULONG_PTR data, LRESULT result) {
-		// Signal the waiting message loop to exit.
-		PostQuitMessage(0);
-	};
-	if (!SendMessageCallback(hwnd,wm_execInWindow,(WPARAM)&func,(LPARAM)data, callback, NULL))
-		return;
-	MSG msg;
-	// Wait in a message loop until the callback fires and sends WM_QUIT.
-	// We also abort the loop if WaitMessage fails for some reason.
-	while (GetMessage(&msg, NULL, WM_QUIT, WM_QUIT) > 0);
+	// which breaks us for Firefox multi-process. See Mozilla bug 1297549 comment 14.
+	// Use PostMessage instead.
+	HANDLE event=CreateEvent(NULL,TRUE,FALSE,NULL);
+	PostMessage(hwnd,wm_execInWindow,(WPARAM)&func,(LPARAM)event);
+	WaitForSingleObject(event,INFINITE);
 }

--- a/nvdaHelper/remote/inProcess.h
+++ b/nvdaHelper/remote/inProcess.h
@@ -11,8 +11,8 @@ void inProcess_initialize();
 void inProcess_terminate();
 
 #include <functional>
-typedef std::function<void()> execInWindow_funcType;
-void execInWindow(HWND hwnd, execInWindow_funcType func);
+typedef std::function<void()> execInThread_funcType;
+bool execInThread(long threadID, execInThread_funcType func);
 
 
 #endif

--- a/nvdaHelper/remote/inProcess.h
+++ b/nvdaHelper/remote/inProcess.h
@@ -11,8 +11,8 @@ void inProcess_initialize();
 void inProcess_terminate();
 
 #include <functional>
-typedef std::function<void(void*)> execInWindow_funcType;
-void execInWindow(HWND hwnd, execInWindow_funcType func,void* data);
+typedef std::function<void()> execInWindow_funcType;
+void execInWindow(HWND hwnd, execInWindow_funcType func);
 
 
 #endif

--- a/nvdaHelper/remote/nvdaHelperRemote.def
+++ b/nvdaHelper/remote/nvdaHelperRemote.def
@@ -8,7 +8,7 @@ EXPORTS
 	unregisterWinEventHook
 	registerWindowsHook
 	unregisterWindowsHook
-	execInWindow
+	execInThread
 	logMessage
 	NVDALogCrtReportHook
 	nvdaInProcUtils_winword_expandToLine

--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -38,9 +38,12 @@ void VBufBackend_t::initialize() {
 		LOG_DEBUG(L"Calling renderThread_initialize on backend at "<<this);
 		this->renderThread_initialize();
 	};
-	LOG_DEBUG(L"Calling execInWindow");
-	execInWindow((HWND)UlongToHandle(rootDocHandle),func);
-	LOG_DEBUG(L"execInWindow complete");
+	LOG_DEBUG(L"Calling execInThread");
+	if(!execInThread(renderThreadID,func)) {
+		LOG_ERROR(L"Could not execute renderThread_initialize in UI thread");
+	} else {
+		LOG_DEBUG(L"execInThread complete");
+	}
 }
 
 void VBufBackend_t::forceUpdate() {
@@ -226,9 +229,12 @@ void VBufBackend_t::terminate() {
 			LOG_DEBUG(L"Calling renderThread_terminate on backend at "<<this);
 			this->renderThread_terminate();
 		};
-		LOG_DEBUG(L"Calling execInWindow");
-		execInWindow((HWND)UlongToHandle(rootDocHandle),func);
-		LOG_DEBUG(L"execInWindow complete");
+		LOG_DEBUG(L"Calling execInThread");
+		if(!execInThread(renderThreadID,func)) {
+			LOG_ERROR(L"Could not execute renderThread_terminate in UI thread");
+		} else {
+			LOG_DEBUG(L"execInThread complete");
+		}
 	} else {
 		LOG_DEBUG(L"render thread already terminated");
 	}

--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -34,12 +34,12 @@ void VBufBackend_t::initialize() {
 	int renderThreadID=GetWindowThreadProcessId((HWND)UlongToHandle(rootDocHandle),NULL);
 	LOG_DEBUG(L"render threadID "<<renderThreadID);
 	registerWindowsHook(WH_CALLWNDPROC,destroy_callWndProcHook);
-	auto func = [&] (void* data) {
+	auto func = [&] {
 		LOG_DEBUG(L"Calling renderThread_initialize on backend at "<<this);
 		this->renderThread_initialize();
 	};
 	LOG_DEBUG(L"Calling execInWindow");
-	execInWindow((HWND)UlongToHandle(rootDocHandle),func, NULL);
+	execInWindow((HWND)UlongToHandle(rootDocHandle),func);
 	LOG_DEBUG(L"execInWindow complete");
 }
 
@@ -222,12 +222,12 @@ void VBufBackend_t::terminate() {
 		LOG_DEBUG(L"Render thread not terminated yet");
 		int renderThreadID=GetWindowThreadProcessId((HWND)UlongToHandle(rootDocHandle),NULL);
 		LOG_DEBUG(L"render threadID "<<renderThreadID);
-		auto func = [&] (void* data) {
+		auto func = [&] {
 			LOG_DEBUG(L"Calling renderThread_terminate on backend at "<<this);
 			this->renderThread_terminate();
 		};
 		LOG_DEBUG(L"Calling execInWindow");
-		execInWindow((HWND)UlongToHandle(rootDocHandle),func, NULL);
+		execInWindow((HWND)UlongToHandle(rootDocHandle),func);
 		LOG_DEBUG(L"execInWindow complete");
 	} else {
 		LOG_DEBUG(L"render thread already terminated");


### PR DESCRIPTION
Replace nvdaHelperRemote's execInWindow with execInThread, which uses PostThreadMessage rather than PostMessage.
This still allows us to execute code in a thread via the message queue (avoiding Gecko E10s issues with SendMessage) but also still fixes #6422 as the message will still be received even if the window is destroyed.