### PR TITLE
Safer config saving

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -12,7 +12,6 @@ import _winreg
 import ctypes
 import ctypes.wintypes
 import os
-import osreplace
 import sys
 from cStringIO import StringIO
 import itertools
@@ -602,7 +601,7 @@ class ConfigManager(object):
 		if oldName.lower() != newName.lower() and os.path.isfile(newFn):
 			raise ValueError("A profile with the same name already exists: %s" % newName)
 
-		osreplace.replace(oldFn, newFn)
+		os.rename(oldFn, newFn)
 		# Update any associated triggers.
 		allTriggers = self.triggersToProfiles
 		saveTrigs = False

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,3 +1,8 @@
+#fileUtils.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2016 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
 import os
 import osreplace
 from contextlib import contextmanager

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,0 +1,16 @@
+import os
+import osreplace
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from logHandler import log
+
+@contextmanager
+def FaultTolerantFile(name):
+	dirpath, filename = os.path.split(name)
+	with NamedTemporaryFile(dir=dirpath, prefix=filename, suffix='.tmp', delete=False) as f:
+		log.debug(f.name)
+		yield f
+		f.flush()
+		os.fsync(f)
+		f.close()
+		osreplace.replace(f.name, name)

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,6 +1,6 @@
 #fileUtils.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2016 NV Access Limited
+#Copyright (C) 2017 NV Access Limited, Bram Duvigneau
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 import os
@@ -9,8 +9,23 @@ from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from logHandler import log
 
+#: Constant; flag for MoveFileEx(). If a file with the destination filename already exists, it is overwritten.
+MOVEFILE_REPLACE_EXISTING = 1
+
 @contextmanager
 def FaultTolerantFile(name):
+	'''Used to write out files in a more fault tolerant way. A temporary file is used, and replaces the 
+	file `name' when the context manager scope ends and the the context manager __exit__ is called. This
+	means writing out the complete file can be performed with less concern of corrupting the original file
+	if the process is interrupted by windows shutting down.
+
+	Usage:
+		with FaultTolerantFile("myFile.txt") as f:
+			f.write("This is a test")
+
+	This creates a temporary file, and the writes actually happen on this temp file. At the end of the 
+	`with` block, when `f` goes out of context the temporary file is closed and, this temporary file replaces "myFile.txt"
+	'''
 	dirpath, filename = os.path.split(name)
 	with NamedTemporaryFile(dir=dirpath, prefix=filename, suffix='.tmp', delete=False) as f:
 		log.debug(f.name)
@@ -18,7 +33,6 @@ def FaultTolerantFile(name):
 		f.flush()
 		os.fsync(f)
 		f.close()
-		MOVEFILE_REPLACE_EXISTING = 1
 		moveFileResult = ctypes.windll.kernel32.MoveFileExW(f.name, name, MOVEFILE_REPLACE_EXISTING)
 		if moveFileResult == 0:
 			raise ctypes.WinError()

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -4,7 +4,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 import os
-import osreplace
+import ctypes
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from logHandler import log
@@ -18,4 +18,7 @@ def FaultTolerantFile(name):
 		f.flush()
 		os.fsync(f)
 		f.close()
-		osreplace.replace(f.name, name)
+		MOVEFILE_REPLACE_EXISTING = 1
+		moveFileResult = ctypes.windll.kernel32.MoveFileExW(f.name, name, MOVEFILE_REPLACE_EXISTING)
+		if moveFileResult == 0:
+			raise ctypes.WinError()

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -23,6 +23,7 @@ import api
 import speech
 import characterProcessing
 import config
+from fileUtils import FaultTolerantFile
 import watchdog
 from logHandler import log
 import globalVars
@@ -360,7 +361,8 @@ class GlobalGestureMap(object):
 					else:
 						outSect[script] = [outVal, gesture]
 
-		out.write()
+		with FaultTolerantFile(out.filename) as f:
+			out.write(f)
 
 class InputManager(baseObject.AutoPropertyObject):
 	"""Manages functionality related to input from the user.


### PR DESCRIPTION
Fixes #3165 

This supersedes #5916. Rather than use [osreplace ](https://pypi.python.org/pypi/pyosreplace/0.1) use `MoveFileExW` called with `ctypes`

Generally the approach is to lessen the chance that ALL config is lost if NVDA is interrupted during the saving process. This is done by first writing to a temporary file and then using this to replace the target config file.

There is a chance that some recently changed configuration will not be saved, if the saving process is interrupted while the temp file is being written. However this will no longer result in ALL config being lost. 