### PR TITLE
Use OneCore speech on windows 10 by default rather than eSpeak

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -10,6 +10,7 @@ import os
 import pkgutil
 import config
 import baseObject
+import winVersion
 import globalVars
 from logHandler import log
 from  synthSettingsRing import SynthSettingsRing
@@ -75,7 +76,8 @@ def setSynth(name,isFallback=False):
 		_curSynth=None
 		return True
 	if name=='auto':
-		name='espeak'
+		# Default to OneCore on Windows 10 and above, and eSpeak on previous Operating Systems
+		name='oneCore' if winVersion.winVersion.major>=10 else 'espeak'
 	if _curSynth:
 		_curSynth.cancel()
 		_curSynth.terminate()


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
For many years, NVDA has used eSpeak as its default voice because we could not trust the quality or existence of SAPI4 or SAPI5 voices on each machine NVDA is run on. However, as much as eSpeak is very popular with power users, it is not very well liked at all by beginners. It would greatly help the update of NVDA if we could default to a nicer sounding voice.

### Description of how this pull request fixes the issue:
Windows 10 now comes with OneCore speech voices. There are mostly high quality, and  most of the major languages in Windows now have speech packs meaning that  the vast majority of  Windows 10 machines will now come with a suitable voice included.
This PR changes the default synthesizer on windows 10 from espeak to oneCore. If for some reason the machine does not have any oneCore voices (I.e. the synthDriver fails to load, then it will still fall back to eSpeak). On previous Operating systems, the default remains as eSpeak.

### Testing performed:
Ran NVDA with a new configuration on both Windows 10 and Windows 8. The Windows 10 NVDA chose oneCore, the Windows 8 NVDA chose eSpeak.

### Known issues with pull request:
None.

### Change log entry:
Changes:
The default speech synthesizer when running on Windows 10 is now oneCore speech rather than eSpeak.