### PR TITLE
Add some missing translator comments and check for missing translator comments in future

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,9 +75,8 @@ build_script:
  - 'echo scons args: %sconsArgs%'
  - py scons.py source %sconsArgs%
  # We don't need launcher to run tests, so run the tests before launcher.
- # We also build the translation template (pot) just to ensure it succeeds.
- - py scons.py tests pot %sconsArgs%
- # We don't actually need the pot as a build artifact though.
+ - py scons.py tests %sconsArgs%
+ # The pot gets built by tests, but we don't actually need it as a build artifact.
  - del output\*.pot
  - 'echo scons output targets: %sconsOutTargets%'
  - py scons.py %sconsOutTargets% %sconsArgs%

--- a/readme.md
+++ b/readme.md
@@ -208,20 +208,26 @@ scons launcher version=test1
 ## Running Automated Tests
 If you make a change to the NVDA code, you should run NVDA's automated tests.
 These tests help to ensure that code changes do not unintentionally break functionality that was previously working.
-Currently, NVDA has only one kind of automated testing: unit tests.
+Currently, NVDA has two kinds of automated testing: unit tests and translatable string checks.
 
-To run the unit tests, first change directory to the root of the NVDA source distribution as above.
+To run the tests, first change directory to the root of the NVDA source distribution as above.
 Then, run:
 
 ```
 scons tests
 ```
 
-To run only specific tests, specify them using the `unitTests` variable on the command line.
+To run only specific unit tests, specify them using the `unitTests` variable on the command line.
 The tests should be provided as a comma separated list.
 Each test should be specified as a Python module, class or method relative to the `tests\unit` directory.
 For example, to run only methods in the `TestMove` and `TestSelection` classes in the file `tests\unit\test_cursorManager.py` file, run this command:
 
 ```
 scons tests unitTests=test_cursorManager.TestMove,test_cursorManager.TestSelection
+```
+
+To run only the translatable string checks (which check that all translatable strings have translator comments), run:
+
+```
+scons checkPot
 ```

--- a/sconstruct
+++ b/sconstruct
@@ -399,8 +399,4 @@ env.Alias("symbolsArchive", symbolsArchive)
 
 env.Default(dist)
 
-if "tests" in COMMAND_LINE_TARGETS:
-	target = env.SConscript("tests/unit/sconscript", exports=["env"])
-	env.Depends(target, sourceDir)
-	env.AlwaysBuild(target)
-	tests = env.Alias("tests", target)
+env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -363,6 +363,8 @@ class WordDocumentCommentQuickNavItem(WordDocumentCollectionQuickNavItem):
 		author=self.collectionItem.author
 		date=self.collectionItem.date
 		text=self.collectionItem.range.text
+		# Translators: The label shown for a comment in the NVDA Elements List dialog in Microsoft Word.
+		# {text}, {author} and {date} will be replaced by the corresponding details about the comment.
 		return _(u"comment: {text} by {author} on {date}").format(author=author,text=text,date=date)
 
 	def rangeFromCollectionItem(self,item):
@@ -380,6 +382,10 @@ class WordDocumentRevisionQuickNavItem(WordDocumentCollectionQuickNavItem):
 		date=self.collectionItem.date
 		description=self.collectionItem.formatDescription or ""
 		text=(self.collectionItem.range.text or "")[:100]
+		# Translators: The label shown for an editor revision (tracked change)  in the NVDA Elements List dialog in Microsoft Word.
+		# {revisionType} will be replaced with the type of revision; e.g. insertion, deletion or property.
+		# {description} will be replaced with a description of the formatting changes, if any.
+		# {text}, {author} and {date} will be replaced by the corresponding details about the revision.
 		return _(u"{revisionType} {description}: {text} by {author} on {date}").format(revisionType=revisionType,author=author,text=text,date=date,description=description)
 
 class WordDocumentSpellingErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
@@ -390,7 +396,8 @@ class WordDocumentSpellingErrorQuickNavItem(WordDocumentCollectionQuickNavItem):
 	@property
 	def label(self):
 		text=self.collectionItem.text
