### PR TITLE
BrowseModeDocumentTextInfo.getControlFieldSpeech: Report the name of groupings (such as fieldsets) for quicknav and focus jumps, similar to how landmark labels are reported.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -987,7 +987,6 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 
 	def getControlFieldSpeech(self, attrs, ancestorAttrs, fieldType, formatConfig=None, extraDetail=False, reason=None):
 		textList = []
-		role=attrs.get('role')
 		landmark = attrs.get("landmark")
 		if formatConfig["reportLandmarks"] and fieldType == "start_addedToControlFieldStack" and landmark:
 			try:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1284,6 +1284,10 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 	def event_focusEntered(self,obj,nextHandler):
 		if obj==self.rootNVDAObject:
 			self._enteringFromOutside = True
+		# Even if passThrough is enabled, we still completely drop focusEntered events here. 
+		# In order to get them back when passThrough is enabled, we replay them with the _replayFocusEnteredEvents method in event_gainFocus.
+		# The reason for this is to ensure that focusEntered events are delayed until a focus event has had a chance to disable passthrough mode.
+		# As in this case we would  not want them.
 
 	def _shouldIgnoreFocus(self, obj):
 		"""Determines whether focus on a given object should be ignored.
@@ -1366,7 +1370,7 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 				# Although we are going to speak the object rather than textInfo content, we still need to silently speak the textInfo content so that the textInfo speech cache is updated correctly.
 				# Not doing this would cause  later browseMode speaking to either not speak controlFields it had entered, or speak controlField exits after having already exited.
 				# See #7435 for a discussion on this.
-				speech.speakTextInfo(focusInfo,reason=controlTypes.REASON_FOCUS,onlyCache=True)
+				speech.speakTextInfo(focusInfo,reason=controlTypes.REASON_ONLYCACHE)
 				self._replayFocusEnteredEvents()
 				nextHandler()
 			focusInfo.collapse()

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -987,6 +987,7 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 
 	def getControlFieldSpeech(self, attrs, ancestorAttrs, fieldType, formatConfig=None, extraDetail=False, reason=None):
 		textList = []
+		role=attrs.get('role')
 		landmark = attrs.get("landmark")
 		if formatConfig["reportLandmarks"] and fieldType == "start_addedToControlFieldStack" and landmark:
 			try:
@@ -998,6 +999,12 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 				textList.append(aria.landmarkRoles[landmark])
 			else:
 				textList.append(_("%s landmark") % aria.landmarkRoles[landmark])
+		# #3321: Report the name of groupings (such as fieldsets) for quicknav and focus jumps
+		elif reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role==controlTypes.ROLE_GROUPING: 
+			try:
+				textList.append(attrs["name"])
+			except KeyError:
+				pass
 		textList.append(super(BrowseModeDocumentTextInfo, self).getControlFieldSpeech(attrs, ancestorAttrs, fieldType, formatConfig, extraDetail, reason))
 		return " ".join(textList)
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -999,12 +999,6 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 				textList.append(aria.landmarkRoles[landmark])
 			else:
 				textList.append(_("%s landmark") % aria.landmarkRoles[landmark])
-		# #3321: Report the name of groupings (such as fieldsets) for quicknav and focus jumps
-		elif reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role==controlTypes.ROLE_GROUPING: 
-			try:
-				textList.append(attrs["name"])
-			except KeyError:
-				pass
 		textList.append(super(BrowseModeDocumentTextInfo, self).getControlFieldSpeech(attrs, ancestorAttrs, fieldType, formatConfig, extraDetail, reason))
 		return " ".join(textList)
 

--- a/source/speech.py
+++ b/source/speech.py
@@ -725,7 +725,8 @@ def _speakTextInfo_addMath(speechSequence, info, field):
 	except (NotImplementedError, LookupError):
 		return
 
-def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlTypes.REASON_QUERY,index=None,onlyInitialFields=False,suppressBlanks=False,onlyCache=False):
+def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlTypes.REASON_QUERY,index=None,onlyInitialFields=False,suppressBlanks=False):
+	onlyCache=reason==controlTypes.REASON_ONLYCACHE
 	if isinstance(useCache,SpeakTextInfoState):
 		speakTextInfoState=useCache
 	elif useCache:

--- a/source/speech.py
+++ b/source/speech.py
@@ -725,7 +725,7 @@ def _speakTextInfo_addMath(speechSequence, info, field):
 	except (NotImplementedError, LookupError):
 		return
 
-def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlTypes.REASON_QUERY,index=None,onlyInitialFields=False,suppressBlanks=False):
+def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlTypes.REASON_QUERY,index=None,onlyInitialFields=False,suppressBlanks=False,onlyCache=False):
 	if isinstance(useCache,SpeakTextInfoState):
 		speakTextInfoState=useCache
 	elif useCache:
@@ -851,10 +851,11 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 		lastLanguage=language
 
 	if onlyInitialFields or (unit in (textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD) and len(textWithFields)>0 and len(textWithFields[0])==1 and all((isinstance(x,textInfos.FieldCommand) and x.command=="controlEnd") for x in itertools.islice(textWithFields,1,None) )): 
-		if onlyInitialFields or any(isinstance(x,basestring) for x in speechSequence):
-			speak(speechSequence)
-		if not onlyInitialFields: 
-			speakSpelling(textWithFields[0],locale=language if autoLanguageSwitching else None)
+		if not onlyCache:
+			if onlyInitialFields or any(isinstance(x,basestring) for x in speechSequence):
+				speak(speechSequence)
+			if not onlyInitialFields: 
+				speakSpelling(textWithFields[0],locale=language if autoLanguageSwitching else None)
 		if useCache:
 			speakTextInfoState.controlFieldStackCache=newControlFieldStack
 			speakTextInfoState.formatFieldAttributesCache=formatFieldAttributesCache
@@ -963,7 +964,7 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 		if not isinstance(useCache,SpeakTextInfoState):
 			speakTextInfoState.updateObj()
 
-	if speechSequence:
+	if not onlyCache and speechSequence:
 		if reason==controlTypes.REASON_SAYALL:
 			speakWithoutPauses(speechSequence)
 		else:

--- a/source/speech.py
+++ b/source/speech.py
@@ -1160,6 +1160,9 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 	elif fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_TABLE and tableID:
 		# Table.
 		return " ".join((nameText,roleText,stateText, getSpeechTextForProperties(_tableID=tableID, rowCount=attrs.get("table-rowcount"), columnCount=attrs.get("table-columncount")),levelText))
+	elif nameText and reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role==controlTypes.ROLE_GROUPING:
+		# #3321: Report the name of groupings (such as fieldsets) for quicknav and focus jumps
+		return " ".join((nameText,roleText))
 	elif fieldType in ("start_addedToControlFieldStack","start_relative") and role in (controlTypes.ROLE_TABLECELL,controlTypes.ROLE_TABLECOLUMNHEADER,controlTypes.ROLE_TABLEROWHEADER) and tableID:
 		# Table cell.
 		reportTableHeaders = formatConfig["reportTableHeaders"]


### PR DESCRIPTION
### Link to issue number:
Fixes #3321
Fixes #6979 

### Summary of the issue:
When jumping by quicknav or focus in browseMode, legends on fieldsets are not reported.


### Description of how this pull request fixes the issue:
Announce the name of the fieldset (grouping) similar to how we announce the label of landmarks, but only do this for reason_focus so that we do not double speak the name due to it also being reachable by the caret within the content.

### Known issues with pull request:
This will happen fr all groupings with a name in browseMode. Would there be some groupings that have badly calculated names that should not be spoken? Should we limit this specifically to fieldset somehow?
This works in Firefox and Chrome. But not in Edge as they do not correctly set the name of their fieldset groupings. A bug has been filed. This does not work in IE as we would have to add code to calculate the name of a fieldset from its legend ourselves. Is this worth doing?

### Change log entry:
Section: changes
In Browse mode for Firefox and Chrome, the name of form field groups are now announced when moving into them with quick navigation or when tabbing.
