### PR TITLE
Support Windows 10 Mail in creaters update (the executable name changed)

### DIFF
--- a/source/appModules/hxoutlook.py
+++ b/source/appModules/hxoutlook.py
@@ -1,0 +1,7 @@
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2017 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+# An alias for hxmail appModule
+from hxmail import *


### PR DESCRIPTION
Simply add an alias appModule called hxoutlook that points to hxmail.
Fixes #7289