### PR TITLE
Support the HTML5 required attribute in MSHTML documents

### DIFF
--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -469,6 +469,7 @@ inline void getAttributesFromHTMLDOMNode(IHTMLDOMNode* pHTMLDOMNode,wstring& nod
 	macro_addHTMLAttributeToMap(L"onclick",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"onmousedown",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"onmouseup",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
+	macro_addHTMLAttributeToMap(L"required",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	//ARIA properties:
 	macro_addHTMLAttributeToMap(L"role",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"aria-valuenow",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);

--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -753,8 +753,9 @@ class MSHTML(IAccessible):
 		state=aria.ariaSortValuesToNVDAStates.get(ariaSort)
 		if state is not None:
 			states.add(state)
+		htmlRequired='required' in self.HTMLAttributes
 		ariaRequired=self.HTMLAttributes['aria-required']
-		if ariaRequired=="true":
+		if htmlRequired or ariaRequired=="true":
 			states.add(controlTypes.STATE_REQUIRED)
 		ariaSelected=self.HTMLAttributes['aria-selected']
 		if ariaSelected=="true":

--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -71,6 +71,7 @@ class HTMLAttribCache(object):
 	def __init__(self,HTMLNode):
 		self.HTMLNode=HTMLNode
 		self.cache={}
+		self.containsCache={}
 
 	def __getitem__(self,item):
 		try:
@@ -83,6 +84,23 @@ class HTMLAttribCache(object):
 			value=None
 		self.cache[item]=value
 		return value
+
+	def __contains__(self,item):
+		try:
+			return self.containsCache[item]
+		except LookupError:
+			pass
+		value = self[item]
+		if value is not None:
+			contains = True
+			self.containsCache[item]=contains
+			return contains
+		try:
+			contains= self.HTMLNode.hasAttribute(item)
+		except (COMError,NameError):
+			contains = False
+		self.containsCache[item]=contains
+		return contains
 
 nodeNamesToNVDARoles={
 	"FRAME":controlTypes.ROLE_FRAME,

--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -90,15 +90,12 @@ class HTMLAttribCache(object):
 			return self.containsCache[item]
 		except LookupError:
 			pass
-		value = self[item]
-		if value is not None:
-			contains = True
-			self.containsCache[item]=contains
-			return contains
-		try:
-			contains= self.HTMLNode.hasAttribute(item)
-		except (COMError,NameError):
-			contains = False
+		contains=item in self.cache
+		if not contains:
+			try:
+				contains=self.HTMLNode.hasAttribute(item)
+			except (COMError,NameError):
+				pass
 		self.containsCache[item]=contains
 		return contains
 

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2016 NV Access Limited, Babbage B.V.
+#Copyright (C) 2009-2017 NV Access Limited, Babbage B.V.
 
 from comtypes import COMError
 import eventHandler
@@ -77,7 +77,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			states.add(controlTypes.STATE_EDITABLE)
 		if 'HTMLAttrib::onclick' in attrs or 'HTMLAttrib::onmousedown' in attrs or 'HTMLAttrib::onmouseup' in attrs:
 			states.add(controlTypes.STATE_CLICKABLE)
-		if attrs.get('HTMLAttrib::aria-required','false')=='true':
+		if 'HTMLAttrib::required' in attrs or attrs.get('HTMLAttrib::aria-required','false')=='true':
 			states.add(controlTypes.STATE_REQUIRED)
 		description=None
 		ariaDescribedBy=attrs.get('HTMLAttrib::aria-describedby')


### PR DESCRIPTION
### Link to issue number:
As far as I know, this pr has no dedicated issue for itself. This pr is based on findings in https://github.com/nvaccess/nvda/issues/7320#issuecomment-310827282

### Summary of the issue:
NVDA does not report the required state of a html element when the HTML5 required attribute is used for this.

### Description of how this pull request fixes the issue:
Added support for required in de NVDAHelper MSHTML vbuf backend and associated python code.

### Testing performed:
For required

```
<input id="name" required type="text" />
```

For not required

```
<input id="name" type="text" />
```

Note that required="false" will still result in required state being added, but this is no bug according to [the spec](https://www.w3schools.com/tags/att_input_required.asp). I've seen the same behaviour in Firefox.

### Change log entry:
I consider the absence of this feature to be a bug.

* Bug fixes
    + In MSHTML documents, the HTML5 required attribute is now supported to indicate the required state of a form field (#7321)