### PR TITLE
Early support for mathematical content in Kindle for PC.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2015-2016 NV Access Limited
+#Copyright (C) 2015-2017 NV Access Limited
 
 """Support for the IAccessible2 rich text model first implemented by Mozilla.
 This is now used by other applications as well.
@@ -633,3 +633,14 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			# No common ancestor.
 			return 1
 		return selfAncTi.compareEndPoints(otherAncTi, which)
+
+	def _get_NVDAObjectAtStart(self):
+		obj = self._startObj
+		# If the start is an embedded object that doesn't have text (e.g. graphic or math),
+		# _startObj will be the text parent that embeds it.
+		# However, we want this property to return the embedded object.
+		# This is necessary to allow interaction with math in browse mode, for example.
+		embedded = _getEmbedded(obj, self._start._startOffset)
+		if embedded:
+			return embedded
+		return obj

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -25,6 +25,7 @@ import IAccessibleHandler
 import winUser
 from logHandler import log
 import ui
+import config
 
 class ElementsListDialog(browseMode.ElementsListDialog):
 	ELEMENT_TYPES = (
@@ -220,11 +221,17 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 		return text
 
 	def getTextWithFields(self, formatConfig=None):
+		if not formatConfig:
+			formatConfig = config.conf["documentFormatting"]
 		items = super(BookPageViewTextInfo, self).getTextWithFields(formatConfig=formatConfig)
 		for item in items:
 			if isinstance(item, textInfos.FieldCommand) and item.command == "formatChange":
 				if formatConfig['reportPage']:
 					item.field['page-number'] = self.obj.pageNumber
+			elif (isinstance(item, textInfos.FieldCommand) and item.command == "controlStart"
+					and item.field.get("mathMl")):
+				# We have MathML, so don't report alt text (if any) as content.
+				item.field.pop("content", None)
 		return items
 
 	def getFormatFieldSpeech(self, attrs, attrsCache=None, formatConfig=None, reason=None, unit=None, extraDetail=False , initialFormat=False, separator=speech.CHUNK_SEPARATOR):
@@ -271,6 +278,21 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 		log.debug("Setting selection to (%d, %d)" % (sel._startOffset, sel._endOffset))
 		sel.updateSelection()
 
+	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
+		field = super(BookPageViewTextInfo, self)._getControlFieldForObject(obj, ignoreEditableText=ignoreEditableText)
+		if field and field["role"] == controlTypes.ROLE_MATH:
+			try:
+				field["mathMl"] = obj.mathMl
+			except LookupError:
+				mathMl = None
+		return field
+
+	def getMathMl(self, field):
+		mathMl = field.get("mathMl")
+		if not mathMl:
+			raise LookupError("No mathml attribute")
+		return mathMl
+
 class BookPageView(DocumentWithPageTurns,IAccessible):
 	"""Allows navigating page text content with the arrow keys."""
 
@@ -308,6 +330,14 @@ class PageTurnFocusIgnorer(IAccessible):
 			return False
 		return super(PageTurnFocusIgnorer,self).shouldAllowIAccessibleFocusEvent
 
+class Math(IAccessible):
+
+	def _get_mathMl(self):
+		mathMl = self.IA2Attributes.get("mathml")
+		if not mathMl:
+			raise LookupError
+		return mathMl
+
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
@@ -318,6 +348,8 @@ class AppModule(appModuleHandler.AppModule):
 				or (hasattr(obj,'IAccessibleTextObject') and obj.name=="Book Page View")
 			):
 				clsList.insert(0,BookPageView)
+			elif obj.role == controlTypes.ROLE_MATH:
+				clsList.insert(0, Math)
 		return clsList
 
 	def event_NVDAObject_init(self, obj):

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -284,7 +284,7 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 			try:
 				field["mathMl"] = obj.mathMl
 			except LookupError:
-				mathMl = None
+				pass
 		return field
 
 	def getMathMl(self, field):

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -389,7 +389,10 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		@param obj: The object to activate.
 		@type obj: L{NVDAObjects.NVDAObject}
 		"""
