### PR TITLE
Add landmark property to the base NVDAObject

### DIFF
--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -494,7 +494,6 @@ class EdgeNode(UIA):
 		return False
 
 	def _get_landmark(self):
-		"""Fetches the aria landmark role for this object."""
 		landmarkId=self._getUIACacheablePropertyValue(UIAHandler.UIA_LandmarkTypePropertyId)
 		if not landmarkId: # will be 0 for non-landmarks
 			return None

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -839,6 +839,13 @@ Tries to force this object to take the focus.
 		log.debug("Potential unimplemented child class: %r" %self)
 		return None
 
+	def _get_landmark(self):
+		"""If this object represents an ARIA landmark, fetches the ARIA landmark role.
+		@return: ARIA landmark role else None
+		@rtype: String or None
+		"""
+		return None
+
 	def _reportErrorInPreviousWord(self):
 		try:
 			# self might be a descendant of the text control; e.g. Symphony.


### PR DESCRIPTION
### Link to issue number:
Fixes #7490

### Summary of the issue:
Regression from #7328, sometimes an error is raised while navigating through a document in Edge, for example a PDF document.

### Description of how this pull request fixes the issue:
Adds the landmark property added in #7328 to the base NVDAObject, so getting the landmark property from an object always returns something.

### Testing performed:
@derekriemer: Could you please double check whether this fixes the PDF issue you reported?

### Known issues with pull request:
None I'm aware of

### Change log entry:
None, regression from 2017.2.

@MichaelDCurran, since this is a regression from 2017.2, I think this is best merged into master after @DerekRiemer confirms that it fixes the issue.