### PR TITLE
No longer try to fetch the title of charts in MS word when cursoring around as this causes the document to look like it has been changed.

### DIFF
--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -647,9 +647,6 @@ inline int generateInlineShapeXML(IDispatch* pDispatchRange, int offset, wostrin
 	if(_com_dispatch_raw_propget(pDispatchShape,wdDISPID_INLINESHAPE_TYPE,VT_I4,&shapeType)!=S_OK) {
 		return 0;
 	}
-	if(_com_dispatch_raw_propget(pDispatchShape,wdDISPID_INLINESHAPE_HASCHART,VT_BOOL,&shapeHasChart)!=S_OK) {
-		return 0;
-	}
 	wstring altTextStr=L"";
 	if(_com_dispatch_raw_propget(pDispatchShape,wdDISPID_INLINESHAPE_ALTERNATIVETEXT,VT_BSTR,&altText)==S_OK&&altText) {
 		for(int i=0;altText[i]!='\0';++i) {
@@ -665,20 +662,6 @@ inline int generateInlineShapeXML(IDispatch* pDispatchRange, int offset, wostrin
 		SysFreeString(altText);
 	}
 	altText=NULL;
-	if(_com_dispatch_raw_propget(pDispatchShape,wdDISPID_INLINESHAPE_HASCHART,VT_BOOL,&shapeHasChart)==S_OK&&shapeHasChart) {
-		if(_com_dispatch_raw_propget(pDispatchShape,wdDISPID_INLINESHAPE_CHART,VT_DISPATCH,&pDispatchChart)==S_OK&&pDispatchChart) {
-			if(_com_dispatch_raw_propget(pDispatchChart,wdDISPID_CHART_HASTITLE,VT_BOOL,&chartHasTitle)==S_OK&&chartHasTitle) {
-				if(_com_dispatch_raw_propget(pDispatchChart,wdDISPID_CHART_CHARTTITLE,VT_DISPATCH,&pDispatchChartTitle)==S_OK&&pDispatchChartTitle) {
-					if(_com_dispatch_raw_propget(pDispatchChartTitle,wdDISPID_CHARTTITLE_TEXT,VT_BSTR,&altText)==S_OK&&altText) {
-						for(int i=0;altText[i]!='\0';++i) {
-							appendCharToXML(altText[i],altTextStr,true);
-						}
-						SysFreeString(altText);
-					}
-				}
-			}
-		}
-	}
 	XMLStream<<L"<control _startOfNode=\"1\" role=\""<<((shapeType==wdInlineShapePicture||shapeType==wdInlineShapeLinkedPicture)?L"graphic":(shapeType==wdInlineShapeChart?L"chart":L"object"))<<L"\" value=\""<<altTextStr<<L"\"";
 	if(shapeType==wdInlineShapeEmbeddedOLEObject) {
 		XMLStream<<L" shapeoffset=\""<<offset<<L"\"";


### PR DESCRIPTION
### Link to issue number:
Closes #8038 

### Summary of the issue:
After reading any message in Microsoft Outlook that has inline shapes such as graphics, embedded objects or charts, NVDA causes Outlook to ask if you want to save the message.
Similarly, the same content in Microsoft Word also causes Word to ask if you want to save changes.
This has been tracked down to a call to shape.haschart in NVDAHelperRemote's winword support in order to fetch a chart's title when cursoring around a document.
This was added in #7046.

### Description of how this pull request fixes the issue:
To get around this regression, this PR removes the block of code that calls shape.hasChart and other chart calls to fetch the title. Note that there was actually an error in that code where the call to hasChart was duplicated several lines above as well. The duplication however was not the cause of the issue. These have both been removed.
Removing this code means that NVDA can no longer report the title of a chart when cursoring around a word / Outlook document, however it still reports  "chart" which is enough to alert the user to the fact there is a chart there.

### Testing performed:
Opened several messages containing inline shapes in both outlook and Word 2016. cursored to those inline shapes (including a graphic and a chart), and then closed the documents. The application no longer asked if I wanted to save changes.

### Known issues with pull request:
Obviously, it is annoying that we can no longer announce the chart title. However, if the user really needs it, interacting with the chart allows them to access it. Note however that interacting with the chart will cause the document to look like it has changed. This is still better than doing it  for any graphic or embedded object though.
 
### Change log entry:
None needed.