### PR TITLE
Treat integers in screen locations as signed ints to allow coordinates to be negative

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -186,7 +186,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 			point=textInfos.Point(p.x,p.y)
 		else:
 			res=watchdog.cancellableSendMessage(self.obj.windowHandle,EM_POSFROMCHAR,offset,None)
-			point=textInfos.Point(winUser.LOWORD(res),winUser.HIWORD(res))
+			point=textInfos.Point(winUser.GET_X_LPARAM(res),winUser.GET_Y_LPARAM(res))
 		(left,top,width,height)=self.obj.location
 		point.x=point.x+left
 		point.y=point.y+top

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -22,7 +22,7 @@ import windowUtils
 
 def wcharToInt(c):
 	i=ord(c)
-	return i if i<32768 else i-65536
+	return i if i<0x8000 else i-0x10000
 
 def detectStringDirection(s):
 	direction=0

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -22,7 +22,7 @@ import windowUtils
 
 def wcharToInt(c):
 	i=ord(c)
-	return i if i<0x8000 else i-0x10000
+	return c_short(i).value
 
 def detectStringDirection(s):
 	direction=0

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -1,3 +1,9 @@
+#displayModel.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2006-2017 NV Access Limited, Babbage B.V.
+
 from ctypes import *
 from ctypes.wintypes import RECT
 from comtypes import BSTR
@@ -13,6 +19,10 @@ from textInfos.offsets import OffsetsTextInfo
 import watchdog
 from logHandler import log
 import windowUtils
+
+def wcharToInt(c):
+	i=ord(c)
+	return i if i<32768 else i-65536
 
 def detectStringDirection(s):
 	direction=0
