### PR TITLE
Both sleep before and after closing the connection to a handy tech display

### DIFF
--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -661,10 +661,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		try:
 			super(BrailleDisplayDriver, self).terminate()
 		finally:
+			# We must sleep before closing the  connection as not doing this can leave the display in a bad state where it can not be re-initialized.
+			# This has been observed for Easy Braille displays.
+			time.sleep(self.timeout)
 			# Make sure the device gets closed.
-			# If it doesn't, we may not be able to re-open it later.
 			self._dev.close()
-			# We must sleep after closing, as it sometimes takes some time for the device to disconnect.
+			# We also must sleep after closing, as it sometimes takes some time for the device to disconnect.
+			# This has been observed for Active Braille displays.
 			time.sleep(self.timeout)
 
 	def _get_atc(self):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Some Handy Tech displays have problems with NVDA rapidly reconnecting to a device. In these cases, (i.e. by choosing the Handy Tech driver from the braille selection dialog while it was already connected), NVDA will show the error message telling that a device can't be found. This includes the following cases:

* Active Braille: When there is no sleep time of at least 0.2 seconds **after** closing the com port to the Bluetooth interface.
* Easy Braille: When there is no sleep time of at least 0.2 seconds **before** closing the com port to the Bluetooth interface.

More technically, connecting to the Bluetooth COM port in both cases results into an access denied error.

### Description of how this pull request fixes the issue:
To stay on the safe side, this pr will make the handy tech driver sleep 0.2 seconds before and 0.2 seconds after closing the connection to a device. While indeed, it slows things down, it improves things in a major way for both the Active Braille and Easy Braille devices. it is also most likely that other displays suffer from one of the two cases above.

### Testing performed:
Tested rapid reconnection for Active Braille and Easy Braille displays over Bluetooth.

### Known issues with pull request:
* It is basically a work around. May be we should consider flushing serial buffers, but in that case, it is still possible that the back ground thread writes to a display while we're closing it.

### Change log entry:
None. I think it will suffice to say that this is related to the stability improvements that have been introduced in #8016