### PR TITLE
Adding Kyrgyz Language (locale dir)

### DIFF
--- a/source/locale/ky/LC_MESSAGES/nvda.po
+++ b/source/locale/ky/LC_MESSAGES/nvda.po
@@ -1,0 +1,8650 @@
+﻿# Kyrgyz translation NVDA
+msgid ""
+msgstr ""
+"Project-Id-Version: Kyrgyz translation NVDA\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-09 11:51+1000\n"
+"PO-Revision-Date: 2016-08-12 11:19+0800\n"
+"Main-Contact: <joshua.richard.meyer@gmail.com>\n"
+"Language-Team: Empower Blind People\n"
+"Language: ky\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+"X-Generator: Poedit 1.6.11\n"
+
+#. Translators: Message to indicate User Account Control (UAC) or other secure desktop screen is active.
+msgid "Secure Desktop"
+msgstr "корголуучу иш столу"
+
+#. Translators: A mode  that allows typing in the actual 'native' characters for an east-Asian input method language currently selected, rather than alpha numeric (Roman/English) characters.
+msgid "Native input"
+msgstr "баштапкы киргизүү"
+
+#. Translators: a mode that lets you type in alpha numeric (roman/english) characters, rather than 'native' characters for the east-Asian input method  language currently selected.
+msgid "Alpha numeric input"
+msgstr "тамгалык-санариптик киргизүү"
+
+#. Translators: for East-Asian input methods, a mode that allows typing in full-shaped (full double-byte) characters, rather than the smaller half-shaped ones.
+msgid "Full shaped mode"
+msgstr  "толук түр режими"
+
+#. Translators: for East-Asian input methods, a mode that allows typing in half-shaped (single-byte) characters, rather than the larger full-shaped (double-byte) ones.
+msgid "Half shaped mode"
+msgstr "жарым-жартылай түрдө режими" 
+
+#. Translators: For Japanese character input: half-shaped (single-byte) alpha numeric (roman/english) mode.
+msgid "half alphanumeric"
+msgstr "Жарым-жартылай тамгалык-санариптик" 
+
+#. Translators: For Japanese character input: half-shaped (single-byte) Katacana input mode.
+msgid "half katakana"
+msgstr "Жарым-жартылай katakana" 
+
+#. Translators: For Japanese character input: alpha numeric (roman/english) mode.
+msgid "alphanumeric"
+msgstr "тамгалык-санариптик"
+#. Translators: For Japanese character input: Hiragana input mode.
+msgid "hiragana"
+msgstr "хирагана"
+
+#. Translators: For Japanese character input: Katacana input mode.
+msgid "katakana"
+msgstr "катакана"
+
+#. Translators: For Japanese character input: half katakana roman input mode.
+msgid "half katakana roman"
+msgstr "аралаш киргизүү латын катакана" 
+
+#. Translators: For Japanese character input: Hiragana Roman input mode.
+msgid "hiragana roman"
+msgstr "латын хирагана" 
+
+#. Translators: For Japanese character input: Katacana Roman input mode.
+msgid "katakana roman"
+msgstr "латын катакана" 
+
+#. Translators: a message when the IME open status changes to opened
+msgid "IME opened"
+msgstr "Киргизүү ыкмасынын редактору ачык" 
+
+#. Translators: a message when the IME open status changes to closed
+msgid "IME closed"
+msgstr "Киргизүү ыкмасынын редактору жабык" 
+
+#. Translators: the label for an unknown language when switching input methods.
+msgid "unknown language"
+msgstr  "Белгисиз тил"
+
+#. Translators: The label for an unknown input method when switching input methods.
+msgid "unknown input method"
+msgstr  "Белгисиз киргизүү ыкмасы"
+
+#. Translators: the message announcing the language and keyboard layout when it changes
+#, python-brace-format
+msgid "{language} - {layout}"
+msgstr "{тил} - {жайгашуусу}" 
+
+#. Translators: This is presented when errors are found in an appModule (example output: error in appModule explorer).
+#, python-format
+msgid "Error in appModule %s"
+msgstr "модул %sте ката" 
+
+#. Translators: Reported for the banner landmark, normally found on web pages.
+msgid "banner"
+msgstr "Баннер"
+
+#. Translators: Reported for the complementary landmark, normally found on web pages.
+msgid "complementary"
+msgstr "Кошумча"
+
+#. Translators: Reported for the contentinfo landmark, normally found on web pages.
+msgid "content info"
+msgstr "Мазмуну боюнча маалымат" 
+
+#. Translators: Reported for the main landmark, normally found on web pages.
+msgid "main"
+msgstr "негизги" 
+
+#. Translators: Reported for the navigation landmark, normally found on web pages.
+msgid "navigation"
+msgstr "Багыт"
+
+#. Translators: Reported for the search landmark, normally found on web pages.
+msgid "search"
+msgstr  "Издөө"
+
+#. Translators: Reported for the form landmark, normally found on web pages.
+#. Translators: Identifies a form (controls such as edit boxes, combo boxes and so on).
+msgid "form"
+msgstr "формасы" 
+
+#. Translators: Reported for a significant region, normally found on web pages.
+msgid "region"
+msgstr "регион" 
+
+#. Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
+#. See the Audio Ducking Mode section of the User Guide for details.
+msgid "No ducking"
+msgstr " үнүн өчүрүү"
+
+#. Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
+#. See the Audio Ducking Mode section of the User Guide for details.
+msgid "Duck when outputting speech and sounds"
+msgstr "сүйлөө жана дабышты киргизүүдө үнүн өчүрүү"
+
+#. Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
+#. See the Audio Ducking Mode section of the User Guide for details.
+msgid "Always duck"
+msgstr "Дайыма үнүн өчүрүү"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Arabic grade 1"
+msgstr "Арабский (первая ступень)" Арабча (биринчи этабы)
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Farsi grade 1"
+msgstr "Фарси (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Assamese grade 1"
+msgstr "Ассамча (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Bengali grade 1"
+msgstr "Бенгалча (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Bulgarian 8 dot computer braille"
+msgstr "Сегиз чекиттүү"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Welsh grade 1"
+msgstr "Валлийче (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Welsh grade 2"
+msgstr "Валлийче (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Czech grade 1"
+msgstr "Чех тили (биринчи баскычы)"   
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Danish 6 dot grade 1"
+msgstr "Даниялык алты чекиттүү(биинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Danish 8 dot grade 1"
+msgstr "Даниялык сегиз чекиттүү(биинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Danish 6 dot grade 2"
+msgstr "Даниялык алты чекиттүү(экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Danish 8 dot grade 2"
+msgstr "Даниялык сегиз чекиттүү(экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "German 8 dot computer braille"
+msgstr "Немец сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "German grade 0"
+msgstr " Немисче (нөл баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "German grade 1"
+msgstr "немисче (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "German grade 2"
+msgstr "немисче (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.K.) 8 dot computer braille"
+msgstr "Англисче (Улуу Британия) сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.K.) grade 1"
+msgstr "Англисче (Улуу Британия) биринчи баскычы"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.K.) grade 2"
+msgstr "Англисче (Улуу Британия)экинчи баскычы"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.S.) 6 dot computer braille"
+msgstr "Англисче(АКШ) алты чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.S.) 8 dot computer braille"
+msgstr ""Англисче(АКШ) сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.S.) grade 1"
+msgstr "Англисче (АКШ) биринчи баскычы"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "English (U.S.) grade 2"
+msgstr "Англисче (АКШ) (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Spanish 8 dot computer braille"
+msgstr "Испанча сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Spanish grade 1"
+msgstr  "Испанча биринчи баскычы"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Estonian grade 0"
+msgstr "Эстонский (нулевая ступень)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Ethiopic grade 1"
+msgstr "Эфиопия тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Finnish 6 dot"
+msgstr "Фин тили  алты чекиттүү"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Finnish 8 dot computer braille"
+msgstr "Фин тили сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "French (unified) 6 dot computer braille"
+msgstr "Французча стандарт алты чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "French (unified) 8 dot computer braille"
+msgstr "Французча сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "French (unified) Grade 2"
+msgstr "Французскча стандарт (экинчи баскычы)" 
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "French (Canada) grade 1"
+msgstr "Французча (Канада) (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "French (Canada) grade 2"
+msgstr "Французча (Канада) (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Irish grade 1"
+msgstr "Ирландия тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Irish grade 2"
+msgstr "Ирландия тили ('экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Gujarati grade 1"
+msgstr "Гуджарати (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Koine Greek"
+msgstr "Койне Грек"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Greek (Greece) grade 1"
+msgstr "Грекче (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Hebrew 8 dot computer braille"
+msgstr "Иврит сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Hindi grade 1"
+msgstr "Хинди (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Croatian 8 dot computer braille"
+msgstr "Хорват тили сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Hungarian 8 dot computer braille"
+msgstr "Венгер тили сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Hungarian grade 1"
+msgstr "Венгер тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Icelandic 8 dot computer braille"
+msgstr "Исландия тили сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Italian 6 dot computer braille"
+msgstr "Итальянча алты чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Italian 8 dot computer braille"
+msgstr "Итальянча сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Kannada grade 1"
+msgstr "Каннада (биринчи этабы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Korean grade 1 (2006)"
+msgstr "Корейче (биринчи баскычы) (2006)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Korean grade 2 (2006)"
+msgstr "Корейче (экинчи баскычы) (2006)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Korean grade 1"
+msgstr "Корейче (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Korean grade 2"
+msgstr "Корейче (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Kashmiri grade 1"
+msgstr "Кашмир (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Latvian grade 1"
+msgstr "Латыш тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Malayalam grade 1"
+msgstr "Малаялам (биринчи баскычы)" 
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Manipuri gr (биринчи баскычы)" 
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Mongolian"
+msgstr "Монгол тили"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Marathi grade 1"
+msgstr "Маратхи (биринчи баскычы)" 
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Dutch (Belgium) grade 1"
+msgstr "Голландия тили (Бельгия) (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Dutch (Netherlands) grade 1"
+msgstr "Голландия тили (Нидерланды) (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Norwegian 8 dot computer braille"
+msgstr "Норвеж тили сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Norwegian grade 0"
+msgstr "Норвеж тили (Ноль баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Norwegian grade 1"
+msgstr "Норвеж тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Norwegian grade 2"
+msgstr "Норвеж тили (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Norwegian grade 3"
+msgstr "Норвеж тили (үчүнчү баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Nepali grade 1"
+msgstr "Непал тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Oriya grade 1"
+msgstr "Ория (биринчи баскычы)" 
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Polish 8 dot computer braille"
+msgstr "Польша тили сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Polish grade 1"
+msgstr "Польша тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Portuguese 8 dot computer braille"
+msgstr "Португалча сегиз чекиттүү брайль компьютери"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Portuguese grade 1"
+msgstr "Португалча (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Portugese grade 2"
+msgstr "Португалча экинчи баскычы"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Punjabi grade 1"
+msgstr "Панджаби (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Russian braille for computer code"
+msgstr "Орусча компьютердик брайль"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Russian grade 1"
+msgstr "Орусча (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Sanskrit grade 1"
+msgstr "Санскрит (биринчи баскычы)"
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Swedish grade 1"
+msgstr "Швед тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Slovak grade 1"
+msgstr "Словак тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Slovene grade 1"
+msgstr "Словения тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Serbian grade 1"
+msgstr "Серб тили (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Tamil grade 1"
+msgstr "Тамиль (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Telegu grade 1"
+msgstr "Телугу (биринчи баскычы)" 
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Turkish grade 1"
+msgstr "Туркчо (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Unified English Braille Code grade 1"
+msgstr "Англисче стандарт (биринчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Unified English Braille Code grade 2"
+msgstr "Английсче стандарт (экинчи баскычы)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Chinese (Hong Kong, Cantonese)"
+msgstr "Кытайча (Гонконг, Кантон)"
+
+#. Translators: The name of a braille table displayed in the
+#. braille settings dialog.
+msgid "Chinese (Taiwan, Mandarin)"
+msgstr "Кытайча (Тайвань, Мандарин)"
+
+#. Translators: Displayed in braille for an object which is an
+#. editable text field.
+msgid "edt"
+msgstr "|р|"
+
+#. Translators: Displayed in braille for an object which is a
+#. list.
+msgid "lst"
+msgstr "|тз|"
+
+#. Translators: Displayed in braille for an object which is a
+#. menu bar.
+msgid "mnubar"
+msgstr "|мб|"
+
+#. Translators: Displayed in braille for an object which is a
+#. menu.
+msgid "mnu"
+msgstr "|м|"
+
+#. Translators: Displayed in braille for an object which is a
+#. button.
+msgid "btn"
+msgstr "|б|"
+
+#. Translators: Displayed in braille for an object which is a
+#. check box.
+msgid "chk"
+msgstr "|флж|"
+
+#. Translators: Displayed in braille for an object which is a
+#. radio button.
+msgid "rbtn"
+msgstr "|рб|"
+
+#. Translators: Displayed in braille for an object which is a
+#. combo box.
+msgid "cbo"
+msgstr "|ксп|"
+
+#. Translators: Displayed in braille for an object which is a
+#. link.
+msgid "lnk"
+msgstr "|ш|"
+
+#. Translators: Displayed in braille for an object which is a
+#. dialog.
+msgid "dlg"
+msgstr "|длг|"
+
+#. Translators: Displayed in braille for an object which is a
+#. tree view.
+msgid "tv"
+msgstr "|пд|"
+
+#. Translators: Displayed in braille for an object which is a
+#. table.
+msgid "tb"
+msgstr "|тб|"
+
+#. Translators: Displayed in braille for an object which is a
+#. separator.
+msgid "-----"
+msgstr "-----"
+
+#. Translators: Displayed in braille for an object which is a
+#. graphic.
+msgid "gra"
+msgstr "|грф|"
+
+#. Translators: Displayed in braille when an object (e.g. a check box) is checked.
+msgid "(x)"
+msgstr "(x)"
+
+#. Translators: Displayed in braille when an object (e.g. a check box) is half checked.
+msgid "(-)"
+msgstr "(-)"
+
+#. Translators: Displayed in braille when an object is selected.
+msgid "sel"
+msgstr "тнд"
+
+#. Translators: Displayed in braille when an object has a popup (usually a sub-menu).
+msgid "submnu"
+msgstr "|жм|"
+
+#. Translators: Displayed in braille when an object supports autocompletion.
+msgid "..."
+msgstr "..."
+
+#. Translators: Displayed in braille when an object (e.g. a tree view item) is expanded.
+msgid "-"
+msgstr "-"
+
+#. Translators: Displayed in braille when an object (e.g. a tree view item) is collapsed.
+msgid "+"
+msgstr "+"
+
+#. Translators: Displayed in braille when an object (e.g. an editable text field) is read-only.
+msgid "ro"
+msgstr "|тч|"
+
+#. Translators: Displayed in braille when an object is clickable.
+msgid "clk"
+msgstr "|щлк|"
+
+#. Translators: Displayed in braille when an object (e.g. a check box) is not checked.
+msgid "( )"
+msgstr "( )"
+
+#. Translators: The description of a braille cursor shape.
+msgid "Dots 7 and 8"
+msgstr " чекиттер 7 жана 8"
+
+#. Translators: The description of a braille cursor shape.
+msgid "Dot 8"
+msgstr "чекит 8"
+
+#. Translators: The description of a braille cursor shape.
+msgid "All dots"
+msgstr "бардык чекиттер"
+
+#. Translators: Displayed in braille for a heading with a level.
+#. %s is replaced with the level.
+#, python-format
+msgid "h%s"
+msgstr "з%s"
+
+#. Translators: Displayed in braille for a link which has been visited.
+msgid "vlnk"
+msgstr "|кн|"
+
+#. Translators: Indicates that a particular state on an object is negated.
+#. Separate strings have now been defined for commonly negated states (e.g. not selected and not checked),
+#. but this still might be used in some other cases.
+#. %s will be replaced with the negated state.
+#, python-format
+msgid "not %s"
+msgstr " %s эмес"
+
+#. Translators: Brailled to indicate the position of an item in a group of items (such as a list).
+#. {number} is replaced with the number of the item in the group.
+#. {total} is replaced with the total number of items in the group.
+#. Translators: Spoken to indicate the position of an item in a group of items (such as a list).
+#. {number} is replaced with the number of the item in the group.
+#. {total} is replaced with the total number of items in the group.
+#, python-brace-format
+msgid "{number} of {total}"
+msgstr "{сан}  {жыйынтыкl}"
+
+#. Translators: Displayed in braille when an object (e.g. a tree view item) has a hierarchical level.
+#. %s is replaced with the level.
+#, python-format
+msgid "lv %s"
+msgstr "|у%s|"
+
+#. Translators: Displayed in braille for a table cell row number.
+#. %s is replaced with the row number.
+#, python-format
+msgid "r%s"
+msgstr "стр%s"
+
+#. Translators: Displayed in braille for a table cell column number.
+#. %s is replaced with the column number.
+#, python-format
+msgid "c%s"
+msgstr "стлб%s"
+
+#. Translators: Displayed in braille at the end of a control field such as a list or table.
+#. %s is replaced with the control's role.
+#, python-format
+msgid "%s end"
+msgstr "|аягы %s|"
+
+#. Translators: String representing the automatic port selection for braille displays.
+msgid "Automatic"
+msgstr "Автоматикалык"
+
+#. Translators: Reported before braille input in input help mode.
+msgid "braille"
+msgstr "брайль менен"
+
+#. Translators: Reported when braille space is pressed with dots in input help mode.
+msgid "space with dot"
+msgstr "боштук чекит менен"
+
+#. Translators: Reported when braille dots are pressed in input help mode.
+msgid "dot"
+msgstr "чекит"
+
+#. Translators: Reported when braille space is pressed in input help mode.
+#. Translators: This is the name of a key on the keyboard.
+msgid "space"
+msgstr "боштук"
+
+msgid "Focus mode"
+msgstr "түзөтүү режими"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Browse mode"
+msgstr "карап чыгуу тартиби"
+
+#. Translators: Reported when single letter navigation in browse mode is turned off.
+msgid "Single letter navigation off"
+msgstr "тез багыттоо өчүрүлгөн"
+
+#. Translators: Reported when single letter navigation in browse mode is turned on.
+msgid "Single letter navigation on"
+msgstr "тез багыттоо жандырылды" 
+
+#. Translators: the description for the toggleSingleLetterNavigation command in browse mode.
+msgid ""
+"Toggles single letter navigation on and off. When on, single letter keys in "
+"browse mode jump to various kinds of elements on the page. When off, these "
+"keys are passed to the application"
+msgstr ""
+"Тез багыттону өчүрүп жандырат.Эгерде жанг юолсо,анда карап чыгуу тартибинде"
+"Тез багыттоо баскычтары,ар кайсы элементтер боюнча жылдырып"
+"типтерди бетте. Эгерде өчүрүлгөн болсо, анда бул баскычтар тезинен которулат "
+"колдонмого"
+
+#. Translators: a message when a particular quick nav command is not supported in the current document.
+msgid "Not supported in this document"
+msgstr "Бул документте колдобойт"
+
+#. Translators: the description for the Elements List command in browse mode.
+msgid "Lists various types of elements in this document"
+msgstr "Ар кайсы типтеги элементтердин тизмесин чакыртырат"
+
+#. Translators: the description for the activatePosition script on browseMode documents.
+msgid "Activates the current object in the document"
+msgstr "Документтеги азыркы объекти ишке киргизет"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading"
+msgstr "Кийинки баш сөзгө өтөт"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading"
+msgstr "Кийинки баш сөз жок "
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading"
+msgstr "Мурунку баш сөзгө өтөт"
+згө
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading"
+msgstr "Мурунку баш сөз жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading at level 1"
+msgstr "кийинки баш создун биринчи баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading at level 1"
+msgstr "кийинки  баш сөзгдун биринчи баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading at level 1"
+msgstr "мурунку баш создун биринчи денгелине отот "
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading at level 1"
+msgstr "кийинки баш создун биринчи баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading at level 2"
+msgstr "кийинки баш создун экинчи баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading at level 2"
+msgstr "кийинки баш создун экинчи баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading at level 2"
+msgstr "мурунку баш создун экинчи баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading at level 2"
+msgstr "мурунку баш создун экинчи баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading at level 3"
+msgstr "кийинки баш создун учунчу баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading at level 3"
+msgstr "кийинки баш создун учунчу баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading at level 3"
+msgstr "Мурунку баш создун учунчу баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading at level 3"
+msgstr "мурунку баш создун учунчу баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading at level 4"
+msgstr "кийинки баш созду тортунчу баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading at level 4"
+msgstr "кийинки баш создун тортунчу баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading at level 4"
+msgstr "Мурунку баш создун тортунчу баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading at level 4"
+msgstr "мурунку баш создун тортунчу баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading at level 5"
+msgstr "кийинки баш создун бешинчи баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading at level 5"
+msgstr "баш создун бешинчи баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading at level 5"
+msgstr "мурунку баш создун бешинчи баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading at level 5"
+msgstr "мурунку баш создун  бешинчи баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next heading at level 6"
+msgstr "кийинки баш создун алтынчы баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next heading at level 6"
+msgstr "кийинки баш создун алтынчы баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous heading at level 6"
+msgstr "мурунку баш создун алтынчы баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous heading at level 6"
+msgstr "кийинки баш создун алтынчы баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next table"
+msgstr "кийинки таблицага отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next table"
+msgstr "кийинки таблица жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous table"
+msgstr "мурунку таблицага отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous table"
+msgstr "Мурунку таблица жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next link"
+msgstr "Кийинки шилтемеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next link"
+msgstr "Кийинки шилтеме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous link"
+msgstr "Мурунку шилтемеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous link"
+msgstr "Мурунку шилтеме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next visited link"
+msgstr "Каралып чыккан кийинки шилтемеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next visited link"
+msgstr "Кийинки каралып чыккан шилтеме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous visited link"
+msgstr "мурунку каралып чыккан шилтеме жок"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous visited link"
+msgstr "Мурунку каралып чыккан шилтеме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next unvisited link"
+msgstr "Кийинки каралбаган шилтемеге отот "
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next unvisited link"
+msgstr "Кийинки каралбаган шилтеме шок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous unvisited link"
+msgstr "Мурунку карабаган шилтемеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous unvisited link"
+msgstr "Мурунку каралбаган шилтеме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next form field"
+msgstr " Форманын кийинки четине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next form field"
+msgstr "Форманын кийинки чети жок "
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous form field"
+msgstr "Форманын мурунку четине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous form field"
+msgstr "Форманын мурунку чети жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next list"
+msgstr "Кийинки тизмеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next list"
+msgstr "Кийинки тизме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous list"
+msgstr "Мурунку тизмеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous list"
+msgstr "Мурунку тизме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next list item"
+msgstr " Кийнки тизменин элементине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next list item"
+msgstr "Тизменин кийинки элементи жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous list item"
+msgstr "Тизменин мурунку элементине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous list item"
+msgstr "Тизменин мурунку элементи жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next button"
+msgstr "Кийинки баскычка отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next button"
+msgstr "Кийинки баскыч жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous button"
+msgstr "Мурунку баскычка отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous button"
+msgstr "Мурунку баскыч жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next edit field"
+msgstr "Переходит на следующее поле редактора "
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next edit field"
+msgstr "Нет следующего поля редактора"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous edit field"
+msgstr "Редактордун мурунку четине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous edit field"
+msgstr "Редактордун мурунку чети жок "
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next frame"
+msgstr "Кийинки чегине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next frame"
+msgstr "Кийинги чеги жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous frame"
+msgstr "Мурунку чегине отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous frame"
+msgstr "Мурунку чеги жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next separator"
+msgstr "Кийинки болгучко отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next separator"
+msgstr "Нет следующего разделителя Кийники болгуч жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous separator"
+msgstr "Мурунку болгучко отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous separator"
+msgstr "Мурунку болгуч жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next radio button"
+msgstr "Кийинки уналгы-баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next radio button"
+msgstr "Кийинки уналгы-баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous radio button"
+msgstr "Мурунку уналгы-баскычына отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous radio button"
+msgstr "Мурунку уналгы-баскычы жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next combo box"
+msgstr "Кийинки кураштырылган тизмеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next combo box"
+msgstr "Кийинки кураштырылган тизме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous combo box"
+msgstr "Мурунку кураштырылган тизме жок"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous combo box"
+msgstr "Мурунку кураштырылган тизме жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next check box"
+msgstr "Кийнки желекчеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next check box"
+msgstr "Кийники желекче жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous check box"
+msgstr "Мурунку желекчеге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous check box"
+msgstr "Мурунку желекче жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next graphic"
+msgstr "кийики графикалык элементке отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next graphic "
+msgstr "кийинки графикалык элемент жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous graphic"
+msgstr "Мурунку графикалык элементке отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous graphic"
+msgstr "Мурунку графикалык элемент жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next block quote"
+msgstr "Кийинки цитатага отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next block quote"
+msgstr "Кийинки цитата жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous block quote"
+msgstr "Мурунку цитатага отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous block quote"
+msgstr "Мурунку цитата жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "skips forward past a block of links"
+msgstr "Топтон кийинки текстке отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no more text after a block of links"
+msgstr "Топтон кийинки текст жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "skips backward past a block of links"
+msgstr "Топ шилтемеден мурунку текстке отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no more text before a block of links"
+msgstr "Топ шилтемеден мурунку текстке отот"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next landmark"
+msgstr "Кийинки ориентирге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next landmark"
+msgstr "Кийинки ориентир жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous landmark"
+msgstr "Мурунку ориентирге отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous landmark"
+msgstr "Мурунку ориентир жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next embedded object"
+msgstr "Кийинки орнотулган объектке отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next embedded object"
+msgstr "Кийинки ортнотулган объект жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous embedded object"
+msgstr "Мурунку орнотулган объектке отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous embedded object"
+msgstr "Мурунку орнотулган объект жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the next annotation"
+msgstr "Кийнки эскертууго отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no next annotation"
+msgstr "Нет следующего примечания Кийинки эскертуу жок"
+
+#. Translators: Input help message for a quick navigation command in browse mode.
+msgid "moves to the previous annotation"
+msgstr "Мурунку эскертууго отот"
+
+#. Translators: Message presented when the browse mode element is not found.
+msgid "no previous annotation"
+msgstr "Мурунку эскертуу жок"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "Lin&ks"
+msgstr "шилтемелер"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "&Headings"
+msgstr  "Аталыштар"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "Lan&dmarks"
+msgstr "Багыттык белгилер"
+
+#. Translators: The title of the browse mode Elements List dialog.
+msgid "Elements List"
+msgstr "Элементтердин тизмеги"
+
+#. Translators: The label of a group of radio buttons to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "Type:"
+msgstr "түрү"
+
+#. Translators: The label of an editable text field to filter the elements
+#. in the browse mode Elements List dialog.
+msgid "&Filter by:"
+msgstr "&чыпка"
+
+#. Translators: The label of a button to activate an element
+#. in the browse mode Elements List dialog.
+msgid "&Activate"
+msgstr "&активдештирүү"
+
+#. Translators: The label of a button to move to an element
+#. in the browse mode Elements List dialog.
+msgid "&Move to"
+msgstr "&өтүү"
+
+#. Translators: This is spoken and brailled to indicate a landmark (example output: main landmark).
+#, python-format
+msgid "%s landmark"
+msgstr "%s Багыттык белги"
+
+#. Translators: This is spoken to indicate what has been selected. for example 'selected hello world'
+#, python-format
+msgid "selected %s"
+msgstr "белгиленген %S"
+
+#. Translators: the message presented when the activateLongDescription script cannot locate a long description to activate.
+msgid "No long description"
+msgstr "Толук суроттолушу жок"
+
+#. Translators: the description for the activateLongDescription script on browseMode documents.
+msgid "Shows the long description at this position if one is found."
+msgstr "Бул онуттогу толук суроттомону корсотот, эгерде андай бар болсо"
+
+
+#. Translators: Reported when the user attempts to move to the start or end of a container (list, table, etc.)
+#. But there is no container.
+msgid "Not in a container"
+msgstr "Контейнерде эмес"
+
+#. Translators: Description for the Move to start of container command in browse mode.
+msgid "Moves to the start of the container element, such as a list or table"
+msgstr "Контейнердин башкы элементине отот,мисалы тизменин же таблицанын"
+
+#. Translators: a message reported when:
+#. Review cursor is at the bottom line of the current navigator object.
+#. Landing at the end of a browse mode document when trying to jump to the end of the current container.
+#. Translators: a message reported when review cursor is at the bottom line of the current navigator object.
+msgid "Bottom"
+msgstr "Астынкы"
+
+#. Translators: Description for the Move past end of container command in browse mode.
+msgid "Moves past the end  of the container element, such as a list or table"
+msgstr "Контейнердин акыркы элементине отот,мисалы тизменин же таблицанын"
+
+#. Translators: The level at which the given symbol will be spoken.
+msgctxt "symbolLevel"
+msgid "none"
+msgstr "Эч нерсе"
+
+#. Translators: The level at which the given symbol will be spoken.
+msgctxt "symbolLevel"
+msgid "some"
+msgstr "Кээбир"
+
+#. Translators: The level at which the given symbol will be spoken.
+msgctxt "symbolLevel"
+msgid "most"
+msgstr "Копчулук"
+
+#. Translators: The level at which the given symbol will be spoken.
+msgctxt "symbolLevel"
+msgid "all"
+msgstr "Баары"
+
+#. Translators: The level at which the given symbol will be spoken.
+msgctxt "symbolLevel"
+msgid "сыпат"
+msgstr "Символ"
+
+#. Translators: An option for when a symbol itself will be sent to the synthesizer.
+#. See the "Punctuation/symbol pronunciation" section of the User Guide for details.
+msgctxt "symbolPreserve"
+msgid "never"
+msgstr "Эч качан"
+
+#. Translators: An option for when a symbol itself will be sent to the synthesizer.
+#. See the "Punctuation/symbol pronunciation" section of the User Guide for details.
+msgctxt "symbolPreserve"
+msgid "always"
+msgstr "Ар дайым"
+
+#. Translators: An option for when a symbol itself will be sent to the synthesizer.
+#. See the "Punctuation/symbol pronunciation" section of the User Guide for details.
+msgctxt "symbolPreserve"
+msgid "only below symbol's level"
+msgstr "Бир гана эгерде пунктуация денгели символ денгээлинен томон болгон чакта"
+
+#. Translators: the color white (HSV saturation0%, value 100%)
+msgctxt "color hue"
+msgid "white"
+msgstr "ак"
+
+#. Translators: the color very light grey (HSV saturation 0%, value 84%)
+msgctxt "color hue"
+msgid "very light grey"
+msgstr "ото ачык боз"
+
+#. Translators: the color light grey (HSV saturation 0%, value 66%)
+msgctxt "color hue"
+msgid "light grey"
+msgstr "ачык боз"
+
+#. Translators: the color grey (HSV saturation 0%, value 50%)
+msgctxt "color hue"
+msgid "grey"
+msgstr "боз"
+
+#. Translators: the color dark grey (HSV saturation 0%, value 34%)
+msgctxt "color hue"
+msgid "dark grey"
+msgstr "ток боз"
+
+#. Translators: the color very dark grey (HSV saturation 0%, value 16%)
+msgctxt "color hue"
+msgid "very dark grey"
+msgstr "ото ток боз"
+
+#. Translators: the color black (HSV saturation 0%, value 0%)
+msgctxt "color hue"
+msgid "black"
+msgstr "кара"
+
+#. Translators: The color red (HSV hue 0 degrees)
+msgctxt "color hue"
+msgid "red"
+msgstr "кызыл"
+
+#. Translators: The color between  red and orange (HSV hue 15 degrees)
+msgctxt "color hue"
+msgid "red-orange"
+msgstr "кызгыл сары"
+
+#. Translators: The color orange (HSV hue 30 degrees)
+msgctxt "color hue"
+msgid "orange"
+msgstr "саргылт"
+
+#. Translators: The color between  orange and yellow (HSV hue 45 degrees)
+msgctxt "color hue"
+msgid "orange-yellow"
+msgstr "саргыот сары"
+
+#. Translators: The color yellow (HSV hue 60 degrees)
+msgctxt "color hue"
+msgid "yellow"
+msgstr "сары"
+
+#. Translators: The color between  yellow and green (HSV hue 90 degrees)
+msgctxt "color hue"
+msgid "yellow-green"
+msgstr "сары-жашыл"
+
+#. Translators: The color green (HSV hue 120 degrees)
+msgctxt "color hue"
+msgid "green"
+msgstr "жашыл"
+
+#. Translators: The color between  green and aqua (HSV hue 150 degrees)
+msgctxt "color hue"
+msgid "green-aqua"
+msgstr "жашыл-кок"
+
+#. Translators: The color aqua (HSV hue 180 degrees)
+msgctxt "color hue"
+msgid "aqua"
+msgstr "когултур"
+
+#. Translators: The color between  aqua and blue (HSV hue 210 degrees)
+msgctxt "color hue"
+msgid "aqua-blue"
+msgstr "кок-когултур"
+
+#. Translators: The color blue (HSV hue 240 degrees)
+msgctxt "color hue"
+msgid "blue"
+msgstr "кок"
+
+#. Translators: The color between  blue and purple (HSV hue 270 degrees)
+msgctxt "color hue"
+msgid "blue-purple"
+msgstr "кок-сыя тус"
+
+#. Translators: The color purple (HSV hue 300 degrees)
+msgctxt "color hue"
+msgid "purple"
+msgstr "Сыя тус"
+
+#. Translators: The color between  purple and pink (HSV hue 312 degrees)
+msgctxt "color hue"
+msgid "purple-pink"
+msgstr "кызгылт- сыя тус"
+
+#. Translators: The color pink (HSV hue 324 degrees)
+msgctxt "color hue"
+msgid "pink"
+msgstr "кызгылт"
+
+#. Translators: The color between  pink and red (HSV hue 342 degrees)
+msgctxt "color hue"
+msgid "pink-red"
+msgstr "кызгелт-кызыл"
+
+#. Translators: a bright color (HSV saturation 100% and value 100%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "bright {color}"
+msgstr "ачык {тус}"
+
+#. Translators: color (HSV saturation 100% and value 72%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "{color}"
+msgstr "{тус}"
+
+#. Translators: a dark color (HSV saturation 100% and value 44%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "кунурт {тус}"
+msgstr "кунурт{тус}"
+
+#. Translators: a very dark color (HSV saturation 100% and value 16%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "very dark {color}"
+msgstr "ото кунурт {тус}"
+
+#. Translators: a light pale color (HSV saturation 50% and value 100%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "light pale {color}"
+msgstr "ачык-кумсаргын {тус}"
+
+#. Translators: a pale color (HSV saturation 50% and value 72%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "pale {color}"
+msgstr "кумсарган{тус}"
+
+#. Translators: a dark pale color (HSV saturation 50% and value 44%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "dark pale {color}"
+msgstr "кунурт кумсарган {тус}"
+
+#. Translators: a very dark color (HSV saturation 50% and value 16%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "very dark pale {color}"
+msgstr "ото кунурт, кумсарган {тус}"
+
+#. Translators: a light color almost white - hardly any hue (HSV saturation 10% and value 100%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "{color} white"
+msgstr "ачык {тус}"
+
+#. Translators: a color almost grey - hardly any hue (HSV saturation 10% and value 72%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "{color} grey"
+msgstr "кумсарган {тус}"
+
+#. Translators: a dark color almost grey - hardly any hue (HSV saturation 10% and value 44%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "dark {color} grey"
+msgstr "кунурт-кумсарган {тус}"
+
+#. Translators: a very dark color almost grey - hardly any hue (HSV saturation 10% and value 16%)
+#, python-brace-format
+msgctxt "color variation"
+msgid "very dark {color} grey"
+msgstr "ото кунурт, кумсарган{тус} боз"
+
+#. Translators: The color between  red and brown (HSV hue 15 degrees, below 50% brightness)
+msgctxt "color hue"
+msgid "red-brown"
+msgstr "крызыл-курон"
+
+#. Translators: The color brown (HSV hue 30 degrees, below 50% brightness)
+msgctxt "color hue"
+msgid "brown"
+msgstr "курон"
+
+#. Translators: The color between  brown and yellow (HSV hue 45 degrees, below 50% brightness)
+msgctxt "color hue"
+msgid "brown-yellow"
+msgstr "курон-сары"
+
+#. Translators: The word for an unknown control type.
+#. Translators: Reported when the type of a chart is not known.
+msgid "unknown"
+msgstr "белгисиз"
+
+# An open-source (and free) Screen Reader for the Windows Operating System
+# Created by Michael Curran, with help from James Teh and others
+# Copyright (C) 2006-2008 Michael Curran <mick@kulgan.net>
+#. Translators: The word for window of a program such as document window.
+msgid "window"
+msgstr "Терезе"
+
+#. Translators: Used to identify title bar of a program.
+msgid "title bar"
+msgstr "Терезенини аталышы"
+
+#. Translators: The word used for pane such as desktop pane.
+msgid "pane"
+msgstr "аймагы"
+
+#. Translators: The word used to denote a dialog box such as open dialog.
+msgid "dialog"
+msgstr "Диалог"
+
+#. Translators: The text used to identify check boxes such as select check box.
+msgid "check box"
+msgstr "Желекче"
+
+#. Translators: The text used to identify radio buttons such as yes or no radio button.
+msgid "radio button"
+msgstr "Уналгы-баскыч"
+
+#. Translators: The word used to identify a static text such as dialog text.
+msgid "text"
+msgstr "Текст"
+
+#. Translators: The word used to identify edit fields such as subject edit field.
+msgid "edit"
+msgstr "Редактор"
+
+#. Translators: The word used to identify a button such as OK button.
+msgid "button"
+msgstr "Баскыч"
+
+#. Translators: Text used to identify menu bar of a program.
+msgid "menu bar"
+msgstr "Менюнун сабы"
+
+#. Translators: Used to identify a menu item such as an item in file menu.
+msgid "menu item"
+msgstr "менюнун элементи"
+
+#. Translators: The word used for menus such as edit menu.
+#. Translators: Identifies a menu such as file menu.
+msgid "menu"
+msgstr "Меню"
+
+#. Translators: Used to identify combo boxes such as file type combo box.
+msgid "combo box"
+msgstr "Бириктирилген тизме"
+
+#. Translators: The word used for lists such as folder list.
+msgid "list"
+msgstr "Тизме"
+
+#. Translators: Used to identify a list item such as email list items.
+msgid "list item"
+msgstr "Тизменин элементи"
+
+#. Translators: The word used to identify graphics such as webpage graphics.
+msgid "graphic"
+msgstr "График"
+
+#. Translators: Used to identify help balloon (a circular window with helpful text such as notification text).
+msgid "help balloon"
+msgstr "Всплывающее системное сообщение Калкып чыккан системалык билдиртмелер"
+
+#. Translators: Used to identify a tooltip (a small window with additional text about selected item such as file information).
+msgid "tool tip"
+msgstr "Калкып чыккан кенешме"
+
+#. Translators: Identifies a link in webpage documents.
+msgid "link"
+msgstr "Шилтеме"
+
+#. Translators: Identifies a treeview (a tree-like structure such as treeviews for subfolders).
+msgid "tree view"
+msgstr "Дарак"
+
+#. Translators: Identifies a tree view item.
+msgid "tree view item"
+msgstr "Дарактын элементи"
+
+#. Translators: The word presented for tabs in a tab enabled window.
+msgctxt "controlType"
+msgid "tab"
+msgstr "Тиркеме"
+
+#. Translators: Identifies a tab control such as webpage tabs in web browsers.
+msgid "tab control"
+msgstr "Тиркеме"
+
+#. Translators: Identifies a slider such as volume slider.
+msgid "slider"
+msgstr "тандап алма"
+
+#. Translators: Identifies a progress bar such as NvDA update progress.
+msgid "progress bar"
+msgstr "Ишке ашыруунун корсоткучу"
+
+#. Translators: Identifies a scroll bar.
+msgid "scroll bar"
+msgstr "жылдыртма"
+
+#. Translators: Identifies a status bar (text at the bottom bar of the screen such as cursor position in a document).
+msgid "status bar"
+msgstr "Абалдын сабы "
+
+#. Translators: Identifies a table such as ones used in various websites.
+msgid "table"
+msgstr "Таблица"
+
+#. Translators: Identifies a cell in a table.
+msgid "cell"
+msgstr "Ячейка"
+
+#. Translators: Identifies a column (a group of vertical cells in a table).
+msgid "column"
+msgstr "Мамыча"
+
+#. Translators: Identifies a row (a group of horizontal cells in a table).
+msgid "row"
+msgstr "Сап"
+
+#. Translators: Identifies a frame (a smaller window in a webpage or a document).
+msgid "Чеги"
+msgstr "Фрейм"
+
+#. Translators: Identifies a tool bar.
+msgid "tool bar"
+msgstr "Куралдар панели "
+
+#. Translators: Identifies a column header in tables and spreadsheets.
+msgid "column header"
+msgstr "Мамычанын аталышы"
+
+#. Translators: Identifies a row header in tables and spreadsheets.
+msgid "row header"
+msgstr "Саптын аталышы"
+
+#. Translators: Identifies a drop down button (a button that, when clicked, opens a menu of its own).
+msgid "drop down button"
+msgstr "Тушурулгон менюнун баскычы"
+
+#. Translators: Identifies an element.
+msgid "clock"
+msgstr "Саат"
+
+#. Translators: Identifies a separator (a horizontal line drawn on the screen).
+msgid "Разделитель"
+msgstr "Болгуч"
+
+#. Translators: Identifies a heading (a bold text used for identifying a section).
+msgid "heading"
+msgstr "аталышы"
+
+#. Translators: Identifies a heading level.
+msgid "heading 1"
+msgstr "Аталыш 1"
+
+#. Translators: Identifies a heading level.
+msgid "heading 2"
+msgstr "Аталыш 2"
+
+#. Translators: Identifies a heading level.
+msgid "heading 3"
+msgstr Аталыш 3"
+
+#. Translators: Identifies a heading level.
+msgid "heading 4"
+msgstr "Аталыш 4"
+
+#. Translators: Identifies a heading level.
+msgid "heading 5"
+msgstr "Аталыш 5"
+
+#. Translators: Identifies a heading level.
+msgid "heading 6"
+msgstr "Аталыш 6"
+
+#. Translators: Identifies a paragraph (a group of text surrounded by blank lines).
+msgid "paragraph"
+msgstr "Абзац"
+
+#. Translators: Presented for a section in a document which is a block quotation;
+#. i.e. a long quotation in a separate paragraph distinguished by indentation, etc.
+#. See http://en.wikipedia.org/wiki/Block_quotation
+msgid "block quote"
+msgstr "Цитата"
+
+#. Translators: Identifies a table header (a short text at the start of a table which describes what the table is about).
+msgid "table header"
+msgstr "Таблицанын аталышы"
+
+#. Translators: Identifies a table body (the main body of the table).
+msgid "table body"
+msgstr "Таблицанын денеси"
+
+#. Translators: Identifies a table footer (text placed at the end of the table).
+msgid "table footer"
+msgstr "Таблицанын астынкы болугу"
+
+#. Translators: Identifies a document (for example, a webpage document).
+msgid "document"
+msgstr "Документ"
+
+#. Translators: Identifies an animation in a document or a webpage.
+msgid "animation"
+msgstr "Анимация"
+
+#. Translators: Identifies an application in webpages.
+msgid "application"
+msgstr "Колдонмо"
+
+#. Translators: Identifies a box element.
+msgid "box"
+msgstr "Блок"
+
+#. Translators: Identifies a grouping (a number of related items grouped together, such as related options in dialogs).
+msgid "grouping"
+msgstr "Топко болуу"
+
+#. Translators: Identifies a property page such as drive properties dialog.
+msgid "property page"
+msgstr "Озгочолуктордун бети"
+
+#. Translators: Identifies a canvas element on webpages (a box with some background color with some text drawn on the box, like a canvas).
+msgid "canvas"
+msgstr "Боз кендир"
+
+#. Translators: Identifies a caption (usually a short text identifying a picture or a graphic on websites).
+msgid "caption"
+msgstr "Колу"
+
+#. Translators: Identifies a check menu item (a menu item with a checkmark as part of the menu item's name).
+msgid "check menu item"
+msgstr "Желек менен элемент"
+
+#. Translators: Identifies a data edit field.
+msgid "date edit"
+msgstr "Дата редактору"
+
+#. Translators: Identifies an icon.
+msgid "icon"
+msgstr "Белги"
+
+#. Translators: Identifies a directory pane.
+msgid "directory pane"
+msgstr "мукаба аймагы"
+
+#. Translators: Identifies an embedded object such as flash content on webpages.
+msgid "embedded object"
+msgstr "орнотулган объект"
+
+#. Translators: Identifies an end note.
+msgid "end note"
+msgstr "Аяктоочу шилтеме"
+
+#. Translators: Identifies a footer (usually text).
+msgid "footer"
+msgstr "Астынкы болук"
+
+#. Translators: Identifies a foot note (text at the end of a passage or used for anotations).
+msgid "foot note"
+msgstr "Шилтеме"
+
+#. Translators: Reported for an object which is a glass pane; i.e.
+#. a pane that is guaranteed to be on top of all panes beneath it.
+msgid "glass pane"
+msgstr "Айнек аймагы"
+
+#. Translators: Identifies a header (usually text at top of documents or on tops of pages).
+msgid "header"
+msgstr "Аталышы"
+
+#. Translators: Identifies an image map (a type of graphical link).
+msgid "image map"
+msgstr "Карта суроту"
+
+#. Translators: Identifies an input window.
+msgid "input window"
+msgstr "Киргизуу терезеси"
+
+#. Translators: Identifies a label.
+msgid "label"
+msgstr "Тез чакырма"
+
+#. Translators: Identifies a note field.
+msgid "note"
+msgstr "эсбелги"
+
+#. Translators: Identifies a page.
+msgid "page"
+msgstr "Бет"
+
+#. Translators: Identifies a radio menu item.
+msgid "radio menu item"
+msgstr "Уналгыбаскыч-элемент"
+
+#. Translators: Identifies a layered pane.
+msgid "layered pane"
+msgstr "Копкабаттуу аймак"
+
+#. Translators: Identifies a redundant object.
+msgid "redundant object"
+msgstr "ашыкча объект"
+
+#. Translators: Identifies a root pane.
+msgid "root pane"
+msgstr "Тамыр аймагы"
+
+#. Translators: May be reported for an editable text object in a toolbar.
+#. This is deprecated and is not often (if ever) used.
+msgid "edit bar"
+msgstr "Ондоо сабы"
+
+#. Translators: Identifies a terminal window such as command prompt.
+msgid "terminal"
+msgstr "Терминал"
+
+#. Translators: Identifies a rich edit box (an edit box which allows entering formatting commands in addition to text; encountered on webpages and NvDA log viewer).
+msgid "rich edit"
+msgstr "Коп саптуу редактор"
+
+#. Translators: Identifies a ruler object (commonly seen on some webpages and in some Office programs).
+msgid "ruler"
+msgstr "Сызгыч"
+
+#. Translators: Identifies a scroll pane.
+msgid "scroll pane"
+msgstr "Кайталоо аймагы"
+
+#. Translators: Identifies a section of text.
+msgid "section"
+msgstr "Болук"
+
+#. Translators: Identifies a shape.
+msgid "shape"
+msgstr "солокот"
+
+#. Translators: Identifies a split pane.
+msgid "split pane"
+msgstr "Болунгон аймак"
+
+#. Translators: Reported for a view port; i.e. an object usually used in a scroll pane
+#. which represents the portion of the entire data that the user can see.
+#. As the user manipulates the scroll bars, the contents of the view port can change.
+msgid "view port"
+msgstr "Кароочу терезе"
+
+#. Translators: Reported for an object that forms part of a menu system
+#. but which can be undocked from or torn off the menu system
+#. to exist as a separate window.
+msgid "tear off menu"
+msgstr "Болунгон меню"
+
+#. Translators: Identifies a text frame (a frame window which contains text).
+msgid "text frame"
+msgstr "Текст чеги"
+
+#. Translators: Identifies a toggle button (a button used to toggle something).
+msgid "toggle button"
+msgstr "откоруу баскычы"
+
+msgid "border"
+msgstr "Чеги"
+
+#. Translators: Identifies a caret object.
+msgid "caret"
+msgstr "чекит киргизуучу"
+
+#. Translators: Identifies a character field (should not be confused with edit fields).
+msgid "character"
+msgstr "Символ"
+
+#. Translators: Identifies a chart (commonly seen on some websites and in some Office documents).
+msgid "chart"
+msgstr "Схема"
+
+#. Translators: Identifies a cursor object.
+msgid "cursor"
+msgstr "Курсор"
+
+#. Translators: Identifies a diagram (seen on some websites and on Office documents).
+msgid "diagram"
+msgstr "Диаграмма"
+
+#. Translators: Identifies a dial object.
+msgid "dial"
+msgstr "диск топтому"
+
+#. Translators: Identifies a drop list.
+msgid "drop list"
+msgstr "тушуучу тизме"
+
+#. Translators: Identifies a split button (a control which performs different actions when different parts are clicked).
+msgid "split button"
+msgstr "Болунгон баскыч"
+
+#. Translators: Identifies a menu button (a button which opens a menu of items).
+msgid "menu button"
+msgstr "меню баскычы"
+
+#. Translators: Reported for a button which expands a grid when it is pressed.
+msgid "drop down button grid"
+msgstr "тушуучу меню менен мамыча баскычы"
+
+#. Translators: Identifies mathematical content.
+msgid "math"
+msgstr "Математикалык туюнтма"
+
+#. Translators: Identifies a grip control.
+msgid "grip"
+msgstr "Ячейка"
+
+#. Translators: Identifies a hot key field (a field where one can enter a hot key for something, such as assigning shortcut for icons on the desktop).
+msgid "hot key field"
+msgstr "Ысык клавишанын чети"
+
+#. Translators: Identifies an indicator control.
+msgid "indicator"
+msgstr "Корсоткуч"
+
+#. Translators: Identifies a spin button (a button used to go through options in a spinning fashion).
+msgid "spin button"
+msgstr "Айлануу баскычы"
+
+#. Translators: Identifies a sound clip on websites.
+msgid "sound"
+msgstr "Ун"
+
+#. Translators: Identifies a whitespace.
+msgid "white space"
+msgstr "Ак мейкиндик"
+
+#. Translators: Identifies a tree view button.
+msgid "tree view button"
+msgstr "Дарак баскычы"
+
+#. Translators: Identifies an IP address (an IP address field element).
+msgid "IP address"
+msgstr "IP адрес"
+
+#. Translators: Identifies a desktop icon (the icons on the desktop such as computer and various shortcuts for programs).
+msgid "desktop icon"
+msgstr "Иш столунун белгиси"
+
+#. Translators: Identifies an alert message such as file download alert in Internet explorer 9 and above.
+#. Translators: Identifies an alert window or bar (usually on Internet Explorer 9 and above for alerts such as file downloads or pop-up blocker).
+msgid "alert"
+msgstr "Билдируу"
+
+#. Translators: Identifies an internal frame (commonly called iframe; usually seen when browsing some sites with Internet Explorer).
+msgid "IFrame"
+msgstr "IЧеги"
+
+#. Translators: Identifies desktop pane (the desktop window).
+msgid "desktop pane"
+msgstr "иш столунун аймагы"
+
+#. Translators: Identifies an option pane.
+msgid "option pane"
+msgstr "параметр аймагы"
+
+#. Translators: Identifies a color chooser.
+msgid "color chooser"
+msgstr "Тусту тандоо"
+
+#. Translators: Identifies a file chooser (to select a file or groups of files from a list).
+msgid "file chooser"
+msgstr "Файлды тандоо"
+
+msgid "filler"
+msgstr "Толтургуч"
+
+#. Translators: Identifies a panel control for grouping related options.
+msgid "panel"
+msgstr "Панель"
+
+#. Translators: Identifies a password field (a protected edit field for entering passwords such as when logging into web-based email sites).
+msgid "password edit"
+msgstr "жашырын белги редактору"
+
+#. Translators: Identifies a font chooser.
+msgid "font chooser"
+msgstr "шрифтти тандоо"
+
+msgid "line"
+msgstr "Строка"
+
+#. Translators: Identifies a font name.
+msgid "font name"
+msgstr "шрифттин аталышы"
+
+#. Translators: Identifies font size.
+msgid "font size"
+msgstr "шрифттин колому "
+
+#. Translators: Describes text formatting.
+#. Translators: Reported when text is bolded.
+msgid "bold"
+msgstr "Жырымкара шрифт"
+
+#. Translators: Describes text formatting.
+msgid "ITALIC"
+msgstr "Курсив"
+
+#. Translators: Describes text formatting.
+msgid "underline"
+msgstr "Сызылган"
+
+#. Translators: Describes text formatting.
+msgid "foreground color"
+msgstr "шрифттин тусу"
+
+#. Translators: Describes text formatting.
+msgid "background color"
+msgstr "фондун тусу"
+
+#. Translators: Describes text formatting.
+#. Translators: Reported for superscript text.
+msgid "superscript"
+msgstr "саптын ойдосундогу"
+
+#. Translators: Describes text formatting.
+#. Translators: Reported for subscript text.
+msgid "subscript"
+msgstr "саптын астындагы"
+
+#. Translators: Describes style of text.
+#. Translators: a Microsoft Word revision type (style change)
+msgid "style"
+msgstr "Стиль"
+
+#. Translators: Describes text formatting.
+msgid "indent"
+msgstr "Абзац кемтиги"
+
+#. Translators: Describes text formatting.
+msgid "alignment"
+msgstr "Туздоо"
+
+#. Translators: Identifies a data grid control (a grid which displays data).
+msgid "data grid"
+msgstr "Маалымат сеткасы"
+
+msgid "data item"
+msgstr "мааламат элементи"
+
+msgid "header item"
+msgstr "аталыштын элементи"
+
+#. Translators: Identifies a thumb control (a button-like control for changing options).
+msgid "thumb control"
+msgstr "айландыруучу сызгычтын жугуртмосу"
+
+msgid "calendar"
+msgstr "жылнаама"
+
+#. Translators: This is presented when a control or document is unavailable.
+msgid "unavailable"
+msgstr "жеткилсиздик"
+
+#. Translators: This is presented when a control has focus.
+msgid "focused"
+msgstr "фокуста"
+
+#. Translators: This is presented when the control is selected.
+msgid "selected"
+msgstr "тандалган"
+
+#. Translators: This is presented when a document is busy.
+msgid "busy"
+msgstr "бош эмес"
+
+#. Translators: This is presented when a button is pressed.
+msgid "pressed"
+msgstr "басылган"
+
+#. Translators: This is presented when a check box is checked.
+msgid "checked"
+msgstr "бегиленген"
+
+#. Translators: This is presented when a three state check box is half checked.
+msgid "half checked"
+msgstr "жарым андалган"
+
+#. Translators: This is presented when the control is a read-only control such as read-only edit box.
+msgid "read only"
+msgstr "окууга гана"
+
+#. Translators: This is presented when a tree view or submenu item is expanded.
+msgid "expanded"
+msgstr "ачык"
+
+#. Translators: This is presented when a tree view or submenu is collapsed.
+msgid "collapsed"
+msgstr "жабык"
+
+#. Translators: This is presented when a control or a document becomes invisible.
+msgid "invisible"
+msgstr "корунбогон"
+
+#. Translators: This is presented when a visited link is encountered.
+msgid "visited"
+msgstr "каралган"
+
+#. Translators: This is presented when a link is encountered.
+msgid "linked"
+msgstr "байланган"
+
+#. Translators: This is presented when the control menu item has a submenu.
+msgid "subMenu"
+msgstr "субменю"
+
+#. Translators: This is presented when a protected control or a document is encountered.
+msgid "protected"
+msgstr "корголгон"
+
+#. Translators: This is presented when a required form field is encountered.
+msgid "required"
+msgstr "керек"
+
+#. Translators: Reported when an object no longer exists in the user interface;
+#. i.e. it is dead and is no longer usable.
+msgid "defunct"
+msgstr "жок"
+
+#. Translators: This is presented when an invalid entry has been made.
+msgid "invalid entry"
+msgstr "туура эмес кириш"
+
+msgid "modal"
+msgstr "модалдык"
+
+#. Translators: This is presented when a field supports auto completion of entered text such as email address field in Microsoft Outlook.
+msgid "has auto complete"
+msgstr "автотолтууру камтыйт"
+
+#. Translators: This is presented when an edit field allows typing multiple lines of text such as comment fields on websites.
+msgid "multi line"
+msgstr "копсаптуу"
+
+msgid "iconified"
+msgstr "белгиленген"
+
+#. Translators: Presented when the current control is located off screen.
+msgid "off screen"
+msgstr "экрандан сырткы"
+
+#. Translators: Presented when the control allows selection such as text fields.
+msgid "selectable"
+msgstr "белгилоого жеткиликтуу"
+
+#. Translators: Presented when a control can be moved to using system focus.
+msgid "focusable"
+msgstr "фокусталган"
+
+#. Translators: Presented when a control allows clicking via mouse (mostly presented on web controls).
+msgid "clickable"
+msgstr "чыкылдатуу менен"
+
+msgid "editable"
+msgstr "ондолуучу"
+
+msgid "checkable"
+msgstr "белгиленуучу"
+
+msgid "draggable"
+msgstr "жылдыруучу"
+
+msgid "dragging"
+msgstr "жылдыруу"
+
+#. Translators: Reported where an object which is being dragged can be dropped.
+#. This is only reported for objects which support accessible drag and drop.
+msgid "drop target"
+msgstr "жылдыруунун максатту пункту"
+
+msgid "sorted"
+msgstr "сорттолгон"
+
+msgid "sorted ascending"
+msgstr "отсортировано по возрастанию"
+
+msgid "sorted descending"
+msgstr "азайуу тартибинде сорттолгон"
+
+#. Translators: a state that denotes that an object (usually a graphic) has a long description.
+msgid "has long description"
+msgstr "толук суроттого ээ"
+
+#. Translators: a state that denotes that an object is pinned in its current location
+msgid "pinned"
+msgstr "орнотулган"
+
+#. Translators: a state that denotes the existance of a formula on a spreadsheet cell
+msgid "has formula"
+msgstr "формуланы камтыйт"
+
+#. Translators: a state that denotes the existance of a comment.
+#. Translators: Reported when text contains a comment.
+msgid "has comment"
+msgstr "эскертууну камтыйт"
+
+#. Translators: a state that denotes that the object is covered partially or fully by another object
+msgid "obscured"
+msgstr "жабык"
+
+#. Translators: a state that denotes that the object(text) is cropped as it couldn't be accommodated in the allocated/available space
+msgid "cropped"
+msgstr "кесилген"
+
+#. Translators: a state that denotes that the object(text) is overflowing into the adjacent space
+msgid "overflowing"
+msgstr "толгон"
+
+#. Translators: a state that denotes that the object is unlocked (such as an unlocked cell in a protected Excel spreadsheet).
+msgid "unlocked"
+msgstr "ачылган"
+
+#. Translators: This is presented when a selectable object (e.g. a list item) is not selected.
+msgid "not selected"
+msgstr "тандалбаган"
+
+#. Translators: This is presented when a checkbox is not checked.
+msgid "not checked"
+msgstr "белгиленген эмес"
+
+#. Translators: A message informing the user that there are errors in the configuration file.
+msgid ""
+"Your configuration file contains errors. Your configuration has been reset "
+"to factory defaults.\n"
+"More details about the errors can be found in the log file."
+msgstr "регистр файлынан кошумча маалымат алууга болот"
+"Ваш файл конфигурации содержит ошибки. Конфигурация сброшена к заводским "
+"настройкам.\n"
+"Более подробную информацию об ошибках можно найти в журнале."
+
+#. Translators: The title of the dialog to tell users that there are errors in the configuration file.
+msgid "Configuration File Error"
+msgstr "конфигурация файлынын катасы"
+
+msgid ""
+"Your gesture map file contains errors.\n"
+"More details about the errors can be found in the log file."
+msgstr "Сиздин колбелгилерди кошуучу файлыныз катаны камтыйт"
+"Каталар боюнча толугураак маалыматты журналдан алууга болот."
+
+msgid "gesture map File Error"
+msgstr "Колбелгилерди кошуу файлында ката"
+
+#. Translators: This is spoken when NVDA is starting.
+msgid "Loading NVDA. Please wait..."
+msgstr "Жуктоо NVDA. Сураныч, кутуп турунуз..."
+
+#. Translators: This is shown on a braille display (if one is connected) when NVDA starts.
+msgid "NVDA started"
+msgstr "NVDA ишке киргизилди"
+
+#. Translators: Title of a dialog to find text.
+msgid "Find"
+msgstr "Издөө"
+
+#. Translators: Dialog text for NvDA's find command.
+msgid "Type the text you wish to find"
+msgstr "Издөө учун текстти киргизиниз"
+
+#. Translators: An option in find dialog to perform case-sensitive search.
+#. Translators: This is a label for a checkbox in add dictionary entry dialog.
+msgid "Case &sensitive"
+msgstr " &каттону эске алуу"
+
+#, python-format
+msgid "text \"%s\" not found"
+msgstr "Текст \"%s\"табылбады"
+
+msgid "Find Error"
+msgstr "Катаны Издөө"
+
+#. Translators: Input help message for NVDA's find command.
+msgid "find a text string from the current cursor position"
+msgstr "учурдагы курсор багытынан текстти Издөө"
+
+#. Translators: Input help message for find next command.
+msgid ""
+"find the next occurrence of the previously entered text string from the "
+"current cursor's position"
+msgstr ""
+"учурдагы курсор багытынан кийинки киргизилген тексттти Издөө"
+
+#. Translators: Input help message for find previous command.
+msgid ""
+"find the previous occurrence of the previously entered text string from the "
+"current cursor's position"
+msgstr ""
+"учурдагы курсор багытынан мурунку киргизилген тексттти Издөө"
+
+#. Translators: Reported when there is no text selected (for copying).
+msgid "No selection"
+msgstr "Тандоо жок"
+
+#. Translators: Message presented when text has been copied to clipboard.
+msgid "Copied to clipboard"
+msgstr "Алмашуу буферине копияланды"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Text review"
+msgstr "тексти карап чыгуу"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Object navigation"
+msgstr "Объектуу навигация"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "System caret"
+msgstr "Системалык каретка"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Mouse"
+msgstr "Чычканча"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Speech"
+msgstr "соз"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Configuration"
+msgstr "Конфигурация"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Braille"
+msgstr "Брайль"
+
+#. Translators: The name of a category of NVDA commands.
+msgctxt "script category"
+msgid "Tools"
+msgstr "Тейлоо"
+
+#. Translators: The name of a category of NVDA commands.
+#. Translators: a touch screen gesture
+msgid "Touch screen"
+msgstr "Сенсордук экран"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "System focus"
+msgstr "Системалык фокус"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "System status"
+msgstr "Система абалы"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Input"
+msgstr "Кириш"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Document formatting"
+msgstr "документти форматтоо"
+
+#. Translators: a message when audio ducking is not supported on this machine
+msgid "Audio ducking not supported"
+msgstr "Дабышты азайтуу колдолулбайт"
+
+#. Translators: Describes the Cycle audio ducking mode command.
+msgid ""
+"Cycles through audio ducking modes which determine when NVDA lowers the "
+"volume of other sounds"
+msgstr ""
+"Циклтурундо дабышты азайтуу режимин алмаштырып турат, алар "
+"NVDA качан сырткы дабыштардын унун азайтуу керек болгондо"
+
+#. Translators: This will be presented when the input help is toggled.
+msgid "input help on"
+msgstr "Кириш справкасы жандырылды"
+
+#. Translators: This will be presented when the input help is toggled.
+msgid "input help off"
+msgstr "Кириш справкасы очурулду"
+
+#. Translators: Input help mode message for toggle input help command.
+msgid ""
+"Turns input help on or off. When on, any input such as pressing a key on the "
+"keyboard will tell you what script is associated with that input, if any."
+msgstr "Кириш справкасын очуруп-жандырат. "
+"Включает и выключает режим справки по вводу. При включённом режиме, для "
+"любого жеста ввода (например при нажатии клавиш на клавиатуре), читается "
+"описание соответствующей команды, закреплённой за жестом."
+
+#. Translators: This is presented when sleep mode is deactivated, NVDA will continue working as expected.
+msgid "Sleep mode off"
+msgstr "Уктоо твртиби очук"
+
+#. Translators: This is presented when sleep mode is activated, the focused application is self voicing, such as klango or openbook.
+msgid "Sleep mode on"
+msgstr "Уктоо тартиби жанык"
+
+#. Translators: Input help mode message for toggle sleep mode command.
+msgid "Toggles  sleep mode on and off for  the active application."
+msgstr "Активдуу колдонмолор учун уктоо тартибин очуруп-жандырат"
+
+#. Translators: Input help mode message for report current line command.
+msgid ""
+"Reports the current line under the application cursor. Pressing this key "
+"twice will spell the current line"
+msgstr ""
+
+"Курсор багыттында окуйт"эжгерде эки жолу басылган болсо окуйт
+
+#. Translators: Reported when left mouse button is clicked.
+msgid "Left click"
+msgstr "Щелчок левой кнопкой мыши Сол чычканды чыкылдатуу"
+
+#. Translators: Input help mode message for left mouse click command.
+msgid "Clicks the left mouse button once at the current mouse position"
+msgstr ""
+"Учурдагы корсотуу багытынын сол чычканды бир жолу чыкылдатат" 
+
+#. Translators: Reported when right mouse button is clicked.
+msgid "Right click"
+msgstr "Он чычканды чыкылдатуу"
+
+#. Translators: Input help mode message for right mouse click command.
+msgid "Clicks the right mouse button once at the current mouse position"
+msgstr ""
+ "Учурдагы корсотуу багытынын он чычканды бир жолу чыкылдатат" 
+
+#. Translators: This is presented when the left mouse button lock is released (used for drag and drop).
+msgid "Left mouse button unlock"
+msgstr "Чычкандын сол баскычы койберилген"
+
+#. Translators: This is presented when the left mouse button is locked down (used for drag and drop).
+msgid "Left mouse button lock"
+msgstr " Чычкандын сол баскычы басылды"
+
+#. Translators: Input help mode message for left mouse lock/unlock toggle command.
+msgid "Locks or unlocks the left mouse button"
+msgstr "Чычкандын сол баскычын басат же койберет"
+
+#. Translators: This is presented when the right mouse button lock is released (used for drag and drop).
+msgid "Right mouse button unlock"
+msgstr "Чычкандын он баскычы койберилди"
+
+#. Translators: This is presented when the right mouse button is locked down (used for drag and drop).
+msgid "Right mouse button lock"
+msgstr "Чычкандын он баскычы басылган"
+
+#. Translators: Input help mode message for right mouse lock/unlock command.
+msgid "Locks or unlocks the right mouse button"
+msgstr "Чычкандын он баскычын басат же койберет"
+
+#, python-format
+msgid "Selected %s"
+msgstr "тандалды %s"
+
+#. Translators: Input help mode message for report current selection command.
+msgid ""
+"Announces the current selection in edit controls and documents. If there is "
+"no selection it says so."
+msgstr "редакциалауучу башкаруу элементтеги же документтеги текстти окуйт"
+"Ал жок мезгилинде кабар берет"
+
+#. Translators: Input help mode message for report date and time command.
+msgid ""
+"If pressed once, reports the current time. If pressed twice, reports the "
+"current date"
+msgstr "Учурдагы убакыт тууралуу маалымат берет. Эгерде эки жолу басылса, учурдагы дата тууралуу малаымат берет"
+
+#. Translators: Reported when there are no settings to configure in synth settings ring (example: when there is no setting for language).
+msgid "No settings"
+msgstr "Парамерлер жок"
+
+#. Translators: Input help mode message for increase synth setting value command.
+msgid "Increases the currently active setting in the synth settings ring"
+msgstr "Синтезатордогу ырастоо тегерегиндеги активдуу параметрлердин мазмунун кобойтот"
+
+#. Translators: Input help mode message for decrease synth setting value command.
+msgid "Decreases the currently active setting in the synth settings ring"
+msgstr "Синтезатордогу ырастоо тегерегиндеги активдуу параметрлердин мазмунун азайтат"
+
+
+#. Translators: Input help mode message for next synth setting command.
+msgid "Moves to the next available setting in the synth settings ring"
+msgstr "Синтезатордогу ырастоо тегерегиндеги кийинки активдуу параметрине отот"
+
+
+#. Translators: Input help mode message for previous synth setting command.
+msgid "Moves to the previous available setting in the synth settings ring"
+msgstr "Синтезатордогу ырастоо тегерегиндеги мурунку активдуу параметрине отот"
+
+#. Translators: The message announced when toggling the speak typed characters keyboard setting.
+msgid "speak typed characters off"
+msgstr "Киргизилуучу символдорду окуу очурулгон"
+
+#. Translators: The message announced when toggling the speak typed characters keyboard setting.
+msgid "speak typed characters on"
+msgstr "Киргизилуучу символдорду окуу жандырылган"
+
+#. Translators: Input help mode message for toggle speaked typed characters command.
+msgid "Toggles on and off the speaking of typed characters"
+msgstr "Киргизуу учурунда символдорду окууну жандырып очурот"
+
+#. Translators: The message announced when toggling the speak typed words keyboard setting.
+msgid "speak typed words off"
+msgstr "Киргизилуучу создорду окуу очурулгон"
+
+#. Translators: The message announced when toggling the speak typed words keyboard setting.
+msgid "speak typed words on"
+msgstr "Киргизилуучу создорду окуу жандырылган"
+
+#. Translators: Input help mode message for toggle speak typed words command.
+msgid "Toggles on and off the speaking of typed words"
+msgstr  "Киргизуу учурунда создорду окууну жандырып очурот"
+
+#. Translators: The message announced when toggling the speak typed command keyboard setting.
+msgid "speak command keys off"
+msgstr "буйрук баскычтарды окуу очурулгон"
+
+#. Translators: The message announced when toggling the speak typed command keyboard setting.
+msgid "speak command keys on"
+msgstr "буйрук баскычтарды окуу жандырылган"
+
+#. Translators: Input help mode message for toggle speak command keys command.
+msgid ""
+"Toggles on and off the speaking of typed keys, that are not specifically "
+"characters"
+msgstr "символ болбогон баскычтарды ундуу кылууну очуруп жандырат"
+
+#. Translators: The message announced when toggling the report font name document formatting setting.
+msgid "report font name off"
+msgstr "шрифттин аталышын окуу очурулгон"
+
+#. Translators: The message announced when toggling the report font name document formatting setting.
+msgid "report font name on"
+msgstr  "шрифттин аталышын окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report font name command.
+msgid "Toggles on and off the reporting of font changes"
+msgstr " шрифтти озгортуу тууралуу жарыяну очуруп жандырат"
+
+#. Translators: The message announced when toggling the report font size document formatting setting.
+msgid "report font size off"
+msgstr "шрифттин коломун окуу очурулгон"
+
+#. Translators: The message announced when toggling the report font size document formatting setting.
+msgid "report font size on"
+msgstr "шрифттин коломун окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report font size command.
+msgid "Toggles on and off the reporting of font size changes"
+msgstr " шрифттин коломун озгортуу тууралуу жарыяну очуруп жандырат"
+
+#. Translators: The message announced when toggling the report font attributes document formatting setting.
+msgid "report font attributes off"
+msgstr " шрифттин атрибуттарын окуу очурулгон"
+
+#. Translators: The message announced when toggling the report font attributes document formatting setting.
+msgid "report font attributes on"
+msgstr  "шрифттин атрибуттарын окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report font attributes command.
+msgid "Toggles on and off the reporting of font attributes"
+msgstr "Шрифтин атрибуттары тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report revisions document formatting setting.
+msgid "report revisions off"
+msgstr "Редакторду текшерууну окууну очурулгон"
+
+#. Translators: The message announced when toggling the report revisions document formatting setting.
+msgid "report revisions on"
+msgstr"Редакторду текшерууну окууну жандырылган"
+
+#. Translators: Input help mode message for toggle report revisions command.
+msgid "Toggles on and off the reporting of revisions"
+msgstr "Редакторду текшеруу тууралуу жарыяларды очуруп жандырат"
+
+#. Translators: The message announced when toggling the report emphasis document formatting setting.
+msgid "report emphasis off"
+msgstr "акцентоону окуу очурулгон"
+
+#. Translators: The message announced when toggling the report emphasis document formatting setting.
+msgid "report emphasis on"
+msgstr "акцентоону окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report emphasis command.
+msgid "Toggles on and off the reporting of emphasis"
+msgstr "акцентоо тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report colors document formatting setting.
+msgid "report colors off"
+msgstr "тусторду окуу очурулгон"
+
+#. Translators: The message announced when toggling the report colors document formatting setting.
+msgid "report colors on"
+msgstr  "тусторду окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report colors command.
+msgid "Toggles on and off the reporting of colors"
+msgstr "тустор тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report alignment document formatting setting.
+msgid "report alignment off"
+msgstr "туздоону окуу очурулгон"
+
+#. Translators: The message announced when toggling the report alignment document formatting setting.
+msgid "report alignment on"
+msgstr "туздоону окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report alignment command.
+msgid "Toggles on and off the reporting of text alignment"
+msgstr "туздоо тууралуу жарыяларды очуруп жандырат"
+
+#. Translators: The message announced when toggling the report style document formatting setting.
+msgid "report style off"
+msgstr "стилди окуу очурулгон"
+
+#. Translators: The message announced when toggling the report style document formatting setting.
+msgid "report style on"
+msgstr "стилди окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report style command.
+msgid "Toggles on and off the reporting of style changes"
+msgstr "стилди озгортуу тууралуу жарыяларды очуруп жандырат" 
+
+#. Translators: The message announced when toggling the report spelling errors document formatting setting.
+msgid "report spelling errors off"
+msgstr "орфографиялык каталарды окуу очурулгон"
+
+#. Translators: The message announced when toggling the report spelling errors document formatting setting.
+msgid "report spelling errors on"
+msgstr "орфографиялык каталарды окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report spelling errors command.
+msgid "Toggles on and off the reporting of spelling errors"
+msgstr "орфографиялык каталар тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report pages document formatting setting.
+msgid "report pages off"
+msgstr "беттердин номурун окуу очурулгон"
+
+#. Translators: The message announced when toggling the report pages document formatting setting.
+msgid "report pages on"
+msgstr "беттердин номурун окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report pages command.
+msgid "Toggles on and off the reporting of pages"
+msgstr "беттердин номуру тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report line numbers document formatting setting.
+msgid "report line numbers off"
+msgstr "саптардын номурун окуу очурулгон"
+
+#. Translators: The message announced when toggling the report line numbers document formatting setting.
+msgid "report line numbers on"
+msgstr "саптардын номурун окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report line numbers command.
+msgid "Toggles on and off the reporting of line numbers"
+msgstr "саптардын номурун окуу жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report line indentation document formatting setting.
+msgid "report line indentation off"
+msgstr "саптын чегинуусун окуу очурулгон"
+
+#. Translators: The message announced when toggling the report line indentation document formatting setting.
+msgid "report line indentation on"
+msgstr "саптын чегинуусун окуу выключено"
+
+#. Translators: Input help mode message for toggle report line indentation command.
+msgid "Toggles on and off the reporting of line indentation"
+msgstr "саптын чегинуусу тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report paragraph indentation document formatting setting.
+msgid "report paragraph indentation off"
+msgstr "абзацтын чегинуусун окуу очурулгон"
+
+#. Translators: The message announced when toggling the report paragraph indentation document formatting setting.
+msgid "report paragraph indentation on"
+msgstr "абзацтын чегинуусун окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report paragraph indentation command.
+msgid "Toggles on and off the reporting of paragraph indentation"
+msgstr "абзацтын чегинуусу тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report line spacing document formatting setting.
+msgid "report line spacing off"
+msgstr "саптар аралык араны окуу очурулгон"
+
+#. Translators: The message announced when toggling the report line spacing document formatting setting.
+msgid "report line spacing on"
+msgstr "саптар аралык араны окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report line spacing command.
+msgid "Toggles on and off the reporting of line spacing"
+msgstr "саптар арасы тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report tables document formatting setting.
+msgid "report tables off"
+msgstr "таблицаны окуу очурулгон"
+
+#. Translators: The message announced when toggling the report tables document formatting setting.
+msgid "report tables on"
+msgstr "таблицаны окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report tables command.
+msgid "Toggles on and off the reporting of tables"
+msgstr "Таблицалардын жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report table row/column headers document formatting setting.
+msgid "report table row and column headers off"
+msgstr "аталыштардын сабын жана мамычаларын окуу очурулгон"
+
+#. Translators: The message announced when toggling the report table row/column headers document formatting setting.
+msgid "report table row and column headers on"
+msgstr "аталыштардын сабын жана мамычаларын окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report table row/column headers command.
+msgid "Toggles on and off the reporting of table row and column headers"
+msgstr "аталыштардын сабын жана мамычалары тууралуу жарыяны очуруп жандырат"
+
+#. Translators: The message announced when toggling the report table cell coordinates document formatting setting.
+msgid "report table cell coordinates off"
+msgstr "мамычалардын жайгашуусун окуу очурулгон"
+
+#. Translators: The message announced when toggling the report table cell coordinates document formatting setting.
+msgid "report table cell coordinates on"
+msgstr "мамычалардын жайгашуусун окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report table cell coordinates command.
+msgid "Toggles on and off the reporting of table cell coordinates"
+msgstr "таблицадагы мамычалардын жайгашуусунун жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report links document formatting setting.
+msgid "report links off"
+msgstr "Шилтемелерди окуу очурулгон"
+
+#. Translators: The message announced when toggling the report links document formatting setting.
+msgid "report links on"
+msgstr "Шилтемелерди окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report links command.
+msgid "Toggles on and off the reporting of links"
+msgstr " шилтемелердин жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report comments document formatting setting.
+msgid "report comments off"
+msgstr "эскертуулорду окуу очурулгон"
+
+#. Translators: The message announced when toggling the report comments document formatting setting.
+msgid "report comments on"
+msgstr "эскертуулорду окуу очурулгон"
+
+#. Translators: Input help mode message for toggle report comments command.
+msgid "Toggles on and off the reporting of comments"
+msgstr "эскертуулордун жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report lists document formatting setting.
+msgid "report lists off"
+msgstr "тизмелерди окуу очурулгон"
+
+#. Translators: The message announced when toggling the report lists document formatting setting.
+msgid "report lists on"
+msgstr "тизмелерди окуу жандырылган"
+#. Translators: Input help mode message for toggle report lists command.
+msgid "Toggles on and off the reporting of lists"
+msgstr "тизмелердин жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report headings document formatting setting.
+msgid "report headings off"
+msgstr "аталыштарды окуу очурулгон"
+
+#. Translators: The message announced when toggling the report headings document formatting setting.
+msgid "report headings on"
+msgstr  "аталыштарды окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report headings command.
+msgid "Toggles on and off the reporting of headings"
+msgstr "аталыштардын жарыясын очуруп жандырат" 
+
+#. Translators: The message announced when toggling the report block quotes document formatting setting.
+msgid "report block quotes off"
+msgstr "цитаталарды окуу очурулгон"
+
+#. Translators: The message announced when toggling the report block quotes document formatting setting.
+msgid "report block quotes on"
+msgstr "цитаталарды окуу очурулгон"
+
+#. Translators: Input help mode message for toggle report block quotes command.
+msgid "Toggles on and off the reporting of block quotes"
+msgstr "цитаталардын жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report landmarks document formatting setting.
+msgid "report landmarks off"
+msgstr "багыттарды окуу очурулгон"
+
+#. Translators: The message announced when toggling the report landmarks document formatting setting.
+msgid "report landmarks on"
+msgstr "багыттарды окуу очурулгон"
+
+#. Translators: Input help mode message for toggle report landmarks command.
+msgid "Toggles on and off the reporting of landmarks"
+msgstr "багыттардын жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report frames document formatting setting.
+msgid "report frames off"
+msgstr "чектерди окуу очурулгон"
+
+#. Translators: The message announced when toggling the report frames document formatting setting.
+msgid "report frames on"
+msgstr "чектерди окуу очурулгон"
+
+#. Translators: Input help mode message for toggle report frames command.
+msgid "Toggles on and off the reporting of frames"
+msgstr "чектердин жарыясын очуруп жандырат"
+
+#. Translators: The message announced when toggling the report if clickable document formatting setting.
+msgid "report if clickable off"
+msgstr "интерактивдуу элементтердин жарыясын очуруп жандыруу"
+
+#. Translators: The message announced when toggling the report if clickable document formatting setting.
+msgid "report if clickable on"
+msgstr "интерактивдуу элементтерди окуу жандырылган"
+
+#. Translators: Input help mode message for toggle report if clickable command.
+msgid "Toggles on and off reporting if clickable"
+msgstr "интерактивдуу элементтердин жарыясын очуруп жандырат"
+
+#. Translators: Reported when the user cycles through speech symbol levels
+#. which determine what symbols are spoken.
+#. %s will be replaced with the symbol level; e.g. none, some, most and all.
+#, python-format
+msgid "Symbol level %s"
+msgstr " %s пунктуация дегээли"
+
+#. Translators: Input help mode message for cycle speech symbol level command.
+msgid ""
+"Cycles through speech symbol levels which determine what symbols are spoken"
+msgstr "Пунктуация денгээлин ун беруу арасында которот, алар айрыкча кайсы символдор айтылаарын аныктайт"
+
+
+#. Translators: Reported when the object has no location for the mouse to move to it.
+msgid "Object has no location"
+msgstr "Объектин жайгашуусу жок"
+
+#. Translators: Input help mode message for move mouse to navigator object command.
+msgid "Moves the mouse pointer to the current navigator object"
+msgstr "учурдагы багыттагычтын обектисине чычкандын корсотуучусун жылдырат"
+
+#. Translators: Reported when attempting to move the navigator object to the object under mouse pointer.
+msgid "Move navigator object to mouse"
+msgstr "багыттагычты чычканга алып келуу"
+
+#. Translators: Input help mode message for move navigator object to mouse command.
+msgid ""
+"Sets the navigator object to the current object under the mouse pointer and "
+"speaks it"
+msgstr "Чычкандын корсоткучунун алдындагы объектиге багыттагычты орнотот жана окуйт"
+
+#. Translators: reported when there are no other available review modes for this object
+msgid "No next review mode"
+msgstr "кийинки коруу тартиби жок"
+
+#. Translators: Script help message for next review mode command.
+msgid ""
+"Switches to the next review mode (e.g. object, document or screen) and "
+"positions the review position at the point of the navigator object"
+msgstr "Кийинки коруу тартибине еоторулат (мисалы, объект,документ жана экран) жана обектин багыттагычынын чектиндеги коруу багыттын орнотот "
+
+#. Translators: reported when there are no  other available review modes for this object
+msgid "No previous review mode"
+msgstr "Мурунку коруу тартиби жок"
+
+#. Translators: Script help message for previous review mode command.
+msgid ""
+"Switches to the previous review mode (e.g. object, document or screen) and "
+"positions the review position at the point of the navigator object"
+msgstr"Мурунку коруу тартибине еоторулат (мисалы, объект,документ жана экран) жана обектин багыттагычынын чектиндеги коруу багыттын орнотот "
+
+#. Translators: The message announced when toggling simple review mode.
+msgid "Simple review mode off"
+msgstr "Женилдетилген коруу тартиби очурулгон"
+
+#. Translators: The message announced when toggling simple review mode.
+msgid "Женилдетилген коруу тартиби жандырылган"
+
+#. Translators: Input help mode message for toggle simple review mode command.
+msgid "Toggles simple review mode on and off"
+msgstr "Женилдетилген коруу тартибин жандырып очурот"
+
+#. Translators: Reported when the user tries to perform a command related to the navigator object
+#. but there is no current navigator object.
+msgid "No navigator object"
+msgstr "Багыттагычтын объекти жок"
+
+#. Translators: Indicates something has been copied to clipboard (example output: title text copied to clipboard).
+#, python-format
+msgid "%s copied to clipboard"
+msgstr "%s алмашуу буферине копияланды"
+
+#. Translators: Input help mode message for report current navigator object command.
+msgid ""
+"Reports the current navigator object. Pressing twice spells this "
+"information, and pressing three times Copies name and value of this  object "
+"to the clipboard"
+msgstr "Багыттагычтын объектисин окуйт. Эки жолу басканда бул маалыматты символдор аркылуу маалымдайт. Эгерде уч жолу басылса, атын жана маанисин алмашуу буферине копиялайт"
+
+#. Translators: message when there is no location information for the review cursor
+msgid "No location information"
+msgstr "жайгашуусу тууралуу маалымат жок "
+
+#. Translators: Description for report review cursor location command.
+msgid ""
+"Reports information about the location of the text or object at the review "
+"cursor. Pressing twice may provide further detail."
+msgstr "Тексттин жана каралуучу курсордогу объектин  жайгашуусу тууралуу маалыматты жарыялайт. Экии жолу басуу кошумча маалыматты камсыздайт "
+
+
+#. Translators: Reported when attempting to move the navigator object to focus.
+msgid "Move to focus"
+msgstr "Багыттагычты фокуска каратуу"
+
+#. Translators: Input help mode message for move navigator object to current focus command.
+msgid ""
+"Sets the navigator object to the current focus, and the review cursor to the "
+"position of the caret inside it, if possible."
+msgstr ""
+"Устанавливает навигатор на объект в системном фокусе и просмотровый курсор в "
+"позицию каретки в этом объекте, если это возможно."
+
+#. Translators: Reported when:
+#. 1. There is no focusable object e.g. cannot use tab and shift tab to move to controls.
+#. 2. Trying to move focus to navigator object but there is no focus.
+msgid "No focus"
+msgstr "Фокус жок"
+
+#. Translators: Reported when attempting to move focus to navigator object.
+msgid "Move focus"
+msgstr "Фокусту багыттагычка"
+
+#. Translators: Reported when trying to move caret to the position of the review cursor but there is no caret.
+msgid "No caret"
+msgstr "каретка жок"
+
+#. Translators: Input help mode message for move focus to current navigator object command.
+msgid ""
+"Pressed once sets the keyboard focus to the navigator object, pressed twice "
+"sets the system caret to the position of the review cursor"
+msgstr "Системалык фокусту багыттагычтын объектисине орнотот"
+ 
+
+#. Translators: Reported when there is no containing (parent) object such as when focused on desktop.
+msgid "No containing object"
+msgstr "Камтыычу объект жок"
+
+#. Translators: Input help mode message for move to parent object command.
+msgid "Moves the navigator object to the object containing it"
+msgstr "учурдагы объекти камтуучуга багыттагычты которот"
+
+#. Translators: Reported when there is no next object (current object is the last object).
+#. Translators: a message when there is no next object when navigating
+msgid "No next"
+msgstr "Кийинкиси жок"
+
+#. Translators: Input help mode message for move to next object command.
+msgid "Moves the navigator object to the next object"
+msgstr "Багыттагычты кийинки объектке которот"
+
+#. Translators: Reported when there is no previous object (current object is the first object).
+#. Translators: a message when there is no previous object when navigating
+msgid "No previous"
+msgstr "Мурункусу жок"
+
+#. Translators: Input help mode message for move to previous object command.
+msgid "Moves the navigator object to the previous object"
+msgstr "Багыттагычты мурунку объектке которот"
+
+#. Translators: Reported when there is no contained (first child) object such as inside a document.
+msgid "No objects inside"
+msgstr "Ичиндеги объектилер жок"
+
+#. Translators: Input help mode message for move to first child object command.
+msgid "Moves the navigator object to the first object inside it"
+msgstr "Учурдагыны камтуучу биринчи объектиге багыттагычты которот"
+
+#. Translators: a message reported when the action at the position of the review cursor or navigator object is performed.
+msgid "Activate"
+msgstr "Активдештируу"
+
+#. Translators: the message reported when there is no action to perform on the review position or navigator object.
+msgid "No action"
+msgstr "Кыймыл аракет жок"
+
+#. Translators: Input help mode message for activate current object command.
+msgid ""
+"Performs the default action on the current navigator object (example: "
+"presses it if it is a button)."
+msgstr "Озунон озу аракетин ишке ашырат багыттагычтын устунон (мисалы, эгер баскыч болсо басат)"
+
+
+#. Translators: a message reported when review cursor is at the top line of the current navigator object.
+msgid "Top"
+msgstr "Ойдодогу"
+
+#. Translators: Input help mode message for move review cursor to top line command.
+msgid ""
+"Moves the review cursor to the top line of the current navigator object and "
+"speaks it"
+msgstr "Байкоочу курсорду багыттагычтын биринчи сабына которот жана аны окуйт"
+
+
+#. Translators: Input help mode message for move review cursor to previous line command.
+msgid ""
+"Moves the review cursor to the previous line of the current navigator object "
+"and speaks it"
+msgstr "Байкоочу курсорду багыттагычтын мурунку объект сабына которот жана аны окуйт"
+
+#. Translators: Input help mode message for read current line under review cursor command.
+msgid ""
+"Reports the line of the current navigator object where the review cursor is "
+"situated. If this key is pressed twice, the current line will be spelled. "
+"Pressing three times will spell the line using character descriptions."
+msgstr "Багыттагычтын байкоочу курсор объектисинин астындагы сапты окуйт. Эгерде эки жолу басылган болсо, символ менен айтып чыгат.Эгерде уч жолу басылган болсо сиволдордун фонетикалык суроттосун окуйт"
+
+
+#. Translators: Input help mode message for move review cursor to next line command.
+msgid ""
+"Moves the review cursor to the next line of the current navigator object and "
+"speaks it"
+msgstr "Байкоочу курсорду багыттагычтын объектисинин кийинки сабына которот жана аны окуйт"
+
+#. Translators: Input help mode message for move review cursor to bottom line command.
+msgid ""
+"Moves the review cursor to the bottom line of the current navigator object "
+"and speaks it"
+msgstr "Байкоочу курсорду багыттагычынын объектисин акыркы сабына которот жана аны окуйт"
+
+#. Translators: Input help mode message for move review cursor to previous word command.
+msgid ""
+"Moves the review cursor to the previous word of the current navigator object "
+"and speaks it"
+msgstr "Байкоочу курсорду багыттагычтын объектисин мурунку созго которот жана аны окуйт"
+
+#. Translators: Input help mode message for report current word under review cursor command.
+msgid ""
+"Speaks the word of the current navigator object where the review cursor is "
+"situated. Pressing twice spells the word. Pressing three times spells the "
+"word using character descriptions"
+msgstr "Багыттагычтын объектисинин байкоочу курсорунун астындагы созду окуйт.Эгерде эки жолу басылган болсо символ менен айтат.Эгерде уч жолу басылса, символдордун фонетикалык суроттосун окуйт"
+
+
+#. Translators: Input help mode message for move review cursor to next word command.
+msgid ""
+"Moves the review cursor to the next word of the current navigator object and "
+"speaks it"
+msgstr "Байкоочу курсорду багыттагычтын объектисин кийинки созго которот жана аны окуйт"
+
+#. Translators: a message reported when review cursor is at the leftmost character of the current navigator object's text.
+msgid "Left"
+msgstr "Сол"
+
+#. Translators: Input help mode message for move review cursor to start of current line command.
+msgid ""
+"Moves the review cursor to the first character of the line where it is "
+"situated in the current navigator object and speaks it"
+msgstr "Байкоочу курсорду багыттагычтын объектисин учурдагы сабынын биринчи символуна которот жана аны окуйт"
+
+
+#. Translators: Input help mode message for move review cursor to previous character command.
+msgid ""
+"Moves the review cursor to the previous character of the current navigator "
+"object and speaks it"
+msgstr "Байкоочу курсорду багыттагычтын объектисин кийинкисимволунакоторот жана аны окуйт"
+
+
+#. Translators: Input help mode message for report current character under review cursor command.
+msgid ""
+"Reports the character of the current navigator object where the review "
+"cursor is situated. Pressing twice reports a description or example of that "
+"character. Pressing three times reports the numeric value of the character "
+"in decimal and hexadecimal"
+msgstr "Багыттагычтын объектисинин байкоочу курсорунун астындагы символду окуйт.Эгерде эки жолу басылган болсо символдордун фонетикалык суроттосун окуйт символ менен айтат.Эгерде уч жолу басылса,ондук он алтылык маанисин окуйт "
+
+
+#. Translators: a message reported when review cursor is at the rightmost character of the current navigator object's text.
+msgid "Right"
+msgstr "Он"
+
+#. Translators: Input help mode message for move review cursor to next character command.
+msgid ""
+"Moves the review cursor to the next character of the current navigator "
+"object and speaks it"
+msgstr "Байкоочу курсорду багыттагычынын объектисин кийинки объектине которот жана аны окуйт"
+
+#. Translators: Input help mode message for move review cursor to end of current line command.
+msgid ""
+"Moves the review cursor to the last character of the line where it is "
+"situated in the current navigator object and speaks it"
+msgstr "Байкоочу курсорду багыттагычынын объектисин учурдагы саптын акыркы символуна которот жана аны окуйт"
+
+
+#. Translators: A speech mode which disables speech output.
+msgid "Speech mode off"
+msgstr "Очурулгон"
+
+#. Translators: A speech mode which will cause NVDA to beep instead of speaking.
+msgid "Speech mode beeps"
+msgstr "Сигналдар"
+
+#. Translators: The normal speech mode; i.e. NVDA will talk as normal.
+msgid "Speech mode talk"
+msgstr "Соз"
+
+#. Translators: Input help mode message for toggle speech mode command.
+msgid ""
+"Toggles between the speech modes of off, beep and talk. When set to off NVDA "
+"will not speak anything. If beeps then NVDA will simply beep each time it "
+"its supposed to speak something. If talk then NVDA wil just speak normally."
+msgstr "NVDA ун коштоо тартибин очук, Сигналдар, Соз, арасында озгортот.Очурулгон абалда NVDA эч нерсе окубайт. Сигналдар тартибинде , экранда жаны маалымат пайда болгондо,NVDA жогору сапаттуу дабыштарды чыгарат. Соз тартибинде турган абалда NVDA окуяларды активдуу синтезатор турундо ун коштоп берет "
+
+
+#. Translators: Input help mode message for move to next document with focus command, mostly used in web browsing to move from embedded object to the webpage document.
+msgid "Moves the focus to the next closest document that contains the focus"
+msgstr "Докуменнтар арасындагы фокусту которот"
+
+#. Translators: Input help mode message for toggle focus and browse mode command in web browsing and other situations.
+msgid ""
+"Toggles between browse mode and focus mode. When in focus mode, keys will "
+"pass straight through to the application, allowing you to interact directly "
+"with a control. When in browse mode, you can navigate the document with the "
+"cursor, quick navigation keys, etc."
+msgstr " Байкоо жана Редакциалоо тартиптери арасында которот. Редакциалоо тартибинде баскычтар туздон туз колдонмого берилет, аны менен башкаруунун активдуу элементти менен иш жургуузуго жол берет. Байкоо тартибинде документтин мазмунун курсор, NVDA тез жетуу баскычтары ж.б. аркылуу  корууго болот"
+"
+
+#. Translators: Input help mode message for quit NVDA command.
+msgid "Quits NVDA!"
+msgstr "NVDA жумушун аяктайт!"
+
+#. Translators: Input help mode message for show NVDA menu command.
+msgid "Shows the NVDA menu"
+msgstr "NVDA менюсун чакыртырат"
+
+#. Translators: Input help mode message for say all in review cursor command.
+msgid ""
+"Reads from the review cursor up to end of current text, moving the review "
+"cursor as it goes"
+msgstr "Байкоочу курсордон баштап тексттин аягына чейин окуйт, аны менен бирге байкоочу курсорду текст боюнча жылдырып турат"
+
+
+#. Translators: Input help mode message for say all with system caret command.
+msgid ""
+"Reads from the system caret up to the end of the text, moving the caret as "
+"it goes"
+msgstr "Каретканы текст боюнча жалдыруу менен бирге, системалык кареткадан тексттин аягына чейин окуйт"
+
+#. Translators: Reported when trying to obtain formatting information (such as font name, indentation and so on) but there is no formatting information for the text under cursor.
+msgid "No formatting information"
+msgstr "форматто тууралуу маалымат жок"
+
+#. Translators: title for formatting information dialog.
+msgid "Formatting"
+msgstr "Форматтоо"
+
+#. Translators: Input help mode message for report formatting command.
+msgid ""
+"Reports formatting info for the current review cursor position within a "
+"document. If pressed twice, presents the information in browse mode"
+msgstr "Байкоочу курсордун учурдагы жайгашуусундагы документти форматтоо тууралуу маалымдайт"
+"Эки жолу басканда бул маалыматты байкоо тартибинде тартуулайт"
+
+#. Translators: Input help mode message for report current focus command.
+msgid "Reports the object with focus. If pressed twice, spells the information"
+msgstr "Объектти системалык фокуста окуйт. Эки жолу баскан мезгилде бул маалымат символдор менен окулат"
+
+
+#. Translators: Reported when there is no status line for the current program or window.
+msgid "No status line found"
+msgstr "жайгашуу сабын табууга мумкун болбоду"
+
+#. Translators: Input help mode message for report status line text command.
+msgid ""
+"Reads the current application status bar and moves the navigator to it. If "
+"pressed twice, spells the information"
+msgstr "Учурдагы колдонмонун жайгашуу сабын окуйт жана ал жерге багыттагычты алып келет.Эки жолу баскан учурда бул маалымат символдор менен окулат "
+
+
+#. Translators: presented when the mouse tracking is toggled.
+msgid "Mouse tracking off"
+msgstr "Чычканды андуу очурулгон"
+
+#. Translators: presented when the mouse tracking is toggled.
+msgid "Mouse tracking on"
+msgstr "Чычканды андуу жандырылган"
+
+#. Translators: Input help mode message for toggle mouse tracking command.
+msgid "Toggles the reporting of information as the mouse moves"
+msgstr "Чыкындын корсоткучун жылдырган учурда, маалыматты ун коштоо менен айтууну которот"
+
+#. Translators: Reported when there is no title text for current program or window.
+msgid "No title"
+msgstr "Аталышы жок"
+
+#. Translators: Input help mode message for report title bar command.
+msgid ""
+"Reports the title of the current application or foreground window. If "
+"pressed twice, spells the title. If pressed three times, copies the title to "
+"the clipboard"
+msgstr " Алдынкы пландагы учурдагы колдонмонун же терезенин аталышы тууралуу маалымдайт"
+"Эки жолу басканда аны символдор менен айтат. Уч жолу басканда аталышта алмашуу буферине кочурот"
+
+
+#. Translators: Input help mode message for read foreground object command (usually the foreground window).
+msgid "Speaks the current foreground object"
+msgstr "Алдынкы пландагы объекти окуйт"
+
+#. Translators: Input help mode message for developer info for current navigator object command, used by developers to examine technical info on navigator object. This command also serves as a shortcut to open NVDA log viewer.
+msgid ""
+"Logs information about the current navigator object which is useful to "
+"developers and activates the log viewer so the information can be examined."
+msgstr "Багыттагычтын учурдагы объектиси тууралуу маалыматты журналдын файлына кошот жана журналды байкоочуну аны кароо учун ишке киргизет, ал кийинчерээк ойлоп чыгаруучулар учун пайдалуу болушу мумкун "
+
+
+#. Translators: A mode where no progress bar updates are given.
+msgid "No progress bar updates"
+msgstr "Ун коштобоо"
+
+#. Translators: A mode where progress bar updates will be spoken.
+msgid "Speak progress bar updates"
+msgstr "Айтуу"
+
+#. Translators: A mode where beeps will indicate progress bar updates (beeps rise in pitch as progress bar updates).
+msgid "Beep for progress bar updates"
+msgstr Ун сигналдарды ишке ашыруу"
+
+#. Translators: A mode where both speech and beeps will indicate progress bar updates.
+msgid "Beep and speak progress bar updates"
+msgstr "ун сигналдырды айтуу жана ишке ашыруу"
+
+#. Translators: Input help mode message for toggle progress bar output command.
+msgid ""
+"Toggles between beeps, speech, beeps and speech, and off, for reporting "
+"progress bar updates"
+msgstr "Ишке киргизуу корсоткучтордун жанылануусуна ун коштоону ар кандай ыкмалары арасында которуу  "
+
+
+#. Translators: presented when the present dynamic changes is toggled.
+msgid "report dynamic content changes off"
+msgstr "Динамикалык озгоруулордун мазмунун окуу очурулгон"
+
+#. Translators: presented when the present dynamic changes is toggled.
+msgid "report dynamic content changes on"
+msgstr  "Динамикалык озгоруулордун мазмунун окуу жандылылган"
+
+#. Translators: Input help mode message for toggle dynamic content changes command.
+msgid ""
+"Toggles on and off the reporting of dynamic content changes, such as new "
+"text in dos console windows"
+msgstr " "Динамикалык озгоруулордун мазмунун окуусун очуруп жандырат,мисалы DOS консольдогу жаны тексттерди окуу""
+
+
+#. Translators: presented when toggled.
+msgid "caret moves review cursor off"
+msgstr "Байкоочу курсорду кареткага байлоо очурулгон"
+
+#. Translators: presented when toggled.
+msgid "caret moves review cursor on"
+msgstr  "Байкоочу курсорду кареткага  байлоо жандырылган"
+#. Translators: Input help mode message for toggle caret moves review cursor command.
+msgid ""
+"Toggles on and off the movement of the review cursor due to the caret moving."
+msgstr"кареткой" "Байкоочу курсорду системалык каретканын артынан жылуусун очуруп жандырылган" 
+
+
+#. Translators: presented when toggled.
+msgid "focus moves navigator object off"
+msgstr "Багыттагычты фокуска байлоо очурулгон"
+
+#. Translators: presented when toggled.
+msgid "focus moves navigator object on"
+msgstr "Багыттагычты фокуска байлоо жандырылган"
+
+#. Translators: Input help mode message for toggle focus moves navigator object command.
+msgid ""
+"Toggles on and off the movement of the navigator object due to focus changes"
+msgstr " системалык фокустун артынан багыттагычтын жылуусун очуруп жандырат"
+
+
+#. Translators: This is presented when there is no battery such as desktop computers and laptops with battery pack removed.
+msgid "No system battery"
+msgstr "Системалык баттарея жок"
+
+#. Translators: This is presented to inform the user of the current battery percentage.
+#, python-format
+msgid "%d percent"
+msgstr "%d пайыз"
+
+#. Translators: This is presented when AC power is connected such as when recharging a laptop battery.
+msgid "AC power on"
+msgstr "Электр тармагынан заряд алуу"
+
+#. Translators: This is the estimated remaining runtime of the laptop battery.
+#, python-brace-format
+msgid "{hours:d} hours and {minutes:d} minutes remaining"
+msgstr " {hours:d} саат жана {minutes:d} мунот калды"
+
+#. Translators: Input help mode message for report battery status command.
+msgid "Reports battery status and time remaining if AC is not plugged in"
+msgstr "Электр тармагынан очук учурда,батарея абалын жана заряды бутуу саатын маалымдайт"
+
+
+#. Translators: Spoken to indicate that the next key press will be sent straight to the current program as though NVDA is not running.
+msgid "Pass next key through"
+msgstr "Баскычты калтырып кетуу"
+
+#. Translators: Input help mode message for pass next key through command.
+msgid ""
+"The next key that is pressed will not be handled at all by NVDA, it will be "
+"passed directly through to Windows."
+msgstr ""
+"Следующее нажатие клавиши или комбинации клавиш не будет обрабатываться "
+"NVDA,созсуз Windows откоруп берет"
+
+#. Translators: Indicates the name of the current program (example output: Currently running application is explorer.exe).
+#. Note that it does not give friendly name such as Windows Explorer; it presents the file name of the current application.
+#. If there is an appModule for the current program, NVDA speaks the name of the module after presenting this message.
+#, python-format
+msgid "Currently running application is %s"
+msgstr "%s колдонмо иштеп жатат"
+
+#. Translators: Indicates the name of the appModule for the current program (example output: and currently loaded module is explorer).
+#. For example, the complete message for Windows explorer is: Currently running application is explorer.exe and currently loaded module is explorer.
+#. This message will not be presented if there is no module for the current program.
+#, python-format
+msgid " and currently loaded module is %s"
+msgstr " ал учун %s модулу жуктолгон"
+
+#. Translators: Input help mode message for report current program name and app module name command.
+msgid ""
+"Speaks the filename of the active application along with the name of the "
+"currently loaded appModule"
+msgstr "активдуу колдонмо жана ал учун жуктолгон модулдун аткарылуучу файлынын аталышын маалымдайт"
+
+
+#. Translators: Input help mode message for go to general settings dialog command.
+msgid "Shows the NVDA general settings dialog"
+msgstr "NVDA жалпы ондотмолорун диалогун чакыртырат "
+
+#. Translators: Input help mode message for go to synthesizer dialog command.
+msgid "Shows the NVDA synthesizer dialog"
+msgstr "NVDA иштетилуучу синтезаторунун тандоо диалогун чакыртырат"
+
+#. Translators: Input help mode message for go to voice settings dialog command.
+msgid "Shows the NVDA voice settings dialog"
+msgstr "NVDA иштетилуучу ундун тандоо диалгун чакыртырат"
+
+#. Translators: Input help mode message for go to braille settings dialog command.
+msgid "Shows the NVDA braille settings dialog"
+msgstr "NVDA брайл ондотмолорун диалогун чакыртырат"
+
+#. Translators: Input help mode message for go to keyboard settings dialog command.
+msgid "Shows the NVDA keyboard settings dialog"
+msgstr "NVDA баскычтарынын ондотмо диалогун чакыртырат"
+
+#. Translators: Input help mode message for go to mouse settings dialog command.
+msgid "Shows the NVDA mouse settings dialog"
+msgstr "NVDA чычкандын ондотмо диалогун чакыртат"
+
+#. Translators: Input help mode message for go to review cursor settings dialog command.
+msgid "Shows the NVDA review cursor settings dialog"
+msgstr "NVDA байкоочу курсорун ондотмо диалогун чакыртат"
+
+#. Translators: Input help mode message for go to input composition dialog.
+msgid "Shows the NVDA input composition settings dialog"
+msgstr "NVDA азиялык символдорун киргизууну калыптоо ондотмолорун диалогун чакыртат"
+
+#. Translators: Input help mode message for go to object presentation dialog command.
+msgid "Shows the NVDA object presentation settings dialog"
+msgstr "NVDA объектилерин корсотуу ондомо диалогун чакыртырат"
+
+#. Translators: Input help mode message for go to browse mode dialog command.
+msgid "Shows the NVDA browse mode settings dialog"
+msgstr "NVDA байкоо тартибин ондотмолорун диалогун чакыртырат"
+
+#. Translators: Input help mode message for go to document formatting dialog command.
+msgid "Shows the NVDA document formatting settings dialog"
+msgstr "NVDA документин форматын ун коштоо ондотмолорун диалогун чакыртырат"
+
+#. Translators: Input help mode message for opening default dictionary dialog.
+msgid "Shows the NVDA default dictionary dialog"
+msgstr "NVDA жалпы создугун чакыртырат"
+
+#. Translators: Input help mode message for opening voice-specific dictionary dialog.
+msgid "Shows the NVDA voice-specific dictionary dialog"
+msgstr "NVDA ундуу создугун чакыртырат"
+
+#. Translators: Input help mode message for opening temporary dictionary.
+msgid "Shows the NVDA temporary dictionary dialog"
+msgstr "NVDA убактылуу создугун чакыртат"
+
+#. Translators: Input help mode message for go to punctuation/symbol pronunciation dialog.
+msgid "Shows the NVDA symbol pronunciation dialog"
+msgstr "NVDA символдорун айтылуусун/ пунктуациясын диалогун чакыртат"
+
+#. Translators: Input help mode message for go to input gestures dialog command.
+msgid "Shows the NVDA input gestures dialog"
+msgstr "NVDA колбелгилерди киргизуу диалогун чакыртырат"
+
+#. Translators: Input help mode message for save current configuration command.
+msgid "Saves the current NVDA configuration"
+msgstr "NVDA учурдагы кофигурациясын сактайт"
+
+#. Translators: Input help mode message for apply last saved or default settings command.
+msgid ""
+"Pressing once reverts the current configuration to the most recently saved "
+"state. Pressing three times reverts to factory defaults."
+msgstr "Бир жолку басуу учурдагы конфигурацияны акыркы сакталган абалына кайтарат. Уч жолку басуу баштапкы ондомолоруна кайтарат"
+
+
+#. Translators: Input help mode message for activate python console command.
+msgid "Activates the NVDA Python Console, primarily useful for development"
+msgstr ""
+"Активирует Python консоль NVDA. Эн башкы, ойлоп чыгаруучулар тарабынан иштетилет"
+
+#. Translators: Input help mode message for activate manage add-ons command.
+msgid ""
+"Activates the NVDA Add-ons Manager to install and uninstall add-on packages "
+"for NVDA"
+msgstr "NVDA кошумчалоо менеджерин ишке киргизет"
+
+#. Translators: The message announced when disabling speech viewer.
+msgid "speech viewer disabled"
+msgstr "созду байкагыч очурулгон"
+
+#. Translators: The message announced when enabling speech viewer.
+msgid "speech viewer enabled"
+msgstr "созду байкагыч жандырылган"
+
+#. Translators: Input help mode message for toggle speech viewer command.
+msgid ""
+"Toggles the NVDA Speech viewer, a floating window that allows you to view "
+"all the text that NVDA is currently speaking"
+msgstr "NVDA созду байкагычты очуруп жандырат"
+
+#. Translators: One of the options for tethering braille (see the comment on "braille tethered to" message for more information).
+msgid "review"
+msgstr "байкагыч курсору"
+
+#. Translators: One of the options for tethering braille (see the comment on "braille tethered to" message for more information).
+msgid "focus"
+msgstr "системалык фокус"
+
+#. Translators: Reports which position braille is tethered to (braille can be tethered to either focus or review position).
+#, python-format
+msgid "Braille tethered to %s"
+msgstr "Брайль  %s га байланган"
+
+#. Translators: Input help mode message for toggle braille tether to command (tethered means connected to or follows).
+msgid "Toggle tethering of braille between the focus and the review position"
+msgstr "брайльдин системдик фокус менен байкагыч курсордун арасындагы байланууну которот"
+
+
+#. Translators: The message announced when toggling the braille cursor.
+msgid "Braille cursor off"
+msgstr "брайль курсору очурулгон "
+
+#. Translators: The message announced when toggling the braille cursor.
+msgid "Braille cursor on"
+msgstr "брайль курсору жандырылган"
+
+#. Translators: Input help mode message for toggle braille cursor command.
+msgid "Toggle the braille cursor on and off"
+msgstr "брайль курсорун очуруп жандыруу"
+
+#. Translators: A message reported when changing the braille cursor shape when the braille cursor is turned off.
+msgid "Braille cursor is turned off"
+msgstr "брайль курсору очурулгон"
+
+#. Translators: Reports which braille cursor shape is activated.
+#, python-format
+msgid "Braille cursor %s"
+msgstr "%s брайль курсору"
+
+#. Translators: Input help mode message for cycle braille cursor shape command.
+msgid "Cycle through the braille cursor shapes"
+msgstr "брайль курсорунун калыптарын которот"
+
+#. Translators: Presented when there is no text on the clipboard.
+msgid "There is no text on the clipboard"
+msgstr "алмашуу буферинде текст жок"
+
+#. Translators: If the number of characters on the clipboard is greater than about 1000, it reports this message and gives number of characters on the clipboard.
+#. Example output: The clipboard contains a large portion of text. It is 2300 characters long.
+#, python-format
+msgid ""
+"The clipboard contains a large portion of text. It is %s characters long"
+msgstr "Алмашуу буфери чон коломдогу %s символ тексттин камтыйт"
+
+#. Translators: Input help mode message for report clipboard text command.
+msgid "Reports the text on the Windows clipboard"
+msgstr "буфериндеги текстти окуйт"
+
+#. Translators: Indicates start of review cursor text to be copied to clipboard.
+msgid "Start marked"
+msgstr "Начало фрагменттин башталышы"
+
+#. Translators: Input help mode message for mark review cursor position for a select or copy command (that is, marks the current review cursor position as the starting point for text to be selected).
+msgid ""
+"Marks the current position of the review cursor as the start of text to be "
+"selected or copied"
+msgstr "байкоочу курсордун учурдагы ордун белгилейт тандалуучу же кочурулуучу тексттин фрагменттин башы катары белгилейт  "
+
+
+#. Translators: Presented when attempting to copy some review cursor text but there is no start marker.
+msgid "No start marker set"
+msgstr "фрагменттин башы белгиленген эмес"
+
+#. Translators: Presented when text has already been marked for selection, but not yet copied.
+msgid "Press twice to copy or reset the start marker"
+msgstr "кочуруу учун эки жолу басыныз же фрагменттин башын таштап салыныз "
+
+#. Translators: Presented when there is no text selection to copy from review cursor.
+msgid "No text to copy"
+msgstr "кочуруу учун фрагмент жок"
+
+#. Translators: Presented when unable to select the marked text.
+msgid "Can't select text, press twice to copy"
+msgstr "текстти белгилоого болбойт, кочуруу учун эки жолу басыныз"
+
+#. Translators: Presented when some review text has been copied to clipboard.
+msgid "Review selection copied to clipboard"
+msgstr "тандалган фрагмент алмашуу буферине кочурулду"
+
+#. Translators: Presented when unable to copy to the clipboard because of an error.
+msgid "Unable to copy"
+msgstr "Кочурмо ишке ашпады"
+
+#. Translators: Input help mode message for the select then copy command. The select then copy command first selects the review cursor text, then copies it to the clipboard.
+msgid "If pressed once, the text from the previously set start marker up to and "
+"including the current position of the review cursor is selected. If pressed "
+"twice, the text is copied to the clipboard"
+msgstr "Эгерде бир жолу басылса фрагменттин башынан тандайт, байкоочу курсордун учурдагы ордуна чейин белгилейт. Эгерде эки жолу басылса алмашуу буферине кочурот "
+
+
+#. Translators: Input help mode message for a braille command.
+msgid "Scrolls the braille display back"
+msgstr "брайль сабын артка турот"
+
+#. Translators: Input help mode message for a braille command.
+msgid "Scrolls the braille display forward"
+msgstr "брайль сабын алдыга турот"
+
+#. Translators: Input help mode message for a braille command.
+msgid "Routes the cursor to or activates the object under this braille cell"
+msgstr "Багыттагычты которот же объекти брайль мамычасын астында ишке ктргизет"
+
+#. Translators: Input help mode message for a braille command.
+msgid "Moves the braille display to the previous line"
+msgstr "Брайль чагылтуусун мурунку сапка которот"
+
+#. Translators: Input help mode message for a braille command.
+msgid "Moves the braille display to the next line"
+msgstr "Брайль чагылуусун мурунку сапка которот"
+
+#. Translators: Input help mode message for a braille command.
+msgid "Inputs braille dots via the braille keyboard"
+msgstr "Брайль шрифти менен брайль баскычын басып жатат"
+
+#. Translators: Input help mode message for a braille command.
+msgid "Moves the braille display to the current focus"
+msgstr "брайльды учурдагы фокуска которот"
+
+#. Translators: Presented when plugins (app modules and global plugins) are reloaded.
+msgid "Plugins reloaded"
+msgstr "Плагин коп жуктолгон"
+
+#. Translators: Input help mode message for reload plugins command.
+msgid ""
+"Reloads app modules and global plugins without restarting NVDA, which can be "
+"Useful for developers"
+msgstr "колдонмолордун модулун жана глобалдык плагндареди NVDA жуктоосуз кайра жуктойт.ойлоп чыгаруучулар учун абдан ынгайлуу"
+
+#. Translators: Input help mode message for a touchscreen gesture.
+msgid ""
+"Moves to the next object in a flattened view of the object navigation "
+"hierarchy"
+msgstr "иерархиянын кийинки объектине отот объектуу навигациянын экранды байкоо тартибинде которот"
+
+#. Translators: Input help mode message for a touchscreen gesture.
+msgid ""
+"Moves to the previous object in a flattened view of the object navigation "
+"hierarchy"
+msgstr "иерархиянын мурунку объектине отот объектуу навигациянын экранды байкоо тартибинде которот"
+
+
+#. Translators: Cycles through available touch modes (a group of related touch gestures; example output: "object mode"; see the user guide for more information on touch modes).
+#, python-format
+msgid "%s mode"
+msgstr "%s тартиби"
+
+#. Translators: Input help mode message for a touchscreen gesture.
+msgid "Cycles between available touch modes"
+msgstr "Жеткиликтуу сесордук тартибтер арасында которуу жургузот"
+
+#. Translators: Input help mode message for a touchscreen gesture.
+msgid "Reports the object and content directly under your finger"
+msgstr "Объект жана мазмунду манжа астында маалыматтайт"
+
+#. Translators: Input help mode message for a touchscreen gesture.
+msgid ""
+"Reports the new object or content under your finger if different to where "
+"your finger was last"
+msgstr "Манжаныз астындагы же жаны объект тууралуу мааламаттайт эгерде бири бирнен айырмаланса, манжыныз акыркы жолу кайсыл жерде болгонун маалымдайт"
+
+#. Translators: Describes the command to open the Configuration Profiles dialog.
+msgid "Shows the NVDA Configuration Profiles dialog"
+msgstr "NVDA конфигурациясынын профиль диалогторун чакыртырат"
+
+#. Translators: Reported when the user attempts math interaction
+#. with something that isn't math.
+msgid "Not math"
+msgstr "Математиалык туюнтма жок"
+
+#. Translators: Describes a command.
+msgid "Begins interaction with math content"
+msgstr "Математикалык туюнтма менен оз ара аркеттешууну баштайт"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Emulated system keyboard keys"
+msgstr "системалык баскычтын эмуляцияланган баскычтары"
+
+#. Translators: The name of a category of NVDA commands.
+msgid "Miscellaneous"
+msgstr "Башкалар"
+
+#. Translators: The shortcut key used to start NVDA.
+#. This should normally be left as is, but might be changed for some locales
+#. if the default key causes problems for the normal locale keyboard layout.
+#. The key must be formatted as described in this article:
+#. http://msdn.microsoft.com/en-us/library/3zb1shc6%28v=vs.84%29.aspx
+msgid "CTRL+ALT+N"
+msgstr "CTRL+ALT+N"
+
+#. Translators: A label for a shortcut in start menu and a menu entry in NVDA menu (to go to NVDA website).
+msgid "NVDA web site"
+msgstr "NVDA Web-сайты"
+
+#. Translators: A label for a shortcut item in start menu to uninstall NVDA from the computer.
+msgid "Uninstall NVDA"
+msgstr "NVDAны очуруу"
+
+#. Translators: A label for a shortcut item in start menu to open current user's NVDA configuration directory.
+msgid "Explore NVDA user configuration directory"
+msgstr "Просмотреть папку пользовательских настроек NVDA"
+
+#. Translators: The label of the NVDA Documentation menu in the Start Menu.
+msgid "Documentation"
+msgstr "Документация"
+
+#. Translators: The label of the Start Menu item to open the Commands Quick Reference document.
+msgid "Commands Quick Reference"
+msgstr "Буйруктардын кыскача маалымдамасы"
+
+#. Translators: A label for a shortcut in start menu to open NVDA user guide.
+msgid "User Guide"
+msgstr "Колдонуучулардын колдонмосу"
+
+#. Translators: A file extension label for NVDA add-on package.
+msgid "NVDA add-on package"
+msgstr "NVDA кошумчалоо файлы"
+
+#. Translators: This is the name of the back key found on multimedia keyboards for controlling the web-browser.
+msgid "back"
+msgstr "Артка"
+
+#. Translators: This is the name of the forward key found on multimedia keyboards for controlling the web-browser.
+msgid "forward"
+msgstr "Алдыга"
+
+#. Translators: This is the name of the refresh key found on multimedia keyboards for controlling the web-browser.
+msgid "refresh"
+msgstr "Жанылоо"
+
+#. Translators: This is the name of the stop key found on multimedia keyboards for controlling the web-browser.
+msgid "browser stop"
+msgstr "браузерди токтотуу"
+
+#. Translators: This is the name of the back key found on multimedia keyboards to goto the search page of the web-browser.
+msgid "search page"
+msgstr "Бетти Издөө"
+
+#. Translators: This is the name of the favorites key found on multimedia keyboards to open favorites in the web-browser.
+msgid "favorites"
+msgstr "Тандалма"
+
+#. Translators: This is the name of the home key found on multimedia keyboards to goto the home page in the web-browser.
+msgid "home page"
+msgstr "Уй бетти"
+
+#. Translators: This is the name of the mute key found on multimedia keyboards to control playback volume.
+msgid "mute"
+msgstr "Выключить звук"
+
+#. Translators: This is the name of the volume down key found on multimedia keyboards to reduce playback volume.
+msgid "volume down"
+msgstr "ун бийиктигин азайтуу"
+
+#. Translators: This is the name of the volume up key found on multimedia keyboards to increase playback volume.
+msgid "volume up"
+msgstr "Ун бийиктигин жогорулатуу"
+
+#. Translators: This is the name of the next track key found on multimedia keyboards to skip to next track in the mediaplayer.
+msgid "next track"
+msgstr "Кийинки жолчо"
+
+#. Translators: This is the name of the next track key found on multimedia keyboards to skip to next track in the mediaplayer.
+msgid "previous track"
+msgstr "Мурунку жолчо"
+
+#. Translators: This is the name of the stop key found on multimedia keyboards to stop the current playing track in the mediaplayer.
+msgid "stop"
+msgstr "Токто"
+
+#. Translators: This is the name of the play/pause key found on multimedia keyboards to play/pause the current playing track in the mediaplayer.
+msgid "play pause"
+msgstr "Ойнотуу/ тыныгуу"
+
+#. Translators: This is the name of the launch email key found on multimedia keyboards to open an email client.
+msgid "email"
+msgstr "Почта"
+
+#. Translators: This is the name of the launch mediaplayer key found on multimedia keyboards to launch the mediaplayer.
+msgid "media player"
+msgstr "Музыкальный проигрыватель"
+
+#. Translators: This is the name of the launch custom application 1 key found on multimedia keyboards to launch a user-defined application.
+msgid "custom application 1"
+msgstr "Биринчи колдонуучу учун колдонмо"
+
+#. Translators: This is the name of the launch custom application 2 key found on multimedia keyboards to launch a user-defined application.
+msgid "custom application 2"
+msgstr "Экинчи колдонуучу колдонмо"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "backspace"
+msgstr "кери журум клавишасы"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "caps lock"
+msgstr "caps lock"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "ctrl"
+msgstr "ctrl"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "alt"
+msgstr "alt"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "shift"
+msgstr "shift"
+
+# An open-source (and free) Screen Reader for the Windows Operating System
+# Created by Michael Curran, with help from James Teh and others
+# Copyright (C) 2006-2007 Michael Curran <mick@kulgan.net>
+#. Translators: This is the name of a key on the keyboard.
+msgid "windows"
+msgstr "windows"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "enter"
+msgstr "enter"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad enter"
+msgstr "enter сандык баскычка"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "escape"
+msgstr "escape"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "page up"
+msgstr "page up"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "page down"
+msgstr "page down"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "end"
+msgstr "end"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "home"
+msgstr "home"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "delete"
+msgstr "delete"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad delete"
+msgstr "delete сандык баскычтар блогунда"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "left arrow"
+msgstr "сол жебе"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "right arrow"
+msgstr "он жебе"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "up arrow"
+msgstr "жогору жебе"
+
+# An open-source (and free) Screen Reader for the Windows Operating System
+# Created by Michael Curran, with help from James Teh and others
+# Copyright (C) 2006-2007 Michael Curran <mick@kulgan.net>
+#. Translators: This is the name of a key on the keyboard.
+msgid "down arrow"
+msgstr "астынкы жебе"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "applications"
+msgstr "колдонмолор"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "num lock"
+msgstr "num lock"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "print screen"
+msgstr "экранды басуу"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "scroll lock"
+msgstr "scroll lock"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 4"
+msgstr " сандык блоктогу 4"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 6"
+msgstr" сандык блоктогу 6"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 8"
+msgstr " сандык блоктогу 8"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 2"
+msgstr " сандык блоктогу 2"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 9"
+msgstr " сандык блоктогу 9"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 3"
+msgstr " сандык блоктогу 3"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 1"
+msgstr " сандык блоктогу 1"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 7"
+msgstr " сандык блоктогу 7"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad 5"
+msgstr " сандык блоктогу 5"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad divide"
+msgstr "санариптик блоктогу кыйшык сызгыч"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad multiply"
+msgstr "санариптик блок"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad minus"
+msgstr "санариптик блокто кемиттуу"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad plus"
+msgstr "санариптик блоктогу плюс"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad decimal"
+msgstr "ондук белгиленгич "
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numpad insert"
+msgstr "блоке санариптик блокко киргизуу ганарарын кылабыз"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 0"
+msgstr "0"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 1"
+msgstr "1"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 2"
+msgstr "2"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 3"
+msgstr "3"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 4"
+msgstr "4"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 5"
+msgstr "5"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 6"
+msgstr "6"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 7"
+msgstr "7"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 8"
+msgstr "8"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "numLock numpad 9"
+msgstr "9"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "insert"
+msgstr "киргизуу"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "сол control"
+msgstr "левый control"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "он control"
+msgstr "он control"
+
+# An open-source (and free) Screen Reader for the Windows Operating System
+# Created by Michael Curran, with help from James Teh and others
+# Copyright (C) 2006-2007 Michael Curran <mick@kulgan.net>
+#. Translators: This is the name of a key on the keyboard.
+msgid "left windows"
+msgstr "сол windows"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "сол shift"
+msgstr "сол shift"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "right shift"
+msgstr " он shift"
+#. Translators: This is the name of a key on the keyboard.
+msgid "left alt"
+msgstr "сол alt"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "right alt"
+msgstr "он alt"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "right windows"
+msgstr "биринчи windows"
+
+#. Translators: This is the name of a key on the keyboard.
+msgid "break"
+msgstr "break"
+
+#. Translators: This is the name of a key on the keyboard.
+msgctxt "keyLabel"
+msgid "tab"
+msgstr "tab"
+
+#. Translators: One of the keyboard layouts for NVDA.
+msgid "desktop"
+msgstr "устолдун устундогу"
+
+#. Translators: One of the keyboard layouts for NVDA.
+msgid "laptop"
+msgstr "ноутбук"
+
+msgid "on"
+msgstr "жандырылган"
+
+#. Translators: An option for progress bar output in the Object Presentation dialog
+#. which disables reporting of progress bars.
+#. See Progress bar output in the Object Presentation Settings section of the User Guide.
+msgid "off"
+msgstr "очурулгон"
+
+#. Translators: Used when describing keys on the system keyboard with a particular layout.
+#. %s is replaced with the layout name.
+#. For example, in English, this might produce "laptop keyboard".
+#, python-format
+msgid "%s keyboard"
+msgstr "%sбаскычтоп"
+
+#. Translators: Used when describing keys on the system keyboard applying to all layouts.
+msgid "keyboard, all layouts"
+msgstr "баскычтоп, баардык орундаштыруулар"
+
+#. Translators: The name of a language supported by NVDA.
+msgctxt "languageName"
+msgid "Amharic"
+msgstr "Амхар"
+
+#. Translators: The name of a language supported by NVDA.
+msgctxt "languageName"
+msgid "Aragonese"
+msgstr "Арагон"
+
+#. Translators: The name of a language supported by NVDA.
+msgctxt "languageName"
+msgid "Arabic"
+msgstr "Араб"
+
+#. Translators: The name of a language supported by NVDA.
+msgctxt "languageName"
+msgid "Nepali"
+msgstr "Непалдык"
+
+#. Translators: The name of a language supported by NVDA.
+msgctxt "languageName"
+msgid "Serbian (Latin)"
+msgstr "Сербдик (Латинский)"
+
+#. Translators: the label for the Windows default NVDA interface language.
+msgid "User default"
+msgstr "өзү аныкталма маани"
+
+#. Translators: Reported when mouse cursor shape changes (example output: edit cursor).
+#, python-format
+msgid "%s cursor"
+msgstr "%s курсор"
+
+#. Translators: The description of the NVDA service.
+msgid ""
+"Allows NVDA to run on the Windows Logon screen, UAC screen and other secure "
+"screens."
+msgstr ""
+" NVDA Windows экранына кируудо иштоого руксат берет , козомол зкранында "
+"каттоо эсеби жана башка коргонулган экрандарда."
+
+msgid "Type help(object) to get help about object."
+msgstr " объект боюнча маалымат алуу учун help(object)ти   басыныз "
+
+msgid "Type exit() to exit the console"
+msgstr " консолиден чыгуу учун exit()ти басыныз"
+
+msgid "NVDA Python Console"
+msgstr "NVDA Консоль Python"
+
+#. Translators: One of the review modes.
+msgid "Object review"
+msgstr "Объект"
+
+#. Translators: One of the review modes.
+msgid "Document review"
+msgstr "иш кагаз"
+
+#. Translators: One of the review modes.
+msgid "Screen review"
+msgstr "Экран"
+
+#, python-format
+msgid "Emulates pressing %s on the system keyboard"
+msgstr "клавиатурада   %s басуусун  Эмулирует "
+
+#. Translators: This is spoken when NVDA moves to an empty line.
+#. Translators: This is spoken when the line is considered blank.
+msgid "blank"
+msgstr "бош"
+
+#. Translators: cap will be spoken before the given letter when it is capitalized.
+#, python-format
+msgid "cap %s"
+msgstr "чон %s"
+
+#. Translators: This is spoken when the given line has no indentation.
+msgid "no indent"
+msgstr "кемтик жок"
+
+#. Translators: This is spoken when the user has selected a large portion of text. Example output "1000 characters"
+#, python-format
+msgid "%d characters"
+msgstr "%d белги"
+
+#. Translators: This is spoken while the user is in the process of selecting something, For example: "hello selected"
+#, python-format
+msgid "%s selected"
+msgstr "%s белгиленген"
+
+#. Translators: This is spoken to indicate what has been unselected. for example 'hello unselected'
+#, python-format
+msgid "%s unselected"
+msgstr "%s белгиленген эмес"
+
+#. Translators: This is spoken to indicate when the previous selection was removed and a new selection was made. for example 'hello world selected instead'
+#, python-format
+msgid "%s selected instead"
+msgstr "%s ордуна белгиленген"
+
+#. Translators: Reported when selection is removed.
+msgid "selection removed"
+msgstr "болуп корсотуу очурулгон"
+
+#. Translators: Reported when drag and drop is finished.
+#. This is only reported for objects which support accessible drag and drop.
+msgid "done dragging"
+msgstr " жылдыруу бутту"
+
+#. Translators: Speaks current row number (example output: row 3).
+#, python-format
+msgid "row %s"
+msgstr "Сап %s"
+
+#. Translators: Speaks current column number (example output: column 3).
+#, python-format
+msgid "column %s"
+msgstr "тилке %s"
+
+#. Translators: Speaks number of columns and rows in a table (example output: with 3 rows and 2 columns).
+#, python-brace-format
+msgid "with {rowCount} rows and {columnCount} columns"
+msgstr "Из {rowCount} саптар жана {columnCount} тилкелер"
+
+#. Translators: Speaks number of columns (example output: with 4 columns).
+#, python-format
+msgid "with %s columns"
+msgstr " %s тилкелерден"
+
+#. Translators: Speaks number of rows (example output: with 2 rows).
+#, python-format
+msgid "with %s rows"
+msgstr " %s саптардан "
+
+#. Translators: Speaks the item level in treeviews (example output: level 2).
+#, python-format
+msgid "level %s"
+msgstr " %sденгээли"
+
+#. Translators: Speaks number of items in a list (example output: list with 5 items).
+#, python-format
+msgid "with %s items"
+msgstr " %s элементтерден"
+
+#. Translators: Indicates end of something (example output: at the end of a list, speaks out of list).
+#, python-format
+msgid "out of %s"
+msgstr " %s сырткары"
+
+#. Translators: Indicates the page number in a document.
+#. %s will be replaced with the page number.
+#, python-format
+msgid "page %s"
+msgstr " %s бети"
+
+#. Translators: Speaks the heading level (example output: heading level 2).
+#, python-format
+msgid "heading level %d"
+msgstr " денгээлдин баш аты %d"
+
+#. Translators: Indicates the style of text.
+#. A style is a collection of formatting settings and depends on the application.
+#. %s will be replaced with the name of the style.
+#, python-format
+msgid "style %s"
+msgstr "Стиль %s"
+
+#. Translators: Indicates that text has reverted to the default style.
+#. A style is a collection of formatting settings and depends on the application.
+msgid "default style"
+msgstr "озу аныкталма стиль "
+
+#. Translators: Reported when there are two background colors.
+#. This occurs when, for example, a gradient pattern is applied to a spreadsheet cell.
+#. {color1} will be replaced with the first background color.
+#. {color2} will be replaced with the second background color.
+#, python-brace-format
+msgid "{color1} to {color2}"
+msgstr "{color1}  {color2} га"
+
+#. Translators: Reported when both the text and background colors change.
+#. {color} will be replaced with the text color.
+#. {backgroundColor} will be replaced with the background color.
+#, python-brace-format
+msgid "{color} on {backgroundColor}"
+msgstr "{color}  {backgroundColor}га"
+
+#. Translators: Reported when the text color changes (but not the background color).
+#. {color} will be replaced with the text color.
+#, python-brace-format
+msgid "{color}"
+msgstr "{color}"
+
+#. Translators: Reported when the background color changes (but not the text color).
+#. {backgroundColor} will be replaced with the background color.
+#, python-brace-format
+msgid "{backgroundColor} background"
+msgstr "фондун тусу {backgroundColor}"
+
+#, python-brace-format
+msgid "background pattern {pattern}"
+msgstr "бедер {pattern}"
+
+#. Translators: Indicates the line number of the text.
+#. %s will be replaced with the line number.
+#, python-format
+msgid "line %s"
+msgstr "Сап %s"
+
+#. Translators: Reported when text is marked as having been inserted
+msgid "inserted"
+msgstr "коюлган"
+
+#. Translators: Reported when text is no longer marked as having been inserted.
+msgid "not inserted"
+msgstr "коюлбаган"
+
+#. Translators: Reported when text is marked as having been deleted
+msgid "deleted"
+msgstr "очурулгон"
+
+#. Translators: Reported when text is no longer marked as having been  deleted.
+msgid "not deleted"
+msgstr "очурулбогон"
+
+#. Translators: Reported when text is revised.
+#, python-format
+msgid "revised %s"
+msgstr "ондолгон %s"
+
+#. Translators: Reported when text is not revised.
+#, python-format
+msgid "no revised %s"
+msgstr "ондоолор жок %s"
+
+#. Translators: Reported when text is marked
+msgid "marked"
+msgstr "белгиленген"
+
+#. Translators: Reported when text is no longer marked
+msgid "not marked"
+msgstr "белгиленбеген"
+
+#. Translators: Reported when text is marked as strong (e.g. bold)
+msgid "strong"
+msgstr "коп басым жасалган"
+
+#. Translators: Reported when text is no longer marked as strong (e.g. bold)
+msgid "not strong"
+msgstr "коп басым жасалбаган"
+
+#. Translators: Reported when text is marked as emphasised
+msgid "emphasised"
+msgstr "басым жасалган"
+
+#. Translators: Reported when text is no longer marked as emphasised
+msgid "not emphasised"
+msgstr "басым жасалбаган"
+
+#. Translators: Reported when text is not bolded.
+msgid "no bold"
+msgstr "кара шрифт жок"
+
+#. Translators: Reported when text is italicized.
+msgid "italic"
+msgstr "Курсив"
+
+#. Translators: Reported when text is not italicized.
+msgid "no italic"
+msgstr " курсив жок"
+
+#. Translators: Reported when text is formatted with double strikethrough.
+#. See http://en.wikipedia.org/wiki/Strikethrough
+msgid "double strikethrough"
+msgstr "кош сызып очуруу"
+
+#. Translators: Reported when text is formatted with strikethrough.
+#. See http://en.wikipedia.org/wiki/Strikethrough
+msgid "strikethrough"
+msgstr "сызып очурулгон"
+
+#. Translators: Reported when text is formatted without strikethrough.
+#. See http://en.wikipedia.org/wiki/Strikethrough
+msgid "no strikethrough"
+msgstr "сызыпи очурулгон жок"
+
+#. Translators: Reported when text is underlined.
+msgid "underlined"
+msgstr "асты сызылган"
+
+#. Translators: Reported when text is not underlined.
+msgid "not underlined"
+msgstr "асты сызылган эмес"
+
+#. Translators: Reported for text which is at the baseline position;
+#. i.e. not superscript or subscript.
+msgid "baseline"
+msgstr "таяныч сызык боюнча"
+
+#. Translators: Reported when text is left-aligned.
+msgid "align left"
+msgstr "сол кыр боюнча тегиздоо"
+
+#. Translators: Reported when text is centered.
+msgid "align center"
+msgstr "борбор боюнча тегиздоо"
+
+#. Translators: Reported when text is right-aligned.
+msgid "align right"
+msgstr "он кыр боюнча тегиздоо"
+
+#. Translators: Reported when text is justified.
+#. See http://en.wikipedia.org/wiki/Typographic_alignment#Justified
+msgid "align justify"
+msgstr "эни боюнча тегиздоо"
+
+#. Translators: Reported when text is justified with character spacing (Japanese etc)
+#. See http://kohei.us/2010/01/21/distributed-text-justification/
+msgid "align distributed"
+msgstr "тегиздоо болуштурулду"
+
+#. Translators: Reported when text has reverted to default alignment.
+msgid "align default"
+msgstr "озу аныкталма боюнча тегиздоо"
+
+#. Translators: the label for paragraph format left indent
+msgid "left indent"
+msgstr "сол тараптан кемтик"
+
+#. Translators: the message when there is no paragraph format left indent
+msgid "no left indent"
+msgstr "сол тараптан кемтик жок"
+
+#. Translators: the label for paragraph format right indent
+msgid "right indent"
+msgstr "он тараптан кемтик"
+
+#. Translators: the message when there is no paragraph format right indent
+msgid "no right indent"
+msgstr "он тараптан кемтик жок"
+
+#. Translators: the label for paragraph format hanging indent
+msgid "hanging indent"
+msgstr "асма кемтик"
+
+#. Translators: the message when there is no paragraph format hanging indent
+msgid "no hanging indent"
+msgstr "асма кемтик жок"
+
+#. Translators: the label for paragraph format first line indent
+msgid "first line indent"
+msgstr "биринчи саптын кемтиги"
+
+#. Translators: the message when there is no paragraph format first line indent
+msgid "no first line indent"
+msgstr "биринчи саптын кемтиги жок"
+
+#. Translators: Reported when text is vertically top-aligned.
+msgid "vertical align top"
+msgstr "устунку кыр боюнча тигинен тегиздоо"
+
+#. Translators: Reported when text is vertically middle aligned.
+msgid "vertical align middle"
+msgstr "борбор боюнча тигинен тегиздоо"
+
+#. Translators: Reported when text is vertically bottom-aligned.
+msgid "vertical align bottom"
+msgstr "ылдыйкы кыр боюнча тигинен тегиздоо"
+
+#. Translators: Reported when text is vertically aligned on the baseline.
+msgid "vertical align baseline"
+msgstr "башкы сызык боюнча тигинен тегиздоо"
+
+#. Translators: Reported when text is vertically justified.
+msgid "vertical align justified"
+msgstr "тигинен  тегиздоо белгиленди"
+
+#. Translators: Reported when text is vertically justified but with character spacing (For some Asian content).
+msgid "vertical align distributed"
+msgstr "тигинен тегиздоо болуштурулду"
+
+#. Translators: Reported when text has reverted to default vertical alignment.
+msgid "vertical align default"
+msgstr "озу аныкталма тигинен тегиздоо"
+
+#. Translators: a type of line spacing (E.g. single line spacing)
+#, python-format
+msgid "line spacing %s"
+msgstr "сап аралык интервал %s"
+
+#. Translators: Reported when text no longer contains a comment.
+msgid "out of comment"
+msgstr "эскертуудон сырткары"
+
+#. Translators: Reported when text contains a spelling error.
+msgid "spelling error"
+msgstr "орфографиялык ката"
+
+#. Translators: Reported when moving out of text containing a spelling error.
+msgid "out of spelling error"
+msgstr "орфографиялык катадан сырткары"
+
+#. Translators: Indicates end of a table.
+msgid "out of table"
+msgstr "таблицадан сырткары"
+
+#. Translators: reports number of columns and rows in a table (example output: table with 3 columns and 5 rows).
+#, python-brace-format
+msgid "table with {columnCount} columns and {rowCount} rows"
+msgstr " {columnCount} тилкеден жана {rowCount} саптан таблица"
+
+msgid "NVDA Speech Viewer"
+msgstr "созду крап чыгуу NVDA"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "&Language"
+msgstr "&тил"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Language"
+msgstr "тил"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "&Voice"
+msgstr "&"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Voice"
+msgstr "ун"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "V&ariant"
+msgstr "В&ариант"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Variant"
+msgstr "Вариант"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "&Rate"
+msgstr "& ылдамдык"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Rate"
+msgstr "ылдамдык"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "V&olume"
+msgstr "ун бийиктиги"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Volume"
+msgstr "ун бийиктиги"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "&Pitch"
+msgstr "&Бийиктик"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Pitch"
+msgstr "бийиктик"
+
+#. Translators: Label for a setting in voice settings dialog.
+msgid "&Inflection"
+msgstr "&Интонация"
+
+#. Translators: Label for a setting in synth settings ring.
+msgctxt "synth setting"
+msgid "Inflection"
+msgstr "Интонация"
+
+msgid "text mode"
+msgstr "тексттик режим"
+
+msgid "object mode"
+msgstr "объекттик режим"
+
+#. Translators: a touch screen action performed once
+#, python-brace-format
+msgid "single {action}"
+msgstr "бир гана  жолу {action}"
+
+#. Translators: a touch screen action performed twice
+#, python-brace-format
+msgid "double {action}"
+msgstr "эки жолу {action}"
+
+#. Translators: a touch screen action performed 3 times
+#, python-brace-format
+msgid "tripple {action}"
+msgstr "уч жолу {action}"
+
+#. Translators: a touch screen action performed 4 times
+#, python-brace-format
+msgid "quadruple {action}"
+msgstr "торт жолу {action}"
+
+#. Translators: a touch screen action using multiple fingers
+#, python-brace-format
+msgid "{numFingers} finger {action}"
+msgstr "{action} {numFingers} манжалар менен"
+
+#. Translators: a very quick touch and release of a finger on a touch screen
+msgctxt "touch action"
+msgid "tap"
+msgstr "тийуу"
+
+#. Translators: a very quick touch and release, then another touch with no release, on a touch screen
+msgctxt "touch action"
+msgid "tap and hold"
+msgstr "тийуу жана кармап туруу"
+
+#. Translators: a touch with no release, on a touch screen.
+msgctxt "touch action"
+msgid "hold"
+msgstr "кармап туруу"
+
+#. Translators: a quick swipe of a finger in an up direction, on a touch screen.
+msgctxt "touch action"
+msgid "flick up"
+msgstr "ойдого барактоо"
+
+#. Translators: a quick swipe of a finger in an down direction, on a touch screen.
+msgctxt "touch action"
+msgid "flick down"
+msgstr "ылдыйга барактоо"
+
+#. Translators: a quick swipe of a finger in a left direction, on a touch screen.
+msgctxt "touch action"
+msgid "flick left"
+msgstr "солго барактоо"
+
+#. Translators: a quick swipe of a finger in a right direction, on a touch screen.
+msgctxt "touch action"
+msgid "flick right"
+msgstr "онго барактоо"
+
+#. Translators:  a finger has been held on the touch screen long enough to be considered as hovering
+msgctxt "touch action"
+msgid "hover down"
+msgstr "ылдыйга жылуу"
+
+#. Translators: A finger is still touching the touch screen and is moving around with out breaking contact.
+msgctxt "touch action"
+msgid "hover"
+msgstr "жылуу"
+
+#. Translators: a finger that was hovering (touching the touch screen for a long time) has been released
+msgctxt "touch action"
+msgid "hover up"
+msgstr "ойдого жылуу"
+
+#. Translators: The title for the dialog used to present general NVDA messages in browse mode.
+msgid "NVDA Message"
+msgstr "Билдируу NVDA"
+
+#. Translators: The title of the dialog displayed while manually checking for an NVDA update.
+msgid "Checking for Update"
+msgstr "жаныланууну текшеруу"
+
+#. Translators: The progress message displayed while manually checking for an NVDA update.
+msgid "Checking for update"
+msgstr "жаныланууну текшерилет"
+
+#. Translators: A message indicating that an error occurred while checking for an update to NVDA.
+msgid "Error checking for update."
+msgstr "жаныланууну текшеруудогу ката."
+
+#. Translators: The title of an error message dialog.
+#. Translators: The title of a dialog presented when an error occurs.
+#. Translators: The title of the message box
+msgid "Error"
+msgstr "ката"
+
+#. Translators: The title of the dialog informing the user about an NVDA update.
+msgid "NVDA Update"
+msgstr "жанылануу NVDA"
+
+#. Translators: A message indicating that an updated version of NVDA is available.
+#. {version} will be replaced with the version; e.g. 2011.3.
+#, python-brace-format
+msgid "NVDA version {version} is available."
+msgstr "жеткиликтуу NVDA {version}."
+
+#. Translators: A message indicating that no update to NVDA is available.
+msgid "No update available."
+msgstr "жеткиликтуу жанылануу жок"
+
+#. Translators: The label of a button to download and install an NVDA update.
+msgid "Download and &install update"
+msgstr "жанылынууну жуктоо жана орнотуу"
+
+#. Translators: The label of a button to download an NVDA update.
+msgid "&Download update"
+msgstr "&жаныланууну жуктоо"
+
+#. Translators: The label of a button to remind the user later about performing some action.
+msgid "Remind me &later"
+msgstr "эскертуу &кечирээк"
+
+#. Translators: The label of a button to close a dialog.
+#. Translators: The label of a button to close the Addons dialog.
+#. Translators: The label of a button to close a dialog.
+msgid "&Close"
+msgstr "&жабуу"
+
+#. Translators: The title of the dialog displayed while downloading an NVDA update.
+msgid "Downloading Update"
+msgstr "жаныланууну жуктоо"
+
+#. Translators: The progress message indicating that a connection is being established.
+msgid "Connecting"
+msgstr "Байланыш"
+
+#. Translators: The progress message indicating that a download is in progress.
+msgid "Downloading"
+msgstr "Жуктоо"
+
+#. Translators: A message indicating that an error occurred while downloading an update to NVDA.
+msgid "Error downloading update."
+msgstr "Жаныланууну жуктоодогу ката."
+
+#. Translators: The message presented when the update has been successfully downloaded
+#. and is about to be installed.
+msgid "Update downloaded. It will now be installed."
+msgstr "Жанылануу жуктолду жана азыр орнотулат."
+
+#. Translators: The title of the dialog displayed when the update is about to be installed.
+msgid "Install Update"
+msgstr "Жаныланууну орнотуу"
+
+msgid ""
+"We need your help in order to continue to improve NVDA.\n"
+"This project relies primarily on donations and grants. By donating, you are "
+"helping to fund full time development.\n"
+"If even $10 is donated for every download, we will be able to cover all of "
+"the ongoing costs of the project.\n"
+"All donations are received by NV Access, the non-profit organisation which "
+"develops NVDA.\n"
+"Thank you for your support."
+msgstr ""
+" Биз NVDA ны жакшыртууну улантууда сиздин жардамынызга муктажбыз.\n"
+"Бул проект курмандык кылуулардан жана гранттан коз каранды, акчаны кайыр кылып беруу менен сиз толук баалуу иштелуусун колдойсуз..\n"
+"Эгерде адамдар ар бир сатып алууда жок дегенде 10$ кайыр квлвп берсе, бул проекти иштеп чыгууга кеткен чыгымды актоого жетмек. .\n"
+"БУТ КАЙЫР БЕРУУЛОРДУ NV AccessТ КОМПАНИЯСЫ АЛАТ, комерциялык эмес компания, "
+" NVDAиштеп чыгуу менен алектенген компания.\n"
+"Колдоонуз учун рахмат."
+"Спасибо вам за поддержку."
+
+
+#. Translators: The title of the dialog requesting donations from users.
+msgid "Please Donate"
+msgstr "Сураныч , проектке жардам бериниз"
+
+#. Translators: The label of the button to donate
+#. in the "Please Donate" dialog.
+msgid "&Donate"
+msgstr "&тартуу кылуу"
+
+#. Translators: The label of the button to decline donation
+#. in the "Please Donate" dialog.
+msgid "&Not now"
+msgstr "&азыр эмес"
+
+#. Translators: The label of a button to indicate that the user is finished donating
+#. in the "Please Donate" dialog.
+msgid "&Done"
+msgstr "&тартуу кылынды"
+
+msgid "NonVisual Desktop Access"
+msgstr "NonVisual Desktop Access"
+
+msgid "A free and open source screen reader for Microsoft Windows"
+msgstr ""
+"  Microsoft Windowsго ачык баштапкы сырдык соз менен экранга  кирууго мумкундук берген Эркин программа "
+""
+
+#, python-brace-format
+msgid "Copyright (C) {years} NVDA Contributors"
+msgstr "Автордук укук(C) {years} NVDA contributors"
+
+#, python-brace-format
+msgid ""
+"{longName} ({name})\n"
+"Version: {version}\n"
+"URL: {url}\n"
+"{copyright}\n"
+"\n"
+"{name} is covered by the GNU General Public License (Version 2). You are "
+"free to share or change this software in any way you like as long as it is "
+"accompanied by the license and you make all source code available to anyone "
+"who wants it. This applies to both original and modified copies of this "
+"software, plus any derivative works.\n"
+"For further details, you can view the license from the Help menu.\n"
+"It can also be viewed online at: http://www.gnu.org/licenses/old-licenses/"
+"gpl-2.0.html\n"
+"\n"
+"{name} is developed by NV Access, a non-profit organisation committed to "
+"helping and promoting free and open source solutions for blind and vision "
+"impaired people.\n"
+"If you find NVDA useful and want it to continue to improve, please consider "
+"donating to NV Access. You can do this by selecting Donate from the NVDA "
+"menu."
+msgstr ""
+"{longName} ({name})\n"
+"Версия: {version}\n"
+"URL: {url}\n"
+"{copyright}\n"
+"\n"
+"{name}  GNU General Public License уруксаттаманын негизинде таралат "
+"(Version "
+" сиз бул программаны уруксаттаманы тутуу менен жана баштапкы сырдык созду бардык каалочуларга беруу менен гана аны тара ып жана/ же озгорто аласыз. "
+"Бул бирдей негизде анын тупнускасына, жана анын озгортулгон нускаларына жана ошондой эле анын чыгарылма нускаларына тиешелуу.   "
+"\n"
+" лицензияны кененирээк менюдан караныз \"Маалымдама\".\n"
+" аны   онлайн да коро аласыз: http://www.gnu.org/licenses/old-"
+"licenses/gpl-2.0.html\n"
+"\n"
+"{name}  NV Access те иштелип чыгат, ачык баштапкы сырдык соз менен иштоону колдоо жана онойлоштурууну максат кылган, коруу менен койгойлору бар адамдар учун жаратылган коммерциялык эмес организация, .\n"
+"Эгерде сиз NVDны керектуу деп эсептесениз жана ал онугуусун улантуусун кааласаныз менюдан \"кайыр кылуу\" деген тандоону кылсаныз болот., "
+
+#. Translators: the message that is shown when the user tries to install an add-on from windows explorer and NVDA is not running.
+#, python-brace-format
+msgid ""
+"Cannot install NVDA add-on from {path}.\n"
+"You must be running NVDA to be able to install add-ons."
+msgstr ""
+" {path}.\n дан кошумча NVDA ны орнотуу мумкун эмес"
+"кошумчулалоону орнотуу учун NVDA ишке киргизилген болуш керек."
+
+#. Translators: Reports navigator object's dimensions (example output: object edges positioned 20 per cent from left edge of screen, 10 per cent from top edge of screen, width is 40 per cent of screen, height is 50 per cent of screen).
+#, python-brace-format
+msgid ""
+"Object edges positioned {left:.1f} per cent from left edge of screen, "
+"{top:.1f} per cent from top edge of screen, width is {width:.1f} per cent of "
+"screen, height is {height:.1f} per cent of screen"
+msgstr ""
+" объекттин чеги  {left:.1f} процент ондон сол кырга жайгашкан.  "
+"экран, {top:.1f} процента снизу от верхнего края экрана, Ширина объекта "
+"{width:.1f} процент экрандын кендиги, бийиктиги - {height:.1f} процент экрандык бийиктик "
+
+
+#. Translators: a message announcing a candidate's character and description.
+#, python-brace-format
+msgid "{symbol} as in {description}"
+msgstr "{symbol} как в {description}"
+
+#. Translators: a formatted message announcing a candidate's number and candidate text.
+#, python-brace-format
+msgid "{number} {candidate}"
+msgstr "{number} {candidate}"
+
+#. Translators: The message reported when a user attempts to use a table movement command
+#. but the cursor can't be moved in that direction because it is at the edge of the table.
+msgid "Edge of table"
+msgstr " таблицанын чеги"
+
+#. Translators: The description of an NVDA command.
+msgid "Moves the navigator object to the next column"
+msgstr "Навигаторду кийинки тилкеге орнотот"
+
+#. Translators: The description of an NVDA command.
+msgid "Moves the navigator object to the previous column"
+msgstr " навигаторду мурунку тилкеге орнотот "
+
+#. Translators: The description of an NVDA command.
+msgid "Moves the navigator object and focus to the next row"
+msgstr "навигаторду жана системалык фокусту кийинки сапка орноштурат"
+
+#. Translators: The description of an NVDA command.
+msgid "Moves the navigator object and focus to the previous row"
+msgstr " навигаторду жана   системалык фокусту мурунку сапка орноштурат"
+
+#. Translators: The label for a 'composition' Window that appears when the user is typing one or more east-Asian characters into a document.
+msgid "Composition"
+msgstr "Кирууну  калыптандыруу"
+
+#. Translators: The label for a 'candidate' list that shows a choice of symbols a user can choose from when typing east-Asian characters into a document.
+#. Translators: A label for a 'candidate' list which contains symbols the user can choose from  when typing east-asian characters into a document.
+msgid "Candidate"
+msgstr "Вариант"
+
+msgid "Display"
+msgstr "Дисплей"
+
+#. Translators: The title of Start menu/screen in your language (only the word start).
+msgid "Start"
+msgstr "Негизги"
+
+#. Translators: Reported when no track is playing in Foobar 2000.
+msgid "No track playing"
+msgstr "Трек ойнотулбайт"
+
+#. Translators: The description of an NVDA command for Foobar 2000.
+msgid "Reports the remaining time of the currently playing track, if any"
+msgstr " ойнотулуп жаткан тректин аягына чейинки калган убакытты билдирет"
+
+#. Translators: This is presented to inform the user that no instant message has been received.
+msgid "No message yet"
+msgstr "билдируу жок"
+
+#. Translators: The description of an NVDA command to view one of the recent messages.
+msgid "Displays one of the recent messages"
+msgstr "акыркы билдируулордун бирин окуп жатат"
+
+#. Translators: This Outlook Express message has an attachment
+#. Translators: when an email has attachments
+msgid "has attachment"
+msgstr "тиркеме бар"
+
+#. Translators: this Outlook Express message is flagged
+msgid "flagged"
+msgstr "белгиленген"
+
+#. Translators: This is presented in outlook or live mail to indicate email attachments.
+msgid "Attachments"
+msgstr "Тиркеме"
+
+#. Translators: This is presented in outlook or live mail when creating a new email 'to:' or 'recipient:'
+msgid "To:"
+msgstr "Кимге:"
+
+#. Translators: This is presented in outlook or live mail when sending an email to a newsgroup
+msgid "Newsgroup:"
+msgstr "Жанылыктар топтому:"
+
+#. Translators: This is presented in outlook or live mail, email carbon copy
+msgid "CC:"
+msgstr "Кочурмо:"
+
+#. Translators: This is presented in outlook or live mail, email subject
+msgid "Subject:"
+msgstr "Тема:"
+
+#. Translators: This is presented in outlook or live mail, email sender
+msgid "From:"
+msgstr "дан:"
+
+#. Translators: This is presented in outlook or live mail, date of email
+msgid "Date:"
+msgstr "Дата:"
+
+#. Translators: This is presented in outlook or live mail
+msgid "Forward to:"
+msgstr "кайра даректоо:"
+
+#. Translators: This is presented in outlook or live mail
+msgid "Answer to:"
+msgstr "жооп беруу:"
+
+#. Translators: This is presented in outlook or live mail
+msgid "Organisation:"
+msgstr "Организация:"
+
+#. Translators: This is presented in outlook or live mail
+msgid "Distribution:"
+msgstr "Дистрибуция:"
+
+#. Translators: This is presented in outlook or live mail
+msgid "Key words:"
+msgstr "Ачкыч создор:"
+
+#. Translators: This is presented in outlook or live mail, email blind carbon copy
+msgid "BCC:"
+msgstr "комуско нуска:"
+
+#. Translators: Displayed in outlook or live mail to indicate an email is unread
+#. Translators: when an email is unread
+msgid "unread"
+msgstr "окулбаган"
+
+#. Translators: for a high importance email
+msgid "high importance"
+msgstr "зор маанилуулук"
+
+#. Translators: For a low importance email
+msgid "low importance"
+msgstr "томон маанилуулук"
+
+#. Translators: This is presented in outlook or live mail, email subject
+#, python-format
+msgid "subject: %s"
+msgstr "Тема: %s"
+
+#. Translators: This is presented in outlook or live mail, email received time
+#, python-format
+msgid "received: %s"
+msgstr "кабыл алынды: %s"
+
+#. Translators: This is presented in outlook or live mail, indicating email attachments
+msgid "attachment"
+msgstr "тиркеме"
+
+#. Translators: This is presented in outlook or live mail, email sent date
+#, python-format
+msgid "sent: %s"
+msgstr "жонотулду: %s"
+
+#. Translators: The title for the dialog shown while Microsoft Outlook initializes.
+msgid "Waiting for Outlook..."
+msgstr "Кутуудо Outlook..."
+
+#. Translators: a message reporting the time range (i.e. start time to end time) of an Outlook calendar entry
+#, python-brace-format
+msgid "{startTime} to {endTime}"
+msgstr "{startTime}  {endTime}боюнча"
+
+#. Translators: A message reported when on a calendar appointment in Microsoft Outlook
+#, python-brace-format
+msgid "Appointment {subject}, {time}"
+msgstr "жолугушуу {subject}, {time}"
+
+#. Translators: a message when the current time slot on an Outlook Calendar has an appointment
+msgid "Has appointment"
+msgstr "Жолугушууну камтыйт"
+
+#. Translators: the email is a meeting request
+msgid "meeting request"
+msgstr "жолугушууга сурам"
+
+#. Translators: this message is reported when there are no
+#. notes for translators to be presented to the user in Poedit.
+msgid "No notes for translators."
+msgstr "котормочуларга эскертуу жок."
+
+#. Translators: this message is reported when NVDA is unable to find
+#. the 'Notes for translators' window in poedit.
+msgid "Could not find Notes for translators window."
+msgstr "котормочуларга эскертууго терезени таба албады."
+
+#. Translators: The description of an NVDA command for Poedit.
+msgid "Reports any notes for translators"
+msgstr " котормочуларга эскертмени окуп жатат."
+
+#. Translators: this message is reported when NVDA is unable to find
+#. the 'comments' window in poedit.
+msgid "Could not find comment window."
+msgstr " пикир айтууга терезени таба алган жок."
+
+#. Translators: this message is reported when there are no
+#. comments to be presented to the user in the translator
+#. comments window in poedit.
+msgid "No comment."
+msgstr "пикир айтуу жок."
+
+#. Translators: The description of an NVDA command for Poedit.
+msgid "Reports any comments in the comments window"
+msgstr "ылайык келген терезеде пикир айтууну окуп жатат"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Title placeholder"
+msgstr "Аталышты толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Text placeholder"
+msgstr " текстти толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Center Title placeholder"
+msgstr " аталыштын борборун толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Subtitle placeholder"
+msgstr "кошумча соз башын толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Vertical Title placeholder"
+msgstr " тик аталышын толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Vertical Text placeholder"
+msgstr " тик текстти толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Object placeholder"
+msgstr " объектти толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Chart placeholder"
+msgstr "диаграмманы толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Bitmap placeholder"
+msgstr "Суротту толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Media Clip placeholder"
+msgstr " медиа клипти толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Org Chart placeholder"
+msgstr " орг диаграмманы толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Table placeholder"
+msgstr "таблицаны толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Slide Number placeholder"
+msgstr "слайддын номерин толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Header placeholder"
+msgstr "жогорку колонтитулду толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Footer placeholder"
+msgstr " томонку колонтитулду толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Date placeholder"
+msgstr " датаны толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Vertical Object placeholder"
+msgstr " тик объектти толтуруу"
+
+#. Translators: Describes a type of placeholder shape in Microsoft PowerPoint.
+msgid "Picture placeholder"
+msgstr " суроттолушту толтуруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Slide view"
+msgstr "Слайддарды коруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Slide Master view"
+msgstr " слайддардын мастерин коруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Notes page"
+msgstr "эсбелги бети"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Handout Master view"
+msgstr " Беруу Мастерин коруу"
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Notes Master view"
+msgstr "Эсбелги Мастерин коруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Outline view"
+msgstr "Улгу коруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Slide Sorter view"
+msgstr "Слайддарды сортточуну коруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Title Master view"
+msgstr "Аталыш Мастерин коруу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Normal view"
+msgstr "Кадимки корунуш"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Print Preview"
+msgstr "Басып чыгыруунун алдын ала коруусу"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Thumbnails"
+msgstr "Миниатюралар"
+
+#. Translators: a label for a particular view or pane in Microsoft PowerPoint
+msgid "Master Thumbnails"
+msgstr "миниатюралар мастери"
+
+#. Translators: the label for a slide in Microsoft PowerPoint.
+#, python-brace-format
+msgid "Slide {slideNumber}"
+msgstr "Слайд {slideNumber}"
+
+#. Translators: A message when a shape is infront of another shape on a Powerpoint slide
+#, python-brace-format
+msgid "covers left of {otherShape} by {distance:.3g} points"
+msgstr "covers left of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is behind  another shape on a powerpoint slide
+#, python-brace-format
+msgid "behind left of {otherShape} by {distance:.3g} points"
+msgstr "behind left of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is infront of another shape on a Powerpoint slide
+#, python-brace-format
+msgid "covers top of {otherShape} by {distance:.3g} points"
+msgstr "covers top of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is behind another shape on a powerpoint slide
+#, python-brace-format
+msgid "behind top of {otherShape} by {distance:.3g} points"
+msgstr "behind top of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is infront of another shape on a Powerpoint slide
+#, python-brace-format
+msgid "covers right of {otherShape} by {distance:.3g} points"
+msgstr "covers right of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is behind another shape on a powerpoint slide
+#, python-brace-format
+msgid "behind right of {otherShape} by {distance:.3g} points"
+msgstr "behind right of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is infront of another shape on a Powerpoint slide
+#, python-brace-format
+msgid "covers bottom of {otherShape} by {distance:.3g} points"
+msgstr "covers bottom of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is behind another shape on a powerpoint slide
+#, python-brace-format
+msgid "behind bottom of {otherShape} by {distance:.3g} points"
+msgstr "behind bottom of {otherShape} by {distance:.3g} points"
+
+#. Translators: A message when a shape is infront of another shape on a Powerpoint slide
+#, python-brace-format
+msgid "covers  {otherShape}"
+msgstr "covers  {otherShape}"
+
+#. Translators: A message when a shape is behind another shape on a powerpoint slide
+#, python-brace-format
+msgid "behind {otherShape}"
+msgstr "behind {otherShape}"
+
+#. Translators: For a shape within a Powerpoint Slide, this is the distance in points from the shape's left edge to the slide's left edge
+#, python-brace-format
+msgid "{distance:.3g} points from left slide edge"
+msgstr "  слайддын сол кырынан {distance:.3g} чекиттер"
+
+#. Translators: For a shape too far  off the left  edge of a Powerpoint Slide, this is the distance in points from the shape's left edge (off the slide) to the slide's left edge (where the slide starts)
+#, python-brace-format
+msgid "Off left slide edge by {distance:.3g} points"
+msgstr " слайддын сол кырынан  {distance:.3g} points"
+
+#. Translators: For a shape within a Powerpoint Slide, this is the distance in points from the shape's top edge to the slide's top edge
+#, python-brace-format
+msgid "{distance:.3g} points from top slide edge"
+msgstr "{distance:.3g}  слайддын он кырынан чекит"
+
+#. Translators: For a shape too far  off the top   edge of a Powerpoint Slide, this is the distance in points from the shape's top edge (off the slide) to the slide's top edge (where the slide starts)
+#, python-brace-format
+msgid "Off top slide edge by {distance:.3g} points"
+msgstr "слайддын жогорку кырынан   {distance:.3g} чекит "
+
+#. Translators: For a shape within a Powerpoint Slide, this is the distance in points from the shape's right edge to the slide's right edge
+#, python-brace-format
+msgid "{distance:.3g} points from right slide edge"
+msgstr "{distance:.3g} чекит слайддын он кырынан"
+
+#. Translators: For a shape too far  off the right  edge of a Powerpoint Slide, this is the distance in points from the shape's right edge (off the slide) to the slide's right edge (where the slide starts)
+#, python-brace-format
+msgid "Off right slide edge by {distance:.3g} points"
+msgstr "слайддын он кырынан  {distance:.3g}  чекит"
+
+#. Translators: For a shape within a Powerpoint Slide, this is the distance in points from the shape's bottom edge to the slide's bottom edge
+#, python-brace-format
+msgid "{distance:.3g} points from bottom slide edge"
+msgstr " слайддын томонку кырынан {distance:.3g} чекит"
+
+#. Translators: For a shape too far  off the bottom edge of a Powerpoint Slide, this is the distance in points from the shape's bottom edge (off the slide) to the slide's bottom edge (where the slide starts)
+#, python-brace-format
+msgid "Off bottom slide edge by {distance:.3g} points"
+msgstr "слайддын томонку кырынан  {distance:.3g} чекит"
+
+#. Translators: The description for a script
+msgid ""
+"Toggles between reporting the speaker notes or the actual slide content. "
+"This does not change what is visible on-screen, but only what the user can "
+"read with NVDA"
+msgstr ""
+"Эсбелги менен экрандын окуусун слайддын мазмуну мене алмаштырып турат. Бул экрандын мазмунун озгортпой  эле, колдонуучуга NVDA нын жардамы менен информацияны корууго жардам берет ."
+
+#. Translators: The title of the current slide (with notes) in a running Slide Show in Microsoft PowerPoint.
+#, python-brace-format
+msgid "Slide show notes - {slideName}"
+msgstr " слайд шоунун эсбелгилери - {slideName}"
+
+#. Translators: The title of the current slide in a running Slide Show in Microsoft PowerPoint.
+#, python-brace-format
+msgid "Slide show - {slideName}"
+msgstr " слайддарды коргозуу - {slideName}"
+
+#. Translators: The title for a Slide show in Microsoft PowerPoint that has completed.
+msgid "Slide Show - complete"
+msgstr "Слайддарды коргозуу  - бутту"
+
+#. Translators: The message for no notes  for a slide in a slide show
+msgid "No notes"
+msgstr "эсбелги жок"
+
+#. Translators: The message for an empty slide in a slide show
+msgid "Empty slide"
+msgstr "Бош слайд"
+
+#. Translators: A title for a dialog shown while Microsoft PowerPoint initializes
+msgid "Waiting for Powerpoint..."
+msgstr "Powerpoint ту кутуудо..."
+
+#. Translators: The name of the NVDA command category for Skype specific commands.
+msgid "Skype"
+msgstr "Skype"
+
+msgid "Reports and moves the review cursor to a recent message"
+msgstr " акыркы билдирууну окуп жана ага курсорду жылдырат"
+
+#. Translators: Indicates that a contact stopped typing.
+msgid "Typing stopped"
+msgstr "Кабылш алуу бутту"
+
+# An open-source (and free) Screen Reader for the Windows Operating System
+# Created by Michael Curran, with help from James Teh and others
+# Copyright (C) 2006-2008 Michael Curran <mick@kulgan.net>
+#. Translators: This is the name of a button in sound recorder.
+msgid "Rewind"
+msgstr "туруу"
+
+#. Translators: This is the name of a button in sound recorder.
+msgid "Fast forward"
+msgstr "Тез алдыга"
+
+#. Translators: This is the name of a button in sound recorder.
+msgid "Play"
+msgstr "Ойнотуу"
+
+#. Translators: This is the name of a button in sound recorder.
+msgid "Stop"
+msgstr "Стоп"
+
+#. Translators: This is the name of a button in sound recorder.
+msgid "Record"
+msgstr "Жаздыруу"
+
+msgid "left"
+msgstr "сол"
+
+msgid "right"
+msgstr "правый"
+
+#. Translators: the user has pressed the shuffle tracks toggle in winamp, shuffle is now on.
+msgctxt "shuffle"
+msgid "on"
+msgstr "жанык"
+
+#. Translators: the user has pressed the shuffle tracks toggle in winamp, shuffle is now off.
+msgctxt "shuffle"
+msgid "off"
+msgstr "выключено"
+
+#. Translators: the user has pressed the repeat track toggle in winamp, repeat is now on.
+msgctxt "repeat"
+msgid "on"
+msgstr "очурулгон"
+
+#. Translators: the user has pressed the repeat track toggle in winamp, repeat is now off.
+msgctxt "repeat"
+msgid "off"
+msgstr "очурулгон"
+
+#. Translators: The name of a braille display.
+msgid "ALVA BC640/680 series"
+msgstr "ALVA BC640/680"
+
+#. Translators: Names of braille displays.
+msgid "Baum/HumanWare/APH braille displays"
+msgstr "Baum/HumanWare/APH"
+
+#. Translators: Name of a serial communications port.
+#. Translators: Name of a serial communications port
+#. Translators: Name of a serial communications port.
+#. Translators: Name of a serial communications port
+#, python-brace-format
+msgid "Serial: {portName}"
+msgstr "Ырааттуу: {portName}"
+
+#. Translators: Names of braille displays
+msgid "HumanWare BrailleNote"
+msgstr "HumanWare BrailleNote"
+
+#. Translators: The name of a series of braille displays.
+msgid "HumanWare Brailliant BI/B series"
+msgstr "HumanWare Brailliant BI/B"
+
+#. Translators: The name of a braille display.
+msgid "EcoBraille displays"
+msgstr "EcoBraille"
+
+#. Translators: Names of braille displays.
+msgid "Freedom Scientific Focus/PAC Mate series"
+msgstr "Freedom Scientific Focus/PAC Mate"
+
+#. Translators: The name of a key on a braille display, that scrolls the display to show previous/next part of a long line.
+msgid "display scroll"
+msgstr " экранды турдуруу"
+
+#. Translators: The name of a key on a braille display, that scrolls the display to show the next/previous line.
+msgid "line scroll"
+msgstr " саптарды турдуруу"
+
+#. Translators: Names of braille displays.
+msgid "Handy Tech braille displays"
+msgstr "Handy Tech"
+
+msgid "Show the Handy Tech driver configuration window."
+msgstr "ондоо терезесин корсотуу Handy Tech."
+
+#. Translators: Name of a braille display.
+msgid "MDV Lilli"
+msgstr "MDV Lilli"
+
+#. Translators: Is used to indicate that braille support will be disabled.
+msgid "No braille"
+msgstr " брайль жок"
+
+#. Translators: Names of braille displays.
+msgid "Papenmeier BRAILLEX newer models"
+msgstr " Papenmeier BRAILLEX жаны моделдери"
+
+#. Translators: Describes action of routing buttons on a braille display.
+msgid "Route to and report formatting"
+msgstr "Корсотулгон орунга откорулот жана форматтоону жарыялайт"
+
+#. Translators: Names of braille displays.
+msgid "Papenmeier BRAILLEX older models"
+msgstr " Papenmeier BRAILLEX эскирген моделдери"
+
+#. Translators: Names of braille displays.
+msgid "Seika braille displays"
+msgstr "Seika"
+
+#. Translators: Reported when last saved configuration has been applied by using revert to saved configuration option in NVDA menu.
+msgid "Configuration applied"
+msgstr "Конфигурация колдонулду"
+
+#. Translators: Reported when configuration has been restored to defaults by using restore configuration to factory defaults item in NVDA menu.
+msgid "Configuration restored to factory defaults"
+msgstr "Конфигурация заводдук ондоолорго келди "
+
+#. Translators: Reported when current configuration cannot be saved while NVDA is running in secure mode such as in Windows login screen.
+msgid "Cannot save configuration - NVDA in secure mode"
+msgstr " конфигурацияны сактоо мумкун эмес - NVDA работает на защищённом экране"
+
+#. Translators: Reported when current configuration has been saved.
+msgid "Configuration saved"
+msgstr "Конфигурация сакталды"
+
+#. Translators: Message shown when current configuration cannot be saved such as when running NVDA from a CD.
+msgid "Could not save configuration - probably read only file system"
+msgstr ""
+"конфигурацияны сактоо мумкун болгон жок , балким, NVDA окууга гмна мумкун болгон аймактан ишке киргизилген "
+
+#. Translators: Message shown when attempting to open another NVDA settings dialog when one is already open (example: when trying to open keyboard settings when general settings dialog is open).
+msgid "An NVDA settings dialog is already open. Please close it first."
+msgstr "Ондоолор Диалогу  NVDA ачык.Сураныч , биринчи аны жабыныз."
+
+#. Translators: Title for default speech dictionary dialog.
+msgid "Default dictionary"
+msgstr "Жалпы создук
+
+#. Translators: Title for voice dictionary for the current voice such as current eSpeak variant.
+#, python-format
+msgid "Voice dictionary (%s)"
+msgstr "ундук создук(%s)"
+
+#. Translators: Title for temporary speech dictionary dialog (the voice dictionary that is active as long as NvDA is running).
+msgid "Temporary dictionary"
+msgstr "Убактылуу создук"
+
+#. Translators: The title of the dialog to show about info for NVDA.
+msgid "About NVDA"
+msgstr "NVDA жонундо"
+
+#. Translators: The label for the menu item to open general Settings dialog.
+msgid "&General settings..."
+msgstr "&ОЖалпы ондоолор..."
+
+msgid "General settings"
+msgstr "Жалпы Ондоолор"
+
+#. Translators: The label for the menu item to open Synthesizer settings dialog.
+msgid "&Synthesizer..."
+msgstr "&Синтезатор..."
+
+msgid "Change the synthesizer to be used"
+msgstr " колдонулуп жаткан  синтезаторду озгортуу"
+
+#. Translators: The label for the menu item to open Voice Settings dialog.
+msgid "&Voice settings..."
+msgstr "&Ундор..."
+
+msgid "Choose the voice, rate, pitch and volume to use"
+msgstr "Изменить  синтезатордун унун, ылдамдыгын, бийиктигин жана башка параметрлерин озгортуу "
+
+#. Translators: The label for the menu item to open Braille Settings dialog.
+msgid "B&raille settings..."
+msgstr "&Брайль..."
+
+#. Translators: The label for the menu item to open Keyboard Settings dialog.
+msgid "&Keyboard settings..."
+msgstr "&Клавиатура..."
+
+msgid ""
+"Configure keyboard layout, speaking of typed characters, words or command "
+"keys"
+msgstr ""
+"Настройка раскладки клавиатуры, чтения вводимых символов, слов и командных "
+"клавиш"
+
+#. Translators: The label for the menu item to open Mouse Settings dialog.
+msgid "&Mouse settings..."
+msgstr "&чычкан..."
+
+msgid "Change reporting of mouse shape and object under mouse"
+msgstr " чычкандын коргозмосун жана анын алдындагы объекттерди окуусунун формасын озгортуу"
+
+#. Translators: The label for the menu item to open Review Cursor dialog.
+msgid "Review &cursor..."
+msgstr "Коруучу &курсор..."
+
+msgid "Configure how and when the review cursor moves"
+msgstr " кандай жана кайсы учурларда коруучу курсор жылуусун ондоо"
+
+#. Translators: The label for the menu item to open Input Composition Settings dialog.
+msgid "&Input composition settings..."
+msgstr "& азиаттык символдордун киргизуусун форматто..."
+
+msgid ""
+"Configure how NVDA reports input composition and candidate selection for "
+"certain languages"
+msgstr ""
+" киргизууну форматтоо жана кээ бир тилдерге кандидатты тандоону NVDA кантип билдируусун ондоо"
+
+#. Translators: The label for the menu item to open Object Presentation dialog.
+msgid "&Object presentation..."
+msgstr "& объекттин коргозмосу..."
+
+msgid "Change reporting of objects"
+msgstr " объекттин окуусун озгортуу"
+
+#. Translators: The label for the menu item to open Browse Mode settings dialog.
+msgid "&Browse mode..."
+msgstr "Режим & сереп..."
+
+msgid "Change virtual buffers specific settings"
+msgstr "виртуалдык буферлердин атайын ондоолорун озгортуу"
+
+#. Translators: The label for the menu item to open Document Formatting settings dialog.
+msgid "Document &formatting..."
+msgstr "& документтерди форматтоо..."
+
+msgid "Change settings of document properties"
+msgstr "Изменение чтения форматирования документтерди форматтоону окуусун озгортуу"
+
+#. Translators: The label for the menu item to open Default speech dictionary dialog.
+msgid "&Default dictionary..."
+msgstr "&ЖАЛПЫ СОЗДУК..."
+
+msgid ""
+"A dialog where you can set default dictionary by adding dictionary entries "
+"to the list"
+msgstr ""
+" Жалпы создукту форматтоого , керектуу макалаларды тизмекке кошууга мумкунчулук берген диалог."
+
+#. Translators: The label for the menu item to open Voice specific speech dictionary dialog.
+msgid "&Voice dictionary..."
+msgstr "&Ундук создук..."
+
+msgid ""
+"A dialog where you can set voice-specific dictionary by adding dictionary "
+"entries to the list"
+msgstr ""
+" керектуу макалаларды кошуп , ундук создукту тузууго мумкунчулук берген диалог"
+
+#. Translators: The label for the menu item to open Temporary speech dictionary dialog.
+msgid "&Temporary dictionary..."
+msgstr "&Убактылуу создук..."
+
+msgid ""
+"A dialog where you can set temporary dictionary by adding dictionary entries "
+"to the edit box"
+msgstr ""
+"  керектуу макалаларды кошуп , убактылуу создукту тузууго мумкунчулук берген диалог"
+
+#. Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
+msgid "Speech &dictionaries"
+msgstr "&Суйлоо создуктору"
+
+#. Translators: The label for the menu item to open Punctuation/symbol pronunciation dialog.
+msgid "&Punctuation/symbol pronunciation..."
+msgstr " символдорду айтуу/пунктуации..."
+
+#. Translators: The label for the menu item to open the Input Gestures dialog.
+msgid "I&nput gestures..."
+msgstr "кируу жансоосу"
+
+#. Translators: The label for Preferences submenu in NVDA menu.
+msgid "&Preferences"
+msgstr "&Параметрлер"
+
+#. Translators: The label for the menu item to open NVDA Log Viewer.
+msgid "View log"
+msgstr "журналды карап чыгуу"
+
+#. Translators: The label for the menu item to toggle Speech Viewer.
+msgid "Speech viewer"
+msgstr "суйлоону кароочу"
+
+#. Translators: The label for the menu item to open NVDA Python Console.
+msgid "Python console"
+msgstr "Консоль Python"
+
+#. Translators: The label of a menu item to open the Add-ons Manager.
+msgid "Manage &add-ons..."
+msgstr "кошумчаларды башкаруу..."
+
+#. Translators: The label for the menu item to create a portable copy of NVDA from an installed or another portable version.
+msgid "Create portable copy..."
+msgstr " кочурмо нусканы жаратуу..."
+
+#. Translators: The label for the menu item to install NVDA on the computer.
+msgid "&Install NVDA..."
+msgstr "& NVDA ны орнотуу..."
+
+#. Translators: The label for the menu item to reload plugins.
+msgid "Reload plugins"
+msgstr " плагиндерди кайрадан жуктоо"
+
+#. Translators: The label for the Tools submenu in NVDA menu.
+msgid "Tools"
+msgstr "Сервис"
+
+#. Translators: The label of a menu item to open NVDA user guide.
+msgid "&User Guide"
+msgstr "&Колдонуучунун колдонмосу"
+
+#. Translators: The label of a menu item to open the Commands Quick Reference document.
+msgid "Commands &Quick Reference"
+msgstr "& кыскача командалар маалымдамасы"
+
+#. Translators: The label for the menu item to open What's New document.
+msgid "What's &new"
+msgstr "эмне& жаны"
+
+msgid "NVDA &web site"
+msgstr "&Web-сайт NVDA"
+
+#. Translators: The label for the menu item to view NVDA License document.
+msgid "L&icense"
+msgstr "&Лицензиондук маалымдашуу"
+
+#. Translators: The label for the menu item to view NVDA Contributors list document.
+msgid "C&ontributors"
+msgstr "С& иштеп чыгуучулар тизмеги"
+
+#. Translators: The label for the menu item to open NVDA Welcome Dialog.
+msgid "We&lcome dialog..."
+msgstr "Диалог &Кош келиниз"
+
+#. Translators: The label of a menu item to manually check for an updated version of NVDA.
+msgid "&Check for update..."
+msgstr "&жаныланууну текшеруу..."
+
+#. Translators: The label for the menu item to open About dialog to get information about NVDA.
+msgid "About..."
+msgstr " программа жонундо..."
+
+#. Translators: The label for the Help submenu in NVDA menu.
+msgid "&Help"
+msgstr "&Маалымдама"
+
+#. Translators: The label for the menu item to open the Configuration Profiles dialog.
+msgid "&Configuration profiles..."
+msgstr " конфигурациялар профилдери..."
+
+#. Translators: The label for the menu item to revert to saved configuration.
+msgid "&Revert to saved configuration"
+msgstr "& сакталган конфигурацияга кайтуу"
+
+msgid "Reset all settings to saved state"
+msgstr " бардык ондоолорду сакталган абалга алып келуу"
+
+#. Translators: The label for the menu item to reset settings to default settings.
+#. Here, default settings means settings that were there when the user first used NVDA.
+msgid "&Reset configuration to factory defaults"
+msgstr "& конфигурацияны  заводдук ондоолорго алып келуу  "
+
+msgid "Reset all settings to default state"
+msgstr "бардык ондоолорду сакталган абалга алып келуу"
+#. Translators: The label for the menu item to save current settings.
+msgid "&Save configuration"
+msgstr "& конфигурацияны сактоо"
+
+msgid "Write the current configuration to nvda.ini"
+msgstr "учурдагы конфигурацияны  nvd га жазуу.ini"
+
+#. Translators: The label for the menu item to open donate page.
+msgid "Donate"
+msgstr "Садага"
+
+msgid "E&xit"
+msgstr "ч&ыгуу"
+
+#. Translators: The title of the dialog to exit NVDA
+msgid "Exit NVDA"
+msgstr "NVDA ишин бутуруу"
+
+msgid ""
+"Welcome to NVDA!\n"
+"Most commands for controlling NVDA require you to hold down the NVDA key "
+"while pressing other keys.\n"
+"By default, the numpad insert and main insert keys may both be used as the "
+"NVDA key.\n"
+"You can also configure NVDA to use the CapsLock as the NVDA key.\n"
+"Press NVDA+n at any time to activate the NVDA menu.\n"
+"From this menu, you can configure NVDA, get help and access other NVDA "
+"functions.\n"
+msgstr ""
+"Добро пожаловать в NVDA!\n"
+"Көпчүлүк NVDA буйруктар иш-кармоо NVDA өзгөрткүч баскыч болуп саналат, ал эми «
+«Башка баскычтарды басуу. \ N»
+"Демейки, санариптик блогун жана кадимки кой Кыстаруу кошумча катары «
+«Modifier негизги NVDA. \ N»
+«Ошондой эле, сиз NVDA klavishi- катары Capslock колдонуу үчүн күүлөй аласыз»
+«NVDA өзгөрткүч \. N»
+«Пресс NVDA + н NVDA менюну көрсөтүү үчүн кайсы убакта болбосун. \ N»
+«Бул менюда сиз NVDA тарамдатса болот, башка жардам жана алууга;»
+«Программасынын милдеттери. \ N»
+#. Translators: The title of the Welcome dialog when user starts NVDA for the first time.
+msgid "Welcome to NVDA"
+msgstr " NVDA га кош келдиниз"
+
+msgid "Options"
+msgstr "Параметры"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Use CapsLock as an NVDA modifier key"
+msgstr " CapsLock ту  как клавиш-модификатор NVDA катары колдонуу"
+
+#. Translators: The label of a check box in the Welcome dialog.
+#. Translators: The label for a setting in general settings to allow NVDA to start after logging onto Windows (if checked, NvDA will start automatically after loggin into Windows; if not, user must start NVDA by pressing the shortcut key (CTRL+Alt+N by default).
+msgid "&Automatically start NVDA after I log on to Windows"
+msgstr "& Windows ко киргенден кийин NVDA  ны автожуктоо  "
+
+#. Translators: This is a label for a checkbox in welcome dialog to show welcome dialog at startup.
+msgid "Show this dialog when NVDA starts"
+msgstr " NVDA жуктоодо бул диалогду корсотуу"
+
+#. Translators: The label of the license text which will be shown when NVDA installation program starts.
+msgid "License Agreement"
+msgstr "Лицензиялык келишим"
+
+#. Translators: The label for a checkbox in NvDA installation program to agree to the license agreement.
+msgid "I &agree"
+msgstr "мен &макулмун"
+
+#. Translators: The label of the button in NVDA installation program to install NvDA on the user's computer.
+msgid "&Install NVDA on this computer"
+msgstr "& NVDA ны бул  компьютерге орноштуруу"
+
+#. Translators: The label of the button in NVDA installation program to create a portable version of NVDA.
+msgid "Create &portable copy"
+msgstr "&ташылма нусканы жаратуу"
+
+#. Translators: The label of the button in NVDA installation program to continue using the installation program as a temporary copy of NVDA.
+msgid "&Continue running"
+msgstr "&Жумушту улантыныз"
+
+#. Translators: The message displayed while a portable copy of NVDA is bieng created.
+msgid "Please wait while a portable copy of NVDA is created."
+msgstr "Сураныч,NVDA кочурмосу калыптанганга чейин куто турунуз."
+
+#. Translators: a message dialog asking to retry or cancel when NVDA portable copy creation fails
+msgid "NVDA is unable to remove or overwrite a file."
+msgstr "NVDA файлды кочуроалбайт же очуроалбайт."
+
+#. Translators: The message displayed when an error occurs while creating a portable copy of NVDA.
+#. %s will be replaced with the specific error message.
+#, python-format
+msgid "Failed to create portable copy: %s"
+msgstr "Которулуучу кочурмону калыптаганга мумкун болбоду: %s"
+
+#. Translators: The message displayed when a portable copy of NVDA has been successfully created.
+#. %s will be replaced with the destination directory.
+#, python-format
+msgid "Successfully created a portable copy of NVDA at %s"
+msgstr "%s олунда которулуучу кочурмо ийгиликтуу турдо калыптанды"
+
+#. Translators: The title of the NVDA log viewer window.
+msgid "NVDA Log Viewer"
+msgstr " NVDA журналын кароочусу"
+
+#. Translators: The label for a menu item in NVDA log viewer to refresh log messages.
+msgid "Refresh\tF5"
+msgstr "Жаныртуу\tF5"
+
+#. Translators: The label for a menu item in NVDA log viewer to save log file.
+msgid "Save &as...\tCtrl+S"
+msgstr "&Турдо сактоо...\tCtrl+S"
+
+#. Translators: The title of a menu in NVDA Log Viewer.
+msgid "Log"
+msgstr "Журнал"
+
+#. Translators: Label of a menu item in NVDA Log Viewer.
+msgid "Save As"
+msgstr "турдо сактоо"
+
+#. Translators: Dialog text presented when NVDA cannot save a log file.
+#, python-format
+msgid "Error saving log: %s"
+msgstr "Журналды сактоо катасы: %s"
+
+#. Translators: This is the label for the general settings dialog.
+msgid "General Settings"
+msgstr "жалпы ондомолор"
+
+#. Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
+msgid "info"
+msgstr "маалымат"
+
+#. Translators: One of the log levels of NVDA (the debug warning shows debugging messages and warnings as NVDA runs).
+msgid "debug warning"
+msgstr "отладка тууралуу билдирме"
+
+#. Translators: One of the log levels of NVDA (the input/output shows keyboard commands and/or braille commands as well as speech and/or braille output of NVDA).
+msgid "input/output"
+msgstr "кируу/чыгуу"
+
+#. Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
+msgid "debug"
+msgstr "отладка"
+
+#. Translators: The label for a setting in general settings to select NVDA's interface language (once selected, NVDA must be restarted; the option user default means the user's Windows language will be used).
+msgid "&Language (requires restart to fully take effect):"
+msgstr "&тил (колдонуу учун кайрадан жандыруу керек):"
+
+#. Translators: The list of languages for NVDA.
+msgid "Language"
+msgstr "тил"
+
+#. Translators: The label for a setting in general settings to save current configuration when NVDA exits (if it is not checked, user needs to save configuration before quitting NVDA).
+msgid "&Save configuration on exit"
+msgstr "&Чыгуу учурунда конфигурацияны автоматтык турдо сактоо"
+
+#. Translators: The label for a setting in general settings to ask before quitting NVDA (if not checked, NVDA will exit without asking the user for action).
+msgid "Sho&w exit options when exiting NVDA"
+msgstr "NVDA жабуу учурунда чыгуу варинттарын корсотуу"
+
+#. Translators: The label for a setting in general settings to play sounds when NVDA starts or exits.
+msgid "&Play sounds when starting or exiting NVDA"
+msgstr "NVDA баштатуу же жабуу учурунда ундорду ойнотуу"
+
+#. Translators: The label for a setting in general settings to select logging level of NVDA as it runs (available options and what they are logged are found under comments for the logging level messages themselves).
+msgid "L&ogging level:"
+msgstr "&журналды жургузуу денгээли:"
+
+#. Translators: A combo box to choose log level (possible options are info, debug warning, input/output and debug).
+msgid "Log level"
+msgstr "Отчет денгээли"
+
+#. Translators: The label for a setting in general settings to allow NVDA to come up in Windows login screen (useful if user needs to enter passwords or if multiple user accounts are present to allow user to choose the correct account).
+msgid ""
+"Use NVDA on the Windows logon screen (requires administrator privileges)"
+msgstr ""
+"NVDA Киргизуу экранындагы Windows колдонуу(башкаруучу укугу керек)"
+
+#. Translators: The label for a button in general settings to copy current user settings to system settings (to allow current settings to be used in secure screens such as User Account Control (UAC) dialog).
+msgid ""
+"Use currently saved settings on the logon and other secure screens (requires "
+"administrator privileges)"
+msgstr "Системага кируу экранындагы акыркы сакталган конфигурацияны жана башка корголуучу экрандагы (эки башкаруучу укгугу зарыл) колдонуу"
+
+
+#. Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA (if not checked, user must check for updates manually).
+msgid "Automatically check for &updates to NVDA"
+msgstr "NVDA &жанылануусун автомттык турдо текшеруу"
+
+#. Translators: A message to warn the user when attempting to copy current settings to system settings.
+msgid ""
+"Add-ons were detected in your user settings directory. Copying these to the "
+"system profile could be a security risk. Do you still wish to copy your "
+"settings?"
+msgstr ""
+"Сиздин колдонуучу ондомолор паканызда кошумчалар байкалган."
+"Аларды системалык профилге кочуруу коотуу болушу мумкун. "
+"Сизидин ондомолрду кочуруу уланталсынбы?"
+
+#. Translators: The title of the dialog presented while settings are being copied
+msgid "Copying Settings"
+msgstr "ондомолорду кочуруу"
+
+#. Translators: The message displayed while settings are being copied to the system configuration (for use on Windows logon etc)
+msgid "Please wait while settings are copied to the system configuration."
+msgstr ""
+"Сураныч, системалык конфигурацияга ондомолор кочурулгонго чейин куто турунуз"
+
+#. Translators: a message dialog asking to retry or cancel when copying settings  fails
+msgid ""
+"Unable to copy a file. Perhaps it is currently being used by another process "
+"or you have run out of disc space on the drive you are copying to."
+msgstr ""
+"Невозможно скопировать файл. Возможно он используется другим процессом или "
+"Бул файлды которуучу дискте бош орун жетишсиз"
+
+#. Translators: the title of a retry cancel dialog when copying settings  fails
+msgid "Error Copying"
+msgstr "Кочурмо учурунда ката"
+
+#. Translators: The message displayed when errors were found while trying to copy current configuration to system settings.
+msgid "Error copying NVDA user settings"
+msgstr "Ошибка при копировании пользовательских настроек NVDA"
+
+#. Translators: The message displayed when copying configuration to system settings was successful.
+msgid "Successfully copied NVDA user settings"
+msgstr "NVDA колдонуу ондомолору ийгиликтуу кочурулду"
+
+#, python-format
+msgid "Error in %s language file"
+msgstr "%s тилдик файлында ката"
+
+msgid "Language Error"
+msgstr "Тил катасы"
+
+msgid "This change requires administrator privileges."
+msgstr "Это изменение требует прав администратора"
+
+msgid "Insufficient Privileges"
+msgstr "Укуктардын жетишсиздиги"
+
+#. Translators: The message displayed after NVDA interface language has been changed.
+msgid ""
+"For the new language to take effect, the configuration must be saved and "
+"NVDA must be restarted. Press enter to save and restart NVDA, or cancel to "
+"manually save and exit at a later time."
+msgstr "Жаны тилди колдонуу учун конфигурацианы NVDAны сактоо жана кайра жандыруу керек. Ишти аткаруу учун Enterди басыныз , диалогтон чыгуу учун жана андан ары механикалык турдо улантуу учун  Escapeти басыныз"
+"
+
+#. Translators: The title of the dialog which appears when the user changed NVDA's interface language.
+msgid "Language Configuration Change"
+msgstr "тилдин алмашуусу"
+
+#. Translators: This is the label for the synthesizer dialog.
+msgid "Synthesizer"
+msgstr "Синтезатор"
+
+#. Translators: This is a label for the select
+#. synthesizer combobox in the synthesizer dialog.
+msgid "&Synthesizer:"
+msgstr "&Синтезатор:"
+
+#. Translators: This is the label for the select output
+#. device combo in the synthesizer dialog. Examples of
+#. of an output device are default soundcard, usb
+#. headphones, etc.
+msgid "Output &device:"
+msgstr "&чыгаруу тузулмосу:"
+
+#. Translators: This is a label for the audio ducking combo box in the Audio Settings dialog
+msgid "Audio &ducking mode:"
+msgstr "&унду ылдыйлатуу тартиби:"
+
+#. Translators: This message is presented when
+#. NVDA is unable to load the selected
+#. synthesizer.
+#, python-format
+msgid "Could not load the %s synthesizer."
+msgstr "синтезатор %s синтезаторун жуктоого мумкун болбоду."
+
+msgid "Synthesizer Error"
+msgstr "синтезатор катасы"
+
+#. Translators: This is the label for the voice settings dialog.
+msgid "Voice Settings"
+msgstr "ун ондомолору"
+
+#. Translators: This is the label for a checkbox in the
+#. voice settings dialog (if checked, text will be read using the voice for the language of the text).
+msgid "Automatic language switching (when supported)"
+msgstr "&тилдердин автоматикалык турдо которуу (мумкун болсо)"
+#. Translators: This is the label for a checkbox in the
+#. voice settings dialog (if checked, different voices for dialects will be used to read text in that dialect).
+msgid "Automatic dialect switching (when supported)"
+msgstr "&диалекттердин автоматикалык турдо которуу (мумкун болсо)"
+
+#. Translators: This is the label for a combobox in the
+#. voice settings dialog (possible choices are none, some, most and all).
+msgid "Punctuation/symbol &level:"
+msgstr "&пунктуация денгээли:"
+
+#. Translators: This is the label for a checkbox in the
+#. voice settings dialog (if checked, text will be read using the voice for the language of the text).
+msgid "Trust voice's language when processing characters and symbols"
+msgstr "белгилерди жана пунктуация символдорду окуу учун синтезатор тилин колдонуу"
+
+#. Translators: This is a label for a setting in voice settings (an edit box to change voice pitch for capital letters; the higher the value, the pitch will be higher).
+msgid "Capital pitch change percentage"
+msgstr "башкылар учун узундукту алмаштыруу пайызы"
+
+#. Translators: This is the label for a checkbox in the
+#. voice settings dialog.
+msgid "Say &cap before capitals"
+msgstr "Айтуу \"&Чон\" чон тамгалар алдында"
+
+#. Translators: This is the label for a checkbox in the
+#. voice settings dialog.
+msgid "&Beep for capitals"
+msgstr "Чон тамгалар алдындагы &сигнал"
+
+#. Translators: This is the label for a checkbox in the
+#. voice settings dialog.
+msgid "Use &spelling functionality if supported"
+msgstr "Мумкун болсо &символсайынкы маанини колжонуу"
+
+#. Translators: This is the label for the keyboard settings dialog.
+msgid "Keyboard Settings"
+msgstr "Колбаскыч"
+
+#. Translators: This is the label for a combobox in the
+#. keyboard settings dialog.
+msgid "&Keyboard layout:"
+msgstr "&колбаскычтын тузулушу:"
+
+#. Translators: This is the name of a combobox in the keyboard settings dialog.
+msgid "Keyboard layout"
+msgstr "колбаскычтын тузулушу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Use numpad Insert as an NVDA modifier key"
+msgstr "NVDA модификатор-баскычы катары сандык блоктогу Insert колдонуу "
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Use extended Insert as an NVDA modifier key"
+msgstr "NVDA модификатор баскычы катары кадимки Insert баскычын колдонуу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Speak typed &characters"
+msgstr "Киргизуудо симаолдорду окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Speak typed &words"
+msgstr "Киргизуудо создорду окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Speech interrupt for typed characters"
+msgstr "Жазылган символдор учун созду токтотуу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Speech interrupt for Enter key"
+msgstr "Enter баскычы учун созду токтотуп туруу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Allow skim &reading in Say All"
+msgstr "&Узгултуксуз окуу тартибинде тез окууга уруксат беруу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Beep if typing lowercase letters when caps lock is on"
+msgstr "СapsLock тартибинде чонтамгаларды жазууда ун сигналы"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Speak command &keys"
+msgstr "&буйрук баскычтарын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Play sound for &spelling errors while typing"
+msgstr "текстти бассууда орфографиялык каталар кеткенде унду чыгаруу"
+
+#. Translators: This is the label for a checkbox in the
+#. keyboard settings dialog.
+msgid "Handle keys from other &applications"
+msgstr "&башка колдонмолордун баскычтарын иштетуу"
+
+#. Translators: Message to report wrong configuration of the NVDA key
+msgid "At least one key must be used as the NVDA key."
+msgstr "эн азынан 1 баскыч, NVDA модификаторунун баскычы катары колдонулушу керек"
+
+
+#. Translators: This is the label for the mouse settings dialog.
+msgid "Mouse Settings"
+msgstr "Чычкан"
+
+#. Translators: This is the label for a checkbox in the
+#. mouse settings dialog.
+msgid "Report mouse &shape changes"
+msgstr "&чычкандын корсоткучунун формасынын озгоруусун окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. mouse settings dialog.
+msgid "Enable mouse &tracking"
+msgstr "&чыканды аркалоону жандыруу"
+
+#. Translators: This is the label for a combobox in the
+#. mouse settings dialog.
+msgid "Text &unit resolution:"
+msgstr "&Текстти окуу бирдигин колому:"
+
+#. Translators: This is the name of a combobox in the mouse settings dialog.
+msgid "text reporting unit"
+msgstr "Текстти окуу бирдиги"
+
+#. Translators: This is the label for a checkbox in the
+#. mouse settings dialog.
+msgid "Report &role when mouse enters object"
+msgstr "Чычканды тууралагнда объектин озгоруусун окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. mouse settings dialog.
+msgid "&Play audio coordinates when mouse moves"
+msgstr "чычкан жылганда озгорулуучу сигнал"
+
+#. Translators: This is the label for a checkbox in the
+#. mouse settings dialog.
+msgid "&Brightness controls audio coordinates volume"
+msgstr "Чыкандын которуулусу сигналынын жарыгын контролдоо"
+
+#. Translators: This is the label for the review cursor settings dialog.
+msgid "Review Cursor Settings"
+msgstr "Бакоо курсорунун ондотмолору"
+
+#. Translators: This is the label for a checkbox in the
+#. review cursor settings dialog.
+msgid "Follow system &focus"
+msgstr "&системалык курсорду аркалоо"
+
+#. Translators: This is the label for a checkbox in the
+#. review cursor settings dialog.
+msgid "Follow System &Caret"
+msgstr "&системалык каретканы аркалоо"
+
+#. Translators: This is the label for a checkbox in the
+#. review cursor settings dialog.
+msgid "Follow &mouse cursor"
+msgstr "&чыкандын корсоткучун аркалоо"
+
+#. Translators: This is the label for a checkbox in the
+#. review cursor settings dialog.
+msgid "Simple review mode"
+msgstr "Женилдетилген байкоо тартиби"
+
+#. Translators: This is the label for the Input Composition settings dialog.
+msgid "Input Composition Settings"
+msgstr "Киргизууну форматтоо ондотмосу"
+
+#. Translators: This is the label for a checkbox in the
+#. Input composition settings dialog.
+msgid "Automatically report all available &candidates"
+msgstr "&баардык жеткилуккту варианттарды автоматтык турдо окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. Input composition settings dialog.
+msgid "Announce &selected candidate"
+msgstr "&тандалган вариантты окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. Input composition settings dialog.
+msgid "Always include short character &description when announcing candidates"
+msgstr "Ар дайым иероглифтин кыскача суротомосун жандыруу"
+
+#. Translators: This is the label for a checkbox in the
+#. Input composition settings dialog.
+msgid "Report changes to the &reading string"
+msgstr "алдын ала форматтонун тилке озгортуулорун окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. Input composition settings dialog.
+msgid "Report changes to the &composition string"
+msgstr "киргизүү тилкелерин сызык өзгөртүүсун окуу"
+
+#. Translators: This is the label for the object presentation dialog.
+msgid "Object Presentation"
+msgstr "объекти тартуулоо"
+
+#. Translators: An option for progress bar output in the Object Presentation dialog
+#. which reports progress bar updates by speaking.
+#. See Progress bar output in the Object Presentation Settings section of the User Guide.
+msgid "Speak"
+msgstr "Айтуу"
+
+#. Translators: An option for progress bar output in the Object Presentation dialog
+#. which reports progress bar updates by beeping.
+#. See Progress bar output in the Object Presentation Settings section of the User Guide.
+msgid "Beep"
+msgstr "ун сигналдарын ойнотуу"
+
+#. Translators: An option for progress bar output in the Object Presentation dialog
+#. which reports progress bar updates by both speaking and beeping.
+#. See Progress bar output in the Object Presentation Settings section of the User Guide.
+msgid "Speak and beep"
+msgstr "Ун сигналдарын айтуу жана ойнотуу"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report &tooltips"
+msgstr "Читать всплывающие &подсказки"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report &help balloons"
+msgstr "&калкып чыгуучу системалык билдируулорду окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report object shortcut &keys"
+msgstr "объекттин &тез жеткируу баскычын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report object &position information"
+msgstr "&позицию объектин жайгашуусун окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Guess object &position information when unavailable"
+msgstr "объектин жайгашуусу тууралуу так эмес маалыматты колдонуу"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report object &descriptions"
+msgstr "&объекттин сурроттосун окуу"
+
+#. Translators: This is the label for a combobox in the
+#. object presentation settings dialog.
+msgid "Progress &bar output:"
+msgstr "&Аткаруунун корсоткучторуно ун коштоо:"
+
+#. Translators: This is the name of a combobox in the
+#. object presentation settings dialog.
+msgid "Progress bar output"
+msgstr "Аткаруунун корсоткучторуно ун коштоо"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report background progress bars"
+msgstr "Аткаруунун фондук корсоткучторуно ун коштоо"
+
+#. Translators: This is the label for a checkbox in the
+#. object presentation settings dialog.
+msgid "Report dynamic &content changes"
+msgstr "Мазмундун днамикалык озгоруулорун окуу"
+
+#. Translators: This is the label for the browse mode settings dialog.
+msgid "Browse Mode"
+msgstr "Байкоо тартиби"
+
+#. Translators: This is the label for a textfield in the
+#. browse mode settings dialog.
+msgid "&Maximum number of characters on one line"
+msgstr "&сап учун символдордун эн коп саны"
+
+#. Translators: This is the label for a textfield in the
+#. browse mode settings dialog.
+msgid "&Number of lines per page"
+msgstr "&беттеги саптардын саны"
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "Use &screen layout (when supported)"
+msgstr "Экран сунуштоону колдонуп, (колдоо болсо)"
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "Automatic &Say All on page load"
+msgstr "Жүктөө учурунда автоматикалык бет окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "Include l&ayout tables"
+msgstr «Жайгаштыруу үчүн пайдаланылган столдорду ичинде»
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "Automatic focus mode for focus changes"
+msgstr «Сен өзгөртүүнү качан режимди өзгөртүү үчүн автоматтык которуу»
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "Automatic focus mode for caret movement"
+msgstr "«Aвтоматтык арабаны көчүп менен режимди өзгөртүү которулуп»
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "Audio indication of focus and browse modes"
+msgstr "«Үн режими көрсөткүчү кароо жана түзөтүү»
+
+#. Translators: This is the label for a checkbox in the
+#. browse mode settings dialog.
+msgid "&Trap all non-command gestures from reaching the document"
+msgstr "&командалык жандоолорго тыйуу салуу"
+
+#. Translators: This is the label for the document formatting dialog.
+msgid "Document Formatting"
+msgstr "Документти форматтоо"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Announce formatting changes after the cursor (can cause a lag)"
+msgstr «Курсор кийин формат өзгөртүүлөрдү Оку: (а крутой себеп болушу мүмкүн)»
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &font name"
+msgstr "шрифттин аталышын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report font &size"
+msgstr "&шрифта колому"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report font attri&butes"
+msgstr "&шрифттин атрибуттарын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &alignment"
+msgstr "&туздоону окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &colors"
+msgstr "&тусторду окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report co&mments"
+msgstr "&эскертуулорду окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &editor revisions"
+msgstr "редактордун текшеруулорун окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report e&mphasis"
+msgstr "а&кцентирлоону окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report st&yle"
+msgstr "Читать &стиль"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report spelling e&rrors"
+msgstr "орфографиялык каталарды окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &pages"
+msgstr "&бет номурларын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report line &numbers"
+msgstr "&тилке номерлерин окуу"
+
+#. Translators: This message is presented in the document formatting settings dialogue
+#. If this option is selected, NVDA will cound the leading spaces and tabs of a line and speak it.
+#.
+msgid "Report l&ine indentation"
+msgstr "&тилке чектелуулорун окуу"
+
+#. Translators: This message is presented in the document formatting settings dialogue
+#. If this option is selected, NVDA will report paragraph indentation if available.
+msgid "Report &paragraph indentation"
+msgstr "& абзац чектелуулорун окуу"
+
+#. Translators: This message is presented in the document formatting settings dialogue
+#. If this option is selected, NVDA will report line spacing if available.
+msgid "Report &line spacing"
+msgstr "&тилкеаралык интервал"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &tables"
+msgstr "&таблицаларды окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report table row/column h&eaders"
+msgstr "&таблицадагы тилке жана саптардын аталыштарын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report table cell c&oordinates"
+msgstr "&таблицадагы мамычалардын координаттарын окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report lin&ks"
+msgstr "&шилтемелерди окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &headings"
+msgstr "&аталыштарды окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report &lists"
+msgstr "&тизмелерди окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report block &quotes"
+msgstr "&цитаталарды окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report lan&dmarks"
+msgstr "&белгижайларды окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report fra&mes"
+msgstr "&чекттерди окуу"
+
+#. Translators: This is the label for a checkbox in the
+#. document formatting settings dialog.
+msgid "Report if &clickable"
+msgstr "&интерактивдуу элементтерди окуу"
+
+#. Translators: This is a label for an Entry Type radio button in add dictionary entry dialog.
+msgid "&Anywhere"
+msgstr "&Ар жерде"
+
+#. Translators: This is a label for an Entry Type radio button in add dictionary entry dialog.
+msgid "Whole &word"
+msgstr "Бутун &соз"
+
+#. Translators: This is a label for an Entry Type radio button in add dictionary entry dialog.
+msgid "&Regular expression"
+msgstr "дайымкы билдируу"
+
+#. Translators: This is the label for the edit dictionary entry dialog.
+msgid "Edit Dictionary Entry"
+msgstr "создук беренени ондоо"
+
+#. Translators: This is a label for an edit field in add dictionary entry dialog.
+msgid "&Pattern"
+msgstr "&улгу"
+
+#. Translators: This is a label for an edit field in add dictionary entry dialog and in punctuation/symbol pronunciation dialog.
+msgid "&Replacement"
+msgstr "&алмаштыруу"
+
+#. Translators: This is a label for an edit field in add dictionary entry dialog.
+msgid "&Comment"
+msgstr "&тушундурмо"
+
+#. Translators: This is a label for a set of radio buttons in add dictionary entry dialog.
+msgid "&Type"
+msgstr "&Тип"
+
+#. Translators: This is an error message to let the user know that the dictionary entry is not valid.
+#, python-format
+msgid "Regular Expression error: \"%s\"."
+msgstr "Дайымкы айтымдагы каталар: \"%s\"."
+
+msgid "Dictionary Entry Error"
+msgstr "Создук беренелердин катасы"
+
+#. Translators: The label for the combo box of dictionary entries in speech dictionary dialog.
+msgid "&Dictionary entries"
+msgstr "&Создук беренелери"
+
+#. Translators: The label for a column in dictionary entries list used to identify comments for the entry.
+#. Translators: Title of a dialog edit an Excel comment
+msgid "Comment"
+msgstr "Эскертме"
+
+#. Translators: The label for a column in dictionary entries list used to identify pattern (original word or a pattern).
+msgid "Pattern"
+msgstr "улгу"
+
+#. Translators: The label for a column in dictionary entries list and in a list of symbols from symbol pronunciation dialog used to identify replacement for a pattern or a symbol
+msgid "Replacement"
+msgstr "алмаштыруу"
+
+#. Translators: The label for a column in dictionary entries list used to identify whether the entry is case sensitive or not.
+msgid "case"
+msgstr "каттоо"
+
+#. Translators: The label for a column in dictionary entries list used to identify whether the entry is a regular expression, matches whole words, or matches anywhere.
+msgid "Type"
+msgstr "Тип"
+
+#. Translators: The label for a button in speech dictionaries dialog to add new entries.
+#. Translators: The label for a button in the Symbol Pronunciation dialog to add a new symbol.
+#. Translators: The label of a button to add a gesture in the Input Gestures dialog.
+msgid "&Add"
+msgstr "&Кошуу"
+
+#. Translators: The label for a button in speech dictionaries dialog to edit existing entries.
+msgid "&Edit"
+msgstr "&Редакциалоо"
+
+#. Translators: This is the label for the add dictionary entry dialog.
+msgid "Add Dictionary Entry"
+msgstr "Создук беренесин кошуу"
+
+#. Translators: This is the label for the braille settings dialog.
+msgid "Braille Settings"
+msgstr "Брайля Ондотмолору"
+
+#. Translators: The label for a setting in braille settings to choose a braille display.
+msgid "Braille &display:"
+msgstr "Брайльевский &дисплеи:"
+
+#. Translators: The label for a setting in braille settings to choose the connection port (if the selected braille display supports port selection).
+msgid "&Port:"
+msgstr "&Порт:"
+
+#. Translators: The label for a setting in braille settings to select the output table (the braille table used to read braille text on the braille display).
+msgid "&Output table:"
+msgstr "Брайль чыгаруу таблицасы:"
+
+#. Translators: The label for a setting in braille settings to select the input table (the braille table used to type braille characters on a braille keyboard).
+msgid "&Input table:"
+msgstr "Брайль киргизуу таблицасы:"
+
+#. Translators: The label for a setting in braille settings to expand the current word under cursor to computer braille.
+msgid "E&xpand to computer braille for the word at the cursor"
+msgstr "курсор астындагы создор учун кыскажазууну колдонбонуз"
+
+#. Translators: The label for a setting in braille settings to show the cursor.
+msgid "&Show cursor"
+msgstr "Курсорду корсотуу"
+
+#. Translators: The label for a setting in braille settings to change cursor blink rate in milliseconds (1 second is 1000 milliseconds).
+msgid "Cursor blink rate (ms)"
+msgstr "курсордун ирмоо ылдаамдыгы (мс)"
+
+#. Translators: The label for a setting in braille settings to select the cursor shape.
+msgid "Cursor &shape:"
+msgstr "&курсордун формасы:"
+
+#. Translators: The label for a setting in braille settings to change how long a message stays on the braille display (in seconds).
+msgid "Message timeout (sec)"
+msgstr "Время задержки сообщений (сек)"
+
+#. Translators: The label for a setting in braille settings to set whether braille should be tethered to focus or review cursor.
+msgid "Braille tethered to:"
+msgstr "брайльды байлоо:"
+
+#. Translators: The label for a setting in braille settings to read by paragraph (if it is checked, the commands to move the display by lines moves the display by paragraphs instead).
+msgid "Read by &paragraph"
+msgstr "абзац менен окуу"
+
+#. Translators: The label for a setting in braille settings to enable word wrap (try to avoid spliting words at the end of the braille display).
+msgid "Avoid splitting &words when possible"
+msgstr "Мумкун болсо ортодогу создорду болбонуз"
+
+#, python-format
+msgid "Could not load the %s display."
+msgstr "Дисплейди жуктогонго мумкун болбоду %s."
+
+msgid "Braille Display Error"
+msgstr "Брайль дисплейинин катасы"
+
+#. Translators: This is the label for the add symbol dialog.
+msgid "Add Symbol"
+msgstr "символду кошуу"
+
+#. Translators: This is the label for the edit field in the add symbol dialog.
+msgid "Symbol:"
+msgstr "Символ:"
+
+#. Translators: This is the label for the symbol pronunciation dialog.
+#. %s is replaced by the language for which symbol pronunciation is being edited.
+#, python-format
+msgid "Symbol Pronunciation (%s)"
+msgstr "символодорду айтуу (%s)"
+
+#. Translators: The label for symbols list in symbol pronunciation dialog.
+msgid "&Symbols"
+msgstr "&Символдор"
+
+#. Translators: The label for a column in symbols list used to identify a symbol.
+msgid "Symbol"
+msgstr "Символ"
+
+#. Translators: The label for a column in symbols list used to identify a symbol's speech level (either none, some, most, all or character).
+msgid "Level"
+msgstr "Денгээл"
+
+#. Translators: The label for a column in symbols list which specifies when the actual symbol will be sent to the synthesizer (preserved).
+#. See the "Punctuation/Symbol Pronunciation" section of the User Guide for details.
+msgid "Preserve"
+msgstr "Передавать синтезатору"
+
+#. Translators: The label for the edit field in symbol pronunciation dialog to change the pronunciation of a symbol.
+msgid "Change symbol"
+msgstr "символду озгортуу"
+
+#. Translators: The label for the combo box in symbol pronunciation dialog to change the speech level of a symbol.
+msgid "&Level"
+msgstr "&Денгээл"
+
+#. Translators: The label for the combo box in symbol pronunciation dialog to change when a symbol is sent to the synthesizer.
+msgid "&Send actual symbol to synthesizer"
+msgstr "Чыныгы символду синтезаторго откоруу:"
+
+#. Translators: The label for a button in the Symbol Pronunciation dialog to remove a symbol.
+msgid "Re&move"
+msgstr "Очуруу"
+
+#. Translators: An error reported in the Symbol Pronunciation dialog when adding a symbol that is already present.
+#, python-format
+msgid "Symbol \"%s\" is already present."
+msgstr "Символ \"%s\" бар."
+
+#. Translators: The title of the Input Gestures dialog where the user can remap input gestures for commands.
+msgid "Input Gestures"
+msgstr "Киргизуу жандоолору"
+
+#. Translators: The label of a text field to search for gestures in the Input Gestures dialog.
+msgctxt "inputGestures"
+msgid "&Filter by:"
+msgstr "&Фильтр:"
+
+#. Translators: Describes a gesture in the Input Gestures dialog.
+#. {main} is replaced with the main part of the gesture; e.g. alt+tab.
+#. {source} is replaced with the gesture's source; e.g. laptop keyboard.
+#, python-brace-format
+msgid "{main} ({source})"
+msgstr "{main} ({source})"
+
+#. Translators: The prompt to enter a gesture in the Input Gestures dialog.
+msgid "Enter input gesture:"
+msgstr Жандоону киргизиниз:"
+
+#. Translators: An error displayed when saving user defined input gestures fails.
+msgid "Error saving user defined gestures - probably read only file system."
+msgstr "Колдонуучунун кол белгилерин аныктоого мумкун болбоду, балким NVDA бир гана окуу жаатынан жуктолгон"
+
+
+#. Translators: Describes a command.
+msgid "Exit math interaction"
+msgstr "Математикалык оз ара аракеттенууну бутуруу"
+
+#. Translators: Reported when the user attempts math interaction
+#. but math interaction is not supported.
+msgid "Math interaction not supported."
+msgstr "Математиказык оз ара айкашуу колдонулбайт."
+
+#. Translators: name of the default espeak varient.
+msgctxt "espeakVarient"
+msgid "none"
+msgstr "Эч нерсе"
+
+#. Translators: This is the name of the rate boost voice toggle
+#. which further increases the speaking rate when enabled.
+msgid "Rate boos&t"
+msgstr "&Экстратездетуу"
+
+#. Translators: Description for a speech synthesizer.
+msgid "No speech"
+msgstr "Соз жок"
+
+msgid "word"
+msgstr "Соз"
+
+#. Translators: current position in a document as a percentage of the document length
+#, python-brace-format
+msgid "{curPercent:.0f}%"
+msgstr "{curPercent:.0f}%"
+
+#. Translators: the current position's screen coordinates in pixels
+#, python-brace-format
+msgid "at {x}, {y}"
+msgstr "координатар: {x}, {y}"
+
+#. Translators: Reported when a page reloads (example: after refreshing a webpage).
+msgid "Refreshed"
+msgstr "Жанырылды"
+
+#. Translators: Reported while loading a document.
+msgid "Loading document..."
+msgstr "Документти жуктоо..."
+
+#. Translators: the description for the refreshBuffer script on virtualBuffers.
+msgid "Refreshes the document content"
+msgstr "Документтин мазмунун жанылайт"
+
+#. Translators: Presented when use screen layout option is toggled.
+msgid "Use screen layout on"
+msgstr "Экранндык корсотуу жандырылган"
+
+#. Translators: Presented when use screen layout option is toggled.
+msgid "Use screen layout off"
+msgstr "Экранндык корсотуу очурулгон"
+
+#. Translators: the description for the toggleScreenLayout script on virtualBuffers.
+msgid ""
+"Toggles on and off if the screen layout is preserved while rendering the "
+"document content"
+msgstr "документин экрандык корсотуусун очуруп жандырат"
+
+#. Translators: The message reported when a user attempts to use a table movement command
+#. when the cursor is not within a table.
+#. Translators: a message when trying to perform an action on a cell when not in one in Microsoft word
+msgid "Not in a table cell"
+msgstr "таблицанын мамычасынан сыртта"
+
+#. Translators: the description for the next table row script on virtualBuffers.
+msgid "moves to the next table row"
+msgstr "Таблицанын кийинки тилкесине отот"
+
+#. Translators: the description for the previous table row script on virtualBuffers.
+msgid "moves to the previous table row"
+msgstr "Таблицанын мурунку тилкесине отот"
+
+#. Translators: the description for the next table column script on virtualBuffers.
+msgid "moves to the next table column"
+msgstr "Беттин кийинки тилкесине отот"
+
+#. Translators: the description for the previous table column script on virtualBuffers.
+msgid "moves to the previous table column"
+msgstr "Беттин мурунку тилкесине отот"
+
+msgid "Taskbar"
+msgstr "тапшырма панели"
+
+#. Translators: a color, broken down into its RGB red, green, blue parts.
+#, python-brace-format
+msgid "RGB red {rgb.red}, green {rgb.green}, blue {rgb.blue}"
+msgstr "RGB кызыл {rgb.red}, жашыл {rgb.green}, кок{rgb.blue}"
+
+#, python-format
+msgid "%s items"
+msgstr "%s элементти"
+
+msgid "invoke"
+msgstr "Активдештируу
+msgid "Desktop"
+msgstr "Иш столу"
+
+#. Translators: The default color of text when a color has not been set by the author.
+#. Translators: The default background color  when a color has not been set by the author.
+#. Translators: the default (automatic) color in Microsoft Word
+msgid "default color"
+msgstr "озу аныкталма тус"
+
+#. Translators: The color of text cannot be detected.
+#. Translators: The background color cannot be detected.
+msgid "Unknown color"
+msgstr "Белгисиз тус"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Excel controls the pattern.
+msgid "automatic"
+msgstr "автоматтык"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Checkerboard
+msgid "diagonal crosshatch"
+msgstr "диоганалдуу чакмактуу"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Criss-cross lines
+msgid "thin diagonal crosshatch"
+msgstr "ичке диоганалдуу чакмактуу"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Dark diagonal lines running from the upper left to the lower right
+msgid "reverse diagonal stripe"
+msgstr "оодарылган диоганалдуу суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. 12.5% gray
+#, no-python-format
+msgid "12.5% gray"
+msgstr "12,50% боз"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. 25% gray
+#, no-python-format
+msgid "25% gray"
+msgstr "25% боз"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. 50% gray
+#, no-python-format
+msgid "50% gray"
+msgstr "50% боз"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. 75% gray
+#, no-python-format
+msgid "75% gray"
+msgstr "75% боз"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. 6.25% gray
+#, no-python-format
+msgid "6.25% gray"
+msgstr "6,25% боз"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Grid
+msgid "thin horizontal crosshatch"
+msgstr "ичке, горизонталдуу,чакмактуу"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Dark horizontal lines
+msgid "horizontal stripe"
+msgstr "горизонталдуу суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Light diagonal lines running from the upper left to the lower right
+msgid "thin reverse diagonal stripe"
+msgstr "ичке, оодарылган диоганалдуу суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Light horizontal lines
+msgid "thin horizontal stripe"
+msgstr "ичке горизонталдуу суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Light diagonal lines running from the lower left to the upper right
+msgid "thin diagonal stripe"
+msgstr "ичке, диоганалдуу суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Light vertical bars
+msgid "thin vertical stripe"
+msgstr "ичке,тике суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. No pattern
+msgid "none"
+msgstr "жок"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. 75% dark moire
+msgid "thick diagonal crosshatch"
+msgstr "толук, диоганалдуу клеткалуу"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Solid color
+msgid "solid"
+msgstr "чылгый"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Dark diagonal lines running from the lower left to the upper right
+msgid "diagonal stripe"
+msgstr "диагоналдуу суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+#. Dark vertical bars
+msgid "vertical stripe"
+msgstr "тике суртум"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+msgid "linear gradient"
+msgstr "сызыктуу градиент"
+
+#. Translators: A type of background pattern in Microsoft Excel.
+msgid "rectangular gradient"
+msgstr "Тенбурчтуу градиент"
+
+#. Translators: the description for the elements list command in Microsoft Excel.
+msgid "Lists various types of elements in this spreadsheet"
+msgstr "Бул таблицадагы ар кайсы элементтердин тизмесин чакыртырат"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "&Charts"
+msgstr "&Диаграммалар"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "C&omments"
+msgstr "Эскертуулор"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "Fo&rmulas"
+msgstr "Формулалар"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "&Form fields"
+msgstr "&форманын чектери"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "&Sheets"
+msgstr "&барактар"
+
+#. Translators: Used to express an address range in excel.
+#, python-brace-format
+msgid "{start} through {end}"
+msgstr "{start} по {end}"
+
+#. Translators: a message reported in the SetColumnHeader script for Excel.
+#. Translators: a message reported in the SetRowHeader script for Excel.
+#. Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+#. Translators: a message reported in the SetRowHeader script for Microsoft Word.
+msgid ""
+"Cannot set headers. Please enable reporting of table headers in Document "
+"Formatting Settings"
+msgstr"аталыштарды окууга мүмкүн болбой жатат. \ Сураныч параметрди орнтунуз,» Саптардын аталыштарын  жана таблицадагы тилкелерди окуу\орнотмолордо\ документти форматтоо"
+
+#. Translators: a message reported in the SetColumnHeader script for Excel.
+#, python-brace-format
+msgid "Set {address} as start of column headers"
+msgstr "{address} тилке аталыштарын башы катары тандоо"
+
+#. Translators: a message reported in the SetColumnHeader script for Excel.
+#, python-brace-format
+msgid "Already set {address} as start of column headers"
+msgstr ""
+"{address} координаттары тилке башынын аталышы катары орнотулган"
+
+#. Translators: a message reported in the SetColumnHeader script for Excel.
+#, python-brace-format
+msgid "Removed {address}    from column headers"
+msgstr "{address} тилке аталыштарынан очурулуп салынган"
+
+#. Translators: a message reported in the SetColumnHeader script for Excel.
+#, python-brace-format
+msgid "Cannot find {address}    in column headers"
+msgstr "{address} координттарын тилке аталыштарында табууга мумкун эмес"
+
+msgid ""
+"Pressing once will set this cell as the first column header for any cells "
+"lower and to the right of it within this region. Pressing twice will forget "
+"the current column header for this cell."
+msgstr «Бир жолу басканда,NVDA бул сапта аталышын камтыганын көрсөтүп турат, »
+«алар астындагы мамычалар аркылуу өзүнөн окуп жаткан тилке. Эки жолку басуу орнотууларды нолго тушурот»
+
+#. Translators: a message reported in the SetRowHeader script for Excel.
+#, python-brace-format
+msgid "Set {address} as start of row headers"
+msgstr "{address} координаттарын баш тилкенине аталышы катары орнотуу"
+
+#. Translators: a message reported in the SetRowHeader script for Excel.
+#, python-brace-format
+msgid "Already set {address} as start of row headers"
+msgstr"{address} координаттары баш тилкенин аталышы катары орнотулган"
+
+#. Translators: a message reported in the SetRowHeader script for Excel.
+#, python-brace-format
+msgid "Removed {address}    from row headers"
+msgstr "{address}Тилке аталыштарынан очурулгон"
+
+#. Translators: a message reported in the SetRowHeader script for Excel.
+#, python-brace-format
+msgid "Cannot find {address}    in row headers"
+msgstr "{address} координаттарын саптардын аталышынан табууга болбой жатат"
+
+msgid ""
+"Pressing once will set this cell as the first row header for any cells lower "
+"and to the right of it within this region. Pressing twice will forget the "
+"current row header for this cell."
+msgstr " Бир жолу басуу NVDAга бул тилке сап учун аталыштарды камтуусун корсотот, алар автоматтык турдо бул тилкени котргондо окулат. Эки жолку бассуу орнотмолорду нолго келтирет"
+
+#, python-brace-format
+msgid "Input Message is {title}: {message}"
+msgstr "Киргизуу учун билдируу{title}: {message}"
+
+#, python-brace-format
+msgid "Input Message is {message}"
+msgstr "{message} Киргизуу учун билдируу"
+
+#. Translators: A message in Excel when there is no comment
+msgid "Not on a comment"
+msgstr "Эскертуу жок "
+
+#. Translators: the description  for a script for Excel
+msgid "Reports the comment on the current cell"
+msgstr "Учурдагы мамыча учун эскертуулорду окуйт"
+
+#. Translators: Dialog text for
+#, python-brace-format
+msgid "Editing comment for cell {address}"
+msgstr "{address} координатор мамычалары учун  эскертуулорду редакциалоо "
+
+#. Translators: This is presented in Excel to show the current selection, for example 'a1 c3 through a10 c10'
+#, python-brace-format
+msgid "{firstAddress} {firstContent} through {lastAddress} {lastContent}"
+msgstr "{firstAddress} {firstContent} по {lastAddress} {lastContent}"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Area"
+msgstr "Аймактар менен коломдуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Stacked Area"
+msgstr "Аймак жана топтом менен коломдуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "100 percent Stacked Area"
+msgstr "Нормалдуу аймак жана топтом менен"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Clustered Bar"
+msgstr "Топ менен коломдуу сызыктуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Stacked Bar"
+msgstr "Топтом менен коломдуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D 100 percent Stacked Bar"
+msgstr "нормалдуу коломдуу сызыктуу топтом менен диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Column"
+msgstr "уч олчомдуу гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Clustered Column"
+msgstr "Топ менен коломдуу гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Stacked Column"
+msgstr "Топтому менен коломдуу гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D 100 percent Stacked Column"
+msgstr "Нормадагы коломдуу гисторгамма топтому менен"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Line"
+msgstr "коломдуу чийкел"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Pie"
+msgstr "Коломдуу айланма диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Exploded 3D Pie"
+msgstr "Коломдуу кесилген тегерек диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Area"
+msgstr "Аймагы менен диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Stacked Area"
+msgstr "Диаграмма аймактары менен, топому менен"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Clustered Bar"
+msgstr "Топ менен сызыктуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Bar of Pie"
+msgstr "тегерек диаграмманын сызыгы"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Stacked Bar"
+msgstr "топтом менен сызыктуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "100 percent Stacked Bar"
+msgstr "Нормалуу сызыктуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Bubble"
+msgstr "Кобуктуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Bubble with 3D effects"
+msgstr "кобуктуу диаграмманын коломдуу варианты"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Clustered Column"
+msgstr "топ гистограммасы"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Stacked Column"
+msgstr "топтоо гистограммасы"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "100 percent Stacked Column"
+msgstr "нормадагы гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Clustered Cone Bar"
+msgstr "топчо менен кондук"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Stacked Cone Bar"
+msgstr "топтоо менен кондук"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "100 percent Stacked Cone Bar"
+msgstr "Нормадагы топто менен кондук гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "3D Cone Column"
+msgstr "Коломдуу кондук гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Clustered Cone Column"
+msgstr "группировка менен кондук гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Stacked Cone Column"
+msgstr "Топтоо менен кодук гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "100 percent Stacked Cone Column"
+msgstr "Кондук калыбындагы топтоо гистограммалар"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Clustered Cylinder Bar"
+msgstr "Цилиндр калыбынтагы топтуу"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Stacked Cylinder Bar"
+msgstr "Цилиндр калыбындагы топтолмо"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "100 percent Stacked Cylinder Bar"
+msgstr "Нормалданган цилиндр калыбындагы чөмөлө"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "3D Cylinder Column"
+msgstr "
+Коломдуу цилиндр калыбындагы гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "100 percent Stacked Cylinder Column"
+msgstr "Цилинр турундогу топтоолгон гистограммалар"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Doughnut"
+msgstr "Шакектуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Exploded Doughnut"
+msgstr "Кесилген шакектуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Line"
+msgstr "Катар"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Line with Markers"
+msgstr "белгиленген чийкел"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Stacked Line with Markers"
+msgstr «Турган топтоо программасы жеке баалуулуктар маркер менен белгиленет»
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "100 percent Stacked Line with Markers"
+msgstr "Жеке баалуулуктар маркерлер менен белгиленип жаткан нормалуу диаграмма "
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Stacked Line"
+msgstr "Топтолуштуу чийкел"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "100 percent Stacked Line"
+msgstr "Топтолуштуу аталган чийкел"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Pie"
+msgstr "Айланпа диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Exploded Pie"
+msgstr "Кесилген айланпа диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Pie of Pie"
+msgstr "Экинчи жолку айланпа диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Clustered Pyramid Bar"
+msgstr "Топтуу пирамидалык"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Stacked Pyramid Bar"
+msgstr "Пирамидалык топтолуу менен"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "100 percent Stacked Pyramid Bar"
+msgstr "Нормированная пирамидальная с накоплением"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "3D Pyramid Column"
+msgstr "Объёмная пирамидальная гистограмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Clustered Pyramid Column"
+msgstr "Пирамидалык топтуу мамылуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "Stacked Pyramid Column"
+msgstr "Пирамидалык мамылуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-b22a8bb9-a673-4d7f-b481-aa747c48eb3d
+msgid "100 percent Stacked Pyramid Column"
+msgstr "аталган пирамидалык мамылуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Radar"
+msgstr "Жалбырактуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Filled Radar"
+msgstr "Толтурулган жалбырактуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Radar with Data Markers"
+msgstr "Маалымат туткасы менен жалбырактуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "High-Low-Close"
+msgstr "уч маанини камтыган биржалык диаграмма (эн жогору курс, эн томонку курс, жабуу курсу) "
+"Биржевая диаграмма отображает наборы данных из трёх значений (самый высокий "
+"курс, самый низкий курс, курс закрытия)"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Open-High-Low-Close"
+msgstr "торт маанини камтыган биржалык диаграмма (ачуу курс, эн жогору курс, эн томонку курс, жабуу курсу) "
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Volume-High-Low-Close"
+msgstr "торт маанини камтыган биржалык диаграмма (колом, эн жогору курс, эн томонку курс, жабуу курсу)"
+"Биржевая диаграмма для наборов из четырёх значений (объём, самый высокий "
+"курс, самый низкий курс, курс закрытия)"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Volume-Open-High-Low-Close"
+msgstr "беш маанини камтыган биржалык диаграмма (колом, ачуу курс, эн жогору курс, эн томонку курс, жабуу курсу) "
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Surface"
+msgstr "Объёмдуу бетки диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Surface (Top View)"
+msgstr "Устуу дианрамма (устун куорунуш)"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Surface (Top View wireframe)"
+msgstr "Сымдуу бет"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "3D Surface (wireframe)"
+msgstr "Объёмдуу,сымдуу бет"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Scatter"
+msgstr "Чекиттуу диаграмма"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Scatter with Lines"
+msgstr "Чекиттуу диаграмма сызыктар менен"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Scatter with Lines and No Data Markers"
+msgstr "Чекиттуу диаграмма маркери жок маалыматтар"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Scatter with Smoothed Lines"
+msgstr "Чекиттуу диаграмма тегиз сызыктар менен"
+
+#. Translators: A type of chart in Microsoft Excel.
+#. See https://support.office.com/en-in/article/Available-chart-types-a019c053-ba7f-4c46-a09a-82e17f3ee5be
+msgid "Scatter with Smoothed Lines and No Data Markers"
+msgstr "Чекиттуу диаграмма тегиз сызыктар менен анан маркери жок маалыматтар"
+
+#. Translators: Message reporting the title and type of a chart.
+#, python-brace-format
+msgid "Chart title: {chartTitle}, type: {chartType}"
+msgstr "{chartType} башы менен {chartTitle}"
+
+#. Translators: Reported when there is no title for an axis in a chart.
+msgid "Not defined"
+msgstr "Аныкталган жок"
+
+#. Translators: A type of axis in a chart.
+#. Translators: The category axis in a Microsoft Excel chart.
+#. See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
+msgid "Category"
+msgstr "Категориясы"
+
+#. Translators: A type of axis in a chart.
+#. Translators: The value axis in a Microsoft Excel chart.
+#. See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
+msgid "Value"
+msgstr "Мазмуну"
+
+#. Translators: A type of axis in a chart.
+#. Translators: The series axis in a Microsoft Excel chart.
+#. See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
+msgid "Series"
+msgstr "Катар"
+
+#. Translators: Message reporting the type and title of an axis in a chart.
+#. For example, this might report "Category axis is month"
+#, python-brace-format
+msgid "{axisName} Axis is {axisTitle}"
+msgstr "Тип огу {axisName} башы менен {axisTitle}"
+
+#. Translators: Indicates that there is 1 series in a chart.
+msgid "There is 1 series in this chart"
+msgstr "Бул диаграммада жалпы 1 катар"
+
+#. Translators: Indicates the number of series in a chart where there are multiple series.
+#, python-format
+msgid "There are total %d series in this chart"
+msgstr "Бул диаграммада жалпы %d катарлар"
+
+#. Translators: Specifies the number and name of a series when listing series in a chart.
+#, python-brace-format
+msgid "series {number} {name}"
+msgstr "катар {number} {name}"
+
+#. Translators: Indicates that there are no series in a chart.
+msgid "No Series defined."
+msgstr "Катарлар аныкталган эмес."
+
+#. Translators: A slice in a pie chart.
+msgid "slice"
+msgstr "сектор"
+
+#. Translators: A column in a column chart.
+msgctxt "chart"
+msgid "column"
+msgstr "тилке"
+
+#. Translators: A data point in a line chart.
+msgid "data point"
+msgstr "маалыматтар чекити"
+
+#. Translators: A segment of a chart for charts which don't have a specific name for segments.
+msgid "item"
+msgstr "элемент"
+
+#, python-brace-format
+msgid "Series color: {colorName} "
+msgstr "Катардын тусу: {colorName} "
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Display Unit Label"
+msgstr "Показать метку цены деления"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Major Gridlines"
+msgstr "Негизги сетка сызыгы"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Minor Gridlines"
+msgstr "Жардамчы сетка сызыгы"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Pivot Chart Drop Zone"
+msgstr "Pivot Chart Drop Zone"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Pivot Chart Field Button"
+msgstr "Pivot Chart Field Button"
+
+# An open-source (and free) Screen Reader for the Windows Operating System
+# Created by Michael Curran, with help from James Teh and others
+# Copyright (C) 2006-2007 Michael Curran <mick@kulgan.net>
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Down Bars"
+msgstr "Томондотуу тилкеси"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Drop Lines"
+msgstr "Проекция сызыгы"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Hi Lo Lines"
+msgstr "Hi Lo Lines"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Radar Axis Labels"
+msgstr "Жалбырактуу огу белгиси"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Series Lines"
+msgstr "Сериялардын сызыктары"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Up Bars"
+msgstr "Тилкелер жогорулатуу"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Corners"
+msgstr "Бурчтар"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Data Table"
+msgstr "Маалыматтар таблицасы"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Floor"
+msgstr "Негизи"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Nothing"
+msgstr "Эчнерсе"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Walls"
+msgstr "Капталдары"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Data Label"
+msgstr "Маалыматтар колу"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Error Bars"
+msgstr "Чек кемчиликтери"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "X Error Bars"
+msgstr "Чек кемчиликтеринин боюнча X"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Y Error Bars"
+msgstr "Чек кемчиликтеринин боюнча Y"
+
+#. Translators: A type of element in a Microsoft Excel chart.
+msgid "Shape"
+msgstr "Фигура"
+
+#. Translators: Details about a series in a chart.
+#. For example, this might report "foo series 1 of 2"
+#, python-brace-format
+msgid "{seriesName} series {seriesIndex} of {seriesCount}"
+msgstr "{seriesName} ряд {seriesIndex} ичинен {seriesCount}"
+
+#. Translators: For line charts, indicates no change from the previous data point on the left
+#, python-brace-format
+msgid "no change from point {previousIndex}, "
+msgstr "чегинде озгоруулор жок {previousIndex}, "
+
+#. Translators: For line charts, indicates an increase from the previous data point on the left
+#, python-brace-format
+msgid "Increased by {incrementValue} from point {previousIndex}, "
+msgstr "которулду мынчага {incrementValue} чегинде {previousIndex}, "
+
+#. Translators: For line charts, indicates a decrease from the previous data point on the left
+#, python-brace-format
+msgid "decreased by {decrementValue} from point {previousIndex}, "
+msgstr "азайды мынчага {decrementValue} чегинде {previousIndex}, "
+
+#. Translators: Specifies the category of a data point.
+#. {categoryAxisTitle} will be replaced with the title of the category axis; e.g. "Month".
+#. {categoryAxisData} will be replaced with the category itself; e.g. "January".
+#, python-brace-format
+msgid "{categoryAxisTitle} {categoryAxisData}: "
+msgstr "{categoryAxisTitle} {categoryAxisData}: "
+
+#. Translators: Specifies the category of a data point.
+#. {categoryAxisData} will be replaced with the category itself; e.g. "January".
+#, python-brace-format
+msgid "Category {categoryAxisData}: "
+msgstr "Категория {categoryAxisData}: "
+
+#. Translators: Specifies the value of a data point.
+#. {valueAxisTitle} will be replaced with the title of the value axis; e.g. "Amount".
+#. {valueAxisData} will be replaced with the value itself; e.g. "1000".
+#, python-brace-format
+msgid "{valueAxisTitle} {valueAxisData}"
+msgstr "{valueAxisTitle} {valueAxisData}"
+
+#. Translators: Specifies the value of a data point.
+#. {valueAxisData} will be replaced with the value itself; e.g. "1000".
+#, python-brace-format
+msgid "value {valueAxisData}"
+msgstr "мазмуну {valueAxisData}"
+
+#. Translators: Details about a slice of a pie chart.
+#. For example, this might report "fraction 25.25 percent slice 1 of 5"
+#, python-brace-format
+msgid ""
+" fraction {fractionValue:.2f} Percent slice {pointIndex} of {pointCount}"
+msgstr ""
+" секторду тузуучу {fractionValue:.2f} процент {pointIndex} ичинен "
+"{pointCount}"
+
+#. Translators: Details about a segment of a chart.
+#. For example, this might report "column 1 of 5"
+#, python-brace-format
+msgid " {segmentType} {pointIndex} of {pointCount}"
+msgstr " {segmentType} {pointIndex} из {pointCount}"
+
+#. Translators: The primary axis group in a Microsoft Excel chart.
+msgid "Primary"
+msgstr "Башкы огу менен"
+
+#. Translators: The secondary axis group in a Microsoft Excel chart.
+msgid "Secondary"
+msgstr "Комокчу огу менен"
+
+#. Translators: Details about an axis in a chart.
+#, python-brace-format
+msgid "Chart axis, type: {axisType}, group: {axisGroup}, title: {axisTitle}"
+msgstr ""
+"Диаграмманын огу, тип: {axisType}, группа: {axisGroup}, башы: {axisTitle}"
+
+#. Translators: Details about an untitled axis in a chart.
+#, python-brace-format
+msgid "Chart axis, type: {axisType}, group: {axisGroup}"
+msgstr "Диаграмманын огу, тип: {axisType}, группа: {axisGroup}"
+
+#. Translators: Indicates a chart axis title in Microsoft Excel.
+msgid "Chart axis title"
+msgstr "Диаграмманын ог башы"
+
+#. Translators: Indicates a trendline in a Microsoft Excel chart.
+#. See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
+msgid "trendline"
+msgstr "трендтин сызыгы"
+
+#. Translators: Describes the squared symbol used in the label for a trendline in a Microsoft Excel chart.
+msgid " squared "
+msgstr " квадрат "
+
+#. Translators: Details about a chart title in Microsoft Excel.
+#, python-brace-format
+msgid "Chart title: {chartTitle}"
+msgstr "Диаграмманын башы: {chartTitle}"
+
+#. Translators: Indicates an untitled chart in Microsoft Excel.
+msgid "Untitled chart"
+msgstr "Аты жок диаграмма"
+
+#. Translators: Details about the chart area in a Microsoft Excel chart.
+#, python-brace-format
+msgid ""
+"Chart area, height: {chartAreaHeight}, width: {chartAreaWidth}, top: "
+"{chartAreaTop}, left: {chartAreaLeft}"
+msgstr ""
+"Диаграмманын областы, бийиктиги: {chartAreaHeight}, туурасы: {chartAreaWidth}, "
+"усту: {chartAreaTop}, сол жак: {chartAreaLeft}"
+
+#. Translators: Indicates the chart area of a Microsoft Excel chart.
+msgid "Chart area "
+msgstr "Диаграмманын областы "
+
+#. Translators: Details about the plot area of a Microsoft Excel chart.
+#, python-brace-format
+msgid ""
+"Plot area, inside height: {plotAreaInsideHeight:.0f}, inside width: "
+"{plotAreaInsideWidth:.0f}, inside top: {plotAreaInsideTop:.0f}, inside left: "
+"{plotAreaInsideLeft:.0f}"
+msgstr ""
+"Ичиндеги куруу областын бийиктиги: {plotAreaInsideHeight:.0f}, ичиндеги туурасы: "
+"{plotAreaInsideWidth:.0f}, ички устундо: {plotAreaInsideTop:.0f}, сол жакта "
+"ичинде: {plotAreaInsideLeft:.0f}"
+
+#. Translators: Indicates the plot area of a Microsoft Excel chart.
+msgid "Plot area "
+msgstr "Куруунун областы"
+
+#. Translators: Indicates the legend in a Microsoft Excel chart.
+#. See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
+msgid "Legend"
+msgstr "Легенда"
+
+#. Translators: Indicates that there is no legend in a Microsoft Excel chart.
+msgid "No legend"
+msgstr "Легенда жок"
+
+#. Translators: Details about a legend entry for a series in a Microsoft Excel chart.
+#. For example, this might report "Legend entry for series Temperature 1 of 2"
+#, python-brace-format
+msgid "Legend entry for series {seriesName} {seriesIndex} of {seriesCount}"
+msgstr "Легенданын элементтери катар учун {seriesName} {seriesIndex} ичинен {seriesCount}"
+
+#. Translators: Details about a legend key for a series in a Microsoft Excel chart.
+#. For example, this might report "Legend key for series Temperature 1 of 2"
+#. See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
+#, python-brace-format
+msgid "Legend key for Series {seriesName} {seriesIndex} of {seriesCount}"
+msgstr "Легенданын ключу катар учун {seriesName} {seriesIndex} ичинен {seriesCount}"
+
+#. Translators: a Microsoft Word revision type (inserted content)
+msgid "insertion"
+msgstr "кыстырма"
+
+#. Translators: a Microsoft Word revision type (deleted content)
+msgid "deletion"
+msgstr "очуруу"
+
+#. Translators: a Microsoft Word revision type (changed content property, e.g. font, color)
+msgid "property"
+msgstr "Сапаты"
+
+#. Translators: a Microsoft Word revision type (changed paragraph number)
+msgid "paragraph number"
+msgstr "абзацтын номри"
+
+#. Translators: a Microsoft Word revision type (display field)
+msgid "display field"
+msgstr "индикациянын аянты"
+
+#. Translators: a Microsoft Word revision type (reconcile)
+msgid "reconcile"
+msgstr "Келишуу"
+
+#. Translators: a Microsoft Word revision type (conflicting revision)
+msgid "conflict"
+msgstr "Чыр-чатак"
+
+#. Translators: a Microsoft Word revision type (replaced content)
+msgid "replace"
+msgstr "Алмаштыруу"
+#. Translators: a Microsoft Word revision type (changed paragraph property, e.g. alignment)
+msgid "paragraph property"
+msgstr "абзацтын сапаты"
+
+#. Translators: a Microsoft Word revision type (table)
+msgid "table property"
+msgstr "таблицанын сапаты"
+
+#. Translators: a Microsoft Word revision type (section property)
+msgid "section property"
+msgstr "болуктун сапаты"
+
+#. Translators: a Microsoft Word revision type (style definition)
+msgid "style definition"
+msgstr "стилди аныктоо"
+
+#. Translators: a Microsoft Word revision type (moved from)
+msgid "moved from"
+msgstr "Кочурулгон жерден"
+
+#. Translators: a Microsoft Word revision type (moved to)
+msgid "moved to"
+msgstr "кочурулгон устуно"
+
+#. Translators: a Microsoft Word revision type (inserted table cell)
+msgid "cell insertion"
+msgstr "уячаларды кыстыруу"
+
+#. Translators: a Microsoft Word revision type (deleted table cell)
+msgid "cell deletion"
+msgstr "Уячалардын очуруучу"
+
+#. Translators: a Microsoft Word revision type (merged table cells)
+msgid "cell merge"
+msgstr "Уячалардын биригуусу"
+
+msgid "Comments"
+msgstr "Тушундурмолор"
+
+msgid "Endnotes"
+msgstr "Тушундурмо"
+
+msgid "Even pages footer"
+msgstr "анан беттин шилтемеси"
+
+msgid "Even pages header"
+msgstr "анан беттин башы"
+
+msgid "First page footer"
+msgstr "Беттин алгачкы шилтемеси"
+
+msgid "First page header"
+msgstr "Беттин алгачкы башы"
+
+msgid "Footnotes"
+msgstr "Шилтемелер"
+
+msgid "Primary footer"
+msgstr "Алгачкы колонтитул"
+
+msgid "Primary header"
+msgstr "Алгачкы баш"
+
+msgid "Text frame"
+msgstr "Тексттик фрейм"
+
+#, python-brace-format
+msgid "comment: {text} by {author} on {date}"
+msgstr "эскертуу: {text}. {author}, {date}"
+
+#, python-brace-format
+msgid "{revisionType} {description}: {text} by {author} on {date}"
+msgstr "{revisionType} {description}: {text}. {author}, {date}"
+
+#. Translators: single line spacing
+msgctxt "line spacing value"
+msgid "single"
+msgstr "бир кабат"
+
+#. Translators: double line spacing
+msgctxt "line spacing value"
+msgid "double"
+msgstr "кош"
+
+#. Translators:  line spacing of 1.5 lines
+msgctxt "line spacing value"
+msgid "1.5 lines"
+msgstr "бир жарым"
+
+#. Translators: exact (minimum) line spacing
+msgctxt "line spacing value"
+msgid "exact"
+msgstr "туура"
+
+#. Translators: line spacing of at least x point
+#, python-format
+msgctxt "line spacing value"
+msgid "at least %.1f pt"
+msgstr "минимум %.1f pt"
+
+#. Translators: line spacing of x lines
+#, python-format
+msgctxt "line spacing value"
+msgid "%.1f lines"
+msgstr "%.1f саптар"
+
+#. Translators: the title of the message dialog desplaying an MS Word table description.
+msgid "Table description"
+msgstr "Таблицаны суроттоо"
+
+#. Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+#, python-brace-format
+msgid "Set row {rowNumber} column {columnNumber} as start of column headers"
+msgstr ""
+"Сап {rowNumber} тилкден {columnNumber} орнотулган катары "
+"тилкелердин башы учун"
+
+#. Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+#, python-brace-format
+msgid ""
+"Already set row {rowNumber} column {columnNumber} as start of column headers"
+msgstr ""
+"сап {rowNumber} тилкеден {columnNumber} орнотулган катары "
+"тилкелердин башы учун"
+
+#. Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+#, python-brace-format
+msgid "Removed row {rowNumber} column {columnNumber}  from column headers"
+msgstr ""
+"Сап {rowNumber} тилкеден {columnNumber} тилкелердин башынан очурулгон"
+
+#. Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+#, python-brace-format
+msgid "Cannot find row {rowNumber} column {columnNumber}  in column headers"
+msgstr ""
+"Сапты табууга мумкун болбоду {rowNumber} тилке {columnNumber} баш саптарда "
+"тилкерердин"
+
+msgid ""
+"Pressing once will set this cell as the first column header for any cells "
+"lower and to the right of it within this table. Pressing twice will forget "
+"the current column header for this cell."
+msgstr ""
+"Бирдик баскылоо корсотот NVDA, бул сап баш камтыйт "
+"тилкелер, алар автоматтык турдо окулуп бул саптары боюнча откоруудо"
+"бул сап менен. Кош баскылоо орнотууну таштайт."
+
+#. Translators: a message reported in the SetRowHeader script for Microsoft Word.
+#, python-brace-format
+msgid "Set row {rowNumber} column {columnNumber} as start of row headers"
+msgstr ""
+"Тилке {columnNumber} саптан {rowNumber} катары орнотулган "
+"саптардын"
+
+#. Translators: a message reported in the SetRowHeader script for Microsoft Word.
+#, python-brace-format
+msgid ""
+"Already set row {rowNumber} column {columnNumber} as start of row headers"
+msgstr ""
+"Тилке {columnNumber} саптан {rowNumber} катары орнотулган "
+"саптардын башы"
+
+#. Translators: a message reported in the SetRowHeader script for Microsoft Word.
+#, python-brace-format
+msgid "Removed row {rowNumber} column {columnNumber}  from row headers"
+msgstr ""
+"Тилке {columnNumber} саптан {rowNumber} саптардын аталышынан очурулгон"
+
+#. Translators: a message reported in the SetRowHeader script for Microsoft Word.
+#, python-brace-format
+msgid "Cannot find row {rowNumber} column {columnNumber}  in row headers"
+msgstr ""
+"Сапты табууга мумкун болбоду {rowNumber} тилке {columnNumber} саптардын аталышы"
+
+msgid ""
+"Pressing once will set this cell as the first row header for any cells lower "
+"and to the right of it within this table. Pressing twice will forget the "
+"current row header for this cell."
+msgstr ""
+"Бирдик баскылоо корсотот NVDA, бул столбец камтыйт аталыштары учун  "
+"сап, алар автоматтык турдо окулуп бул саптары боюнча откоруудо "
+"тилке. Кош баскылоо орнотууну таштайт"
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Bold on"
+msgstr "Кара шрифт кошулган"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Bold off"
+msgstr "Кара шриф очурулгон"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Italic on"
+msgstr "Курсив кошулган"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Italic off"
+msgstr "Курсив очурулгон"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Underline on"
+msgstr "Астын сызып кою кошулган"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Underline off"
+msgstr "Астын сызып кою очурулгон"
+
+#. Translators: a an alignment in Microsoft Word
+msgid "Left aligned"
+msgstr "Сол кыры менен туздоо"
+
+#. Translators: a an alignment in Microsoft Word
+msgid "centered"
+msgstr "Ортодо туздоо"
+
+#. Translators: a an alignment in Microsoft Word
+msgid "Right aligned"
+msgstr "Он кыры менен туздоо"
+
+#. Translators: a an alignment in Microsoft Word
+msgid "Justified"
+msgstr "Ээни боюнча туздоо"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Superscript"
+msgstr "Беттин усту"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Subscript"
+msgstr "Беттин асты"
+
+#. Translators: a message when toggling formatting in Microsoft word
+msgid "Baseline"
+msgstr "таяныч сызык"
+
+#. Translators: a message reported when a paragraph is moved below another paragraph
+#, python-format
+msgid "Moved below %s"
+msgstr "астына киргизилген %s"
+
+#. Translators: a message reported when a paragraph is moved below a blank paragraph
+msgid "Moved below blank paragraph"
+msgstr "Бош абзацтын астына киргизилген"
+
+#. Translators: a message reported when a paragraph is moved above another paragraph
+#, python-format
+msgid "Moved above %s"
+msgstr "Астына киргизилген %s"
+
+#. Translators: a message reported when a paragraph is moved above a blank paragraph
+msgid "Moved above blank paragraph"
+msgstr "Бош абзацтын устундо киргизилген"
+
+#. Translators: the message when the outline level / style is changed in Microsoft word
+#, python-brace-format
+msgid "{styleName} style, outline level {outlineLevel}"
+msgstr "стиль {styleName}, Тузулуш денгээли {outlineLevel}"
+
+#. Translators: a message when increasing or decreasing font size in Microsoft Word
+#, python-brace-format
+msgid "{size:g} point font"
+msgstr "{size:g} арип пункттары"
+
+#. Translators: a measurement in Microsoft Word
+#, python-brace-format
+msgid "{offset:.3g} characters"
+msgstr "{offset:.3g} символдор"
+
+#. Translators: a measurement in Microsoft Word
+#, python-brace-format
+msgid "{offset:.3g} inches"
+msgstr "{offset:.3g} дюйм"
+
+#. Translators: a measurement in Microsoft Word
+#, python-brace-format
+msgid "{offset:.3g} centimeters"
+msgstr "{offset:.3g} сантиметр"
+
+#. Translators: a measurement in Microsoft Word
+#, python-brace-format
+msgid "{offset:.3g} millimeters"
+msgstr "{offset:.3g} миллиметр"
+
+#. Translators: a measurement in Microsoft Word
+#, python-brace-format
+msgid "{offset:.3g} points"
+msgstr "{offset:.3g} чекит"
+
+#. Translators: a measurement in Microsoft Word
+#. See http://support.microsoft.com/kb/76388 for details.
+#, python-brace-format
+msgid "{offset:.3g} picas"
+msgstr "{offset:.3g} пик"
+
+#. Translators: a message when there is no comment to report in Microsoft Word
+msgid "No comments"
+msgstr "Тушундурмолор жок"
+
+#. Translators: a description for a script
+msgid "Reports the text of the comment where the System caret is located."
+msgstr " Тутумдук каретапозициясында эскертуулорду окуп жатат."
+
+#. Translators: a message when switching to single line spacing  in Microsoft word
+msgid "Single line spacing"
+msgstr "бир кабат сап аралыгы"
+
+#. Translators: a message when switching to double line spacing  in Microsoft word
+msgid "Double line spacing"
+msgstr "Эки эсе сап аралыгы"
+
+#. Translators: a message when switching to 1.5 line spaceing  in Microsoft word
+msgid "1.5 line spacing"
+msgstr "бир жарым сап аралыгы"
+
+#. Translators: The message reported when a user attempts to use a table movement command
+#. when the cursor is not withnin a table.
+msgid "Not in table"
+msgstr "Таблицадан сырткары"
+
+#. Translators: The label of a radio button to select the type of element
+#. in the browse mode Elements List dialog.
+msgid "&Annotations"
+msgstr "&Примечания"
+
+#. Translators: The name of a series of braille displays.
+msgid "HIMS Braille Sense/Braille EDGE/Smart Beetle series"
+msgstr "HIMS Braille Sense/Braille EDGE/Smart Beetle"
+
+#. Translators: The name of a braille display.
+msgid "HIMS SyncBraille"
+msgstr "HIMS SyncBraille"
+
+#~ msgid "This cell is non-editable"
+#~ msgstr "Бул уяча редакцияланбайт"
+
+#~ msgid "checker"
+#~ msgstr "диагоналдуу чакмактуу"
+
+#~ msgid "crisscross"
+#~ msgstr "жука, диагоналдуу чакмактуу"
+
+#~ msgid "down"
+#~ msgstr "тонкорулгон диагоналдуу штрих"
+
+#~ msgid "gray16"
+#~ msgstr "12,50%-ык сур"
+
+#~ msgid "gray25"
+#~ msgstr "25% сур"
+
+#~ msgid "gray50"
+#~ msgstr "50%-ык сур"
+
+#~ msgid "gray75"
+#~ msgstr "75%-ык сур"
+
+#~ msgid "grid"
+#~ msgstr "жука, горизонталдуу чакмак"
+
+#~ msgid "light down"
+#~ msgstr "Жука, тонкорулгон диагоналдуу штрих"
+
+#~ msgid "light up"
+#~ msgstr "Ичке, диагоналдууй штрих"
+
+#~ msgid "light vertical"
+#~ msgstr "Ичке, тике штрих"
+
+#~ msgid "semi gray75"
+#~ msgstr "семиз, диагоналдуу чакмактуу"
+
+#~ msgid "up"
+#~ msgstr "диагоналдуу штрих"
+
+#~ msgid "unknown color"
+#~ msgstr "Белгисиз тус"
+
+#~ msgctxt "color name"
+#~ msgid "Alice Blue"
+#~ msgstr "Кок Элис"
+
+#~ msgctxt "color name"
+#~ msgid "Antique White"
+#~ msgstr "Байыркы ак"
+
+#~ msgctxt "color name"
+#~ msgid "Aqua"
+#~ msgstr "Дениз толкуну тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Aquamarine"
+#~ msgstr "Аквамарин тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Azure"
+#~ msgstr "Ач Когултур"
+
+#~ msgctxt "color name"
+#~ msgid "Beige"
+#~ msgstr "Ачык сары кызгылт"
+
+#~ msgctxt "color name"
+#~ msgid "Bisque"
+#~ msgstr "Бисквит тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Blanched Almond"
+#~ msgstr "Тазаланган бадам"
+
+#~ msgctxt "color name"
+#~ msgid "Blue"
+#~ msgstr "Кок"
+
+#~ msgctxt "color name"
+#~ msgid "Blue Violet"
+#~ msgstr "Кок-кызгылт кок"
+
+#~ msgctxt "color name"
+#~ msgid "Burly Wood"
+#~ msgstr "Саргыч"
+
+#~ msgctxt "color name"
+#~ msgid "Cadet Blue"
+#~ msgstr "Сур-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Chartreuse"
+#~ msgstr "Ач жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Chocolate"
+#~ msgstr "Шоколад тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Coral"
+#~ msgstr "Моржан тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Cornflower Blue"
+#~ msgstr "Ачык кок тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Cornsilk"
+#~ msgstr "Жибек тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Crimson"
+#~ msgstr "Терен-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Cyan"
+#~ msgstr "Когултур"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Blue"
+#~ msgstr "Терен-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Cyan"
+#~ msgstr "Терен-когултур"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Goldenrod"
+#~ msgstr "Терен-алтын тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Green"
+#~ msgstr "Терен-жашыл"
+#~ msgctxt "color name"
+#~ msgid "Dark Khaki"
+#~ msgstr "Терен хаки"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Magenta"
+#~ msgstr "Терен-кара кочкул"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Olive Green"
+#~ msgstr "Терен саргыч жашылтустуу-жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Orange"
+#~ msgstr "Терен-кызгылт сары"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Orchid"
+#~ msgstr "Терен-орхидея тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Red"
+#~ msgstr "Терен-кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Salmon"
+#~ msgstr "терен-саргылтым кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Sea Green"
+#~ msgstr "Терен-жашыл дениз"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Slate Blue"
+#~ msgstr "Терен-кочкул кок"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Slate Gray"
+#~ msgstr "Терен-кочкул сур"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Turquoise"
+#~ msgstr "Терен-бирюза тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Dark Violet"
+#~ msgstr "Каралжын-"
+
+#~ msgctxt "color name"
+#~ msgid "Deep Pink"
+#~ msgstr "Терен кызгылт"
+
+#~ msgctxt "color name"
+#~ msgid "Deep Sky Blue"
+#~ msgstr "Терен асман -когултур"
+
+#~ msgctxt "color name"
+#~ msgid "Dim Gray"
+#~ msgstr "Боз сур"
+
+#~ msgctxt "color name"
+#~ msgid "Dodger Blue"
+#~ msgstr "Коргоочу-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Fire Brick"
+#~ msgstr "Кирпич тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Floral White"
+#~ msgstr "Гулдуу ак"
+
+#~ msgctxt "color name"
+#~ msgid "Forest Green"
+#~ msgstr "Токой тустуу жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Fuchsia"
+#~ msgstr "Фуксия"
+
+#~ msgctxt "color name"
+#~ msgid "Gainsboro"
+#~ msgstr "Гейнсборо"
+
+#~ msgctxt "color name"
+#~ msgid "Ghost White"
+#~ msgstr "Боз ак"
+
+#~ msgctxt "color name"
+#~ msgid "Gold"
+#~ msgstr "Золотой"
+
+#~ msgctxt "color name"
+#~ msgid "Goldenrod"
+#~ msgstr "Золотисто-берёзовый"
+
+#~ msgctxt "color name"
+#~ msgid "Gray"
+#~ msgstr "Сур"
+
+#~ msgctxt "color name"
+#~ msgid "Green Yellow"
+#~ msgstr "Сары-жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Honeydew"
+#~ msgstr "Бал тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Hot Pink"
+#~ msgstr "Ачык-кызгылт"
+
+#~ msgctxt "color name"
+#~ msgid "Indian Red"
+#~ msgstr "Каштан тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Indigo"
+#~ msgstr "Индиго"
+
+#~ msgctxt "color name"
+#~ msgid "Ivory"
+#~ msgstr "Пил соогу тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Khaki"
+#~ msgstr "Хаки"
+
+#~ msgctxt "color name"
+#~ msgid "Lavender"
+#~ msgstr "Лаванда тустуу-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Lavender Blush"
+#~ msgstr "Кызгылт-лаванда тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Lawn Green"
+#~ msgstr "Жашыл чотчул"
+
+#~ msgctxt "color name"
+#~ msgid "Lemon Chiffon"
+#~ msgstr "Лимон-ачык сары кызгылт 
+"
+
+#~ msgctxt "color name"
+#~ msgid "Light Blue"
+#~ msgstr "Ач- кок"
+
+#~ msgctxt "color name"
+#~ msgid "Light Coral"
+#~ msgstr "Ач-моржан тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Light Cyan"
+#~ msgstr "Ач-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Light Goldenrod Yellow"
+#~ msgstr "Ач-жашыл алтын тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Light Green"
+#~ msgstr "Ач-жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Light Pink"
+#~ msgstr "Ач-кызгыл"
+
+#~ msgctxt "color name"
+#~ msgid "Light Salmon"
+#~ msgstr "Ач-саргыч кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Light Sea Green"
+#~ msgstr "ач-жашыл дениз"
+
+#~ msgctxt "color name"
+#~ msgid "Light Sky Blue"
+#~ msgstr "Ач асман-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Light Slate Gray"
+#~ msgstr "Ач-сур шифер"
+
+#~ msgctxt "color name"
+#~ msgid "Light Steel Blue"
+#~ msgstr Ач-кок болот"
+
+#~ msgctxt "color name"
+#~ msgid "Light Yellow"
+#~ msgstr "Ач-сары"
+
+#~ msgctxt "color name"
+#~ msgid "Lime"
+#~ msgstr "Лимон тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Lime Green"
+#~ msgstr "лимондуу-жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Linen"
+#~ msgstr "Лен тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Magenta"
+#~ msgstr "Малина тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Maroon"
+#~ msgstr "Курон-малина тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Aquamarine"
+#~ msgstr "Орточо аквамарин тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Blue"
+#~ msgstr "Орточо-Кок"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Orchid"
+#~ msgstr "Орточо-орхидея"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Purple"
+#~ msgstr "Орточо-кызгылт-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Sea Green"
+#~ msgstr "Орточо жашыл дениз"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Slate Blue"
+#~ msgstr "Орточо кочкул-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Spring Green"
+#~ msgstr "Орточо жашыл-жаз"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Turquoise"
+#~ msgstr "Орточо-бирюза тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Medium Violet Red"
+#~ msgstr "Орточо-кызыл-кызгылт-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Midnight Blue"
+#~ msgstr "Тун ыран-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Mint Cream"
+#~ msgstr "Жалбыз-ачык-сары кызгылт"
+
+#~ msgctxt "color name"
+#~ msgid "Misty Rose"
+#~ msgstr "Кунурт-кызгылт"
+
+#~ msgctxt "color name"
+#~ msgid "Moccasin"
+#~ msgstr "Мокасин"
+
+#~ msgctxt "color name"
+#~ msgid "Navajo White"
+#~ msgstr "навахо ак"
+
+#~ msgctxt "color name"
+#~ msgid "Navy"
+#~ msgstr "Ток-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Old Lace"
+#~ msgstr "Эски тор"
+
+#~ msgctxt "color name"
+#~ msgid "Olive"
+#~ msgstr "Саргыч жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Olive Drab"
+#~ msgstr "Назик-саргыл-кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Orange Red"
+#~ msgstr "Саргыл-кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Orchid"
+#~ msgstr "Орхидея"
+
+#~ msgctxt "color name"
+#~ msgid "Pale Goldenrod"
+#~ msgstr "Кунурт- алтынсымал ач кок"
+
+#~ msgctxt "color name"
+#~ msgid "Pale Green"
+#~ msgstr "Кунурт-жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Pale Turquoise"
+#~ msgstr "Кунурт-ач кок"
+
+#~ msgctxt "color name"
+#~ msgid "Pale Violet Red"
+#~ msgstr "Ачык кызыл-кызгылт-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Papaya Whip"
+#~ msgstr "саргылтым папайя тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Peach Puff"
+#~ msgstr "Шабдаалы тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Peru"
+#~ msgstr "Ач-курон"
+
+#~ msgctxt "color name"
+#~ msgid "Pink"
+#~ msgstr "Кызгылт"
+
+#~ msgctxt "color name"
+#~ msgid "Plum"
+#~ msgstr "Слива тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Powder Blue"
+#~ msgstr "электро-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Red"
+#~ msgstr "Кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Rosy Brown"
+#~ msgstr "РКызгылт-курон"
+
+#~ msgctxt "color name"
+#~ msgid "Royal Blue"
+#~ msgstr "Ач- кок"
+
+#~ msgctxt "color name"
+#~ msgid "Saddle Brown"
+#~ msgstr "Тери-курон"
+
+#~ msgctxt "color name"
+#~ msgid "Salmon"
+#~ msgstr "Саргылтым кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Sandy Brown"
+#~ msgstr "Кум тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Sea Green"
+#~ msgstr "Жашыл дениз"
+
+#~ msgctxt "color name"
+#~ msgid "Seashell"
+#~ msgstr "Дениз кобугунун тусу"
+
+#~ msgctxt "color name"
+#~ msgid "Sienna"
+#~ msgstr "Охра"
+
+#~ msgctxt "color name"
+#~ msgid "Silver"
+#~ msgstr "Кумуш тустуу"
+
+#~ msgctxt "color name"
+#~ msgid "Sky Blue"
+#~ msgstr "Асман-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Slate Blue"
+#~ msgstr "Кочкул-кок"
+
+#~ msgctxt "color name"
+#~ msgid "Slate Gray"
+#~ msgstr "Кочкул-сур"
+
+#~ msgctxt "color name"
+#~ msgid "Snow"
+#~ msgstr "Апапак"
+
+#~ msgctxt "color name"
+#~ msgid "Spring Green"
+#~ msgstr "Жаз жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Steel Blue"
+#~ msgstr "кок болот"
+
+#~ msgctxt "color name"
+#~ msgid "Tan"
+#~ msgstr "Ач курон"
+
+
+#~ msgctxt "color name"
+#~ msgid "Teal"
+#~ msgstr "Кок-жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Thistle"
+#~ msgstr "Тикенек"
+
+#~ msgctxt "color name"
+#~ msgid "Tomato"
+#~ msgstr "Кызыл"
+
+#~ msgctxt "color name"
+#~ msgid "Turquoise"
+#~ msgstr "Ачык жашыл"
+
+#~ msgctxt "color name"
+#~ msgid "Violet"
+#~ msgstr "Сыя кок"
+
+#~ msgctxt "color name"
+#~ msgid "Wheat"
+#~ msgstr "Буудай ондуу"
+
+#~ msgctxt "color name"
+#~ msgid "White Smoke"
+#~ msgstr "кунурт-ак"
+
+#~ msgid "The start marker must reside within the same object"
+#~ msgstr "Фрагменттин башталгычы ошол эле объектиде орнотулат"
+
+#~ msgid "report grammar errors off"
+#~ msgstr "грамматикалык каталарды окуу очук"
+
+#~ msgid "report grammar errors on"
+#~ msgstr "ограмматикалык каталарды окуу жанган"
+
+#~ msgid "Toggles on and off the reporting of grammar errors"
+#~ msgstr "грамматикалык каталардын жарыясын очурурот жана жандырат"
+
+#~ msgid "grammar error"
+#~ msgstr "грамматикалык каталар"
+
+#~ msgid "out of grammar error"
+#~ msgstr "грамматикалык катадан сырткы"
+
+#~ msgid "Report &grammar errors"
+#~ msgstr "Окуу &грамматикалык каталар"
+
+#~ msgid "browse mode"
+#~ msgstr "корсотуу режими"
+
+#~ msgid "activate"
+#~ msgstr "ишке киргизуу"
+
+#~ msgid "no next"
+#~ msgstr "кийинкиси жок"
+
+#~ msgid "no previous"
+#~ msgstr "нет предыдущего"
+
+#~ msgid "edge of table"
+#~ msgstr "Таблицанын чеги"
+
+#~ msgid "%g characters"
+#~ msgstr "%g символдор"
+
+#~ msgid "%g pt"
+#~ msgstr "%g пункттар"
+
+#~ msgid "no comments"
+#~ msgstr "комментарийсиз"
+
+#~ msgid ""
+#~ "Presents a list of charts, cells with comments and cells with formulas"
+#~ msgstr "Диаграмма,комментарий жана формулаларды камтуучу ячейкаларды тартуулайт"
+
+#, fuzzy
+#~ msgid "Default color"
+#~ msgstr "өзү аныкталма түс"
+
+#~ msgid "unselecting %s"
+#~ msgstr "тандалбаган %s"
+
+#~ msgid "unrevised"
+#~ msgstr "Текшерилбеген"
+
+#~ msgid "unknown author"
+#~ msgstr "Белгисиз автор"
+
+#~ msgid "unknown date"
+#~ msgstr "Белгисиз кун"
+
+#~ msgid "{revisionType} by {revisionAuthor} on {revisionDate}"
+#~ msgstr "{revisionType} "Каралып чыккан" {revisionAuthor} в {revisionDate}"

