### PR TITLE
Properly show both the alt and windows key toggle gestures in the input gestures dialog

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2017,8 +2017,8 @@ class GlobalCommands(ScriptableObject):
 	def script_braille_toggleWindows(self, gesture):
 		brailleInput.handler.toggleModifier("leftWindows")
 	# Translators: Input help mode message for a braille command.
-	script_braille_toggleAlt.__doc__= _("Virtually toggles the left windows key to emulate a keyboard shortcut with braille input")
-	script_braille_toggleAlt.category=inputCore.SCRCAT_KBEMU
+	script_braille_toggleWindows.__doc__= _("Virtually toggles the left windows key to emulate a keyboard shortcut with braille input")
+	script_braille_toggleWindows.category=inputCore.SCRCAT_KBEMU
 	script_braille_toggleAlt.bypassInputHelp = True
 
 	def script_braille_toggleNVDAKey(self, gesture):


### PR DESCRIPTION
### Link to issue number:
Fixes #8233 

### Summary of the issue:
In Input gestures/Emulated system keyboard keys, there is no entry to virtually toggle the state of the alt key.

### Description of how this pull request fixes the issue:
In the script declaration for the windows key toggle, the doc string and category were accidentally overridden on the alt key toggle script rather than set on the windows key toggle script. This has now been fixed.

### Testing performed:
Made sure that both the alt and left window key scripts now show up in the input gestures dialog.

### Known issues with pull request:
None

### Change log entry:
None, as this code hasn't been in a release yet.