### PR TITLE
Add a script to browse mode to toggle inclusion of layout tables

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1762,12 +1762,12 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 
 	def script_toggleIncludeLayoutTables(self,gesture):
 		if config.conf["documentFormatting"]["includeLayoutTables"]:
-			# Translators: The message announced when toggling the include layout tables document formatting setting.
-			state = _("include layout tables off")
+			# Translators: The message announced when toggling the include layout tables browse mode setting.
+			state = _("layout tables off")
 			config.conf["documentFormatting"]["includeLayoutTables"]=False
 		else:
-			# Translators: The message announced when toggling the report tables document formatting setting.
-			state = _("include layout tables on")
+			# Translators: The message announced when toggling the include layout tables browse mode setting.
+			state = _("layout tables on")
 			config.conf["documentFormatting"]["includeLayoutTables"]=True
 		ui.message(state)
 	# Translators: Input help mode message for include layout tables command.

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1760,6 +1760,19 @@ class BrowseModeDocumentTreeInterceptor(cursorManager.CursorManager,BrowseModeTr
 	# Translators: the description for the previous table column script on browseMode documents.
 	script_previousColumn.__doc__ = _("moves to the previous table column")
 
+	def script_toggleIncludeLayoutTables(self,gesture):
+		if config.conf["documentFormatting"]["includeLayoutTables"]:
+			# Translators: The message announced when toggling the include layout tables document formatting setting.
+			state = _("include layout tables off")
+			config.conf["documentFormatting"]["includeLayoutTables"]=False
+		else:
+			# Translators: The message announced when toggling the report tables document formatting setting.
+			state = _("include layout tables on")
+			config.conf["documentFormatting"]["includeLayoutTables"]=True
+		ui.message(state)
+	# Translators: Input help mode message for include layout tables command.
+	script_toggleIncludeLayoutTables.__doc__=_("Toggles on and off the inclusion of layout tables in browse mode")
+
 	NOT_LINK_BLOCK_MIN_LEN = 30
 	def _isSuitableNotLinkBlock(self,range):
 		return len(range.text)>=self.NOT_LINK_BLOCK_MIN_LEN

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1412,6 +1412,8 @@ When off, they will not be reported nor found with quick navigation.
 However, the content of the tables will still be included as normal text.
 This option is turned off by default.
 
+To toggle inclusion of layout tables from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
 ==== Configuring reporting of fields such as links and headings ====
 Please see the options in the [Document Formatting Settings dialog #DocumentFormattingSettings] to configure the fields that are reported when navigating, such as links, headings and tables.
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Some tables on the web, even though they have data, are treated as layout tables as they don't follow the convention that headers are required for a table to be treated as a data table. It is currently not possible to switch inclusion of layout tables on the fly while in browse mode.

### Description of how this pull request fixes the issue:
Adds an unbound script to browse mode to toggle layout tables. Even though this is a document formatting setting according to the config spec, I made this browse mode only due to the fact that from a UX perspectieve, this is a browse mode setting.

### Testing performed:
Toggled this setting while in a layout table in Firefox browse mode, detection changed on the fly as expected.

### Known issues with pull request:
None i'm aware of

### Change log entry:
* Changes
    + An unbound command has been added for browse mode to toggle the inclusion of layout tables on the fly. You can find this command in the Browse mode category of the Input Gestures dialog.