### PR TITLE
fraction unicode symbols and up and down arrows, layout cleanup for consistency

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -1,6 +1,6 @@
 ﻿#locale/en/symbols.dic
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (c) 2011-2012 NVDA Contributors
+#Copyright (c) 2011-2017 NVDA Contributors
 #This file is covered by the GNU General Public License.
 
 complexSymbols:
@@ -113,52 +113,70 @@ _	line	most
 ×	times	some
 ÷	divide by	some
 ←	left arrow	some
+↑	up arrow	some
 →	right arrow	some
+↓	down arrow	some
 ✓	check	some
 ✔	check	some
-#Mathematical Operators U+2200 to U+220F
 
-∀	For All 	none
-∁	Complement	none
-∂	Partial Derivative	none
-∃	There exists	none
-∄	There Does Not Exist	none
-∅	EMPTY SET	none
-∆	INCREMENT	none
-∇	NABLA	none
-∈	ELEMENT OF	none
-∉	NOT AN ELEMENT OF	none
-∊	SMALL ELEMENT OF	none
-∋	CONTAINS AS MEMBER	none
-∌	DOES NOT CONTAIN AS MEMBER	none
-∍	SMALL CONTAINS AS MEMBER	none
-∎	END OF PROOF	none
-∏	N-ARY PRODUCT	none
+#Mathematical Operators U+2200 to U+220F
+∀	for all	none
+∁	complement	none
+∂	partial derivative	none
+∃	there exists	none
+∄	there does not exist	none
+∅	empty set	none
+∆	increment	none
+∇	nabla	none
+∈	element of	none
+∉	not an element of	none
+∊	small element of	none
+∋	contains as member	none
+∌	does not contain as member	none
+∍	small contains as member	none
+∎	end of proof	none
+∏	n-ary product	none
 
 # Miscellaneous Mathematical Operators
+∑	n-ary summation	none
+√	square root	none
+∛	cube root	none
+∜	fourth root	none
+∝	proportional to	none
+∞	infinity	none
+∟	right angle	none
+∠	angle	none
+∥	parallel to	none
+∦	not parallel to	none
+∧	logical and	none
+∨	logical or	none
+∩	intersection	none
+∪	union	none
+∫	integral	none
+∴	therefore	none
+∵	because	none
+∶	ratio	none
+∷	proportion	none
+≤	less- than or equal to	none
+≥	greater-than or equal to	none
+⊂	subset of	none
+⊃	superset of	none
+⊆	subset of or equal to	none
+⊇	superset of or equal to	none
 
-∑	N-ARY SUMMATION	none
-√	SQUARE ROOT	none
-∛	CUBE ROOT	none
-∜	FOURTH ROOT	none
-∝	PROPORTIONAL TO	none
-∞	INFINITY	none
-∟	RIGHT ANGLE	none
-∠	ANGLE	none
-∥	PARALLEL TO	none
-∦	NOT PARALLEL TO	none
-∧	LOGICAL AND	none
-∨	LOGICAL OR	none
-∩	INTERSECTION	none
-∪	UNION	none
-∫	INTEGRAL	none
-∴	THEREFORE	none
-∵	BECAUSE	none
-∶	RATIO	none
-∷	PROPORTION	none
-≤	LESS-THAN OR EQUAL TO	none
-≥	GREATER-THAN OR EQUAL TO	none
-⊂	SUBSET OF	none
-⊃	SUPERSET OF	none
-⊆	SUBSET OF OR EQUAL TO	none
-⊇	SUPERSET OF OR EQUAL TO	none
+# Vulgur Fractions U+2150 to U+215E
+⅐	one seventh	none
+⅑	one ninth	none
+⅒	one tenth	none
+⅓	one third	none
+⅔	two thirds	none
+⅕	one fifth	none
+⅖	two fifths	none
+⅗	three fifths	none
+⅘	four fifths	none
+⅙	one sixth	none
+⅚	five sixths	none
+⅛	one eighth	none
+⅜	three eights	none
+⅝	five eighths	none
+⅞	seven eighths	none


### PR DESCRIPTION
Added vulgar unicode fractions used for recipes, etc. Also added missing up and down arrows next to left and right. These are used for some computer tutorials. Visual changes--some symbol names were all uppercase, others lowercase. Part of #3805 though other symbols still need to be examined for best suitable implementation.