### PR TITLE
Split braille cursor shape into separate shapes for focus and review

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1570,7 +1570,10 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			return
 		cells = list(self._cells)
 		if self._cursorPos is not None and self._cursorBlinkUp:
-			cells[self._cursorPos] |= config.conf["braille"]["cursorShape"]
+			if self.tether == self.TETHER_FOCUS:
+				cells[self._cursorPos] |= config.conf["braille"]["cursorShapeFocus"]
+			else:
+				cells[self._cursorPos] |= config.conf["braille"]["cursorShapeReview"]
 		self._writeCells(cells)
 
 	def _blink(self):

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -11,7 +11,7 @@ from configobj import ConfigObj
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config 
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 1
+latestSchemaVersion = 2
 
 #: The configuration specification string
 #: @type: String
@@ -56,7 +56,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	showCursor = boolean(default=true)
 	cursorBlink = boolean(default=true)
 	cursorBlinkRate = integer(default=500,min=200,max=2000)
-	cursorShape = integer(default=192,min=1,max=255)
+	cursorShapeFocus = integer(default=192,min=1,max=255)
+	cursorShapeReview = integer(default=128,min=1,max=255)
 	messageTimeout = integer(default=4,min=0,max=20)
 	tetherTo = string(default="focus")
 	readByParagraph = boolean(default=false)

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -38,8 +38,10 @@ def upgradeConfigFrom_1_to_2(profile):
 	# Previously, the same cursor shape was used for focus and review
 	try:
 		cursorShape = int(profile["braille"]["cursorShape"])
-		profile["braille"]["cursorShapeFocus"] = profile["braille"]["cursorShapeReview"] = cursorShape
 	except KeyError as e:
 		# Setting does not exist, no need for upgrade of this setting
 		log.debug("No cursorShape, no action taken.")
 		pass
+	else:
+		del profile["braille"]["cursorShape"]
+		profile["braille"]["cursorShapeFocus"] = cursorShape

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -28,7 +28,18 @@ def upgradeConfigFrom_0_to_1(profile):
 		pass
 	else:
 		newMinBlinkRate = 200
-		if blinkRate < newMinBlinkRate :
+		if blinkRate < newMinBlinkRate:
 			profile["braille"]["cursorBlinkRate"] = newMinBlinkRate
-			if blinkRate < 1 :
+			if blinkRate < 1:
 				profile["braille"]["cursorBlink"] = False
+
+def upgradeConfigFrom_1_to_2(profile):
+	# Schema has been modified to split cursor shape into focus and review shapes
+	# Previously, the same cursor shape was used for focus and review
+	try:
+		cursorShape = int(profile["braille"]["cursorShape"])
+		profile["braille"]["cursorShapeFocus"] = profile["braille"]["cursorShapeReview"] = cursorShape
+	except KeyError as e:
+		# Setting does not exist, no need for upgrade of this setting
+		log.debug("No cursorShape, no action taken.")
+		pass

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1712,13 +1712,17 @@ class GlobalCommands(ScriptableObject):
 			ui.message(_("Braille cursor is turned off"))
 			return
 		shapes = [s[0] for s in braille.CURSOR_SHAPES]
+		if braille.handler.tether == braille.handler.TETHER_FOCUS:
+			cursorShape = "cursorShapeFocus"
+		else:
+			cursorShape = "cursorShapeReview"
 		try:
-			index = shapes.index(config.conf["braille"]["cursorShape"]) + 1
+			index = shapes.index(config.conf["braille"][cursorShape]) + 1
 		except:
 			index = 1
 		if index >= len(braille.CURSOR_SHAPES):
 			index = 0
-		config.conf["braille"]["cursorShape"] = braille.CURSOR_SHAPES[index][0]
+		config.conf["braille"][cursorShape] = braille.CURSOR_SHAPES[index][0]
 		shapeMsg = braille.CURSOR_SHAPES[index][1]
 		# Translators: Reports which braille cursor shape is activated.
 		ui.message(_("Braille cursor %s") % shapeMsg)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1573,18 +1573,30 @@ class BrailleSettingsDialog(SettingsDialog):
 		if not self.showCursorCheckBox.GetValue() or not self.cursorBlinkCheckBox.GetValue() :
 			self.cursorBlinkRateEdit.Disable()
 
-		# Translators: The label for a setting in braille settings to select the cursor shape.
-		cursorShapeLabelText = _("Cursor &shape:")
 		self.cursorShapes = [s[0] for s in braille.CURSOR_SHAPES]
 		cursorShapeChoices = [s[1] for s in braille.CURSOR_SHAPES]
-		self.shapeList = sHelper.addLabeledControl(cursorShapeLabelText, wx.Choice, choices=cursorShapeChoices)
+
+		# Translators: The label for a setting in braille settings to select the cursor shape when tethered to focus.
+		cursorShapeFocusLabelText = _("Cursor shape for &focus:")
+		self.cursorShapeFocusList = sHelper.addLabeledControl(cursorShapeFocusLabelText, wx.Choice, choices=cursorShapeChoices)
 		try:
