### PR TITLE
Fix acknowledgement packet handling causing an error when a display isn't fully initialized

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1892,6 +1892,11 @@ class _BgThread:
 		if _BgThread.exit:
 			# func will see this and exit.
 			return
+		if not handler.display:
+			# Sometimes, the executor is triggered when a display is not fully initialized.
+			# For example, this happens when handling an ACK during initialisation.
+			# We can safely ignore this.
+			return
 		if handler.display._awaitingAck:
 			# Do not write cells when we are awaiting an ACK
 			return


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When an Eurobraille display is being used together with Esybraille or Esysuite self brailling software and this software is initialized before NVDA, NVDA receives ACK packets of the display before the display is fully initialized. This causes the background executor to run, which tries to access handler.display. However, as the display is not fully initialized yet, this causes an attribute error.

### Description of how this pull request fixes the issue:
The executor now returns early if not handler.display, so it does not do anything when it is called by a display that is still being initialized.

### Testing performed:
Tests performed by Eurobraille, starting NVDA with Esybraille or Esysuite running no longer causes errors in the log.

### Known issues with pull request:
None

### Change log entry:
None