### PR TITLE
Underlined accelerator key for Windows 10 OCR... 

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -180,3 +180,4 @@ Nicușor Untilă
 Julien Nabet
 Babbage B.V.
 Ethan Holliger
+Thomas Stivers

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #gui/__init__.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2015 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee
+#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee, Thomas Stivers
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -361,7 +361,7 @@ class SysTrayIcon(wx.TaskBarIcon):
 		self.Bind(wx.EVT_MENU, frame.onDocumentFormattingCommand, item)
 		if winVersion.isUwpOcrAvailable():
 			# Translators: The label for the menu item to open the Windows 10 OCR settings dialog.
-			item = menu_preferences.Append(wx.ID_ANY, _("Windows 10 OCR..."))
+			item = menu_preferences.Append(wx.ID_ANY, _("&Windows 10 OCR..."))
 			self.Bind(wx.EVT_MENU, frame.onUwpOcrCommand, item)
 		subMenu_speechDicts = wx.Menu()
 		if not globalVars.appArgs.secure:


### PR DESCRIPTION
### Link to issue number:
fixes #7477

### Summary of the issue:
Underline the accellerator key for Windows 10 OCR... in the NVDA Preferences menu.

### Description of how this pull request fixes the issue:
Added & before W in the menu item name.

### Testing performed:
Trivial change

### Known issues with pull request:


### Change log entry:

