### PR TITLE
Add additional vid and pid to the ALVA driver to support the protocol converter

### DIFF
--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -88,9 +88,10 @@ ALVA_KEYS = {
 }
 
 USB_IDS = {
+	"VID_0798&PID_0600", # USB protocol converter (from BRLTTY)
 	"VID_0798&PID_0640", # BC640
 	"VID_0798&PID_0680", # BC680
-	"VID_0798&PID_0699", # USB protocol converter
+	"VID_0798&PID_0699", # USB protocol converter (from protocol documentation)
 }
 
 class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):


### PR DESCRIPTION
This pr is based on the rc branch and should possibly be merged there for RC2.

### Link to issue number:
Closes #6731 once again.

### Summary of the issue:
@Adriani90 reported in #1586 that the Converter Card isn't working as expected.

The ALVA protocol reports PID 0x0699 for the protocol converter. However, according to the source of BRLTTY, the PID is 0x0600.

### Description of how this pull request fixes the issue:
I added PID 0x0600 to the driver while leaving 0x0699 around, since we aren't sure whether the 0x0699 PID is false or meant for newer iterations of the converter.

### Testing performed:
None. As @Adriani90 reported this issue, it would be appreciated much if he or someone else could test [this](https://ci.appveyor.com/api/buildjobs/y0stnqb2jjwlaacc/artifacts/output%2Fnvda_snapshot_try-protocolConverterPID-14888%2Cf73ef85b.exe) try build.

### Known issues with pull request:
We should at some point remove the erroneous PID. Braille display auto detection (#1271) might be a good moment for this.

### Change log entry:
Changes since RC1

* The ALVA Protocol Converter should now really work as advertised (#8047)