### PR TITLE
liblouis 3.3.0: new and renamed Croatian tables, removed wrappers.c

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -1,6 +1,6 @@
 ###
 #This file is a part of the NVDA project.
-#URL: http://www.nvda-project.org/
+#URL: https://www.nvaccess.org/
 #Copyright 2011-2017 NV Access Limited, Joseph Lee
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
@@ -63,7 +63,6 @@ sourceFiles = [
 	"compileTranslationTable.c",
 	"lou_translateString.c",
 	"lou_backTranslateString.c",
-	"wrappers.c",
 	"logging.c",
 	"pattern.c",
 	"commonTranslationFunctions.c",

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ For reference, the following dependencies are included in Git submodules:
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), version 1.3
 * [ConfigObj](http://www.voidspace.org.uk/python/configobj.html), version 4.6.0
-* [liblouis](http://www.liblouis.org/), version 3.2.0
+* [liblouis](http://www.liblouis.org/), version 3.3.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -67,6 +67,7 @@ RENAMED_TABLES = {
 	"da-dk-g18.utb":"da-dk-g18.ctb",
 	"en-us-comp8.ctb" : "en-us-comp8-ext.utb",
 	"gr-gr-g1.utb":"el.ctb",
+	"hr.ctb":"hr-comp8.utb",
 	"nl-BE-g1.ctb":"nl-BE-g0.utb",
 	"nl-NL-g1.ctb":"nl-NL-g0.utb",
 	"no-no.ctb":"no-no-comp8.ctb",

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -214,7 +214,7 @@ addTable("he.ctb", _("Hebrew 8 dot computer braille"))
 addTable("hi-in-g1.utb", _("Hindi grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("hr.ctb", _("Croatian 8 dot computer braille"))
+addTable("hr-comp8.utb", _("Croatian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("hu-hu-comp8.ctb", _("Hungarian 8 dot computer braille"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -217,6 +217,9 @@ addTable("hi-in-g1.utb", _("Hindi grade 1"))
 addTable("hr-comp8.utb", _("Croatian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("hr-g1.ctb", _("Croatian grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("hu-hu-comp8.ctb", _("Hungarian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.


### PR DESCRIPTION
### Link to issue number:
#7565 

### Summary of the issue:
New and renamed tables for Croatian

### Description of how this pull request fixes the issue:
New table: hr-g1.ctb for Croatian grade 1.
renamed hr.ctb to hr-comp8.utb for Croatian computer braille table.

### Known issues with pull request:
None.

### Change log entry:
New features: New braille translation table: Croatian grade 1.
Changes: upgraded liblouis braille translator to 3.3.0.

Note: this PR is blocked by a master PR for #7565 that allows NVDA to support liblouis 3.3.0 features.

Thanks.