### PR TITLE
No longer use liblouis pass1only by default

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -64,7 +64,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	readByParagraph = boolean(default=false)
 	wordWrap = boolean(default=true)
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
-	outputPass1Only = boolean(default=true)
+	outputPass1Only = boolean(default=false)
 
 	# Braille display driver settings
 	[[__many__]]


### PR DESCRIPTION
### Link to issue number:
Follow-up of #7702
Closes #7301
Fixes #7693, and possibly other issues
fixes #7526


### Description of this pull request:
In #7702, we introduced a hidden config parameter to toggle the use of Liblouis multipass vs. pass1only. In that pr, pass1only was still enabled, although you could disable it by changing a hidden config parameter. E.g.:
```import config; config.conf["braille"]["outputPass1Only"]=False```

This pr changes the default for outputPass1Only to false, effectively disabling pass1only for everyone except for the users who explicitly decide to enable pass1only by hand again.

Though this is a one liner change, this should *not* go straight to master as it could have major effect on how people experience braille output for certain tables.

### Rationale
According to commit https://github.com/liblouis/liblouis/commit/ac591398930db03ae49e1fb16ef760a45b8adeb6 , output position issues have been fixed in liblouis master, this commit will be in Liblouis 3.4. Note that other screen readers do not use pass1only either, so we don't have to wait for Liblouis 3.4 in order to have this merged.

Also note that liblouis/liblouis#445 states that pass1only will be deprecated in liblouis 3.4 and removed in liblouis 3.5. Thus, as soon as liblouis 3.5 is there and we use that in NVDA, the config parameter should be removed altogether. Cc @josephsl

### Change log entry:
* Bug fixes
    + Fixed malformed braille output for several braille tables, including capital signs in 8 dot contracted Danish braille. (#7526, #7693)