### PR TITLE
Fix a bug causing NVDA to use the wrong language when announcing selected/unselected symbols.

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -596,7 +596,7 @@ def speakSelectionChange(oldInfo,newInfo,speakSelected=True,speakUnselected=True
 				tempInfo=oldInfo.copy()
 				tempInfo.setEndPoint(newInfo,"startToEnd")
 				unselectedTextList.append(tempInfo.text)
-	locale=languageHandler.getLanguage()
+	locale=getCurrentLanguage()
 	if speakSelected:
 		if not generalize:
 			for text in selectedTextList:

--- a/source/speech.py
+++ b/source/speech.py
@@ -122,10 +122,13 @@ def speakMessage(text,index=None):
 	speakText(text,index=index,reason=controlTypes.REASON_MESSAGE)
 
 def getCurrentLanguage():
-	try:
-		language=getSynth().language if config.conf['speech']['trustVoiceLanguage'] else None
-	except NotImplementedError:
-		language=None
+	synth=getSynth()
+	language=None
+	if  synth:
+		try:
+			language=synth.language if config.conf['speech']['trustVoiceLanguage'] else None
+		except NotImplementedError:
+			pass
 	if language:
 		language=languageHandler.normalizeLanguage(language)
 	if not language:


### PR DESCRIPTION
### Summary of the issue:
When languages of the currently selected voice and of NVDA itself
differ, NVDA uses the voice language when announcing typed and erased
characters. This wasn't the case when selecting by character, the NVDA
language was always used.


### Description of how this pull request fixes the issue:
There was a function called "getCurrentLanguage" already present in speech.py. It just needed to be used instead of LanguageHandler to determine the locale used when reading the selected text.
### Testing performed:
I have tested this on the english language version of NVDA and polish espeak and I can confirm that it works correctly now.

### Change log entry:
Bug Fixes
NVDA now uses the correct language when announcing symbols when text is selected.