### PR TITLE
Allow quick navigation for spelling errors in MS Word using w and shift+w

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,6 +1,6 @@
 #appModules/winword.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2016 NV Access Limited, Manish Agrawal, Derek Riemer
+#Copyright (C) 2006-2017 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -391,15 +391,6 @@ class WordDocumentSpellingErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
 	def label(self):
 		return _(u"spelling: {text}").format(text=super(WordDocumentSpellingErrorQuickNavItem,self).label)
 
-class WordDocumentGrammaticalErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
-
-	def rangeFromCollectionItem(self,item):
-		return item
-
-	@property
-	def label(self):
-		return _(u"grammar: {text}").format(text=super(WordDocumentGrammaticalErrorQuickNavItem,self).label)
-
 class WinWordCollectionQuicknavIterator(object):
 	"""
 	Allows iterating over an MS Word collection (e.g. HyperLinks) emitting L{QuickNavItem} objects.
@@ -498,11 +489,6 @@ class SpellingErrorWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIt
 	quickNavItemClass=WordDocumentSpellingErrorQuickNavItem
 	def collectionFromRange(self,rangeObj):
 		return rangeObj.spellingErrors
-
-class GrammaticalErrorWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
-	quickNavItemClass=WordDocumentGrammaticalErrorQuickNavItem
-	def collectionFromRange(self,rangeObj):
-		return rangeObj.grammaticalErrors
 
 class GraphicWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
 	def collectionFromRange(self,rangeObj):
@@ -1024,9 +1010,7 @@ class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 		elif nodeType in ("table","container"):
 			return TableWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 		elif nodeType=="error":
-			spellingErrors=SpellingErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
-			grammaticalErrors=GrammaticalErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
-			return browseMode.mergeQuickNavItemIterators([spellingErrors,grammaticalErrors],direction)
+			return SpellingErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 		elif nodeType=="graphic":
 			return GraphicWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 		elif nodeType.startswith('heading'):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1715,4 +1715,7 @@ class ElementsListDialog(browseMode.ElementsListDialog):
 		# Translators: The label of a radio button to select the type of element
 		# in the browse mode Elements List dialog.
 		("annotation", _("&Annotations")),
+		# Translators: The label of a radio button to select the type of element
+		# in the browse mode Elements List dialog.
+		("spellingError", _("S&pelling/grammar errors")),
 	)

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -389,7 +389,8 @@ class WordDocumentSpellingErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
 
 	@property
 	def label(self):
-		return _(u"spelling: {text}").format(text=super(WordDocumentSpellingErrorQuickNavItem,self).label)
+		text=self.collectionItem.text
+		return _(u"spelling: {text}").format(text=text)
 
 class WinWordCollectionQuicknavIterator(object):
 	"""

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1010,7 +1010,7 @@ class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 			return browseMode.mergeQuickNavItemIterators([comments,revisions],direction)
 		elif nodeType in ("table","container"):
 			return TableWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
-		elif nodeType=="spellingError":
+		elif nodeType=="error":
 			spellingErrors=SpellingErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 			grammaticalErrors=GrammaticalErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 			return browseMode.mergeQuickNavItemIterators([spellingErrors,grammaticalErrors],direction)
@@ -1717,5 +1717,5 @@ class ElementsListDialog(browseMode.ElementsListDialog):
 		("annotation", _("&Annotations")),
 		# Translators: The label of a radio button to select the type of element
 		# in the browse mode Elements List dialog.
-		("spellingError", _("S&pelling/grammar errors")),
+		("error", _("&errors")),
 	)

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -382,6 +382,11 @@ class WordDocumentRevisionQuickNavItem(WordDocumentCollectionQuickNavItem):
 		text=(self.collectionItem.range.text or "")[:100]
 		return _(u"{revisionType} {description}: {text} by {author} on {date}").format(revisionType=revisionType,author=author,text=text,date=date,description=description)
 
