### PR TITLE
Fix problems with ALVA protocol converter and time synchronisation

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1937,7 +1937,7 @@ class _BgThread:
 #: Maps old braille display driver names to new drivers that supersede old drivers.
 RENAMED_DRIVERS = {
 	"syncBraille":"hims",
-	"alvaBc6":"alva"
+	"alvaBC6":"alva"
 }
 
 def initialize():

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -141,8 +141,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		if self.isHid:
 			displaySettings = self._dev.getFeature(ALVA_DISPLAY_SETTINGS_REPORT)
 			self.numCells = ord(displaySettings[ALVA_DISPLAY_SETTINGS_CELL_COUNT_POS])
-			timeStr = self._dev.getFeature(ALVA_RTC_REPORT)[1:ALVA_RTC_STR_LENGTH+1]
-			self._handleTime(timeStr)
+			try:
+				timeStr = self._dev.getFeature(ALVA_RTC_REPORT)[1:ALVA_RTC_STR_LENGTH+1]
+			except:
+				log.debugWarning("Getting time from ALVA display failed", exc_info=True)
+			else:
+				self._handleTime(timeStr)
 			keySettings = self._dev.getFeature(ALVA_KEY_SETTINGS_REPORT)[ALVA_KEY_SETTINGS_POS]
 			self._rawKeyboardInput = bool(ord(keySettings) & ALVA_KEY_RAW_INPUT_MASK)
 		else:

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -34,6 +34,8 @@ ALVA_KEY_SETTINGS_POS = 1 # key settings are stored as bits in 1 byte
 ALVA_RTC_REPORT = b"\x0a"
 ALVA_RTC_STR_LENGTH = 7
 ALVA_RTC_MAX_DRIFT = 5
+ALVA_RTC_MIN_YEAR = 1900
+ALVA_RTC_MAX_YEAR = 3000
 
 ALVA_MODEL_IDS = {
 	0x40: "BC640",
@@ -298,7 +300,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	def _handleTime(self, timeStr):
 		ords = map(ord, timeStr)
 		year=ords[0] | ords[1] << 8
-		if not 1900 <= year <= 3000:
+		if not ALVA_RTC_MIN_YEAR <= year <= ALVA_RTC_MAX_YEAR:
 			log.debug("This ALVA display doesn't reveal clock information")
 			return
 		try:

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -301,14 +301,18 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		if not year:
 			log.debug("This ALVA display doesn't reveal clock information")
 			return
-		displayDateTime = datetime.datetime(
-			year=year,
-			month=ords[2],
-			day=ords[3],
-			hour=ords[4],
-			minute=ords[5],
-			second=ords[6]
-		)
+		try:
+			displayDateTime = datetime.datetime(
+				year=year,
+				month=ords[2],
+				day=ords[3],
+				hour=ords[4],
+				minute=ords[5],
+				second=ords[6]
+			)
+		except ValueError:
+			log.debugWarning("Invalid time/date of Alva display: %r"%timeStr)
+			return
 		localDateTime = datetime.datetime.today()
 		if abs((displayDateTime - localDateTime).total_seconds()) >= ALVA_RTC_MAX_DRIFT:
 			log.debugWarning("Display time out of sync: %s"%displayDateTime.isoformat())

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -293,8 +293,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def _handleTime(self, timeStr):
 		ords = map(ord, timeStr)
+		year=ords[0] | ords[1] << 8
+		if not year:
+			log.debug("This ALVA display doesn't reveal clock information")
+			return
 		displayDateTime = datetime.datetime(
-			year=ords[0] | ords[1] << 8,
+			year=year,
 			month=ords[2],
 			day=ords[3],
 			hour=ords[4],


### PR DESCRIPTION
### Link to issue number:
Closes #6731

### Summary of the issue:
The ALVA protocol converter does not yet work correctly. This is because NVDA requests a feature report for the current display time. The converter returns a time report padded with zeros. Trying to create a datetime.datetime object with zeros raises a ValueError.

### Description of how this pull request fixes the issue:
1. Return early when interpretting a time report that has a year of 0.
2. The request for the display time is now enclosed in a try/except block, failure is handled gracefully.

### Testing performed:
None. @Adriani90 is again kindly asked to perform testing with [this](https://ci.appveyor.com/api/buildjobs/hrb0i89s01acq35l/artifacts/output%2Fnvda_snapshot_try-alvaFix-14899%2Cfd222ab8.exe). @dkager, could you please test this with your BC640?

### Known issues with pull request:
None

### Change log entry:
Changes since RC1

* The ALVA Protocol Converter should now really work as advertised (#8047)