### PR TITLE
OneCore Voices: Fix lag when reporting characters

### DIFF
--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -142,6 +142,11 @@ class SynthDriver(SynthDriver):
 	def speak(self, speechSequence):
 		conv = _OcSsmlConverter(self.language, self.rate, self.pitch, self.volume)
 		text = conv.convertToXml(speechSequence)
+		# #7495: Calling WaveOutOpen blocks for ~100 ms if called from the callback
+		# when the SSML includes marks.
+		# We're not quite sure why.
+		# To work around this, open the device before queuing.
+		self._player.open()
 		self._queueSpeech(text)
 
 	def _queueSpeech(self, item):
@@ -151,6 +156,12 @@ class SynthDriver(SynthDriver):
 			self._processQueue()
 
 	def _processQueue(self):
+		if not self._queuedSpeech:
+			# There are no more queued utterances at this point, so call idle.
+			# This blocks while waiting for the final chunk to play,
+			# so by the time this is done, there might be something queued.
+			log.debug("Calling idle on audio player")
+			self._player.idle()
 		if self._queuedSpeech:
 			item = self._queuedSpeech.pop(0)
 			self._wasCancelled = False
@@ -208,13 +219,6 @@ class SynthDriver(SynthDriver):
 			if prevMarker:
 				self.lastIndex = prevMarker
 			log.debug("Done pushing audio")
-			if not self._queuedSpeech:
-				# There are no more queued utterances at this point, so call idle.
-				# This blocks while waiting for the final chunk to play,
-				# so by the time this is done, there might be something queued.
-				# The call to _processQueue will take care of this.
-				log.debug("Calling idle on audio player")
-				self._player.idle()
 		self._processQueue()
 
 	def _getAvailableVoices(self, onlyValid=True):


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Using OneCore Voices with NVDA, when reporting characters (e.g. using the left and right arrow keys in editable text or review next/previous character), there is a noticeable lag before the character is spoken. This lag is not encountered when reading words, lines or other messages; the voices are very responsive for everything except single characters. Reporting single characters does not suffer from this lag with Narrator.

### Description of how this pull request fixes the issue:
1. When we speak characters, we include indexes, which get translated to SSML marks. Unfortunately, calling WaveOutOpen blocks for ~100 ms if called from the callback when the SSML includes marks. We're not quite sure why.
2. To work around this, open the device before queuing.
3. Move the call to player.idle to _processQueue so that it gets called (thus closing the audio device) even if the UWP code encounters an exception.

### Testing performed:
Tested to ensure that the regressions fixed by #7463 and #7494 did not regress again:

Ducking (#7463):

1. Switched to the Windows OneCore Voices synthesiser.
2. Played some music.
3. Used NVDA+shift+d to set NVDA's audio ducking mode to "Duck when outputting speech and sounds".
4. Confirmed that after NVDA finished speaking, audio was unducked after a short delay.

Several messages in quick succession (#7494):

1. Located a check box. I used the Automatic language switching check box in Voice Settings.
2. Enabled speak typed characters.
3. Pressed space and verified that both "space" and "checked"/"not checked" were reported.
4. Repeated quite a few times to be certain, since this is a little intermittent.

Also tested rapidly pressing keys and holding down keys to ensure that cancelling speech, etc. behaves as expected.

### Known issues with pull request:
None known.

### Change log entry:
Not in release, so not needed.

### Merge notes:
Should be merged straight to master because OneCore voices are in master and we want them to get into 2017.3. However, feedback that everything works correctly from at least one other user would be best. At worst, only affects the OneCore voices driver.