### PR TITLE
New braille translation tables

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -100,6 +100,9 @@ addTable("cy-cy-g2.ctb", _("Welsh grade 2"), contracted=True)
 addTable("cz-cz-g1.utb", _("Czech grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("da-dk-g08.ctb", _("Danish 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("da-dk-g16.ctb", _("Danish 6 dot grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -146,6 +149,9 @@ addTable("en-us-comp6.ctb", _("English (U.S.) 6 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("en-us-comp8.ctb", _("English (U.S.) 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("en-us-comp8-ext.utb", _("English (U.S.) 8 dot extended computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("en-us-g1.ctb", _("English (U.S.) grade 1"))
@@ -241,6 +247,9 @@ addTable("ko-g2.ctb", _("Korean grade 2"), contracted=True)
 addTable("ks-in-g1.utb", _("Kashmiri grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("lt.ctb", _("Lithuanian"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("Lv-Lv-g1.utb", _("Latvian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -316,7 +325,10 @@ addTable("Se-Se-g1.utb", _("Swedish grade 1"))
 addTable("sk-g1.ctb", _("Slovak grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("sl-si-g1.utb", _("Slovene grade 1"))
+addTable("sl-si-comp8.ctb", _("Slovenian 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sl-si-g1.utb", _("Slovenian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sr-g1.ctb", _("Serbian grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -62,6 +62,7 @@ def listTables():
 
 #: Maps old table names to new table names for tables renamed in newer versions of liblouis.
 RENAMED_TABLES = {
+	"ar-fa.utb" : "fa-ir-g1.utb",
 	"da-dk-g16.utb":"da-dk-g16.ctb",
 	"da-dk-g18.utb":"da-dk-g18.ctb",
 	"gr-gr-g1.utb":"el.ctb",
@@ -77,9 +78,6 @@ RENAMED_TABLES = {
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ar-ar-g1.utb", _("Arabic grade 1"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
-addTable("ar-fa.utb", _("Farsi grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("as-in-g1.utb", _("Assamese grade 1"))
@@ -170,6 +168,12 @@ addTable("et-g0.utb", _("Estonian grade 0"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ethio-g1.ctb", _("Ethiopic grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("fa-ir-comp8.ctb", _("Persian 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("fa-ir-g1.utb", _("Persian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("fi.utb", _("Finnish 6 dot"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -65,6 +65,7 @@ RENAMED_TABLES = {
 	"ar-fa.utb" : "fa-ir-g1.utb",
 	"da-dk-g16.utb":"da-dk-g16.ctb",
 	"da-dk-g18.utb":"da-dk-g18.ctb",
+	"en-us-comp8.ctb" : "en-us-comp8-ext.utb",
 	"gr-gr-g1.utb":"el.ctb",
 	"nl-BE-g1.ctb":"nl-BE-g0.utb",
 	"nl-NL-g1.ctb":"nl-NL-g0.utb",
@@ -146,10 +147,7 @@ addTable("en-ueb-g2.ctb", _("Unified English Braille Code grade 2"), contracted=
 addTable("en-us-comp6.ctb", _("English (U.S.) 6 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("en-us-comp8.ctb", _("English (U.S.) 8 dot computer braille"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
-addTable("en-us-comp8-ext.utb", _("English (U.S.) 8 dot extended computer braille"))
+addTable("en-us-comp8-ext.utb", _("English (U.S.) 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("en-us-g1.ctb", _("English (U.S.) grade 1"))


### PR DESCRIPTION
### Link to issue number:
Fixes #6188. Fixes #6550. Fixes #6836. Fixes #7367. Re #6773.

### Summary of the issue:
Users have requested that several braille translation tables be available for selection in NVDA. They are already included in liblouis.

### Description of how this pull request fixes the issue:
1. Adds tables to NVDA's table list: Danish 8 dot computer braille, English (U.S.) 8 dot extended computer braille, Lithuanian, Persian 8 dot computer braille, Persian grade 1, Slovenian 8 dot computer braille.
2. Changes the description for "Slovene grade 1" to "Slovenian grade 1" for consistency.

### Testing performed:
I checked that the files load, but I don't know these braille codes, so I can't do much testing beyond that.

### Known issues with pull request:
None.

### Change log entry:
New Features:

```
- New braille translation tables: Danish 8 dot computer braille, Lithuanian, Persian 8 dot computer braille, Persian grade 1, Slovenian 8 dot computer braille. (#6188, #6550, #6773, #6836, #7367)
- Improved English (U.S.) 8 dot computer braille table, including support for bullets, the euro sign and accented letters. (#6836)
```