### PR TITLE
Don't allow the user to use a content recognition command when already focused in a content recognition result

### DIFF
--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -120,6 +120,11 @@ def recognizeNavigatorObject(recognizer):
 	@type recognizer: L{contentRecog.ContentRecognizer}
 	"""
 	global _activeRecog
+	if isinstance(api.getFocusObject(), RecogResultNVDAObject):
+		# Translators: Reported when content recognition (e.g. OCR) is attempted,
+		# but the user is already reading a content recognition result.
+		ui.message(_("Already in a content recognition result"))
+		return
 	nav = api.getNavigatorObject()
 	left, top, width, height = nav.location
 	try:


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/pull/7361#issuecomment-317327643

### Summary of the issue:
> It seems that in the current situation, one is able to run multiple ocr actions at once, e.g. when the OCR result is shown, you can do another ocr on the result object, and it will show another result.

### Description of how this pull request fixes the issue:
`contentRecog.recogUi.recognizeNavigatorObject` now aborts early if focus is already in a content recog result.

### Testing performed:
1. Opened the Run dialog.
2. Moved the navigator object to the dialog.
3. Pressed NVDA+r.
4. Waited for the result, then pressed NVDA+r again.
5. Confirmed that the expected error was reported and that nothing else happened.

### Known issues with pull request:
None.

### Change log entry:
None, as OCR isn't in a release yet.

### Merge notes:
This is a trivial fix for Win 10 OCR, which is in 2017.3. As such, we want to merge this to master so it also makes it into the release.