### PR TITLE
Add three Danish braille tables

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited, Joseph Lee
+#Copyright (C) 2008-2017 NV Access Limited, Joseph Lee, Davy Kager
 
 """Manages information about available braille translation tables.
 """
@@ -62,6 +62,7 @@ def listTables():
 
 #: Maps old table names to new table names for tables renamed in newer versions of liblouis.
 RENAMED_TABLES = {
+	# "oldName":"newName",
 	"da-dk-g16.utb":"da-dk-g16.ctb",
 	"da-dk-g18.utb":"da-dk-g18.ctb",
 	"gr-gr-g1.utb":"el.ctb",
@@ -73,7 +74,7 @@ RENAMED_TABLES = {
 	"UEBC-g2.ctb":"en-ueb-g2.ctb",
 }
 
-# Add builtin tables.
+# Add built-in tables.
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ar-ar-g1.utb", _("Arabic grade 1"))
@@ -100,6 +101,9 @@ addTable("cy-cy-g2.ctb", _("Welsh grade 2"), contracted=True)
 addTable("cz-cz-g1.utb", _("Czech grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("da-dk-g08.ctb", _("Danish 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("da-dk-g16.ctb", _("Danish 6 dot grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -109,7 +113,13 @@ addTable("da-dk-g18.ctb", _("Danish 8 dot grade 1"))
 addTable("da-dk-g26.ctb", _("Danish 6 dot grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("da-dk-g26l.ctb", _("Danish 6 dot grade 1.5"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("da-dk-g28l.ctb", _("Danish 8 dot grade 1.5"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("de-de-comp8.ctb", _("German 8 dot computer braille"))


### PR DESCRIPTION
### Link to issue number:
Fixes #2835.

### Summary of the issue:
There are a few Danish braille tables in liblouis that are not yet in NVDA.

### Description of how this pull request fixes the issue:
This adds three new Danish braille tables, both input and output:
1. 8-dot computer braille
2. 6-dot grade 1.5 (grade 2l)
3. 8-dot grade 1.5 (grade 2l)

Motivation for including these tables is in https://github.com/nvaccess/nvda/issues/2835#issuecomment-315606412. In short:
* The computer braille table is obviously useful for screen readers.
* The two grade 1.5 tables are used by e.g. deaf-blind people. Their availability would be unique to NVDA.

### Testing performed:
The tables themselves are unit tested in liblouis. I tested that they appear in the braille settings dialog and that they can be activated from there.

### Known issues with pull request:
According to @BueVest:
* The tables are ready but not set in stone, i.e. if the Danish braille committee makes changes.
* The name "grade 1.5" is a bit unfortunate. For the Danish translation of NVDA a more appropriate name would be used.

### Change log entry:
New Features:
* Three new Danish braille tables have been added: 8-dot computer braille, 6-dot grade 1.5 and 8-dot grade 1.5. They are available for braille input and output.