### PR TITLE
Initial unit testing framework and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ uninstaller/UAC.nsh
 *.pyc
 *.pyo
 *.dmp
+tests/unit/nvda.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,9 +56,11 @@ install:
 
 build_script:
  - ps: |
-     $sconsArgs = "launcher version=$env:version"
+     $sconsOutTargets = "launcher"
+     $sconsArgs = "version=$env:version"
      if ($env:release) {
-      $sconsArgs += " changes userGuide developerGuide release=1"
+      $sconsOutTargets += " changes userGuide developerGuide"
+      $sconsArgs += " release=1"
      }
      if ($env:versionType) {
       $sconsArgs += " updateVersionType=$env:versionType"
@@ -68,9 +70,14 @@ build_script:
      $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
      # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
      # It's possible to work around this, but the workarounds have annoying side effects.
+     Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets
      Set-AppveyorBuildVariable "sconsArgs" $sconsArgs
  - 'echo scons args: %sconsArgs%'
- - py scons.py %sconsArgs%
+ - py scons.py source %sconsArgs%
+ # We don't need launcher to run tests, so run the tests before launcher.
+ - py scons.py tests %sconsArgs%
+ - 'echo scons output targets: %sconsOutTargets%'
+ - py scons.py %sconsOutTargets% %sconsArgs%
  # Build symbol store.
  - ps: |
      foreach ($syms in

--- a/nvdaHelper/ISimpleDOM_sconscript
+++ b/nvdaHelper/ISimpleDOM_sconscript
@@ -1,7 +1,7 @@
 ###
 #This file is a part of the NVDA project.
 #URL: http://www.nvda-project.org/
-#Copyright 2006-2010 NVDA contributers.
+#Copyright 2014-2017 NV Access Limited.
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
 #the Free Software Foundation.
@@ -24,5 +24,10 @@ tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile=env.TypeLibra
 	source=idlFile,
 	MIDLFLAGS=['/c_ext','/I',Dir('.')],
 )
+# hack: Ignore midl.exe when deciding to rebuild, as its position in the dependencies
+# is different in the run before the idl files are copied versus subsequent runs.
+midl=env.WhereIs(env["MIDL"])
+for target in (tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile):
+	env.Ignore(target,midl)
 
 Return(['tlbFile','headerFile','iidSourceFile','proxySourceFile','dlldataSourceFile'])

--- a/nvdaHelper/ISimpleDOM_sconscript
+++ b/nvdaHelper/ISimpleDOM_sconscript
@@ -24,7 +24,7 @@ tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile=env.TypeLibra
 	source=idlFile,
 	MIDLFLAGS=['/c_ext','/I',Dir('.')],
 )
-# hack: Ignore midl.exe when deciding to rebuild, as its position in the dependencies
+# #7036: hack: Ignore midl.exe when deciding to rebuild, as its position in the dependencies
 # is different in the run before the idl files are copied versus subsequent runs.
 midl=env.WhereIs(env["MIDL"])
 for target in (tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile):

--- a/nvdaHelper/mathPlayer_sconscript
+++ b/nvdaHelper/mathPlayer_sconscript
@@ -21,7 +21,7 @@ tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile=env.TypeLibra
 	source=idlFile,
 	MIDLFLAGS=['/I',Dir('.')],
 )
-# hack: Ignore midl.exe when deciding to rebuild, as its position in the dependencies
+# #7036: hack: Ignore midl.exe when deciding to rebuild, as its position in the dependencies
 # is different in the run before the idl files are copied versus subsequent runs.
 midl=env.WhereIs(env["MIDL"])
 for target in (tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile):

--- a/nvdaHelper/mathPlayer_sconscript
+++ b/nvdaHelper/mathPlayer_sconscript
@@ -1,7 +1,7 @@
 ###
 #This file is a part of the NVDA project.
 #URL: http://www.nvda-project.org/
-#Copyright 2006-2010 NVDA contributers.
+#Copyright 2014-2017 NV Access Limited.
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
 #the Free Software Foundation.
@@ -21,5 +21,10 @@ tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile=env.TypeLibra
 	source=idlFile,
 	MIDLFLAGS=['/I',Dir('.')],
 )
