### PR TITLE
Fix exception: using indefinite braille messages

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1663,7 +1663,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		"""
 		self.buffer.clear()
 		self.buffer = self.mainBuffer
-		if not config.conf["braille"]["noMessageTimeout"]:
+		if self._messageCallLater:
 			self._messageCallLater.Stop()
 			self._messageCallLater = None
 		self.update()


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/issues/6669#issuecomment-304929030

### Summary of the issue:
This fixes an exception when using the indefinite braille messages feature. For more information see comment on PR #6669 

STR:
- Make sure the default profile does not have the setting to show messages indefinitely.
- Create an app-specific config profile and choose the new feature to show messages indefinitely.
- Go to the application and trigger a message, e.g. by pressing NVDA+t to report the title bar.
- Go to the desktop or switch out of the application.

### Description of how this pull request fixes the issue:
When the "indefinite braille message" option is set, we do not populate _messageCallLater. When dismissing the message, regardless of the current state of the "indefinite braille message" option we only need to stop and clear the _messageCallLater variable if it exists.

### Testing performed:
Ran the steps to reproduce, checked that the log no longer contains an error.

### Known issues with pull request:
None

### Change log entry:
None necessary