### PR TITLE
No longer crash Foobar2000 due to an uninitialized VARIANT

### DIFF
--- a/nvdaHelper/remote/ia2LiveRegions.cpp
+++ b/nvdaHelper/remote/ia2LiveRegions.cpp
@@ -218,6 +218,8 @@ void CALLBACK winEventProcHook(HWINEVENTHOOK hookID, DWORD eventID, HWND hwnd, l
 	}
 	//Retreave the object states, and if its invisible or offscreen ignore the event.
 	VARIANT varState;
+	// #7709: Ensure The VARIANT is initialized, as accState may try to clear it before setting it.
+	VariantInit(&varState);
 	pacc->get_accState(varChild,&varState);
 	VariantClear(&varChild);
 	if(varState.vt==VT_I4&&(varState.lVal&STATE_SYSTEM_INVISIBLE)) {


### PR DESCRIPTION
### Link to issue number:
Fixes #7709 
Fixes #7722

### Summary of the issue:
Foobar2000 crashes when a certain track is reached in a playList.
NVDA receives a namcEhange winEvent, and in responce, fetches the object's MSAA state by calling IAccessible::accState.
Foobar2000's implementation of accState first calls VariantClear on the provided VARIANT, before filling it in with the state.
However, NVDA passed in an uninitialized variant, thus when Foobar2000 calls VariantClear,  it is possible the VARIANT may look like it has data that needs to be freed, which then corrupts the heap.

### Description of how this pull request fixes the issue:
This PR ensures the VARIANT is appropriately initialized before passing it to accState.

### Testing performed:
As I am unable to reproduce the bug, I cannot successfully test that this fixes the issue. A try build has been made: https://ci.appveyor.com/api/buildjobs/jl9lqma0cuk63j0q/artifacts/output%2Fnvda_snapshot_try-i7709-14599%2C4f6cfcf3.exe
Which should be tested on machines that can reproduce the issue.

### Known issues with pull request:
None

### Change log entry:
None, as this only came about with the switch to VS 2017 it seems.