### PR TITLE
Fix broken gesture identifier in freedomscientific driver

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -285,7 +285,13 @@ def NVDAObjectHasUsefulText(obj):
 def _getDisplayDriver(name):
 	return __import__("brailleDisplayDrivers.%s" % name, globals(), locals(), ("brailleDisplayDrivers",)).BrailleDisplayDriver
 
-def getDisplayList():
+def getDisplayList(excludeNegativeChecks=True):
+	"""Gets a list of available display driver names with their descriptions.
+	@param excludeNegativeChecks: excludes all drivers for which the check method returns C{False}.
+	@type excludeNegativeChecks: bool
+	@return: list of tuples with driver names and descriptions.
+	@rtype: [(str,unicode)]
+	"""
 	displayList = []
 	# The display that should be placed at the end of the list.
 	lastDisplay = None
@@ -299,7 +305,7 @@ def getDisplayList():
 				exc_info=True)
 			continue
 		try:
-			if display.check():
+			if not excludeNegativeChecks or display.check():
 				if display.name == "noBraille":
 					lastDisplay = (display.name, display.description)
 				else:

--- a/source/braille.py
+++ b/source/braille.py
@@ -2125,7 +2125,8 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 	def getDisplayTextForIdentifier(cls, identifier):
 		idParts = cls.ID_PARTS_REGEX.search(identifier)
 		if not idParts:
-			raise ValueError("Invalid identifier provided: %s"%identifier)
+			log.error("Invalid braille gesture identifier: %s"%identifier)
+			return handler.display.description, "malformed:%s"%identifier
 		modelName = idParts.group(3)
 		key = idParts.group(4)
 		if modelName: # The identifier contains a model name

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -229,7 +229,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver,ScriptableObject):
 	gestureMap=inputCore.GlobalGestureMap({
 		"globalCommands.GlobalCommands" : {
 			"braille_routeTo":("br(freedomScientific):routing",),
-			"braille_scrollBack" : ("br(freedomScientific):leftAdvanceBar", "br(freedomScientific]:leftBumperBarUp","br(freedomScientific):rightBumperBarUp",),
+			"braille_scrollBack" : ("br(freedomScientific):leftAdvanceBar", "br(freedomScientific):leftBumperBarUp","br(freedomScientific):rightBumperBarUp",),
 			"braille_scrollForward" : ("br(freedomScientific):rightAdvanceBar","br(freedomScientific):leftBumperBarDown","br(freedomScientific):rightBumperBarDown",),
 			"braille_previousLine" : ("br(freedomScientific):leftRockerBarUp", "br(freedomScientific):rightRockerBarUp",),
 			"braille_nextLine" : ("br(freedomScientific):leftRockerBarDown", "br(freedomScientific):rightRockerBarDown",),

--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -1,0 +1,25 @@
+#tests/unit/test_brailleDisplayDrivers.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2017 NV Access Limited, Leonard de Ruijter
+
+"""Unit tests for braille display drivers.
+"""
+
+import unittest
+import braille
+
+class TestGestureMap(unittest.TestCase):
+	"""Tests the integrity of braille display driver gesture maps."""
+
+	def test_identifiers(self):
+		"""Checks whether all defined braille display gestures contain valid braille display key identifiers."""
+		for name, description in braille.getDisplayList(excludeNegativeChecks=False):
+			driver=braille._getDisplayDriver(name)
+			gmap=driver.gestureMap
+			if not gmap:
+				continue
+			for cls, gesture, scriptName in gmap.getScriptsForAllGestures():
+				if gesture.startswith("br"):
+					self.assertRegexpMatches(gesture, braille.BrailleDisplayGesture.ID_PARTS_REGEX)


### PR DESCRIPTION
### Link to issue number:
Fixes #7713.

### Summary of the issue:
When the Freedom Scientific driver is active, the input gestures dialog can't be launched in Master due to braille.BrailleDisplayGesture.getDisplayTextForIdentifier raising a ValueError. It turned out one of the identifiers in the freedomScientific driver was malformed, having the br(freedomscientific] prefix.

### Description of how this pull request fixes the issue:
1. Fixed the malformed identifier in the freedomScientific driver
2. Provided a unit test that checks every display driver gesture map for possible malformed identifiers.
3. Added a keyword arg excludeNegativeChecks to braille.getDisplayList in order to list all braille display drivers, not only those that passed the check.
4. Stopped braille.BrailleDisplayGesture.getDisplayTextForIdentifier from raising a ValueError. instead, an error is logged and the identifier is returned with the prefix "malformed:"

### Testing performed:
Ran the new unit test against the broken freedomScientific driver, it cached the mistake properly.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + Backward scrolling functionality has been fixed for freedom Scientific displays containing a left bumper bar. (#7713)