### PR TITLE
Add debug logging for the time taken to load a virtual buffer.

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -412,6 +412,8 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	def _loadBuffer(self):
 		try:
+			if log.isEnabledFor(log.DEBUG):
+				startTime = time.time()
 			self.VBufHandle=NVDAHelper.localLib.VBuf_createBuffer(self.rootNVDAObject.appModule.helperLocalBindingHandle,self.rootDocHandle,self.rootID,unicode(self.backendName))
 			if not self.VBufHandle:
 				raise RuntimeError("Could not remotely create virtualBuffer")
@@ -419,6 +421,10 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 			log.error("", exc_info=True)
 			queueHandler.queueFunction(queueHandler.eventQueue, self._loadBufferDone, success=False)
 			return
+		if log.isEnabledFor(log.DEBUG):
+			log.debug("Buffer load took %s sec, %d chars" % (
+				time.time() - startTime,
+				NVDAHelper.localLib.VBuf_getTextLength(self.VBufHandle)))
 		queueHandler.queueFunction(queueHandler.eventQueue, self._loadBufferDone)
 
 	def _loadBufferDone(self, success=True):

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -422,7 +422,7 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 			queueHandler.queueFunction(queueHandler.eventQueue, self._loadBufferDone, success=False)
 			return
 		if log.isEnabledFor(log.DEBUG):
-			log.debug("Buffer load took %s sec, %d chars" % (
+			log.debug("Buffer load took %.3f sec, %d chars" % (
 				time.time() - startTime,
 				NVDAHelper.localLib.VBuf_getTextLength(self.VBufHandle)))
 		queueHandler.queueFunction(queueHandler.eventQueue, self._loadBufferDone)


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
When testing browser and virtual buffer backend performance, it's extremely useful to be able to measure how long it takes to load a buffer. Currently, it's possible to achieve this by looking at the IO timestamps and doing manual math, but this is tedious at best.

### Description of how this pull request fixes the issue:
This logs a simple debug message indicating the time taken and number of characters in the buffer.

### Testing performed:
1. Tested that the message is logged (and accurate) when loading a document and refreshing the buffer with log level set to debug.
2. Tested that loading a document and refreshing the buffer does not log any message (and does not cause any problems) when the log level is set higher than debug.

### Known issues with pull request:
None.

### Change log entry:
I don't think any is needed. I guess we could put this in Changes for Developers, but it's for a pretty specific use case (primarily useful for Firefox multi-process work).