### PR TITLE
Fix Smart Beetle scroll keys

### DIFF
--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2017 Gianluca Casalino, NV Access Limited, Babbage B.V., Leonard de Ruijter, Bram Duvigneau
+#Copyright (C) 2010-2018 Gianluca Casalino, NV Access Limited, Babbage B.V., Leonard de Ruijter, Bram Duvigneau
 
 import _winreg
 import serial
@@ -69,7 +69,9 @@ class Model(AutoPropertyObject):
 			0x02<<8: "f1",
 			0x04<<8: "f2",
 			0x08<<8: "f3",
-			0x10<<8: "f4"
+			0x10<<8: "f4",
+			0x20<<8: "leftSideScroll",
+			0x40<<8: "rightSideScroll"
 		})
 
 class BrailleSense(Model):
@@ -81,8 +83,6 @@ class BrailleSense(Model):
 	def _get_keys(self):
 		keys = super(BrailleSense, self)._get_keys()
 		keys.update({
-			0x20<<8: "leftSideScroll",
-			0x40<<8: "rightSideScroll",
 			0x01<<16: "leftSideScrollUp",
 			0x02<<16: "leftSideScrollDown",
 			0x04<<16: "rightSideScrollUp",

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -71,7 +71,7 @@ class Model(AutoPropertyObject):
 			0x08<<8: "f3",
 			0x10<<8: "f4",
 			0x20<<8: "leftSideScroll",
-			0x40<<8: "rightSideScroll"
+			0x40<<8: "rightSideScroll",
 		})
 
 class BrailleSense(Model):


### PR DESCRIPTION
### Link to issue number:
Fixes #6086

### Summary of the issue:
The Hims Smart Beetle has an internal issue, allowing both the left and right scroll key to send two different key codes, one key code specific to the Braille Sense Classic, and one specific to the Smart Beetle. This has initially been fixed, but regressed again in #7865, for which I'd like to say sorry.

### Description of how this pull request fixes the issue:
Moved the two scroll keys that were missing from the SmartBeetle model class from the BrailleSense2S class to the base Model class.

### Testing performed:
With a Smart Beetle, I no longer intentionally received the "Unknown key" message in the NVDA log.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
   * Detection of scroll keys on Hims Smart Beetle displays is once more no longer unreliable. (#6086)