@@ -168,7 +178,7 @@ def getWindowTextInRect(bindingHandle, windowHandle, left, top, right, bottom,mi
 	characterLocations = []
 	cpBufIt = iter(cpBuf)
 	for cp in cpBufIt:
-		characterLocations.append((ord(cp), ord(next(cpBufIt)), ord(next(cpBufIt)), ord(next(cpBufIt))))
+		characterLocations.append((wcharToInt(cp), wcharToInt(next(cpBufIt)), wcharToInt(next(cpBufIt)), wcharToInt(next(cpBufIt))))
 	return text, characterLocations
 
 def getFocusRect(obj):

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 NV Access Limited
+#Copyright (C) 2012-2017 NV Access Limited, Babbage B.V.
 
 import wx
 import threading
@@ -246,8 +246,8 @@ class TouchHandler(threading.Thread):
 		if msg>=_WM_POINTER_FIRST and msg<=_WM_POINTER_LAST:
 			flags=winUser.HIWORD(wParam)
 			touching=(flags&POINTER_MESSAGE_FLAG_INRANGE) and (flags&POINTER_MESSAGE_FLAG_FIRSTBUTTON)
-			x=winUser.LOWORD(lParam)
-			y=winUser.HIWORD(lParam)
+			x=winUser.GET_X_LPARAM(lParam)
+			y=winUser.GET_Y_LPARAM(lParam)
 			ID=winUser.LOWORD(wParam)
 			if touching:
 				self.trackerManager.update(ID,x,y,False)

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -137,7 +137,7 @@ def consoleWinEventHook(handle,eventID,window,objectID,childID,threadID,timestam
 	# This avoids an extra core cycle.
 	consoleObject.event_textChange()
 	if eventID==winUser.EVENT_CONSOLE_UPDATE_SIMPLE:
-		x=winUser.GET_x_LPARAM(objectID)
+		x=winUser.GET_X_LPARAM(objectID)
 		y=winUser.GET_Y_LPARAM(objectID)
 		consoleScreenBufferInfo=wincon.GetConsoleScreenBufferInfo(consoleOutputHandle)
 		if x<consoleScreenBufferInfo.dwCursorPosition.x and (y==consoleScreenBufferInfo.dwCursorPosition.y or y==consoleScreenBufferInfo.dwCursorPosition.y+1):  

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2010 Michael Curran <mick@kulgan.net>, James Teh <jamie@jantrid.net>
+#Copyright (C) 2009-2017 NV Access Limited, Babbage B.V.
 
 import wx
 import winUser
@@ -137,8 +137,8 @@ def consoleWinEventHook(handle,eventID,window,objectID,childID,threadID,timestam
 	# This avoids an extra core cycle.
 	consoleObject.event_textChange()
 	if eventID==winUser.EVENT_CONSOLE_UPDATE_SIMPLE:
-		x=winUser.LOWORD(objectID)
-		y=winUser.HIWORD(objectID)
+		x=winUser.GET_x_LPARAM(objectID)
+		y=winUser.GET_Y_LPARAM(objectID)
 		consoleScreenBufferInfo=wincon.GetConsoleScreenBufferInfo(consoleOutputHandle)
 		if x<consoleScreenBufferInfo.dwCursorPosition.x and (y==consoleScreenBufferInfo.dwCursorPosition.y or y==consoleScreenBufferInfo.dwCursorPosition.y+1):  
 			eventHandler.queueEvent("typedCharacter",consoleObject,ch=unichr(winUser.LOWORD(childID)))

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -327,12 +327,10 @@ def HIWORD(long):
 	return long>>16
 
 def GET_X_LPARAM(lp):
-	loWord=LOWORD(lp)
-	return loWord if loWord<0x8000 else loWord-0x10000
+	return c_short(LOWORD(lp)).value
 
 def GET_Y_LPARAM(lp):
-	hiWord=LOWORD(lp)
-	return hiWord if hiWord<0x8000 else hiWord-0x10000
+	return c_short(HIWORD(lp)).value
 
 def MAKELONG(lo,hi):
 	return (hi<<16)+lo

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -327,10 +327,12 @@ def HIWORD(long):
 	return long>>16
 
 def GET_X_LPARAM(lp):
-	return cast(pointer(DWORD(LOWORD(lp))),POINTER(c_short)).contents.value
+	loWord=LOWORD(lp)
+	return loWord if loWord<0x8000 else loWord-0x10000
 
 def GET_Y_LPARAM(lp):
-	return cast(pointer(DWORD(HIWORD(lp))),POINTER(c_short)).contents.value
+	hiWord=LOWORD(lp)
+	return hiWord if hiWord<0x8000 else hiWord-0x10000
 
 def MAKELONG(lo,hi):
 	return (hi<<16)+lo

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -1,6 +1,6 @@
 #winUser.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2017 NV Access Limited, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -322,9 +322,15 @@ def MAKEWORD(lo,hi):
 
 def LOWORD(long):
 	return long&0xFFFF
- 
+
 def HIWORD(long):
 	return long>>16
+
+def GET_X_LPARAM(lp):
+	return cast(pointer(DWORD(LOWORD(lp))),POINTER(c_short)).contents.value
+
+def GET_Y_LPARAM(lp):
+	return cast(pointer(DWORD(HIWORD(lp))),POINTER(c_short)).contents.value
 
 def MAKELONG(lo,hi):
 	return (hi<<16)+lo


### PR DESCRIPTION
### Link to issue number:
fixes #7441
fixes #7445 

### Summary of the issue:
From https://github.com/nvaccess/nvda/issues/7441#issue-245303271

> Every character in a display model has its own character location, provided as a rectangle. The list of rectangles is provided as a wide character string by NVDAHelper. These wide characters are converted back to int using ord in displayModel.getWindowTextInRect, however this assumes that the resulting coords should be unsigned, which is incorrect. For example, a rectangle with a left coordinate of -8 would have a coordinate of 65528.

From https://github.com/nvaccess/nvda/issues/7445#issue-245649272:

> NVDAObjects.window.edit._getPointFromOffset is using winUser.HIWORD and winuser.LOWORD. Long story short, it shouldn't.
> 
> From [this page on MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645616(v=vs.85).aspx), which is not very related, the following part also applies here:
> 
> > Important  Do not use the LOWORD or HIWORD macros to extract the x- and y- coordinates of the cursor position because these macros return incorrect results on systems with multiple monitors. Systems with multiple monitors can have negative x- and y- coordinates, and LOWORD and HIWORD treat the coordinates as unsigned quantities.

### Description of how this pull request fixes the issue:
See https://github.com/nvaccess/nvda/issues/7441#issuecomment-317652192 for the displayModel part, with one exception. @DKager argued that we should use hexadecimal values here.

For #7445, the earlier mentioned MSDN article advises to use the GET_X_LPARAM and GET_Y_LPARAM macros. I ported these to python using CTypes. @MichaelDCurran, please let me know when you'd rather have the "i if i<32768 else i-65536" approach for this as well.

### Testing performed:
For #7441: Started and maximized wordpad, and did the following in the python console:

```
import displayModel
dm=displayModel.DisplayModelTextInfo(fg,"all")
[r for r in dm._storyFieldsAndRects[1] if r[0]>2000]
[r for r in dm._storyFieldsAndRects[1] if r[0]<0]
```

Result differed between current master and this new code as expected (i.e. rectangle coordinates came out as negative, which should be the case here)

For #7445, followed the str. Non-negative coordinates returned exactly the same result as before. Negative coordinates now also returned proper coordinates, e.g. x<32769.

### Known issues with pull request:
I wonder whether there is a nicer way  to loop through cpBufIt. iterating the same iterator inside a loop that uses the same iterator seems a bit odd.