### PR TITLE
Implement a generic system for acknowledgement packet handling

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1879,7 +1879,7 @@ class _BgThread:
 				handler.display._awaitingAck = True
 				winKernel.setWaitableTimer(
 					_BgThread.ackTimerHandle,
-					int(handler.display.timeout*1000),
+					int(handler.display.timeout*2000),
 					0,
 					_BgThread.ackTimeoutResetter
 				)

--- a/source/braille.py
+++ b/source/braille.py
@@ -1590,7 +1590,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		# we just replace the data.
 		# This means that if multiple writes occur while an earlier write is still in progress,
 		# we skip all but the last.
-		if not alreadyQueued:
+		if not alreadyQueued and not self.display._awaitingAck:
 			# Queue a call to the background thread.
 			_BgThread.queueApc(_BgThread.executor)
 
@@ -1833,6 +1833,7 @@ class _BgThread:
 		thread.daemon = True
 		thread.start()
 		cls.handle = ctypes.windll.kernel32.OpenThread(winKernel.THREAD_SET_CONTEXT, False, thread.ident)
+		cls.ackTimerHandle = winKernel.createWaitableTimer()
 
 	@classmethod
 	def queueApc(cls, func):
@@ -1843,6 +1844,10 @@ class _BgThread:
 		if not cls.thread:
 			return
 		cls.exit = True
+		if not ctypes.windll.kernel32.CancelWaitableTimer(cls.ackTimerHandle):
+			raise ctypes.WinError()
+		winKernel.closeHandle(cls.ackTimerHandle)
+		cls.ackTimerHandle = None
 		# Wake up the thread. It will exit when it sees exit is True.
 		cls.queueApc(cls.executor)
 		cls.thread.join()
@@ -1866,6 +1871,22 @@ class _BgThread:
 		except:
 			log.error("Error displaying cells. Disabling display", exc_info=True)
 			handler.setDisplayByName("noBraille", isFallback=True)
+		else:
+			if handler.display.receivesAckPackets:
+				handler.display._awaitingAck = True
+				winKernel.setWaitableTimer(
+					_BgThread.ackTimerHandle,
+					int(handler.display.timeout*1000),
+					0,
+					_BgThread.ackTimeoutResetter
+				)
+
+	@winKernel.PAPCFUNC
+	def ackTimeoutResetter(param):
+		if handler.display.receivesAckPackets and handler.display._awaitingAck:
+			log.debugWarning("Waiting for %s ACK packet timed out"%handler.display.name)
+			handler.display._awaitingAck = False
+			_BgThread.queueApc(_BgThread.executor)
 
 	@classmethod
 	def func(cls):
@@ -1932,6 +1953,22 @@ class BrailleDisplayDriver(baseObject.AutoPropertyObject):
 	#: This is also required to use the L{hwIo} module.
 	#: @type: bool
 	isThreadSafe = False
+	#: Whether displays for this driver return acknowledgements for sent packets.
+	#: L{_handleAck} should be called when an ACK is received.
+	#: Note that thread safety is required for the generic implementation to function properly.
+	#: If a display is not thread safe, a driver should manually implement ACK processing.
+	#: @type: bool
+	receivesAckPackets = False
+	#: Whether this driver is awaiting an Ack for a connected display.
+	#: This is set to C{True} after displaying cells when L{receivesAckPackets} is True,
+	#: and set to C{False} by L{_handleAck} or when C{timeout} has elapsed.
+	#: This is for internal use by NVDA core code only and shouldn't be touched by a driver itself.
+	_awaitingAck = False
+	#: Maximum timeout to use for communication with a device (in seconds).
+	#: This can be used for serial connections.
+	#: Furthermore, it is used by L{_BgThread} to stop waiting for missed acknowledgement packets.
+	#: @type: float
+	timeout = 0.2
 
 	@classmethod
 	def check(cls):
@@ -2008,6 +2045,15 @@ class BrailleDisplayDriver(baseObject.AutoPropertyObject):
 					emuGesture = keyboardHandler.KeyboardInputGesture.fromName(scriptName.split(":")[1])
 					if emuGesture.isModifier:
 						yield set(gesture.split(":")[1].split("+")), set(emuGesture._keyNamesInDisplayOrder)
