### PR TITLE
Gecko: Report label in browse mode if it isn't rendered anywhere else 

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -531,15 +531,23 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 	const long childCount = getChildCount(isAriaHidden, pacc);
 
 	const bool isImgMap = role == ROLE_SYSTEM_GRAPHIC && childCount > 0;
+	IA2AttribsMapIt = IA2AttribsMap.find(L"explicit-name");
 	// Whether the name of this node has been explicitly set (as opposed to calculated by descendant)
-	const bool nameIsExplicit = ((IA2AttribsMapIt = IA2AttribsMap.find(L"explicit-name")) != IA2AttribsMap.end() && IA2AttribsMapIt->second == L"true");
+	const bool nameIsExplicit = IA2AttribsMapIt != IA2AttribsMap.end() && IA2AttribsMapIt->second == L"true";
 	// Whether the name is the content of this node.
 	const bool nameIsContent = isEmbeddedApp
-		|| role == ROLE_SYSTEM_LINK || role == ROLE_SYSTEM_PUSHBUTTON || role == IA2_ROLE_TOGGLE_BUTTON || role == ROLE_SYSTEM_MENUITEM || (role == ROLE_SYSTEM_GRAPHIC && !isImgMap) || (role == ROLE_SYSTEM_TEXT && !isEditable) || role == IA2_ROLE_HEADING || role == ROLE_SYSTEM_PAGETAB || role == ROLE_SYSTEM_BUTTONMENU;
-		// || ((role == ROLE_SYSTEM_CHECKBUTTON || role == ROLE_SYSTEM_RADIOBUTTON) && !labelVisible);
+		|| role == ROLE_SYSTEM_LINK 
+		|| role == ROLE_SYSTEM_PUSHBUTTON 
+		|| role == IA2_ROLE_TOGGLE_BUTTON 
+		|| role == ROLE_SYSTEM_MENUITEM 
+		|| (role == ROLE_SYSTEM_GRAPHIC && !isImgMap) 
+		|| (role == ROLE_SYSTEM_TEXT && !isEditable) 
+		|| role == IA2_ROLE_HEADING 
+		|| role == ROLE_SYSTEM_PAGETAB 
+		|| role == ROLE_SYSTEM_BUTTONMENU;
 	// Whether this node has a visible label somewhere else in the tree
 	const bool labelVisible = canDetectLabelVisibility // Not all browsers support getting a node's labelledBy node
-		&&nameIsExplicit&&name&&name[0] //this node must actually have an explicit name
+		&& nameIsExplicit && name && name[0] //this node must actually have an explicit name, and not be just an empty string
 		&&(!nameIsContent||role==ROLE_SYSTEM_TABLE) // We only need to know if the name won't be used as content or if it is a table (for table summary)
 		&&isLabelVisible(pacc); // actually do the check
 	// If the node is explicitly labeled for accessibility, and we haven't used the label as the node's content, and the label does not visibly appear anywhere else in the tree (E.g. aria-label on an edit field)

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -232,6 +232,7 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 	// Defaults.
 	this->shouldDisableTableHeaders = false;
 	this->hasEncodedAccDescription = false;
+	this->canDetectLabelVisibility=false;
 
 	IServiceProvider* serv = NULL;
 	if (pacc->QueryInterface(IID_IServiceProvider, (void**)&serv) != S_OK)
