### PR TITLE
No longer announce final character of Windows 10 security PIN

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -766,7 +766,14 @@ Tries to force this object to take the focus.
 		@return: True if this object is protected (hides its input for passwords), or false otherwise
 		@rtype: boolean
 		"""
-		return False
+		# Objects with the protected state, or with a role of passWordEdit should always be protected.
+		isProtected=(controlTypes.STATE_PROTECTED in self.states or self.role==controlTypes.ROLE_PASSWORDEDIT)
+		# #7908: If this object is currently protected, keep it protected for the rest of its lifetime.
+		# The most likely reason it would lose its protected state is because the object is dying.
+		# In this case it is much more secure to assume it is still protected, thus the end of PIN codes will not be accidentally reported. 
+		if isProtected:
+			self.isProtected=isProtected
+		return isProtected
 
 	def _get_indexInParent(self):
 		"""The index of this object in its parent object.

--- a/source/api.py
+++ b/source/api.py
@@ -244,7 +244,7 @@ def isTypingProtected():
 @rtype: boolean
 """
 	focusObject=getFocusObject()
-	if focusObject and (controlTypes.STATE_PROTECTED in focusObject.states or focusObject.role==controlTypes.ROLE_PASSWORDEDIT):
+	if focusObject and focusObject.isProtected:
 		return True
 	else:
 		return False


### PR DESCRIPTION
### Link to issue number:
Fixes #7908 

### Summary of the issue:
Some PIN code fields (such as in the Windows 10 Sign screen) disappear as soon as the last number is entered. As NVDA interigates the control each time a character is typed to see if the control is protected (in order to suppress reporting the number), the last number is usually reported as the control is dlying or has disappeared by the time NVDA asks.
Note however that focus has not yet moved to something else -- the control has mearly died.
 
### Description of how this pull request fixes the issue:
Logic has been moved from api.isTypingProtected() into the base NVDAObject's isProtected property, which api.isTypingProtected() now checks.
The isProtected property now also caches any positive result, meaning that if the object is found to be protected at least once, then it will stay protected for the rest of its lifetime.
We do not cache *any* result, as it is possible that an object may first report as not protected and then become protected. for security reasons, we always want to bias this to being protected.

### Testing performed:
With speak typed characters on:
* Typed in a PIN to sign into Windows 10. All numbers spoke as "star".
* Typed into some other protected fields such as a web login form in Firefox. Characters spoke as "start".
* Typed in other non-protected fields: Run dialog, other web form fields. Characters spoke correctly.
 
### Known issues with pull request:
We could special case this for the Windows 10 signin PIN field: but the major risk is that Microsoft may change the class name at any stage, therefore suddely unprotecting PINs with NVDA. The current solution protects against any similar usage pattern of a protected field disappearing on the final character.
An annoyence could be that there is a control that deliberately becomes unprotected after entering certain information. Unless the user moves focus away and back again, all further characters will be announced as "start". But I think this is a small price to pay for the removal of the above security risk.

### Change log entry:
Bug fixes:
* NVDA will no longer incorrectly announce the final character of a windows 10 sign-in PIN as the machine unlocks.

