### PR TITLE
Ignore RuntimeError when moving in word.

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -833,7 +833,11 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		if end:
 			oldEndOffset=self._rangeObj.end
 		self._rangeObj.collapse(wdCollapseEnd if end else wdCollapseStart)
-		if end and self._rangeObj.end<oldEndOffset:
+		newEndOffset = self._rangeObj.end
+		# the new endOffset should not have become smaller than the old endOffset, this could cause an infinite loop in
+		# a case where you called move end then collapse until the size of the range is no longer being reduced.
+		# For an example of this see sayAll (specifically readTextHelper_generator in sayAllHandler.py)
+		if end and newEndOffset < oldEndOffset :
 			raise RuntimeError
 
 	def copy(self):

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -120,7 +120,7 @@ class CursorManager(baseObject.ScriptableObject):
 			try:
 				info.collapse(end=posUnitEnd)
 			except RuntimeError:
-				# MS Word has a "virtual linefeed" at the end of the document which can cause RuntimError to be raised.
+				# MS Word has a "virtual linefeed" at the end of the document which can cause RuntimeError to be raised.
 				# In this case it can be ignored.
 				# See #7009
 				pass

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -115,8 +115,15 @@ class CursorManager(baseObject.ScriptableObject):
 		if not self._lastSelectionMovedStart and not oldInfo.isCollapsed:
 			info.move(textInfos.UNIT_CHARACTER,-1)
 		if posUnit is not None:
+			# expand and collapse to ensure that we are aligned with the end of the intended unit
 			info.expand(posUnit)
-			info.collapse(end=posUnitEnd)
+			try:
+				info.collapse(end=posUnitEnd)
+			except RuntimeError:
+				# MS Word has a "virtual linefeed" at the end of the document which can cause RuntimError to be raised.
+				# In this case it can be ignored.
+				# See #7009
+				pass
 			if posUnitEnd:
 				info.move(textInfos.UNIT_CHARACTER,-1)
 		if direction is not None:

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -131,6 +131,7 @@ def readTextHelper_generator(cursor):
 					try:
 						reader.collapse(end=True)
 					except RuntimeError: #MS Word when range covers end of document
+						# Word specific: without this exception to indicate that further collapsing is not posible, say-all could enter an infinite loop.
 						speech.speakWithoutPauses(None)
 						keepReading=False
 			else:


### PR DESCRIPTION
Fix for #7009

When opening a blank word document there seems to be a "virtual line-feed" character. The caret can not be moved past this character (I.E. you can not insert after it). It can be selected and copied, but not deleted. It acts as an exclusive end in `textInfo` end offset. The exception is thrown when the new end offset is less than the old end offset. When calling collapse (with `end=true`) on an object that has its end offset set to this "virtual line-feed" character, the `endOffset` is reduced by one, since start can not be this final character (since its exclusive).

The exception seen in #7009 is used to control the program flow for say-all. Several other options for fixing this have been considered:

### Returning an error code: 
This would require that all implementations of collapse return appropriate values.

### Move the check to the say-all code.
Since say-all seems to be the only thing depending on this functionality (to stop an infinite loop), we could move this check to there. To do this we would be relying on `textInfo.copy()` to cache the pre `collapse` value, and then `textInfo.compareEndpoints()` to see if the `endOffset` was now less. Since there is some concern that `compareEndpoints()` does not behave consistently in all implementations this option is considered too risky.

### Ignore this exception when moving the caret
This PR proposes handling this (by ignoring the exception) in the `_caretMovementScriptHelper` function in `cursorManager.py`.