### PR TITLE
Composable Shell touch keyboard: support emoji panel and other features in Windows 10 Fall Creators Update and later. re #7273

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -21,7 +21,9 @@ class AppModule(appModuleHandler.AppModule):
 		# Therefore, move the navigator object to that item if possible.
 		speech.cancelSpeech()
 		if obj.UIAElement.cachedClassName == "ListViewItem":
-			obj = obj.parent.previous.firstChild
+			obj = obj.parent.previous
+			ui.message(obj.name)
+			obj = obj.firstChild
 		if obj is not None:
 			api.setNavigatorObject(obj)
 			obj.reportFocus()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -16,6 +16,7 @@ import braille
 import ui
 import config
 import winVersion
+from NVDAObjects.UIA import UIA
 
 class AppModule(appModuleHandler.AppModule):
 
@@ -34,7 +35,9 @@ class AppModule(appModuleHandler.AppModule):
 		if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList":
 			obj = obj.firstChild
 		candidate = obj
-		if obj.UIAElement.cachedClassName == "ListViewItem" and obj.parent.UIAElement.cachedAutomationID != "TEMPLATE_PART_ClipboardItemsList":
+		# Sometimes, due to bad tree traversal, something other than the selected item sees this event.
+		parent = obj.parent
+		if obj.UIAElement.cachedClassName == "ListViewItem" and isinstance(parent, UIA) and parent.UIAElement.cachedAutomationID != "TEMPLATE_PART_ClipboardItemsList":
 			# The difference between emoji panel and suggestions list is absence of categories/emoji separation.
 			# Turns out automation ID for the container is different, observed in build 17666 when opening clipboard copy history.
 			candidate = obj.parent.previous

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,0 +1,32 @@
+# App module for Composable Shell (CShell) input panel
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2017 NV Access Limited, Joseph Lee
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""App module for Windows 10 new touch keyboard panel.
+The chief feature is allowing NVDA to announce selected emoji when using the keyboard to search for and select one.
+This is applicable on Windows 10 Fall Creators Update."""
+
+import appModuleHandler
+import api
+import speech
+import braille
+import ui
+
+class AppModule(appModuleHandler.AppModule):
+
+	def event_UIA_elementSelected(self, obj, nextHandler):
+		# #7273: When this is fired on categories, the first emoji from the new category is selected but not announced.
+		# Therefore, move the navigator object to that item if possible.
+		speech.cancelSpeech()
+		if obj.UIAElement.cachedClassName == "ListViewItem":
+			obj = obj.parent.previous.firstChild
+		if obj is not None:
+			api.setNavigatorObject(obj)
+			obj.reportFocus()
+			braille.handler.message(braille.getBrailleTextForProperties(name=obj.name, role=obj.role, positionInfo=obj.positionInfo))
+		else:
+			# Translators: presented when there is no emoji when searching for one in Windows 10 Fall Creators Update and later.
+			ui.message(_("No emoji"))
+		nextHandler()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,12 +1,13 @@
 # App module for Composable Shell (CShell) input panel
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017 NV Access Limited, Joseph Lee
+#Copyright (C) 2017-2018 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-"""App module for Windows 10 new touch keyboard panel.
+"""App module for Windows 10 Modern Keyboard aka new touch keyboard panel.
 The chief feature is allowing NVDA to announce selected emoji when using the keyboard to search for and select one.
-This is applicable on Windows 10 Fall Creators Update."""
+Another feature is to announce candidates for misspellings if suggestions for hardware keyboard is selected.
+This is applicable on Windows 10 Fall Creators Update and later."""
 
 import appModuleHandler
 import api
@@ -19,11 +20,21 @@ class AppModule(appModuleHandler.AppModule):
 	def event_UIA_elementSelected(self, obj, nextHandler):
 		# #7273: When this is fired on categories, the first emoji from the new category is selected but not announced.
 		# Therefore, move the navigator object to that item if possible.
+		# However, in recent builds, name change event is also fired.
+		# For consistent experience, report the new category first by traversing through controls.
 		speech.cancelSpeech()
+		# And no, if running on build 17040 and if this is typing suggestion, do not announce candidate window changes, as it is duplicate announcement and is anoying.
+		if obj.UIAElement.cachedAutomationID == "IME_Candidate_Window":
+			return
+		candidate = obj
 		if obj.UIAElement.cachedClassName == "ListViewItem":
-			obj = obj.parent.previous
-			ui.message(obj.name)
-			obj = obj.firstChild
+			# The difference between emoji panel and suggestions list is absence of categories/emoji separation.
+			# If dealing with keyboard entry suggestions (build 17040 and later), return immediately.
+			candidate = obj.parent.previous
+			if candidate is None:
+				return
+			ui.message(candidate.name)
+			obj = candidate.firstChild
 		if obj is not None:
 			api.setNavigatorObject(obj)
 			obj.reportFocus()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -43,3 +43,10 @@ class AppModule(appModuleHandler.AppModule):
 			# Translators: presented when there is no emoji when searching for one in Windows 10 Fall Creators Update and later.
 			ui.message(_("No emoji"))
 		nextHandler()
+
+	def event_UIA_window_windowOpen(self, obj, nextHandler):
+		# Make sure to announce most recently used emoji first in post-1709 builds.
+		# Fake the announcement by locating 'most recently used" category and calling selected event on this.
+		if obj.childCount == 3:
+			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
+		nextHandler()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -19,6 +19,9 @@ import winVersion
 
 class AppModule(appModuleHandler.AppModule):
 
+	# Cache the most recently selected item.
+	_recentlySelected = None
+
 	def event_UIA_elementSelected(self, obj, nextHandler):
 		# #7273: When this is fired on categories, the first emoji from the new category is selected but not announced.
 		# Therefore, move the navigator object to that item if possible.
@@ -27,6 +30,9 @@ class AppModule(appModuleHandler.AppModule):
 		# #8189: do not announce candidates list itself (not items), as this is repeated each time candidate items are selected.
 		if obj.UIAElement.cachedAutomationID == "CandidateList": return
 		speech.cancelSpeech()
+		# Sometimes clipboard candidates list gets selected, so ask NvDA to descend one more level.
+		if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList":
+			obj = obj.firstChild
 		candidate = obj
 		if obj.UIAElement.cachedClassName == "ListViewItem" and obj.parent.UIAElement.cachedAutomationID != "TEMPLATE_PART_ClipboardItemsList":
 			# The difference between emoji panel and suggestions list is absence of categories/emoji separation.
@@ -40,6 +46,8 @@ class AppModule(appModuleHandler.AppModule):
 			api.setNavigatorObject(obj)
 			obj.reportFocus()
 			braille.handler.message(braille.getBrailleTextForProperties(name=obj.name, role=obj.role, positionInfo=obj.positionInfo))
+			# Cache selected item.
+			self._recentlySelected = obj.name
 		else:
 			# Translators: presented when there is no emoji when searching for one in Windows 10 Fall Creators Update and later.
 			ui.message(_("No emoji"))
@@ -49,7 +57,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Make sure to announce most recently used emoji first in post-1709 builds.
 		# Fake the announcement by locating 'most recently used" category and calling selected event on this.
 		# However, in build 17666 and later, child count is the same for both emoji panel and hardware keyboard candidates list.
-		if winVersion.winVersion.build < 17666 and obj.childCount == 3:
+		if winVersion.winVersion.build <= 17134 and obj.childCount == 3:
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
@@ -64,23 +72,27 @@ class AppModule(appModuleHandler.AppModule):
 					pass
 			# Emoji panel in build 17666 and later (unless this changes).
 			elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
-				self._emojiPanelOpened = True
+				self._emojiPanelJustOpened = True
 				self.event_UIA_elementSelected(obj.firstChild.firstChild.next.next.firstChild.firstChild, nextHandler)
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.
-	_emojiPanelOpened = False
+	_emojiPanelJustOpened = False
 
 	def event_nameChange(self, obj, nextHandler):
-		# On some systems, touch keyboard keys keeps firing name change event.
-		if obj.UIAElement.cachedClassName == "CRootKey":
+		# #49: reported by a user: on some systems, touch keyboard keys keeps firing name change event.
+		# Argh, in build 17704, whenever skin tones are selected, name change is fired by emoji entries (GridViewItem).
+		if ((obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem"))
+		or (obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList")
+		# And no, emoji entries should not be announced here.
+		or (self._recentlySelected is not None and self._recentlySelected in obj.name)):
 			return
 		# The word "blank" is kept announced, so suppress this on build 17666 and later.
-		if winVersion.winVersion.build >= 17672:
+		if winVersion.winVersion.build > 17134:
 			# In build 17672 and later, return immediatley when element selected event on clipboard item was fired just prior to this.
 			if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemIndex" or obj.parent.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList": return
-			if not self._emojiPanelOpened or obj.UIAElement.cachedAutomationID != "TEMPLATE_PART_ExpressionGroupedFullView": speech.cancelSpeech()
-			self._emojiPanelOpened = False
+			if not self._emojiPanelJustOpened or obj.UIAElement.cachedAutomationID != "TEMPLATE_PART_ExpressionGroupedFullView": speech.cancelSpeech()
+			self._emojiPanelJustOpened = False
 		# Don't forget to add "Microsoft Candidate UI" as something that should be suppressed.
 		if obj.UIAElement.cachedAutomationID not in ("TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"):
 			ui.message(obj.name)

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -72,12 +72,16 @@ class AppModule(appModuleHandler.AppModule):
 	_emojiPanelOpened = False
 
 	def event_nameChange(self, obj, nextHandler):
+		# On some systems, touch keyboard keys keeps firing name change event.
+		if obj.UIAElement.cachedClassName == "CRootKey":
+			return
 		# The word "blank" is kept announced, so suppress this on build 17666 and later.
 		if winVersion.winVersion.build >= 17672:
 			# In build 17672 and later, return immediatley when element selected event on clipboard item was fired just prior to this.
 			if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemIndex" or obj.parent.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList": return
 			if not self._emojiPanelOpened or obj.UIAElement.cachedAutomationID != "TEMPLATE_PART_ExpressionGroupedFullView": speech.cancelSpeech()
 			self._emojiPanelOpened = False
-		if obj.UIAElement.cachedAutomationID not in ("TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex"):
+		# Don't forget to add "Microsoft Candidate UI" as something that should be suppressed.
+		if obj.UIAElement.cachedAutomationID not in ("TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"):
 			ui.message(obj.name)
 		nextHandler()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,7 @@ What's New in NVDA
  - ALVA, Baum/HumanWare/APH/Orbit, Eurobraille, Handy Tech, Hims, SuperBraille and HumanWare BrailleNote and Brailliant BI/B displays are currently supported.
  - You can enable this feature by selecting the automatic option from the list of braille displays in NVDA's braille display selection dialog.
  - Please consult the documentation for additional details.
+- Added support for various modern input features introduced in recent Windows 10 releases. These include emoji panel (Fall Creators Update), dictation (Fall Creators Update), hardware keyboard input suggestions (April 2018 Update), and cloud clipboard (RS5). (#7273)
 
 
 == Changes ==


### PR DESCRIPTION
Hi,

Revision: revised in July 2018 to base it on the template.

### Link to issue number:
Fixes #7273

### Summary of the issue:
Support modern keyboard features, including emoji panel, hardware input suggestions, dictation, and cloud clipboard.

### Description of how this pull request fixes the issue:
Adds an app module for Composable Shell keyboard. This overlay app provides the following features:

### Testing performed:
Searching for emojis, dictating text, cloud clipboard paste, entering text with hardware input suggestion turned on in various Windows 10 releases. Note that because it is an app module, it was tested with Windows 10 App Essentials add-on first.

### Known issues with pull request:
None, although features are subject to change.

### Change log entry:
Section: new features:
Added support for modern input features in recent Windows 10 releases. These include emoji panel (Fall Creators Update), dictation (Fall Creators Update), hardware keyboard input suggestions (April 2018 Update), and cloud clipboard (RS5).

### Technical details:

* The new XAML touch keyboard has its own app module.
* If one has United States English keyboard layout and is running build 16215 or later, one can press Windows+period or Windows+semicolon to search for and enter emojis. The keyboard layout requirement was relaxed in build 17134.
* One can also type emoji descriptions to find the exact emoji.
* Each emoji candidate raises element selected event when selected.
* In some cases, when the emoji panel first opens, the first emoji isn't announced because element selected event is not fired then, although window open event is fired.
* This app was later exte3nded to cover dictation (Windws+H), cloud clipboard and announcing hardware input suggestion candidates.

Thanks.