+# hack: Ignore midl.exe when deciding to rebuild, as its position in the dependencies
+# is different in the run before the idl files are copied versus subsequent runs.
+midl=env.WhereIs(env["MIDL"])
+for target in (tlbFile,headerFile,iidSourceFile,proxySourceFile,dlldataSourceFile):
+	env.Ignore(target,midl)
 
 Return(['tlbFile','headerFile','iidSourceFile','proxySourceFile','dlldataSourceFile'])

--- a/readme.md
+++ b/readme.md
@@ -200,3 +200,24 @@ For example, to build a launcher  with a specific version, you might type:
 ```
 scons launcher version=test1
 ```
+
+## Running Automated Tests
+If you make a change to the NVDA code, you should run NVDA's automated tests.
+These tests help to ensure that code changes do not unintentionally break functionality that was previously working.
+Currently, NVDA has only one kind of automated testing: unit tests.
+
+To run the unit tests, first change directory to the root of the NVDA source distribution as above.
+Then, run:
+
+```
+scons tests
+```
+
+To run only specific tests, specify them using the `unitTests` variable on the command line.
+The tests should be provided as a comma separated list.
+Each test should be specified as a Python module, class or method relative to the `tests\unit` directory.
+For example, to run only methods in the `TestMove` and `TestSelection` classes in the file `tests\unit\test_cursorManager.py` file, run this command:
+
+```
+scons tests unitTests=test_cursorManager.TestMove,test_cursorManager.TestSelection
+```

