### PR TITLE
Support for describing images using CaptionBot

### DIFF
--- a/source/contentRecog/cloudRecog.py
+++ b/source/contentRecog/cloudRecog.py
@@ -1,0 +1,97 @@
+#contentRecog/__init__.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2017 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""Support for cloud-based content recognition.
+"""
+
+import os
+import threading
+import tempfile
+import urllib
+import json
+import urllib2
+import wx
+import httpRequest
+from . import ContentRecognizer, SimpleTextResult
+
+class CloudRecognizer(ContentRecognizer):
+	"""Base class for a content recognizer which operates on an image file
+	and runs in a background thread.
+	This is intended for use with cloud-based content recognition services.
+	Subclasses should override the L{recogRequest} method.
+	"""
+
+	def recognize(self, pixels, imgInfo, onResult):
+		bmp = wx.EmptyBitmap(imgInfo.recogWidth, imgInfo.recogHeight, 32)
+		bmp.CopyFromBuffer(pixels, wx.BitmapBufferFormat_RGB32)
+		self._fileName = tempfile.mktemp(prefix="nvda_cloundContentRecog_", suffix=".jpg")
+		bmp.SaveFile(self._fileName, wx.BITMAP_TYPE_JPEG)
+		self._onResult = onResult
+		t = threading.Thread(target=self._bgRecog)
+		t.daemon = True
+		t.start()
+
+	def _bgRecog(self):
+		try:
+			result = self.recogRequest(self._fileName)
+		except Exception as e:
+			result = e
+		finally:
+			os.remove(self._fileName)
+		if self._onResult:
+			self._onResult(result)
+
+	def cancel(self):
+		self._onResult = None
+
+	def recogRequest(self, fileName):
+		"""Perform recognition.
+		This should block until complete and then return the result.
+		It is run in a background thread.
+		@rtype: L{contentRecog.RecognitionResult}
+		"""
+		raise NotImplementedError
+
+class CaptionBot(CloudRecognizer):
+	"""Image recognition using Microsoft's CaptionBot (https://www.captionbot.ai/) service.
+	"""
+	# Based on the captionbot Python package by Tatiana Krikun: https://github.com/krikunts/captionbot
+	BASE_URL = "https://www.captionbot.ai/api/"
+
+	def _init(self):
+		url = self.BASE_URL + "init"
+		resp = urllib2.urlopen(url)
+		self.conversationId = httpRequest.getJsonFromResponse(resp)
+
+	def _upload(self, fileName):
+		url = self.BASE_URL + "upload"
+		with file(fileName, "rb") as fileObj:
+			files = [("file", os.path.basename(fileName), fileObj)]
+			resp = httpRequest.urlopenWithFiles(url, files)
+			return httpRequest.getJsonFromResponse(resp)
+
+	def _message(self, message):
+		url = self.BASE_URL + "message"
+		data = {
+			"userMessage": message,
+			"conversationId": self.conversationId,
+			"waterMark": ""}
+		httpRequest.urlopenWithJson(url, data)
+		# The post request doesn't return anything.
+		# We have to make a get request with the same data to obtain the response.
+		getUrl = url + "?" + urllib.urlencode(data)
+		resp = urllib2.urlopen(getUrl)
+		# This is double JSON encoded.
+		resp = httpRequest.getJsonFromResponse(resp)
+		return json.loads(resp)
+
+	def recogRequest(self, fileName):
+		self._init()
+		imgUrl = self._upload(fileName)
+		resp = self._message(imgUrl)
+		# resp["BotMessages"][0] is the URL, [1] is the caption.
+		text = resp["BotMessages"][1]
+		return SimpleTextResult(text)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2058,6 +2058,13 @@ class GlobalCommands(ScriptableObject):
 	# Translators: Describes a command.
 	script_recognizeWithUwpOcr.__doc__ = _("Recognizes the content of the current navigator object with Windows 10 OCR")
 
+	def script_recognizeWithCaptionBot(self, gesture):
+		from contentRecog import cloudRecog, recogUi
+		recog = cloudRecog.CaptionBot()
+		recogUi.recognizeNavigatorObject(recog)
+	# Translators: Describes a command.
+	script_recognizeWithCaptionBot.__doc__ = _("Describes the image at the current navigator object with CaptionBot")
+
 	__gestures = {
 		# Basic
 		"kb:NVDA+n": "showGui",
@@ -2241,6 +2248,7 @@ class GlobalCommands(ScriptableObject):
 		"kb(desktop):NVDA+control+f2": "test_navigatorDisplayModelText",
 		"kb:NVDA+alt+m": "interactWithMath",
 		"kb:NVDA+r": "recognizeWithUwpOcr",
+		"kb:NVDA+alt+d": "recognizeWithCaptionBot",
 	}
 
 #: The single global commands instance.

--- a/source/httpRequest.py
+++ b/source/httpRequest.py
@@ -1,0 +1,83 @@
+#httpRequest.py
+#A part of NonVisual Desktop Access (NVDA)
+#See the file COPYING for more details.
+#Copyright (C) 2017 Matt Shaw, NV Access Limited
+
+"""Provides HTTP request functionality not supported by urllib2 such as uploading files and JSON post data.
+Ideally, the requests module would be used,
+but requests can't currently be included in NVDA due to licensing issues.
+"""
+
+import mimetypes
+import urllib2
+import json
+
+# Based on code from http://mattshaw.org/news/multi-part-form-post-with-files-in-python/
+BOUNDARY = 'b8c09f07e6e54ff703f8845626a4cb64'
+def encodeMultipartFormData(fields, files):
+	"""
+	fields is a sequence of (name, value) elements for regular form fields.
+	files is a sequence of (name, filename, value) elements for data to be uploaded as files,
+	where value may be a file-like object to be read.
+	Note that all data is read into memory at once.
+	Return (headers, body) ready for HTTP request
+	"""
+	CRLF = '\r\n'
+	L = []
+	for (key, value) in fields:
+		L.append('--' + BOUNDARY)
+		L.append('Content-Disposition: form-data; name="%s"' % key)
+		L.append('')
+		L.append(value)
+	for (key, filename, value) in files:
+		L.append('--' + BOUNDARY)
+		L.append('Content-Disposition: form-data; name="%s"; filename="%s"' % (key, filename))
+		L.append('Content-Type: %s' % getContentType(filename))
+		L.append('')
+		if not isinstance(value, str):
+			value = value.read()
+		L.append(value)
+	L.append('--' + BOUNDARY + '--')
+	L.append('')
+	body = CRLF.join(L)
+	headers = {'Content-Type': 'multipart/form-data; boundary=%s' % BOUNDARY}
+	return headers, body
+
+def getContentType(filename):
+	return mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
+def urlopenWithFiles(url, files, headers=None, **kwargs):
+	"""Extends urllib2.urlopen to support file upload.
+	url and any additional keyword arguments are passed to urllib2.urlopen as is.
+	@param files: A sequence of (name, filename, value) elements for data to be uploaded as files,
+		where value may be a file-like object to be read.
+	@type files: sequence
+	@param headers: HTTP headers.
+	@type: dict of {str: str}
+	"""
+	if not headers:
+		headers = {}
+	multiHeaders, data = encodeMultipartFormData((), files)
+	headers.update(multiHeaders)
+	req = urllib2.Request(url, data=data, headers=headers)
+	return urllib2.urlopen(req, **kwargs)
+
+def urlopenWithJson(url, jsonData, headers=None, **kwargs):
+	"""Extends urllib2.urlopen to support JSON post data.
+	url and any additional keyword arguments are passed to urllib2.urlopen as is.
+	@param jsonData: Object to be serialized to JSON and passed as data.
+	@param headers: HTTP headers.
+	@type: dict of {str: str}
+	"""
+	if not headers:
+		headers = {}
+	headers["Content-Type"] = "application/json"
+	data = json.dumps(jsonData)
+	req = urllib2.Request(url, data=data, headers=headers)
+	return urllib2.urlopen(req, **kwargs)
+
+def getJsonFromResponse(response):
+	"""Get the JSON object from the response to an HTTP request.
+	@param response: The object returned from urlopen.
+	"""
+	return json.loads(response.read())

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -693,7 +693,7 @@ Pressing dot 7 + dot 8 translates any braille input, but without adding a space 
 
 + Content Recognition +
 When authors don't provide sufficient information for a screen reader user to determine the content of something, various tools can be used to attempt to recognize the content from an image.
-NVDA supports the optical character recognition (OCR) functionality built into Windows 10 to recognize text from images.
+NVDA supports the optical character recognition (OCR) functionality built into Windows 10 to recognize text from images, as well as image description using Microsoft's CaptionBot service.
 Additional content recognizers can be provided in NVDA add-ons.
 
 When you use a content recognition command, NVDA recognizes content from the current [navigator object #ObjectNavigation].
@@ -714,6 +714,14 @@ Additional languages can be installed by opening the Start menu, choosing Settin
 
 %kc:beginInclude
 To recognize the text in the current navigator object using Windows 10 OCR, press NVDA+r.
+%kc:endInclude
+
+++  CaptionBot ++
+Microsoft's CaptionBot (https://www.captionbot.ai/) uses computer vision to describe images.
+Please note that any images described with this command are uploaded to and retained by CaptionBot.
+
+%kc:beginInclude
+To describe the image at the current navigator object using CaptionBot, press NVDA+alt+d.
 %kc:endInclude
 
 + Application Specific Features +


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Ideally, images would all have useful alternative text, but this is all too often not the case. This PR adds a command which uses Microsoft's [CaptionBot](https://www.captionbot.ai/) service to describe images.

### Description of how this pull request fixes the issue:
You press NVDA+alt+d to describe the image at the current navigator object. This uploads the image to CaptionBot and retrieves the description.

### Testing performed:
Tried on the NV Access logo on the NV Access website, the picture in the top table of the [Wikipedia article about labrador retrievers](https://en.wikipedia.org/wiki/Labrador_Retriever) and the Desktop.

### Known issues with pull request:
The CaptionBot API is not documented anywhere I could find. However, there are [several](https://pypi.python.org/pypi/captionbot) [publicly](https://www.npmjs.com/package/captionbot) [available](https://daniil.it/captionbot-clients/) [libraries](https://github.com/DeanF/imgcaption) which implement it. I also couldn't find any terms which specifically forbid its usage.

### Change log entry:
In New Features:

```
- NVDA can now use Microsoft's CaptionBot service to describe images. To describe the image at the current navigator object, press NVDA+alt+d. (#7476)
```