### PR TITLE
Fix broken translation template (pot) generation.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,10 @@ build_script:
  - 'echo scons args: %sconsArgs%'
  - py scons.py source %sconsArgs%
  # We don't need launcher to run tests, so run the tests before launcher.
- - py scons.py tests %sconsArgs%
+ # We also build the translation template (pot) just to ensure it succeeds.
+ - py scons.py tests pot %sconsArgs%
+ # We don't actually need the pot as a build artifact though.
+ - del output\*.pot
  - 'echo scons output targets: %sconsOutTargets%'
  - py scons.py %sconsOutTargets% %sconsArgs%
  # Build symbol store.

--- a/sconstruct
+++ b/sconstruct
@@ -382,7 +382,11 @@ env.Clean('devDocs', [devGuide, devDocs_nvda])
 pot = env.Command(outputDir.File("%s.pot" % outFilePrefix),
 	# Don't use sourceDir as the source, as this depends on comInterfaces and nvdaHelper.
 	# We only depend on the Python files.
-	[f for pattern in ("*.py", "*.pyw", r"*\*.py", r"*\*\*.py") for f in env.Glob(os.path.join(sourceDir.path, pattern))],
+	[f for pattern in ("*.py", "*.pyw", r"*\*.py", r"*\*\*.py")
+		for f in env.Glob(os.path.join(sourceDir.path, pattern))
+		# Exclude comInterfaces, since these don't contain translatable strings
+		# and they cause unknown encoding warnings.
+		if not f.path.startswith("source\\comInterfaces\\")],
 	makePot)
 
 env.Alias("pot", pot)

--- a/source/brailleDisplayDrivers/superBrl.py
+++ b/source/brailleDisplayDrivers/superBrl.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.


### PR DESCRIPTION
### Link to issue number:
Fixes regression introduced by #7352.

### Summary of the issue:
The translation system failed to build a translation template due to the superBrl driver.

### Description of how this pull request fixes the issue:
The superBrl braille display driver includes escape sequences which produce non-ASCII characters; e.g. "\xff". Due to a gettext bug, this causes xgettext to fail even though these aren't in translatable strings. See https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911.

1. To work around this, declare encoding as UTF-8 for the superBrl driver.
2. Make AppVeyor build the translation template so that builds fail for problems like this. This way, we learn about such problems long before they get to the translation system.
3. Explicitly exclude source\comInterfaces for scons pot to avoid unknown encoding warnings. These files never contain translatable strings anyway.

I also updated the [Contributing document](https://github.com/nvaccess/nvda/wiki/Contributing) to mention the need for an encoding declaration in this case.

### Testing performed:
1. Locally ensured that `scons pot` succeeded.
2. Pushed a try build with the AppVeyor changes but without the superBrl changes. It failed as expected.
3. Pushed a try build including all changes. It succeeded.

### Known issues with pull request:
None.

### Change log entry:
None needed.

### Merge notes:
This should be merged straight to master. Once done, a mergePot job should be manually triggered on the translation system, since the scheduled job failed.