### PR TITLE
Fix wx assertion when loading the welcome dialog

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -587,7 +587,7 @@ class WelcomeDialog(wx.Dialog):
 		# Translators: The header for the Welcome dialog when user starts NVDA for the first time. This is in larger,
 		# bold lettering 
 		welcomeTextHeader = wx.StaticText(self, label=_("Welcome to NVDA!"))
-		welcomeTextHeader.SetFont(wx.Font(18, wx.NORMAL, wx.NORMAL, wx.BOLD))
+		welcomeTextHeader.SetFont(wx.Font(18, wx.FONTFAMILY_DEFAULT, wx.NORMAL, wx.BOLD))
 		mainSizer.AddSpacer(guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 		mainSizer.Add(welcomeTextHeader,border=20,flag=wx.EXPAND|wx.LEFT|wx.RIGHT)
 		mainSizer.AddSpacer(guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)


### PR DESCRIPTION
### Link to issue number:
#7692

### Summary of the issue:
A wx assertion is triggered when loading the welcome screen. This is written to the log.

### Description of how this pull request fixes the issue:
Use the correct constant for the default font.

### Testing performed:
On Windows 10 and Windows 7
1. Started NVDA with debug logging
1. Opened the welcome dialog and checked that the appearance was as expected.
1. Checked the log to ensure there is no longer any wx assertion

### Known issues with pull request:
None

### Change log entry:
Not a user visible change.