### PR TITLE
Update espeak

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -125,7 +125,6 @@ espeakLib=env.SharedLibrary(
 		"synthdata.c",
 		"synthesize.c",
 		"synth_mbrola.c", # provides symbols used by synthesize.obj, voices.obj, and wavegen.obj
-		"tokenizer.c",
 		"translate.c",
 		"tr_languages.c",
 		"voices.c",


### PR DESCRIPTION
Continue to update Espeak. For the last set of changes that made it into master, see: https://github.com/nvaccess/nvda/pull/7385

### Note:
If you notice a problem with Espeak on next (or master), please open a new issue to discuss this.

### Summary of the issue:
In order to more quickly spot and report issues on Espeak, we are regularly updating espeak to the latest master on our next branch. When this gets to stable we can merge back to nvda master. 

### Description of how this pull request fixes the issue:
This updates the espeak submodule to the latest espeak-ng master commit and fixes any build errors.

### Testing performed:
- Ensure that it builds locally.
- Ensure that the list of voices and variants for espeak look correct in NVDA
- Ensure that espeak can be used

### Known issues with pull request:
None

### Change log entry:
For now none. But perhaps eventually:
```
Espeak-ng has been updated to commit d19da58fa099
```