### PR TITLE
Move voice dict files

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -317,8 +317,9 @@ class ConfigManager(object):
 		self._pendingHandleProfileSwitch = False
 		self._suspendedTriggers = None
 		# Never save the config if running securely or if running from the launcher.
-		# When running from the launcher we dont save settings becuase the user may decide not to install this version,
-		# and these settings may not be compatible with with the already installed version. See #7688
+		# When running from the launcher we don't save settings because the user may decide not to
+		# install this version, and these settings may not be compatible with the already
+		# installed version. See #7688
 		self._shouldWriteProfile = not (globalVars.appArgs.secure or globalVars.appArgs.launcher)
 		self._initBaseConf()
 		#: Maps triggers to profiles.
@@ -382,7 +383,8 @@ class ConfigManager(object):
 		profile.newlines = "\r\n"
 		profileCopy = deepcopy(profile)
 		try:
-			profileUpgrader.upgrade(profile, self.validator, self._writeProfileToFile, self._shouldWriteProfile)
+			writeProfileFunc = self._writeProfileToFile if self._shouldWriteProfile else None
+			profileUpgrader.upgrade(profile, self.validator, writeProfileFunc)
 		except Exception as e:
 			# Log at level info to ensure that the profile is logged.
 			log.info(u"Config before schema update:\n%s" % profileCopy, exc_info=False)
@@ -481,13 +483,13 @@ class ConfigManager(object):
 		"""Save all modified profiles and the base configuration to disk.
 		"""
 		if not self._shouldWriteProfile:
-			log.info("Not writting profile, either --secure or --launcher args present")
+			log.info("Not writing profile, either --secure or --launcher args present")
 			return
 		try:
-			_writeProfileToFile(self.profiles[0].filename, self.profiles[0])
+			self._writeProfileToFile(self.profiles[0].filename, self.profiles[0])
 			log.info("Base configuration saved")
 			for name in self._dirtyProfiles:
-				_writeProfileToFile(self._profileCache[name].filename, self._profileCache[name])
+				self._writeProfileToFile(self._profileCache[name].filename, self._profileCache[name])
 				log.info("Saved configuration profile %s" % name)
 			self._dirtyProfiles.clear()
 		except Exception as e:

--- a/source/config/profileUpgrader.py
+++ b/source/config/profileUpgrader.py
@@ -12,19 +12,22 @@ from . import profileUpgradeSteps
 
 SCHEMA_VERSION_KEY = "schemaVersion"
 
-def upgrade(profile, validator):
+def upgrade(profile, validator, writeProfileToFileFunc, shouldWriteProfileToFile):
+	""" Upgrade a profile in memory and validate it
+	If it is safe to do so, as defined by shouldWriteProfileToFile, the profile is written out.
+	"""
 	# when profile is none or empty we can still validate. It should at least have a version set.
 	_ensureVersionProperty(profile)
 	startSchemaVersion = int(profile[SCHEMA_VERSION_KEY])
 	log.debug("Current config schema version: {0}, latest: {1}".format(startSchemaVersion, latestSchemaVersion))
-
 	for fromVersion in xrange(startSchemaVersion, latestSchemaVersion):
 		_doConfigUpgrade(profile, fromVersion)
 	_doValidation(deepcopy(profile), validator) # copy the profile, since validating mutates the object
 	try:
 		# write out the configuration once the upgrade has been validated. This means that if NVDA crashes for some
 		# other reason the file does not need to be upgraded again.
-		profile.write()
+		if shouldWriteProfileToFile:
+			writeProfileToFileFunc(profile.filename, profile)
 	except Exception as e:
 		log.warning("Error saving configuration; probably read only file system")
 		log.debugWarning("", exc_info=True)

--- a/source/config/profileUpgrader.py
+++ b/source/config/profileUpgrader.py
@@ -12,7 +12,7 @@ from . import profileUpgradeSteps
 
 SCHEMA_VERSION_KEY = "schemaVersion"
 
-def upgrade(profile, validator, writeProfileToFileFunc, shouldWriteProfileToFile):
+def upgrade(profile, validator, writeProfileToFileFunc):
 	""" Upgrade a profile in memory and validate it
 	If it is safe to do so, as defined by shouldWriteProfileToFile, the profile is written out.
 	"""
