### PR TITLE
speech.speakTextInfo: only announce exiting old controlFields if the reason is not reason_focus.

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -800,16 +800,17 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 		else:
 			break
 
-	#Get speech text for any fields in the old controlFieldStack that are not in the new controlFieldStack 
-	endingBlock=False
-	for count in reversed(xrange(commonFieldCount,len(controlFieldStackCache))):
-		text=info.getControlFieldSpeech(controlFieldStackCache[count],controlFieldStackCache[0:count],"end_removedFromControlFieldStack",formatConfig,extraDetail,reason=reason)
-		if text:
-			speechSequence.append(text)
-		if not endingBlock and reason==controlTypes.REASON_SAYALL:
-			endingBlock=bool(int(controlFieldStackCache[count].get('isBlock',0)))
-	if endingBlock:
-		speechSequence.append(SpeakWithoutPausesBreakCommand())
+	# #2591: If the reason is not focus, Speak the exit of any controlFields not in the new stack.
+	if reason!=controlTypes.REASON_FOCUS:
+		endingBlock=False
+		for count in reversed(xrange(commonFieldCount,len(controlFieldStackCache))):
+			text=info.getControlFieldSpeech(controlFieldStackCache[count],controlFieldStackCache[0:count],"end_removedFromControlFieldStack",formatConfig,extraDetail,reason=reason)
+			if text:
+				speechSequence.append(text)
+			if not endingBlock and reason==controlTypes.REASON_SAYALL:
+				endingBlock=bool(int(controlFieldStackCache[count].get('isBlock',0)))
+		if endingBlock:
+			speechSequence.append(SpeakWithoutPausesBreakCommand())
 	# The TextInfo should be considered blank if we are only exiting fields (i.e. we aren't entering any new fields and there is no text).
 	isTextBlank=True
 

--- a/source/speech.py
+++ b/source/speech.py
@@ -800,7 +800,8 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 		else:
 			break
 
-	# #2591: If the reason is not focus, Speak the exit of any controlFields not in the new stack.
+	# #2591: Only if the reason is not focus, Speak the exit of any controlFields not in the new stack.
+	# We don't do this for focus because hearing "out of list", etc. isn't useful when tabbing or using quick navigation and makes navigation less efficient.
 	if reason!=controlTypes.REASON_FOCUS:
 		endingBlock=False
 		for count in reversed(xrange(commonFieldCount,len(controlFieldStackCache))):


### PR DESCRIPTION
### Link to issue number:
Fixes #2591

### Description of how this pull request fixes the issue:
This ensures that quicknav / tabbing etc does not announce many exit messages when jumping to an arbitrary part of a web page.

### Testing performed:
Wikipedia article:
* Arrow through table of contents: list and out of list is appropriately still announced
* When in deep list item of table of contents, quicknav to next heading: no out of list is announced.
 
### Known issues with pull request:
1. Although  exiting old fields is now suppressed for quicknav / focus, entering is not. So for example, we sould still announce a new list, or new table etc, yet we would not announce exiting it next time. I think this is what people want, but it is definitely not symmetrical. If people did want entering suppressed also, we'd need a way of knowing the controlField level the focus / quicknav actually hit, and only speak from there down. But this is impossible at the moment I think.
2. At the moment this pr checks for lack of reason_focus when deciding if exiting controlFields should be spoken. The original issue only talked about quicknav. Either we need to move the quicknav reason int controlTypes to make it acceptable to use in speech, or  perhaps there is an advantage to doing this for all focus (I.e. tabbing etc as well as this is similar to quicknav). It is really reason_caret we don't want to do this for.
 
### Change log entry:
Section: Changes
* In browse mode, tabbing and moving with quick navigation commands no longer announces  jumping out of containers such as lists and tables, which makes navigating more efficient. (#2591)