### PR TITLE
Fix typo in MS Word elements list

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1723,5 +1723,5 @@ class ElementsListDialog(browseMode.ElementsListDialog):
 		("annotation", _("&Annotations")),
 		# Translators: The label of a radio button to select the type of element
 		# in the browse mode Elements List dialog.
-		("error", _("&errors")),
+		("error", _("&Errors")),
 	)


### PR DESCRIPTION
Errors is now properly capitalized. This fix is very trivial and can be merged straight to master.