-		# Translators: the label for a speling error shown in NVDA's Elements List dialog for Microsoft Word
+		# Translators: The label shown for a spelling error in the NVDA Elements List dialog in Microsoft Word.
+		# {text} will be replaced with the text of the spelling error.
 		return _(u"spelling: {text}").format(text=text)
 
 class WinWordCollectionQuicknavIterator(object):

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -13,6 +13,8 @@ import sys
 # Ideally, all of these should get translator comments,
 # but this is not realistic right now.
 # A message should be removed from here once a translator comment is added for it.
+# Note that checkPot will fail with an unexpected success
+# if a translator comment is found for one of these messages.
 EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
 	'Focus mode',
 	'%s landmark',
@@ -107,6 +109,10 @@ def checkPot(fileName):
 	"""Returns the number of errors.
 	Also prints error messages and a summary to standard output.
 	"""
+	# This function reads a gettext translation template (pot) line by line,
+	# parsing only the content it needs.
+	# See this link for info about the format of gettext translation files:
+	# https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
 	errors = 0
 	expectedErrors = 0
 	unexpectedSuccesses = 0
@@ -123,18 +129,22 @@ def checkPot(fileName):
 				# Header.
 				continue
 			if line.startswith("#. Translators: "):
+				# This is a comment for translators.
 				# Example: "#. Translators: a message reported in the SetRowHeader script for Microsoft Word."
 				hasComment = True
 				continue
 			if line.startswith("#: "):
+				# This specifies the files and line numbers where this message was found.
 				# Example: "#: NVDAObjects\window\winword.py:1322"
 				# Strip the "#: " prefix (3 chars).
 				sourceLines.append(line[3:])
 				continue
 			if line.startswith('msgctxt "'):
+				# This is the context used to disambiguate messages.
 				context = getStringFromLine(line)
 				continue
 			if line.startswith("msgid "):
+				# This is the untranslated message.
 				# Get the message.
 				if line == 'msgid ""':
 					# Multi-line msgid.
@@ -142,6 +152,7 @@ def checkPot(fileName):
 					msgid = ""
 					for line in pot:
 						if line.startswith("msgstr "):
