### PR TITLE
Better handle dead caret  / selection text ranges in Microsoft Edge

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -268,7 +268,12 @@ class UIATextInfo(textInfos.TextInfo):
 	def __init__(self,obj,position,_rangeObj=None):
 		super(UIATextInfo,self).__init__(obj,position)
 		if _rangeObj:
-			self._rangeObj=_rangeObj.clone()
+			try:
+				self._rangeObj=_rangeObj.clone()
+			except COMError:
+				# IUIAutomationTextRange::clone can sometimes fail, such as in UWP account login screens
+				log.debugWarning("Could not clone range",exc_info=True)
+				raise RuntimeError("Could not clone range")
 		elif position in (textInfos.POSITION_CARET,textInfos.POSITION_SELECTION):
 			try:
 				sel=self.obj.UIATextPattern.GetSelection()

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -336,6 +336,9 @@ class UIABrowseModeDocumentTextInfo(browseMode.BrowseModeDocumentTextInfo,treeIn
 class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseModeDocumentTreeInterceptor):
 
 	TextInfo=UIABrowseModeDocumentTextInfo
+	# UIA browseMode documents cannot remember caret positions across loads (I.e. when going back a page in Edge) 
+	# Because UIA TextRanges are opaque and are tied specifically to one particular document.
+	shouldRememberCaretPositionAcrossLoads=False
 
 	def _iterNodesByType(self,nodeType,direction="next",pos=None):
 		if nodeType.startswith("heading"):


### PR DESCRIPTION
### Link to issue number:
MS bug 14251419: NVDA Desktop : MSA : We are blocked to Enter password while using NVDA Screen reader.
MS bug 15577569: NVDA announces nothing when user presses ALT + LEFT/RIGHT arrow keys. 

### Summary of the issue:
In many cases, the UIA textRanges we get from Microsoft Edge, may become broken or die if the page mutates a significant amount.
Two examples:
* Going back to a previous page with alt+leftArrow: The caret position we had stored previously for that document is now dead and cannot be used to rstore the caret position.
* Signing into a Microsoft Account with the standard Microsoft Account screen:  after entering an email address and pressing enter, nothing is reported for the focus as you move around the page, and links cannot be activated. In this case the caret position we had stored on the cursorManager had died because of signficant page mutations.

### Description of how this pull request fixes the issue:
1. UIABrowsemode documents no longer support remembering the last caret position on a previous document. This never worked and only caused errors.
2. the Edge TreeInterceptor document  overrides makeTextInfo to detect when a broken caret is being fetched. In this case it falls back to using the first position in the document, and updates the stored selection with this.

### Testing performed:
* Read and navigated multiple pages in Microsoft Edge, including switching back and forth in the history. When switching, the new page would be read from the top. Previously in most cases an error would occur and the page would not read.
* Tried signing into a Microsoft Account: Settings -> accounts -> email and app acocunts -> Add a Microsoft Account. After entering the email address and pressing enter, NVDA correctly reported the password field, and all other controls as focus moved.
 
### Known issues with pull request:

### Change log entry:
Bug fixes:
* NVDA no longer fails to read focused controls in the Microsoft Account sig-in screen in Settings after entering an email address.
* NVDA no longer fails to read the page when going back to a previous page in Microsoft Edge.
