### PR TITLE
Enhance add-on installation messages to display version information

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -130,7 +130,7 @@ class AddonsDialog(wx.Dialog):
 					break
 			if prevAddon:
 				# Translators: A message asking if the user wishes to update a previously installed add-on with this one.
-				if gui.messageBox(_("A version of this add-on is already installed. Would you like to update it?"),
+				if gui.messageBox(_("A version of this add-on is already installed. Would you like to update it?\nCurrent version:{curversion}\nNew version:{newversion}").format(curversion=addon.manifest["version"], newversion=bundle.manifest["version"]),
 				# Translators: A title for the dialog  asking if the user wishes to update a previously installed add-on with this one.
 				_("Add-on Installation"),
 				wx.YES|wx.NO|wx.ICON_WARNING)!=wx.YES:

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2016 NV Access Limited, Beqa Gozalishvili, Joseph Lee, Babbage B.V.
+#Copyright (C) 2012-2017 NV Access Limited, Beqa Gozalishvili, Joseph Lee, Babbage B.V.
 
 import os
 import wx
@@ -129,12 +129,26 @@ class AddonsDialog(wx.Dialog):
 					prevAddon=addon
 					break
 			if prevAddon:
-				# Translators: A message asking if the user wishes to update a previously installed add-on with this one.
-				if gui.messageBox(_("A version of this add-on is already installed. Would you like to update it?\nCurrent version:{curversion}\nNew version:{newversion}").format(curversion=addon.manifest["version"], newversion=bundle.manifest["version"]),
-				# Translators: A title for the dialog  asking if the user wishes to update a previously installed add-on with this one.
-				_("Add-on Installation"),
-				wx.YES|wx.NO|wx.ICON_WARNING)!=wx.YES:
-					return
+				summary=bundle.manifest["summary"]
+				curVersion=prevAddon.manifest["version"]
+				newVersion=bundle.manifest["version"]
+				if gui.messageBox(
+					# Translators: A message asking if the user wishes to update an add-on with the same version currently installed according to the version number.
+					_("You are about to install version {newVersion} of {summary}, which appears to be already installed. Would you still like to update?").format(
+						summary=summary,
+						newVersion=newVersion
+					)
+					if curVersion==newVersion else 
+					# Translators: A message asking if the user wishes to update a previously installed add-on with this one.
+					_("A version of this add-on is already installed. Would you like to update {summary} version {curVersion} to version {newVersion}?").format(
+						summary=summary,
+						curVersion=curVersion,
+						newVersion=newVersion
+					),
+					# Translators: A title for the dialog  asking if the user wishes to update a previously installed add-on with this one.
+					_("Add-on Installation"),
+					wx.YES|wx.NO|wx.ICON_WARNING)!=wx.YES:
+						return
 				prevAddon.requestRemove()
 			progressDialog = gui.IndeterminateProgressDialog(gui.mainFrame,
 			# Translators: The title of the dialog presented while an Addon is being installed.


### PR DESCRIPTION
### Link to issue number:
fixes #5324

### Summary of the issue:
When updating add-ons, it is not yet clear from which version to which version you're updating.

### Description of how this pull request fixes the issue:
1. Show the old version and new version in the message that states that you are updating a currently installed add-on.
2. Show an alternative message when you're trying to update an add-on to the same version
3. In these confirmation messages, also show the summary (readable name) of the add-on.

### Testing performed:
Updated add-ons to newer and same versions, the messages did show up as expected.

### Known issues with pull request:
None I'm aware of

### Credits
Many thanks to @beqabeqa473 for the initial work.