### PR TITLE
Fix espeak freeze with certain Tamil symbol

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -155,12 +155,19 @@ env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspat
 
 #Compile all dictionaries
 missingDicts=['zhy', ] #'mt','tn','tt']
+#Excluded Emoji files for some languages.
+excludeEmojiFileFor=[
+	'ta', # #7740 the ள் symbol causes a problem in espeak if emoji for ta is used.
+	]
 dictSourcePath=espeakRepo.Dir('dictsource').abspath
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]
 	if lang in missingDicts: continue
 	dictFileName = lang+'_dict'
 	dictFile=env.Command(espeakRepo.Dir('espeak-ng-data').File(dictFileName),f,espeak_compileDict_buildAction)
+	emojiFileName = os.path.join(espeakRepo.abspath,'dictsource',lang+'_emoji')
+	if lang in excludeEmojiFileFor and os.path.exists(emojiFileName):
+		os.remove(emojiFileName)
 	dictDeps=env.Glob(os.path.join(espeakRepo.abspath,'dictsource',lang+'_*'))
 	dictDeps.remove(f)
 	env.Depends(dictFile,dictDeps)


### PR DESCRIPTION
The introduction of an emoji file seems to cause an issue with certain
symbols being read by espeak.

### Link to issue number:
Symbol freezes NVDA when Read #7740

### Summary of the issue:
Warning, this section contains the symbol.
When the ள் symbol is encountered by espeak 1.49.2 with the ta_emoji file, espeak seems to freeze.

### Description of how this pull request fixes the issue:
As a quick fix for this issue prior to release, this change ensures that the emoji file for Tamil is not included in the espeak dictionary compilation. 

### Testing performed:
- Tested reading the symbol from notepad from master and observed the freeze. 
- Removed ta_emoji file and rebuilt. Observed the symbol can be read. I don't know the pronunciation of this symbol so can not ensure that it was correctly read.
- Built a try build of this branch: https://ci.appveyor.com/api/buildjobs/ux1v4wj356282hqg/artifacts/output%2Fnvda_snapshot_try-i7740-fixEspeakFreezeWithTamilEmoji-14614%2C6f53b534.exe
- Ensured that running this try build from launcher, reads the symbol.

### Known issues with pull request:
This PR will disable the emoji support for the Tamil language.

### Change log entry:
None.