### PR TITLE
Add more default task switching gestures to freedom scientific braille displays

### DIFF
--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -247,6 +247,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver,ScriptableObject):
 			"kb:control+end" : ("br(freedomScientific):dot4+dot5+dot6+brailleSpaceBar",),
 			"kb:alt" : ("br(freedomScientific):dot1+dot3+dot4+brailleSpaceBar",),
 			"kb:alt+tab" : ("br(freedomScientific):dot2+dot3+dot4+dot5+brailleSpaceBar",),
+			"kb:alt+shift+tab" : ("br(freedomScientific):dot1+dot2+dot5+dot6+brailleSpaceBar",),
+			"kb:win+tab" : ("br(freedomScientific):dot2+dot3+dot4+brailleSpaceBar",),
 			"kb:escape" : ("br(freedomScientific):dot1+dot5+brailleSpaceBar",),
 			"kb:windows" : ("br(freedomScientific):dot2+dot4+dot5+dot6+brailleSpaceBar",),
 			"kb:windows+d" : ("br(freedomScientific):dot1+dot2+dot3+dot4+dot5+dot6+brailleSpaceBar",),

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1748,6 +1748,8 @@ Please see the display's documentation for descriptions of where these keys can 
 | control+end key | brailleSpaceBar+dot4+dot5+dot6 |
 | alt key | brailleSpaceBar+dot1+dot3+dot4 |
 | alt+tab key | brailleSpaceBar+dot2+dot3+dot4+dot5 |
+| alt+shift+tab key | brailleSpaceBar+dot1+dot2+dot5+dot6 |
+| windows+tab key | brailleSpaceBar+dot2+dot3+dot4 |
 | escape key | brailleSpaceBar+dot1+dot5 |
 | windows key | brailleSpaceBar+dot2+dot4+dot5+dot6 |
 | space key | brailleSpaceBar |


### PR DESCRIPTION
Summary: The Freedom Scientific braille display driver only provides a gesture for alt+tab by default.

Fixes: this pr adds gestures for alt shift tab (dots 1-2-5-6 with space), and windows tab (dots 2-3-4 with space).

Suggested what's new entry (section 'changes'): Add default gestures for alt shift tab and windows tab with all supported Freedom Scientific  braille displays.
