### PR TITLE
Rename BrailleDisplayGesture.routingIndex to index, and add the index to the display name of gestures

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2148,7 +2148,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 	"""A button, wheel or other control pressed on a braille display.
 	Subclasses must provide L{source} and L{id}.
 	Optionally, L{model} can be provided to facilitate model specific gestures.
-	L{routingIndex} should be provided for routing buttons.
+	L{index} should be provided for routing buttons or other gestures that have an index.
 	Subclasses can also inherit from L{brailleInput.BrailleInputGesture} if the display has a braille keyboard.
 	If the braille display driver is a L{baseObject.ScriptableObject}, it can provide scripts specific to input gestures from this display.
 	"""
@@ -2180,9 +2180,16 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 		"""
 		raise NotImplementedError
 
-	#: The index of the routing key or C{None} if this is not a routing key.
-	#: @type: int
-	routingIndex = None
+	def _get_index(self):
+		"""@returns: The index (e.g. of a routing key). C{None} if this gesture has no index.
+		@rtype: int
+		"""
+		# L{routingINdex} is deprecated, but we provide backwards compatibility.
+		if getattr(self, "routingINdex", None) is not None:
+			log.debugWarning("Using deprecated routingIndex property for input gesture, "
+				"change or update your braille display driver to use index instead")
+			return self.routingIndex
+		return None
 
 	def _get_identifiers(self):
 		ids = [u"br({source}):{id}".format(source=self.source, id=self.id)]

--- a/source/braille.py
+++ b/source/braille.py
@@ -2207,7 +2207,10 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 			name = brailleInput.BrailleInputGesture._get_displayName(self)
 			if name:
 				return name
-		return self.id
+		id = self.id
+		if self.index is not None:
+			id = "%s %d" % (id, self.index+1)
+		return id
 
 	def _get_scriptableObject(self):
 		display = handler.display

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -440,10 +440,10 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			if group == ALVA_CR_GROUP:
 				if number & ALVA_2ND_CR_MASK:
 					names.append("secondRouting")
-					self.routingIndex = number & ~ALVA_2ND_CR_MASK
+					self.index = number & ~ALVA_2ND_CR_MASK
 				else:
 					names.append("routing")
-					self.routingIndex = number
+					self.index = number
 			else:
 				try:
 					names.append(ALVA_KEYS[group][number])

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -346,11 +346,11 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			if group == BAUM_ROUTING_KEYS:
 				for index in xrange(braille.handler.display.numCells):
 					if groupKeysDown & (1 << index):
-						self.routingIndex = index
+						self.index = index
 						names.append("routing")
 						break
 			elif group == BAUM_ROUTING_KEY:
-				self.routingIndex = groupKeysDown - 1
+				self.index = groupKeysDown - 1
 				names.append("routing")
 			else:
 				for index, name in enumerate(KEY_NAMES[group]):

--- a/source/brailleDisplayDrivers/brailleNote.py
+++ b/source/brailleDisplayDrivers/brailleNote.py
@@ -267,6 +267,6 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			names.update(_dotNames[1 << i] for i in xrange(8)
 					if (1 << i) & dots)
 		elif routing is not None:
-			self.routingIndex = routing
+			self.index = routing
 			names.add('routing')
 		self.id = "+".join(names)

--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -336,7 +336,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 					self.space = False
 			if key >= FIRST_ROUTING_KEY:
 				names.append("routing")
-				self.routingIndex = key - FIRST_ROUTING_KEY
+				self.index = key - FIRST_ROUTING_KEY
 			else:
 				try:
 					names.append(KEY_NAMES[key])

--- a/source/brailleDisplayDrivers/brltty.py
+++ b/source/brailleDisplayDrivers/brltty.py
@@ -108,4 +108,4 @@ class InputGesture(braille.BrailleDisplayGesture):
 		super(InputGesture, self).__init__()
 		self.id = BRLAPI_CMD_KEYS[command]
 		if command == brlapi.KEY_CMD_ROUTE:
-			self.routingIndex = argument
+			self.index = argument

--- a/source/brailleDisplayDrivers/ecoBraille.py
+++ b/source/brailleDisplayDrivers/ecoBraille.py
@@ -263,4 +263,4 @@ class InputGestureRouting(braille.BrailleDisplayGesture):
 	def __init__(self, index):
 		super(InputGestureRouting, self).__init__()
 		self.id = "routing"
-		self.routingIndex = index-1
+		self.index = index-1

--- a/source/brailleDisplayDrivers/eurobraille.py
+++ b/source/brailleDisplayDrivers/eurobraille.py
@@ -619,7 +619,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 				if groupKeysDown & 0x100:
 					names.append("backSpace")
 			if group == EB_KEY_INTERACTIVE: # Routing
-				self.routingIndex = (groupKeysDown & 0x3f)-1
+				self.index = (groupKeysDown & 0x3f)-1
 				names.append("doubleRouting" if groupKeysDown>>8 ==ord(EB_KEY_INTERACTIVE_DOUBLE_CLICK) else "routing")
 			if group == EB_KEY_COMMAND:
 				for key, keyName in display.keys.iteritems():

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -296,10 +296,10 @@ class RoutingGesture(InputGesture):
 
 	def __init__(self,routingIndex,topRow=False):
 		if topRow:
-			self.id="topRouting%d"%(routingIndex+1)
+			self.id="topRouting"
 		else:
 			self.id="routing"
-			self.routingIndex=routingIndex
+		self.index=routingIndex
 		super(RoutingGesture,self).__init__()
 
 class WizWheelGesture(InputGesture):

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -943,7 +943,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			elif isBrailleInput and key in KEY_DOTS:
 				names.append("dot%d"%KEY_DOTS[key])
 			elif KEY_ROUTING <= key < KEY_ROUTING + model.numCells:
-				self.routingIndex = key - KEY_ROUTING
+				self.index = key - KEY_ROUTING
 				names.append("routing")
 			else:
 				try:

--- a/source/brailleDisplayDrivers/hedoMobilLine.py
+++ b/source/brailleDisplayDrivers/hedoMobilLine.py
@@ -200,4 +200,4 @@ class InputGestureRouting(braille.BrailleDisplayGesture):
 		super(InputGestureRouting, self).__init__()
 
 		self.id = "routing"
-		self.routingIndex = index
+		self.index = index

--- a/source/brailleDisplayDrivers/hedoProfiLine.py
+++ b/source/brailleDisplayDrivers/hedoProfiLine.py
@@ -197,4 +197,4 @@ class InputGestureRouting(braille.BrailleDisplayGesture):
 		super(InputGestureRouting, self).__init__()
 
 		self.id = "routing"
-		self.routingIndex = index
+		self.index = index

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -733,5 +733,5 @@ class RoutingInputGesture(braille.BrailleDisplayGesture):
 
 	def __init__(self, routingINdex):
 		super(RoutingInputGesture, self).__init__()
-		self.routingIndex = routingINdex
+		self.index = routingINdex
 		self.id = "routing"

--- a/source/brailleDisplayDrivers/lilli.py
+++ b/source/brailleDisplayDrivers/lilli.py
@@ -114,4 +114,4 @@ class InputGesture(braille.BrailleDisplayGesture):
 		super(InputGesture, self).__init__()
 		self.id = command
 		if (command == LILLI_KEYS[65]):
-			self.routingIndex = argument
+			self.index = argument

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -549,11 +549,11 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 
 		if(driver._baud==1):#brxcom
 			if(keys>255 and keys<512):
-				self.routingIndex = keys-256-driver._voffset
+				self.index = keys-256-driver._voffset
 				self.id = "route"
 				return None
 			elif(keys>511 and keys <786):
-				self.routingIndex = keys-512-driver._voffset
+				self.index = keys-512-driver._voffset
 				self.id="upperRouting"
 				return None
 			else:
@@ -569,7 +569,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 
 		if(len(decodedkeys)==1 and decodedkeys[0]>=32 and decodedkeys[0]<32+driver.numCells*2):
 			#routing keys
-			self.routingIndex = (decodedkeys[0]-32)/2
+			self.index = (decodedkeys[0]-32)/2
 			self.id = "route"
 			if(decodedkeys[0] % 2 == 1):
 				self.id="upperRouting"

--- a/source/brailleDisplayDrivers/papenmeier_serial.py
+++ b/source/brailleDisplayDrivers/papenmeier_serial.py
@@ -260,10 +260,10 @@ class InputGesture(braille.BrailleDisplayGesture):
 			self.id = driver._lastkey
 			return
 		if(pressed==1 and keyindex>=0):
-			self.routingIndex = keyindex-driver._offsetHorizontal
+			self.index = keyindex-driver._offsetHorizontal
 			self.id = "route"
 			if(keyindex>255):
-				self.routingIndex -= 256
+				self.Index -= 256
 				self.id = "upperRouting"
 		elif(pressed == 0):
 			k = brl_keyname(keyindex, driver)

--- a/source/brailleDisplayDrivers/seika.py
+++ b/source/brailleDisplayDrivers/seika.py
@@ -186,4 +186,4 @@ class InputGestureRouting(braille.BrailleDisplayGesture):
 		super(InputGestureRouting, self).__init__()
 
 		self.id = "routing"
-		self.routingIndex = index
+		self.index = index

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1915,13 +1915,13 @@ class GlobalCommands(ScriptableObject):
 	script_braille_scrollForward.category=SCRCAT_BRAILLE
 
 	def script_braille_routeTo(self, gesture):
-		braille.handler.routeTo(gesture.routingIndex)
+		braille.handler.routeTo(gesture.index)
 	# Translators: Input help mode message for a braille command.
 	script_braille_routeTo.__doc__ = _("Routes the cursor to or activates the object under this braille cell")
 	script_braille_routeTo.category=SCRCAT_BRAILLE
 
 	def script_braille_reportFormatting(self, gesture):
-		info = braille.handler.getTextInfoForWindowPos(gesture.routingIndex)
+		info = braille.handler.getTextInfoForWindowPos(gesture.index)
 		if info is None:
 			# Translators: Reported when trying to obtain formatting information (such as font name, indentation and so on) but there is no formatting information for the text under cursor.
 			ui.message(_("No formatting information"))


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
1. BrailleDisplayGestures have a routingIndex property that is used for scripts that route the cursor to a cell or report text formatting for a braille cell. However, there are more cases where setting an index for a gesture is imaginable, such as for Handy Tech ATC where the display registers when you touch a particular cell. Using routingINdex doesn't make much sense in these cases.
2. When pressing a routing button in input help, NVDA only reports routing and doesn't speak the index.

### Description of how this pull request fixes the issue:
1. Rename routingIndex to index in the braille module, globalCommands, and in every braille display driver that implements routing. Index is now an auto property on BrailleDisplayGesture, which allows falling back to the deprecated routingIndex for drivers that haven't yet been updated. For every retrieval of routingIndex using the index dproperty, a debugWarning is logged.
2. In BrailleDisplayGesture, when index is not None, increment the index by one and add it to the display name of the gesture. This allows the index to be reported in input help, without touching the identifier(s) of the gesture.

### Testing performed:
Tested with a Handy Tech Active Braille, NVDA properly reports the index of the pressed routing button in input help.

### Known issues with pull request:
* Handy Tech displays allow pressing multiple routing buttons at once. In this case, NVDA creates an input gesture, however it only has one index. Therefore, when pressing routing 1 and routing 40, NVDA reports "routing + routing 40". We have two options here:

	+ Change gesture.keyNames into a set, in which case "routing" is in the set of names only once
	+ Add the indexes in the gesture identifier. I guess this is more elegant if done properly (i.e. it shouldn't break script assignment to the whole row of routing keys), however it is of course much more work.

### Change log entry:
* Changes
    + When in input help, pressing a routing key on a braille display now reports the index of the pressed key.

* Changes for developers
    + The routingIndex property on braille display gestures has been renamed to index.
        - routingINdex is still supported for backwards compatibility. However, using it will log a deprecation warning.