+							# This begins the translated message, so msgid has ended.
 							break
 						msgid += getStringFromLine(line)
 				else:

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -1,0 +1,192 @@
+#tests/checkPot.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2017 NV Access Limited
+
+"""Check a translation template (pot) for strings without translator comments.
+"""
+
+import sys
+
+# Existing messages that we know don't have translator comments yet.
+# Ideally, all of these should get translator comments,
+# but this is not realistic right now.
+# A message should be removed from here once a translator comment is added for it.
+EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
+	'Focus mode',
+	'%s landmark',
+	'border',
+	'filler',
+	'line',
+	'data item',
+	'header item',
+	'calendar',
+	'video',
+	'audio',
+	'modal',
+	'iconified',
+	'editable',
+	'checkable',
+	'draggable',
+	'dragging',
+	'sorted',
+	'sorted ascending',
+	'sorted descending',
+	'gesture map File Error',
+	'text \\"%s\\" not found',
+	'Find Error',
+	'Selected %s',
+	'on',
+	'Type help(object) to get help about object.',
+	'Type exit() to exit the console',
+	'NVDA Python Console',
+	'Emulates pressing %s on the system keyboard',
+	'continuous section break',
+	'new column section break',
+	'new page section break',
+	'even pages section break',
+	'odd pages section break',
+	'column break',
+	'background pattern {pattern}',
+	'NVDA Speech Viewer',
+	'text mode',
+	'object mode',
+	'NonVisual Desktop Access',
+	'A free and open source screen reader for Microsoft Windows',
+	'Copyright (C) {years} NVDA Contributors',
+	'Display',
+	'Reports and moves the review cursor to a recent message',
+	'left',
+	'right',
+	'Show the Handy Tech driver configuration window.',
+	'Recognition failed',
+	'General settings',
+	'Change the synthesizer to be used',
+	'Choose the voice, rate, pitch and volume to use',
+	'Change reporting of mouse shape and object under mouse',
+	'Configure how and when the review cursor moves',
+	'Change reporting of objects',
+	'Change virtual buffers specific settings',
+	'Change settings of document properties',
+	'NVDA &web site',
+	'Reset all settings to saved state',
+	'Reset all settings to default state',
+	'Write the current configuration to nvda.ini',
+	'E&xit',
+	'Options',
+	'Error renaming profile.',
+	'Use this profile for:',
+	'This change requires administrator privileges.',
+	'Insufficient Privileges',
+	'Synthesizer Error',
+	'Dictionary Entry Error',
+	'Could not load the %s display.',
+	'Braille Display Error',
+	'word',
+	'Taskbar',
+	'%s items',
+	'invoke',
+	'Desktop',
+	'Input Message is {title}: {message}',
+	'Input Message is {message}',
+	'Series color: {colorName} ',
+	'Comments',
+	'Endnotes',
+	'Even pages footer',
+	'Even pages header',
+	'First page footer',
+	'First page header',
+	'Footnotes',
+	'Primary footer',
+	'Primary header',
+	'Text frame',
+}
+
+def checkPot(fileName):
+	"""Returns the number of errors.
+	Also prints error messages and a summary to standard output.
+	"""
+	errors = 0
+	expectedErrors = 0
+	unexpectedSuccesses = 0
+	with file(fileName, "rt") as pot:
+		for line in pot:
+			line = line.rstrip()
+			if not line:
+				# End of message.
+				hasComment = False
+				sourceLines = []
+				context = ""
+				continue
+			if line == 'msgid ""':
+				# Header.
+				continue
+			if line.startswith("#. Translators: "):
+				# Example: "#. Translators: a message reported in the SetRowHeader script for Microsoft Word."
+				hasComment = True
+				continue
+			if line.startswith("#: "):
+				# Example: "#: NVDAObjects\window\winword.py:1322"
+				# Strip the "#: " prefix (3 chars).
+				sourceLines.append(line[3:])
+				continue
+			if line.startswith('msgctxt "'):
+				context = getStringFromLine(line)
+				continue
+			if line.startswith("msgid "):
+				# Get the message.
+				if line == 'msgid ""':
+					# Multi-line msgid.
+					# Subsequent lines are just quoted strings which should be concatenated.
+					msgid = ""
+					for line in pot:
+						if line.startswith("msgstr "):
+							break
+						msgid += getStringFromLine(line)
+				else:
+					# Single line msgid.
+					# Example: msgid "Secure Desktop"
+					msgid = getStringFromLine(line)
+				if context:
+					# The context must be considered as part of the message.
+					message = "[{context}] {msgid}".format(context=context, msgid=msgid)
+				else:
+					message = msgid
+				isExpectedError = message in EXPECTED_MESSAGES_WITHOUT_COMMENTS
+				if not hasComment and isExpectedError:
+					expectedErrors += 1
+					continue
+				if hasComment and isExpectedError:
+					error = ("Message has translator comment, but one wasn't expected.\n"
+						"This is good, but please remove from EXPECTED_MESSAGES_WITHOUT_COMMENTS in tests/checkPot.py")
+					unexpectedSuccesses += 1
+				elif not hasComment:
+					errors += 1
+					error = "Message has no translator comment."
+				else:
+					continue
+				print("{error}\n"
+					"Source lines: {lines}\n"
+					"Message: {message}\n"
+					.format(error=error, lines=" ".join(sourceLines), message=message))
+				continue
+	print("{errors} errors, {unexpectedSuccesses} unexpected successes, {expectedErrors} expected errors"
+		.format(errors=errors, unexpectedSuccesses=unexpectedSuccesses, expectedErrors=expectedErrors))
+	return errors + unexpectedSuccesses
+
+def getStringFromLine(line):
+	if line.startswith('"'):
+		# The quoted string begins at the start of the line.
+		quoted = line
+	else:
+		# The quoted string starts after a command.
+		# Example: msgid "Secure Desktop"
+		quoted = line.split(" ", 1)[1]
+	# Strip the quotes.
+	return quoted[1:-1]
+
+if __name__ == "__main__":
+	# Support command line usage for quick testing.
+	fileName = sys.argv[1]
+	print(checkPot(fileName))

