### PR TITLE
Handle COMError when fetching table header cells in Word documents

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1173,7 +1173,13 @@ class WordDocument(EditableTextWithoutAutoSelectDetection, Window):
 	_curHeaderCellTracker=None
 	def getHeaderCellTrackerForTable(self,table):
 		tableRange=table.range
-		if not self._curHeaderCellTrackerTable or not tableRange.isEqual(self._curHeaderCellTrackerTable.range):
+		# Sometimes there is a valid reference in _curHeaderCellTrackerTable,
+		# but we get a COMError when accessing the range (#6827)
+		try:
+			tableRangesEqual=tableRange.isEqual(self._curHeaderCellTrackerTable.range)
+		except (COMError, AttributeError):
+			tableRangesEqual=False
+		if not tableRangesEqual:
 			self._curHeaderCellTracker=HeaderCellTracker()
 			self.populateHeaderCellTrackerFromBookmarks(self._curHeaderCellTracker,tableRange.bookmarks)
 			self.populateHeaderCellTrackerFromHeaderRows(self._curHeaderCellTracker,table)


### PR DESCRIPTION
### Link to issue number:
Fixes #6827 
### Summary of the issue:
Sometimes there is a reference to a COM object in _curHeaderCellTrackerTable, but the object throws a COMError on accessing one of it's properties, such as range.
Especially in Outlook this problem occurs if an email containing a table has been opened and the user closes that email and opens another email containing tables.
The unhandled COMError prevented the user from reading the email/document.

### Description of how this pull request fixes the issue:
Handle the COMError.

### Testing performed:
Tested on Outlook 2016.

### Known issues with pull request:
None.

### Change log entry:
* Bug fixes
  * Prevent errors while reading emails containing tables in Microsoft Outlook (#6827)