### PR TITLE
Latest espeak to resolve italian pronunciation

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -96,37 +96,49 @@ espeakLib=env.SharedLibrary(
 	target='espeak',
 	srcdir=espeakSrcDir.Dir('libespeak-ng').abspath,
 	source=[
+		# compare to src_libespeak_ng_la_SOURCES in espeak Makefile.am
 		"../ucd-tools/src/case.c",
 		"../ucd-tools/src/categories.c",
 		"../ucd-tools/src/ctype.c",
+		"../ucd-tools/src/proplist.c",
 		"../ucd-tools/src/scripts.c",
 		"../ucd-tools/src/tostring.c",
-		"speech.c",
-		"readclause.c",
+		"compiledata.c",
 		"compiledict.c",
+		"compilembrola.c",
 		"dictionary.c",
 		"encoding.c",
+		"error.c",
+		"espeak_api.c",
+		"ieee80.c",
 		"intonation.c",
-		"setlengths.c",
+		"klatt.c", # we do use KLATT, this is a compile option in espeak
+		"mbrowrap.c", # we do use MBROLA, this is a compile option in espeak
 		"mnemonics.c",
 		"numbers.c",
 		"phoneme.c",
-		"synth_mbrola.c",
+		"phonemelist.c",
+		"readclause.c",
+		"setlengths.c",
+		"spect.c",
+		"speech.c",
 		"synthdata.c",
 		"synthesize.c",
+		"synth_mbrola.c",
+		"tokenizer.c",
 		"translate.c",
 		"tr_languages.c",
 		"voices.c",
 		"wavegen.c",
-		"phonemelist.c",
-		"klatt.c",
-		"compiledata.c",
-		"compilembrola.c",
-		"ieee80.c",
-		"spect.c",
-		"espeak_api.c",
-		"error.c",
 		sonicLib,
+		# espeak does not need to handle its own audio output so dont include:
+		# pcaudiolib\src\audio.c
+		# pcaudiolib\src\windows.c
+		# pcaudiolib\src\xaudio2.cpp
+		# These are for SAPI5, we dont need them:
+		# com\comentrypoints.c
+		# com\ttsengine.cpp
+		# We do not use the ASYNC compile option in espeak.
 	],
 	LIBS=['advapi32'],
 )

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -42,7 +42,7 @@ if 'analyze' in env['nvdaHelperDebugFlags']:
 # Ignore all warnings as the code is not ours
 env.Append(CCFLAGS='/W0')
 
-env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir])
+env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir,espeakSrcDir.Dir('ucd-tools/src/include')])
 
 def espeak_compilePhonemeData_buildEmitter(target,source,env):
 	phSourceIgnores=['error_log','error_intonation','compile_prog_log','compile_report','envelopes.png']
@@ -96,13 +96,21 @@ espeakLib=env.SharedLibrary(
 	target='espeak',
 	srcdir=espeakSrcDir.Dir('libespeak-ng').abspath,
 	source=[
+		"../ucd-tools/src/case.c",
+		"../ucd-tools/src/categories.c",
+		"../ucd-tools/src/ctype.c",
+		"../ucd-tools/src/scripts.c",
+		"../ucd-tools/src/tostring.c",
 		"speech.c",
 		"readclause.c",
 		"compiledict.c",
 		"dictionary.c",
+		"encoding.c",
 		"intonation.c",
 		"setlengths.c",
+		"mnemonics.c",
 		"numbers.c",
+		"phoneme.c",
 		"synth_mbrola.c",
 		"synthdata.c",
 		"synthesize.c",
@@ -130,7 +138,7 @@ env.Depends(phonemeData,espeakLib)
 env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
 
 #Compile all dictionaries
-missingDicts=[] #'mt','tn','tt']
+missingDicts=['zhy'] #'mt','tn','tt']
 dictSourcePath=espeakRepo.Dir('dictsource').abspath
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -193,7 +193,7 @@ class SynthDriver(SynthDriver):
 		voices=OrderedDict()
 		for v in _espeak.getVoiceList():
 			l=v.languages[1:]
-			# #7167: Some languages names require unicode characters EG: Norwegian Bokmål
+			# #7167: Some languages names contain unicode characters EG: Norwegian Bokmål
 			name=v.name.decode("UTF-8")
 			# #5783: For backwards compatibility, voice identifies should always be lowercase
 			identifier=os.path.basename(v.identifier).lower()

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -193,9 +193,11 @@ class SynthDriver(SynthDriver):
 		voices=OrderedDict()
 		for v in _espeak.getVoiceList():
 			l=v.languages[1:]
+			# #7167: Some languages names require unicode characters EG: Norwegian Bokmål
+			name=v.name.decode("UTF-8")
 			# #5783: For backwards compatibility, voice identifies should always be lowercase
 			identifier=os.path.basename(v.identifier).lower()
-			voices[identifier]=VoiceInfo(identifier,v.name,l)
+			voices[identifier]=VoiceInfo(identifier,name,l)
 		return voices
 
 	def _get_voice(self):


### PR DESCRIPTION
Update Espeak to commit 5226ff0

Some changes had to be made to build system so support this Espeak update.
We must now compile and link and include in the search paths `ucd-tools`. To do this, I diffed the the visual studio project files in the espeak project.

I have excluded 'zhy` dictionary since it was failing to build. 

A try build has been given to the user asking for better support, we have not yet had feedback.