--- a/sconstruct
+++ b/sconstruct
@@ -72,6 +72,8 @@ vars.Add("certTimestampServer", "The URL of the timestamping server to use to ti
 vars.Add(PathVariable("outputDir", "The directory where the final built archives and such will be placed", "output",PathVariable.PathIsDirCreate))
 vars.Add(ListVariable("nvdaHelperDebugFlags", "a list of debugging features you require", 'none', ["debugCRT","RTC","analyze"]))
 vars.Add(EnumVariable('nvdaHelperLogLevel','The level of logging you wish to see, lower is more verbose','15',allowed_values=[str(x) for x in xrange(60)]))
+if "tests" in COMMAND_LINE_TARGETS:
+	vars.Add("unitTests", "A list of unit tests to run", "")
 
 #Base environment for this and sub sconscripts
 env = Environment(variables=vars,HOST_ARCH='x86',tools=["textfile","gettext","t2t",keyCommandsDocTool,'doxygen','recursiveInstall'])
@@ -373,3 +375,8 @@ env.Alias("symbolsArchive", symbolsArchive)
 
 env.Default(dist)
 
+if "tests" in COMMAND_LINE_TARGETS:
+	target = env.SConscript("tests/unit/sconscript", exports=["env"])
+	env.Depends(target, sourceDir)
+	env.AlwaysBuild(target)
+	tests = env.Alias("tests", target)

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -1,7 +1,7 @@
 ###
 #This file is a part of the NVDA project.
 #URL: http://www.nvda-project.org/
-#Copyright 2006-2010 NVDA contributers.
+#Copyright 2013-2017 NV Access Limited.
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
 #the Free Software Foundation.
@@ -49,12 +49,14 @@ COM_INTERFACES = {
 }
 
 for k,v in COM_INTERFACES.iteritems():
-	target=Dir('comInterfaces').File(k)
+	targets=[Dir('comInterfaces').File(k),
+		# This buillds a .pyc file as well.
+		Dir('comInterfaces').File(k + "c")]
 	source=clsid=majorVersion=None
 	if isinstance(v,basestring):
-		env.comtypesInterface(target,v)
+		env.comtypesInterface(targets,v)
 	else:
-		env.comtypesInterface(target,Dir('comInterfaces').File('__init__.py'),clsid=v[0],majorVersion=v[1],minorVersion=v[2])
+		env.comtypesInterface(targets,Dir('comInterfaces').File('__init__.py'),clsid=v[0],majorVersion=v[1],minorVersion=v[2])
 
 #When cleaning comInterfaces get rid of everything except for things starting with __ (e.g. __init__.py)
 env.Clean(Dir('comInterfaces'),Glob('comInterfaces/[!_]*')+Glob('comInterfaces/_[!_]*'))

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1,6 +1,6 @@
 #nvwave.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2008 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -11,6 +11,7 @@ import threading
 from ctypes import *
 from ctypes.wintypes import *
 import time
+import atexit
 import wx
 import winKernel
 import wave
@@ -345,3 +346,11 @@ def playWaveFile(fileName, async=True):
 		fileWavePlayerThread.start()
 	else:
 		fileWavePlayer.idle()
+
+# When exiting, ensure fileWavePlayer is deleted before modules get cleaned up.
+# Otherwise, WavePlayer.__del__ will fail with an exception.
+@atexit.register
+def _cleanup():
+	global fileWavePlayer, fileWavePlayerThread
+	fileWavePlayer = None
+	fileWavePlayerThread = None

--- a/source/tones.py
+++ b/source/tones.py
@@ -1,11 +1,12 @@
 #tones.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2009 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 """Utilities to generate and play tones"""
 
+import atexit
 import nvwave
 import config
 import globalVars
@@ -18,6 +19,13 @@ try:
 	player = nvwave.WavePlayer(channels=2, samplesPerSec=int(SAMPLE_RATE), bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
 except:
 	log.warning("Failed to initialize audio for tones")
+	player = None
+
+# When exiting, ensure player is deleted before modules get cleaned up.
+# Otherwise, WavePlayer.__del__ will fail with an exception.
+@atexit.register
+def _cleanup():
+	global player
 	player = None
 
 def beep(hz,length,left=50,right=50):

--- a/tests/system/nvdaConfig/addonsState.pickle
+++ b/tests/system/nvdaConfig/addonsState.pickle
@@ -1,0 +1,12 @@
+(dp1
+S'pendingInstallsSet'
+p2
+c__builtin__
+set
+p3
+((ltRp4
+sS'pendingRemovesSet'
+p5
+g3
+((ltRp6
+s.

--- a/tests/system/test_foo.py
+++ b/tests/system/test_foo.py
@@ -1,0 +1,7 @@
+from . import TestCase
+
+class TestCase(TestCase):
+
+	def test_foo(self):
+		self.keyCommand("NVDA+c")
+		self.expectPresentation([r"Speaking [u'asdf']"])

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -8,7 +8,7 @@
 All unit tests should reside within this package and should be
 divided into modules and packages similar to the code they are testing.
 Test modules must have a C{test_} prefix
-and should contain one or more classes with a C{Test} prefix which subclass L{TestCase}.
+and should contain one or more classes with a C{Test} prefix which subclass C{unittest.TestCase}.
 Methods in test classes should have a C{test_} prefix.
 """
 
@@ -45,7 +45,8 @@ os.chdir(SOURCE_DIR)
 # The path to this package might be relative, so make it absolute,
 # since we just changed directory.
 __path__[0] = UNIT_DIR
-# We don't want logging.
+# We don't want logging for now,
+# though we may optionally want this in future; see #7045.
 import logging
 from logHandler import log
 log.addHandler(logging.NullHandler())
@@ -79,11 +80,3 @@ api.setNavigatorObject(phObj)
 import speech
 speech.speak = lambda speechSequence, symbolLevel=None: None
 speech.speakSpelling = lambda text, locale=None, useCharacterDescriptions=False: None
-
-### Base classes/utility functions.
-
-import unittest
-
-class TestCase(unittest.TestCase):
-	"""The base class which all test case classes should subclass.
-	"""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,89 @@
+#tests/unit/__init__.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2017 NV Access Limited
+
+"""NVDA unit testing.
+All unit tests should reside within this package and should be
+divided into modules and packages similar to the code they are testing.
+Test modules must have a C{test_} prefix
+and should contain one or more classes with a C{Test} prefix which subclass L{TestCase}.
+Methods in test classes should have a C{test_} prefix.
+"""
+
+### Ugly bootstrapping code.
+
+import os
+import sys
+
+# The path to the unit tests.
+UNIT_DIR = os.path.dirname(os.path.abspath(__file__))
+# The path to the top of the repo.
+TOP_DIR = os.path.dirname(os.path.dirname(UNIT_DIR))
+# The path to the NVDA "source" directory.
+SOURCE_DIR = os.path.join(TOP_DIR, "source")
+# Let us import modules from the NVDA source.
+sys.path.insert(1, SOURCE_DIR)
+import sourceEnv
+
+# Set options normally taken from the command line.
+import globalVars
+class AppArgs:
+	# The path from which to load a configuration file.
+	# Ideally, this would be an in-memory, default configuration.
+	# However, config currently requires a path.
+	# We use the unit test directory, since we want a clean config.
+	configPath = UNIT_DIR.decode("mbcs")
+	secure = False
+	disableAddons = True
+globalVars.appArgs = AppArgs()
+
+# We depend on the current directory to load some files;
+# e.g. braille imports louis which loads liblouis.dll using a relative path.
+os.chdir(SOURCE_DIR)
+# The path to this package might be relative, so make it absolute,
+# since we just changed directory.
+__path__[0] = UNIT_DIR
+# We don't want logging.
+import logging
+from logHandler import log
+log.addHandler(logging.NullHandler())
+# There's no point in logging anything at all, since it'll go nowhere.
+log.setLevel(100)
+
+# Much of this should eventually be replaced by stuff which gets reset before each test
+# so the tests are isolated.
+import config
+config.initialize()
+# Initialize languageHandler so that translatable strings work.
+import languageHandler
+languageHandler.setLanguage("en")
+# NVDAObjects need appModuleHandler to be initialized.
+import appModuleHandler
+appModuleHandler.initialize()
+# Anything which notifies of cursor updates requires braille to be initialized.
+import braille
+braille.initialize()
+# The focus and navigator objects need to be initialized to something.
+from NVDAObjects import NVDAObject
+class PlaceholderNVDAObject(NVDAObject):
+	processID = None # Must be implemented to instantiate.
+phObj = PlaceholderNVDAObject()
+import api
+api.setFocusObject(phObj)
+api.setNavigatorObject(phObj)
+
+# Stub speech functions to make them no-ops.
+# Eventually, these should keep track of calls so we can make assertions.
+import speech
+speech.speak = lambda speechSequence, symbolLevel=None: None
+speech.speakSpelling = lambda text, locale=None, useCharacterDescriptions=False: None
+
+### Base classes/utility functions.
+
+import unittest
+
+class TestCase(unittest.TestCase):
+	"""The base class which all test case classes should subclass.
+	"""

--- a/tests/unit/sconscript
+++ b/tests/unit/sconscript
@@ -1,0 +1,29 @@
+###
+#This file is a part of the NVDA project.
+#URL: http://www.nvaccess.org/
+#Copyright 2017 NV Access Limited.
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License version 2.0, as published by
+#the Free Software Foundation.
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#This license can be found at:
+#http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+###
+
+import sys
+
+Import("env")
+
+cmd = [sys.executable, "-m", "unittest"]
+tests = env["unitTests"]
+if tests:
+	# Run specific tests.
+	tests = tests.split(",")
+	cmd += ["tests.unit." + test for test in tests]
+else:
+	# Run all tests.
+	cmd.extend(("discover", "tests.unit", "-t", "."))
+target = env.Command(".", None, [cmd])
+Return('target')

--- a/tests/unit/test_cursorManager.py
+++ b/tests/unit/test_cursorManager.py
@@ -1,0 +1,78 @@
+#tests/unit/test_cursorManager.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2017 NV Access Limited
+
+"""Unit tests for the cursorManager module.
+"""
+
+import unittest
+import cursorManager
+from . import TestCase
+from .textProvider import BasicTextProvider
+
+class CursorManager(cursorManager.CursorManager, BasicTextProvider):
+	"""CursorManager which navigates within a provided string of text.
+	"""
+
+class TestMove(TestCase):
+
+	def test_nextChar(self):
+		cm = CursorManager(text="abc") # Caret at "a"
+		cm.script_moveByCharacter_forward(None)
+		self.assertEqual(cm.selectionOffsets, (1, 1)) # Caret at "b"
+
+	def test_prevChar(self):
+		cm = CursorManager(text="abc", selection=(1, 1)) # Caret at "b"
+		cm.script_moveByCharacter_back(None)
+		self.assertEqual(cm.selectionOffsets, (0, 0)) # Caret at "a"
+
+class TestSelection(TestCase):
+
+	def test_selectNextChar(self):
+		cm = CursorManager(text="abc") # Caret at "a"
+		cm.script_selectCharacter_forward(None)
+		self.assertEqual(cm.selectionOffsets, (0, 1)) # "a" selected
+
+	def test_selectPrevChar(self):
+		cm = CursorManager(text="abc", selection=(1, 1)) # Caret at "b"
+		cm.script_selectCharacter_back(None)
+		self.assertEqual(cm.selectionOffsets, (0, 1)) # "a" selected
+
+	def test_unselectPrevChar(self):
+		cm = CursorManager(text="abc") # Caret at "a"
+		cm.script_selectCharacter_forward(None) # "a" selected
+		cm.script_selectCharacter_back(None) # "a" unselected
+		self.assertEqual(cm.selectionOffsets, (0, 0)) # Caret at "a", no selection
+
+	def test_selForwardThenUnselThenSelBackward(self):
+		"""Test selecting forward, then unselecting and selecting backward.
+		"""
+		cm = CursorManager(text="abc", selection=(1, 1)) # Caret at "b"
+		cm.script_selectCharacter_forward(None) # "b" selected
+		cm.script_selectCharacter_back(None) # "b" unselected, caret at "b"
+		cm.script_selectCharacter_back(None)
+		self.assertEqual(cm.selectionOffsets, (0, 1)) # "a" selected
+
+	def test_selectForwardThenSelBackward(self):
+		"""Test selecting forward, then selecting backward without unselecting.
+		"""
+		cm = CursorManager(text="abc", selection=(1, 1)) # Caret at "b"
+		cm.script_selectCharacter_forward(None) # "b" selected
+		cm.script_selectWord_back(None) # "b" unselected, "a" selected
+		self.assertEqual(cm.selectionOffsets, (0, 1)) # "a" selected
+
+class TestSelectAll(TestCase):
+	"""Tests the select all command starting from different caret positions.
+	"""
+
+	def _selectAllTest(self, caret):
+		"""Tests select all with the caret at the given offset.
+		"""
+		cm = CursorManager(text="abc", selection=(caret, caret))
+		cm.script_selectAll(None)
+		self.assertEqual(cm.selectionOffsets, (0, 3)) # "abc" selected
+
+	def test_selectAllFromStart(self):
+		self._selectAllTest(0) # Caret at "a"

--- a/tests/unit/test_cursorManager.py
+++ b/tests/unit/test_cursorManager.py
@@ -9,14 +9,13 @@
 
 import unittest
 import cursorManager
-from . import TestCase
 from .textProvider import BasicTextProvider
 
 class CursorManager(cursorManager.CursorManager, BasicTextProvider):
 	"""CursorManager which navigates within a provided string of text.
 	"""
 
-class TestMove(TestCase):
+class TestMove(unittest.TestCase):
 
 	def test_nextChar(self):
 		cm = CursorManager(text="abc") # Caret at "a"
@@ -28,7 +27,7 @@ class TestMove(TestCase):
 		cm.script_moveByCharacter_back(None)
 		self.assertEqual(cm.selectionOffsets, (0, 0)) # Caret at "a"
 
-class TestSelection(TestCase):
+class TestSelection(unittest.TestCase):
 
 	def test_selectNextChar(self):
 		cm = CursorManager(text="abc") # Caret at "a"
@@ -41,6 +40,8 @@ class TestSelection(TestCase):
 		self.assertEqual(cm.selectionOffsets, (0, 1)) # "a" selected
 
 	def test_unselectPrevChar(self):
+		"""Depends on behavior tested by test_selectNextChar.
+		"""
 		cm = CursorManager(text="abc") # Caret at "a"
 		cm.script_selectCharacter_forward(None) # "a" selected
 		cm.script_selectCharacter_back(None) # "a" unselected
@@ -48,6 +49,7 @@ class TestSelection(TestCase):
 
 	def test_selForwardThenUnselThenSelBackward(self):
 		"""Test selecting forward, then unselecting and selecting backward.
+		Depends on behavior tested by test_unselectPrevChar.
 		"""
 		cm = CursorManager(text="abc", selection=(1, 1)) # Caret at "b"
 		cm.script_selectCharacter_forward(None) # "b" selected
@@ -57,13 +59,14 @@ class TestSelection(TestCase):
 
 	def test_selectForwardThenSelBackward(self):
 		"""Test selecting forward, then selecting backward without unselecting.
+		Depends on behavior tested by test_selectNextChar.
 		"""
 		cm = CursorManager(text="abc", selection=(1, 1)) # Caret at "b"
 		cm.script_selectCharacter_forward(None) # "b" selected
 		cm.script_selectWord_back(None) # "b" unselected, "a" selected
 		self.assertEqual(cm.selectionOffsets, (0, 1)) # "a" selected
 
-class TestSelectAll(TestCase):
+class TestSelectAll(unittest.TestCase):
 	"""Tests the select all command starting from different caret positions.
 	"""
 

--- a/tests/unit/textProvider.py
+++ b/tests/unit/textProvider.py
@@ -1,0 +1,64 @@
+#tests/unit/textProvider.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2017 NV Access Limited
+
+"""Fake text provider implementation for testing of code which uses TextInfos.
+See the L{BasicTextProvider} class.
+"""
+
+from NVDAObjects import NVDAObject, NVDAObjectTextInfo
+import textInfos
+from textInfos.offsets import Offsets
+
+class BasicTextInfo(NVDAObjectTextInfo):
+	# NVDAHelper is not initialized, so we can't use Uniscribe.
+	useUniscribe = False
+
+	def _get_offsets(self):
+		return (self._startOffset, self._endOffset)
+
+	def updateCaret(self):
+		self.obj.selectionOffsets = (self._startOffset, self._startOffset)
+
+	def updateSelection(self):
+		self.obj.selectionOffsets = self.offsets
+
+class BasicTextProvider(NVDAObject):
+	"""An NVDAObject which makes TextInfos based on a provided string of text.
+	Example usage:
+	>>> obj = BasicTextProvider(text="abcd")
+	>>> ti = obj.makeTextInfo(textInfos.POSITION_CARET)
+	>>> ti.offsets
+	(0, 0)
+	>>> ti.expand(textInfos.UNIT_CHARACTER)
+	>>> ti.text
+	"a"
+	>>> ti.offsets
+	(0, 1)
+	>>> ti.updateSelection()
+	>>> obj.selectionOffsets
+	(0, 1)
+	"""
+
+	processID = None # Must be implemented to instantiate.
+	TextInfo = BasicTextInfo
+
+	def __init__(self, text=None, selection=(0, 0)):
+		"""
+		@param text: The text to provide via TextInfos.
+		@type text: basestring
+		@param selection: The start and end offsets of the initial selection;
+			same start and end is caret with no selection.
+		@type selection: tuple of (int, int)
+		"""
+		super(BasicTextProvider, self).__init__()
+		self.basicText = unicode(text)
+		self.selectionOffsets = selection
+
+	def makeTextInfo(self, position):
+		if position in (textInfos.POSITION_CARET, textInfos.POSITION_SELECTION):
+			start, end = self.selectionOffsets
+			position = Offsets(start, end)
+		return super(BasicTextProvider, self).makeTextInfo(position)


### PR DESCRIPTION
This adds an initial unit testing framework, including necessary changes for SCons and AppVeyor. It also adds some tests for the cursorManager module, which serve both as useful tests and as an example of how this can be used.

This is far from perfect. In particular, there is some pretty ugly bootstrapping code, and because NVDA wasn't originally designed with unit testing in mind, tests aren't isolated from side effects. However, we need to start somewhere and I think we can improve these things over time. Most of the ugliness is in one file and we have a base TestCase so we can provide base setUp and tearDown methods in order to better isolate tests.