### PR TITLE
Change status column of addons to enabled or disabled

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -201,11 +201,11 @@ class AddonsDialog(wx.Dialog):
 			return _("remove")
 		# Need to do this here, as 'isDisabled' overrides other flags.
 		elif addon.isPendingDisable:
-			# Translators: The status shown for an addon when its disabled.
-			return _("disable")
+			# Translators: The status shown for an addon when it requires a restart to become disabled
+			return _("Disabled after restart")
 		elif addon.isPendingEnable:
-			# Translators: The status shown for an addon when its enabled.
-			return _("enable")
+			# Translators: The status shown for an addon when it requires a restart to become enabled
+			return _("Enabled after restart")
 		elif globalVars.appArgs.disableAddons or addon.isDisabled:
 			# Translators: The status shown for an addon when its currently suspended do to addons being disabled.
 			return _("disabled")

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 NV Access Limited, Beqa Gozalishvili, Joseph Lee, Babbage B.V.
+#Copyright (C) 2012-2017 NV Access Limited, Beqa Gozalishvili, Joseph Lee, Babbage B.V., Ethan Holliger
 
 import os
 import wx
@@ -208,10 +208,10 @@ class AddonsDialog(wx.Dialog):
 			return _("enable")
 		elif globalVars.appArgs.disableAddons or addon.isDisabled:
 			# Translators: The status shown for an addon when its currently suspended do to addons being disabled.
-			return _("suspended")
+			return _("disabled")
 		else:
 			# Translators: The status shown for an addon when its currently running in NVDA.
-			return _("running")
+			return _("enabled")
 
 	def refreshAddonsList(self,activeIndex=0):
 		self.addonsList.DeleteAllItems()

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1757,7 +1757,7 @@ Until you do, a status of "remove" will be shown for that add-on in the list.
 
 To disable an add-on, press the disable button.
 To enable a previously disabled add-on, press the enable button.
-You can disable an add-on if the add-on status indicates it is running or enabled, or enable it if the add-on is suspended or disabled.
+You can disable an add-on if the add-on status indicates it is  enabled, or enable it if the add-on is disabled.
 For each press of the enable/disable button, add-on status changes to indicate what will happen when NVDA restarts.
 Just like when you install or remove add-ons, you need to restart NVDA in order for changes to take effect.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1755,10 +1755,11 @@ NVDA will ask if you really wish to do this.
 As with installing, NVDA must be restarted for the add-on to be fully  removed.
 Until you do, a status of "remove" will be shown for that add-on in the list.
 
-To disable an add-on, press the disable button.
-To enable a previously disabled add-on, press the enable button.
-You can disable an add-on if the add-on status indicates it is  enabled, or enable it if the add-on is disabled.
+To disable an add-on, press the "disable" button.
+To enable a previously disabled add-on, press the "enable" button.
+You can disable an add-on if the add-on status indicates it is  "enabled", or enable it if the add-on is "disabled".
 For each press of the enable/disable button, add-on status changes to indicate what will happen when NVDA restarts.
+If the addon was previously disabled, a status will show "enabled after restart". If the addon was previously "Enabled", a status will show "disabled after restart"
 Just like when you install or remove add-ons, you need to restart NVDA in order for changes to take effect.
 
 The manager also has a Close button to close the dialog.


### PR DESCRIPTION
### Link to issue number:
Fixes #7929

### Summary of the issue:
Currently, in the add-on manager, the line with information for each add-on reports whether the add-on is "running" or "suspended".
This PR provides consistencies between the disable and enable buttons and the text that is presented in the "status" column in the addons dialog.

### Description of how this pull request fixes the issue:
Changed the text "running" and "suspended" to "enabled" and "disabled".

### Testing performed:
Running NVDA from source with an addon installed and enabled and disabled the addon. Noticed that the status column changes to appropriate text.

### Known issues with pull request:
None

### Change log entry:
• Changes
The status column in the addons manager has been changed to indicate if the addon is enabled or disabled instead of running or suspended.