### PR TITLE
Improve presentation in Google sheets (with Braille mode enabled)

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -392,7 +392,7 @@ the NVDAObject for IAccessible
 			clsList.insert(0, FocusableUnfocusableContainer)
 
 		if hasattr(self, "IAccessibleTextObject"):
-			if role==oleacc.ROLE_SYSTEM_TEXT or self.IA2States&IAccessibleHandler.IA2_STATE_EDITABLE:
+			if role==oleacc.ROLE_SYSTEM_TEXT or controlTypes.STATE_EDITABLE in self.states:
 				clsList.append(EditableTextWithAutoSelectDetection)
 
 		# Use window class name and role to search for a class match in our static map.
@@ -819,6 +819,9 @@ the NVDAObject for IAccessible
 			return states
 		IAccessible2States=self.IA2States
 		states=states|set(IAccessibleHandler.IAccessible2StatesToNVDAStates[x] for x in (y for y in (1<<z for z in xrange(32)) if y&IAccessible2States) if IAccessibleHandler.IAccessible2StatesToNVDAStates.has_key(x))
+		# Readonly should override editable
+		if controlTypes.STATE_READONLY in states:
+			states.discard(controlTypes.STATE_EDITABLE)
 		try:
 			IA2Attribs=self.IA2Attributes
 		except COMError:
@@ -1086,6 +1089,19 @@ the NVDAObject for IAccessible
 			except COMError:
 				log.debugWarning("IAccessibleTable::columnIndex failed", exc_info=True)
 		raise NotImplementedError
+
+	def _get_cellCoordsText(self):
+		colText=self.IA2Attributes.get('coltext')
+		rowText=self.IA2Attributes.get('rowtext')
+		if rowText is None and isinstance(self.parent,IAccessible):
+			rowText=self.parent.IA2Attributes.get('rowtext')
+		if not rowText and not colText:
+			return
+		if not colText:
+			colText=self.columnNumber
+		if not rowText:
+			rowText=self.rowNumber
+		return "%s %s"%(colText,rowText)
 
 	def _get_columnNumber(self):
 		index=self.IA2Attributes.get('colindex')

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1237,6 +1237,10 @@ the NVDAObject for IAccessible
 			try:
 				info={}
 				info["level"],info["similarItemsInGroup"],info["indexInGroup"]=self.IAccessibleObject.groupPosition
+				# Object's with an IAccessibleTableCell interface should not expose indexInGroup/similarItemsInGroup as the cell's 2d info is much more useful.
+				if self._IATableCell:
+					del info['indexInGroup']
+					del info['similarItemsInGroup']
 				# 0 means not applicable, so remove it.
 				for key, val in info.items():
 					if not val:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -37,6 +37,13 @@ class Ia2Web(IAccessible):
 		placeholder = self.IA2Attributes.get('placeholder', None)
 		return placeholder
 
+	def _get_isPresentableFocusAncestor(self):
+		if self.role==controlTypes.ROLE_TABLEROW:
+			# It is not useful to present IAccessible2 table rows in the focus ancestry as  cells contain row and column information anyway.
+			# Also presenting the rows would cause duplication of information
+			return False
+		return super(Ia2Web,self).isPresentableFocusAncestor
+
 class Document(Ia2Web):
 	value = None
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -643,15 +643,6 @@ class NVDAObject(documentBase.TextContainerObject,baseObject.ScriptableObject):
 				return self.presType_layout
 			if role in (controlTypes.ROLE_TABLEROW,controlTypes.ROLE_TABLECOLUMN,controlTypes.ROLE_TABLECELL) and (not config.conf["documentFormatting"]["reportTables"] or not config.conf["documentFormatting"]["reportTableCellCoords"]):
 				return self.presType_layout
-		if role in (controlTypes.ROLE_TABLEROW,controlTypes.ROLE_TABLECOLUMN):
-			try:
-				table=self.table
-			except NotImplementedError:
-				table=None
-			if table:
-				# This is part of a real table, so the cells will report row/column information.
-				# Therefore, this object is just for layout.
-				return self.presType_layout
 		return self.presType_content
 
 	def _get_simpleParent(self):


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Google has recently introduced a braille mode for Google Sheets, which exposes actual content via browser accessibility, rather than just forcing the AT to speak everything with a live region.
However, this new mode, uses a contenteditable table, thus NVDA tends to announce way too much inforamtion when navigating around. For instance, when moving down a row, NVDA announces the entire row, and also repetes the content of the cell several times. n Firefox it also announces x of y position info on the cell which is yet more pointless information.

### Description of how this pull request fixes the issue:
This PR ensures that if an IAccessible NvDAObject has the readonly state, any existing editable state is removed. In other words, if an IAccessible2 implementation exposes both editable and readonly states, readonly will win. This was a compromize with Google for them to be able to use contenteditable on the table, they also expose the readonly state to convey the editable state should be overridden.
Handling the readonly state in this way ensures that NVDA no longer reports a readonly stable cell in a contenteditable table as being editable text. I.e. it no longer tries to announce the line of text at the caret on the cell.
Also, table rows in IAccessible2 table implementations are no longer treeted as being presentable focus ancestors. This stops the reporting of the entire row when moving from one to another. The cells themselves have enough information.
The PR also adds support for IAccessible2's rowtext and coltext attributes, by exposing them via an NVDAObject's cellCoordsText if one or both of these attributes exist. They are exposed simply as a concatination of colText and rowText, similar to how cell coordinates are presented in MS Excel. Thus Google sheets cell coordinates now are presented the same as MS excel.
Finally,  IAccessible NvDAObjects no longer expose x of y position info if this object supports the IAccessibleTableCell interface. 2d table cell coordinates are much better than 1d index info.
 
### Testing performed:
Navigated around a spreadsheet in Google Sheets with braille mode enabled. Verified the correct information was exposed in both speech and braille.

### Known issues with pull request:
None.

### Change log entry:
New features:
* Early support for Google Sheets with Braille mode enabled.