### PR TITLE
Added translator comments to browseMode.py

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -51,7 +51,8 @@ def reportPassThrough(treeInterceptor,onlyIfChanged=True):
 				# Translators: The mode to interact with controls in documents
 				ui.message(_("Focus mode"))
 			else:
-				# Translators: The mode that presents text in a flat representation that can be navigated with the cursor keys like in a text document
+				# Translators: The mode that presents text in a flat representation
+				# that can be navigated with the cursor keys like in a text document
 				ui.message(_("Browse mode"))
 		reportPassThrough.last = treeInterceptor.passThrough
 reportPassThrough.last = False
@@ -1567,8 +1568,8 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 		info.expand(textInfos.UNIT_CHARACTER)
 		container=self.getEnclosingContainerRange(info)
 		if not container:
-			# Translators: Reported when the user attempts to move to the start or end of a container (list, table, etc.) 
-			# But there is no container. 
+			# Translators: Reported when the user attempts to move to the start or end of a container
+						# (list, table, etc.) but there is no container. 
 			ui.message(_("Not in a container"))
 			return
 		container.collapse()
@@ -1585,8 +1586,8 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 		info.expand(textInfos.UNIT_CHARACTER)
 		container=self.getEnclosingContainerRange(info)
 		if not container:
-			# Translators: Reported when the user attempts to move to the start or end of a container (list, table, etc.) 
-			# But there is no container. 
+			# Translators: Reported when the user attempts to move to the start or end of a container
+			# (list, table, etc.) but there is no container. 
 			ui.message(_("Not in a container"))
 			return
 		container.collapse(end=True)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1569,7 +1569,7 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 		container=self.getEnclosingContainerRange(info)
 		if not container:
 			# Translators: Reported when the user attempts to move to the start or end of a container
-						# (list, table, etc.) but there is no container. 
+			# (list, table, etc.) but there is no container. 
 			ui.message(_("Not in a container"))
 			return
 		container.collapse()

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -48,8 +48,10 @@ def reportPassThrough(treeInterceptor,onlyIfChanged=True):
 			nvwave.playWaveFile(sound)
 		else:
 			if treeInterceptor.passThrough:
+				# Translators: The mode to interact with controls in documents
 				ui.message(_("Focus mode"))
 			else:
+				# Translators: The mode that presents text in a flat representation that can be navigated with the cursor keys like in a text document
 				ui.message(_("Browse mode"))
 		reportPassThrough.last = treeInterceptor.passThrough
 reportPassThrough.last = False
@@ -1583,6 +1585,8 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 		info.expand(textInfos.UNIT_CHARACTER)
 		container=self.getEnclosingContainerRange(info)
 		if not container:
+			# Translators: Reported when the user attempts to move to the start or end of a container (list, table, etc.) 
+			# But there is no container. 
 			ui.message(_("Not in a container"))
 			return
 		container.collapse(end=True)

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -16,7 +16,6 @@ import sys
 # Note that checkPot will fail with an unexpected success
 # if a translator comment is found for one of these messages.
 EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
-	'Focus mode',
 	'%s landmark',
 	'border',
 	'filler',


### PR DESCRIPTION
### Link to issue number:
Fixes #5822

### Summary of the issue:
There were not translator comments for browse mode or focus mode.

### Description of how this pull request fixes the issue:
As discussed in #1410, all strings should have translator comments.

### Testing performed:

### Known issues with pull request:
None

### Change log entry:
None