### PR TITLE
displayModel: second try at recording the actual background color for text when a transparant background color is set.

### DIFF
--- a/nvdaHelper/remote/gdiHooks.cpp
+++ b/nvdaHelper/remote/gdiHooks.cpp
@@ -359,6 +359,7 @@ GlyphTranslatorCache glyphTranslatorCache;
  * @param cbCount the length of the string in characters.
  * @param resultTextSize an optional pointer to a SIZE structure that will contain the size of the text.
  * @param direction >0 for left to right, <0 for right to left, 0 for neutral or unknown. Text must still be passed in in visual order.
+ * @param prevColor the color of the pixel at the origin before the text was drawn, or CLR_INVALID if unknown
   */
 void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* lprc,UINT fuOptions,UINT textAlign, BOOL stripHotkeyIndicator, const wchar_t* lpString, const int codePage, const int* lpdx, int cbCount, LPSIZE resultTextSize, int direction, COLORREF prevColor) {
 	RECT clearRect={0,0,0,0};

--- a/nvdaHelper/remote/gdiHooks.cpp
+++ b/nvdaHelper/remote/gdiHooks.cpp
@@ -360,7 +360,7 @@ GlyphTranslatorCache glyphTranslatorCache;
  * @param resultTextSize an optional pointer to a SIZE structure that will contain the size of the text.
  * @param direction >0 for left to right, <0 for right to left, 0 for neutral or unknown. Text must still be passed in in visual order.
   */
-void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* lprc,UINT fuOptions,UINT textAlign, BOOL stripHotkeyIndicator, const wchar_t* lpString, const int codePage, const int* lpdx, int cbCount, LPSIZE resultTextSize, int direction) {
+void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* lprc,UINT fuOptions,UINT textAlign, BOOL stripHotkeyIndicator, const wchar_t* lpString, const int codePage, const int* lpdx, int cbCount, LPSIZE resultTextSize, int direction, COLORREF prevColor) {
 	RECT clearRect={0,0,0,0};
 	//If a rectangle was provided, convert it to screen coordinates
 	if(lprc) {
@@ -498,7 +498,11 @@ void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* 
 		formatInfo.italic=logFont.lfItalic?true:false;
 		formatInfo.underline=logFont.lfUnderline?true:false;
 		formatInfo.color=GetTextColor(hdc);
-		formatInfo.backgroundColor=GetBkColor(hdc);
+		if (prevColor != CLR_INVALID && GetBkMode(hdc) == TRANSPARENT) {
+			formatInfo.backgroundColor=prevColor;
+		} else {
+			formatInfo.backgroundColor=GetBkColor(hdc);
+		}
 		model->insertChunk(textRect,baselinePoint.y,newText,characterExtents,formatInfo,direction,(fuOptions&ETO_CLIPPED)?&clearRect:NULL);
 		TextInsertionTracker::reportTextInsertion();
 		HWND hwnd=WindowFromDC(hdc);
@@ -512,7 +516,7 @@ void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* 
  * @param lpString the string of ansi text you wish to record.
  * @param codePage the code page used for the string which will be converted to unicode
   */
-void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* lprc,UINT fuOptions,UINT textAlign, BOOL stripHotkeyIndicator, const char* lpString, const int codePage, const int* lpdx, int cbCount, LPSIZE resultTextSize, int direction) {
+void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* lprc,UINT fuOptions,UINT textAlign, BOOL stripHotkeyIndicator, const char* lpString, const int codePage, const int* lpdx, int cbCount, LPSIZE resultTextSize, int direction, COLORREF prevColor) {
 	int newCount=0;
 	wchar_t* newString=NULL;
 	if(lpString&&cbCount) {
@@ -522,7 +526,7 @@ void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* 
 			MultiByteToWideChar(codePage,0,lpString,cbCount,newString,newCount);
 		}
 	}
-	ExtTextOutHelper(model,hdc,x,y,lprc,fuOptions,textAlign,stripHotkeyIndicator,newString,codePage,lpdx,newCount,resultTextSize,direction);
+	ExtTextOutHelper(model,hdc,x,y,lprc,fuOptions,textAlign,stripHotkeyIndicator,newString,codePage,lpdx,newCount,resultTextSize,direction,prevColor);
 	if(newString) free(newString);
 }
 
