### PR TITLE
Added a Braille display driver for the SuperBraille device used primarily in Taiwan.

### DIFF
--- a/source/brailleDisplayDrivers/superBraille.py
+++ b/source/brailleDisplayDrivers/superBraille.py
@@ -1,0 +1,142 @@
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2017 NV Access Limited, Coscell Kao
+
+import serial
+from collections import OrderedDict
+import braille
+import hwPortUtils
+import hwIo
+import time
+import inputCore
+from logHandler import log
+
+BAUD_RATE = 9600
+TIMEOUT = 0.5
+
+# Tags sent by the SuperBraille
+# Sent to identify the display and receive amount of cells this unit has
+DESCRIBE_TAG = "\xff\xff\x0a"
+# Sent to request displaying of cells
+DISPLAY_TAG = "\xff\xff\x04\x00\x99\x00\x50\x00"
+
+class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+	name = "superBrl"
+	# Translators: Names of braille displays.
+	description = _("SuperBraille")
+	isThreadSafe=True
+	_dev=None
+
+	USB_IDs = {
+		"USB\\VID_10C4&PID_EA60", # SuperBraille 3.2
+	}
+
+	@classmethod
+	def getPossiblePorts(cls):
+		ports = OrderedDict()
+		comPorts = list(hwPortUtils.listComPorts(onlyAvailable=True))
+		try:
+			next(cls._getAutoPorts(comPorts))
+			ports.update((cls.AUTOMATIC_PORT,))
+		except StopIteration:
+			pass
+		for portInfo in comPorts:
+			# Translators: Name of a serial communications port.
+			ports[portInfo["port"]] = _("Serial: {portName}").format(portName=portInfo["friendlyName"])
+		print "ports: %s"%ports
+		return ports
+
+	@classmethod
+	def _getAutoPorts(cls, comPorts):
+		for portInfo in comPorts:
+			port = portInfo["port"]
+			hwID = portInfo["hardwareID"]
+			if any(hwID.startswith(x) for x in cls.USB_IDs):
+				portType = "USB serial"
+			else:
+				continue
+			yield port, portType
+
+	@classmethod
+	def check(cls):
+		return True
+
+	def __init__(self,port="Auto"):
+		super(BrailleDisplayDriver, self).__init__()
+		found = False
+		if port == "auto":
+			tryPorts = self._getAutoPorts(hwPortUtils.listComPorts(onlyAvailable=True))
+		else:
+			tryPorts = ((port, "serial"),)
+		for port, portType in tryPorts:
+			log.debug("Checking port %s for a SuperBraille", port)
+			try:
+				self._dev = hwIo.Serial(port, baudrate=BAUD_RATE, stopbits=serial.STOPBITS_ONE, parity=serial.PARITY_NONE, timeout=TIMEOUT, writeTimeout=TIMEOUT, onReceive=self._onReceive)
+				log.debug("Port opened.")
+			except EnvironmentError:
+				continue
+
+			# try to initialize the device and request number of cells
+			self._dev.write(DESCRIBE_TAG)
+			self._dev.waitForRead(TIMEOUT)
+			# Check for cell information
+			if self.numCells:
+				# ok, it is a SuperBraille
+				log.info("Found superBraille device, version %s"%self.version)
+				found = True
+				break
+		else:
+			self._dev.close()
+		if not found:
+			raise RuntimeError, "No SuperBralle found"
+
+	def terminate(self):
+		try:
+			super(BrailleDisplayDriver, self).terminate()
+		finally:
+			self._closeComPort()
+
+	def _closeComPort(self):
+		if self._dev is not None:
+			log.debug("Closing port %s", self._dev.port)
+			# We must sleep before closing the COM port as not doing this can leave the display in a bad state where it can not be re-initialized
+			time.sleep(TIMEOUT)
+			self._dev.close()
+			self._dev = None
+
+	def _onReceive(self,data):
+		# The only info this display ever sends is number of cells and the display version.
+		# It sends 0x00, 0x05, number of cells,  then version string of 8 bytes.
+		if data!='\x00':
+			log.info("unknown first byte")
+			return
+		data=self._dev.read(1)
+		if data!='\x05':
+			log.info("Unknown second byte")
+			return
+		self.numCells = ord(self._dev.read(1))
+		self._dev.read(1)
+		self.version=self._dev.read(8)
+
+	def display(self, cells):
+		# if the serial port is not open don't even try to write
+		if self._dev is None:
+			return
+		out = []
+		for cell in cells:
+			out.append("\x00")
+			out.append(chr(cell))
+		try:
+			self._dev.write(DISPLAY_TAG + "".join(out))
+		except EnvironmentError as e:
+			self._closeComPort()
+			raise e
+
+	gestureMap = inputCore.GlobalGestureMap({
+		"globalCommands.GlobalCommands": {
+			"braille_scrollBack": ("kb:numpadMinus",),
+			"braille_scrollForward": ("kb:numpadPlus",),
+		},
+	})
+

--- a/source/brailleDisplayDrivers/superBrl.py
+++ b/source/brailleDisplayDrivers/superBrl.py
@@ -26,7 +26,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	# Translators: Names of braille displays.
 	description = _("SuperBraille")
 	isThreadSafe=True
-	_dev=None
 
 	USB_IDs = {
 		"USB\\VID_10C4&PID_EA60", # SuperBraille 3.2
@@ -44,7 +43,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		for portInfo in comPorts:
 			# Translators: Name of a serial communications port.
 			ports[portInfo["port"]] = _("Serial: {portName}").format(portName=portInfo["friendlyName"])
-		print "ports: %s"%ports
 		return ports
 
 	@classmethod
@@ -64,16 +62,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def __init__(self,port="Auto"):
 		super(BrailleDisplayDriver, self).__init__()
-		found = False
 		if port == "auto":
 			tryPorts = self._getAutoPorts(hwPortUtils.listComPorts(onlyAvailable=True))
 		else:
 			tryPorts = ((port, "serial"),)
 		for port, portType in tryPorts:
-			log.debug("Checking port %s for a SuperBraille", port)
 			try:
 				self._dev = hwIo.Serial(port, baudrate=BAUD_RATE, stopbits=serial.STOPBITS_ONE, parity=serial.PARITY_NONE, timeout=TIMEOUT, writeTimeout=TIMEOUT, onReceive=self._onReceive)
-				log.debug("Port opened.")
 			except EnvironmentError:
 				continue
 
@@ -84,22 +79,16 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			if self.numCells:
 				# ok, it is a SuperBraille
 				log.info("Found superBraille device, version %s"%self.version)
-				found = True
 				break
+			else:
+				self._dev.close()
 		else:
-			self._dev.close()
-		if not found:
-			raise RuntimeError, "No SuperBralle found"
+			raise RuntimeError, "No SuperBraille found"
 
 	def terminate(self):
 		try:
 			super(BrailleDisplayDriver, self).terminate()
 		finally:
-			self._closeComPort()
-
-	def _closeComPort(self):
-		if self._dev is not None:
-			log.debug("Closing port %s", self._dev.port)
 			# We must sleep before closing the COM port as not doing this can leave the display in a bad state where it can not be re-initialized
 			time.sleep(TIMEOUT)
 			self._dev.close()
@@ -109,29 +98,20 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		# The only info this display ever sends is number of cells and the display version.
 		# It sends 0x00, 0x05, number of cells,  then version string of 8 bytes.
 		if data!='\x00':
-			log.info("unknown first byte")
 			return
 		data=self._dev.read(1)
 		if data!='\x05':
-			log.info("Unknown second byte")
 			return
 		self.numCells = ord(self._dev.read(1))
 		self._dev.read(1)
 		self.version=self._dev.read(8)
 
 	def display(self, cells):
-		# if the serial port is not open don't even try to write
-		if self._dev is None:
-			return
 		out = []
 		for cell in cells:
 			out.append("\x00")
 			out.append(chr(cell))
-		try:
-			self._dev.write(DISPLAY_TAG + "".join(out))
-		except EnvironmentError as e:
-			self._closeComPort()
-			raise e
+		self._dev.write(DISPLAY_TAG + "".join(out))
 
 	gestureMap = inputCore.GlobalGestureMap({
 		"globalCommands.GlobalCommands": {

--- a/source/brailleDisplayDrivers/superBrl.py
+++ b/source/brailleDisplayDrivers/superBrl.py
@@ -83,7 +83,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			else:
 				self._dev.close()
 		else:
-			raise RuntimeError, "No SuperBraille found"
+			raise RuntimeError("No SuperBraille found")
 
 	def terminate(self):
 		try:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2231,7 +2231,7 @@ Please see the [EcoBraille documentation ftp://ftp.once.es/pub/utt/bibliotecnia/
 | Toggle braille tethered to | A |
 %kc:endInclude
 
-++ Super Braille ++
+++ SuperBraille ++
 The SuperBraille device, mostly available in Taiwan, can be connected to by either USB or serial.
 As the SuperBraille does not have any physical typing keys or scrolling buttons, all input must be performed via a standard computer keyboard.
 Due to this, and to maintain compatibility with other screen readers in Taiwan, two key bindings for scrolling the braille display have been provided:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2231,6 +2231,16 @@ Please see the [EcoBraille documentation ftp://ftp.once.es/pub/utt/bibliotecnia/
 | Toggle braille tethered to | A |
 %kc:endInclude
 
+++ Super Braille ++
+The SuperBraille device, mostly available in Taiwan, can be connected to by either USB or serial.
+As the SuperBraille does not have any physical typing keys or scrolling buttons, all input must be performed via a standard computer keyboard.
+Due to this, and to maintain compatibility with other screen readers in Taiwan, two key bindings for scrolling the braille display have been provided:
+%kc:beginInclude
+|| Name | Key |
+| Scroll braille display back | numpadMinus |
+| Scroll braille display forward | numpadPlus | 
+%kc:endInclude
+
 ++ BRLTTY ++
 [BRLTTY http://www.brltty.com/] is a separate program which can be used to support many more braille displays.
 In order to use this, you need to install [BRLTTY for Windows http://www.brltty.com/download.html].


### PR DESCRIPTION
### Summary of the issue:
In Taiwan, the primary braille display that is used is the SuperBraille. this is Taiwan-made and is very popular in Government and education etc, despite its large size and lack of typing and scroll buttons.
Due to other Taiwan-specific screen readers now no longer being maintained, NVDA is fast becoming  a very popular screen reader. However, for NVDA uptake it is essential that the SuperBraille is supported as  individuals and governments have spent significant finances on these displays.

### Description of how this pull request fixes the issue:
There was a 3rd party add-on written for this display. However,  it had issues when restarting NVDA, and was not using the most modern braile display driver techniques in NVDA.
This pull request introduces that code, at the same time addressing the restart bug, and modernizing the driver.
This new driver also stops probing all serial ports, rather only allowing automatic for one particular USB hardware ID, and then allowing manual selection for other serial ports.

### Testing performed:
A SuperBraille v3.2 was used to test while updating this driver.

### Known issues with pull request:
* I have seen this SuperBraille unit start showing garbage after using this driver for a while once. Further testing by the Taiwan community is necessary.
* As this driver has no physical scroll buttons at all, it is necessary to bind scrolling to keyboard gestures. Currently to maintain compatibility with other screen readers in Taiwan, numpadMinus scrolls back and numpadPlus scrolls forward. Obviously the use of numpadPlus eclipses review sayAll in desktop layout. However, as a vast majority of the users of this display expect this behavior, there would be some work in getting a change accepted by the users. 