-			selection = self.cursorShapes.index(config.conf["braille"]["cursorShape"])
-			self.shapeList.SetSelection(selection)
+			selection = self.cursorShapes.index(config.conf["braille"]["cursorShapeFocus"])
+			self.cursorShapeFocusList.SetSelection(selection)
 		except:
 			pass
 		if not self.showCursorCheckBox.GetValue():
-			self.shapeList.Disable()
+			self.cursorShapeFocusList.Disable()
+
+		# Translators: The label for a setting in braille settings to select the cursor shape when tethered to review.
+		cursorShapeReviewLabelText = _("Cursor shape for &review:")
+		self.cursorShapeReviewList = sHelper.addLabeledControl(cursorShapeReviewLabelText, wx.Choice, choices=cursorShapeChoices)
+		try:
+			selection = self.cursorShapes.index(config.conf["braille"]["cursorShapeReview"])
+			self.cursorShapeReviewList.SetSelection(selection)
+		except:
+			pass
+		if not self.showCursorCheckBox.GetValue():
+			self.cursorReviewShapeList.Disable()
 
 		# Translators: The label for a setting in braille settings to change how long a message stays on the braille display (in seconds).
 		messageTimeoutText = _("Message timeout (sec)")
@@ -1635,7 +1647,8 @@ class BrailleSettingsDialog(SettingsDialog):
 		config.conf["braille"]["showCursor"] = self.showCursorCheckBox.GetValue()
 		config.conf["braille"]["cursorBlink"] = self.cursorBlinkCheckBox.GetValue()
 		config.conf["braille"]["cursorBlinkRate"] = self.cursorBlinkRateEdit.GetValue()
-		config.conf["braille"]["cursorShape"] = self.cursorShapes[self.shapeList.GetSelection()]
+		config.conf["braille"]["cursorShapeFocus"] = self.cursorShapes[self.cursorShapeFocusList.GetSelection()]
+		config.conf["braille"]["cursorShapeReview"] = self.cursorShapes[self.cursorShapeReviewList.GetSelection()]
 		config.conf["braille"]["messageTimeout"] = self.messageTimeoutEdit.GetValue()
 		braille.handler.tether = self.tetherValues[self.tetherList.GetSelection()][0]
 		config.conf["braille"]["readByParagraph"] = self.readByParagraphCheckBox.Value
@@ -1670,7 +1683,8 @@ class BrailleSettingsDialog(SettingsDialog):
 	def onShowCursorChange(self, evt):
 		self.cursorBlinkCheckBox.Enable(evt.IsChecked())
 		self.cursorBlinkRateEdit.Enable(evt.IsChecked() and self.cursorBlinkCheckBox.GetValue())
-		self.shapeList.Enable(evt.IsChecked())
+		self.cursorShapeFocusList.Enable(evt.IsChecked())
+		self.cursorShapeReviewList.Enable(evt.IsChecked())
 
 	def onBlinkCursorChange(self, evt):
 		self.cursorBlinkRateEdit.Enable(evt.IsChecked())

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1596,7 +1596,7 @@ class BrailleSettingsDialog(SettingsDialog):
 		except:
 			pass
 		if not self.showCursorCheckBox.GetValue():
-			self.cursorReviewShapeList.Disable()
+			self.cursorShapeReviewList.Disable()
 
 		# Translators: The label for a setting in braille settings to change how long a message stays on the braille display (in seconds).
 		messageTimeoutText = _("Message timeout (sec)")

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -955,13 +955,18 @@ It applies to the system caret and review cursor, but not to the selection indic
 ==== Blink Cursor ====
 This option allows the braille cursor to blink.
 If blinking is turned off, the braille cursor will constantly be in the "up" position.
+The selection indicator is not affected by this option, it is always dots 7 and 8 without blinking.
 
 ==== Cursor Blink Rate (ms) ====
 This option is a numerical field that allows you to change the blink rate of the cursor in milliseconds.
 
-==== Cursor Shape ====
-This option allows you to choose the shape (dot pattern) of the braille cursor.
-The selection indicator is not affected by this option.
+==== Cursor Shape for Focus ====
+This option allows you to choose the shape (dot pattern) of the braille cursor when braille is tethered to focus.
+The selection indicator is not affected by this option, it is always dots 7 and 8 without blinking.
+
+==== Cursor Shape for Review ====
+This option allows you to choose the shape (dot pattern) of the braille cursor when braille is tethered to review.
+The selection indicator is not affected by this option, it is always dots 7 and 8 without blinking.
 
 ==== Message Timeout (sec) ====
 This option is a numerical field that controls how long NVDA messages are displayed on the braille display.


### PR DESCRIPTION
Use case provided by @derekriemer in https://github.com/nvaccess/nvda/issues/7122#issuecomment-298318351
Fixes #7122.

Tested by running the patch, switching between focus and review, and cycling the cursor shape.