@@ -541,6 +545,7 @@ template<typename charType> int  WINAPI hookClass_TextOut<charType>::fakeFunctio
 	UINT textAlign=GetTextAlign(hdc);
 	POINT pos={x,y};
 	if(textAlign&TA_UPDATECP) GetCurrentPositionEx(hdc,&pos);
+	COLORREF prevColor = GetPixel(hdc, x, y);
 	//Call the real function
 	BOOL res;
 	{
@@ -554,7 +559,7 @@ template<typename charType> int  WINAPI hookClass_TextOut<charType>::fakeFunctio
 	//If we can't get a display model then stop here.
 	if(!model) return res;
 	//Calculate the size of the text
-	ExtTextOutHelper(model,hdc,pos.x,pos.y,NULL,0,textAlign,FALSE,lpString,CP_THREAD_ACP,NULL,cbCount,NULL,false);
+	ExtTextOutHelper(model,hdc,pos.x,pos.y,NULL,0,textAlign,FALSE,lpString,CP_THREAD_ACP,NULL,cbCount,NULL,false,prevColor);
 	model->release();
 	return res;
 }
@@ -600,7 +605,7 @@ template<typename WA_POLYTEXT> BOOL WINAPI hookClass_PolyTextOut<WA_POLYTEXT>::f
 			curPos.y=curPptxt->y;
 		}
 		//record the text