@@ -258,6 +259,7 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 	iaApp = NULL;
 
 	if (wcscmp(toolkitName, L"Gecko") == 0) {
+		this->canDetectLabelVisibility=true;
 		if (wcsncmp(toolkitVersion, L"1.", 2) == 0) {
 			if (wcsncmp(toolkitVersion, L"1.9.2.", 6) == 0) {
 				// Gecko 1.9.2.x.
@@ -279,11 +281,11 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 	SysFreeString(toolkitVersion);
 }
 
-bool isLabelVisible(IAccessible2* acc) {
+bool isLabelVisible(IAccessible2* pacc2) {
 	VARIANT child, target;
 	child.vt = VT_I4;
 	child.lVal = 0;
-	if (acc->accNavigate(NAVRELATION_LABELLED_BY, child, &target) != S_OK)
+	if (pacc2->accNavigate(NAVRELATION_LABELLED_BY, child, &target) != S_OK)
 		return false;
 	IAccessible2* targetAcc;
 	HRESULT res;
@@ -529,11 +531,23 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 	const long childCount = getChildCount(isAriaHidden, pacc);
 
 	const bool isImgMap = role == ROLE_SYSTEM_GRAPHIC && childCount > 0;
+	// Whether the name of this node has been explicitly set (as opposed to calculated by descendant)
+	const bool nameIsExplicit = ((IA2AttribsMapIt = IA2AttribsMap.find(L"explicit-name")) != IA2AttribsMap.end() && IA2AttribsMapIt->second == L"true");
 	// Whether the name is the content of this node.
 	const bool nameIsContent = isEmbeddedApp
-		|| role == ROLE_SYSTEM_LINK || role == ROLE_SYSTEM_PUSHBUTTON || role == IA2_ROLE_TOGGLE_BUTTON || role == ROLE_SYSTEM_MENUITEM || (role == ROLE_SYSTEM_GRAPHIC && !isImgMap) || (role == ROLE_SYSTEM_TEXT && !isEditable) || role == IA2_ROLE_HEADING || role == ROLE_SYSTEM_PAGETAB || role == ROLE_SYSTEM_BUTTONMENU
-		|| ((role == ROLE_SYSTEM_CHECKBUTTON || role == ROLE_SYSTEM_RADIOBUTTON) && !isLabelVisible(pacc));
-
+		|| role == ROLE_SYSTEM_LINK || role == ROLE_SYSTEM_PUSHBUTTON || role == IA2_ROLE_TOGGLE_BUTTON || role == ROLE_SYSTEM_MENUITEM || (role == ROLE_SYSTEM_GRAPHIC && !isImgMap) || (role == ROLE_SYSTEM_TEXT && !isEditable) || role == IA2_ROLE_HEADING || role == ROLE_SYSTEM_PAGETAB || role == ROLE_SYSTEM_BUTTONMENU;
+		// || ((role == ROLE_SYSTEM_CHECKBUTTON || role == ROLE_SYSTEM_RADIOBUTTON) && !labelVisible);
+	// Whether this node has a visible label somewhere else in the tree
+	const bool labelVisible = canDetectLabelVisibility // Not all browsers support getting a node's labelledBy node
+		&&nameIsExplicit&&name&&name[0] //this node must actually have an explicit name
+		&&(!nameIsContent||role==ROLE_SYSTEM_TABLE) // We only need to know if the name won't be used as content or if it is a table (for table summary)
+		&&isLabelVisible(pacc); // actually do the check
+	// If the node is explicitly labeled for accessibility, and we haven't used the label as the node's content, and the label does not visibly appear anywhere else in the tree (E.g. aria-label on an edit field)
+	// then ensure that the label is always reported along withe the node
+	// We must exclude tables from this though as table summaries / captions are handled very specifically
+	if(canDetectLabelVisibility&&nameIsExplicit&&!nameIsContent&&(role!=ROLE_SYSTEM_TABLE)&&!labelVisible) {
+		parentNode->addAttribute(L"alwaysReportName",L"true");
+	}
 
 	IAccessibleText* paccText=NULL;
 	IAccessibleHypertext* paccHypertext=NULL;
@@ -577,7 +591,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 			|| isEmbeddedApp
 			|| role == ROLE_SYSTEM_OUTLINE
 			|| role == ROLE_SYSTEM_EQUATION
-			|| (nameIsContent && (IA2AttribsMapIt = IA2AttribsMap.find(L"explicit-name")) != IA2AttribsMap.end() && IA2AttribsMapIt->second == L"true")
+			|| (nameIsContent && nameIsExplicit)
 		) {
 			renderChildren = false;
 		}
@@ -664,7 +678,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 				(!description.empty() && (tempNode = buffer->addTextFieldNode(parentNode, previousNode, description))) ||
 				// If there is no caption, the summary (if any) is the name.
 				// There is no caption if the label isn't visible.
-				(name && !isLabelVisible(pacc) && (tempNode = buffer->addTextFieldNode(parentNode, previousNode, name)))
+				(name && !labelVisible && (tempNode = buffer->addTextFieldNode(parentNode, previousNode, name)))
 			) {
 				if(!locale.empty()) tempNode->addAttribute(L"language",locale);
 				previousNode = tempNode;

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -32,6 +32,7 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	bool shouldDisableTableHeaders;
 	bool hasEncodedAccDescription;
+	bool canDetectLabelVisibility;
 
 	protected:
 


### PR DESCRIPTION
### Link to issue number:
Partial fix for #4773

### Summary of the issue:
Sometimes a web author will use aria-label on a node to convey screen-reader specific information, however the node also has useful and valid content itself (E.g. an edit field, or an iFrame).
NVDA already reports this label when moving to these controls with quick navigation or tabbing, but it should also report it when reading the control with the browse mode caret, as this label will not be rendered anywhere else.
Of course care must be taken to ensure this is in deed a label set by aria-label and not say a label from aria-labelledby or an associated html label tag.  The one exception to this is if the associated label node is hidden from the screen.
 
### Description of how this pull request fixes the issue:
In Firefox and other Mozilla Gecko products, we now convey to NVDA that these labels must always be reported, by exposing the 'alwaysReportName' attribute on these nodes from the vbufbackend.

### Testing performed:
Tested browsers by arrowing up and down the page with NVDA's screen layout mode off, using the document from 
[sr_only_labels.html.txt](https://github.com/nvaccess/nvda/files/1240739/sr_only_labels.html.txt)


### Known issues with pull request:
Note that it is not supported in other browsers because:
* Chrome does not yet have a performant way of locating a node's label node (IAccessible2_2::RelationTargetsOfType should be implemented)
* Edge has no means of asking a node if its name (label) has been explicitly set by the author
* We are not expending any effort for Internet Explorer now, though PRs will be accepted from the community 

### Change log entry:
Bug fixes:
Accessible labels for controls in Mozilla Firefox are now more readily reported in browse mode when the label does not appear as content itself. (#4773)