### PR TITLE
Non-modal dialogs should remain in the parent browseMode treeInterceptor

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -524,8 +524,11 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 	// Whether this is the root node.
 	bool isRoot = ID == this->rootID;
 	// Whether this is an embedded application.
+	// either it is an embedded object, or
+	// it is an application or dialog that is not the root node,
+	// But if a dialog, it must be also modal
 		bool isEmbeddedApp = role == IA2_ROLE_EMBEDDED_OBJECT
-			|| (!isRoot && (role == ROLE_SYSTEM_APPLICATION || role == ROLE_SYSTEM_DIALOG));
+			|| (!isRoot && (role == ROLE_SYSTEM_APPLICATION || (role == ROLE_SYSTEM_DIALOG && states&IA2_STATE_MODAL)));
 	// Whether this node is interactive.
 	// Certain objects are never interactive, even if other checks are true.
 	bool isNeverInteractive = parentNode->isHidden||(!isEditable && (isRoot || role == ROLE_SYSTEM_DOCUMENT || role == IA2_ROLE_INTERNAL_FRAME));

--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -492,6 +492,7 @@ inline void getAttributesFromHTMLDOMNode(IHTMLDOMNode* pHTMLDOMNode,wstring& nod
 	macro_addHTMLAttributeToMap(L"aria-atomic",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"aria-current",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"aria-placeholder",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
+	macro_addHTMLAttributeToMap(L"aria-modal",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	pHTMLAttributeCollection2->Release();
 }
 
@@ -874,6 +875,8 @@ VBufStorage_fieldNode_t* MshtmlVBufBackend_t::fillVBuf(VBufStorage_buffer_t* buf
 		language=static_cast<MshtmlVBufStorage_controlFieldNode_t*>(parentNode)->language;
 	}
 
+	bool isModal=(tempIter=attribsMap.find(L"HTMLAttrib::aria-modal"))!=attribsMap.end()&&tempIter->second==L"true";
+
 	// get parent's formatState
 	unsigned int formatState=0;
 	if(parentNode) {
@@ -1128,7 +1131,7 @@ if(!(formatState&FORMATSTATE_INSERTED)&&nodeName.compare(L"INS")==0) {
 	} else if(nodeName.compare(L"BR")==0) {
 		LOG_DEBUG(L"node is a br tag, adding a line feed as its text.");
 		contentString=L"\n";
-	} else if((!isRoot&&(IARole==ROLE_SYSTEM_APPLICATION||IARole==ROLE_SYSTEM_DIALOG))
+	} else if((!isRoot&&(IARole==ROLE_SYSTEM_APPLICATION||(isModal&&IARole==ROLE_SYSTEM_DIALOG)))
 		||IARole==ROLE_SYSTEM_OUTLINE
 		||nodeName.compare(L"MATH")==0
 	) {

--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -770,6 +770,9 @@ class MSHTML(IAccessible):
 		ariaInvalid=self.HTMLAttributes['aria-invalid']
 		if ariaInvalid=="true":
 			states.add(controlTypes.STATE_INVALID_ENTRY)
+		ariaModal=self.HTMLAttributes['aria-modal']
+		if ariaModal=="true":
+			states.add(controlTypes.STATE_MODAL)
 		ariaGrabbed=self.HTMLAttributes['aria-grabbed']
 		if ariaGrabbed=="true":
 			states.add(controlTypes.STATE_DRAGGING)

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -668,6 +668,10 @@ class WebDialog(NVDAObject):
 	"""
 
 	def _get_shouldCreateTreeInterceptor(self):
-		if self.parent.treeInterceptor:
-			return True
-		return False
+		if controlTypes.STATE_MODAL not in self.states:
+			# Non-modal dialogs should not get a treeInterceptor by default 
+			return False
+		elif not self.parent.treeInterceptor:
+			# Dialogs not part of an existing treeInterceptor should not get  their own treeInterceptor by default.
+			return False
+		return True


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
The aria-modal html attribute was added to ARIA 1.1 to state whether a dialog / alertdialog is modal or not. Modal means that the user cannot interact with anything else in the application while the dialog is currently visible. 
Currently NVDA treets all web dialogs as modal as it  gives the dialog a new browseMode document, limited to that dialog, and also does not render any of the dialog's content in the existing parent browseMode document.
To conform with aria-modal, it should only do this if aria-modal is true, and otherwise keep the dialog as part of the parent browseMode document.

### Description of how this pull request fixes the issue:
* MSHTML NVDAObject: map aria-modal="true"  to NVDA's STATE_MODAL.
* MSHTML vbufBackend: only refuse to render the content of a dialog if the dialog node has aria-modal="true".
* Gecko/Chrome vbufBackend: only refuse to render the content of a dialog if the dialog node has aria-modal="true".
* No longer set focus to dialogs in browseMode when pressing enter on them if they do not have the modal state. 
* WebDialog NVDAObject behaviour: shouldCreateTreeInterceptor now refuses to create a treeInterceptor for a dialog if it does not have the modal state.

In short, now if a web dialog is not modal, all of its content will appear in the existing browseMode document. However, if the dialog is modal, then  its content will not be accessible in the existing browseMode document, and a new browseMode document limited to the dialog will be used. This was the previous behaviour for all web dialogs.

### Testing performed:
Using the html testcase: 
[dialog-modal-modeless.html.txt](https://github.com/nvaccess/nvda/files/1930487/dialog-modal-modeless.html.txt)

Tested modal and non-modal dialogs in Chrome, Firefox and Internet Explorer.
 1. Open the testcase in the browser
2. in BrowseMode arrow to the modal dialog button and activate it.
3. Ensure that NVDA reads the content of the dialog.
4. Ensure that it is impossible to arrow outside of this dialog in browseMode.
5. Dismiss the dialog by pressing Ok.
6. Activate the modeless dialog button.
7. Ensure NVDA reads the content of the dialog.
8. Ensure that arrowing up and down can move out of the dialog content and down to the original dialog buttons.

### Known issues with pull request:
Behaviour for any web dialog that does not specify aria-modal at all will now act as though aria-modal="false". It previously would have acted like aria-modal="true". However, this seems to be in line with the ARIA specification. Web authors should explicitly apply aria-modal to be clar what they want in future.
  
### Change log entry:
Changes:
Some dialogs on the web that are not specifically treeted as modal dialogs now appear in the same browseMode document as the surrounding web document, rather than getting their own browseMode document.