### PR TITLE
Sconscript: use WIN32_WINNT_WIN7 in architecture sconscript

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -1,7 +1,7 @@
 ###
 #This file is a part of the NVDA project.
-#URL: http://www.nvda-project.org/
-#Copyright 2006-2010 NVDA contributers.
+#URL: https://www.nvaccess.org/
+#Copyright 2006-2017 NV Access Limited
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
 #the Free Software Foundation.
@@ -34,7 +34,7 @@ release=env['release']
 signExec=env['signExec'] if env['certFile'] else None
 
 #Some defines and includes for the environment
-env.Append(CPPDEFINES=['UNICODE','_CRT_SECURE_NO_DEPRECATE',('LOGLEVEL','${nvdaHelperLogLevel}'),('_WIN32_WINNT','_WIN32_WINNT_WS03')])
+env.Append(CPPDEFINES=['UNICODE','_CRT_SECURE_NO_DEPRECATE',('LOGLEVEL','${nvdaHelperLogLevel}'),('_WIN32_WINNT','_WIN32_WINNT_WIN7')])
 env.Append(CCFLAGS=['/W3','/WX'])
 if 'analyze' in debug:
 	env.Append(CCFLAGS=['/analyze'])


### PR DESCRIPTION
### Link to issue number:
#6718 (based on work done via #7546)
### Summary of the issue:
None

### Description of how this pull request fixes the issue:
Currently architecture sconscript assumes use of WIN32_WINNT_WS03 to make NVDA compatible with Windows XP SP2 and later. Now that XP support is gone, it would be better to target Windows 7 by using WIN32_WINNT_Win7.

### Testing performed:
NVDA compiled successfully with the changes made.

### Known issues with pull request:
None.

### Change log entry:
None (can be part of 7546).
