### PR TITLE
User guide: use 'Screen Reader: Supported' designation in Kindle section

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -700,7 +700,7 @@ When in a conversation:
 
 ++ Kindle for PC ++
 NVDA supports reading and navigating books in Amazon Kindle for PC.
-This functionality is only available in Kindle books that support "Enhanced Typesetting", which you can check on the details page for the book.
+This functionality is only available in Kindle books designated with "Screen Reader: Supported" which you can check on the details page for the book.
 
 Browse mode is used to read books.
 It is enabled automatically when you open a book or focus the book area.


### PR DESCRIPTION
Resolves the following:

* #6982: As noted in today's Amazon blog post: use the words "Screen Reader: Supported" instead of "Enhanced Typesetting".
Fixes #6982.