### PR TITLE
Change hotkey for filter field in Elements List from alt+f to alt+e (…

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -795,7 +795,7 @@ class ElementsListDialog(wx.Dialog):
 
 		# Translators: The label of an editable text field to filter the elements
 		# in the browse mode Elements List dialog.
-		filterText = _("&Filter by:")
+		filterText = _("Filt&er by:")
 		labeledCtrl = gui.guiHelper.LabeledControlHelper(self, filterText, wx.TextCtrl)
 		self.filterEdit = labeledCtrl.control
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)


### PR DESCRIPTION
### Link to issue number:
Fixes issue #7569

### Summary of the issue:

Now there is a clash between alt+f for the filter field and the Form fields radio button.

### Description of how this pull request fixes the issue:

Change the hotkey for the filter field in the elements list from f to e to prevent clashes with  "Form fields" radio button.

### Testing performed:

Opened the elements list in Firefox and verified the hotkey changed.

### Known issues with pull request:
- None

### Change log entry:
* Changes: The hotkey for the filter field in the elements list in browse mode is changed from alt+f to alt+e (#7569)