### PR TITLE
Stop labels for checkboxes / radioButtons from being reported twice when tabbing / quicknavving in browse Mode, for Chrome / Firefox.

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -549,7 +549,8 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 		|| (role == ROLE_SYSTEM_TEXT && !isEditable) 
 		|| role == IA2_ROLE_HEADING 
 		|| role == ROLE_SYSTEM_PAGETAB 
-		|| role == ROLE_SYSTEM_BUTTONMENU;
+		|| role == ROLE_SYSTEM_BUTTONMENU
+		|| ((role == ROLE_SYSTEM_CHECKBUTTON || role == ROLE_SYSTEM_RADIOBUTTON) && !isLabelVisible(pacc));
 	// Whether this node has a visible label somewhere else in the tree
 	const bool labelVisible = canDetectLabelVisibility // Not all browsers support getting a node's labelledBy node
 		&& nameIsExplicit && name && name[0] //this node must actually have an explicit name, and not be just an empty string


### PR DESCRIPTION
### Link to issue number:
Fixes #7960 

### Summary of the issue:
When tabbing or quickNaving to checkboxes or radio buttons in Firefox and Chrome in Browse mode, NVDA may report the label twice. Once as a symantic label, and once as the content.
This was caused by unneeded code in PR #7513.
that PR stopped treeting checkboxes and radio buttons has having name from content, no matter if their label was visible or not. This was probably to work around a previous bug in Chrome, but is certainly not needed now for  that pr or any other checkboxes / radio buttons I can find.

### Description of how this pull request fixes the issue:
This PR simply puts back the line that classes checkboxes and radio buttons as name is content in the Gecko vbufBackend.

### Testing performed:
I ran through the tests in Chrome and Firefox provided on pr #7513, and most importantly the testcase provided in issue #7860. Double reporting no longer occurs, and  the added cutnionality in PR #7513 still works as expected.
  
### Known issues with pull request:
None

### Change log entry:
Bug Fixes:
* Labels of checkboxes and radio buttons in Chrome and Firefox are no longer reported twice when tabbing or using quick navigation in Browse mode. (#7960)