### PR TITLE
Fix crash in BrailleDisplayDriver._getModifierGestures where the function assumes that the script name is a string, while it is in fact a None

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2024,7 +2024,7 @@ class BrailleDisplayDriver(baseObject.AutoPropertyObject):
 			for scriptCls, gesture, scriptName in globalMap.getScriptsForAllGestures():
 				if (any(gesture.startswith(prefix.lower()) for prefix in prefixes)
 					and scriptCls is globalCommands.GlobalCommands
-					and scriptName.startswith("kb")):
+					and scriptName and scriptName.startswith("kb")):
 					emuGesture = keyboardHandler.KeyboardInputGesture.fromName(scriptName.split(":")[1])
 					if emuGesture.isModifier:
 						yield set(gesture.split(":")[1].split("+")), set(emuGesture._keyNamesInDisplayOrder)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
As reported by @dkager, braille.BrailleDisplayDriver._getModifierGestures fails horribly in the case where someone has explicitly overridden a braille display gesture, setting it to perform no action instead. In that case, the scriptName is None.

### Description of how this pull request fixes the issue:
In braille.BrailleDisplayDriver._getModifierGestures, first check the boolean value of scriptName before calling the startswith method on it.

This is a quick fix, but as @dkager noted that the resulting behavior could be quite disastrous sometimes, it has some priority. I think it can be merged straight to master given its simpleness.

### Testing performed:
Tried to reproduce the issue as described above with positive outcome.

### Known issues with pull request:
None

