### PR TITLE
Fix mistake in displayModel.DisplayModelTextInfo.getTextInChunks

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -475,7 +475,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 				if lineEndOffset>=self._endOffset:
 					return
 			return
-		for chunk in super(DisplayModelTextInfo,self)._getTextInChunks(unit):
+		for chunk in super(DisplayModelTextInfo,self).getTextInChunks(unit):
 			yield chunk
 
 class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In the getTextInChunks method on displayModel.DisplayModelTextInfo, a fallback with super is used for reading units other than line. However, the function tries to call _getTextInChunks on the super object, which does not exist.

### Description of how this pull request fixes the issue:
Removes the leading underscore from the super(DisplayModelTextInfo,self).getTextInChunks call so that it actually succeeds.

### Testing performed:
In Wordpad

```
import displayModel
next(displayModel.DisplayModelTextInfo(fg,"all").getTextInChunks("readingChunk"))
```

### Known issues with pull request:
None