### PR TITLE
Prevent freezes on every focus change if Firefox stops responding.

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -126,6 +126,13 @@ class Gecko_ia2(VirtualBuffer):
 			return False
 		if not winUser.isWindow(root.windowHandle):
 			return False
+		if not root.isInForeground:
+			# #7818: Subsequent checks make COM calls.
+			# The chances of a buffer dying while the window is in the background are
+			# low, so don't make COM calls in this case; just treat it as alive.
+			# This prevents freezes on every focus change if the browser process
+			# stops responding; e.g. it froze, crashed or is being debugged.
+			return True
 		try:
 			isDefunct=bool(root.IAccessibleObject.states&IAccessibleHandler.IA2_STATE_DEFUNCT)
 		except COMError:


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
If Firefox (or Chrome or any other app based on these) stopped responding, NVDA often freezes every time the focused changes, even if the browser is in the background. In the case of a freeze or crash, this makes it very difficult to recover from this situation. This also makes it extremely difficult for a developer to debug Firefox or Chrome, since debugging necessarily suspends the process.

### Description of how this pull request fixes the issue:
This occurred because NVDA queried the document on every focus change to see if it was alive, but that query blocked in the case of an unresponsive process.

Now, we don't query if the process is in the background. We just assume the document is alive in this case. The chances of a document dying while the browser is in the backgroud are low anyway. However, if this did occur, the buffer will still be killed once the browser comes to the foreground or gets exited.

### Testing performed:
1. Used browse mode in a document in Firefox, then broke into the process with a debugger. Confirmed that NVDA did not freeze when I moved the focus.
2. Confirmed that buffers are still destroyed when closing tabs or exiting Firefox.

### Known issues with pull request:
None.

### Change log entry:
Bug Fixes:

```
- NVDA no longer sometimes freezes on every focus change if Firefox or Chrome have stopped responding such as due to a freeze or crash. (#7818)
```