### PR TITLE
Update espeak

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -105,7 +105,7 @@ espeakLib=env.SharedLibrary(
 		"../ucd-tools/src/tostring.c",
 		"compiledata.c",
 		"compiledict.c",
-		"compilembrola.c",
+#		"compilembrola.c", # we dont use MBROLA, this is a compile option in espeak
 		"dictionary.c",
 		"encoding.c",
 		"error.c",
@@ -113,7 +113,7 @@ espeakLib=env.SharedLibrary(
 		"ieee80.c",
 		"intonation.c",
 		"klatt.c", # we do use KLATT, this is a compile option in espeak
-		"mbrowrap.c", # we do use MBROLA, this is a compile option in espeak
+#		"mbrowrap.c", # we don't use MBROLA, this is a compile option in espeak
 		"mnemonics.c",
 		"numbers.c",
 		"phoneme.c",
@@ -124,7 +124,7 @@ espeakLib=env.SharedLibrary(
 		"speech.c",
 		"synthdata.c",
 		"synthesize.c",
-		"synth_mbrola.c",
+		"synth_mbrola.c", # provides symbols used by synthesize.obj, voices.obj, and wavegen.obj
 		"tokenizer.c",
 		"translate.c",
 		"tr_languages.c",
@@ -145,6 +145,11 @@ espeakLib=env.SharedLibrary(
 
 phonemeData=env.espeak_compilePhonemeData(espeakRepo.Dir('espeak-ng-data'),espeakRepo.Dir('phsource'))
 env.Depends(phonemeData,espeakLib)
+for i in phonemeData:
+	iDir = espeakRepo.Dir('espeak-ng-data').abspath
+	l = len(iDir) + 1
+	fileName = i.abspath[l:]
+	env.InstallAs(os.path.join(synthDriversDir.Dir('espeak-ng-data').abspath, fileName), i)
 
 # Move any extra dictionaries into dictsource for compilation
 env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
@@ -155,13 +160,23 @@ dictSourcePath=espeakRepo.Dir('dictsource').abspath
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]
 	if lang in missingDicts: continue
-	dictFile=env.Command(espeakRepo.Dir('espeak-ng-data').File(lang+'_dict'),f,espeak_compileDict_buildAction)
+	dictFileName = lang+'_dict'
+	dictFile=env.Command(espeakRepo.Dir('espeak-ng-data').File(dictFileName),f,espeak_compileDict_buildAction)
 	dictDeps=env.Glob(os.path.join(espeakRepo.abspath,'dictsource',lang+'_*'))
 	dictDeps.remove(f)
 	env.Depends(dictFile,dictDeps)
 	env.Depends(dictFile,[espeakLib,phonemeData])
 	#Dictionaries can not be compiled in parallel, force SCons not to do this
 	env.SideEffect('_espeak_compileDict',dictFile)
+	env.InstallAs(os.path.join(synthDriversDir.Dir('espeak-ng-data').abspath, dictFileName), dictFile)
 
 env.Install(synthDriversDir,espeakLib)
-env.RecursiveInstall(synthDriversDir.Dir('espeak-ng-data'),espeakRepo.Dir('espeak-ng-data').abspath)
+
+# install espeak-ng-data
+targetEspeakDataDir=synthDriversDir.Dir('espeak-ng-data')
+espeakDataSource=espeakRepo.Dir('espeak-ng-data')
+espeakDataSourceAbsPath=espeakDataSource.abspath
+
+# also install the lang and voices/!v directories. Exclude the voices/mb directory since we are not using mbrola.
+env.RecursiveInstall(targetEspeakDataDir.Dir('lang'),espeakDataSource.Dir('lang').abspath)
+env.RecursiveInstall(targetEspeakDataDir.Dir('voices').Dir('!v'),espeakDataSource.Dir('voices').Dir('!v').abspath)

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -175,7 +175,6 @@ env.Install(synthDriversDir,espeakLib)
 # install espeak-ng-data
 targetEspeakDataDir=synthDriversDir.Dir('espeak-ng-data')
 espeakDataSource=espeakRepo.Dir('espeak-ng-data')
-espeakDataSourceAbsPath=espeakDataSource.abspath
 
 # also install the lang and voices/!v directories. Exclude the voices/mb directory since we are not using mbrola.
 env.RecursiveInstall(targetEspeakDataDir.Dir('lang'),espeakDataSource.Dir('lang').abspath)

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -150,7 +150,7 @@ env.Depends(phonemeData,espeakLib)
 env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
 
 #Compile all dictionaries
-missingDicts=['zhy'] #'mt','tn','tt']
+missingDicts=['zhy', 'an'] #'mt','tn','tt']
 dictSourcePath=espeakRepo.Dir('dictsource').abspath
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -96,37 +96,49 @@ espeakLib=env.SharedLibrary(
 	target='espeak',
 	srcdir=espeakSrcDir.Dir('libespeak-ng').abspath,
 	source=[
+		# compare to src_libespeak_ng_la_SOURCES in espeak Makefile.am
 		"../ucd-tools/src/case.c",
 		"../ucd-tools/src/categories.c",
 		"../ucd-tools/src/ctype.c",
+		"../ucd-tools/src/proplist.c",
 		"../ucd-tools/src/scripts.c",
 		"../ucd-tools/src/tostring.c",
-		"speech.c",
-		"readclause.c",
+		"compiledata.c",
 		"compiledict.c",
+		"compilembrola.c",
 		"dictionary.c",
 		"encoding.c",
+		"error.c",
+		"espeak_api.c",
+		"ieee80.c",
 		"intonation.c",
-		"setlengths.c",
+		"klatt.c", # we do use KLATT, this is a compile option in espeak
+		"mbrowrap.c", # we do use MBROLA, this is a compile option in espeak
 		"mnemonics.c",
 		"numbers.c",
 		"phoneme.c",
-		"synth_mbrola.c",
+		"phonemelist.c",
+		"readclause.c",
+		"setlengths.c",
+		"spect.c",
+		"speech.c",
 		"synthdata.c",
 		"synthesize.c",
+		"synth_mbrola.c",
+		"tokenizer.c",
 		"translate.c",
 		"tr_languages.c",
 		"voices.c",
 		"wavegen.c",
-		"phonemelist.c",
-		"klatt.c",
-		"compiledata.c",
-		"compilembrola.c",
-		"ieee80.c",
-		"spect.c",
-		"espeak_api.c",
-		"error.c",
 		sonicLib,
+		# espeak does not need to handle its own audio output so dont include:
+		# pcaudiolib\src\audio.c
+		# pcaudiolib\src\windows.c
+		# pcaudiolib\src\xaudio2.cpp
+		# These are for SAPI5, we dont need them:
+		# com\comentrypoints.c
+		# com\ttsengine.cpp
+		# We do not use the ASYNC compile option in espeak.
 	],
 	LIBS=['advapi32'],
 )

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -42,7 +42,7 @@ if 'analyze' in env['nvdaHelperDebugFlags']:
 # Ignore all warnings as the code is not ours
 env.Append(CCFLAGS='/W0')
 
-env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir])
+env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir,espeakSrcDir.Dir('ucd-tools/src/include')])
 
 def espeak_compilePhonemeData_buildEmitter(target,source,env):
 	phSourceIgnores=['error_log','error_intonation','compile_prog_log','compile_report','envelopes.png']
@@ -96,13 +96,21 @@ espeakLib=env.SharedLibrary(
 	target='espeak',
 	srcdir=espeakSrcDir.Dir('libespeak-ng').abspath,
 	source=[
+		"../ucd-tools/src/case.c",
+		"../ucd-tools/src/categories.c",
+		"../ucd-tools/src/ctype.c",
+		"../ucd-tools/src/scripts.c",
+		"../ucd-tools/src/tostring.c",
 		"speech.c",
 		"readclause.c",
 		"compiledict.c",
 		"dictionary.c",
+		"encoding.c",
 		"intonation.c",
 		"setlengths.c",
+		"mnemonics.c",
 		"numbers.c",
+		"phoneme.c",
 		"synth_mbrola.c",
 		"synthdata.c",
 		"synthesize.c",
@@ -130,7 +138,7 @@ env.Depends(phonemeData,espeakLib)
 env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
 
 #Compile all dictionaries
-missingDicts=[] #'mt','tn','tt']
+missingDicts=['zhy'] #'mt','tn','tt']
 dictSourcePath=espeakRepo.Dir('dictsource').abspath
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -155,7 +155,7 @@ for i in phonemeData:
 env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
 
 #Compile all dictionaries
-missingDicts=['zhy', 'an'] #'mt','tn','tt']
+missingDicts=['zhy', ] #'mt','tn','tt']
 dictSourcePath=espeakRepo.Dir('dictsource').abspath
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]

--- a/site_scons/site_tools/recursiveInstall.py
+++ b/site_scons/site_tools/recursiveInstall.py
@@ -36,12 +36,6 @@ def recursive_install(env, path ):
         ( os.path.join(path, '*')
         , strings=False
         )
-    nodes.extend \
-            ( env.Glob \
-                ( os.path.join(path, '*.*')
-                , strings=False
-                )
-            )
     out = []
     for n in nodes:
         if n.isdir():

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -193,7 +193,7 @@ class SynthDriver(SynthDriver):
 		voices=OrderedDict()
 		for v in _espeak.getVoiceList():
 			l=v.languages[1:]
-			# #7167: Some languages names require unicode characters EG: Norwegian Bokmål
+			# #7167: Some languages names contain unicode characters EG: Norwegian Bokmål
 			name=v.name.decode("UTF-8")
 			# #5783: For backwards compatibility, voice identifies should always be lowercase
 			identifier=os.path.basename(v.identifier).lower()

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -193,9 +193,11 @@ class SynthDriver(SynthDriver):
 		voices=OrderedDict()
 		for v in _espeak.getVoiceList():
 			l=v.languages[1:]
+			# #7167: Some languages names require unicode characters EG: Norwegian Bokmål
+			name=v.name.decode("UTF-8")
 			# #5783: For backwards compatibility, voice identifies should always be lowercase
 			identifier=os.path.basename(v.identifier).lower()
-			voices[identifier]=VoiceInfo(identifier,v.name,l)
+			voices[identifier]=VoiceInfo(identifier,name,l)
 		return voices
 
 	def _get_voice(self):


### PR DESCRIPTION
### Note:
If you notice a problem with Espeak on next (or master), please open a new issue to discuss this.

### Summary of the issue:
In order to more quickly spot and report issues on Espeak, we are regularly updating espeak to the latest master on our next branch. When this gets to stable we can merge back to nvda master. 

### Description of how this pull request fixes the issue:
This updates the espeak submodule to the latest espeak-ng master commit and fixes any build errors.

### In depth discussion of the changes:
Compiling mbrowrap was causing an issue, and we dont use mbrola anyway, so this was removed. It was noticed that a bunch of mbrola voices were listed in espeak but did not seem to do anything. The sconscript has been modified to exclude the 'espeak-ng-data/voice/mb' directory. This means that we can no longer recursively install espeak-ng-data and must instead manually install the files, and then recursive install for lang and voices/!v subfolders.

Removed lines from recursive install that seem unnecessary. `glob path/*.*` should not add anything to `glob path/*`

Allow unicode characters in espeak language names. Fixes part of #7167 - selecting Norwegian Bokmål no longer causes an error.

Added compilation of several missing files, and commented on why we dont compile other files. Tried to make the list of compiled files match the files listed in the automake used in espeak-ng

### Testing performed:
- Ensure that it builds locally and on appveyor.
- Ensure that the list of voices and variants for espeak look correct in NVDA
- Ensure that espeak can be used

### Known issues with pull request:
None

### Change log entry:
For now none. But perhaps eventually:
```
Espeak-ng has been updated to commit 01919cd48a566cdf34347784b2e74554b376e900
```
