### PR TITLE
Fix up support of jumping over replaced content (ARIA label etc) when reading in Edge

### DIFF
--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -70,19 +70,22 @@ class EdgeTextInfo(UIATextInfo):
 		condition=UIAHandler.handler.clientObject.createOrCondition(UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_RuntimeIdPropertyId,runtimeID),condition)
 		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)
 		cacheRequest=UIAHandler.handler.clientObject.createCacheRequest()
+		cacheRequest.addProperty(UIAHandler.UIA_NamePropertyId)
 		cacheRequest.addProperty(UIAHandler.UIA_AriaPropertiesPropertyId)
 		element=walker.normalizeElementBuildCache(element,cacheRequest)
 		while element and not UIAHandler.handler.clientObject.compareElements(element,self.obj.UIAElement):
-			ariaProperties=element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
-			if ('label=' in ariaProperties)  or ('labelledby=' in ariaProperties):
-				return element
-			try:
-				range=self.obj.UIATextPattern.rangeFromChild(element)
-			except COMEror:
-				return
-			text=range.getText(-1)
-			if not text or text.isspace():
-				return element
+			name=element.getCachedPropertyValue(UIAHandler.UIA_NamePropertyId)
+			if name:
+				ariaProperties=element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
+				if ('label=' in ariaProperties)  or ('labelledby=' in ariaProperties):
+					return element
+				try:
+					range=self.obj.UIATextPattern.rangeFromChild(element)
+				except COMError:
+					return
+				text=range.getText(-1)
+				if not text or text.isspace():
+					return element
 			element=walker.getParentElementBuildCache(element,cacheRequest)
 
 	def _moveToEdgeOfReplacedContent(self,back=False):
@@ -96,9 +99,9 @@ class EdgeTextInfo(UIATextInfo):
 			return
 		if not back:
 			range.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start,range,UIAHandler.TextPatternRangeEndpoint_End)
+			range.move(UIAHandler.TextUnit_Character,-1)
 		else:
 			range.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,range,UIAHandler.TextPatternRangeEndpoint_Start)
-			range.move(UIAHandler.TextUnit_Character,1)
 		self._rangeObj=range
 
 	def _collapsedMove(self,unit,direction,skipReplacedContent):


### PR DESCRIPTION
Fixes #7143 

* EdgeTextInfo.UIAElementAtStartWithReplacedContent:  Ensure the element we have found in the ancestry does include a valid name, as if it has none, we'd never use it to replace content anyway. This will stop (sometimes large) chunks of the page from being non-navigable.

* EdgeTextInfo._moveToEdgeOfReplacedContent: Correct logic so that  we really land on the edge of replaced content. Previously this would cause the first character after the replaced content to be skipped, and also cause  you to be stuck on the first character of the replaced content when moving previous character out of it. The old logic may have been confused by very old builds of Edge with bugs pre Creators Update.

These changes address all the problems mentioned in the summary of Issue #7143 I.e.:
On the page mentioned:
* h and shift+h now move through all headings, and do not skip or get stuck in a loop
* Reading down the page with down arrow / review next line no longer skips the entire Main section
* Pressing shift+1 from the bottom of the page no longer freezes NVDA.
