### PR TITLE
Report the same formatting when pressing the reportFormatting script multiple times

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1290,7 +1290,7 @@ class GlobalCommands(ScriptableObject):
 			"reportBorderStyle":True,"reportBorderColor":True,
 		}
 		textList=[]
-		info=api.getReviewPosition()
+		info=api.getReviewPosition().copy()
 
 		# First, fetch indentation.
 		line=info.copy()


### PR DESCRIPTION
### Link to issue number:
Fixes #7869 

### Summary of the issue:
When pressing the reportFormatting script multiple times, such as for showing the formatting in browseMode, the formatting can be different from the first time you press it.
The reason is that code in the reportFormatting script (or code it calls) may mutate the TextInfo such as expanding to line etc. Which then means that asking for the formatting is asking for a different position.
The reviewPosition could be copied before fetching formatting.

### Description of how this pull request fixes the issue:
The reportFormatting script now makes sure to copy the reviewPosition first.

### Testing performed:
Followed the steps to reproduce in #7869 with success.

### Known issues with pull request:

### Change log entry:
Bug fixes:
* Pressing the report formatting script no longer moves the reviewPosition and therefore pressing it multiple times no longer gives different results. (#7869)