### PR TITLE
Do not allow the name to be content when the object is editable

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -804,7 +804,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 			}
 		}
 
-		if ((nameIsContent || role == IA2_ROLE_SECTION || role == IA2_ROLE_TEXT_FRAME) && !nodeHasUsefulContent(parentNode)) {
+		if (!isEditable && (nameIsContent || role == IA2_ROLE_SECTION || role == IA2_ROLE_TEXT_FRAME) && !nodeHasUsefulContent(parentNode)) {
 			// If there is no useful content and the name can be the content,
 			// render the name if there is one.
 			if(name) {


### PR DESCRIPTION
### Link to issue number:
Fixes #7153

### Summary of the issue:
In some situations (see issue for details) the label of an edit field is read as the value in browse mode.

### Description of how this pull request fixes the issue:
When dealing with an editable object, the name should not be used as content.

### Testing performed:
Compared the output of chrome in browse mode using the data URI examples provided on the issue. 

### Change log entry:
Bug fixes:
- Editable div elements in Chrome are no longer have their label reported as their value while in browse mode.