@@ -26,7 +26,7 @@ def upgrade(profile, validator, writeProfileToFileFunc, shouldWriteProfileToFile
 	try:
 		# write out the configuration once the upgrade has been validated. This means that if NVDA crashes for some
 		# other reason the file does not need to be upgraded again.
-		if shouldWriteProfileToFile:
+		if writeProfileToFileFunc:
 			writeProfileToFileFunc(profile.filename, profile)
 	except Exception as e:
 		log.warning("Error saving configuration; probably read only file system")

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -1,6 +1,6 @@
 #speechDictHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2017 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -11,10 +11,11 @@ import os
 import codecs
 import api
 import config
+from . import dictFormatUpgrade
+from .speechDictVars import speechDictsPath
 
 dictionaries = {}
 dictTypes = ("temp", "voice", "default", "builtin") # ordered by their priority E.G. voice specific speech dictionary is processed before the default
-speechDictsPath=os.path.join(globalVars.appArgs.configPath, "speechDicts")
 
 # Types of speech dictionary entries:
 ENTRY_TYPE_ANYWHERE = 0 # String can match anywhere
@@ -118,9 +119,16 @@ def loadVoiceDict(synth):
 	"""Loads appropriate dictionary for the given synthesizer.
 It handles case when the synthesizer doesn't support voice setting.
 """
+	try:
+		dictFormatUpgrade.doAnyUpgrades(synth)
+	except:
+		log.error("error trying to upgrade dictionaries", exc_info=True)
+		pass
 	if synth.isSupported("voice"):
-		voiceName = synth.availableVoices[synth.voice].name
-		fileName=r"%s\%s-%s.dic"%(speechDictsPath,synth.name,api.filterFileName(voiceName))
+		voice = synth.availableVoices[synth.voice].name
+		baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
 	else:
-		fileName=r"%s\%s.dic"%(speechDictsPath,synth.name)
+		baseName=r"{synth}.dic".format(synth=synth.name)
+	voiceDictsPath = dictFormatUpgrade.voiceDictsPath
+	fileName= os.path.join(voiceDictsPath, synth.name, baseName)
 	dictionaries["voice"].load(fileName)

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -30,6 +30,12 @@ def createVoiceDictFileName(synthName, voiceName):
 def doAnyUpgrades(synth):
 	""" Do any upgrades required for the synth passed in.
 	"""
+	if globalVars.appArgs.launcher:
+		# When running from the launcher we dont upgrade dicts becuase the user may decide not to install this version,
+		# and the dict location may not be compatible with with the already installed version. See #7688
+		# We allow the upgrade when secure arg is present so that dictionaries work on secure screens.
+		return
+
 	# We know the transform required for Espeak, so try regardless of
 	# the synth currently set.
 	_doEspeakDictUpgrade()

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -1,8 +1,8 @@
 # -*- coding: UTF-8 -*-
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2017 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """Upgrade speech dict files
 """
@@ -18,6 +18,9 @@ voiceDictsPath = os.path.join(speechDictsPath, r"voiceDicts.v1")
 voiceDictsBackupPath = os.path.join(speechDictsPath, r"voiceDictsBackup.v0")
 
 def createVoiceDictFileName(synthName, voiceName):
+	""" Creates a filename used for the voice dictionary files.
+	this is in the format synthName-voiceName.dic
+	"""
 	fileNameFormat = u"{synth}-{voice}.dic"
 	return fileNameFormat.format(
 			synth = synthName,
@@ -25,6 +28,8 @@ def createVoiceDictFileName(synthName, voiceName):
 			)
 
 def doAnyUpgrades(synth):
+	""" Do any upgrades required for the synth passed in.
+	"""
 	# We know the transform required for Espeak, so try regardless of
 	# the synth currently set.
 	_doEspeakDictUpgrade()
@@ -40,9 +45,8 @@ def doAnyUpgrades(synth):
 	_doSynthVoiceDictBackupAndMove(synth.name)
 
 def _doSynthVoiceDictBackupAndMove(synthName, oldFileNameToNewFileNameList=None):
-	""" move all files for the synth to the backup dir
-			for each file in the backup dir copy it to the synthvoice dir 
-			using the new name if it we have one.
+	""" Move all files for the synth to the backup dir for each file in the backup
+	dir copy it to the synthvoice dir using the new name if it we have one.
 	"""
 	import shutil
 	

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -1,0 +1,203 @@
+# -*- coding: UTF-8 -*-
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2017 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""Upgrade speech dict files
+"""
+
+import globalVars
+import os
+import api
+import glob
+from logHandler import log
+from .speechDictVars import speechDictsPath
+
+voiceDictsPath = os.path.join(speechDictsPath, r"voiceDicts.v1")
+voiceDictsBackupPath = os.path.join(speechDictsPath, r"voiceDictsBackup.v0")
+
+def createVoiceDictFileName(synthName, voiceName):
+	fileNameFormat = u"{synth}-{voice}.dic"
+	return fileNameFormat.format(
+			synth = synthName,
+			voice = api.filterFileName(voiceName)
+			)
+
+def doAnyUpgrades(synth):
+	# We know the transform required for Espeak, so try regardless of
+	# the synth currently set.
+	_doEspeakDictUpgrade()
+	
+	if synth.name == "espeak":
+		# nothing more we can do until a different synth is used
+		return
+
+	# for any other synth, we can only do the backup and move if the synth
+	# is loaded, because we need the synth name
+	# For these synths, no name change is required so we dont pass in a name
+	# mapping.
+	_doSynthVoiceDictBackupAndMove(synth.name)
+
+def _doSynthVoiceDictBackupAndMove(synthName, oldFileNameToNewFileNameList=None):
+	""" move all files for the synth to the backup dir
+			for each file in the backup dir copy it to the synthvoice dir 
+			using the new name if it we have one.
+	"""
+	import shutil
+	
+	if not os.path.isdir(voiceDictsPath):
+		os.makedirs(voiceDictsPath)
+	if not os.path.isdir(voiceDictsBackupPath):
+		os.makedirs(voiceDictsBackupPath)
+	
+	newDictPath = os.path.join(voiceDictsPath,synthName)
+	needsUpgrade = not os.path.isdir(newDictPath)
+	if needsUpgrade:
+		log.info("Upgrading voice dictionaries for %s"%synthName)
+
+		# always make the new directory, this prevents the upgrade from
+		# occuring more than once.
+		os.makedirs(newDictPath)
+
+		# look for files that need to be upgraded  in the old voice 
+		# dicts diectory
+		voiceDictGlob=os.path.join(
+				speechDictsPath,
+				r"{synthName}*".format(synthName=synthName)
+				)
+		log.debug("voiceDictGlob: %s"%voiceDictGlob)
+
+		for actualPath in glob.glob(voiceDictGlob):
+			log.debug("processing file: %s" % actualPath)
+			# files will be copied here before we modify them so as to avoid
+			# any data loss.
+			shutil.copy(actualPath, voiceDictsBackupPath)
+			
+			actualBasename = os.path.basename(actualPath)
+			log.debug("basename: %s" % actualBasename)
+			
+			renameTo = actualBasename
+			if oldFileNameToNewFileNameList:
+				for oldFname, newFname in oldFileNameToNewFileNameList:
+					if oldFname == actualBasename:
+						log.debug("renaming {} to {} and moving to {}".format(
+							actualPath,
+							newFname,
+							newDictPath
+							))
+						renameTo = newFname
+						break
+			shutil.move(actualPath, os.path.join(newDictPath, renameTo))
+
+def _doEspeakDictUpgrade():
+	synthName = "espeak"
+	def getNextVoice():
+		for ID, oldNewTuple in espeakNameChanges.items():
+			oldName = oldNewTuple[0]
+			newName = oldNewTuple[1]
+			yield (
+					createVoiceDictFileName(synthName, oldName),
+					createVoiceDictFileName(synthName, newName)
+					)
+	_doSynthVoiceDictBackupAndMove(synthName, list(getNextVoice()))
+
+# the ID maped to old and new names for voices in espeak-ng
+# "old" used in NVDA 2017.3 "new" in NVDA 2017.4
+espeakNameChanges = {
+	"af": [u"afrikaans", u"Afrikaans"],
+	"am": [u"amharic", u"Amharic"],
+	"an": [u"aragonese", u"Aragonese"],
+	"ar": [u"arabic", u"Arabic"],
+	"as": [u"assamese", u"Assamese"],
+	"az": [u"azerbaijani", u"Azerbaijani"],
+	"bg": [u"bulgarian", u"Bulgarian"],
+	"bn": [u"bengali", u"Bengali"],
+	"bs": [u"bosnian", u"Bosnian"],
+	"ca": [u"catalan", u"Catalan"],
+	"cmn": [u"Mandarin", u"Chinese (Mandarin)"],
+	"cs": [u"czech", u"Czech"],
+	"cy": [u"welsh", u"Welsh"],
+	"da": [u"danish", u"Danish"],
+	"de": [u"german", u"German"],
+	"el": [u"greek", u"Greek"],
+	"en-029": [u"en-westindies", u"English (Caribbean)"],
+	"en": [u"english", u"English (Great Britain)"],
+	"en-gb-scotland": [u"en-scottish", u"English (Scotland)"],
+	"en-gb-x-gbclan": [u"english-north", u"English (Lancaster)"],
+	"en-gb-x-gbcwmd": [u"english_wmids", u"English (West Midlands)"],
+	"en-gb-x-rp": [u"english_rp", u"English (Received Pronunciation)"],
+	"en-us": [u"english-us", u"English (America)"],
+	"eo": [u"esperanto", u"Esperanto"],
+	"es": [u"spanish", u"Spanish (Spain)"],
+	"es-419": [u"spanish-latin-am", u"Spanish (Latin America)"],
+	"et": [u"estonian", u"Estonian"],
+	"eu": [u"basque", u"Basque"],
+	"fa": [u"Persian+English-UK", u"Persian"],
+	"fa-latn": [u"persian-pinglish", u"Persian (Pinglish)"],
+	"fi": [u"finnish", u"Finnish"],
+	"fr-be": [u"french-Belgium", u"French (Belgium)"],
+	"fr": [u"french", u"French (France)"],
+	"ga": [u"irish-gaeilge", u"Gaelic (Irish)"],
+	"gd": [u"scottish-gaelic", u"Gaelic (Scottish)"],
+	"gn": [u"guarani", u"Guarani"],
+	"grc": [u"greek-ancient", u"Greek (Ancient)"],
+	"gu": [u"gujarati", u"Gujarati"],
+	"hi": [u"hindi", u"Hindi"],
+	"hr": [u"croatian", u"Croatian"],
+	"hu": [u"hungarian", u"Hungarian"],
+	"hy": [u"armenian", u"Armenian (East Armenia)"],
+	"hy-arevmda": [u"armenian-west", u"Armenian (West Armenia)"],
+	"ia": [u"interlingua", u"Interlingua"],
+	"id": [u"indonesian", u"Indonesian"],
+	"is": [u"icelandic", u"Icelandic"],
+	"it": [u"italian", u"Italian"],
+	"ja": [u"japanese","Japanese"], # Used to have ID 'jp'
+	"jbo": [u"lojban", u"Lojban"],
+	"ka": [u"georgian", u"Georgian"],
+	"kl": [u"greenlandic", u"Greenlandic"],
+	"kn": [u"kannada", u"Kannada"],
+	"ko": [u"Korean", u"Korean"],
+	"ku": [u"kurdish", u"Kurdish"],
+	"ky": [u"kyrgyz", u"Kyrgyz"],
+	"la": [u"latin", u"Latin"],
+	"lfn": [u"lingua_franca_nova", u"Lingua Franca Nova"],
+	"lt": [u"lithuanian", u"Lithuanian"],
+	"lv": [u"latvian", u"Latvian"],
+	"mk": [u"macedonian", u"Macedonian"],
+	"ml": [u"malayalam", u"Malayalam"],
+	"mr": [u"marathi", u"Marathi"],
+	"ms": [u"malay", u"Malay"],
+	"mt": [u"maltese", u"Maltese"],
+	"my": [u"burmese", u"Burmese"],
+	"nci": [u"nahuatl-classical", u"Nahuatl (Classical)"],
+	"ne": [u"nepali", u"Nepali"],
+	"nl": [u"dutch", u"Dutch"],
+	"nb": [u"norwegian", u"Norwegian Bokmål"], # Used to have ID "no"
+	"om": [u"oromo", u"Oromo"],
+	"or": [u"oriya", u"Oriya"],
+	"pa": [u"punjabi", u"Punjabi"],
+	"pap": [u"papiamento", u"Papiamento"],
+	"pl": [u"polish", u"Polish"],
+	"pt": [u"portugal", u"Portuguese (Portugal)"], # Used to have ID "pt-pt"
+	"pt-br": [u"brazil", u"Portuguese (Brazil)"],
+	"ro": [u"romanian", u"Romanian"],
+	"ru": [u"russian", u"Russian"],
+	"si": [u"sinhala", u"Sinhala"],
+	"sk": [u"slovak", u"Slovak"],
+	"sl": [u"slovenian", u"Slovenian"],
+	"sq": [u"albanian", u"Albanian"],
+	"sr": [u"serbian", u"Serbian"],
+	"sv": [u"swedish", u"Swedish"],
+	"sw": [u"swahili", u"Swahili"],
+	"ta": [u"tamil", u"Tamil"],
+	"te": [u"telugu", u"Telugu"],
+	"tn": [u"setswana", u"Setswana"],
+	"tr": [u"turkish", u"Turkish"],
+	"tt": [u"tatar", u"Tatar"],
+	"ur": [u"urdu", u"Urdu"],
+	"vi": [u"vietnam", u"Vietnamese (Northern)"],
+	"vi-vn-x-central": [u"vietnam_hue", u"Vietnamese (Central)"],
+	"vi-vn-x-south": [u"vietnam_sgn", u"Vietnamese (Southern)"],
+	"yue": [u"cantonese", u"Chinese (Cantonese)"],
+}

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -31,8 +31,8 @@ def doAnyUpgrades(synth):
 	""" Do any upgrades required for the synth passed in.
 	"""
 	if globalVars.appArgs.launcher:
-		# When running from the launcher we dont upgrade dicts becuase the user may decide not to install this version,
-		# and the dict location may not be compatible with with the already installed version. See #7688
+		# When running from the launcher we don't upgrade dicts because the user may decide not to install this version,
+		# and the dict location may not be compatible with the already installed version. See #7688
 		# We allow the upgrade when secure arg is present so that dictionaries work on secure screens.
 		return
 

--- a/source/speechDictHandler/speechDictVars.py
+++ b/source/speechDictHandler/speechDictVars.py
@@ -1,0 +1,10 @@
+# -*- coding: UTF-8 -*-
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2017 NVDA Contributors <http://www.nvda-project.org/>
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import os
+import globalVars
+
+speechDictsPath=os.path.join(globalVars.appArgs.configPath, "speechDicts")

--- a/source/speechDictHandler/speechDictVars.py
+++ b/source/speechDictHandler/speechDictVars.py
@@ -1,8 +1,8 @@
 # -*- coding: UTF-8 -*-
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2017 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import os
 import globalVars

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -37,6 +37,7 @@ class AppArgs:
 	configPath = UNIT_DIR.decode("mbcs")
 	secure = False
 	disableAddons = True
+	launcher = False
 globalVars.appArgs = AppArgs()
 
 # We depend on the current directory to load some files;


### PR DESCRIPTION
### Link to issue number:
#7592

### Summary of the issue:
Espeak voice names have changed, voice dictionaries use the voice name in their filename, now NVDA is not able to find the dictionaries with the new voice name.

### Description of how this pull request fixes the issue:
This PR uses a mapping of the old to new espeak voice names to rename the dictionary files. Old files are backed up to preserve the old name in case something goes wrong. The files are put into a versioned directory to make future updates to the names possible.

### Testing performed:
Created a default dictionary, and a voice dictionary for each of the synths on my system (espeak, SAPI5, OneCore) using NVDA 2017.3.
Copied these into the branch, and ensured that the dictionaries can be loaded.

### Known issues with pull request:
This does not use the voice ID, so future regressions due to name changes of synth voices are possible. This was done because synths such as SAPI5 and OneCore use registry paths as their ID's. These are not friendly to end users, who should be able to manually identify and manage their dictionary files. These long ID's also run the risk of creating file paths that exceed maximum length.  

Any users on master or next builds who have created new dictionary entries, or renamed old dictionaries to work with espeak will have to manually fix their dictionary files.

### Change log entry:
 In Changes:
`- Voice dictionary files are now versioned and have been moved to the 'speechDicts/voiceDicts.v1' directory. (#7592)`

