### PR TITLE
Dev docs: use absolute path when creating development documentation, include missing speech dict handler in NVDA 2017.4

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -362,10 +362,10 @@ devDocs_nvda = env.Command(devDocsOutputDir.Dir("nvda"), None, [[
 	sys.executable, "-c", "import sourceEnv; from epydoc.cli import cli; cli()",
 	"--output", "${TARGET.abspath}",
 	"--quiet", "--html", "--include-log", "--no-frames",
-	"--name", "NVDA", "--url", "http://www.nvaccess.org/",
+	"--name", "NVDA", "--url", "https://www.nvaccess.org/",
 	"*.py", "appModules", "brailleDisplayDrivers", r"comInterfaces\__init__.py",
 	"config", "contentRecog", "globalPlugins", "gui", "mathPres", "NVDAObjects",
-	"synthDrivers", "textInfos", "virtualBuffers",
+	"speechDictHandler", "synthDrivers", "textInfos", "virtualBuffers",
 ]])
 
 env.Alias('devDocs', [devGuide, devDocs_nvda])

--- a/source/sourceEnv.py
+++ b/source/sourceEnv.py
@@ -11,7 +11,7 @@ import sys
 import os
 
 # Get the path to the top of the repo; i.e. where include and miscDeps are.
-TOP_DIR = os.path.dirname(os.path.dirname(__file__))
+TOP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # Directories containing Python modules included in git submodules.
 PYTHON_DIRS = (
 	os.path.join(TOP_DIR, "include", "scons", "src", "engine"),


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Dev docs building fixes, including inability to generate development documentation in 2017.4, change of address fomr http to https, include speech dict handler.

### Description of how this pull request fixes the issue:
Modifies sconstruct and source env module:

* Sconstruct: http to https for nvaccess.org website in dev docs, include speechDictHandler folder introduced in NVDA 2017.4.
* SourceEnv: no more backward traversal when defining top directory. Absolute path is now used to allow building source code as well as dev docs.

### Testing performed:
Ran scons source and scons devDocs on cmd.exe and PowerShell with success each time.

### Known issues with pull request:
None

### Change log entry:
None
