### PR TITLE
Fix incorrect arguments in signature of ContentRecognizer.recognize abstract method

### DIFF
--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -32,7 +32,7 @@ class ContentRecognizer(object):
 		"""
 		return 1
 
-	def recognize(self, pixels, width, height, imageInfo, onResult):
+	def recognize(self, pixels, imageInfo, onResult):
 		"""Asynchronously recognize content from an image.
 		This method should not block.
 		Only one recognition can be performed at a time.


### PR DESCRIPTION
### Link to issue number:
Fixes mistake in #7361.

### Summary of the issue:
The signature for `contentRecog.ContentRecognizer.recognize` includes `width` and `height` parameters that were removed, are no longer passed by callers and are no longer included in subclasses. Because this is an abstract method, it never gets called, so this has no implication on the code that gets executed. However, it is certainly bad for developers who subclass ContentRecognizer.

### Description of how this pull request fixes the issue:
Removes the parameters. :)

### Testing performed:
Confirmed that Windows 10 OCR still works in the Run dialog.

### Known issues with pull request:
None.

### Change log entry:
None needed; code not in a release.

### Merge notes:

Should be merged straight to master because we want this to be fixed in the release. Very low risk. No impact on translatable strings.