### PR TITLE
Add Vietnamese grade 1 braille table

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -348,6 +348,9 @@ addTable("tr.ctb", _("Turkish grade 1"))
 addTable("unicode-braille.utb", _("Unicode braille"), output=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("vi-g1.ctb", _("Vietnamese grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.


### PR DESCRIPTION
### Link to issue number:
Fixes #7518.

### Summary of the issue:
The Vietnamese grade 1 table is not currently in NVDA, but according to @tmthywynn8 it is ready to go.

### Description of how this pull request fixes the issue:
Adds the `vi-g1.ctb` braille table from liblouis.

### Testing performed:
- Checked that the table can be selected from the Braille preferences dialog.
- Checked that the table outputs text without causing errors.

### Known issues with pull request:
None.

### Change log entry:
#### New features
* New braille translation table: Vietnamese grade 1.