### PR TITLE
Use Python launcher if present

### DIFF
--- a/scons.bat
+++ b/scons.bat
@@ -1,5 +1,13 @@
 @echo off
 rem We need this script because .py probably isn't in pathext.
 rem We can't just call python -c because it may not be in the path.
-rem Python registers itself with the .py extension, so call scons.py.
-"%~dp0\scons.py" %*
+rem Instead, find the python launcher (installed by python 3)
+where py >nul
+if not ERRORLEVEL 0 (
+	rem Python registers itself with the .py extension, so call scons.py.
+	"%~dp0\scons.py" %*
+) else (
+	rem Python launcher is present in the PATH
+	rem Call python 2.7 for 32 bits
+	py -2.7-32 "%~dp0\scons.py" %*
+)

--- a/scons.bat
+++ b/scons.bat
@@ -2,11 +2,12 @@
 rem We need this script because .py probably isn't in pathext.
 rem We can't just call python -c because it may not be in the path.
 rem Instead, find the python launcher (installed by python 3)
-where py >nul&& (
+where py 1>nul 2>&1
+if "%ERRORLEVEL%" == "0" (
 	rem Python launcher is present in the PATH
 	rem Call python 2.7 for 32 bits
 	py -2.7-32 "%~dp0\scons.py" %*
-) || (
+) else (
 	rem Python registers itself with the .py extension, so call scons.py.
 	"%~dp0\scons.py" %*
 )

--- a/scons.bat
+++ b/scons.bat
@@ -2,12 +2,11 @@
 rem We need this script because .py probably isn't in pathext.
 rem We can't just call python -c because it may not be in the path.
 rem Instead, find the python launcher (installed by python 3)
-where py >nul
-if not ERRORLEVEL 0 (
-	rem Python registers itself with the .py extension, so call scons.py.
-	"%~dp0\scons.py" %*
-) else (
+where py >nul&& (
 	rem Python launcher is present in the PATH
 	rem Call python 2.7 for 32 bits
 	py -2.7-32 "%~dp0\scons.py" %*
+) || (
+	rem Python registers itself with the .py extension, so call scons.py.
+	"%~dp0\scons.py" %*
 )


### PR DESCRIPTION
I was having some problems because I have two Python interpreters installed.

Sometimes various interpreters registered to run python scripts can cause problems when running in Windows 10, mainly if you have Python3 installed alongside with python2.

This is a quick workaround to fix this thing.

I've tested it and it works well.

Cheers,