### PR TITLE
Fixed Brailliant BI dot 7 missing backspace ( #7186)

### DIFF
--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -255,6 +255,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			"kb:alt": ("br(brailliantB):space+dot1+dot3+dot4",),
 			"kb:escape": ("br(brailliantB):space+dot1+dot5",),
 			"kb:enter": ("br(brailliantB):dot8",),
+			"kb:backspace": ("br(brailliantB):dot7",),
 			"kb:windows+d": ("br(brailliantB):c1+c4+c5",),
 			"kb:windows": ("br(brailliantB):space+dot3+dot4",),
 			"kb:alt+tab": ("br(brailliantB):space+dot2+dot3+dot4+dot5",),


### PR DESCRIPTION
### Link to issue number:
Brailliant BI Dot 7 Backspace not working #7186

### Summary of the issue:
dot 7 key does not backspace but instead gives \7/ code

### Description of how this pull request fixes the issue:
Adds in missing line for the backspace  in the brailliantB display drive file

 
### Testing performed:
Opened text editors and was able to backspace/ delete characters using dot 7 key
