### PR TITLE
make sure About dialog text is shown localized

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -5,6 +5,12 @@
 
 import os
 
+"""
+This module contains non-localizable version information for NVDA such as the version string and major and minor numbers etc.
+Any localizable version information should be placed in the versionInfo module, not this one.
+This module exists separately so that it can be imported for version checks before localization is initialized.
+"""
+
 def _updateVersionFromVCS():
 	"""Update the version from version control system metadata if possible.
 	"""

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,0 +1,45 @@
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2017 NV Access Limited
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import os
+
+def _updateVersionFromVCS():
+	"""Update the version from version control system metadata if possible.
+	"""
+	global version
+	# The root of the Git working tree will be the parent of this module's directory.
+	gitDir = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".git")
+	try:
+		head = file(os.path.join(gitDir, "HEAD"), "r").read().rstrip()
+		if not head.startswith("ref: "):
+			# Detached head.
+			version = "source-DETACHED-%s" % head[:7]
+			return
+		# Strip the "ref: " prefix to get the ref.
+		ref = head[5:]
+		commit = file(os.path.join(gitDir, ref), "r").read().rstrip()
+		version = "source-%s-%s" % (
+			os.path.basename(ref),
+			commit[:7])
+	except:
+		pass
+
+# ticket:3763#comment:19: name must be str, not unicode.
+# Otherwise, py2exe will break.
+name="NVDA"
+version_year=2017
+version_major=4
+version_minor=0
+version_build=0
+version="%s.%s.%sdev"%(version_year,version_major,version_minor)
+publisher="unknown"
+updateVersionType=None
+try:
+	from _buildVersion import version, publisher, updateVersionType, version_build
+except ImportError:
+	_updateVersionFromVCS()
+
+# A test version is anything other than a final or rc release.
+isTestVersion = not version[0].isdigit() or "alpha" in version or "beta" in version or "dev" in version

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -18,7 +18,7 @@ import winsound
 import traceback
 from types import MethodType, FunctionType
 import globalVars
-import versionInfo
+import buildVersion
 
 ERROR_INVALID_WINDOW_HANDLE = 1400
 ERROR_TIMEOUT = 1460
@@ -190,7 +190,7 @@ class RemoteHandler(logging.Handler):
 
 	def __init__(self):
 		#Load nvdaHelperRemote.dll but with an altered search path so it can pick up other dlls in lib
-		path=os.path.abspath(os.path.join(u"lib",versionInfo.version,u"nvdaHelperRemote.dll"))
+		path=os.path.abspath(os.path.join(u"lib",buildVersion.version,u"nvdaHelperRemote.dll"))
 		h=ctypes.windll.kernel32.LoadLibraryExW(path,0,LOAD_WITH_ALTERED_SEARCH_PATH)
 		if not h:
 			raise OSError("Could not load %s"%path) 
@@ -218,11 +218,8 @@ class FileHandler(logging.StreamHandler):
 		logging.StreamHandler.close(self)
 
 	def handle(self,record):
-		# versionInfo must be imported after the language is set. Otherwise, strings won't be in the correct language.
-		# Therefore, don't import versionInfo if it hasn't already been imported.
-		versionInfo = sys.modules.get("versionInfo")
 		# Only play the error sound if this is a test version.
-		shouldPlayErrorSound = versionInfo and versionInfo.isTestVersion
+		shouldPlayErrorSound =  buildVersion.isTestVersion
 		if record.levelno>=logging.CRITICAL:
 			try:
 				winsound.PlaySound("SystemHand",winsound.SND_ALIAS)

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -4,6 +4,12 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+"""
+This module contains localizable version information such as description, copyright and About messages etc.
+As there are localizable strings at module level, this can only be imported once localization is set up via languageHandler.initialize.
+To access version information for programmatic version checks before languageHandler.initialize, use the buildVersion module which contains all the non-localizable version information such as major and minor version, and version string etc.
+"""
+ 
 import os
 from buildVersion import *
 

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -5,43 +5,9 @@
 #See the file COPYING for more details.
 
 import os
+from buildVersion import *
 
-def _updateVersionFromVCS():
-	"""Update the version from version control system metadata if possible.
-	"""
-	global version
-	# The root of the Git working tree will be the parent of this module's directory.
-	gitDir = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".git")
-	try:
-		head = file(os.path.join(gitDir, "HEAD"), "r").read().rstrip()
-		if not head.startswith("ref: "):
-			# Detached head.
-			version = "source-DETACHED-%s" % head[:7]
-			return
-		# Strip the "ref: " prefix to get the ref.
-		ref = head[5:]
-		commit = file(os.path.join(gitDir, ref), "r").read().rstrip()
-		version = "source-%s-%s" % (
-			os.path.basename(ref),
-			commit[:7])
-	except:
-		pass
-
-# ticket:3763#comment:19: name must be str, not unicode.
-# Otherwise, py2exe will break.
-name="NVDA"
 longName=_("NonVisual Desktop Access")
-version_year=2017
-version_major=4
-version_minor=0
-version_build=0
-version="%s.%s.%sdev"%(version_year,version_major,version_minor)
-publisher="unknown"
-updateVersionType=None
-try:
-	from _buildVersion import version, publisher, updateVersionType, version_build
-except ImportError:
-	_updateVersionFromVCS()
 description=_("A free and open source screen reader for Microsoft Windows")
 url="http://www.nvaccess.org/"
 copyrightYears="2006-2017"
@@ -59,5 +25,3 @@ It can also be viewed online at: http://www.gnu.org/licenses/old-licenses/gpl-2.
 {name} is developed by NV Access, a non-profit organisation committed to helping and promoting free and open source solutions for blind and vision impaired people.
 If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu.""").format(**globals())
 
-# A test version is anything other than a final or rc release.
-isTestVersion = not version[0].isdigit() or "alpha" in version or "beta" in version or "dev" in version


### PR DESCRIPTION
### Link to issue number:
Fixes #7770 

### Summary of the issue:
The versionInfo module contains  some localized strings at module level. If this module is imported too early, these strings will not be localized correctly.  Commit 1fcc7fe added the import of versionInfo to the top of logHandler, thereby causing this issue to occur.
logHandler required versionInfo.version to calculate the correct path for nvdaHelperRemote.dll for remote logging.
As versionInfo was imported before languageHandler was initialized, text such as the message in the About dialog was always displayed in English.

### Description of how this pull request fixes the issue:
This PR splits out non-localizable version data from versionInfo into a new buildVersion module. This allows importing of buildVersion in places where the version is needed before languageHandler is initialized. Specifically, this is now used in logHandler to stop versionInfo being accidentally imported too early.
Note that the content of the buildVersion module is imported into versionInfo, so versionInfo can continue to be used as normal where ever it is safe to do so. Use buildVersion directly  for code that could be run before languageHandler is initialized.
 
### Testing performed:
* Run as source, switching language to French and ensuring the About dialog message is displayed in French. It did.
* Tried installing over the top of another copy that is still running so that it deliberately fails and logs a message from the installer via remote logging. It did.
* Closed the old copy and retried the install. It succeeded.
* Run the installed copy, switching the language to French and ensuring the text in the About dialog was displayed in French. It was.

### Known issues with pull request:
None

### Change log entry:
Changes from rc1 to rc2:
* The text in NVDA's About Dialog is again correctly shown in the user's configured language.
