### PR TITLE
Change the default braille table to Unified English Braille Code grade 1

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -50,8 +50,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 # Braille settings
 [braille]
 	display = string(default=noBraille)
-	translationTable = string(default=en-us-comp8.ctb)
-	inputTable = string(default=en-us-comp8.ctb)
+	translationTable = string(default=en-ueb-g1.ctb)
+	inputTable = string(default=en-ueb-g1.ctb)
 	expandAtCursor = boolean(default=true)
 	showCursor = boolean(default=true)
 	cursorBlink = boolean(default=true)


### PR DESCRIPTION
### Link to issue number:
Fixes #6952.

### Summary of the issue:
While well known by users who have used computers with braille in the past, English U.S. computer braille is not well known by braille users in general; e.g. putting numbers in lower cells. Now that Unified English Braille has become standard in major English speaking countries, it seems to be the most suitable as a default choice.

### Description of how this pull request fixes the issue:
Changes the default table in the config spec.

### Testing performed:
Tested that the table is chosen when no table is set in the config.

### Known issues with pull request:
Does not account for other languages, but this is not new and should be dealt with separately. See #290.

### Change log entry:
Changes:

```
- The default braille table is now Unified English Braille Code grade 1. (#6952)
```