### PR TITLE
PythonConsole: the list of completions in the autocomplete context menu no longer shows  any objec path leading up to the final symbol being completed

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -249,7 +249,9 @@ class ConsoleUI(wx.Frame):
 		if self.completionAmbiguous:
 			menu = wx.Menu()
 			for comp in completions:
-				item = menu.Append(wx.ID_ANY, comp)
+				# Only show text after the last dot (so as to not keep repeting the class or module in the context menu)
+				label=comp.split('.')[-1]
+				item = menu.Append(wx.ID_ANY, label)
 				self.Bind(wx.EVT_MENU,
 					lambda evt, completion=comp: self._insertCompletion(original, completion),
 					item)

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2013 NV Access Limited
+#Copyright (C) 2008-2017 NV Access Limited
 
 import watchdog
 
@@ -250,7 +250,7 @@ class ConsoleUI(wx.Frame):
 			menu = wx.Menu()
 			for comp in completions:
 				# Only show text after the last dot (so as to not keep repeting the class or module in the context menu)
-				label=comp.split('.')[-1]
+				label=comp.rsplit('.',1)[-1]
 				item = menu.Append(wx.ID_ANY, label)
 				self.Bind(wx.EVT_MENU,
 					lambda evt, completion=comp: self._insertCompletion(original, completion),


### PR DESCRIPTION
This object path was always the same for all items for a given completion  and caused choosing an item to be inefficient for the user (especially for large menus).

 An example:
 typing nav.parent.n and pressing tab used to list:
 nav.parent.name
 nav.parent.next
 Now it lists:
 name
 next