### PR TITLE
Explorer: do not announce 'unknown' when opening quick link menu and selecting items from it (Windows+X)

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -268,10 +268,10 @@ class AppModule(appModuleHandler.AppModule):
 			return
 
 		if wClass in ("ForegroundStaging", "LauncherTipWnd", "ApplicationManager_DesktopShellWindow"):
-			# #5116: The Windows 10 Task View fires foreground/focus on this weird invisible window before and after it appears.
+			# #5116: The Windows 10 Task View fires foreground/focus on this weird invisible window and foreground staging screen before and after it appears.
 			# This causes NVDA to report "unknown", so ignore it.
 			# We can't do this using shouldAllowIAccessibleFocusEvent because this isn't checked for foreground.
-			# #8137: also seen when opening quick link menu (Windows+X).
+			# #8137: also seen when opening quick link menu (Windows+X) on Windows 8 and later.
 			return
 
 		if wClass == "WorkerW" and obj.role == controlTypes.ROLE_PANE and obj.name is None:

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,6 +1,6 @@
 #appModules/explorer.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Joseph Lee
+#Copyright (C) 2006-2018 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -267,10 +267,11 @@ class AppModule(appModuleHandler.AppModule):
 			# Therefore, if there is a pending focus event, don't bother handling this event.
 			return
 
-		if wClass == "ForegroundStaging":
+		if wClass in ("ForegroundStaging", "LauncherTipWnd", "ApplicationManager_DesktopShellWindow"):
 			# #5116: The Windows 10 Task View fires foreground/focus on this weird invisible window before and after it appears.
 			# This causes NVDA to report "unknown", so ignore it.
 			# We can't do this using shouldAllowIAccessibleFocusEvent because this isn't checked for foreground.
+			# #8137: also seen when opening quick link menu (Windows+X).
 			return
 
 		if wClass == "WorkerW" and obj.role == controlTypes.ROLE_PANE and obj.name is None:


### PR DESCRIPTION
### Link to issue number:
Fixes #8137 

### Summary of the issue:
Do not announce "unknown" when opening quick link menu and selecting items in there (Windows+X).

### Description of how this pull request fixes the issue:
Windows with the class name of LauncherTipWnd and ApplicationManager_DesktopShellWindow fires focus events, causing NVDA to announce 'unknown' when opening quick link menu (Windows+X) and selecting an item from this menu. Suppress this if possible.

### Testing performed:
Tested on version 1803 and earlier builds.

### Known issues with pull request:
None

### Change log entry:
Bug fixes: On Windows 8 and later, NVDA will no longer announce "unknown" when opening quick link menu )Windows+X) and selecting items from this menu. (#8137)
