### PR TITLE
Update Spotify app module to support recent versions of Spotify.

### DIFF
--- a/source/appModules/spotify.py
+++ b/source/appModules/spotify.py
@@ -9,9 +9,15 @@
 
 import appModuleHandler
 import controlTypes
+from NVDAObjects.IAccessible import IAccessible
 import eventHandler
 
 class AppModule(appModuleHandler.AppModule):
+
+	def event_NVDAObject_init(self, obj):
+		if obj.windowClassName == "Chrome_RenderWidgetHostHWND" and isinstance(obj, IAccessible) and obj.IAccessibleChildID < 0 and obj.role == controlTypes.ROLE_UNKNOWN:
+			# #5439: Focus seems to hit Chromium objects that die before we can fetch them.
+			obj.shouldAllowIAccessibleFocusEvent = False
 
 	def event_gainFocus(self, obj, nextHandler):
 		if not eventHandler.isPendingEvents("gainFocus") and obj.windowClassName == "Chrome_WidgetWin_0" and obj.role == controlTypes.ROLE_WINDOW:

--- a/source/appModules/spotify.py
+++ b/source/appModules/spotify.py
@@ -2,30 +2,27 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2013 NV Access Limited
+#Copyright (C) 2013-2017 NV Access Limited, James Teh
 
 """App module for Spotify
 """
 
 import appModuleHandler
 import controlTypes
-from NVDAObjects.IAccessible import IAccessible
 import eventHandler
 
 class AppModule(appModuleHandler.AppModule):
 
-	def event_NVDAObject_init(self, obj):
-		if obj.windowClassName == "Chrome_RenderWidgetHostHWND" and isinstance(obj, IAccessible) and obj.IAccessibleChildID < 0 and obj.role == controlTypes.ROLE_UNKNOWN:
-			# #5439: Focus seems to hit Chromium objects that die before we can fetch them.
-			obj.shouldAllowIAccessibleFocusEvent = False
-
 	def event_gainFocus(self, obj, nextHandler):
 		if not eventHandler.isPendingEvents("gainFocus") and obj.windowClassName == "Chrome_WidgetWin_0" and obj.role == controlTypes.ROLE_WINDOW:
 			# Spotify doesn't fire focus on the correct object when it gets the foreground.
+			# Instead, it fires focus on a window ancestor.
+			# Try to get the correct focus.
 			try:
-				focus = obj.activeChild.activeChild
+				focus = obj.firstChild.firstChild.activeChild
 			except AttributeError:
 				focus = None
 			if focus:
+				# Bounce focus to the correct object.
 				return eventHandler.executeEvent("gainFocus", focus)
 		return nextHandler()


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:

Spotify doesn't fire focus on the correct object when it comes to the foreground (e.g. after alt+tab). I fixed this for an older version of Spotify in #5439, but this is broken in the current version of Spotify.

### Description of how this pull request fixes the issue:

Spotify fires focus on an ancestor window instead of the correct focus. However, the trick we previously used to get the correct focus no longer works. Switch to a new trick which does work.

### Testing performed:

Tested with Spotify 1.0.66.478.g1296534d:

1. Verified that moving around the document in browse mode, searching and moving through a song list in focus mode does not result in focus loss.
2. Verified that alt+tabbing out of Spotify and back in again restores focus to where it last was.
3. Verified that searching and then pressing enter on an artist in the search results does not result in focus loss.

### Known issues with pull request:
None known.

### Change log entry:
In Bug Fixes:

```
- Focus is now once again restored correctly when returning to Spotify from another application. (#7689)
```