### PR TITLE
OneCore voices: Fix "Duck when outputting speech and sounds" functionality

### DIFF
--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -173,6 +173,7 @@ class SynthDriver(SynthDriver):
 			# which will eventually process the queue again.
 			self._dll.ocSpeech_speak(self._handle, item)
 			return
+		self._player.idle()
 		log.debug("Queue empty, done processing")
 		self._isProcessing = False
 


### PR DESCRIPTION
### Link to issue number:
Fixes #7431.

### Summary of the issue:
With the OneCore voices synthesiser, with ducking set to "Duck when outputting speech and sounds", Audio isn't unducked when speech finishes as it should be.

### Description of how this pull request fixes the issue:
The driver now calls WavePlayer.idle as it should after pushing the last chunk of audio if there is no more speech in the queue.

### Testing performed:
Tested with an installed copy as per the STR in https://github.com/nvaccess/nvda/issues/7431#issuecomment-319227100:

1. Switched to the Windows OneCore Voices synthesiser.
2. Played some music.
3. Used NVDA+shift+d to set NVDA's audio ducking mode to "Duck when outputting speech and sounds".
4. Confirmed that after NVDA finished speaking, audio was unducked after a short delay.

### Known issues with pull request:
None.

### Change log entry:
None needed, as this hasn't yet been in a release.

### Merge notes:
Should be merged straight to master because OneCore voices are in master and we want them to get into 2017.3. Low risk, and at worst, only affects the OneCore voices driver.

@MichaelDCurran, as discussed, it'd be great if you could test this as well, just to confirm.