### PR TITLE
Update configobj to 5.1.0dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "include/wxPython"]
 	path = include/wxPython
 	url = https://github.com/nvaccess/wxPython-bin.git
+[submodule "include/configobj"]
+	path = include/configobj
+	url = https://github.com/DiffSK/configobj.git

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ For reference, the following dependencies are included in Git submodules:
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 910f4c2
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
-* [ConfigObj](https://pypi.python.org/pypi/configobj), version 5.0.6
+* [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [liblouis](http://www.liblouis.org/), version 3.6.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ For reference, the following dependencies are included in Git submodules:
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 910f4c2
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
-* [ConfigObj](http://www.voidspace.org.uk/python/configobj.html), version 4.6.0
+* [ConfigObj](https://pypi.python.org/pypi/configobj), version 5.0.6
 * [liblouis](http://www.liblouis.org/), version 3.6.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest

--- a/source/sourceEnv.py
+++ b/source/sourceEnv.py
@@ -17,7 +17,7 @@ PYTHON_DIRS = (
 	os.path.join(TOP_DIR, "include", "scons", "src", "engine"),
 	os.path.join(TOP_DIR, "include", "pyserial"),
 	os.path.join(TOP_DIR, "include", "comtypes"),
-	os.path.join(TOP_DIR, "include", "configobj"),
+	os.path.join(TOP_DIR, "include", "configobj", "src", "configobj"),
 	os.path.join(TOP_DIR, "include", "wxPython"),
 	os.path.join(TOP_DIR, "miscDeps", "python"),
 )

--- a/source/sourceEnv.py
+++ b/source/sourceEnv.py
@@ -1,6 +1,6 @@
 #sourceEnv.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2013-2018 NV Access Limited
+#Copyright (C) 2013-2018 NV Access Limited, Leonard de Ruijter
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -17,6 +17,7 @@ PYTHON_DIRS = (
 	os.path.join(TOP_DIR, "include", "scons", "src", "engine"),
 	os.path.join(TOP_DIR, "include", "pyserial"),
 	os.path.join(TOP_DIR, "include", "comtypes"),
+	os.path.join(TOP_DIR, "include", "configobj"),
 	os.path.join(TOP_DIR, "include", "wxPython"),
 	os.path.join(TOP_DIR, "miscDeps", "python"),
 )


### PR DESCRIPTION
### Link to issue number:
Closes #4470 

### Summary of the issue:
configobj is currently on version 4.6.0, which is pretty old. The current stable version is 5.0.6, it is said to add full support for Python 3, but later commits suggest that support had to be improved for version 3.4 and 3.5. Also, version 5.0.6 contained the bug as described in https://github.com/nvaccess/nvda/pull/7945#issuecomment-361480397, it didn't allow executing `from validate import *`.

### Description of how this pull request fixes the issue:
Adds a configobj submodule to the repository on github, and uses its current master version in favor of the version from miscdeps, which can be removed if this gets eventually merged.

### Testing performed:
Ran NVDA from source, the configuration persisted. Also, ran tests as proposed by @feerrenrut, see https://github.com/nvaccess/nvda/pull/7945#issuecomment-412271948 for results.

### Known issues with pull request:
I've seen a case where NVDA did restore its configuration to factory defaults, but that might have been because of me fiddling with the config in a majorly destructive way. This was in the 5.0.6 situation, and I don't have steps to reproduce.
