### PR TITLE
Include milliseconds in log timestamps.

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -307,6 +307,9 @@ def initialize(shouldDoRemoteLogging=False):
 	logging.addLevelName(Logger.DEBUGWARNING, "DEBUGWARNING")
 	logging.addLevelName(Logger.IO, "IO")
 	if not shouldDoRemoteLogging:
+		# This produces log entries such as the following:
+		# IO - inputCore.InputManager.executeGesture (09:17:40.724):
+		# Input: kb(desktop):v
 		logFormatter=Formatter("%(levelname)s - %(codepath)s (%(asctime)s.%(msecs)03d):\n%(message)s", "%H:%M:%S")
 		if globalVars.appArgs.secure:
 			# Don't log in secure mode.

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,3 +1,9 @@
+#logHandler.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2007-2016 NV Access Limited, Rui Batista
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
 """Utilities and classes to manage logging in NVDA"""
 
 import os
@@ -301,7 +307,7 @@ def initialize(shouldDoRemoteLogging=False):
 	logging.addLevelName(Logger.DEBUGWARNING, "DEBUGWARNING")
 	logging.addLevelName(Logger.IO, "IO")
 	if not shouldDoRemoteLogging:
-		logFormatter=Formatter("%(levelname)s - %(codepath)s (%(asctime)s):\n%(message)s", "%H:%M:%S")
+		logFormatter=Formatter("%(levelname)s - %(codepath)s (%(asctime)s.%(msecs)03d):\n%(message)s", "%H:%M:%S")
 		if globalVars.appArgs.secure:
 			# Don't log in secure mode.
 			logHandler = logging.NullHandler()


### PR DESCRIPTION
This will make it possible to measure response time in logs. We almost always want things to respond faster than one second, so second granularity is useless for this purpose.

I used the technique suggested in [this Stackoverflow answer](http://stackoverflow.com/a/7517430).