### PR TITLE
Report alerts conveied by UI Automation's systemAlert event

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1289,6 +1289,14 @@ class UIA(Window):
 			return
 		return super(UIA, self).event_valueChange()
 
+	def event_UIA_systemAlert(self):
+		"""
+		A base implementation for UI Automation's system Alert event.
+		This just reports the element that received the alert in speech and braille, similar to how focus is presented.
+		Skype for business toast notifications being one example.
+		"""
+		self.reportFocus()
+
 class TreeviewItem(UIA):
 
 	def _get_value(self):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1295,7 +1295,9 @@ class UIA(Window):
 		This just reports the element that received the alert in speech and braille, similar to how focus is presented.
 		Skype for business toast notifications being one example.
 		"""
-		self.reportFocus()
+		speech.speakObject(self, reason=controlTypes.REASON_FOCUS)
+		# Ideally, we wouldn't use getBrailleTextForProperties directly.
+		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
 
 class TreeviewItem(UIA):
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -131,6 +131,7 @@ UIAEventIdsToNVDAEventNames={
 	#UIA_AsyncContentLoadedEventId:"documentLoadComplete",
 	#UIA_ToolTipClosedEventId:"hide",
 	UIA_Window_WindowOpenedEventId:"UIA_window_windowOpen",
+	UIA_SystemAlertEventId:"UIA_systemAlert",
 }
 
 class UIAHandler(COMObject):


### PR DESCRIPTION
A basic implementation that just reports the element that received the event in speech and braille, similar to focus.
The main use case is Skype For Business toast notifications.
Fixes #7281