+
+	def _handleAck(self):
+		"""Base implementation to handle acknowledgement packets."""
+		if not self.receivesAckPackets:
+			raise NotImplementedError("This display driver does not support ACK packet handling")
+		if not ctypes.windll.kernel32.CancelWaitableTimer(_BgThread.ackTimerHandle):
+			raise ctypes.WinError()
+		self._awaitingAck = False
+		_BgThread.queueApc(_BgThread.executor)
 
 class BrailleDisplayGesture(inputCore.InputGesture):
 	"""A button, wheel or other control pressed on a braille display.

--- a/source/braille.py
+++ b/source/braille.py
@@ -1861,6 +1861,9 @@ class _BgThread:
 		if _BgThread.exit:
 			# func will see this and exit.
 			return
+		if handler.display._awaitingAck:
+			# Do not write cells when we are awaiting an ACK
+			return
 		with _BgThread.queuedWriteLock:
 			data = _BgThread.queuedWrite
 			_BgThread.queuedWrite = None

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -55,6 +55,26 @@ def CreateFile(fileName,desiredAccess,shareMode,securityAttributes,creationDispo
 	return res
 
 
+def createWaitableTimer(securityAttributes=None, manualReset=False, name=None):
+	res = kernel32.CreateWaitableTimerW(securityAttributes, manualReset, name)
+	if res==0:
+		raise ctypes.WinError()
+	return res
+
+def setWaitableTimer(handle, dueTime, period, completionRoutine, arg=None, resume=False):
+	res = kernel32.SetWaitableTimer(
+		handle,
+		# due time is in 100 nanosecond intervals, relative time should be negated.
+		byref(LARGE_INTEGER(dueTime*-10000)),
+		period,
+		completionRoutine,
+		arg,
+		resume
+	)
+	if res==0:
+		raise ctypes.WinError()
+	return True
+
 
 def openProcess(*args):
 	return kernel32.OpenProcess(*args)

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -56,12 +56,44 @@ def CreateFile(fileName,desiredAccess,shareMode,securityAttributes,creationDispo
 
 
 def createWaitableTimer(securityAttributes=None, manualReset=False, name=None):
+	"""Wrapper to the kernel32 CreateWaitableTimer function.
+	Consult https://msdn.microsoft.com/en-us/library/windows/desktop/ms682492.aspx for Microsoft's documentation.
+	In contrast with the original function, this wrapper assumes the following defaults.
+	@param securityAttributes: Defaults to C{None};
+		The timer object gets a default security descriptor and the handle cannot be inherited.
+		The ACLs in the default security descriptor for a timer come from the primary or impersonation token of the creator.
+	@type securityAttributes: pointer to L{SECURITY_ATTRIBUTES}
+	@param manualReset: Defaults to C{False} which means the timer is a synchronization timer.
+		If C{True}, the timer is a manual-reset notification timer.
+	@type manualReset: bool
+	@param name: Defaults to C{None}, the timer object is created without a name.
+	@type name: unicode
+	"""
 	res = kernel32.CreateWaitableTimerW(securityAttributes, manualReset, name)
 	if res==0:
 		raise ctypes.WinError()
 	return res
 
-def setWaitableTimer(handle, dueTime, period, completionRoutine, arg=None, resume=False):
+def setWaitableTimer(handle, dueTime, period=0, completionRoutine=None, arg=None, resume=False):
+	"""Wrapper to the kernel32 SETWaitableTimer function.
+	Consult https://msdn.microsoft.com/en-us/library/windows/desktop/ms686289.aspx for Microsoft's documentation.
+	@param handle: A handle to the timer object.
+	@type handle: int
+	@param dueTime: Relative time (in miliseconds).
+		Note that the original function requires relative time to be supplied as a negative nanoseconds value.
+	@type dueTime: int
+	@param period: Defaults to 0, timer is only executed once.
+		Value should be supplied in miliseconds.
+	@type period: int
+	@param completionRoutine: The function to be executed when the timer elapses.
+	@type completionRoutine: L{PAPCFUNC}
+	@param arg: Defaults to C{None}; a pointer to a structure that is passed to the completion routine.
+	@type arg: L{ctypes.c_void_p}
+	@param resume: Defaults to C{False}; the system is not restored.
+		If this parameter is TRUE, restores a system in suspended power conservation mode 
+		when the timer state is set to signaled.
+	@type resume: bool
+	"""
 	res = kernel32.SetWaitableTimer(
 		handle,
 		# due time is in 100 nanosecond intervals, relative time should be negated.


### PR DESCRIPTION
### Link to issue number:
Closes #7721.

### Summary of the issue:
From https://github.com/nvaccess/nvda/issues/7721#issue-270713977

> For several braille displays, when sending a packet, the display acknowledges the receipt of a packet. This is a mechanism to make sure that a packet has been delivered to a braille display in a correct way. Several displays have such a feature, including Handy Tech, Eurobraille and Freedom Scientific displays.

### Description of how this pull request fixes the issue:
This pr implements ACK packet handling on the main BrailleDisplayDriver class itself, rather than specific for every braille display. Currently, only the Handy Tech driver makes use of this generic functionality. This functionality will also be used for the Eurobraille braille display driver (#7488).

### Testing performed:
Tested using a Handy Tech Basic Braille, which has some issues with updating the display if ACK handling is disabled. Difference between ACK handling enabled and disabled is clearly noticeable. Also tested in my eurobraille-native branch. The ACK timer is properly reset in case of a missed ack, and a debug warning is logged.

### Known issues with pull request:
None i'm aware of.

### Change log entry:
* Changes for developers:
    + Implemented a generic system in braille.BrailleDisplayDriver to deal with displays which send confirmation/acknowledgement packets. See the handyTech braille display driver as an example. (#7590, #7721)