### PR TITLE
Fix spurious reporting of aria-hidden focus ancestors in Firefox.

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -793,7 +793,7 @@ Tries to force this object to take the focus.
 		@return: C{True} if it should be presented in the focus ancestry, C{False} if not.
 		@rtype: bool
 		"""
-		if self.presentationType == self.presType_layout:
+		if self.presentationType in (self.presType_layout, self.presType_unavailable):
 			return False
 		if self.role in (controlTypes.ROLE_TREEVIEWITEM, controlTypes.ROLE_LISTITEM, controlTypes.ROLE_PROGRESSBAR, controlTypes.ROLE_EDITABLETEXT):
 			return False


### PR DESCRIPTION
### Link to issue number:
Fixes #5741.

### Summary of the issue:
If an author (incorrectly) focuses something inside an aria-hidden element in Firefox, NVDA will report all of the aria-hidden ancestors, even if they would have been layout otherwise.

### Description of how this pull request fixes the issue:
When presentationType is unavailable, isPresentableFocusAncestor should be False, just as it is for layout. Previously, it was True.
Unfortunately, NVDA's message dialogs are sometimes briefly treated as unavailable when they get focus. We still want them to be reported. Work around this in the app module for NVDA itself.

### Testing performed:
1. Tested with the test case provided in https://github.com/nvaccess/nvda/issues/5741#issuecomment-312801852.
2. Tested that pressing enter to open details for a tweet on Twitter no longer reports "section" several times.

### Known issues with pull request:
None.

### Change log entry:
In Bug Fixes:

```
- In Firefox, NVDA no longer spuriously reports "section" several times when opening details for a tweet on twitter.com. (#5741)
```