### PR TITLE
Remove all eSpeak emoji dictsource files

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -155,19 +155,17 @@ env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspat
 
 #Compile all dictionaries
 missingDicts=['zhy', ] #'mt','tn','tt']
-#Excluded Emoji files for some languages.
-excludeEmojiFileFor=[
-	'ta', # #7740 the ள் symbol causes a problem in espeak if emoji for ta is used.
-	]
 dictSourcePath=espeakRepo.Dir('dictsource').abspath
+# Remove emoji files before compiling dictionaries as currently many of these simply crash eSpeak at runtime
+emojiGlob = os.path.join(espeakRepo.abspath,'dictsource','*_emoji')
+for f in glob(emojiGlob):
+	print("Removing emoji file: %s"%f)
+	os.remove(f)
 for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
 	lang=f.name.split('_')[0]
 	if lang in missingDicts: continue
 	dictFileName = lang+'_dict'
 	dictFile=env.Command(espeakRepo.Dir('espeak-ng-data').File(dictFileName),f,espeak_compileDict_buildAction)
-	emojiFileName = os.path.join(espeakRepo.abspath,'dictsource',lang+'_emoji')
-	if lang in excludeEmojiFileFor and os.path.exists(emojiFileName):
-		os.remove(emojiFileName)
 	dictDeps=env.Glob(os.path.join(espeakRepo.abspath,'dictsource',lang+'_*'))
 	dictDeps.remove(f)
 	env.Depends(dictFile,dictDeps)


### PR DESCRIPTION
### Link to issue number:
Fixes #7805 

### Summary of the issue:
Currently many of the emoji ditsource files in eSpeak cause freezes or crashes at runtime.

### Description of how this pull request fixes the issue:
This PR removes all _emoji dictsource files from eSpeak before compiling the dictionaries.

### Testing performed:
Ran NVDA and had it speak the offending Indian characters from #7805. It no longer freezes.

### Known issues with pull request:
No emoji support for any language. However, this support was far from great as it repeted symbols, or announced junk at the end, or... froze.

### Change log entry:
changes From rc3:
* Removed eSpeak's new emoji support as this was causing eSpeak to freeze when reading certain symbols from languages such as Hindi.

 