### PR TITLE
Include the Desktop UWP redistributables in NVDA for Onecore features rather than the Onecore redistributables

### DIFF
--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -44,7 +44,7 @@ localWin10Lib = env.SharedLibrary(
 # Therefore, we must include it.
 # VS 2017 keeps changing the path to reflect the latest major.minor.build version which we canot easily find out.
 # Therefore  Search these versioned directories from newest to oldest  to collect all the files we need.
-vcRedistDirs = glob.glob(os.path.join(progFilesX86, r"Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.1*\onecore\x86\Microsoft.VC141.CRT"))
+vcRedistDirs = glob.glob(os.path.join(progFilesX86, r"Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT"))
 if len(vcRedistDirs)==0:
 	raise RuntimeError("Could not locate vc redistributables. Perhaps the Universal Windows Platform component in visual Studio is not installed") 
 vcRedistDirs.sort(reverse=True)


### PR DESCRIPTION
### Link to issue number:
Fixes #7975 

### Summary of the issue:
NVDA fails to run on Windows 7 when a certain version of the Visual Studio 2017 Redistributables are installed.
This is due to a conflict between our copies and the installed copies.
Currently we bundle the redistributables in order to support Onecore Voices and OCR on Windows 10 systems that do not yet come with redistributibles 14.1 or higher (such as Windows 10 Nov 2015 and earlier).
However, it seems we have been copying the wrong redistributables into our build.  Two copies of these dlls come with VS 2017, We were copying in the "Onecore" ones rather than the Desktop ones, under the assumption that we needed the onecore ones to access onecore features.
Testing shows this is not necessary. The Desktop ones allow access to onecore features, and removes the errors on Windows 7 due to the conflict.

### Description of how this pull request fixes the issue:
We now copy the Desktop msvcp vccorelib and vcruntime dlls, rather than the Onecore ones.

### Testing performed:
Tested NVDA on Windows 10 Nov 2015 (with no existing redistributables). Can use windows Onecore voices. Deleting the dlls from our build makes the Onecore synth driver fail, thus NVDA is successfully making use of them.
Tested NVDA on Windows 10 insider build 17093. Windows Onecore voices continue to work.
At least one user who was experiencing the error on Windows 7 has tested a build with the correct redistributables and reports the errors have gone away.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:
* NVDA no longer fails to start on Windows 7 complaining about an internal api-ms dll., when a particular version of the Visual Studio 2017 redistributables have been installed by another application.
