### PR TITLE
Fix build failure for nvdaHelperLocalWin10 on 32 bit Windows.

### DIFF
--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -26,6 +26,9 @@ debug=env['nvdaHelperDebugFlags']
 release=env['release']
 signExec=env['signExec'] if env['certFile'] else None
 progFilesX86 = os.getenv("ProgramFiles(x86)")
+if not progFilesX86:
+	# 32 bit system, so only one Program Files directory.
+	progFilesX86 = os.getenv("ProgramFiles")
 
 env.Append(CPPDEFINES=[
 	'UNICODE', '_CRT_SECURE_NO_DEPRECATE',


### PR DESCRIPTION
### Link to issue number:
None. This fixes a build failure reported in [this nvda-devel thread](http://nabble.nvda-project.org/The-build-error-in-master-branch-td42228.html). This is a regression introduced by #7110.

### Summary of the issue:
On 32 bit Windows, running `scons source` fails with the following output:

> ```
> scons: Reading SConscript files ... 
> TypeError: object of type 'NoneType' has no len(): 
>    File "C:\Users\kvark\nvda\github\SConstruct", line 184: 
>      envWin10.SConscript('nvdaHelper/localWin10/sconscript', 
> exports={'env': envW 
> in10, 'libInstallDir': sourceLibDir}, variant_dir='build/x86/localWin10') 
>    File 
> "C:\Users\kvark\nvda\github\miscDeps\python\SCons\Script\SConscript.py", 
>   line 551: 
>      return _SConscript(self.fs, *files, **subst_kw) 
>    File 
> "C:\Users\kvark\nvda\github\miscDeps\python\SCons\Script\SConscript.py", 
>   line 260: 
>      exec _file_ in call_stack[-1].globals 
>    File "C:\Users\kvark\nvda\github\build\x86\localWin10\sconscript", 
> line 70: 
>      vcRedist = os.path.join(progFilesX86, r"Microsoft Visual Studio 
> 14.0\VC\redi 
> st\onecore\x86\Microsoft.VC140.CRT") 
>    File "C:\Python27\lib\ntpath.py", line 65: 
>      result_drive, result_path = splitdrive(path) 
>    File "C:\Python27\lib\ntpath.py", line 115: 
>      if len(p) > 1: 
> ```

### Description of how this pull request fixes the issue:
The sconscript for nvdaHelperLocalWin10 uses the ProgramFilesX86 environment variable, which I assumed was set even on 32 bit Windows. (I assumed it would be equal to ProgramFiles for compatibility.) My assumption was incorrect. When this environment variable isn't present, we now fall back to the ProgramFiles environment variable, since there's only one Program Files directory on 32 bit Windows.

### Testing performed:
I tested building on my 64 bit system. The reporter confirmed that this branch builds on his 32 bit system in the same nvda-devel thread.

### Known issues with pull request:
None known.

### Change log entry:
None; this bug never made it into a release, so it doesn't need to be included.