+class WordDocumentSpellingErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
+
+	def rangeFromCollectionItem(self,item):
+		return item
+
 class WinWordCollectionQuicknavIterator(object):
 	"""
 	Allows iterating over an MS Word collection (e.g. HyperLinks) emitting L{QuickNavItem} objects.
@@ -475,6 +480,16 @@ class RevisionWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterato
 	quickNavItemClass=WordDocumentRevisionQuickNavItem
 	def collectionFromRange(self,rangeObj):
 		return rangeObj.revisions
+
+class SpellingErrorWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
+	quickNavItemClass=WordDocumentSpellingErrorQuickNavItem
+	def collectionFromRange(self,rangeObj):
+		return rangeObj.spellingErrors
+
+class GrammaticalErrorWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
+	quickNavItemClass=WordDocumentSpellingErrorQuickNavItem
+	def collectionFromRange(self,rangeObj):
+		return rangeObj.grammaticalErrors
 
 class GraphicWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
 	def collectionFromRange(self,rangeObj):
@@ -994,9 +1009,13 @@ class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 			revisions=RevisionWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 			return browseMode.mergeQuickNavItemIterators([comments,revisions],direction)
 		elif nodeType in ("table","container"):
-			 return TableWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
+			return TableWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
+		elif nodeType=="spellingError":
+			spellingErrors=SpellingErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
+			grammaticalErrors=GrammaticalErrorWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
+			return browseMode.mergeQuickNavItemIterators([spellingErrors,grammaticalErrors],direction)
 		elif nodeType=="graphic":
-			 return GraphicWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
+			return GraphicWinWordCollectionQuicknavIterator(nodeType,self,direction,rangeObj,includeCurrent).iterate()
 		elif nodeType.startswith('heading'):
 			return self._iterHeadings(nodeType,direction,rangeObj,includeCurrent)
 		else:

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -387,6 +387,19 @@ class WordDocumentSpellingErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
 	def rangeFromCollectionItem(self,item):
 		return item
 
+	@property
+	def label(self):
+		return _(u"spelling: {text}").format(text=super(WordDocumentSpellingErrorQuickNavItem,self).label)
+
+class WordDocumentGrammaticalErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
+
+	def rangeFromCollectionItem(self,item):
+		return item
+
+	@property
+	def label(self):
+		return _(u"grammar: {text}").format(text=super(WordDocumentGrammaticalErrorQuickNavItem,self).label)
+
 class WinWordCollectionQuicknavIterator(object):
 	"""
 	Allows iterating over an MS Word collection (e.g. HyperLinks) emitting L{QuickNavItem} objects.
@@ -487,7 +500,7 @@ class SpellingErrorWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIt
 		return rangeObj.spellingErrors
 
 class GrammaticalErrorWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
-	quickNavItemClass=WordDocumentSpellingErrorQuickNavItem
+	quickNavItemClass=WordDocumentGrammaticalErrorQuickNavItem
 	def collectionFromRange(self,rangeObj):
 		return rangeObj.grammaticalErrors
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -687,6 +687,15 @@ qn("annotation", key="a",
 	prevDoc=_("moves to the previous annotation"),
 	# Translators: Message presented when the browse mode element is not found.
 	prevError=_("no previous annotation"))
+qn("spellingError", key="p",
+	# Translators: Input help message for a quick navigation command in browse mode.
+	nextDoc=_("moves to the next spelling error"),
+	# Translators: Message presented when the browse mode element is not found.
+	nextError=_("no next spelling error"),
+	# Translators: Input help message for a quick navigation command in browse mode.
+	prevDoc=_("moves to the previous spelling error"),
+	# Translators: Message presented when the browse mode element is not found.
+	prevError=_("no previous spelling error"))
 del qn
 
 class ElementsListDialog(wx.Dialog):

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -687,15 +687,15 @@ qn("annotation", key="a",
 	prevDoc=_("moves to the previous annotation"),
 	# Translators: Message presented when the browse mode element is not found.
 	prevError=_("no previous annotation"))
