### PR TITLE
Dialogs in web pages in Firefox and Chrome  now get browseMode if the parent document also has browseMode

### DIFF
--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -1021,7 +1021,7 @@ if(!(formatState&FORMATSTATE_INSERTED)&&nodeName.compare(L"INS")==0) {
 	// Whether the name is the content of this node.
 	bool nameIsContent = (IARole == ROLE_SYSTEM_LINK || IARole == ROLE_SYSTEM_PUSHBUTTON || IARole == ROLE_SYSTEM_MENUITEM || IARole == ROLE_SYSTEM_GRAPHIC || IARole == ROLE_SYSTEM_PAGETAB
 		|| ariaRole == L"heading" || (nodeName[0] == L'H' && iswdigit(nodeName[1]))
-		|| nodeName == L"OBJECT" || nodeName == L"APPLET" || IARole == ROLE_SYSTEM_APPLICATION || IARole == ROLE_SYSTEM_DIALOG);
+		|| nodeName == L"OBJECT" || nodeName == L"APPLET" || (!isRoot && (IARole == ROLE_SYSTEM_APPLICATION || IARole == ROLE_SYSTEM_DIALOG)));
 	// True if the name definitely came from the author.
 	bool nameFromAuthor=false;
 

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -13,7 +13,7 @@ import oleacc
 import IAccessibleHandler
 import controlTypes
 from logHandler import log
-from NVDAObjects.behaviors import Dialog, FocusableUnfocusableContainer
+from NVDAObjects.behaviors import Dialog, WebDialog 
 from . import IAccessible
 from .ia2TextMozilla import MozillaCompoundTextInfo
 
@@ -45,21 +45,6 @@ class Document(Ia2Web):
 
 class Application(Document):
 	shouldCreateTreeInterceptor = False
-
-class WebDialog(Document):
-	"""
-	A dialog that will use a treeInterceptor if its parent currently does.
-	"""
-
-	def _get_shouldCreateTreeInterceptor(self):
-		if self.parent.treeInterceptor:
-			return True
-		return False
-
-	# For dialogs that will get browseMode and are focusable themselves (have a tabindex):
-	# Allow setting focus to the dialog directly, rather than its first focusable descendant
-	def _get__alwaysFocusFirstfocusableDescendant(self):
-		return not self.shouldCreateTreeInterceptor
 
 class BlockQuote(Ia2Web):
 	role = controlTypes.ROLE_BLOCKQUOTE

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -603,9 +603,6 @@ class FocusableUnfocusableContainer(NVDAObject):
 	isFocusable = True
 
 	def setFocus(self):
-		# provide a way for  sub or super classes to disable this focusable descendant behaviour if necessary.
-		if not getattr(self,'_alwaysFocusFirstfocusableDescendant',True) and super(FocusableUnfocusableContainer,self).isFocusable: 
-			return super(FocusableUnfocusableContainer,self).setFocus()
 		for obj in self.recursiveDescendants:
 			if obj.isFocusable:
 				obj.setFocus()
