### PR TITLE
Remove AutoPropertyObject dependency on __init__

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -44,7 +44,9 @@ class AutoPropertyType(type):
 		except KeyError:
 			cacheByDefault=any(getattr(base, "cachePropertiesByDefault", False) for base in bases)
 
-		props=(x[5:] for x in dict.keys() if x[0:5] in ('_get_','_set_','_del_'))
+		# given _get_myVal, _set_myVal, and _del_myVal: "myVal" would be output 3 times
+		# use a set comprehension to ensure unique values, "myVal" only needs to occur once.
+		props={x[5:] for x in dict.keys() if x[0:5] in ('_get_','_set_','_del_')}
 		for x in props:
 			g=dict.get('_get_%s'%x,None)
 			s=dict.get('_set_%s'%x,None)
@@ -95,11 +97,14 @@ class AutoPropertyObject(object):
 	#: @type: bool
 	cachePropertiesByDefault = False
 
-	def __init__(self):
+
+	def __new__(cls, *args, **kwargs):
+		self = super(AutoPropertyObject, cls).__new__(cls)
 		#: Maps properties to cached values.
 		#: @type: dict
 		self._propertyCache={}
 		self.__instances[self]=None
+		return self
 
 	def _getPropertyViaCache(self,getterMethod=None):
 		if not getterMethod:


### PR DESCRIPTION
### Link to issue number:
No issue number.

### Summary of the issue:
A class that inherits from `AutoPropertyObject` and does not (forgets to) call super in the `__init__` function, would result in a failure for `CachedGetter` properties.
An example of this is [BrailleBuffer](https://github.com/nvaccess/nvda/blob/master/source/braille.py#L1071)

To reproduce the error, in the NVDA python console:
```
import braille
braille.handler.buffer.brailleToRawPos
```
gives:
```
braille.handler.buffer.brailleToRawPos
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "baseObject.pyc", line 34, in __get__
  File "baseObject.pyc", line 108, in _getPropertyViaCache
AttributeError: 'BrailleBuffer' object has no attribute '_propertyCache'
```

### Description of how this pull request fixes the issue:
Create the _cachedProperties dictionary in the __new__function, this is always called automatically.
A missing super call on `AutoPropertyObject` children no longer causes failure for `CachedGetter` properties. 

While here I noticed that there is the possibility that the generator expression for transforming the dictionary keys (such as `_get_myVal`, `_set_myVal`, and `_del_myVal`) would result in duplicates ("myVal" would be output 3 times). This results in unnecessary iterations of the loop that follows. Converting this to a set comprehension avoids that. 

### Testing performed:
Ran NVDA and ran the following in the NVDA python console without getting an error:
```
import braille
braille.handler.buffer.brailleToRawPos
```

### Known issues with pull request:
None

### Change log entry:
None