### PR TITLE
FF/Chrome/IE browseMode quicknav includes rich text widgets (contentEditable) in edit and formField commands

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -397,6 +397,10 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 		LOG_DEBUG(L"pacc->get_states failed");
 		IA2States=0;
 	}
+	// Remove state_editible from tables as Gecko exposes it for ARIA grids which is not in the ARIA spec. 
+	if(IA2States&IA2_STATE_EDITABLE&&role==ROLE_SYSTEM_TABLE) {
+			IA2States-=IA2_STATE_EDITABLE;
+	}
 	//Add each state that is on, as an attrib
 	for(int i=0;i<32;++i) {
 		int state=1<<i;

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -148,25 +148,30 @@ inline void outputEscapedAttribute(wostringstream& out, const wstring& text) {
 }
 
 bool VBufStorage_fieldNode_t::matchAttributes(const std::vector<std::wstring>& attribs, const std::wregex& regexp) {
-	wostringstream test;
+	wostringstream regexpInput;
 	wstring parentPrefix=L"parent::";
 	for (vector<wstring>::const_iterator attribName = attribs.begin(); attribName != attribs.end(); ++attribName) {
-		outputEscapedAttribute(test, *attribName);
-		test << L":";
-		// A given attribute can contain a parent prefix, which means the parent node will be checked for that attribute instead of this one. 
+		outputEscapedAttribute(regexpInput, *attribName);
+		regexpInput << L":";
+		// A given attribute can start with a parent prefix, which means the parent node will be checked for that attribute instead of this one. 
+		// E.g. "parent::IAccessible2::role".
+		// Although we will only redirect  the attribute to the parent if the parent prefix is found at the very beginning of the string (I.e. index 0),
+		// an attribute like "blah_grandparent::color" is not an error and will be processed literally like any other attribute.
 		if(this->parent&&attribName->find(parentPrefix)==0) {
 			VBufStorage_attributeMap_t::const_iterator foundAttrib = this->parent->attributes.find(attribName->substr(parentPrefix.length()));
-			if (foundAttrib != this->parent->attributes.end())
-				outputEscapedAttribute(test, foundAttrib->second);
-			test << L";";
+			if (foundAttrib != this->parent->attributes.end()) {
+				outputEscapedAttribute(regexpInput, foundAttrib->second);
+			}
+			regexpInput << L";";
 		} else { // not a parent attribute
 			VBufStorage_attributeMap_t::const_iterator foundAttrib = attributes.find(*attribName);
-			if (foundAttrib != attributes.end())
-				outputEscapedAttribute(test, foundAttrib->second);
-			test << L";";
+			if (foundAttrib != attributes.end()) {
+				outputEscapedAttribute(regexpInput, foundAttrib->second);
+			}
+			regexpInput << L";";
 		}
 	}
-	return regex_match(test.str(), regexp);
+	return regex_match(regexpInput.str(), regexp);
 }
 
 int VBufStorage_fieldNode_t::calculateOffsetInTree() const {

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -149,13 +149,22 @@ inline void outputEscapedAttribute(wostringstream& out, const wstring& text) {
 
 bool VBufStorage_fieldNode_t::matchAttributes(const std::vector<std::wstring>& attribs, const std::wregex& regexp) {
 	wostringstream test;
+	wstring parentPrefix=L"parent::";
 	for (vector<wstring>::const_iterator attribName = attribs.begin(); attribName != attribs.end(); ++attribName) {
 		outputEscapedAttribute(test, *attribName);
 		test << L":";
-		VBufStorage_attributeMap_t::const_iterator foundAttrib = attributes.find(*attribName);
-		if (foundAttrib != attributes.end())
-			outputEscapedAttribute(test, foundAttrib->second);
-		test << L";";
+		// A given attribute can contain a parent prefix, which means the parent node will be checked for that attribute instead of this one. 
+		if(this->parent&&attribName->find(parentPrefix)==0) {
+			VBufStorage_attributeMap_t::const_iterator foundAttrib = this->parent->attributes.find(attribName->substr(parentPrefix.length()));
+			if (foundAttrib != this->parent->attributes.end())
+				outputEscapedAttribute(test, foundAttrib->second);
+			test << L";";
+		} else { // not a parent attribute
+			VBufStorage_attributeMap_t::const_iterator foundAttrib = attributes.find(*attribName);
+			if (foundAttrib != attributes.end())
+				outputEscapedAttribute(test, foundAttrib->second);
+			test << L";";
+		}
 	}
 	return regex_match(test.str(), regexp);
 }

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -264,14 +264,23 @@ class MSHTML(VirtualBuffer):
 		elif nodeType=="formField":
 			attrs=[
 				{"IAccessible::role":[oleacc.ROLE_SYSTEM_PUSHBUTTON,oleacc.ROLE_SYSTEM_RADIOBUTTON,oleacc.ROLE_SYSTEM_CHECKBUTTON,oleacc.ROLE_SYSTEM_OUTLINE],"IAccessible::state_%s"%oleacc.STATE_SYSTEM_READONLY:[None]},
-				{"IAccessible::role":[oleacc.ROLE_SYSTEM_COMBOBOX,oleacc.ROLE_SYSTEM_TEXT]},
+				{"IAccessible::role":[oleacc.ROLE_SYSTEM_COMBOBOX]},
+				# Focusable edit fields (input type=text, including readonly ones)
+				{"IAccessible::role":[oleacc.ROLE_SYSTEM_TEXT],"IAccessible::state_%s"%oleacc.STATE_SYSTEM_FOCUSABLE:[1]},
+				# Any top-most content editable element (E.g. an editable div for rhich text editing) 
+				{"IHTMLElement::isContentEditable":[1],"parent::IHTMLElement::isContentEditable":[0,None]},
 				{"IHTMLDOMNode::nodeName":["SELECT"]},
 				{"HTMLAttrib::role":["listbox"]},
 			]
 		elif nodeType=="button":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_PUSHBUTTON]}
 		elif nodeType=="edit":
-			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_TEXT,oleacc.ROLE_SYSTEM_COMBOBOX],"IAccessible::state_%s"%oleacc.STATE_SYSTEM_FOCUSABLE:[1],"IHTMLElement::isContentEditable":[1]}
+			attrs=[
+				# Focusable edit fields (input type=text, including readonly ones)
+				{"IAccessible::role":[oleacc.ROLE_SYSTEM_TEXT],"IAccessible::state_%s"%oleacc.STATE_SYSTEM_FOCUSABLE:[1]},
+				# Any top-most content editable element (E.g. an editable div for rhich text editing) 
+				{"IHTMLElement::isContentEditable":[1],"parent::IHTMLElement::isContentEditable":[0,None]},
+			]
 		elif nodeType=="radioButton":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_RADIOBUTTON],"IAccessible::state_%s"%oleacc.STATE_SYSTEM_FOCUSABLE:[1]}
 		elif nodeType=="comboBox":

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -210,6 +210,7 @@ class Gecko_ia2(VirtualBuffer):
 			attrs=[
 				{"IAccessible::role":[oleacc.ROLE_SYSTEM_PUSHBUTTON,oleacc.ROLE_SYSTEM_BUTTONMENU,oleacc.ROLE_SYSTEM_RADIOBUTTON,oleacc.ROLE_SYSTEM_CHECKBUTTON,oleacc.ROLE_SYSTEM_COMBOBOX,oleacc.ROLE_SYSTEM_LIST,oleacc.ROLE_SYSTEM_OUTLINE,IAccessibleHandler.IA2_ROLE_TOGGLE_BUTTON],"IAccessible::state_%s"%oleacc.STATE_SYSTEM_READONLY:[None]},
 				{"IAccessible::role":[oleacc.ROLE_SYSTEM_COMBOBOX,oleacc.ROLE_SYSTEM_TEXT],"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1]},
+				{"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1],"parent::IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[None]},
 			]
 		elif nodeType=="list":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_LIST]}
