### PR TITLE
Improve compatibility of NVDA for Windows 10 on ARM64.  

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -432,7 +432,7 @@ class AppModule(baseObject.ScriptableObject):
 		"""Whether the underlying process is a 64 bit process.
 		@rtype: bool
 		"""
-		if os.environ.get("PROCESSOR_ARCHITEW6432") != "AMD64":
+		if os.environ.get("PROCESSOR_ARCHITEW6432") not in ("AMD64","ARM64"):
 			# This is 32 bit Windows.
 			self.is64BitProcess = False
 			return False

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -169,10 +169,23 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 	except:
 		log.error("internal_keyDownEvent", exc_info=True)
 	finally:
-		# #6017: handle typed characters for UWP apps in Win10 RS2 and above where we can't detect typed characters in-process 
+		# #6017: handle typed characters in Win10 RS2 and above where we can't detect typed characters in-process 
 		# This code must be in the 'finally' block as code above returns in several places yet we still want to execute this particular code.
 		focus=api.getFocusObject()
-		if winVersion.winVersion.build>=14986 and not gestureExecuted and not isNVDAModifierKey(vkCode,extended) and not vkCode in KeyboardInputGesture.NORMAL_MODIFIER_KEYS and focus.windowClassName.startswith('Windows.UI.Core'):
+		if (
+			# This is only possible in Windows 10 RS2 and above
+			winVersion.winVersion.build>=14986
+			# And we only want to do this if the gesture did not result in an executed action 
+			and not gestureExecuted 
+			# and not if this gesture is a modifier key
+			and not isNVDAModifierKey(vkCode,extended) and not vkCode in KeyboardInputGesture.NORMAL_MODIFIER_KEYS
+			and ( # Either of
+				# We couldn't inject in-process, and its not a console window (console windows have their own specific typed character support)
+				(not focus.appModule.helperLocalBindingHandle and focus.windowClassName!='ConsoleWindowClass')
+				# or the focus is within a UWP app, where WM_CHAR never gets sent 
+				or focus.windowClassName.startswith('Windows.UI.Core')
+			)
+		):
 			keyStates=(ctypes.c_byte*256)()
 			for k in xrange(256):
 				keyStates[k]=ctypes.windll.user32.GetKeyState(k)


### PR DESCRIPTION
### Summary of the issue:
Windows 10 (Desktop) will be available for running on ARM64 devices in the near future. This version of Windows (code named Cobalt) Will be able to run any existing x86 application through an x86 emulation layer similar to WOW64 on x86-64 builds of Windows.
More info: https://channel9.msdn.com/Events/Build/2017/P4171
However there are the following limitations:

####  Injection
NVDA cannot inject into any ARM64 or ARM32 process (as we do not have any dlls compiled for these architectures, nor is it currently possible to do so with VS / windows SDK). 
The largest limitation here is that speaking of typed characters does not work in ARM processes, but does for other x86 ones.
We definitely use injection for other things as well, but these are not as important anymore for core Windows Operating System reatures. Note that all 3rd party desktop applictions on ARM devices must be x86. Therefore, as an example, NVDA will still work fine with Mozilla Firefox, or in deed even Microsoft Office.

#### 64-bit identification
NVDA does not currently treat ARM64 as a 64-bit architecture.
This means that where we have 64-bit specific code, such as for SysListivew32, it is not used and therefore these controls remain inaccessible. Examples being the list in Registry Editor, and the list in the Details tab of Task Manager.

### Description of how this pull request fixes the issue:
* In windows 10 RS2 and above it is possible to support speaking of typed characters with out injection via ToUnicodeEx. We already do this for Microsoft Edge and other UWP apps. Therefore this PR extends that support to any application where we cannot inject (I.e. we do not have a binding handle to our in-proc RPC interfaces). However, the one exclusion  Windows consoles where they already have their own typed character support separate to this.
 * appModuleHandler.AppModule.is64BitProcess now treats ARM64 as 64-bit as it does for AMD64. This allows our 64 bit support for SysListview32 controls to work and therefore regedit and task manager are again accessible.

### Testing performed:


### Known issues with pull request:
* This does not solve other reasons why we need to inject, such as display model or virtualBuffers etc. However, this is not relevant until 3rd party apps start becoming compiled for ARM64. Note that though when they do start becoming compiled, at that stage we should also be able to compile are own DLLs for ARM64 and therefore  be able to inject again.
* responsiveness is noticeably worse for NVDA interacting with other x86 applications on ARM64 due to double emulation.  One day in the future we may consider compiling all of NVDA for ARM64 and remove one layer of emulation, however all x86 applications running on an ARM device will always have some kind of performance loss.
 
### Change log entry:
New features:
* Initial support for Windows 10 on ARM64.  