### PR TITLE
Fix reading tables in LibreOffice (#8125) by catching NotImplementedE…

### DIFF
--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2018 NV Access Limited
+#Copyright (C) 2010-2018 NV Access Limited, Bram Duvigneau
 
 import winUser
 import textInfos
@@ -17,6 +17,7 @@ from NVDAObjects import behaviors
 import api
 import config
 import review
+from logHandler import log
 
 class CompoundTextInfo(textInfos.TextInfo):
 
@@ -151,8 +152,17 @@ class CompoundTextInfo(textInfos.TextInfo):
 			field["table-id"] = 1 # FIXME
 			field["table-rownumber"] = obj.rowNumber
 			field["table-columnnumber"] = obj.columnNumber
-			field['table-rowsspanned']=obj.rowSpan
-			field['table-columnsspanned']=obj.columnSpan
+			# Row/column span is not supported by all implementations (e.g. LibreOffice)
+			try:
+				field['table-rowsspanned']=obj.rowSpan
+			except NotImplementedError:
+				log.debug("Row span not supported")
+				pass
+			try:
+				field['table-columnsspanned']=obj.columnSpan
+			except NotImplementedError:
+				log.debug("Column span not supported")
+				pass
 		return field
 
 	def __eq__(self, other):


### PR DESCRIPTION
Fix reading of tables in LibreOffice

### Link to issue number:
Fixes #8125 
### Summary of the issue:
Tables don't read, but give an error sound.

### Description of how this pull request fixes the issue:
Ignore row/column spans in compound documents if the implementation doesn't support them.

### Testing performed:
Tested in LibreOffice.

### Known issues with pull request:
None.

### Change log entry:
None, since this is a regression from the previous release and doesn't have any user visible changes.