### PR TITLE
Pressing Enter to close Start menu in Windows 10 no longer results in NVDA announcing search field text. re #7370.

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1468,10 +1468,6 @@ class SearchField(EditableTextWithSuggestions, UIA):
 	"""An edit field that presents suggestions based on a search term.
 	"""
 
-	def initOverlayClass(self):
-		# #7370: do not announce text when start menu (searchui) closes.
-		self.announceNewLineText = self.appModule.appName != "searchui"
-
 	def event_UIA_controllerFor(self):
 		# Only useful if suggestions appear and disappear.
 		if self == api.getFocusObject() and len(self.controllerFor)>0:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1468,6 +1468,10 @@ class SearchField(EditableTextWithSuggestions, UIA):
 	"""An edit field that presents suggestions based on a search term.
 	"""
 
+	def initOverlayClass(self):
+		# #7370: do not announce text when start menu (searchui) closes.
+		self.announceNewLineText = self.appModule.appName != "searchui"
+
 	def event_UIA_controllerFor(self):
 		# Only useful if suggestions appear and disappear.
 		if self == api.getFocusObject() and len(self.controllerFor)>0:

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -1,10 +1,16 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2015-2016  NV Access Limited
+#Copyright (C) 2015-2017 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 import appModuleHandler
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
+from NVDAObjects.UIA import UIA, SearchField
+
+class StartMenuSearchField(SearchField):
+
+		# #7370: do not announce text when start menu (searchui) closes.
+	announceNewLineText = False
 
 class AppModule(appModuleHandler.AppModule):
 
@@ -16,3 +22,6 @@ class AppModule(appModuleHandler.AppModule):
 				clsList.remove(ContentGenericClient)
 			except ValueError:
 				pass
+		elif isinstance(obj, UIA):
+			if obj.UIAElement.cachedAutomationID == "SearchTextBox":
+				clsList.insert(0, StartMenuSearchField)


### PR DESCRIPTION
Resolves the following:

* Fixes #7370: In Windows 10's start menu, pressing Enter to close the menu after entering search term results in NVDA announcing search field text.
Suggested what's new entry:

section: bug fixes


In start menu in Windows 10, pressing Enter to close the start menu after a search no longer causes NVDA to announce search text.

Thanks.