### PR TITLE
Fix Acrobat Reader crash in PDF documents with empty ActualText attributes

### DIFF
--- a/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
+++ b/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
@@ -417,6 +417,8 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 	}
 
 	IPDDomNode* domNode = getPDDomNode(varChild, servprov);
+	if (!domNode)
+		LOG_DEBUGWARNING(L"Couldn't get IPDDomNode for docHandle " << docHandle << L" id " << ID);
 
 	IPDDomElement* domElement = NULL;
 	LOG_DEBUG(L"Trying to get IPDDomElement");
@@ -489,7 +491,7 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 	LOG_DEBUG(L"childCount is "<<childCount);
 
 	bool deletePageNum = false;
-	if (!pageNum && (pageNum = this->getPageNum(domNode)))
+	if (!pageNum && domNode && (pageNum = this->getPageNum(domNode)))
 		deletePageNum = true;
 
 	#define addAttrsToTextNode(node) { \
@@ -692,11 +694,14 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 		}
 
 		// Hereafter, tempNode is the text node (if any).
-		tempNode = renderText(buffer, parentNode, previousNode, domNode, domElement, useNameAsContent, parentNode->language, textFlags, pageNum);
-		if (tempNode) {
-			// There was text.
-			previousNode = tempNode;
-		}
+		if (domNode) {
+			tempNode = renderText(buffer, parentNode, previousNode, domNode, domElement, useNameAsContent, parentNode->language, textFlags, pageNum);
+			if (tempNode) {
+				// There was text.
+				previousNode = tempNode;
+			}
+		} else
+			tempNode = NULL;
 
 		if (name)
 			SysFreeString(name);

--- a/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
+++ b/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
@@ -417,8 +417,9 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 	}
 
 	IPDDomNode* domNode = getPDDomNode(varChild, servprov);
-	if (!domNode)
+	if (!domNode) {
 		LOG_DEBUGWARNING(L"Couldn't get IPDDomNode for docHandle " << docHandle << L" id " << ID);
+	}
 
 	IPDDomElement* domElement = NULL;
 	LOG_DEBUG(L"Trying to get IPDDomElement");
@@ -491,8 +492,9 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 	LOG_DEBUG(L"childCount is "<<childCount);
 
 	bool deletePageNum = false;
-	if (!pageNum && domNode && (pageNum = this->getPageNum(domNode)))
+	if (!pageNum && domNode && (pageNum = this->getPageNum(domNode))) {
 		deletePageNum = true;
+	}
 
 	#define addAttrsToTextNode(node) { \
 		node->addAttribute(L"language", parentNode->language); \
@@ -700,8 +702,9 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 				// There was text.
 				previousNode = tempNode;
 			}
-		} else
+		} else {
 			tempNode = NULL;
+		}
 
 		if (name)
 			SysFreeString(name);


### PR DESCRIPTION
adobeAcrobat vbuf backend: get_PDDomNode can fail and return null, so check for a null pointer before trying to use it.

Fixes #7034. Fixes the first part of #7021.

Changes entry: in Bug Fixes:

```
- Adobe Acrobat Reader no longer crashes in certain PDF documents (specifically, those containing empty ActualText attributes). (#7021, #7034)
```