### PR TITLE
negative state label for pressed

### DIFF
--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -566,6 +566,8 @@ negativeStateLabels={
 	STATE_SELECTED:_("not selected"),
 	# Translators: This is presented when a checkbox is not checked.
 	STATE_CHECKED:_("not checked"),
+	# Translators: This is presented when a button is not pressed.
+	STATE_PRESSED:_("not pressed"),
 }
 
 silentRolesOnFocus={


### PR DESCRIPTION
This patch enables better translations regarding button state which is not pressed.
Currently, "pressed" and "not pressed" is not independent, so Japanese translation is difficult.
The HTML example is as follows (tested with Firefox and proposed patch), which is used as Facebook Like buttons.

```
<html>
  <body>
    <div>
      <a href="#" role="button" aria-pressed="false">button 1</a>
    </div>
    <div>
      <a href="#" role="button" aria-pressed="true">button 2</a>
    </div>
  </body>
</html>
```
