### PR TITLE
Make all braille landmark abbreviations translatable

### DIFF
--- a/source/aria.py
+++ b/source/aria.py
@@ -66,22 +66,22 @@ ariaSortValuesToNVDAStates={
 
 landmarkRoles = {
 	# Translators: Reported for the banner landmark, normally found on web pages.
-	"banner": _("banner"),
+	"banner": pgettext("aria", "banner"),
 	# Translators: Reported for the complementary landmark, normally found on web pages.
-	"complementary": _("complementary"),
+	"complementary": pgettext("aria", "complementary"),
 	# Translators: Reported for the contentinfo landmark, normally found on web pages.
-	"contentinfo": _("content info"),
+	"contentinfo": pgettext("aria", "content info"),
 	# Translators: Reported for the main landmark, normally found on web pages.
-	"main": _("main"),
+	"main": pgettext("aria", "main"),
 	# Translators: Reported for the navigation landmark, normally found on web pages.
-	"navigation": _("navigation"),
+	"navigation": pgettext("aria", "navigation"),
 	# Translators: Reported for the search landmark, normally found on web pages.
-	"search": _("search"),
+	"search": pgettext("aria", "search"),
 	# Translators: Reported for the form landmark, normally found on web pages.
-	"form": _("form"),
+	"form": pgettext("aria", "form"),
 	# Strictly speaking, region isn't a landmark, but it is very similar.
 	# Translators: Reported for a significant region, normally found on web pages.
-	"region": _("region"),
+	"region": pgettext("aria", "region"),
 }
 
 htmlNodeNameToAriaLandmarkRoles = {

--- a/source/braille.py
+++ b/source/braille.py
@@ -380,22 +380,22 @@ negativeStateLabels = {
 
 landmarkLabels = {
 	# Translators: Displayed in braille for the banner landmark, normally found on web pages.
-	"banner": _("bnnr"),
+	"banner": pgettext("braille landmark abbreviation", "bnnr"),
 	# Translators: Displayed in braille for the complementary landmark, normally found on web pages.
-	"complementary": _("cmpl"),
+	"complementary": pgettext("braille landmark abbreviation", "cmpl"),
 	# Translators: Displayed in braille for the contentinfo landmark, normally found on web pages.
-	"contentinfo": _("cinf"),
+	"contentinfo": pgettext("braille landmark abbreviation", "cinf"),
 	# Translators: Displayed in braille for the main landmark, normally found on web pages.
-	"main": _("main"),
+	"main": pgettext("braille landmark abbreviation", "main"),
 	# Translators: Displayed in braille for the navigation landmark, normally found on web pages.
-	"navigation": _("navi"),
+	"navigation": pgettext("braille landmark abbreviation", "navi"),
 	# Translators: Displayed in braille for the search landmark, normally found on web pages.
-	"search": _("srch"),
+	"search": pgettext("braille landmark abbreviation", "srch"),
 	# Translators: Displayed in braille for the form landmark, normally found on web pages.
-	"form": _("form"),
+	"form": pgettext("braille landmark abbreviation", "form"),
 	# Strictly speaking, region isn't a landmark, but it is very similar.
 	# Translators: Displayed in braille for a significant region, normally found on web pages.
-	"region": _("rgn"),
+	"region": pgettext("braille landmark abbreviation", "rgn"),
 }
 
 #: Cursor shapes


### PR DESCRIPTION
### Link to issue number:
#3975, #6813

### Summary of the issue:
Two landmark names, main and form, are already quite short so they were not abbreviated in braille. This causes an overlap with the general definitions in aria.py. That in turn makes them untranslatable. See https://github.com/nvaccess/nvda/issues/3975#issuecomment-306117455

### Description of how this pull request fixes the issue:
The translatable strings for all landmark names in aria.py and braille.py now use `pgettext`. This is technically only necessary for main and form, but for consistency I did this for all landmark names.

### Testing performed:
Syntax checked. Output of `scons pot` checked. Ran the code on websites with several landmark types.

### Known issues with pull request:
None that I know of.

### Change log entry:
None.