### PR TITLE
sysListview32 IAccessible NVDAObject:  make the text buffer for receiving listview column text larger than 260 characters to accommodate modern Twitter clients.

### DIFF
--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #NVDAObjects/IAccessible/sysListView32.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NV Access Limited, Peter Vágner
+#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -70,7 +70,7 @@ LVCF_SUBITEM=8
 LVCF_IMAGE=16
 LVCF_ORDER=32
 
-# The size of a buffer to hold a listview column's text.
+# The size of a buffer to hold text for listview items and columns etc 
 # #7828: Windows headers define this as 260 characters. However this is not long enough for modern Twitter clients that need at least 280 characters.
 # Therefore, round it up to the nearest power of 2
 CBEMAXSTRLEN=512

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -70,7 +70,10 @@ LVCF_SUBITEM=8
 LVCF_IMAGE=16
 LVCF_ORDER=32
 
-CBEMAXSTRLEN=260
+# The size of a buffer to hold a listview column's text.
+# #7828: Windows headers define this as 260 characters. However this is not long enough for modern Twitter clients that need at least 280 characters.
+# Therefore, round it up to the nearest power of 2
+CBEMAXSTRLEN=512
 
 # listview header window messages
 HDM_FIRST=0x1200


### PR DESCRIPTION
### Link to issue number: 
Fixes #7820 

### Summary of the issue: 
When NVDA fetches text from sysListview32 columns, it uses a buffer of 260 characters. This number is defined in the Windows headers as CBEMAXSTRLEN.
 However, Twitter clients that use a sysListview32 window control to show their tweets now have to fit 280 characters into their listview text.
 Therefore, when NVDA fetches the text, some of the tweet text is cut off.

### Description of how this pull request fixes the issue: 
Change the CBEMAXSTRLEN variable that NVDA uses as the buffer size to something hire than 260. In this case, 512 seemed good as it was the next power of 2.

### Testing performed:  
Read some Tweets that were 280 characters with NVDA, in the chicken Nugget Twitter client. 

### Known issues with pull request: 
In twitter clients such as Chicken Nugget, NVDA will no longer ignore the last 20 characters of 280 character tweets when reading them. (#7828)

 
 

### Change log entry:
