### PR TITLE
Add ConsoleWindowClass to badUIAWindowClasses as the UIA implementation for win32 Console windows is not usable yet.

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -62,6 +62,8 @@ badUIAWindowClassNames=[
 	"_WwG",
 	"EXCEL7",
 	"Button",
+	# #7497: Windows 10 Fall Creators Update has an incomplete UIA implementation for console windows, therefore for now we should ignore it.
+	# It does not implement caret/selection, and probably has no new text events.
 	"ConsoleWindowClass",
 ]
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -62,6 +62,7 @@ badUIAWindowClassNames=[
 	"_WwG",
 	"EXCEL7",
 	"Button",
+	"ConsoleWindowClass",
 ]
 
 NVDAUnitsToUIAUnits={


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In Windows 10 build 16257, Microsoft introduced a UIA implementation for Win32 console windows. Not only does this conflict with our existing support, their UIA implementation is not yet complete (I.e. caret support is lacking, and most likely no useful events for new text).
As this implementation will be in the Fall Creaters update released before NVDA 2017.4, we should for now ignore this UIA implementation, and revisit how we should handle it properly if the implementation improves.

### Description of how this pull request fixes the issue:
ConsoleWindowClass is added to _UIAHandler.badUIAWindowClasses.

### Testing performed:
* Started a cmd prompt from the run dialog
* Started Ubuntu from the Start Screen
* Started NVDA from an existing Ubuntu session

All of these tests showed NVDA functioning the way it used to before the new UIA implementation in 16257.

### Known issues with pull request:
None.

### Change log entry:
Probably none needed as getting this in 2017.3 before the general public notice would be good.