### PR TITLE
Update the Audacity appModule

### DIFF
--- a/source/appModules/audacity.py
+++ b/source/appModules/audacity.py
@@ -1,15 +1,14 @@
 #appModules/audacity.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2010 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2018 NVDA Contributors <https://www.nvaccess.org/>
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 import appModuleHandler
-import winUser
 import controlTypes
 
 class AppModule(appModuleHandler.AppModule):
 
 	def event_NVDAObject_init(self,obj):
 		if obj.windowClassName=="Button" and not obj.role in [controlTypes.ROLE_MENUBAR, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_POPUPMENU]:
-			obj.name=winUser.getWindowText(obj.windowHandle).replace('&','')
+			obj.name=obj.name.replace('&','')

--- a/source/appModules/audacity.py
+++ b/source/appModules/audacity.py
@@ -1,6 +1,7 @@
+# -*- coding: UTF-8 -*-
 #appModules/audacity.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NVDA Contributors <https://www.nvaccess.org/>
+#Copyright (C) 2006-2018 NV Access Limited, Robert Hänggi
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 


### PR DESCRIPTION
### Link to issue number:
#8100 78

### Summary of the issue:
In response to a request from the Audacity developers (issue #8178).
The workaround with window text for buttons is no longer needed.
Audacity versions that are released and still supported at the moment of this writing won't show a difference.
The upcoming 2.3.0 version, on the other hand, will greatly profit from the change.

### Description of how this pull request fixes the issue:
As it should be, the IAccessible name is used instead of the window text.
The ampersand is however still replaced with an empty string.
This is only needed for older versions of WxWidgets.

### Testing performed:
Yes, versions above 2.x.

### Known issues with pull request:
None known.

### Change log entry:
No visible change for the user.