### PR TITLE
2017.2 what's new: spelling fixes, entry consistency for some items

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,8 +8,8 @@
 == New Features ==
 - Cell border information can now be reported in Microsoft Excel by using `NVDA+f`. (#3044)
 - Added support for aria-current attributes. (#6358)
-- Support automatic language switching in Microsoft Edge. (#6852)
-- Support Windows Calculator on Windows 10 Enterprise LTSB (Long-Term Servicing Branch) and Server. (#6914)
+- Automatic language switching is now supported in Microsoft Edge. (#6852)
+- Added support for Windows Calculator on Windows 10 Enterprise LTSB (Long-Term Servicing Branch) and Server. (#6914)
 - Performing the read current line command three times quickly spells the line with character descriptions. (#6893)
 
 
@@ -20,33 +20,33 @@
 == Bug Fixes ==
 - Web page menu items (menu item checkbox's and radio buttons) can now be activated while in browse mode. (#6735)
 - Excel sheet name reporting is now translated. (#6848)
-- Pressing ESC while the configuration profile "Confirm Deletion" prompt is active now dismisses the dialog. (#6851)
-- Fix some crashes in Mozilla Firefox and other Gecko applications where the multi-process feature is enabled. (#6885)
-- Reporting of the background color in screen review is now more accurate when  text was drawn with a transparant background (#6467) 
+- Pressing escape while the configuration profile "Confirm Deletion" dialog is active now dismisses the dialog. (#6851)
+- Fixed some crashes in Mozilla Firefox and other Gecko applications where the multi-process feature is enabled. (#6885)
+- Reporting of background color in screen review is now more accurate when  text was drawn with a transparent background. (#6467)
 - Improved support for aria-describedby in Internet Explorer 11, including support within iframes and when multiple IDs are provided. (#5784)
-- In the Windows Creaters Update, NVDA's audio ducking again works as in previous Windows releases (I.e. Duck with speech and sounds, always duck, and no ducking are all available). (#6933)
+- In the Windows 10 Creators Update, NVDA's audio ducking again works as in previous Windows releases (I.e. Duck with speech and sounds, always duck, and no ducking are all available). (#6933)
 - NVDA will no longer fail to navigate to or report certain (UIA) controls where a keyboard shortcut is not defined. (#6779)
 - Two empty spaces are no longer added in keyboard shortcut information for certain (UIA) controls. (#6790)
 - Certain combinations of keys on HIMS displays (e.g. space+dot4) no longer fail intermittently. (#3157)
 - Fixed an issue when opening a serial port on systems using certain languages other than English which caused connecting to braille displays to fail in some cases. (#6845)
 - Reduced the chance of configuration file being corrupted when Windows shuts down. Configuration files are now written to a temporary file before replacing the actual configuration file. (#3165)
 - When performing the read current line command twice quickly to spell the line, the appropriate language is now used for the spelled characters. (#6726)
-- Navigating by line in Microsoft Edge is now up to 3x faster in the Windows 10 Creaters Update. (#6994)
-- NVDA no longer announces "Web Runtime grouping" when focusing Microsoft Edge documents in the Windows 10 Creaters Update (#6948)
+- Navigating by line in Microsoft Edge is now up to three times faster in the Windows 10 Creators Update. (#6994)
+- NVDA no longer announces "Web Runtime grouping" when focusing Microsoft Edge documents in the Windows 10 Creators Update. (#6948)
 
 
 == Changes for Developers ==
-- Commandline arguments are now processed with Python's argparser module, rather than optparser. This allows certain options such as -r and -q to be handled exclusively. (#6865)
+- Commandline arguments are now processed with Python's argparse module, rather than optparse. This allows certain options such as -r and -q to be handled exclusively. (#6865)
 - core.callLater now queues the callback to NVDA's main queue after the given delay, rather than waking the core and executing it directly. This stops possible freezes due to the  core accidentally going to sleep after processing a callback, in the midle of  a modal call such as the desplaying of a message box. (#6797)
 - The InputGesture.identifiers property has been changed so that it is no longer normalized. (#6945)
  - Subclasses no longer need to normalize identifiers before returning them from this property.
  - If you want normalized identifiers, there is now an InputGesture.normalizedIdentifiers property which normalizes the identifiers returned by the identifiers property .
 - The InputGesture.logIdentifier property is now deprecated. Callers should use InputGesture.identifiers[0] instead. (#6945)
 - Deprecated code removed:
- - `speech.REASON_*` constants, `controlTypes.REASON_*` should be used instead. (#6846)
- - `i18nName` for synth settings, `displayName` and `displayNameWithAccelerator` should be used instead. (#6846, #5185)
+ - `speech.REASON_*` constants: `controlTypes.REASON_*` should be used instead. (#6846)
+ - `i18nName` for synth settings: `displayName` and `displayNameWithAccelerator` should be used instead. (#6846, #5185)
  - `config.validateConfig`. (#6846, #667)
- - `config.save`. (#6846)
+ - `config.save`. (#6846, #667)
 - The list of completions in the autocomplete context menu of the PythonConsole no longer shows  any objec path leading up to the final symbol being completed. (#7023)
 - There is now a unit testing framework for NVDA. (#7026)
  - Unit tests and infrastructure are located in the tests/unit directory. See the docstring in the tests\unit\__init__.py file for details.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,7 @@
 - Automatic language switching is now supported in Microsoft Edge. (#6852)
 - Added support for Windows Calculator on Windows 10 Enterprise LTSB (Long-Term Servicing Branch) and Server. (#6914)
 - Performing the read current line command three times quickly spells the line with character descriptions. (#6893)
+- New language: Burmese.
 
 
 == Changes ==


### PR DESCRIPTION
Specific changes:

* Creaters update-> Creators Update.
* Added #667 reference to config.save removal.
* For auto-language switching in Edge, rephrased it to make it align with similar entries.
* config profiles/delete dialog: esc -> escape for consistency.
* Edge line navigation: 3x -> three times.

Thanks.