### PR TITLE
gecko_ia2 vbuf backend: Support IAccessibleHypertext2 to improve performance for Firefox multi-process.

### DIFF
--- a/nvdaHelper/common/ia2utils.h
+++ b/nvdaHelper/common/ia2utils.h
@@ -53,7 +53,6 @@ class HyperlinkGetter {
 	virtual IAccessibleHyperlinkPtr next();
 
 	protected:
-	long count;
 	long index = 0;
 	virtual IAccessibleHyperlinkPtr get(const unsigned long index) = 0;
 };
@@ -84,6 +83,8 @@ class Ht2HyperlinkGetter: public HyperlinkGetter {
 	private:
 	IAccessibleHypertext2Ptr hypertext;
 	IAccessibleHyperlink** rawLinks = nullptr;
+	long count;
+	void maybeFetch();
 };
 
 /**

--- a/nvdaHelper/common/ia2utils.h
+++ b/nvdaHelper/common/ia2utils.h
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2006-2010 NVDA contributers.
+Copyright 2007-2017 NV Access Limited, Mozilla Corporation
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -15,8 +15,12 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #ifndef _VBUF_IA2UTILS_H
 #define _VBUF_IA2UTILS_H
 
+#include <comdef.h>
+#include <comip.h>
 #include <string>
 #include <map>
+#include <memory>
+#include <ia2.h>
 
 /**
  * Convert an IAccessible2 attributes string to a map of attribute keys and values.
@@ -28,5 +32,68 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * @param attribsMap: The map into which the attributes should be placed, with keys and values as strings.
  */
 void IA2AttribsToMap(const std::wstring &attribsString, std::map<std::wstring, std::wstring> &attribsMap);
+
+_COM_SMARTPTR_TYPEDEF(IAccessible2, IID_IAccessible2);
+_COM_SMARTPTR_TYPEDEF(IAccessibleHypertext, IID_IAccessibleHypertext);
+_COM_SMARTPTR_TYPEDEF(IAccessibleHypertext2, IID_IAccessibleHypertext2);
+_COM_SMARTPTR_TYPEDEF(IAccessibleHyperlink, IID_IAccessibleHyperlink);
+
+/**
+ * Base class to support retrieving hyperlinks (embedded objects) from
+ * IAccessibleHypertext or IAccessibleHypertext2.
+ * Callers should use the makeHyperlinkGetter factory function,
+ * rather than instantiating subclasses directly.
+ */
+class HyperlinkGetter {
+	public:
+	virtual ~HyperlinkGetter() {}
+
+	/** Get the next hyperlink.
+	 */
+	virtual IAccessibleHyperlinkPtr next();
+
+	protected:
+	long count;
+	long index = 0;
+	virtual IAccessibleHyperlinkPtr get(const unsigned long index) = 0;
+};
+
+/** Supports retrieval of hyperlinks from IAccessibleHypertext.
+ */
+class HtHyperlinkGetter: public HyperlinkGetter {
+	public:
+	HtHyperlinkGetter(IAccessibleHypertextPtr hypertext);
+
+	protected:
+	virtual IAccessibleHyperlinkPtr get(const unsigned long index) override;
+
+	private:
+	IAccessibleHypertextPtr hypertext;
+};
+
+/** Supports retrieval of hyperlinks from IAccessibleHypertext2.
+ */
+class Ht2HyperlinkGetter: public HyperlinkGetter {
+	public:
+	Ht2HyperlinkGetter(IAccessibleHypertext2Ptr hypertext);
+	virtual ~Ht2HyperlinkGetter();
+
+	protected:
+	virtual IAccessibleHyperlinkPtr get(const unsigned long index) override;
+
+	private:
+	IAccessibleHypertext2Ptr hypertext;
+	IAccessibleHyperlink** rawLinks = nullptr;
+};
+
+/**
+ * Create an appropriate HyperlinkGetterto retrieve hyperlinks
+ * (embedded objects) if they are supported.
+ * IAccessibleHypertext2 will be used in preference to IAccessibleHypertext.
+ * @param acc The accessible to use.
+ * @return A pointer to the HyperlinkGetter
+ *  or a null pointer if hyperlinks aren't supported.
+ */
+std::unique_ptr<HyperlinkGetter> makeHyperlinkGetter(IAccessible2* acc);
 
 #endif

--- a/nvdaHelper/common/ia2utils.h
+++ b/nvdaHelper/common/ia2utils.h
@@ -87,7 +87,7 @@ class Ht2HyperlinkGetter: public HyperlinkGetter {
 };
 
 /**
- * Create an appropriate HyperlinkGetterto retrieve hyperlinks
+ * Create an appropriate HyperlinkGetter to retrieve hyperlinks
  * (embedded objects) if they are supported.
  * IAccessibleHypertext2 will be used in preference to IAccessibleHypertext.
  * @param acc The accessible to use.


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
With Firefox multi-process, rendering a virtual buffer for browse mode now makes cross-process calls, since the content document accessibility tree is now in another process. This has a substantial impact on performance. The more cross-process calls we can reduce, the better. This PR introduces a change which fetches all embedded children at once, rather than fetching each in a separate call.

### Description of how this pull request fixes the issue:
IAccessibleHypertext2::hyperlinks allows all embedded objects to be retrieved at once, rather than retrieving them one at a time.

This improves performance for cross-process renders, which is the case for Firefox multi-process.
IAccessibleHypertext is still supported and will be used if the newer interface is not present.

In addition:

1. Don't bother calling hyperlinkIndex, since in Gecko (and Chrome), hyperlinks correspond with embedded object characters.
2. Use a constant for the embedded object character.

### Testing performed:
confirmed that the World War I Wikipedia article renders as expected in:

1. A build of Firefox which supports IAHypertext2. (This is now in Firefox nightly.)
2. A build that does not.
3. Chrome Canary, which does not support IAHypertext2.

Using IAHypertext2 seems to shave up to a second off the render time for the World War I article, though it's difficult to provide concrete numbers because the time seems to be a little variable.

### Known issues with pull request:
None know.

### Change log entry:
In Bug Fixes:

```
- Slight performance improvement when rendering large amounts of content in Mozilla Firefox 58 and later. (#7719)
```