### PR TITLE
Make config profile switches also reflect a different tether setting

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
+#Copyright (C) 2008-2018 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
 
 import sys
 import itertools
@@ -1845,6 +1845,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		display = config.conf["braille"]["display"]
 		if display != self.display.name:
 			self.setDisplayByName(display)
+		self._tether = config.conf["braille"]["tetherTo"]
 
 class _BgThread:
 	"""A singleton background thread used for background writes and raw braille display I/O.


### PR DESCRIPTION
### Link to issue number:
None, regression caused by #2385 

### Summary of the issue:
Since auto tethering is implemented, we are using a _tether property on the braille handler to reflect the internal tethering state, since it can be changed by auto tethering without changing the state in the configuration. However, it seems I/we missed the fact that this internal state should be updated properly as soon as one switches a config profile. If not, which is the current situation, the following will occur.

1. Set NVDA to be manually tethered to focus
2. Create a new config profile that is manually tethered to review
3. Switch profiles
4. When you switch to the review profile, NVDA will still be tethered to focus.

### Description of how this pull request fixes the issue:
Sets the internal _tether property according to the configuration on every profile switch.

### Testing performed:
@dkager tested the case as described above. I will give auto tethering a test in an hour or two, but expect no issues with that, as the state of tethering is handled by the auto tethering mechanism anyway.

### Known issues with pull request:
None

### Change log entry:
None