### PR TITLE
`ui.browseableMessage()`: Fix an Unicode problem when NVDA is installed in a path containing a non-ASCII character

### DIFF
--- a/source/ui.py
+++ b/source/ui.py
@@ -42,7 +42,7 @@ def browseableMessage(message,title=None , isHtml=False):
 	@param isHtml: Whether the message is html
 	@type isHtml: boolean
 	"""
-	htmlFileName  = os.path.realpath( 'message.html' )
+	htmlFileName  = os.path.realpath( u'message.html' )
 	if not os.path.isfile(htmlFileName ): 
 		raise LookupError(htmlFileName )
 	moniker = POINTER(IUnknown)()


### PR DESCRIPTION
If NVDA is installed in a path containing a non-ASCII character (eg: éè), `ui.browseableMessage()` fails.

```
>>> import ui
>>> ui.browseableMessage('test')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "ui.pyo", line 49, in browseableMessage
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 7: ordinal not in range(128)
```