### PR TITLE
Updated app module to work properly with total comander 64bit

### DIFF
--- a/source/appModules/totalcmd64.py
+++ b/source/appModules/totalcmd64.py
@@ -1,2 +1,49 @@
-#Use the app module for Total Commander 32 bit version.
-from totalcmd import *
+#appModules/totalcmd.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2012 NVDA Contributors
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import appModuleHandler
+from NVDAObjects.IAccessible import IAccessible
+import speech
+import controlTypes
+import ui
+
+oldActivePannel=0
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if obj.windowClassName in ("LCLListBox", "LCLListBox.UnicodeClass"):
+			clsList.insert(0, TCList)
+
+class TCList(IAccessible):
+
+	def event_gainFocus(self):
+		global oldActivePannel
+		if oldActivePannel !=self.windowControlID:
+			oldActivePannel=self.windowControlID
+			obj=self
+			while obj and obj.parent and obj.parent.windowClassName!="TTOTAL_CMD":
+				obj=obj.parent
+			counter=0
+			while obj and obj.previous and obj.windowClassName!="TPanel":
+				obj=obj.previous
+				if obj.windowClassName!="TDrivePanel":
+					counter+=1
+			if counter==3:
+				ui.message(_("left"))
+			else:
+				ui.message(_("right"))
+		super(TCList,self).event_gainFocus()
+
+	def reportFocus(self):
+		if self.name:
+			speakList=[]
+			if controlTypes.STATE_SELECTED in self.states:
+				speakList.append(controlTypes.stateLabels[controlTypes.STATE_SELECTED])
+			speakList.append(self.name.split("\\")[-1])
+			speech.speakMessage(" ".join(speakList))
+		else:
+			super(TCList,self).reportFocus()


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Creating this pull request on behalf of @novalis7747!
In Total commander 64bit, NVDA does not report the same information compared to Total Commander 32bit. It does not announce selections and left and right panels.

### Description of how this pull request fixes the issue:
The app module "totalcmd64.py" links to "totalcmd.py" which is wrong since total commander 64bit has other class names for list views than the 32bit version. Thus, "totalcmd.py" is mostly copied into "totalcmd64.py" with following exceptions:
1. The classname "TMyListBox" changed to "LCLListBox"
2. The counters to determine if the cursor is on the left or right panel changed from "if counter==2:" to "if counter==3:"

### Testing performed:
Yes, with different versions of Total Commander 64bit.

### Known issues with pull request:
None

### Change log entry:
* Changes