### PR TITLE
recognizeNavigatorObject: Fail gracefully if object's location property returns None.

### DIFF
--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -126,13 +126,19 @@ def recognizeNavigatorObject(recognizer):
 		ui.message(_("Already in a content recognition result"))
 		return
 	nav = api.getNavigatorObject()
-	left, top, width, height = nav.location
+	# Translators: Reported when content recognition (e.g. OCR) is attempted,
+	# but the content is not visible.
+	notVisibleMsg = _("Content is not visible")
+	try:
+		left, top, width, height = nav.location
+	except TypeError:
+		log.debugWarning("Object returned location %r" % nav.location)
+		ui.message(notVisibleMsg)
+		return
 	try:
 		imgInfo = RecogImageInfo.createFromRecognizer(left, top, width, height, recognizer)
 	except ValueError:
-		# Translators: Reported when content recognition (e.g. OCR) is attempted,
-		# but the content is not visible.
-		ui.message(_("Content is not visible"))
+		ui.message(notVisibleMsg)
 		return
 	if _activeRecog:
 		_activeRecog.cancel()


### PR DESCRIPTION
### Link to issue number:
Reported by @DerekRiemer in https://github.com/nvaccess/nvda/pull/7476#issuecomment-326910592.

### Summary of the issue:
If you attempt to recognize an object where the location property returns None for some reason (e.g. the object died), you get this unhandled exception:

> ERROR - scriptHandler.executeScript (03:14:01.536):
> error executing script: <bound method GlobalCommands.script_recognizeWithCaptionBot of <globalCommands.GlobalCommands object at 0x0595E2D0>> with gesture u'alt+NVDA+d'
> Traceback (most recent call last):
> File "scriptHandler.py", line 187, in executeScript
> script(gesture)
> File "globalCommands.py", line 2064, in script_recognizeWithCaptionBot
> recogUi.recognizeNavigatorObject(recog)
> File "contentRecog\recogUi.py", line 129, in recognizeNavigatorObject
> left, top, width, height = nav.location
> TypeError: 'NoneType' object is not iterable

### Description of how this pull request fixes the issue:
We catch the TypeError exception, report "Content is not visible" to the user and log a debugWarning.

### Testing performed:
1. Opened google.com in Firefox.
2. Turned off caret moves review cursor (NVDA+6) and focus moves navigator object (NVDA+7).
3. Opened nvaccess.org.
4. Pressed NVDA+r.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:

```
- When using a content recognition command (e.g. NVDA+r), NVDA now reports an error message instead of nothing if the navigator object has disappeared. (#7567)
```