### PR TITLE
Support math in Chrome

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -58,7 +58,9 @@ class Math(Ia2Web):
 		try:
 			node = self.IAccessibleObject.QueryInterface(ISimpleDOMNode)
 			# Try the data-mathml attribute.
-			attr = node.attributesForNames(1, (BSTR * 1)("data-mathml"), (c_short * 1)(0,))
+			attrNames = (BSTR * 1)("data-mathml")
+			namespaceIds = (c_short * 1)(0)
+			attr = node.attributesForNames(1, attrNames, namespaceIds)
 			if attr:
 				import mathPres
 				if not mathPres.getLanguageFromMath(attr) and self.language:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -2,14 +2,17 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2015 NV Access Limited
+#Copyright (C) 2006-2017 NV Access Limited
 
 """Base classes with common support for browsers exposing IAccessible2.
 """
 
+from ctypes import c_short
+from comtypes import COMError, BSTR
 import oleacc
 import IAccessibleHandler
 import controlTypes
+from logHandler import log
 from NVDAObjects.behaviors import Dialog
 from . import IAccessible
 from .ia2TextMozilla import MozillaCompoundTextInfo
@@ -48,6 +51,32 @@ class Editor(Ia2Web):
 class EditorChunk(Ia2Web):
 	beTransparentToMouse = True
 
+class Math(Ia2Web):
+
+	def _get_mathMl(self):
+		from comtypes.gen.ISimpleDOM import ISimpleDOMNode
+		try:
+			node = self.IAccessibleObject.QueryInterface(ISimpleDOMNode)
+			# Try the data-mathml attribute.
+			attr = node.attributesForNames(1, (BSTR * 1)("data-mathml"), (c_short * 1)(0,))
+			if attr:
+				import mathPres
+				if not mathPres.getLanguageFromMath(attr) and self.language:
+					attr = mathPres.insertLanguageIntoMath(attr, self.language)
+				return attr
+			if self.IA2Attributes.get("tag") != "math":
+				# This isn't MathML.
+				raise LookupError
+			if self.language:
+				attrs = ' xml:lang="%s"' % self.language
+			else:
+				attrs = ""
+			return "<math%s>%s</math>" % (attrs, node.innerHTML)
+		except COMError:
+			log.debugWarning("Error retrieving math. "
+				"Not supported in this browser or ISimpleDOM COM proxy not registered.", exc_info=True)
+			raise LookupError
+
 def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 	"""Determine the most appropriate class if this is an IA2 web object.
 	This should be called after finding any classes for the specific web implementation.
@@ -64,6 +93,8 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 		clsList.append(BlockQuote)
 	elif iaRole == oleacc.ROLE_SYSTEM_ALERT:
 		clsList.append(Dialog)
+	elif iaRole == oleacc.ROLE_SYSTEM_EQUATION:
+		clsList.append(Math)
 
 	isApp = iaRole in (oleacc.ROLE_SYSTEM_APPLICATION, oleacc.ROLE_SYSTEM_DIALOG)
 	if isApp:

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -3,14 +3,13 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2015 NV Access Limited, Peter Vágner
+#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner
 
 from collections import namedtuple
-from ctypes import c_short
 import IAccessibleHandler
 import oleacc
 import winUser
-from comtypes import IServiceProvider, COMError, BSTR
+from comtypes import IServiceProvider, COMError
 import eventHandler
 import controlTypes
 from . import IAccessible, Dialog, WindowRoot
@@ -156,27 +155,6 @@ class TextLeaf(Mozilla):
 	role = controlTypes.ROLE_STATICTEXT
 	beTransparentToMouse = True
 
-class Math(Mozilla):
-
-	def _get_mathMl(self):
-		from comtypes.gen.ISimpleDOM import ISimpleDOMNode
-		node = self.IAccessibleObject.QueryInterface(ISimpleDOMNode)
-		# Try the data-mathml attribute.
-		attr = node.attributesForNames(1, (BSTR * 1)("data-mathml"), (c_short * 1)(0,))
-		if attr:
-			import mathPres
-			if not mathPres.getLanguageFromMath(attr) and self.language:
-				attr = mathPres.insertLanguageIntoMath(attr, self.language)
-			return attr
-		if self.IA2Attributes.get("tag") != "math":
-			# This isn't MathML.
-			raise LookupError
-		if self.language:
-			attrs = ' xml:lang="%s"' % self.language
-		else:
-			attrs = ""
-		return "<math%s>%s</math>" % (attrs, node.innerHTML)
-
 def findExtraOverlayClasses(obj, clsList):
 	"""Determine the most appropriate class if this is a Mozilla object.
 	This works similarly to L{NVDAObjects.NVDAObject.findOverlayClasses} except that it never calls any other findOverlayClasses method.
@@ -238,7 +216,6 @@ _IAccessibleRolesToOverlayClasses = {
 	IAccessibleHandler.IA2_ROLE_EMBEDDED_OBJECT: EmbeddedObject,
 	"embed": EmbeddedObject,
 	"object": EmbeddedObject,
-	oleacc.ROLE_SYSTEM_EQUATION: Math,
 }
 
 #: Roles that mightn't set the focused state when they are focused.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -542,7 +542,7 @@ This requires that MathPlayer 4 is installed on the computer.
 MathPlayer is available as a free download from: http://www.dessci.com/en/products/mathplayer/
 
 NVDA supports the following types of mathematical content:
-- MathML in Mozilla Firefox and Microsoft Internet Explorer.
+- MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.
 - Design Science MathType in Microsoft Word and PowerPoint. MathType needs to be installed in order for this to work. The trial version is sufficient.
 - MathML in Adobe Reader. Note that this is not an official standard yet, so there is currently no publicly available software that can produce this content.
 -


### PR DESCRIPTION
### Link to issue number:
No specific issue. However, lack of support for math in Chrome was mentioned in https://github.com/nvaccess/nvda/issues/5555#issuecomment-160582068. [Chromium issue 426650](https://bugs.chromium.org/p/chromium/issues/detail?id=426650) is the issue I filed against Chrome requesting the bits we needed to make this work.

### Summary of the issue:
Math is currently supported in Firefox and IE, but not Chrome. This PR makes it work in Chrome.

### Description of how this pull request fixes the issue:
Now that the Chrome issue linked above is fixed (and has been for a few months), we can use the same math retrieval code we use for Firefox. Since both Firefox and Chrome use `NVDAObjects.IAccessible.ia2Web`, I moved the math code from `NVDAObjects.IAccessible.mozilla` into `ia2Web`. In addition to moving the code, we also catch COMError because this isn't yet in Chrome stable and because this can fail in Firefox too if the ISimpleDOM COM proxy isn't registered.

### Testing performed:
Tested the following test case in Firefox nightly (55.0a1 (2017-05-16)), Chrome canary (60.0.3102.0) and Chrome stable (58.0.3029.110):
`data:text/html,<math><mfrac><mn>2</mn><mi>x</mi></mfrac></math>text`
In Firefox and Chrome stable, I got "2 over x text" as expected.
In Chrome stable, I got just "text", which is expected because math isn't supported there.

### Known issues with pull request:
Math isn't supported in Chrome stable at present, but we handle it gracefully and this will just start working once Chrome 59 is released and users are updated. [Chrome 59 is due on 6 June](https://www.chromium.org/developers/calendar), which is more than two months before NVDA 2017.3 will be released, so I didn't see any need to mention the Chrome version number in the User Guide.

### Change log entry:
In New Features:

```
- Mathematical content (provided as MathML) is now supported in Google Chrome. (#7184)
```