### PR TITLE
Limit NVDA to running only on at least Windows 7 SP1 or Windows Server 2008 R2 SP1

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -60,7 +60,7 @@ except:
 
 # Check OS version requirements
 import winVersion
-if not winVersion.canRunVc2010Builds():
+if not winVersion.isSupportedOS():
 	winUser.MessageBox(0, unicode(ctypes.FormatError(winUser.ERROR_OLD_WIN_VERSION)), None, winUser.MB_ICONERROR)
 	sys.exit(1)
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -16,20 +16,12 @@ if winVersion.service_pack_major!=0:
 		winVersionText+=".%d"%winVersion.service_pack_minor
 winVersionText+=" %s" % ("workstation","domain controller","server")[winVersion.product_type-1]
 
+def isSupportedOS():
+	# NVDA can only run on Windows 7 Service pack 1 and above
+	return (winVersion.major,winVersion.minor,winVersion.service_pack_major) >= (6,1,1)
+
 def canRunVc2010Builds():
-	if (winVersion.major, winVersion.minor) < (5, 1):
-		# Earlier than Windows XP.
-		return False
-	if winVersion.major == 5:
-		if winVersion.minor == 1:
-			# Windows XP for x86.
-			return winVersion.service_pack_major >= 2
-		if winVersion.minor == 2 and winVersion.product_type!=1: 
-			# Windows Server 2003.
-			# (5.2 x64 is Windows XP x64. Its RTM is based on Server 2003 sp1,
-			# so all versions should be fine.)
-			return winVersion.service_pack_major >= 1
-	return True
+	return isSupportedOS()
 
 UWP_OCR_DATA_PATH = os.path.expandvars(r"$windir\OCR")
 def isUwpOcrAvailable():

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -60,10 +60,8 @@ For further details, you can [view the full licence. http://www.gnu.org/licenses
 
 + System Requirements +
 - Operating Systems: all 32-bit and 64-bit editions of Windows 7, Windows 8, Windows 8.1, Windows 10, and all Server Operating Systems starting from Windows Server 2008 R2.
-
-  - For Windows 7, NVDA requires Service Pack 1 or higher.
-  - For Windows Server 2008 R2, NVDA requires Service Pack 1 or higher.
- 
+ - For Windows 7, NVDA requires Service Pack 1 or higher.
+ - For Windows Server 2008 R2, NVDA requires Service Pack 1 or higher.
 - Memory: 256 mb or more of RAM
 - Processor speed: 1.0 ghz or above
 - About 90 MB of storage space.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -59,11 +59,11 @@ This applies to both original and modified copies of this software, plus any der
 For further details, you can [view the full licence. http://www.gnu.org/licenses/old-licenses/gpl-2.0.html]
 
 + System Requirements +
-- Operating Systems: all 32-bit and 64-bit editions of Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1 and Windows 10 (including Server operating Systems)
- - For Windows XP 32-bit, NVDA requires Service Pack 2 or higher.
- - For Windows Server 2003, NVDA requires Service Pack 1 or higher.
- - For Windows Vista, NVDA requires Service Pack 2 and the [KB2763674 https://support.microsoft.com/en-us/kb/2763674] update.
- Both of these should be installed if all available updates are applied via Windows Update.
+- Operating Systems: all 32-bit and 64-bit editions of Windows 7, Windows 8, Windows 8.1, Windows 10, and all Server Operating Systems starting from Windows Server 2008 R2.
+
+  - For Windows 7, NVDA requires Service Pack 1 or higher.
+  - For Windows Server 2008 R2, NVDA requires Service Pack 1 or higher.
+ 
 - Memory: 256 mb or more of RAM
 - Processor speed: 1.0 ghz or above
 - About 90 MB of storage space.


### PR DESCRIPTION
### Summary of the issue:
It is becoming increasingly harder to maintain support for older Operating Systems while at the same time fixing bugs and adding new features for newer Operating systems. While fixing #7269 with pr #7535, support for Windows XP was broken.

### Description of how this pull request fixes the issue:
With the merge of this PR, NV Access  chooses to drop support of Operating systems older than Windows 7 SP1 or Windows Server 2008 R2 SP1.
See the official news release from NV Access at: https://www.nvaccess.org/post/nvda-2017-4-drops-support-for-older-operating-systems/

Windows 7 SP1 and Windows Server 2008 R2 SP1 were chosen specifically as Microsoft no longer offers mainstream or extended support for XP, Vista, or Windows 7 with no Service Pack. Windows Server 2008 apparently is still in extended support, however we only have 7 active users. The Windows 10 SDK also only supports these Operating Systems at a minimum, and  APIs needed in #7535 are only supported in Windows 7 and above.

This PR adds code to the start of NVDA that will show a standard Windows dialog alerting the user to the fact their Operating System is too old for this application, if they try to run it on anything less than Windows 7 SP1 or Windows Server 2008 R2 SP1.
NVDA was already displaying this dialog for Windows XP before the latest Service Pack.
This PR by itself deliberately does not introduce any breaking changes a part from the version check and user guide update. Once this is merged, other PRs can be created for such things as upgrading the Windows SDK etc.

Please note: NV Access will continue to offer the NVDA 2017.3 download from its website for those users who cannot switch to a newer Operating System. Similarly, the NV Access update server will keep users  of these older Operating Systems at NVDA 2017.3.
 
### Change log entry:
Changes:
* The minimum supported Operating System for NVDA is now Windows 7 with Service Pack 1, or Windows Server 2008 R2 with Service Pack 1.