@@ -663,3 +660,14 @@ class EditableTextWithSuggestions(NVDAObject):
 		"""
 		if config.conf["presentation"]["reportAutoSuggestionsWithSound"]:
 			nvwave.playWaveFile(r"waves\suggestionsClosed.wav")
+
+class WebDialog(NVDAObject):
+	"""
+	A dialog that will use a treeInterceptor if its parent currently does.
+	This  can be used to ensure that dialogs on the web get browseMode by default, unless inside an ARIA application
+	"""
+
+	def _get_shouldCreateTreeInterceptor(self):
+		if self.parent.treeInterceptor:
+			return True
+		return False

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -603,6 +603,9 @@ class FocusableUnfocusableContainer(NVDAObject):
 	isFocusable = True
 
 	def setFocus(self):
+		# provide a way for  sub or super classes to disable this focusable descendant behaviour if necessary.
+		if not getattr(self,'_alwaysFocusFirstfocusableDescendant',True) and super(FocusableUnfocusableContainer,self).isFocusable: 
+			return super(FocusableUnfocusableContainer,self).setFocus()
 		for obj in self.recursiveDescendants:
 			if obj.isFocusable:
 				obj.setFocus()

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -78,8 +78,11 @@ class ControlField(Field):
 			or (role == controlTypes.ROLE_LIST and controlTypes.STATE_READONLY not in states)
 		):
 			return self.PRESCAT_SINGLELINE
-		elif role in (controlTypes.ROLE_SEPARATOR, controlTypes.ROLE_FOOTNOTE, controlTypes.ROLE_ENDNOTE, controlTypes.ROLE_EMBEDDEDOBJECT, controlTypes.ROLE_APPLICATION, controlTypes.ROLE_DIALOG, controlTypes.ROLE_MATH):
+		elif role in (controlTypes.ROLE_SEPARATOR, controlTypes.ROLE_FOOTNOTE, controlTypes.ROLE_ENDNOTE, controlTypes.ROLE_EMBEDDEDOBJECT, controlTypes.ROLE_MATH):
 			return self.PRESCAT_MARKER
+		elif role in (controlTypes.ROLE_APPLICATION, controlTypes.ROLE_DIALOG):
+			# Applications and dialogs should be reported as markers when embedded within content, but not when they themselves are the root
+			return self.PRESCAT_MARKER if ancestors else self.PRESCAT_LAYOUT 
 		elif role in (controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLECOLUMNHEADER, controlTypes.ROLE_TABLEROWHEADER):
 			return self.PRESCAT_CELL
 		elif (

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -164,8 +164,8 @@ class MSHTML(VirtualBuffer):
 	def __init__(self,rootNVDAObject):
 		super(MSHTML,self).__init__(rootNVDAObject,backendName="mshtml")
 		# As virtualBuffers must be created at all times for MSHTML to support live regions,
-		# Force focus mode for anything other than a document (e.g. dialog, application)
-		if rootNVDAObject.role!=controlTypes.ROLE_DOCUMENT:
+		# Force focus mode for applications, and dialogs with no parent treeInterceptor (E.g. a dialog embedded in an application)  
+		if rootNVDAObject.role==controlTypes.ROLE_APPLICATION or (rootNVDAObject.role==controlTypes.ROLE_DIALOG and (not rootNVDAObject.parent or not rootNVDAObject.parent.treeInterceptor or rootNVDAObject.parent.treeInterceptor.passThrough)):
 			self.disableAutoPassThrough=True
 			self.passThrough=True
 


### PR DESCRIPTION
### Link to issue number:
Fixes #4493 

### Summary of the issue:
The web accessibility community has requested that dialogs be navigable the same way any normal web document is (I.e. has NVDA browseMode by default), unless they are embedded in an application. Currently NVDA treats dialogs similar to applications in that browseMode is not available by default.

### Description of how this pull request fixes the issue:
Dialogs in Firefox and Chrome will now get browseMode by default if the parent document has a treeInterceptor.
This involved creating a new WebDialog NVDAObject class in ia2web and using this for dialogs in place of Application.
Also, a change was made to FocusableUnfocusableContainer behavior to allow a sub or super class to choose to allow setFocus to fallback to setting focus to the object itself rather than the first focusable descendant, if the object itself definitely is focusable. Many dialogs on the web do ahve a tabindex of -1 and the UX is better if we can set focus to the dialog not the descendant when providing browseMode on first activation so it reads from the top.

### Testing performed:
A div with role=dialog in a standard web document, and also role=dialog inside an div with role=application in a web document.
Tested in both Chrome and Firefox.

### Known issues with pull request:
This does not change Internet Explorer as we are no longer supporting new features, and Edge currently has limitations in its text patterns which make this impossible (namely there is no specific text pattern for each dialog to bound browseMode).

### Change log entry:
Section: Changes
* Web dialogs in Firefox and Chrome web browsers now automatically use browse Mode, unless inside of a web application. (#4493)