@@ -218,7 +219,10 @@ class Gecko_ia2(VirtualBuffer):
 		elif nodeType=="button":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_PUSHBUTTON,oleacc.ROLE_SYSTEM_BUTTONMENU,IAccessibleHandler.IA2_ROLE_TOGGLE_BUTTON]}
 		elif nodeType=="edit":
-			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_TEXT,oleacc.ROLE_SYSTEM_COMBOBOX],"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1]}
+			attrs=[
+				{"IAccessible::role":[oleacc.ROLE_SYSTEM_TEXT],"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1]},
+				{"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1],"parent::IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[None]},
+			]
 		elif nodeType=="frame":
 			attrs={"IAccessible::role":[IAccessibleHandler.IA2_ROLE_INTERNAL_FRAME]}
 		elif nodeType=="separator":


### PR DESCRIPTION
### Link to issue number:
Fixes #5534

## Summary of the issue:
Rich text editors are becoming more prevalent on the web. Users expect that they can jump to these fields with NVDA quicknav commands they already know, such as e (edit) and f (formField).
These rich text editors are usually implemented either by a div with contentEditable="true" or sometimes an iframe with an embedded document  set to design mode.
 
### Description of how this pull request fixes the issue:
This PR makes it possible to jump to these rich text widgets  with quick navigation in Firefox, Chrome and Internet Explorer.
In simple terms, quick navigation needs to locate the next element that is contentEditable, but whos parent is not contentEditable, as we do not wish to locate all descendants of the editable container.
To enable matching in this way, virtualBuffer searching attributes can now be prefixed with "parent::" which tells the buffer to check the parent node for that particular attribute, rather than the node it is actually looking at in the search. Which now means it is possible to construct a search that checks for contentEditable on a node, but a lack of contentEditable on its parent.
The quicknav search rules for Gecko and mshtml were updated to make use of this new parent prefix, so that they can locate top-most contentEditable nodes.

## Testing performed:
Tested in Firefox, Chrome and IE [testcases.zip](https://github.com/nvaccess/nvda/files/1188711/testcases.zip): 
* content_editable.html: made sure that both e and f found the editable section.
* designMode.html: made sure that both e and f found the editable document.
* formFields.html: made sure that e and f found all the edit fields, including the read-only one.

### Known issues with pull request:
This is not supported in Edge due to contentEditables not getting their own text pattern.

### Change log entry:
What's new:
* In Firefox, Chrome and Internet Explorer, quick navigation to edit fields and form fields now includes editable rich text content (I.e. contentEditable). (#5534)