### PR TITLE
cursorManager: Fix selecting to end of line when caret is already at end

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -334,13 +334,10 @@ class CursorManager(baseObject.ScriptableObject):
 			self._selectionMovementScriptHelper(unit=textInfos.UNIT_LINE,direction=-1)
 
 	def script_selectToEndOfLine(self,gesture):
-		curInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
-		curInfo.collapse()
-		tempInfo=curInfo.copy()
-		curInfo.expand(textInfos.UNIT_CHARACTER)
-		tempInfo.expand(textInfos.UNIT_LINE)
-		if curInfo.compareEndPoints(tempInfo,"endToEnd")<0:
-			self._selectionMovementScriptHelper(unit=textInfos.UNIT_LINE,direction=1)
+		# #7157: There isn't necessarily a line ending character or insertion point at the end of a line.
+		# Therefore, always allow select to end of line,
+		# even if the caret is already on the last character of the line.
+		self._selectionMovementScriptHelper(unit=textInfos.UNIT_LINE,direction=1)
 
 	def script_selectToTopOfDocument(self,gesture):
 		self._selectionMovementScriptHelper(toPosition=textInfos.POSITION_FIRST)

--- a/tests/unit/test_cursorManager.py
+++ b/tests/unit/test_cursorManager.py
@@ -27,6 +27,13 @@ class TestMove(unittest.TestCase):
 		cm.script_moveByCharacter_back(None)
 		self.assertEqual(cm.selectionOffsets, (0, 0)) # Caret at "a"
 
+	def test_endOfLine(self):
+		"""End of line in a CursorManager moves to the last character; there is no "insertion point".
+		"""
+		cm = CursorManager(text="ab") # Caret at "a"
+		cm.script_endOfLine(None)
+		self.assertEqual(cm.selectionOffsets, (1, 1)) # Caret at "b"
+
 class TestSelection(unittest.TestCase):
 
 	def test_selForward(self):
@@ -154,6 +161,15 @@ class TestSelection(unittest.TestCase):
 		cm = CursorManager(text="ab\ncd", selection=(4, 4)) # Caret at "d"
 		cm.script_selectToBeginningOfLine(None)
 		self.assertEqual(cm.selectionOffsets, (3, 4)) # "c" selected
+
+	def test_selToEndOfLineAtEnd(self):
+		"""Test selecting to the end of the line after moving to the end of the line (#7157).
+		End of line in a CursorManager moves to the last character; there is no "insertion point".
+		So, doing this must select the last character.
+		"""
+		cm = CursorManager(text="ab", selection=(1, 1)) # Caret at "b"
+		cm.script_selectToEndOfLine(None)
+		self.assertEqual(cm.selectionOffsets, (1, 2)) # "b" selected
 
 	def test_selToBeginningOfLineAtBeginning(self):
 		"""Test selecting to the beginning of the line when the caret is already at the beginning of the line.


### PR DESCRIPTION
In browse mode, you can now select or unselect to the end of the line using shift+end even when the caret is on the last character of the line.

Fixes #7157.