### PR TITLE
Fix cursor routing for the MDV Lilli display driver

### DIFF
--- a/source/brailleDisplayDrivers/lilli.py
+++ b/source/brailleDisplayDrivers/lilli.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2011 Gianluca Casalino <gianluca@spazioausili.net>, Alberto Benassati <benassati@cavazza.it>
+#Copyright (C) 2008-2017 NV Access Limited, Gianluca Casalino, Alberto Benassati, Babbage B.V.
 
 from logHandler import log
 from ctypes import *
@@ -76,14 +76,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			except:
 				pass
 			if not key: break
-			if (key <= 64) or ((key >= 257) and (key <= 296)): 
+			if (key <= 0x40) or ((key >= 0x101) and (key <= 0x128)): 
 				self._onKeyPress(key)
 
 	def _onKeyPress(self, key):
 		try:
-			if (key >= 257) and (key <= 296):                                 
-				inputCore.manager.executeGesture(InputGesture(LILLI_KEYS[65],key-256))
-			elif (key <= 64):
+			if (key >= 0x101) and (key <= 0x128):                                 
+				inputCore.manager.executeGesture(InputGesture(LILLI_KEYS[65],key-0x101))
+			elif (key <= 0x40):
 				inputCore.manager.executeGesture(InputGesture(LILLI_KEYS[key],0))
 		except inputCore.NoInputGestureAction:
 			pass

--- a/source/brailleDisplayDrivers/lilli.py
+++ b/source/brailleDisplayDrivers/lilli.py
@@ -19,9 +19,9 @@ lilliCellsMap=[]
 KEY_CHECK_INTERVAL = 50
 
 LILLI_KEYS = [
-	"", "F1", "F2", "F3", "F4",  "F5", "F6", "F7", "F8", "F9", "F10", "LF", "UP", "RG", "DN", "", 
-	"", "SF1", "SF2", "SF3", "SF4",  "SF5", "SF6", "SF7", "SF8", "SF9", "SF10", "SLF", "SUP", "SRG", "SDN", "", 
-	"", "LF1", "LF2", "LF3", "LF4",  "LF5", "LF6", "LF7", "LF8", "LF9", "LF10", "LLF", "LUP", "LRG", "LDN", "", 
+	"", "F1", "F2", "F3", "F4",  "F5", "F6", "F7", "F8", "F9", "F10", "LF", "UP", "RG", "DN", "",
+	"", "SF1", "SF2", "SF3", "SF4",  "SF5", "SF6", "SF7", "SF8", "SF9", "SF10", "SLF", "SUP", "SRG", "SDN", "",
+	"", "LF1", "LF2", "LF3", "LF4",  "LF5", "LF6", "LF7", "LF8", "LF9", "LF10", "LLF", "LUP", "LRG", "LDN", "",
 	"", "SLF1", "SLF2", "SLF3", "SLF4",  "SLF5", "SLF6", "SLF7", "SLF8", "SLF9", "SLF10", "SLLF", "SLUP", "SLRG", "SLDN", "SFDN", "SFUP",
 	"route"
 ]
@@ -76,12 +76,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			except:
 				pass
 			if not key: break
-			if (key <= 0x40) or ((key >= 0x101) and (key <= 0x128)): 
+			if (key <= 0x40) or ((key >= 0x101) and (key <= 0x128)):
 				self._onKeyPress(key)
 
 	def _onKeyPress(self, key):
 		try:
-			if (key >= 0x101) and (key <= 0x128):                                 
+			if (key >= 0x101) and (key <= 0x128):
 				inputCore.manager.executeGesture(InputGesture(LILLI_KEYS[65],key-0x101))
 			elif (key <= 0x40):
 				inputCore.manager.executeGesture(InputGesture(LILLI_KEYS[key],0))
@@ -90,7 +90,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def display(self, cells):
 		cells="".join(chr(lilliCellsMap[x]) for x in cells)
-		lilliDll.WriteBuf(cells) 
+		lilliDll.WriteBuf(cells)
 
 	gestureMap = inputCore.GlobalGestureMap({
 		"globalCommands.GlobalCommands": {


### PR DESCRIPTION
### Link to issue number:
Fixes #7469 

### Summary of the issue:
For MDV Lilli displays, using a cursor routing key moves the cursor one position ahead of the actual cell it should be positioned.

### Description of how this pull request fixes the issue:
The routing indexes started at 1, but they should be zero based. Subtracted an additional 1 in index calculation. Also, converted some decimal values to hexadecimal values to improve readability

### Testing performed:
@dreinn tested this, see https://github.com/nvaccess/nvda/issues/7469#issuecomment-319910224
