### PR TITLE
Expose available UIA patterns in developer info

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -712,7 +712,11 @@ class UIA(Window):
 			return
 		cacheRequest=UIAHandler.handler.clientObject.createCacheRequest()
 		for ID in IDs:
-			cacheRequest.addProperty(ID)
+			try:
+				cacheRequest.addProperty(ID)
+			except COMError:
+				log.debug("Couldn't add property ID %d to cache request, most likely unsupported on this version of Windows"%ID)
+				continue
 		cacheElement=self.UIAElement.buildUpdatedCache(cacheRequest)
 		for ID in IDs:
 			elementCache[ID]=cacheElement

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -964,6 +964,21 @@ class UIA(Window):
 		except Exception as e:
 			ret="Exception: %s"%e
 		info.append("UIA className: %s"%ret)
+		patternsAvailable = []
+		patternAvailableConsts = dict(
+			(const, name) for name, const in UIAHandler.__dict__.iteritems()
+			if name.startswith("UIA_Is") and name.endswith("PatternAvailablePropertyId")
+		)
+		self._prefetchUIACacheForPropertyIDs(list(patternAvailableConsts))
+		for const, name in patternAvailableConsts.iteritems():
+			try:
+				res = self._getUIACacheablePropertyValue(const)
+			except COMError:
+				res = False
+			if res:
+				# Every name has the same format, so the string indexes can be safely hardcoded here.
+				patternsAvailable.append(name[6:-19])
+		info.append("UIA patterns available: %s"%", ".join(patternsAvailable))
 		return info
 
 	def _get_name(self):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2017 NV Access Limited, Joseph Lee, Mohammad Suliman
+#Copyright (C) 2009-2018 NV Access Limited, Joseph Lee, Mohammad Suliman, Babbage B.V.
 
 """Support for UI Automation (UIA) controls."""
 
@@ -716,7 +716,6 @@ class UIA(Window):
 				cacheRequest.addProperty(ID)
 			except COMError:
 				log.debug("Couldn't add property ID %d to cache request, most likely unsupported on this version of Windows"%ID)
-				continue
 		cacheElement=self.UIAElement.buildUpdatedCache(cacheRequest)
 		for ID in IDs:
 			elementCache[ID]=cacheElement


### PR DESCRIPTION
### Link to issue number:
Closes #5712 

### Summary of the issue:
As @dave090679, it would be helpful to have available UIA patterns in the developer info for easier inspection of available UIA patterns.

### Description of how this pull request fixes the issue:
This is based on @dave090679's proposal, but it also does some things a bit different.

1. It evaluates all UIAHandler.UIA_Is*PatternAvailablePropertyId constants on the UIAHandler. This means that this code doesn't have to be updated when new patterns become available.
2. Rather than fetching every property in a separate call, this uses UIA._prefetchUIACacheForPropertyIDs to request all properties in one cache request.

### Testing performed:
Tested fetching developer info on Windows 10 X64 and in a Win7x86 vm. See also the discussion with @josephsl in #5712. Concerns regarding compatibility with older versions of Windows 10 should be taken care of.

### Known issues with pull request:
None

### Example output
* A list item in Windows Explorer
    + UIA patterns available: LegacyIAccessiblePattern, InvokePattern, ScrollItemPattern, SelectionItemPattern, ValuePattern
* A table item in the Outlook 2016 inbox
    + UIA patterns available: LegacyIAccessiblePattern, GridItemPattern, InvokePattern, ScrollItemPattern, SelectionItemPattern, ValuePattern
* The wifi toggle button in Windows 10 wifi settings
    + UIA patterns available: LegacyIAccessiblePattern, ScrollItemPattern, TogglePattern

### Change log entry:
+ Changes for developers:
    * The developer info for UIA objects now contains a list of the UIA patterns available. (#5712)