### PR TITLE
Fix regression in backwards panning introduced with the new focus context presentation settings

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1132,7 +1132,7 @@ class BrailleBuffer(baseObject.AutoPropertyObject):
 		# Loop through the currently displayed regions in reverse order
 		# If focusToHardLeft is set for one of the regions, the display shouldn't scroll further back than the start of that region
 		for region, regionStart, regionEnd in reversed(list(self.regionsWithPositions)):
-			if regionStart<=endPos:
+			if regionStart<endPos:
 				if region.focusToHardLeft:
 					# Only scroll to the start of this region.
 					restrictPos = regionStart

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -55,6 +55,11 @@ class TestFocusContextPresentation(unittest.TestCase):
 		self.assertEqual(braille.handler.buffer.windowEndPos,self.regionsWithPositions[2].end)
 		# This also means that the window start position is equal to the start position of the 3rd region
 		self.assertEqual(braille.handler.buffer.windowStartPos,self.regionsWithPositions[2].start)
+		# Scroll the braille window back
+		braille.handler.scrollBack()
+		# Both the focus object and its parents should be visible
+		self.assertEqual(braille.handler.buffer.windowEndPos,self.regionsWithPositions[2].end)
+		self.assertEqual(braille.handler.buffer.windowStartPos,0)
 
 	def test_changedContext(self):
 		"""Test for the case where the focus object as well as ancestry differences should be visible on the display"""
@@ -71,6 +76,11 @@ class TestFocusContextPresentation(unittest.TestCase):
 		# Only the focus object should be visible now, equivalent to scroll only
 		self.assertEqual(braille.handler.buffer.windowEndPos,self.regionsWithPositions[2].end)
 		self.assertEqual(braille.handler.buffer.windowStartPos,self.regionsWithPositions[2].start)
+		# Scroll the braille window back
+		braille.handler.scrollBack()
+		# Both the focus object and its parents should be visible
+		self.assertEqual(braille.handler.buffer.windowEndPos,self.regionsWithPositions[2].end)
+		self.assertEqual(braille.handler.buffer.windowStartPos,0)
 		# Clean up the cached focus ancestors
 		# specifically, the desktop object (ancestor 0) has no associated region
 		# We will keep the region for the dialog (ancestor 1) and consider the list (ancestor 2) as new for this test


### PR DESCRIPTION
### Link to issue number:
Fixes #7468

### Technical background
When panning backwards, the end position of the window is set to the previous start position. Thus, the end position of the window belongs to the region that was initially focused hard left. We should *not* check focusTohardLeft for this region again. regionStart should be less than endPos, and not less than or equal to it.

@JCSTeh: Could you please review this and merge straight into master? This is a very trivial code change (e.g. it only removes a single equals).