### PR TITLE
Allow setting good UIA windows in core or per appModule

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #appModuleHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -433,6 +433,13 @@ class AppModule(baseObject.ScriptableObject):
 			return False
 		self.is64BitProcess = not res
 		return self.is64BitProcess
+
+	def isGoodUIAWindow(self,hwnd):
+		"""
+		returns true if the UIA implementation of the given window must be used, regardless whether native or not.
+		Warning: this may be called outside of NVDA's main thread, therefore do not try accessing NVDAObjects and such, rather just check window  class names.
+		"""
+		return False
 
 	def isBadUIAWindow(self,hwnd):
 		"""

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -436,14 +436,19 @@ class AppModule(baseObject.ScriptableObject):
 
 	def isGoodUIAWindow(self,hwnd):
 		"""
-		returns true if the UIA implementation of the given window must be used, regardless whether native or not.
+		returns C{True} if the UIA implementation of the given window must be used, regardless whether native or not.
+		This function is the counterpart of and takes precedence over L{isBadUIAWindow}.
+		If both functions return C{False}, the decision of whether to use UIA for the window is left to core.
 		Warning: this may be called outside of NVDA's main thread, therefore do not try accessing NVDAObjects and such, rather just check window  class names.
 		"""
 		return False
 
 	def isBadUIAWindow(self,hwnd):
 		"""
-		returns true if the UIA implementation of the given window must be ignored due to it being broken in some way.
+		returns C{True} if the UIA implementation of the given window must be ignored due to it being broken in some way.
+		This function is the counterpart of L{isGoodUIAWindow}.
+		When both functions return C{True}, L{isGoodUIAWindow} takes precedence.
+		If both functions return C{False}, the decision of whether to use UIA for the window is left to core.
 		Warning: this may be called outside of NVDA's main thread, therefore do not try accessing NVDAObjects and such, rather just check window  class names.
 		"""
 		return False


### PR DESCRIPTION
### Link to issue number:
Closes #7961

### Summary of the issue:
It is currently possible to implement `isBadUIAWindow` on the appModule level to use IAccessible for windows that are reported as native UIA. The opposite is not yet offered.

### Description of how this pull request fixes the issue:
This allows appModule writers to implement `isGoodUIAWindow`. If this returns `True`, UIA is always used, regardless whether UIA is implemented natively or the MSAA proxy is active.

There is now also a `goodUIAWindowClassNames` list on `_UIAHandler`, which is used for WDAG.

### Testing performed:
Tested this in Notepad, all MSAA objects instantly changed into UIA objects.

### Known issues with pull request:
* I've not yet tested this with WDAG.
* When the core decides that a window is good, an appModule can't override this behaviour. Note that strictly spoken, this is not a limitation of this pr, as this was already the case before.

### Change log entry:
* Changes for developers
    + App modules can now force certain windows to always use UIA by implementing the isGoodUIAWindow method. (#7961)