### PR TITLE
NVDAObjects/UIA: recognize UWP tooltips

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -28,7 +28,7 @@ from logHandler import log
 from UIAUtils import *
 from NVDAObjects.window import Window
 from NVDAObjects import NVDAObjectTextInfo, InvalidNVDAObject
-from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDetection, Dialog, Notification, EditableTextWithSuggestions
+from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDetection, Dialog, Notification, EditableTextWithSuggestions, ToolTip
 import braille
 from locationHelper import RectLTWH
 import ui
@@ -787,6 +787,9 @@ class UIA(Window):
 			clsList.append(Toast_win8)
 		elif self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and "ToastView" in self.UIAElement.cachedAutomationId: # Windows 10
 			clsList.append(Toast_win10)
+		# #8118: treat UWP tooltips as proper tooltips, especially those found in Microsoft Edge and other apps.
+		elif UIAClassName=="ToolTip" and self.UIAElement.cachedFrameworkID == "XAML":
+			clsList.append(UWPToolTip)
 		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
 			from . import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
@@ -1640,6 +1643,12 @@ class Toast_win10(Notification, UIA):
 			self.__class__._lastToastTimestamp = toastTimestamp
 			self.__class__._lastToastRuntimeID = toastRuntimeID
 		Notification.event_alert(self)
+
+
+class UWPToolTip(ToolTip, UIA):
+
+	event_UIA_toolTipOpened=ToolTip.event_show
+
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
 #This causes major lags when using this control with Braille in NVDA. (#2759) 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -789,7 +789,7 @@ class UIA(Window):
 			clsList.append(Toast_win10)
 		# #8118: treat UWP tooltips as proper tooltips, especially those found in Microsoft Edge and other apps.
 		elif UIAClassName=="ToolTip" and self.UIAElement.cachedFrameworkID == "XAML":
-			clsList.append(UWPToolTip)
+			clsList.append(XAMLToolTip)
 		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
 			from . import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
@@ -1645,7 +1645,7 @@ class Toast_win10(Notification, UIA):
 		Notification.event_alert(self)
 
 
-class UWPToolTip(ToolTip, UIA):
+class XAMLToolTip(ToolTip, UIA):
 
 	event_UIA_toolTipOpened=ToolTip.event_show
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -787,9 +787,10 @@ class UIA(Window):
 			clsList.append(Toast_win8)
 		elif self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and "ToastView" in self.UIAElement.cachedAutomationId: # Windows 10
 			clsList.append(Toast_win10)
-		# #8118: treat UWP tooltips as proper tooltips, especially those found in Microsoft Edge and other apps.
-		elif UIAClassName=="ToolTip" and self.UIAElement.cachedFrameworkID == "XAML":
-			clsList.append(XAMLToolTip)
+		# #8118: treat UIA tool tips (including those found in UWP apps) as proper tool tips, especially those found in Microsoft Edge and other apps.
+		# Windows 8.x toast, although a form of tool tip, is covered separately.
+		elif UIAControlType==UIAHandler.UIA_ToolTipControlTypeId:
+			clsList.append(ToolTip)
 		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
 			from . import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
@@ -1645,7 +1646,7 @@ class Toast_win10(Notification, UIA):
 		Notification.event_alert(self)
 
 
-class XAMLToolTip(ToolTip, UIA):
+class ToolTip(ToolTip, UIA):
 
 	event_UIA_toolTipOpened=ToolTip.event_show
 


### PR DESCRIPTION
### Link to issue number:
Fixes #8118 

### Summary of the issue:
Recognize UWP/XAML tooltips such as ones from Microsoft Edge as proper tooltips.

### Description of how this pull request fixes the issue:
Tooltips from universal apps are powered by XAML and has a specific class name (for now). Prior to this, these tooltips were not announced by NVDA. Cases include Edge's Settings button tooltip, which displays hotkey information (Alt+X) in Insider Preview builds. Thus recognize them as proper tooltips through an overlay class powered by NVDAObjects.behaviors.ToolTip.

### Testing performed:
Tested Edge on Windows 10 Versions 1703 (Creators Update), 1709 (Fall Creators Update) and 1803 preview (Spring Creators Update).

### Known issues with pull request:
None at this time.

### Change log entry:
Bug fixes: In Windows 10, NVDA will announce tooltips from universal apps if NVDA is configured to report tooltips in object presentation dialog.