-		obj.doAction()
+		try:
+			obj.doAction()
+		except NotImplementedError:
+			log.debugWarning("doAction not implemented")
 
 	def _activatePosition(self,obj=None):
 		if not obj:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -545,15 +545,18 @@ A key command is provided to return to the original page containing the embedded
 | Move to containing browse mode document | NVDA+control+space | Moves the focus out of the current embedded object and into the document that contains it |
 %kc:endInclude
 
-+ Reading Mathematical Content +
++ Reading Mathematical Content +[ReadingMath]
 Using MathPlayer 4 from Design Science, NVDA can read and interactively navigate supported mathematical content.
 This requires that MathPlayer 4 is installed on the computer.
 MathPlayer is available as a free download from: http://www.dessci.com/en/products/mathplayer/
 
 NVDA supports the following types of mathematical content:
 - MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.
-- Design Science MathType in Microsoft Word and PowerPoint. MathType needs to be installed in order for this to work. The trial version is sufficient.
-- MathML in Adobe Reader. Note that this is not an official standard yet, so there is currently no publicly available software that can produce this content.
+- Design Science MathType in Microsoft Word and PowerPoint.
+MathType needs to be installed in order for this to work. The trial version is sufficient.
+- MathML in Adobe Reader.
+Note that this is not an official standard yet, so there is currently no publicly available software that can produce this content.
+- Math in Kindle for PC for books with accessible math.
 -
 
 When reading a document, NVDA will speak any supported mathematical content where it occurs.
@@ -577,7 +580,7 @@ By default, the review cursor follows the system caret, so you can usually use t
 
 At this point, you can use MathPlayer commands such as the arrow keys to explore the expression.
 For example, you can move through the expression with the left and right arrow keys and zoom into a portion of the expression such as a fraction using the down arrow key.
-Please see the MathPlayer documentation for further information.
+Please see the MathPlayer documentation about navigation commands for further information: https://www.dessci.com/en/products/mathplayer/navigation_commands.htm
 
 When you wish to return to the document, simply press the escape key.
 
@@ -855,6 +858,9 @@ You can manually turn to the next page with the pageDown key and turn to the pre
 
 Single letter navigation is supported for links and graphics, but only within the current page.
 Navigating by link also includes footnotes.
+
+NVDA provides early support for reading and interactive navigation of mathematical content for books with accessible math.
+Please see the [Reading Mathematical Content #ReadingMath] section for further information.
 
 +++ Text Selection +++
 Kindle allows you to perform various functions on selected text, including obtaining a dictionary definition, adding notes and highlights, copying the text to the clipboard and searching the web.


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
A future version of Kindle will expose MathML for books which contain it. We can thus provide access to math in those books using our existing math support.

### Description of how this pull request fixes the issue:
Kindle implementation:

1. A future version of Kindle will expose MathML on embedded objects with ROLE_SYSTEM_EQUATION via a "mathml" IAccessible2 object attribute.
2. Alternatively, if there is no MathML, alt text might be exposed instead via accName.
3. Both MathML and alt text can be exposed, in which case we should always use the MathML.

In this PR:

1. Update the Kindle app module to fetch MathML accordingly. It also ensures that alt text (which is placed in the "content" ControlField attribute) doesn't get reported if there is MathML.
2. MozillaCompoundTextInfo NVDAObjectAtStart property: Return the embedded object for graphics, math, etc. instead of the parent document. This is necessary to allow for interaction with math.
3. BrowseModeTreeInterceptor: When activating an NVDAObject, if doAction isn't implemented, just ignore it rather than throwing an exception. Otherwise, pressing enter on a graphic (which can't be activated in Kindle) throws an exception.
4. Update the User Guide with details about this, as well as adding a link to the MathPlayer documentation about navigation commands.

### Testing performed:
Tested with builds and test cases provided by Amazon. Unfortunately, neither builds nor content are publicly available yet.

### Known issues with pull request:
No known issues with the implementation. One concern is that content probably won't be publicly available before NVDA 2017.4 is released, so this won't get any public testing before release. However, we don't want to wait until 2018.1 for this to be available, so we're announcing it as "early support".

### Change log entry:
New Features:

```
- Early support for reading and interactive navigation of mathematical content for Kindle books with accessible math. (#7536)
```