-		ExtTextOutHelper(model,hdc,curPos.x,curPos.y,&curClearRect,curPptxt->uiFlags,textAlign,FALSE,curPptxt->lpstr,CP_THREAD_ACP,curPptxt->pdx,curPptxt->n,&curTextSize,false);
+		ExtTextOutHelper(model,hdc,curPos.x,curPos.y,&curClearRect,curPptxt->uiFlags,textAlign,FALSE,curPptxt->lpstr,CP_THREAD_ACP,curPptxt->pdx,curPptxt->n,&curTextSize,false,CLR_INVALID);
 		//If the DC's current position should be used,  move our idea of it by the size of the text just recorded
 		if(textAlign&TA_UPDATECP) {
 			curPos.x+=curTextSize.cx;
@@ -724,6 +729,7 @@ template<typename charType> BOOL __stdcall hookClass_ExtTextOut<charType>::fakeF
 	UINT textAlign=GetTextAlign(hdc);
 	POINT pos={x,y};
 	if(textAlign&TA_UPDATECP) GetCurrentPositionEx(hdc,&pos);
+	COLORREF prevColor = GetPixel(hdc, x, y);
 	//Call the real function
 	BOOL res;
 	{
@@ -744,7 +750,7 @@ template<typename charType> BOOL __stdcall hookClass_ExtTextOut<charType>::fakeF
 	if(psa) {
 		direction=(psa->fRTL)?-1:1;
 	}
-	ExtTextOutHelper(model,hdc,pos.x,pos.y,lprc,fuOptions,textAlign,FALSE,lpString,CP_THREAD_ACP,lpDx,cbCount,NULL,direction);
+	ExtTextOutHelper(model,hdc,pos.x,pos.y,lprc,fuOptions,textAlign,FALSE,lpString,CP_THREAD_ACP,lpDx,cbCount,NULL,direction,prevColor);
 	//Release the displayModel and return
 	model->release();
 	return res;
@@ -1028,10 +1034,10 @@ HRESULT WINAPI fake_ScriptStringOut(SCRIPT_STRING_ANALYSIS ssa,int iX,int iY,UIN
 	//The next two extTextOutHelper calls must keep their direction argument as 1. 
 	//This is because ScriptStringAnalyze gave us a string in logical order and therefore we need to make sure that NVDA does not try to detect and possibly reverse.
 	if(i->second.iCharset==-1) { //Unicode
-		ExtTextOutHelper(model,i->second.hdc,iX,iY,prc,uOptions,GetTextAlign(i->second.hdc),stripHotkeyIndicator,(wchar_t*)(i->second.pString),CP_THREAD_ACP,NULL,i->second.cString,NULL,1);
+		ExtTextOutHelper(model,i->second.hdc,iX,iY,prc,uOptions,GetTextAlign(i->second.hdc),stripHotkeyIndicator,(wchar_t*)(i->second.pString),CP_THREAD_ACP,NULL,i->second.cString,NULL,1,CLR_INVALID);
 	} else { // character set
 		int codePage=charSetToCodePage(i->second.iCharset);
-		ExtTextOutHelper(model,i->second.hdc,iX,iY,prc,uOptions,GetTextAlign(i->second.hdc),stripHotkeyIndicator,(char*)(i->second.pString),codePage,NULL,i->second.cString,NULL,1);
+		ExtTextOutHelper(model,i->second.hdc,iX,iY,prc,uOptions,GetTextAlign(i->second.hdc),stripHotkeyIndicator,(char*)(i->second.pString),codePage,NULL,i->second.cString,NULL,1,CLR_INVALID);
 	}
 	model->release();
 	LeaveCriticalSection(&criticalSection_ScriptStringAnalyseArgsByAnalysis);

--- a/nvdaHelper/remote/gdiHooks.cpp
+++ b/nvdaHelper/remote/gdiHooks.cpp
@@ -499,7 +499,7 @@ void ExtTextOutHelper(displayModel_t* model, HDC hdc, int x, int y, const RECT* 
 		formatInfo.italic=logFont.lfItalic?true:false;
 		formatInfo.underline=logFont.lfUnderline?true:false;
 		formatInfo.color=GetTextColor(hdc);
-		if (prevColor != CLR_INVALID && GetBkMode(hdc) == TRANSPARENT) {
+		if (prevColor != CLR_INVALID) {
 			formatInfo.backgroundColor=prevColor;
 		} else {
 			formatInfo.backgroundColor=GetBkColor(hdc);

--- a/nvdaHelper/remote/gdiHooks.cpp
+++ b/nvdaHelper/remote/gdiHooks.cpp
@@ -546,7 +546,10 @@ template<typename charType> int  WINAPI hookClass_TextOut<charType>::fakeFunctio
 	UINT textAlign=GetTextAlign(hdc);
 	POINT pos={x,y};
 	if(textAlign&TA_UPDATECP) GetCurrentPositionEx(hdc,&pos);
-	COLORREF prevColor = GetPixel(hdc, x, y);
+	COLORREF prevColor = CLR_INVALID;
+	if (GetBkMode(hdc) == TRANSPARENT) {
+		prevColor = GetPixel(hdc, x, y);
+	}
 	//Call the real function
 	BOOL res;
 	{
@@ -730,7 +733,10 @@ template<typename charType> BOOL __stdcall hookClass_ExtTextOut<charType>::fakeF
 	UINT textAlign=GetTextAlign(hdc);
 	POINT pos={x,y};
 	if(textAlign&TA_UPDATECP) GetCurrentPositionEx(hdc,&pos);
-	COLORREF prevColor = GetPixel(hdc, x, y);
+	COLORREF prevColor = CLR_INVALID;
+	if (GetBkMode(hdc) == TRANSPARENT) {
+		prevColor = GetPixel(hdc, x, y);
+	}
 	//Call the real function
 	BOOL res;
 	{


### PR DESCRIPTION
This PR is based on PR #6844 which was reverted due to performance reasons.

It improves upon #6844 by only calling GetPixel if the text being written  is using a bk mode of transparent, greatly reducing the amount of calls.

This extra commit from @mwcampbell was provided as a patch attached to #6467. 
Fixes #6467