### PR TITLE
Gecko_ia2 virtualBuffer's isAlive property: provide a roughly 14x speed-up, greatly reducing the lag seen when 10s of tabs are open in Firefox or chrome 

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -119,14 +119,15 @@ class Gecko_ia2(VirtualBuffer):
 		root=self.rootNVDAObject
 		if not root:
 			return False
-		if not winUser.isWindow(root.windowHandle) or controlTypes.STATE_DEFUNCT in root.states:
+		if not winUser.isWindow(root.windowHandle):
 			return False
 		try:
-			if not NVDAObjects.IAccessible.getNVDAObjectFromEvent(root.windowHandle,winUser.OBJID_CLIENT,root.IA2UniqueID):
-				return False
-		except:
-			return False
-		return True
+			isDefunct=bool(root.IAccessibleObject.states&IAccessibleHandler.IA2_STATE_DEFUNCT)
+		except COMError:
+			# If IAccessible2 states can not be fetched at all, defunct should be assumed as the object has clearly been disconnected or is dead
+			isDefunct=True
+		return not isDefunct
+
 
 	def getNVDAObjectFromIdentifier(self, docHandle, ID):
 		return NVDAObjects.IAccessible.getNVDAObjectFromEvent(docHandle, winUser.OBJID_CLIENT, ID)


### PR DESCRIPTION
### Link to issue number:
Fixes #3138

### Summary of the issue:
On every focus change, NVDA runs ```treeInterceptorHandler.cleanup()``` in order to kill off any dead virtualBuffers left from no longer existing documents. Gecko_ia2 virtualBuffer's isAlive property called AccessibleObjectFromEvent as one of the ways to validate if the document still existed. However, calling this many times can be very slow, and could produce a major lag on a system with 10s of tabs open in Firefox or Chrome. This call is no longer necessary these days as we can detect this by checking if the root object has the defunct state, or its properties no longer work.

### Description of how this pull request fixes the issue:
The call to AccessibleObjectFromEvent has been removed.  Also, rather than using the states property on the NVDAObject to check for defaunct, use the raw IAccessible2::States property instead. This is more direct and much faster, plus we can also catch any possible COMError and treat this the same as if defunct was there.
Note that Chrome currently produces a COMError when calling IAccessible2::states when dealing with an object for a document that has closed, rather than still supporting IA2_STATE_DEFUNCT.

## Testing performed:
In both Firefox and Chrome:
* Opened www.google.com/, checked the length of treeInterceptorHandler.runningTable was 1.
* Refreshed the page. Made sure that length of runningTable was still 1.
* Opened another 24 tabs to google.com. Validated that the length of runningTable was now 25.
* Timed treeInterceptorHandler.cleanup, noting that before the change it was 70 ms  on my machine, but with the change now down to 5 ms. 
* Closed each tab in turn, occasionally validating that length of runningTable was decreasing.
* Closed the browser and validated that runningTable was 0.

### Change log entry:
Bug fixes:
* NVDA no longer becomes noticeably slower when many tabs are open in either Firefox or Chrome web browsers.