### PR TITLE
Ensure NVDA updates succeed with Controlled folder Access enabled

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -36,6 +36,7 @@ with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\Microsoft\Windows\Cur
 defaultInstallPath=os.path.join(programFilesPath, versionInfo.name)
 
 def createShortcut(path,targetPath=None,arguments=None,iconLocation=None,workingDirectory=None,hotkey=None,prependSpecialFolder=None):
+	# #7696: The shortcut is only physically saved to disk if it does not already exist, or one or more properties have changed. 
 	wsh=_getWSH()
 	if prependSpecialFolder:
 		specialPath=wsh.SpecialFolders(prependSpecialFolder)

--- a/source/installer.py
+++ b/source/installer.py
@@ -44,16 +44,24 @@ def createShortcut(path,targetPath=None,arguments=None,iconLocation=None,working
 		os.makedirs(os.path.dirname(path))
 	shortcutExists=os.path.isfile(path)
 	short=wsh.CreateShortcut(path)
-	short.TargetPath=targetPath
-	if arguments:
+	needsSave=not shortcutExists
+	if short.targetPath!=targetPath:
+		short.TargetPath=targetPath
+		needsSave=True
+	if arguments and short.arguments!=arguments:
 		short.arguments=arguments
+		needsSave=True
 	if not shortcutExists and hotkey:
 		short.Hotkey=hotkey
-	if iconLocation:
+		needsSave=True
+	if iconLocation and short.iconLocation!=iconLocation:
 		short.IconLocation=iconLocation
-	if workingDirectory:
+		needsSave=True
+	if workingDirectory and short.workingDirectory!=workingDirectory:
 		short.workingDirectory=workingDirectory
-	short.Save()
+		needsSave=True
+	if needsSave:
+		short.Save()
 
 def getStartMenuFolder(noDefault=False):
 	try:


### PR DESCRIPTION
### Link to issue number:
Fixes #7696 

### Summary of the issue:
NVDA installs fail if Windows 10's Controlled Folder Access is enabled as NVDA is unable to create the desktop shortcut.
### Description of how this pull request fixes the issue:
The interactive NVDA install has always asked the user if it should create a desktop shortcut (if no previous install was detected), or to keep the existing desktop shortcut (if a previous install was detected). However, if the user had chosen to keep the existing shortcut, NVDA would still update / re-save the desktop shortcut (but keeping the shortcut key in tact). 
this PR now changes installer.createShortcut so that a shortcut is only physically saved to disc if it does not already exist, or one or more of its properties differ from what the new NVDA install requires. 
this means that  if the user updates NVDA via NVDA's update feature, or  installs via the launcher and chooses to keep the existing Desktop shortcut, the install will now succeed, even if controlled folder access is enabled.

### Testing performed:
Installed NVDA on Windows 10, with and with out Controlled folder Access, and with and with out an existing desktop shortcut.

### Known issues with pull request:
The install will still fail if the user installs NVDA for the first time, and chooses to create the desktop shortcut. The user can avoid the failiour by unchecking the box, if they are unwilling to disable Controlled Folder Access.

### Change log entry:
Bug fixes:
* NVDA no longer fails to update on systems with Controlled Folder Access enabled (available in the Windows 10 Fall Creaters update)
