### PR TITLE
Update MinHook to 1.3.3

### DIFF
--- a/copying.txt
+++ b/copying.txt
@@ -9,7 +9,7 @@ All applicable licenses are included below.
 = GNU General Public License version 2 =
 Most of the source code for NVDA itself is available under this license.
 
-``
+```
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.

--- a/copying.txt
+++ b/copying.txt
@@ -9,7 +9,7 @@ All applicable licenses are included below.
 = GNU General Public License version 2 =
 Most of the source code for NVDA itself is available under this license.
 
-```
+``
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
@@ -1199,85 +1199,87 @@ e) modify or distribute the source code of any Distributable Code so that any pa
 This applies to MinHook, available from http://github.com/RaMMicHaeL/minhook
 
 ```
-/* 
- *  MinHook - The Minimalistic API Hooking Library for x64/x86
- *  Copyright (c) 2009 Tsuda Kageyu. 
- *  All rights reserved.
- *  
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *  
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. The name of the author may not be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+MinHook - The Minimalistic API Hooking Library for x64/x86
+Copyright (C) 2009-2017 Tsuda Kageyu.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 Portions of this software are Copyright (c) 2008-2009, Vyacheslav Patkov.
 ================================================================================
-/*
- * Hacker Disassembler Engine 32 C
- * Copyright (c) 2008-2009, Vyacheslav Patkov.
- * All rights reserved.
- *
- */
+Hacker Disassembler Engine 32 C
+Copyright (c) 2008-2009, Vyacheslav Patkov.
+All rights reserved.
 
-/*
- * Hacker Disassembler Engine 64 C
- * Copyright (c) 2008-2009, Vyacheslav Patkov.
- * All rights reserved.
- *
- */
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
 
-================================================================================
-Portions of this software are Copyright (c) 2005-2007 Paul Hsieh.
-================================================================================
-/*  A portable stdint.h
- ****************************************************************************
- *  BSD License:
- ****************************************************************************
- *
- *  Copyright (c) 2005-2007 Paul Hsieh
- *  All rights reserved.
- *  
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *  
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. The name of the author may not be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+Hacker Disassembler Engine 64 C
+Copyright (c) 2008-2009, Vyacheslav Patkov.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 = The MIT License =

--- a/nvdaHelper/minHook/sconscript
+++ b/nvdaHelper/minHook/sconscript
@@ -10,15 +10,13 @@ env=env.Clone(CPPPATH=minhookPath.Dir('include'))
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
-HDESourceFile='HDE64/src/HDE64.c' if env['TARGET_ARCH']=='x86_64' else 'HDE32/HDE32.c'
+HDESourceFile='HDE/HDE64.c' if env['TARGET_ARCH']=='x86_64' else 'HDE/HDE32.c'
 
 sourceFiles=[
 	HDESourceFile,
-	'buffer.cpp',
-	'export.cpp',
-	'hook.cpp',
-	'thread.cpp',
-	'trampoline.cpp',
+	'buffer.c',
+	'hook.c',
+	'trampoline.c',
 ]
 
 objFiles=[env.Object('_minHook_%s.obj'%x.replace('/','_'),minhookPath.File('src/%s'%x)) for x in sourceFiles]

--- a/nvdaHelper/remote/apiHook.cpp
+++ b/nvdaHelper/remote/apiHook.cpp
@@ -78,7 +78,7 @@ defMHFP(MH_DisableHook);
 		return false;
 	}
 	if ((res=MH_Initialize_fp())!=MH_OK) {
-		LOG_ERROR("MH_CreateHook failed with " << res);
+		LOG_ERROR("MH_Initialize failed with " << res);
 		FreeLibrary(minhookLibHandle);
 		minhookLibHandle=NULL;
 		return false;

--- a/nvdaHelper/remote/apiHook.cpp
+++ b/nvdaHelper/remote/apiHook.cpp
@@ -106,7 +106,7 @@ void* apiHook_hookFunction(const char* moduleName, const char* functionName, voi
 	void* origFunc;
 	MH_STATUS res;
 	if((res=MH_CreateHook_fp(realFunc,newHookProc,&origFunc))!=MH_OK) {
-		LOG_ERROR("MH_CreateHook failed with " << res);
+		LOG_ERROR("MH_CreateHook for function " << functionName << " in module " << moduleName << " failed with " << res);
 		FreeLibrary(moduleHandle);
 		return NULL;
 	}

--- a/nvdaHelper/remote/apiHook.cpp
+++ b/nvdaHelper/remote/apiHook.cpp
@@ -58,7 +58,6 @@ defMHFP(MH_DisableHook);
 
  bool apiHook_initialize() {
 	LOG_DEBUG("calling MH_Initialize");
-	MH_STATUS res;
 	wstring dllPath=dllDirectory;
 	dllPath+=L"\\minhook.dll";
 	if((minhookLibHandle=LoadLibrary(dllPath.c_str()))==NULL) {
@@ -77,7 +76,8 @@ defMHFP(MH_DisableHook);
 		minhookLibHandle=NULL;
 		return false;
 	}
-	if ((res=MH_Initialize_fp())!=MH_OK) {
+	MH_STATUS res = MH_Initialize_fp();
+	if (res!=MH_OK) {
 		LOG_ERROR("MH_Initialize failed with " << res);
 		FreeLibrary(minhookLibHandle);
 		minhookLibHandle=NULL;
@@ -104,8 +104,8 @@ void* apiHook_hookFunction(const char* moduleName, const char* functionName, voi
 	}
 	LOG_DEBUG("requesting to hook function " << functionName << " at address 0X" << std::hex << realFunc << " in module " << moduleName << " at address 0X" << moduleHandle << " with  new function at address 0X" << newHookProc);
 	void* origFunc;
-	MH_STATUS res;
-	if((res=MH_CreateHook_fp(realFunc,newHookProc,&origFunc))!=MH_OK) {
+	MH_STATUS res = MH_CreateHook_fp(realFunc,newHookProc,&origFunc);
+	if(res!=MH_OK) {
 		LOG_ERROR("MH_CreateHook for function " << functionName << " in module " << moduleName << " failed with " << res);
 		FreeLibrary(moduleHandle);
 		return NULL;
@@ -117,25 +117,23 @@ void* apiHook_hookFunction(const char* moduleName, const char* functionName, voi
 }
 
 bool apiHook_enableHooks() {
-	MH_STATUS res;
 	if(!minhookLibHandle) {
 		LOG_ERROR(L"apiHooks not initialized");
 		return false;
 	}
-	res=MH_EnableHook_fp(MH_ALL_HOOKS);
+	MH_STATUS res=MH_EnableHook_fp(MH_ALL_HOOKS);
 	nhAssert(res==MH_OK);
 	return TRUE;
 }
 
 bool apiHook_terminate() {
-	MH_STATUS res;
 	//If the process is exiting then minHook will have already removed all hooks and unloaded
 	if(isProcessExiting) return true;
 	if(!minhookLibHandle) {
 		LOG_ERROR(L"apiHooks not initialized");
 		return false;
 	}
-	res=MH_DisableHook_fp(MH_ALL_HOOKS);
+	MH_STATUS res=MH_DisableHook_fp(MH_ALL_HOOKS);
 	nhAssert(res==MH_OK);
 	g_hookedFunctions.clear();
 	//Give enough time for all hook functions to complete.

--- a/nvdaHelper/remote/apiHook.cpp
+++ b/nvdaHelper/remote/apiHook.cpp
@@ -39,7 +39,6 @@ typedef MH_STATUS(WINAPI *MH_Uninitialize_funcType)();
 typedef MH_STATUS(WINAPI *MH_CreateHook_funcType)(LPVOID,LPVOID,LPVOID*);
 typedef MH_STATUS(WINAPI *MH_EnableHook_funcType)(LPVOID);
 typedef MH_STATUS(WINAPI *MH_DisableHook_funcType)(LPVOID);
-typedef const char*(WINAPI *MH_StatusToString_funcType)(MH_STATUS);
 
 #define defMHFP(funcName) funcName##_funcType funcName##_fp=NULL
 
@@ -56,7 +55,6 @@ defMHFP(MH_Uninitialize);
 defMHFP(MH_CreateHook);
 defMHFP(MH_EnableHook);
 defMHFP(MH_DisableHook);
-defMHFP(MH_StatusToString);
 
  bool apiHook_initialize() {
 	LOG_DEBUG("calling MH_Initialize");
@@ -80,7 +78,7 @@ defMHFP(MH_StatusToString);
 		return false;
 	}
 	if ((res=MH_Initialize_fp())!=MH_OK) {
-		LOG_ERROR("MH_Initialize failed with " << res << " (" << MH_StatusToString_fp(res) <<")");
+		LOG_ERROR("MH_Initialize failed with " << res);
 		FreeLibrary(minhookLibHandle);
 		minhookLibHandle=NULL;
 		return false;
@@ -108,7 +106,7 @@ void* apiHook_hookFunction(const char* moduleName, const char* functionName, voi
 	void* origFunc;
 	MH_STATUS res;
 	if((res=MH_CreateHook_fp(realFunc,newHookProc,&origFunc))!=MH_OK) {
-		LOG_ERROR("MH_CreateHook failed with " << res << " (" << MH_StatusToString_fp(res) <<")");
+		LOG_ERROR("MH_CreateHook failed with " << res);
 		FreeLibrary(moduleHandle);
 		return NULL;
 	}


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
MinHook, the hooking library used to hook into processes, has been on 1.2.2 for years within NVDA. Version 1.3.3 is the most recent version.

### Description of how this pull request fixes the issue:
This updates MinHook to 1.3.3 and updates the associated sconscript file as well.

### Testing performed:
Try build ran without any observed issues, but wider testing would be appreciated.

### Known issues with pull request:
None
