### PR TITLE
Fix changes on next not on master

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -633,7 +633,7 @@ class MSHTML(IAccessible):
 		return presType
 
 
-	def old_get_shouldAllowIAccessibleFocusEvent(self):
+	def _get_shouldAllowIAccessibleFocusEvent(self):
 		ariaRole=self.HTMLAttributes['aria-role']
 		if ariaRole=="gridcell":
 			return True

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -137,6 +137,7 @@ wdContentControlBuildingBlockGallery=5
 wdContentControlDate=6
 wdContentControlGroup=7
 wdContentControlCheckBox=8
+
 wdNoRevision=0
 wdRevisionInsert=1
 wdRevisionDelete=2

--- a/source/braille.py
+++ b/source/braille.py
@@ -26,8 +26,8 @@ import brailleDisplayDrivers
 import inputCore
 import brailleTables
 from collections import namedtuple
-import scriptHandler
 import re
+import scriptHandler
 
 roleLabels = {
 	# Translators: Displayed in braille for an object which is a

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -36,7 +36,6 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	outputDevice = string(default=default)
 	autoLanguageSwitching = boolean(default=true)
 	autoDialectSwitching = boolean(default=false)
-	readNumbersAs = integer(default=0,min=0,max=3)
 
 	[[__many__]]
 		capPitchChange = integer(default=30,min=-100,max=100)

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -44,7 +44,6 @@ class myDialog(class wx.Dialog):
 """
 import wx
 from wx.lib import scrolledpanel
-import nvdaControls
 
 #: border space to be used around all controls in dialogs
 BORDER_FOR_DIALOGS=10

--- a/source/speech.py
+++ b/source/speech.py
@@ -337,7 +337,7 @@ def speakObject(obj,reason=controlTypes.REASON_QUERY,index=None):
 		# objects that do not report as having navigableText should not report their text content either
 		not obj._hasNavigableText
 	)
-	allowProperties={'name':True,'role':True,'roleText':True,'states':True,'value':True,'description':True,'keyboardShortcut':True,'positionInfo_level':True,'positionInfo_indexInGroup':True,'positionInfo_similarItemsInGroup':True,"cellCoordsText":True,"rowNumber":True,"columnNumber":True,"includeTableCellCoords":True,"columnCount":True,"rowCount":True,"rowHeaderText":True,"columnHeaderText":True, "placeholder":False}
+	allowProperties={'name':True,'role':True,'roleText':True,'states':True,'value':True,'description':True,'keyboardShortcut':True,'positionInfo_level':True,'positionInfo_indexInGroup':True,'positionInfo_similarItemsInGroup':True,"cellCoordsText":True,"rowNumber":True,"columnNumber":True,"includeTableCellCoords":True,"columnCount":True,"rowCount":True,"rowHeaderText":True,"columnHeaderText":True}
 
 	if reason==controlTypes.REASON_FOCUSENTERED:
 		allowProperties["value"]=False
@@ -1571,32 +1571,6 @@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni
 					textList.append(u"%s %s"%(label,newVal))
 				else:
 					textList.append(noVal)
-		verticalAlign=attrs.get("vertical-align")
-		oldverticalAlign=attrsCache.get("vertical-align") if attrsCache is not None else None
-		if (verticalAlign or oldverticalAlign is not None) and verticalAlign!=oldverticalAlign:
-			verticalAlign=verticalAlign.lower() if verticalAlign else verticalAlign
-			if verticalAlign=="top":
-				# Translators: Reported when text is vertically top-aligned.
-				text=_("vertical align top")
-			elif verticalAlign in("center","middle"):
-				# Translators: Reported when text is vertically middle aligned.
-				text=_("vertical align middle")
-			elif verticalAlign=="bottom":
-				# Translators: Reported when text is vertically bottom-aligned.
-				text=_("vertical align bottom")
-			elif verticalAlign=="baseline":
-				# Translators: Reported when text is vertically aligned on the baseline. 
-				text=_("vertical align baseline")
-			elif verticalAlign=="justify":
-				# Translators: Reported when text is vertically justified.
-				text=_("vertical align justified")
-			elif verticalAlign=="distributed":
-				# Translators: Reported when text is vertically justified but with character spacing (For some Asian content). 
-				text=_("vertical align distributed") 
-			else:
-				# Translators: Reported when text has reverted to default vertical alignment.
-				text=_("vertical align default")
-			textList.append(text)
 	if formatConfig["reportLineSpacing"]:
 		lineSpacing=attrs.get("line-spacing")
 		oldLineSpacing=attrsCache.get("line-spacing") if attrsCache is not None else None


### PR DESCRIPTION
Note, this PR intentionally targets next and should be merged there.

### Summary of the issue:
To check if there are any changes on next that are not part of incubating PRs I generated a master+incubating PRs (naming it 'newNext') and diff'd it against next+master (naming it oldNext).

### Description of how this pull request fixes the issue:
newNext was made by starting with the latest master, and applying each of the incubating PRs one by one starting with the oldest (there were no merge conflicts). oldNext is origin/next with the latest master merged into it. and diffed against "oldNext"

The diff and patch were generated with `git diff newNext..oldNext > newNext_dotdot_oldNext.diff`
There seem to be a few differences, here is the patch file:  [newnext_dotdot_oldnext.diff.txt](https://github.com/nvaccess/nvda/files/1452882/newnext_dotdot_oldnext.diff.txt)

This shows the set of changes that go from newNext to oldNext. Essentially the changes in next that will never make it to master.

For each of the changes in this patch I will look at where they came from using the following:

`git log -p --follow -M -S foo -- path/to/file`

Where:
-p indicates to include the patch for the commit in the log entry.
-M shows renames in a readable way.
--follow keep following changes through the old file.
-S foo This is -S option where foo is a search term, for instance, part of the line that we are interested in.

Diff:
```
In source/NVDAObjects/IAccessible/MSHTML.py
@ class MSHTML(IAccessible):
 
-	def _get_shouldAllowIAccessibleFocusEvent(self):
+	def old_get_shouldAllowIAccessibleFocusEvent(self):
```
From commit:
```
commit 9c774cab5cdd385116868ea424f9ce7aa8a28148
Author: Michael Curran <mick@nvaccess.org>
Date:   Mon Feb 1 12:46:23 2016 +1000

    MSHTML NVDAObject: expose focusable and focused states if this object is the active descendant of the focus as IE fails to do this itself. This code was moved from shouldAllowIAccessibleFocusEvent into states.
```
Notes:
Looks like this was probably used to debug something, and accidently left in.

Verdict:
Revert to `def _get_shouldAllowIAccessibleFocusEvent(self):`

Diff:
```
In source/NVDAObjects/window/winword.py
 wdContentControlCheckBox=8
-
 wdNoRevision=0
```
Verdict:
Revert to blank line between `wdContentControlCheckBox` and `wdNoRevision` on next

Diff:
```
In source/braille.py
-import re
 import scriptHandler
+import re
```

Verdict:
Revert to previous import order on next

Diff:
```
In source/config/configSpec.py
+	readNumbersAs = integer(default=0,min=0,max=3)
```

From Commit:
```
commit f8768d83b931980a92c1666e27a5fc176f6b220e
Author: Reef Turner <reef@nvaccess.org>
Date:   Thu Jan 5 18:41:01 2017 +0800

    Fix an issue with the previous merge.

    Merge in question:  Merge remote-tracking branch
    'origin/i6470-LimitCursorBlinkRate' into next
```
Notes:
Originally part of #5930, which is likely to be incubated again.

Verdict:
Revert. While this is likely to be incubated again, I'd prefer not to run the risk of having this forgotten about in the case that the PR is not re-incubated.
This could possibly cause problems for users of next who have the `readNumbersAs` item in their config

Diff:
```
In source/core.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2006-2017 NV Access Limited, Aleksey Sadovoy, Christopher Toth, Joseph Lee, Peter Vágner, Derek Riemer, Babbage B.V.
-#Copyright (C) 2006-2016 NV Access Limited, Aleksey Sadovoy, Christopher Toth, Joseph Lee, Peter Vágner, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
```
Notes:
Looks like a duplicate Copyright line exists on master.

Verdict:
Remove the duplicate on master.
 
Diff:
``` 
In source/gui/guiHelper.py

+import nvdaControls
```
Notes:
This import is not used in the rest of the file.

Verdict:
Remove line from next.

Diff:
```
In source/gui/nvdaControls.py
@ class SelectOnFocusSpinCtrl(wx.SpinCtrl):
 		numChars = len(str(self.GetValue()))
 		self.SetSelection(0, numChars)
 		evt.Skip()
+
```
Notes:
Blank line at end of file.

Verdict:
Add blank line to end of file in master

Diff:
```
In source/gui/settingsDialogs.py
@ class AddSymbolDialog(wx.Dialog):
 		# Translators: This is the label for the edit field in the add symbol dialog.
 		symbolText = _("Symbol:")
 		self.identifierTextCtrl = sHelper.addLabeledControl(symbolText, wx.TextCtrl)
-		
+
 		sHelper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK | wx.CANCEL))
 
 		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
```
Notes:
Removes two tabs.

Verdict:
Remove line with white space errors from master

Diff:
```
In source/speech.py
@def speakObject(obj,reason=controlTypes.REASON_QUERY,index=None):

-	allowProperties={'name':True,'role':True,'roleText':True,'states':True,'value':True,'description':True,'keyboardShortcut':True,'positionInfo_level':True,'positionInfo_indexInGroup':True,'positionInfo_similarItemsInGroup':True,"cellCoordsText":True,"rowNumber":True,"columnNumber":True,"includeTableCellCoords":True,"columnCount":True,"rowCount":True,"rowHeaderText":True,"columnHeaderText":True}
+	allowProperties={'name':True,'role':True,'roleText':True,'states':True,'value':True,'description':True,'keyboardShortcut':True,'positionInfo_level':True,'positionInfo_indexInGroup':True,'positionInfo_similarItemsInGroup':True,"cellCoordsText":True,"rowNumber":True,"columnNumber":True,"includeTableCellCoords":True,"columnCount":True,"rowCount":True,"rowHeaderText":True,"columnHeaderText":True, "placeholder":False}
```
Notes:
Only properties with a value of `True` are required to be listed, the default for missing properties is `False`.
`placeholder` is the only difference, added in next with a value of `False`.

Verdict:
Remove placeholder property from line on the `next` branch.

Diff:
```
In source/speech.py
@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni

+		verticalAlign=attrs.get("vertical-align")
+		oldverticalAlign=attrsCache.get("vertical-align") if attrsCache is not None else None
+		if (verticalAlign or oldverticalAlign is not None) and verticalAlign!=oldverticalAlign:
+			verticalAlign=verticalAlign.lower() if verticalAlign else verticalAlign
+			if verticalAlign=="top":
+				# Translators: Reported when text is vertically top-aligned.
+				text=_("vertical align top")
+			elif verticalAlign in("center","middle"):
+				# Translators: Reported when text is vertically middle aligned.
+				text=_("vertical align middle")
+			elif verticalAlign=="bottom":
+				# Translators: Reported when text is vertically bottom-aligned.
+				text=_("vertical align bottom")
+			elif verticalAlign=="baseline":
+				# Translators: Reported when text is vertically aligned on the baseline. 
+				text=_("vertical align baseline")
+			elif verticalAlign=="justify":
+				# Translators: Reported when text is vertically justified.
+				text=_("vertical align justified")
+			elif verticalAlign=="distributed":
+				# Translators: Reported when text is vertically justified but with character spacing (For some Asian content). 
+				text=_("vertical align distributed") 
+			else:
+				# Translators: Reported when text has reverted to default vertical alignment.
+				text=_("vertical align default")
+			textList.append(text)
```
Notes:
On next this block is duplicated, separated by perhaps 50 lines. Master has this block under the `reportParagraphIndentation`, next has it under that and also `reportAlignment`. Alignment seems like a more logical place for this.

Verdict:
On next:
- Ensure duplicate blocks match exactly.
- Remove the duplicate block from the `reportParagraphIndentation` section
On master:
- Move the block to the `reportAlignment` section.

Diff:
```
In source/speechViewer.py
@ class SpeechViewerFrame(wx.Dialog):
 		return [repr( (i.width, i.height) ) for i in displays]
 
-
 	def savePositionInformation(self):
```
Verdict:
Remove extra blank line from master.

### Testing performed:
- Did a clean rebuild of NVDA
- Checked settings dialogs and speechviewer
- Ensured that vertical-alignment is report in excel 
- Ensured that paragraph indentation is reported in word
- Checked that there is no diff between this and `fixOrphanedChangesOnNext-forMaster + merged PRs that are incubating`

### Known issues with pull request:
None.

### Change log entry:
None