### PR TITLE
Add a appModule for taskMan, to fix some bugs in windows ten.

### DIFF
--- a/source/appModules/taskmgr.py
+++ b/source/appModules/taskmgr.py
@@ -1,0 +1,28 @@
+#appModules/taskmgr.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2018 NV Access Limited, Derek Riemer
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import appModuleHandler
+from NVDAObjects import NVDAObject
+from NVDAObjects.UIA import UIA
+
+def appropriateDescendant(obj):
+	while obj.parent and obj.parent.presentationType != obj.presType_content:
+		if isinstance(obj.parent, UIA) and obj.parent.UIAElement.CachedAutomationID == u"TmViewRow":
+			return True
+		obj = obj.parent
+	return False
+
+class BrokenUIAChild(NVDAObject):
+	#This is A child which is layout, but should be content.
+	presentationType = NVDAObject.presType_content
+
+class AppModule(appModuleHandler.AppModule):
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if isinstance(obj, UIA) and obj.UIAElement.CachedAutomationID == u"TmRowIcon":
+			#This is an icon and really is layout. Don't show it.
+			return
+		if obj.presentationType == obj.presType_layout and appropriateDescendant(obj):
+			clsList.insert(0, BrokenUIAChild)

--- a/source/appModules/taskmgr.py
+++ b/source/appModules/taskmgr.py
@@ -8,14 +8,18 @@ import appModuleHandler
 from NVDAObjects import NVDAObject
 from NVDAObjects.UIA import UIA
 
-def appropriateDescendant(obj):
+def isChildOfRow(obj):
+	"""
+	calculates obj's ancestors  , discovering if this is a child of a row.
+	If obj is a child of a row, this returns true.
+	"""
 	while obj.parent and obj.parent.presentationType != obj.presType_content:
 		if isinstance(obj.parent, UIA) and obj.parent.UIAElement.CachedAutomationID == u"TmViewRow":
 			return True
 		obj = obj.parent
 	return False
 
-class BrokenUIAChild(NVDAObject):
+class BrokenUIAChild(UIA):
 	#This is A child which is layout, but should be content.
 	presentationType = NVDAObject.presType_content
 
@@ -24,5 +28,5 @@ class AppModule(appModuleHandler.AppModule):
 		if isinstance(obj, UIA) and obj.UIAElement.CachedAutomationID == u"TmRowIcon":
 			#This is an icon and really is layout. Don't show it.
 			return
-		if obj.presentationType == obj.presType_layout and appropriateDescendant(obj):
+		if obj.presentationType == obj.presType_layout and isChildOfRow(obj):
 			clsList.insert(0, BrokenUIAChild)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In windows ten, task manager has a bug where the columns for CPU usage, memory, and other information about a process are UIA layout, not content. This fix makes these columns UIA content, so NVDA shows them when using simple review mode.
### Testing performed:
Built NVDA, installed it, and ran it on task manager on windows ten, version 1709.

### Known issues with pull request:

It might or might not work on 8 and 7, I need someone to test this if possible.### Change log entry:

* Bug fixes:
    * Fix a bug in task manager causing NVDA to not allow users to access the contents of specific details about processes.
