### PR TITLE
OneCore Voices: Fix failure to speak some messages when several messages are spoken in quick succession

### DIFF
--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -161,7 +161,6 @@ class SynthDriver(SynthDriver):
 			# which will eventually process the queue again.
 			self._dll.ocSpeech_speak(self._handle, item)
 			return
-		self._player.idle()
 		log.debug("Queue empty, done processing")
 		self._isProcessing = False
 
@@ -209,6 +208,13 @@ class SynthDriver(SynthDriver):
 			if prevMarker:
 				self.lastIndex = prevMarker
 			log.debug("Done pushing audio")
+			if not self._queuedSpeech:
+				# There are no more queued utterances at this point, so call idle.
+				# This blocks while waiting for the final chunk to play,
+				# so by the time this is done, there might be something queued.
+				# The call to _processQueue will take care of this.
+				log.debug("Calling idle on audio player")
+				self._player.idle()
 		self._processQueue()
 
 	def _getAvailableVoices(self, onlyValid=True):


### PR DESCRIPTION
### Link to issue number:
Fixes #7473.

### Summary of the issue:
When several messages are spoken in quick succession, NVDA sometimes fails to speak some messages using OneCore Voices. This occurs, for example, when toggling a check box with the space bar with speak typed characters turned on. In this case, often "space" would be spoken, but not "checked"/"not checked".

### Description of how this pull request fixes the issue:
#7463 modified the oneCore driver to call `player.idle` when there was no more speech in the queue in order to fix audio ducking. Unfortunately, i neglected to realise that because `player.idle` can take some time, there might be more speech queued while it was running.

With this PR, we still check the queue and only call `player.idle` if it is empty. However, we then process the queue after that so that if new utterances arrived in the queue during the `idle` call, we still process them.

### Testing performed:
As per #7473:

1. Located a check box. I used the Automatic language switching check box in Voice Settings.
2. Enabled speak typed characters.
3. Pressed space and verified that both "space" and "checked"/"not checked" were reported.
4. Repeated quite a few times to be certain, since this is a little intermittent.

### Known issues with pull request:
None.

### Change log entry:
None, as this hasn't been in a release yet.

### Merge notes:
Should be merged straight to master because OneCore voices are in master and we want them to get into 2017.3. Low risk, and at worst, only affects the OneCore voices driver.