### PR TITLE
UIAUtils.UIATextRangeAttributeValueFetcher.getValue:  catch COMError 

### DIFF
--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -170,7 +170,10 @@ class UIATextRangeAttributeValueFetcher(object):
 		self.textRange=textRange
 
 	def getValue(self,ID,ignoreMixedValues=False):
-		val=self.textRange.getAttributeValue(ID)
+		try:
+			val=self.textRange.getAttributeValue(ID)
+		except COMError:
+			return UIAHandler.handler.reservedNotSupportedValue
 		if not ignoreMixedValues and val==UIAHandler.handler.ReservedMixedAttributeValue:
 			raise UIAMixedAttributeError
 		return val

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -173,6 +173,7 @@ class UIATextRangeAttributeValueFetcher(object):
 		try:
 			val=self.textRange.getAttributeValue(ID)
 		except COMError:
+			# #7124: some text attributes are not supported in  older Operating Systems 
 			return UIAHandler.handler.reservedNotSupportedValue
 		if not ignoreMixedValues and val==UIAHandler.handler.ReservedMixedAttributeValue:
 			raise UIAMixedAttributeError


### PR DESCRIPTION
IUIAutomationTextRange::getAttributeValue can raise COMError for attribute IDs it doesn't no about (link attribute on E.g. Office 2013 Skype for Business on Windows 7)
Fixes #7124 