--- a/tests/sconscript
+++ b/tests/sconscript
@@ -1,0 +1,40 @@
+###
+#This file is a part of the NVDA project.
+#URL: http://www.nvaccess.org/
+#Copyright 2017 NV Access Limited.
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License version 2.0, as published by
+#the Free Software Foundation.
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#This license can be found at:
+#http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+###
+
+import checkPot
+
+Import("env", "sourceDir", "pot")
+
+unitTests = env.SConscript("unit/sconscript", exports=["env"])
+env.Depends(unitTests, sourceDir)
+env.AlwaysBuild(unitTests)
+
+def checkPotAction(target, source, env):
+	return checkPot.checkPot(source[0].abspath)
+checkPotTarget = env.Command("checkPot", pot, checkPotAction)
+env.Depends(checkPotTarget, pot)
+env.AlwaysBuild(checkPotTarget)
+env.Alias("checkPot", checkPotTarget)
+
+# Determine the targets for scons tests.
+# If specific tests are explicitly specified, only run those.
+explicitUnitTests = env.get("unitTests")
+explicitCheckPot = "checkPot" in COMMAND_LINE_TARGETS
+explicit = explicitUnitTests or explicitCheckPot
+tests = []
+if not explicit or explicitUnitTests:
+	tests.append(unitTests)
+if not explicit or explicitCheckPot:
+	tests.append(checkPotTarget)
+env.Alias("tests", tests)

--- a/tests/unit/sconscript
+++ b/tests/unit/sconscript
@@ -17,7 +17,7 @@ import sys
 Import("env")
 
 cmd = [sys.executable, "-m", "unittest"]
-tests = env["unitTests"]
+tests = env.get("unitTests")
 if tests:
 	# Run specific tests.
 	tests = tests.split(",")


### PR DESCRIPTION
### Link to issue number:
None specifically, but inspired by an omition in #7258.

### Summary of the issue:
All translatable strings should have translator comments explaining them to translators. However, this is sometimes forgotten and this is easy to miss in review.

### Description of how this pull request fixes the issue:
1. Add a few missing translator comments inspired by [reports from translators](https://www.freelists.org/post/nvda-translations/Missing-comment-for-translators-was-About-a-string-for-NVDA-20173).
2. Add some code (`checkPot`) to check for missing translator comments in the translation template (pot). For now, we have a set of expected failures, since fixing all existing 87 messages that don't have translator comments is going to take some work. However, we want to fail for any new messages that get introduced without comments.
3. Run `checkPot` as part of `scons tests`. This means tests (and thus builds) will fail so we learn about these problems early.
4. `checkPot` can also be run alone with `scons checkPot`.
5. Now that `scons tests` runs `checkPot` (which depends on `pot`), don't explicitly run `scons pot` on AppVeyor.

### Testing performed:
1. Tested that unexpected errors cause `checkPot` to fail.
2. Tested that expected errors don't cause `checkPot` to fail, but do get counted in the summary.
3. Added a message that already has a translator comment to the `EXPECTED_MESSAGES_WITHOUT_COMMENTS` set. Tested that this causes an unexpected success and that `checkPot` fails as a result.
4. Tested that `scons tests` runs `checkPot`.
5. Tested that `scons tests unitTests=test_cursorManager` does *not* run `checkPot` (since explicit tests were specified).
6. Tested that an unexpected error causes an AppVeyor build to fail.

### Known issues with pull request:
None.

### Change log entry:
Changes for developers:

```
- "scons tests" now checks that translatable strings have translator comments. You can also run this alone with "scons checkPot". (#7492)
```