### PR TITLE
core.callLater: After the given delay, the callable is now queued so that it gets executed  within NVDA's core pump, rather than executed directly. 

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -466,9 +466,8 @@ def requestPump():
 
 def callLater(delay, callable, *args, **kwargs):
 	"""Call a callable once after the specified number of milliseconds.
-	This is currently a thin wrapper around C{wx.CallLater},
-	but this should be used instead for calls which aren't just for UI,
-	as it notifies watchdog appropriately.
+	As the call is executed within NVDA's core queue, it is possible that execution will take place slightly after the requested time.
+	This function should never be used to execute code that brings up a modal UI as it will cause NVDA's core to block.
 	This function can be safely called from any thread.
 	"""
 	import wx
@@ -478,9 +477,6 @@ def callLater(delay, callable, *args, **kwargs):
 		return wx.CallAfter(wx.CallLater,delay, _callLaterExec, callable, args, kwargs)
 
 def _callLaterExec(callable, args, kwargs):
-	import watchdog
-	watchdog.alive()
-	try:
-		return callable(*args, **kwargs)
-	finally:
-		watchdog.asleep()
+	import queueHandler
+	queueHandler.queueFunction(queueHandler.eventQueue,callable,*args, **kwargs)
+

--- a/source/core.py
+++ b/source/core.py
@@ -479,4 +479,3 @@ def callLater(delay, callable, *args, **kwargs):
 def _callLaterExec(callable, args, kwargs):
 	import queueHandler
 	queueHandler.queueFunction(queueHandler.eventQueue,callable,*args, **kwargs)
-


### PR DESCRIPTION
This will implicitly ensure that watchdog is alive during its execution. This is rather than waking watchdog specifically for this callable, which had the possibility of accidentally putting watchdog back to sleep during a core pump that caused wx to yield or start a modal loop. (#6797)

Fixes #6797 