--- a/source/locale/ky/characterDescriptions.dic
+++ b/source/locale/ky/characterDescriptions.dic
@@ -1,0 +1,42 @@
+﻿#Kyrgyz characterDescriptions.dic
+#A part of NonVisual Desktop Access (NVDA)
+#URL: http://www.nvda-project.org/
+#Data from https://ru.wikipedia.org/wiki/Фонетический_алфавит
+#This file is covered by the GNU General Public License.
+
+а	Анна
+б	Борис
+в	Василий
+г	Григорий
+д	Дмитрий
+е	Елена
+ё	Ёлка
+ж	Женя
+з	Зинаида
+и	Иван
+й	Иван краткий
+к	Константин
+л	Леонид
+м	Михаил
+н	Николай
+о	Ольга
+п	Павел
+р	Роман
+с	Семён
+т	Татьяна
+у	Ульяна
+ф	Фёдор
+х	Харитон
+ц	Цапля
+ч	Человек
+ш	Шура
+щ	Щука
+ъ	Твёрдый знак
+ы	Еры
+ь	Мягкий знак
+э	Эхо
+ю	Юрий
+я	Яков
+ү   ү   
+ө   ө
+ң   ың   

--- a/source/locale/ky/characterDescriptions.dic~
+++ b/source/locale/ky/characterDescriptions.dic~
@@ -1,0 +1,39 @@
+﻿#Kyrgyz characterDescriptions.dic
+#A part of NonVisual Desktop Access (NVDA)
+#URL: http://www.nvda-project.org/
+#Data from https://ru.wikipedia.org/wiki/Фонетический_алфавит
+#This file is covered by the GNU General Public License.
+
+а	Анна
+б	Борис
+в	Василий
+г	Григорий
+д	Дмитрий
+е	Елена
+ё	Ёлка
+ж	Женя
+з	Зинаида
+и	Иван
+й	Иван краткий
+к	Константин
+л	Леонид
+м	Михаил
+н	Николай
+о	Ольга
+п	Павел
+р	Роман
+с	Семён
+т	Татьяна
+у	Ульяна
+ф	Фёдор
+х	Харитон
+ц	Цапля
+ч	Человек
+ш	Шура
+щ	Щука
+ъ	Твёрдый знак
+ы	Еры
+ь	Мягкий знак
+э	Эхо
+ю	Юрий
+я	Яков

