### PR TITLE
log.debugWarning should not raise UnicodeDecodeError when WindowsError occurs

### DIFF
--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -277,12 +277,12 @@ class SynthDriver(SynthDriver):
 		try:
 			hkey = _winreg.OpenKey(rootKey, subkey)
 		except WindowsError as e:
-			log.debugWarning("Could not open registry key %s, %s" % (ID, e))
+			log.debugWarning("Could not open registry key %s, %r" % (ID, e))
 			return False
 		try:
 			langDataPath = _winreg.QueryValueEx(hkey, 'langDataPath')
 		except WindowsError as e:
-			log.debugWarning("Could not open registry value 'langDataPath', %s" % e)
+			log.debugWarning("Could not open registry value 'langDataPath', %r" % e)
 			return False
 		if not langDataPath or not isinstance(langDataPath[0], basestring):
 			log.debugWarning("Invalid langDataPath value")
@@ -293,7 +293,7 @@ class SynthDriver(SynthDriver):
 		try:
 			voicePath = _winreg.QueryValueEx(hkey, 'voicePath')
 		except WindowsError as e:
-			log.debugWarning("Could not open registry value 'langDataPath', %s" % e)
+			log.debugWarning("Could not open registry value 'langDataPath', %r" % e)
 			return False
 		if not voicePath or not isinstance(voicePath[0],basestring):
 			log.debugWarning("Invalid voicePath value")

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -61,7 +61,7 @@ def connectConsole(obj):
 	try:
 		wincon.AttachConsole(processID)
 	except WindowsError as e:
-		log.debugWarning("Could not attach console: %s"%e)
+		log.debugWarning("Could not attach console: %r"%e)
 		return False
 	wincon.SetConsoleCtrlHandler(_consoleCtrlHandler,True)
 	consoleOutputHandle=winKernel.CreateFile(u"CONOUT$",winKernel.GENERIC_READ|winKernel.GENERIC_WRITE,winKernel.FILE_SHARE_READ|winKernel.FILE_SHARE_WRITE,None,winKernel.OPEN_EXISTING,0,None)                                                     


### PR DESCRIPTION
### Link to issue number:
#7673

### Summary of the issue:
When log.debugWarning contains WindowsError object, it may use multibyte characters, so it raises UnicodeDecodeError and some functionality fail because of this.

WindowsError messages are not properly encoded
https://bugs.python.org/issue1754

### Description of how this pull request fixes the issue:

It uses %r rather than %s for WindowsError instances.

As far as I have scanned the current master source, similar potential issue exists in winConsoleHandler.py, so this pull request contains that modification as well.

### Testing performed:

Regarding #7673, OneCore voice is not available for the setup as follows:

* Windows 10 (1709) Japanese 64bit
* English language pack is once added and after that removed for some reason. At the Windows Setting, Microsoft David or Zira are shown as the voice options, but not working.
* NVDA is built from source and run as launcher executable.

Under this condition, this pull request enables the use of OneCore Japanese voices such as Ayumi.

### Known issues with pull request:

### Change log entry:
