### PR TITLE
Ensure NVDA can switch from browseMode to focus mode in Microsoft word when using UIA and braille.

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -283,7 +283,11 @@ class UIATextInfo(textInfos.TextInfo):
 		elif isinstance(position,UIATextInfo): #bookmark
 			self._rangeObj=position._rangeObj
 		elif position==textInfos.POSITION_FIRST:
-			self._rangeObj=self.obj.UIATextPattern.documentRange
+			try:
+				self._rangeObj=self.obj.UIATextPattern.documentRange
+			except COMError:
+				# Error: first position not supported by the UIA text pattern.
+				raise RuntimeError
 			self.collapse()
 		elif position==textInfos.POSITION_LAST:
 			self._rangeObj=self.obj.UIATextPattern.documentRange
@@ -564,7 +568,11 @@ class UIATextInfo(textInfos.TextInfo):
 					continue
 				if log.isEnabledFor(log.DEBUG):
 					log.debug("Fetched child %s (%s)"%(index,childElement.currentLocalizedControlType))
-				childRange=documentTextPattern.rangeFromChild(childElement)
+				try:
+					childRange=documentTextPattern.rangeFromChild(childElement)
+				except COMError as e:
+					log.debug("rangeFromChild failed with %s"%e)
+					childRange=None
 				if not childRange:
 					log.debug("NULL childRange. Skipping")
 					continue

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -156,6 +156,9 @@ class WordDocumentTextInfo(UIATextInfo):
 
 	def getTextWithFields(self,formatConfig=None):
 		fields=super(WordDocumentTextInfo,self).getTextWithFields(formatConfig=formatConfig)
+		if len(fields)==0: 
+			# Nothing to do... was probably a collapsed range.
+			return fields
 		# Fill in page number attributes where NVDA expects
 		try:
 			page=fields[0].field['page-number']

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -55,6 +55,8 @@ class UIATextRangeQuickNavItem(browseMode.TextInfoQuickNavItem):
 	def __init__(self,itemType,document,UIAElementOrRange):
 		if isinstance(UIAElementOrRange,UIAHandler.IUIAutomationElement):
 			UIATextRange=document.rootNVDAObject.getNormalizedUIATextRangeFromElement(UIAElementOrRange)
+			if not UIATextRange:
+				raise ValueError("Could not get text range for UIA element")
 			self._UIAElement=UIAElementOrRange
 		elif isinstance(UIAElementOrRange,UIAHandler.IUIAutomationTextRange):
 			UIATextRange=UIAElementOrRange
@@ -185,9 +187,15 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 	if direction=="up":
 		walker=UIAHandler.handler.clientObject.createTreeWalker(UIACondition)
 		element=position.UIAElementAtStart
-		element=walker.normalizeElement(element)
-		if element and not UIAHandler.handler.clientObject.compareElements(element,document.rootNVDAObject.UIAElement) and not UIAHandler.handler.clientObject.compareElements(element,UIAHandler.handler.rootElement):
-			yield itemClass(itemType,document,element)
+		while element:
+			element=walker.normalizeElement(element)
+			if not element or UIAHandler.handler.clientObject.compareElements(element,document.rootNVDAObject.UIAElement) or UIAHandler.handler.clientObject.compareElements(element,UIAHandler.handler.rootElement):
+				break
+			try:
+				yield itemClass(itemType,document,element)
+			except ValueError:
+				pass # this element was not represented in the document's text content.
+			element=walker.getParentElement(element)
 		return
 	elif direction=="previous":
 		# Fetching items previous to the given position.

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -189,7 +189,11 @@ def UIAControlQuicknavIterator(itemType,document,position,UIACondition,direction
 		element=position.UIAElementAtStart
 		while element:
 			element=walker.normalizeElement(element)
-			if not element or UIAHandler.handler.clientObject.compareElements(element,document.rootNVDAObject.UIAElement) or UIAHandler.handler.clientObject.compareElements(element,UIAHandler.handler.rootElement):
+			if (
+				not element 
+				or UIAHandler.handler.clientObject.compareElements(element,document.rootNVDAObject.UIAElement) 
+				or UIAHandler.handler.clientObject.compareElements(element,UIAHandler.handler.rootElement)
+			):
 				break
 			try:
 				yield itemClass(itemType,document,element)

--- a/source/review.py
+++ b/source/review.py
@@ -6,7 +6,8 @@
 from collections import OrderedDict
 import api
 import winUser
-from NVDAObjects import NVDAObject
+from logHandler import log
+from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 from NVDAObjects.window import Window
 from treeInterceptorHandler import DocumentTreeInterceptor
 from displayModel import DisplayModelTextInfo
@@ -24,7 +25,13 @@ def getObjectPosition(obj):
 	try:
 		pos=obj.makeTextInfo(textInfos.POSITION_CARET)
 	except (NotImplementedError, RuntimeError):
-		pos=obj.makeTextInfo(textInfos.POSITION_FIRST)
+		# No caret supported, try first position instead
+		try:
+			pos=obj.makeTextInfo(textInfos.POSITION_FIRST)
+		except (NotImplementedError, RuntimeError):
+			log.debugWarning("%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo"%obj.TextInfo)
+			# First position not supported either, return first position from a generic NVDAObjectTextInfo 
+			return NVDAObjectTextInfo(obj,textInfos.POSITION_FIRST),obj
 	return pos,pos.obj
 
 def getDocumentPosition(obj):


### PR DESCRIPTION
### Link to issue number:
Closes #8041 

### Summary of the issue:
While using Microsoft Word with UIA supported enabled in NVDA, along with Braille, switching from browseMode to focusMode may sometimes fail. 
This is due to issues such as IUIAutomationTextPattern::documentRange failing to work on charts and other inline shapes, and some checks missing for our own code, such as better detecting collapsed ranges.

### Description of how this pull request fixes the issue:
* UIATextInfo constructor: sometimes it is impossible to get position_first due to buggy UIA implementation  (E.g. A chart  in a Word document). Make sure to catch COMErrors and raise RuntimeError as expected by calling code.
* review.getObjectPosition: Sometimes fetching position_first on a TextInfo could fail (e.g. a chart in Microsoft Word). Ensure we still get something usable back by falling back to a generic NVDAObjectTextInfo which will always support position_first.
* UIABrowseMode's UIAControlQuickNavIterator: when  direction is "up", handle the case where the found element is not actually represented in the document's text and ignore it, and also keep yielding elements until the document is reached, just like all the other directions. Specifically, on a chart in Microsoft word,  we may find a focusable element which isn't represented in the document, going up further does find something useful though.
* UIA wordDocument's getTextwithFields: handle the case where there are no fields at all (probably a collapsed range). This addresses the issue where  exceptions are raised because the page number can not be properly set on a formatField.

### Testing performed:
* Using MS Word 2016, performed the steps to reproduce in #8041.
* Performed similar steps, but while the caret was on a chart.

### Known issues with pull request:
None

### Change log entry:
None. UIA in MS word is not yet official.