--- a/source/locale/ky/gestures.ini
+++ b/source/locale/ky/gestures.ini
@@ -1,0 +1,3 @@
+[browseMode.BrowseModeDocumentTreeInterceptor]
+moveToStartOfContainer = kb:б+shift
+movePastEndOfContainer = kb:б

--- a/source/locale/ky/symbols.dic
+++ b/source/locale/ky/symbols.dic
@@ -1,0 +1,160 @@
+﻿#locale/ru/symbols.dic
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (c) 2011-2012 NVDA Contributors
+#This file is covered by the GNU General Public License.
+
+symbols:
+# identifier	replacement[[	level][	preserve]][	# display name]
+
+# Complex symbols
+. sentence ending	точка	all	always
+! sentence ending	восклицательный знак	all	always
+? sentence ending	вопросительный знак	all	always
+; phrase ending	точка с запятой	most	always
+: phrase ending	двоеточие	most	always
+decimal point		none	always
+in-word '	апостроф	all	norep
+negative number	минус	none	norep
+
+# Whitespace
+\0	чисто	char	# null
+\t	таб
+\n	перевод строки	char
+\f	разделитель страниц	none
+\r	возврат каретки	char
+ 	пробел	char
+ 	пробел	char	# неразрывный пробел
+
+# Standard punctuation/symbols
+!	восклицательный знак	all
+"	кавычка	most
+\#	решётка	some
+$	доллар	all	norep
+£	фунт	all	norep
+€	евро	all	norep
+¢	центы	all	norep
+¥	иена	all	norep
+₹	рупия	some	norep
+₽	рубль	some
+₴	гривна	some
+圓	юань	some
+%	процент	some
+&	амперсант	some
+'	апостроф	all
+(	левая круглая	most	always
+)	правая круглая	most	always
+*	звёздочка	some
++	плюс	some
+,	запятая	all	always
+-	дефис	most
+.	точка	some
+/	косая черта	some
+:	двоеточие	most	norep
+;	точка с запятой	most
+<	меньше	some
+>	больше	some
+=	равно	some
+?	вопросительный знак	all
+@	собака	some
+[	левая квадратная	most
+]	правая квадратная	most
+\\	обратная косая черта	most
+^	крышка	most
+_	подчёркивание	most
+`	обратный апостроф	most
+{	левая фигурная	most
+}	правая фигурная	most
+|	вертикальная черта	most
+~	тильда	most
+
+# Other characters
+•	маркер	some
+…	многоточие	all	always
+...	точка точка точка	all	always
+	маркер	some
+“	левая кавычка	most
+”	правая кавычка	most
+‘	левая одиночная кавычка	most
+’	правая одиночная кавычка	most
+–	тире	most	always
+—	длинное тире	most
+●	кружок	most
+¨	дириезис	most
+‎	метка слева на право	char
+‏	метка справа на лево	char
+■	чёрный квадрат	some
+▪	чёрный квадрат	some
+◾	чёрный квадрат	some
+◦	полый маркер	some
+➔	стрелка вправо	some
+§	раздел	all
+°	градусов	some
+«	левая двойная угловая
+»	правая двойная угловая
+µ	микро	some
+¹	надстрочный знак 1	some
+²	надстрочный знак 2	some
+³	надстрочный знак 3	some
+®	зарегистрировано	some
+™	Торговая марка	some
+©	Авторское право	some
+±	плюс минус	some
+−	минус	some
+×	умножить	some
+÷	разделить на	some
+≈	приблизительно равно	some
+≠	не равно	some
+≪	много меньше	some
+≫	много больше	some
+←	стрелка влево	some
+→	стрелка вправо	some
+✓	отметка	some
+✔	отметка	some
+№	номер	some
+
+#Mathematical Operators U+2200 to U+220F
+
+∀	для всех	none
+∁	дополнение	none
+∂	частный дифференциал	none
+∃	существует	none
+∄	не существует	none
+∅	пустое множество	none
+∆	инкремент	none
+∇	набла	none
+∈	принадлежит	none
+∉	не принадлежит	none
+∊	малое принадлежит	none
+∋	содержит как член	none
+∌	не содержит как член	none
+∍	малое содержит как член	none
+∎	конец доказательства	none
+∏	N-арное произведение	none
+
+# Miscellaneous Mathematical Operators
+
+∑	N-арная сумма	none
+√	квадратный корень	none
+∛	кубический корень	none
+∜	корень четвёртой степени	none
+∝	пропорционально	none
+∞	бесконечность	none
+∟	прямой угол	none
+∠	угол	none
+∥	параллельно	none
+∦	не параллельно	none
+∧	логическое и	none
+∨	логическое или	none
+∩	пересечение	none
+∪	объединение	none
+∫	интеграл	none
+∴	влечёт	none
+∵	поскольку	none
+∶	относится	none
+∷	пропорционально	none
+≤	меньше либо равно	none
+≥	больше либо равно	none
+⊂	содержится в	none
+⊃	содержит	none
+⊆	содержится либо равно	none
+⊇	содержит либо равно	none

--- a/source/locale/ky/symbols.txt
+++ b/source/locale/ky/symbols.txt
@@ -1,0 +1,160 @@
+﻿#locale/ru/symbols.dic
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (c) 2011-2012 NVDA Contributors
+#This file is covered by the GNU General Public License.
+
+symbols:
+# identifier	replacement[[	level][	preserve]][	# display name]
+
+# Complex symbols
+. sentence ending	точка	all	always
+! sentence ending	восклицательный знак	all	always
+? sentence ending	вопросительный знак	all	always
+; phrase ending	точка с запятой	most	always
+: phrase ending	двоеточие	most	always
+decimal point		none	always
+in-word '	апостроф	all	norep
+negative number	минус	none	norep
+
+# Whitespace
+\0	чисто	char	# null
+\t	таб
+\n	перевод строки	char
+\f	разделитель страниц	none
+\r	возврат каретки	char
+ 	пробел	char
+ 	пробел	char	# неразрывный пробел
+
+# Standard punctuation/symbols
+!	восклицательный знак	all
+"	кавычка	most
+\#	решётка	some
+$	доллар	all	norep
+£	фунт	all	norep
+€	евро	all	norep
+¢	центы	all	norep
+¥	иена	all	norep
+₹	рупия	some	norep
+₽	рубль	some
+₴	гривна	some
+圓	юань	some
+%	процент	some
+&	амперсант	some
+'	апостроф	all
+(	левая круглая	most	always
+)	правая круглая	most	always
+*	звёздочка	some
++	плюс	some
+,	запятая	all	always
+-	дефис	most
+.	точка	some
+/	косая черта	some
+:	двоеточие	most	norep
+;	точка с запятой	most
+<	меньше	some
+>	больше	some
+=	равно	some
+?	вопросительный знак	all
+@	собака	some
+[	левая квадратная	most
+]	правая квадратная	most
+\\	обратная косая черта	most
+^	крышка	most
+_	подчёркивание	most
+`	обратный апостроф	most
+{	левая фигурная	most
+}	правая фигурная	most
+|	вертикальная черта	most
+~	тильда	most
+
+# Other characters
+•	маркер	some
+…	многоточие	all	always
+...	точка точка точка	all	always
+	маркер	some
+“	левая кавычка	most
+”	правая кавычка	most
+‘	левая одиночная кавычка	most
+’	правая одиночная кавычка	most
+–	тире	most	always
+—	длинное тире	most
+●	кружок	most
+¨	дириезис	most
+‎	метка слева на право	char
+‏	метка справа на лево	char
+■	чёрный квадрат	some
+▪	чёрный квадрат	some
+◾	чёрный квадрат	some
+◦	полый маркер	some
+➔	стрелка вправо	some
+§	раздел	all
+°	градусов	some
+«	левая двойная угловая
+»	правая двойная угловая
+µ	микро	some
+¹	надстрочный знак 1	some
+²	надстрочный знак 2	some
+³	надстрочный знак 3	some
+®	зарегистрировано	some
+™	Торговая марка	some
+©	Авторское право	some
+±	плюс минус	some
+−	минус	some
+×	умножить	some
+÷	разделить на	some
+≈	приблизительно равно	some
+≠	не равно	some
+≪	много меньше	some
+≫	много больше	some
+←	стрелка влево	some
+→	стрелка вправо	some
+✓	отметка	some
+✔	отметка	some
+№	номер	some
+
+#Mathematical Operators U+2200 to U+220F
+
+∀	для всех	none
+∁	дополнение	none
+∂	частный дифференциал	none
+∃	существует	none
+∄	не существует	none
+∅	пустое множество	none
+∆	инкремент	none
+∇	набла	none
+∈	принадлежит	none
+∉	не принадлежит	none
+∊	малое принадлежит	none
+∋	содержит как член	none
+∌	не содержит как член	none
+∍	малое содержит как член	none
+∎	конец доказательства	none
+∏	N-арное произведение	none
+
+# Miscellaneous Mathematical Operators
+
+∑	N-арная сумма	none
+√	квадратный корень	none
+∛	кубический корень	none
+∜	корень четвёртой степени	none
+∝	пропорционально	none
+∞	бесконечность	none
+∟	прямой угол	none
+∠	угол	none
+∥	параллельно	none
+∦	не параллельно	none
+∧	логическое и	none
+∨	логическое или	none
+∩	пересечение	none
+∪	объединение	none
+∫	интеграл	none
+∴	влечёт	none
+∵	поскольку	none
+∶	относится	none
+∷	пропорционально	none
+≤	меньше либо равно	none
+≥	больше либо равно	none
+⊂	содержится в	none
+⊃	содержит	none
+⊆	содержится либо равно	none
+⊇	содержит либо равно	none


### PR DESCRIPTION
### Summary of the issue:
Adding the initial locale dir for the Kyrgyz language

### Description of how this pull request fixes the issue:
eapeak-ng now has Kyrgyz language support, so now NVDA can make use of it

### Testing performed:
Tested this locale dir on old version of NVDA (1 year ago) on Windows 10. It worked

### Known issues with pull request:
The symbols files come from Russian and need to be translated
