### PR TITLE
Fix model specific gestures for Hims displays

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2243,16 +2243,16 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 	#: Compiled regular expression to match an identifier including an optional model name
 	#: The model name should be an alphanumeric string without spaces.
 	#: @type: RegexObject
-	ID_PARTS_REGEX = re.compile(r"br\((\w+)(\.(\w+))?\):([\w+]+)", re.U)
+	ID_PARTS_REGEX = re.compile(r"br\((\w+)(?:\.(\w+))?\):([\w+]+)", re.U)
 
 	@classmethod
 	def getDisplayTextForIdentifier(cls, identifier):
-		idParts = cls.ID_PARTS_REGEX.search(identifier)
+		idParts = cls.ID_PARTS_REGEX.match(identifier)
 		if not idParts:
 			log.error("Invalid braille gesture identifier: %s"%identifier)
 			return handler.display.description, "malformed:%s"%identifier
-		modelName = idParts.group(3)
-		key = idParts.group(4)
+		modelName = idParts.group(2)
+		key = idParts.group(3)
 		if modelName: # The identifier contains a model name
 			return handler.display.description, "{modelName}: {key}".format(
 				modelName=modelName, key=key

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -707,7 +707,8 @@ class KeyInputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGe
 
 	def __init__(self, model, keys):
 		super(KeyInputGesture, self).__init__()
-		self.model=model.name
+		# Model identifiers should not contain spaces.
+		self.model=model.name.replace(" ", "")
 		self.keys = keys
 		self.keyNames = names = set()
 		isBrailleInput = True

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -99,16 +99,16 @@ class TestDisplayTextForGestureIdentifier(unittest.TestCase):
 	def test_regex(self):
 		regex = braille.BrailleDisplayGesture.ID_PARTS_REGEX
 		self.assertEqual(
-			regex.search('br(noBraille.noModel):noKey1+noKey2').groups(),
-			('noBraille', '.noModel', 'noModel', 'noKey1+noKey2')
+			regex.match('br(noBraille.noModel):noKey1+noKey2').groups(),
+			('noBraille', 'noModel', 'noKey1+noKey2')
 		)
 		self.assertEqual(
-			regex.search('br(noBraille):noKey1+noKey2').groups(),
-			('noBraille', None, None, 'noKey1+noKey2')
+			regex.match('br(noBraille):noKey1+noKey2').groups(),
+			('noBraille', None, 'noKey1+noKey2')
 		)
 		# Also try a string which doesn't match the pattern
 		self.assertEqual(
-			regex.search('br[noBraille.noModel]:noKey1+noKey2'),
+			regex.match('br[noBraille.noModel]:noKey1+noKey2'),
 			None
 		)
 


### PR DESCRIPTION
### Link to issue number:
Fixes #8096

### Summary of the issue:
When pressing model specific gestures on several Hims displays, including the Braille Edge, the global mappings are used rather than the model specific ones.

### Description of how this pull request fixes the issue:
Model identifiers in gestures ought to be without spaces, however spaces weren't stripped from the model names in the Hims driver.

This pr also improves the regex for model specific gestures, using a non-capturing group for the model specific identifier including the preceding dot.

### Testing performed:
 Reported to work as expected by @Piciok in https://github.com/nvaccess/nvda/issues/8096#issuecomment-373906945

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + Model specific gestures to buttons on Hims displays are now working as advertised in the user guide. (#8096)