### PR TITLE
Handy Tech: Correct Bluetooth name for Braille Star 40 and fix gesture identifiers when braille input is on

### DIFF
--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -61,7 +61,7 @@ BLUETOOTH_NAMES = {
 	"Active Braille AB",
 	"Active Star AS",
 	"Basic Braille BB",
-	"Braille Star BS",
+	"Braille Star 40 BS",
 	"Braille Wave BW",
 	"Easy Braille EBR",
 }

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -789,7 +789,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		'br(handytech):rightSpace+b1+b3+b4': 'toggleBrailleInput',
 		'br(handytech.easybraille):left+b1+b3+b4': 'toggleBrailleInput',
 		'br(handytech.easybraille):right+b1+b3+b4': 'toggleBrailleInput',
-		'bk:space+dot1+dot2+dot7': 'toggleBrailleInput',
+		'br(handytech):space+dot1+dot2+dot7': 'toggleBrailleInput',
 	}
 
 	gestureMap = inputCore.GlobalGestureMap({
@@ -858,6 +858,9 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 				self.dots = self._calculateDots()
 				if key in KEY_SPACES or (key in (KEY_LEFT, KEY_RIGHT) and isinstance(model,EasyBraille)):
 					self.space = True
+					names.append("space")
+				elif key in KEY_DOTS:
+					names.append("dot%d"%KEY_DOTS[key])
 			if KEY_ROUTING <= key < KEY_ROUTING + model.numCells:
 				self.routingIndex = key - KEY_ROUTING
 				names.append("routing")

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -853,18 +853,20 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 		self.keys = set(keys)
 
 		self.keyNames = names = []
+		if isBrailleInput:
+			self.dots = self._calculateDots()
 		for key in keys:
-			if isBrailleInput:
-				self.dots = self._calculateDots()
-				if key in KEY_SPACES or (key in (KEY_LEFT, KEY_RIGHT) and isinstance(model,EasyBraille)):
-					self.space = True
-					names.append("space")
-				elif key in KEY_DOTS:
-					names.append("dot%d"%KEY_DOTS[key])
-			if KEY_ROUTING <= key < KEY_ROUTING + model.numCells:
+			if isBrailleInput and (
+				key in KEY_SPACES or (key in (KEY_LEFT, KEY_RIGHT) and isinstance(model,EasyBraille))
+			):
+				self.space = True
+				names.append("space")
+			elif isBrailleInput and key in KEY_DOTS:
+				names.append("dot%d"%KEY_DOTS[key])
+			elif KEY_ROUTING <= key < KEY_ROUTING + model.numCells:
 				self.routingIndex = key - KEY_ROUTING
 				names.append("routing")
-			elif not isBrailleInput:
+			else:
 				try:
 					names.append(model.keys[key])
 				except KeyError:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The new handy tech driver contained a wrong prefix for the Braille Star 40 braille display

### Description of how this pull request fixes the issue:
@bramd fixed the prefix in his handytech-native branch. I created a new branch based on master and cherry-picked that commit. @bramd: For future work on the ht driver, it might be better to start with a new branch, based on master. :)

See also my comment below regarding the last minute fix for braille input gesture identifiers.

### Change log entry:
Changes from rc1 to rc2:
* It is again possible to connect to Handy Tech Braille Star 40 devices using bluetooth
* Fixed an issue where overriding handy tech display gestures resulted into warnings about malformed input gesture identifiers.