### PR TITLE
Include application, dialog elements and audio and video tags for embedded object navigation in browse mode

### DIFF
--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -1,7 +1,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2015-2016 NV Access Limited
+#Copyright (C) 2015-2017 NV Access Limited, Babbage B.V.
 
 from ctypes import byref
 from comtypes import COMError
@@ -298,6 +298,9 @@ class UIABrowseModeDocument(browseMode.BrowseModeDocumentTreeInterceptor):
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		elif nodeType=="nonTextContainer":
 			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ListControlTypeId,UIAHandler.UIA_IsKeyboardFocusablePropertyId:True},{UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ComboBoxControlTypeId})
+			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
+		elif nodeType=="embeddedObject":
+			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_PaneControlTypeId,UIAHandler.UIA_AriaRolePropertyId:[u"application",u"alertdialog",u"dialog"]})
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		raise NotImplementedError
 

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2016 NV Access Limited, Babbage B.V.
+#Copyright (C) 2009-2017 NV Access Limited, Babbage B.V.
 
 from comtypes import COMError
 import eventHandler
@@ -312,7 +312,10 @@ class MSHTML(VirtualBuffer):
 				{"IHTMLDOMNode::nodeName": [VBufStorage_findMatch_word(lr.upper()) for lr in aria.htmlNodeNameToAriaLandmarkRoles]}
 				]
 		elif nodeType == "embeddedObject":
-			attrs = {"IHTMLDOMNode::nodeName": ["OBJECT","EMBED","APPLET"]}
+			attrs = [
+				{"IHTMLDOMNode::nodeName": ["OBJECT","EMBED","APPLET","AUDIO","VIDEO"]},
+				{"IAccessible::role":[oleacc.ROLE_SYSTEM_APPLICATION,oleacc.ROLE_SYSTEM_DIALOG]},
+			]
 		elif nodeType == "separator":
 			attrs = {"IHTMLDOMNode::nodeName": ["HR"]}
 		else:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2016 NV Access Limited, Babbage B.V.
+#Copyright (C) 2008-2017 NV Access Limited, Babbage B.V.
 
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
@@ -239,7 +239,10 @@ class Gecko_ia2(VirtualBuffer):
 					"name": [VBufStorage_findMatch_notEmpty]}
 				]
 		elif nodeType=="embeddedObject":
-			attrs={"IAccessible2::attribute_tag":self._searchableTagValues(["embed","object","applet"])}
+			attrs=[
+				{"IAccessible2::attribute_tag":self._searchableTagValues(["embed","object","applet","audio","video"])},
+				{"IAccessible::role":[oleacc.ROLE_SYSTEM_APPLICATION,oleacc.ROLE_SYSTEM_DIALOG]},
+			]
 		else:
 			return None
 		return attrs

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -499,7 +499,7 @@ The following keys by themselves jump to the next available element, while addin
 - m: frame
 - g: graphic
 - d: landmark
-- o: embedded object
+- o: embedded object (audio and video player, application, dialog, etc.)
 - 1 to 6: headings at levels 1 to 6 respectively
 - a: annotation (comment, editor revision, etc.)
 -
@@ -527,9 +527,10 @@ Once you have chosen an item, you can use the provided buttons in the dialog to 
 %kc:endInclude
 
 ++ Embedded Objects ++
-Pages can include rich content using technologies such as Adobe Flash and Sun Java, as well as applications and dialogs.
+Pages can include rich content using technologies such as Adobe Flash, Oracle Java and HTMl5, as well as applications and dialogs.
 Where these are encountered in browse mode, NVDA will report "embedded object", "application" or "dialog", respectively.
-You can press enter on these objects to interact with them.
+You can quickly move to them using the o and shift+o embedded object single letter navigation keys.
+to interact with these objects, you can press enter on them.
 If it is accessible, you can then tab around it and interact with it like any other application.
 A key command is provided to return to the original page containing the embedded object:
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -527,10 +527,10 @@ Once you have chosen an item, you can use the provided buttons in the dialog to 
 %kc:endInclude
 
 ++ Embedded Objects ++
-Pages can include rich content using technologies such as Adobe Flash, Oracle Java and HTMl5, as well as applications and dialogs.
+Pages can include rich content using technologies such as Adobe Flash, Oracle Java and HTML5, as well as applications and dialogs.
 Where these are encountered in browse mode, NVDA will report "embedded object", "application" or "dialog", respectively.
 You can quickly move to them using the o and shift+o embedded object single letter navigation keys.
-to interact with these objects, you can press enter on them.
+To interact with these objects, you can press enter on them.
 If it is accessible, you can then tab around it and interact with it like any other application.
 A key command is provided to return to the original page containing the embedded object:
 %kc:beginInclude


### PR DESCRIPTION
### Link to issue number:
fixes #7239

### Summary of the issue:
Embedded objects based on the html object tag are getting more rare these days, while we see increasing occurrence of applications, dialogs and audio and video tags inside web pages.

### Description of how this pull request fixes the issue:
This adds applications and dialogs as well as audio/video tags for Internet Explorer, Firefox and Chrome. For Edge, I was unable to cover audio/video tags (see below)

### Testing performed:
I tried navigating http://www.mediaelementjs.com/ with o using all the browsers above. I also created a test html document with alertdialog, dialog and application roles, which also navigated fine.

### Known issues with pull request:
In Edge, audio and video tags are regarded to as embedded object. Technically, they have the group UIA control type. In NVDAObjects.uia.edge.EdgeTextInfo._getControlFieldForObject, groupings are made to report as embedded object in certain situations, but I have not yet found a reliable way to throw the required information to do this reliably in a UIA Multi Property Condition.

### Change log entry:
* Changes
    + In browse mode, the quick navigation command for embedded objects (o and shift+o) now includes audio and video elements as well as elements with the aria roles application and dialog (#7239