### PR TITLE
Support Windows Calculator on Windows 10 Enterprise LTSB (Long-Term Servicing Branch) and Server

### DIFF
--- a/source/appModules/calc.py
+++ b/source/appModules/calc.py
@@ -1,3 +1,12 @@
+#appModules/calc.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2007-2012 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""App module for Windows Calculator (desktop version)
+"""
+
 import appModuleHandler
 import NVDAObjects.IAccessible
 import speech

--- a/source/appModules/win32calc.py
+++ b/source/appModules/win32calc.py
@@ -1,6 +1,6 @@
 #appModules/win32calc.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2012 NV Access Limited
+#Copyright (C) 2007-2017 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/appModules/win32calc.py
+++ b/source/appModules/win32calc.py
@@ -1,0 +1,10 @@
+#appModules/win32calc.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2007-2012 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""App module for Windows Calculator (desktop version) for Windows 10 LTSB (Long-Term Servicing Branch) and Server, only difference being executable name.
+"""
+
+from calc import *


### PR DESCRIPTION
Because UWP isn't fully there, Windows 10 Enterprise LTSB and Server comes with desktop version of calculator except for a different executable name (win32calc as opposed to calc).