### PR TITLE
Use scons 3.0 commit 6a72c4de3e92cae65016578270e6f68e66c4f1e8 from upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 	ignore = untracked
 [submodule "include/scons"]
 	path = include/scons
-	url = https://github.com/nvaccess/scons
+	url = https://github.com/SConsProject/scons

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ For reference, the following dependencies are included in Git submodules:
 * Adobe FlashAccessibility interface typelib
 * [txt2tags](http://txt2tags.sourceforge.net/), version 2.5
 * [MinHook](https://github.com/RaMMicHaeL/minhook), tagged version 1.2.2
-* [SCons](http://www.scons.org/), version 2.4.1
+* [SCons](http://www.scons.org/), version 3.0.0, commit 6a72c4de
 * brlapi Python bindings, version 0.5.7 or later, distributed with [BRLTTY for Windows](http://brl.thefreecat.org/brltty/), version 4.2-2
 * ALVA BC6 generic dll, version 3.0.4.1
 * lilli.dll, version 2.1.0.0


### PR DESCRIPTION
### Link to issue number:
None

### Description of this pull request
Since SCons development has been officially migrated to Github, use SCons from the upstream repository. This updates to commit 6a72c4de3e92cae65016578270e6f68e66c4f1e8, which is a post 3.0 commit that contains some changes for the GIT migration, including a proper .gitignore

### Testing performed:
Ran a succesful build of NVDA

### Known issues with pull request:
None I'm aware of