-qn("spellingError", key="p",
+qn("error", key="w",
 	# Translators: Input help message for a quick navigation command in browse mode.
-	nextDoc=_("moves to the next spelling error"),
+	nextDoc=_("moves to the next error"),
 	# Translators: Message presented when the browse mode element is not found.
-	nextError=_("no next spelling error"),
+	nextError=_("no next error"),
 	# Translators: Input help message for a quick navigation command in browse mode.
-	prevDoc=_("moves to the previous spelling error"),
+	prevDoc=_("moves to the previous error"),
 	# Translators: Message presented when the browse mode element is not found.
-	prevError=_("no previous spelling error"))
+	prevError=_("no previous error"))
 del qn
 
 class ElementsListDialog(wx.Dialog):

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,6 +1,6 @@
 #browseMode.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2016 NV Access Limited
+#Copyright (C) 2007-2017 NV Access Limited, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -502,7 +502,7 @@ The following keys by themselves jump to the next available element, while addin
 - o: embedded object
 - 1 to 6: headings at levels 1 to 6 respectively
 - a: annotation (comment, editor revision, etc.)
-- w: error (spelling error, grammatical error, etc.)
+- w: spelling error
 -
 To move to the beginning or end of containing elements such as lists and tables:
 || Name | Key | Description |
@@ -603,7 +603,7 @@ For further information about Browse mode and Quick Navigation, see the [Browse 
 %kc:beginInclude
 While in Browse mode in Microsoft Word, you can access the Elements List by pressing NVDA+f7.
 %kc:endInclude
-The Elements List can list headings, links, annotations (which includes comments and track changes) and errors (such as spelling and grammatical errors).
+The Elements List can list headings, links, annotations (which includes comments and track changes) and errors (currently limited to spelling errors).
 
 +++ Reporting Comments +++
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -502,6 +502,7 @@ The following keys by themselves jump to the next available element, while addin
 - o: embedded object
 - 1 to 6: headings at levels 1 to 6 respectively
 - a: annotation (comment, editor revision, etc.)
+- w: error (spelling error, grammatical error, etc.)
 -
 To move to the beginning or end of containing elements such as lists and tables:
 || Name | Key | Description |
@@ -602,7 +603,7 @@ For further information about Browse mode and Quick Navigation, see the [Browse 
 %kc:beginInclude
 While in Browse mode in Microsoft Word, you can access the Elements List by pressing NVDA+f7.
 %kc:endInclude
-The Elements List can list headings, links and annotations (which includes comments and track changes).
+The Elements List can list headings, links, annotations (which includes comments and track changes) and errors (such as spelling and grammatical errors).
 
 +++ Reporting Comments +++
 %kc:beginInclude


### PR DESCRIPTION
### Link to issue number:
#6942

### Summary of the issue:
Currently, there is no effective way in MS Word to list and navigate spelling errors. There is the alt+f7 key stroke, but activating that automatically pop ups the context menu to change the particular error.

### Description of how this pull request fixes the issue:
This pull request adds a new quick navigation command for errors, bound to the letter w. Consult the discussion in #6942 for more details about how we made this decision.

The error command navigates to spelling and grammatical errors in Word. Also, errors have been added to the Word elements list and can be listed there.

### Testing performed:
Purposely made some grammar and spelling mistakes. I was able to jump through those with w (forwards) and shift+w (backwards). Also, I was able to list them in the elements list. Spelling errors which are part of grammatical errors are shown at a sub level in the elements list tree, as expected.

### Known issues with pull request:
Spelling and grammar checking while typing should have been enabled in Word for this feature to work correctly. Spelling error checking is enabled by default, for grammar, this doesn't seem to be the case. should we document this?

### Change log entry:
* New features
	+ In Microsoft Word, it is now possible to navigate to spelling and grammatical errors using quick navigation (w and shift+w) (#6942)