### PR TITLE
Significantly speed up heading quick navigation in Microsoft Edge by walking heading Text elements rather than looking at all paragraphs

### DIFF
--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -521,6 +521,10 @@ class EdgeHeadingQuickNavItem(UIATextRangeQuickNavItem):
 		return self.level>parent.level
 
 def EdgeHeadingQuicknavIterator(itemType,document,position,direction="next"):
+	"""
+	A helper for L{EdgeHTMLTreeInterceptor._iterNodesByType} that specifically yields L{EdgeHeadingQuickNavItem} objects found in the given document, starting the search from the given position,  searching in the given direction.
+	See L{browseMode._iterNodesByType} for details on these specific arguments.
+	"""
 	# Edge exposes all headings as UIA elements with a controlType of text, and a level. Thus we can quickly search for these.
 	# However, sometimes when ARIA is used, the level on the element may not match the level in the text attributes.
 	# Therefore we need to search for all levels 1 through 6, even if a specific level is specified.

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -17,7 +17,7 @@ import re
 import aria
 import textInfos
 import UIAHandler
-from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo
+from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, UIATextRangeQuickNavItem,UIAControlQuicknavIterator
 from UIAUtils import *
 from . import UIA, UIATextInfo
 
@@ -508,12 +508,43 @@ class EdgeHTMLRootContainer(EdgeNode):
 			return
 		return super(EdgeHTMLRootContainer,self).event_gainFocus()
 
+class EdgeHeadingQuickNavItem(UIATextRangeQuickNavItem):
+
+	@property
+	def level(self):
+		if not hasattr(self,'_level'):
+			styleVal=getUIATextAttributeValueFromRange(self.textInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId)
+			self._level=styleVal-(UIAHandler.StyleId_Heading1-1) if UIAHandler.StyleId_Heading1<=styleVal<=UIAHandler.StyleId_Heading6 else None
+		return self._level
+
+	def isChild(self,parent):
+		return self.level>parent.level
+
+def EdgeHeadingQuicknavIterator(itemType,document,position,direction="next"):
+	# Edge exposes all headings as UIA elements with a controlType of text, and a level. Thus we can quickly search for these.
+	# However, sometimes when ARIA is used, the level on the element may not match the level in the text attributes.
+	# Therefore we need to search for all levels 1 through 6, even if a specific level is specified.
+	# Though this is still much faster than searching text attributes alone
+	levels=range(1,7)
+	condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_TextControlTypeId,UIAHandler.UIA_LevelPropertyId:levels})
+	levelString=itemType[7:]
+	for item in UIAControlQuicknavIterator(itemType,document,position,condition,direction=direction,itemClass=EdgeHeadingQuickNavItem):
+		# Verify this is the correct heading level via text attributes 
+		if item.level and (not levelString or levelString==str(item.level)): 
+			yield item
+
 class EdgeHTMLTreeInterceptor(cursorManager.ReviewCursorManager,UIABrowseModeDocument):
 
 	TextInfo=UIABrowseModeDocumentTextInfo
 
 	def _get_documentConstantIdentifier(self):
 		return self.rootNVDAObject.parent.name
+
+	def _iterNodesByType(self,nodeType,direction="next",pos=None):
+		if nodeType.startswith("heading"):
+			return EdgeHeadingQuicknavIterator(nodeType,self,pos,direction=direction)
+		else:
+			return super(EdgeHTMLTreeInterceptor,self)._iterNodesByType(nodeType,direction=direction,pos=pos)
 
 	def shouldPassThrough(self,obj,reason=None):
 		# Enter focus mode for selectable list items (<select> and role=listbox)

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -78,7 +78,7 @@ def UIAHeadingQuicknavIterator(itemType,document,position,direction="next"):
 		stop=(curPosition.move(textInfos.UNIT_PARAGRAPH,1 if direction=="next" else -1)==0)
 		firstLoop=False
 
