### PR TITLE
UIA/ToastWin10/build 15063 and later: before announcing toasts, consult last toast message in case a repeat event was fired. re #7128

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1452,6 +1452,16 @@ class Toast_win10(Notification, UIA):
 		event_UIA_window_windowOpen=Notification.event_alert
 	else:
 		event_UIA_toolTipOpened=Notification.event_alert
+	# #7128: in Creators Update (build 15063 and later), due to possible UIA Core problem, toasts are announced repeatedly if UWP apps were used for a while.
+	# Therefore, have a private toast message consultant handy.
+	_lastToastMessage = ""
+
+	def event_UIA_window_windowOpen(self):
+		if sys.getwindowsversion().build >= 15063:
+			if self.name == self._lastToastMessage:
+				return
+			self.__class__._lastToastMessage = self.name
+		Notification.event_alert(self)
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
 #This causes major lags when using this control with Braille in NVDA. (#2759) 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1462,7 +1462,7 @@ class Toast_win10(Notification, UIA):
 		if sys.getwindowsversion().build >= 15063:
 			toastTimestamp = time.time()
 			toastRuntimeID = self.UIAElement.getRuntimeID()
-			if toastRuntimeID == self._lastToastRuntimeID and toastTimestamt-self._lastToastTimestamp < 1.0:
+			if toastRuntimeID == self._lastToastRuntimeID and toastTimestamp-self._lastToastTimestamp < 1.0:
 				return
 			self.__class__._lastToastTimestamp = toastTimestamp
 			self.__class__._lastToastRuntimeID = toastRuntimeID

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -29,6 +29,7 @@ from NVDAObjects.window import Window
 from NVDAObjects import NVDAObjectTextInfo, InvalidNVDAObject
 from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDetection, Dialog, Notification, EditableTextWithSuggestions
 import braille
+import time
 
 class UIATextInfo(textInfos.TextInfo):
 
@@ -1453,14 +1454,18 @@ class Toast_win10(Notification, UIA):
 	else:
 		event_UIA_toolTipOpened=Notification.event_alert
 	# #7128: in Creators Update (build 15063 and later), due to possible UIA Core problem, toasts are announced repeatedly if UWP apps were used for a while.
-	# Therefore, have a private toast message consultant handy.
-	_lastToastMessage = ""
+	# Therefore, have a private toast message consultant (toast timestamp and UIA element runtime ID) handy.
+	_lastToastTimestamp = None
+	_lastToastRuntimeID = None
 
 	def event_UIA_window_windowOpen(self):
 		if sys.getwindowsversion().build >= 15063:
-			if self.name == self._lastToastMessage:
+			toastTimestamp = time.time()
+			toastRuntimeID = self.UIAElement.getRuntimeID()
+			if toastRuntimeID == self._lastToastRuntimeID and toastTimestamt-self._lastToastTimestamp < 1.0:
 				return
-			self.__class__._lastToastMessage = self.name
+			self.__class__._lastToastTimestamp = toastTimestamp
+			self.__class__._lastToastRuntimeID = toastRuntimeID
 		Notification.event_alert(self)
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.


### PR DESCRIPTION
 Fixes #7128: NVDA repeats toast messages if UWP's were used for a while. Noted by @MichaelDCurran as caused by possible issue with UIA Core in build 15063 and later. The issue is specific to Creators Update and later.
Suggested what's new entry:

Section: bug fixes

In Windows 10 Creators Update, NVDA will no longer announce toasts multiple times.

Thanks.
