### PR TITLE
Remove a redundant import in api.py

### DIFF
--- a/source/api.py
+++ b/source/api.py
@@ -183,7 +183,6 @@ def setReviewPosition(reviewPosition,clearNavigatorObject=True):
 	globalVars.reviewPosition=reviewPosition.copy()
 	globalVars.reviewPositionObj=reviewPosition.obj
 	if clearNavigatorObject: globalVars.navigatorObject=None
-	import braille
 	braille.handler.handleReviewMove()
 
 def getNavigatorObject():


### PR DESCRIPTION
Fixes #7389.
Confirmed by @jcsteh that the removed line was redundant. Running with this line removed indeed reveals no errors.