-def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction="next"):
+def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction="next",itemClass=UIATextRangeQuickNavItem):
 	# A part from the condition given, we must always match on the root of the document so we know when to stop walking
 	runtimeID=VARIANT()
 	document.rootNVDAObject.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(UIAHandler.UIA_RuntimeIdPropertyId,byref(runtimeID))
@@ -94,14 +94,14 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 				except COMError:
 					elementRange=None
 				if elementRange:
-					yield UIATextRangeQuickNavItem(itemType,document,elementRange)
+					yield itemClass(itemType,document,elementRange)
 		return
 	if direction=="up":
 		walker=UIAHandler.handler.clientObject.createTreeWalker(UIACondition)
 		element=position.UIAElementAtStart
 		element=walker.normalizeElement(element)
 		if element and not UIAHandler.handler.clientObject.compareElements(element,document.rootNVDAObject.UIAElement) and not UIAHandler.handler.clientObject.compareElements(element,UIAHandler.handler.rootElement):
-			yield UIATextRangeQuickNavItem(itemType,document,element)
+			yield itemClass(itemType,document,element)
 		return
 	elif direction=="previous":
 		# Fetching items previous to the given position.
@@ -159,7 +159,7 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 				elif not curElementMatchedCondition and isUIAElementInWalker(curElement,walker):
 					curElementMatchedCondition=True
 				if curElementMatchedCondition:
-					yield UIATextRangeQuickNavItem(itemType,document,curElement)
+					yield itemClass(itemType,document,curElement)
 			previousSibling=walker.getPreviousSiblingElement(curElement)
 			if previousSibling:
 				gonePreviousOnce=True
@@ -173,7 +173,7 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 				goneParent=True
 				curElementMatchedCondition=True
 				if gonePreviousOnce:
-					yield UIATextRangeQuickNavItem(itemType,document,curElement)
+					yield itemClass(itemType,document,curElement)
 				continue
 			curElement=None
 	else: # direction is next
@@ -220,13 +220,13 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 		# If we are already past our position, and this is a valid child
 		# Then we can emit an item already
 		if goneNextOnce and isUIAElementInWalker(curElement,walker):
-			yield UIATextRangeQuickNavItem(itemType,document,curElement)
+			yield itemClass(itemType,document,curElement)
 		# Start traversing from this child forwards through the document, emitting items for valid elements.
 		while curElement:
 			firstChild=walker.getFirstChildElement(curElement) if goneNextOnce else None
 			if firstChild:
 				curElement=firstChild
-				yield UIATextRangeQuickNavItem(itemType,document,curElement)
+				yield itemClass(itemType,document,curElement)
 			else:
 				nextSibling=None
 				while not nextSibling:
@@ -239,7 +239,7 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 							return
 				curElement=nextSibling
 				goneNextOnce=True
-				yield UIATextRangeQuickNavItem(itemType,document,curElement)
+				yield itemClass(itemType,document,curElement)
 
 class UIABrowseModeDocumentTextInfo(browseMode.BrowseModeDocumentTextInfo,treeInterceptorHandler.RootProxyTextInfo):
 


### PR DESCRIPTION
### Summary of the issue:
Currently navigating by heading in Microsoft Edge is extremely slow on large pages.
For example, when on the World War I wikipedia article in Edge, pressing 1 (to jump to the next heading level 1) can take up to 20 seconds to report there are no more heading ones.
Similarly, jumping heading by heading through the page with h can sometimes take up to 5 seconds locating the next heading.

The current way this is implemented is that NVDA moves through the document by paragraph and checks the text attributes to see if this paragraph is a heading.
 
### Description of how this pull request fixes the issue:
As of the Windows Anniversary update, Edge started exposing  an real UIA element for each heading. It can be identified with a controlType of text, and a level between 1 and 6.
 Therefore, this pull request walks the UIA tree requesting only these elements. When one is found however, it still double checks the text attributes as sometimes the level on the element can be wrong.
Even so, this significantly speeds up heading navigation. Searching for a heading 1 in the World War I article  now takes about 1 to 2 seconds rather than 20.

### Change log entry:
Bug fixes:
* Performing quick navigation to headings in Microsoft Edge is now significantly faster.
