### PR TITLE
Enable liblouis multi pass (disable pass1only flag) with a hidden config parameter

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -371,7 +371,9 @@ class Region(object):
 		L{brailleCursorPos}, L{brailleSelectionStart} and L{brailleSelectionEnd} are similarly updated based on L{cursorPos}, L{selectionStart} and L{selectionEnd}, respectively.
 		@postcondition: L{brailleCells}, L{brailleCursorPos}, L{brailleSelectionStart} and L{brailleSelectionEnd} are updated and ready for rendering.
 		"""
-		mode = louis.dotsIO | louis.pass1Only
+		mode = louis.dotsIO
+		if config.conf["braille"]["outputPass1Only"]:
+			mode |= louis.pass1Only
 		if config.conf["braille"]["expandAtCursor"] and self.cursorPos is not None:
 			mode |= louis.compbrlAtCursor
 		text=unicode(self.rawText).replace('\0','')

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -64,6 +64,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	readByParagraph = boolean(default=false)
 	wordWrap = boolean(default=true)
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
+	outputPass1Only = boolean(default=true)
 
 	# Braille display driver settings
 	[[__many__]]


### PR DESCRIPTION
### Link to issue number:
Provides test possibilities for #7301
Provides a workaround for #7693 

### Summary of the issue:
We currently use pass1only for liblouis translation, as not providing this flag and thus using multi pass theoretically breaks input to output position mapping.

### Description of how this pull request fixes the issue:
Adds outputPass1Only to the braille section of the configuration. This is not visible in the GUI. You can change this by running this from a python console

```
import config; config.conf["braille"]["outputPass1Only"]=False
```

Change it back with 

```
import config; config.conf["braille"]["outputPass1Only"]=True
```

### Testing performed:
I will provide a try build for this later today.

### Known issues with pull request:
None, except it is a bit difficult to change this for non-power users.

### Changes entry
* Changes for developers
    + Added a hidden boolean flag to the braille section in the configuration: "outputPass1Only". (#7301, #7693, #7702)
        - This flag defaults to true. If false, liblouis multi pass rules will be used for braille output.