### PR TITLE
TotalCMD for 32 and 64bit of TC

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -354,7 +354,7 @@ class AutoCompleteListItem(IAccessible):
 			address = self.name
 			if address:
 				speech.cancelSpeech()
-				ui.message(self.name)
+				ui.message(self.name).queue
 
 class CalendarView(IAccessible):
 	"""Support for announcing time slots and appointments in Outlook Calendar.

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -351,8 +351,10 @@ class AutoCompleteListItem(IAccessible):
 		states=self.states
 		focus=api.getFocusObject()
 		if (focus.role==controlTypes.ROLE_EDITABLETEXT or focus.role==controlTypes.ROLE_BUTTON) and controlTypes.STATE_SELECTED in states and controlTypes.STATE_INVISIBLE not in states and controlTypes.STATE_UNAVAILABLE not in states and controlTypes.STATE_OFFSCREEN not in states:
-			speech.cancelSpeech()
-			ui.message(self.name)
+			address = self.name
+			if address:
+				speech.cancelSpeech()
+				ui.message(self.name)
 
 class CalendarView(IAccessible):
 	"""Support for announcing time slots and appointments in Outlook Calendar.

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -13,7 +13,6 @@ import ui
 currIndex = 0
 allIndex = 0
 oldActivePannel=0
-windowName = ""
 
 class AppModule(appModuleHandler.AppModule):
 
@@ -30,7 +29,6 @@ class TCList(IAccessible):
 
 	def event_gainFocus(self):
 		global oldActivePannel
-		global windowName
 		if oldActivePannel !=self.windowControlID:
 			oldActivePannel=self.windowControlID
 			obj=self
@@ -42,10 +40,8 @@ class TCList(IAccessible):
 			try:
 				if obj2.parent.parent.previous.firstChild.role  == 14:
 					ui.message(_("left"))
-					windowName = "left"
 				else:
 					ui.message(_("right"))
-					windowName = "right"
 			except AttributeError:
 				pass
 		super(TCList,self).event_gainFocus()
@@ -63,57 +59,3 @@ class TCList(IAccessible):
 			speech.speakMessage(" ".join(speakList))
 		else:
 			super(TCList,self).reportFocus()
-
-	def script_readActiveTab(self, gesture):
-		try:
-			obj = self.parent.parent.next.next.firstChild.firstChild.firstChild
-			children = obj.children
-			for child in children:
-				if controlTypes.STATE_SELECTED in child.states:
-					infoString = (" %s %s" % (_(windowName), child.name))
-					ui.message(infoString)
-		except AttributeError:
-			pass
-
-		try:
-			obj = self.parent.parent.next.next.next.next.firstChild.firstChild.firstChild
-			children = obj.children
-			for child in children:
-				if controlTypes.STATE_SELECTED in child.states:
-					infoString = (" %s %s" % (_(windowName), child.name))
-					ui.message(infoString)
-		except AttributeError:
-			pass
-		if not children:
-			try:
-				obj = self.parent.parent.next.next.firstChild
-				children = obj.children
-				str2 = ":\\"
-				for child in children:
-					str1 = child.name
-					if child.name:
-						if str1.find(str2) != -1:
-							if windowName == "left":
-								infoString = (" %s %s" % (_(windowName), str1))
-								ui.message(infoString)
-			except AttributeError:
-				pass
-		
-			try:
-				obj = self.parent.parent.next.next.next.next.firstChild
-				children = obj.children
-				str2 = ":\\"
-				for child in children:
-					str1 = child.name
-					if child.name:
-						if str1.find(str2) != -1:
-							infoString = (" %s %s" % (_(windowName), str1))
-							ui.message(infoString)
-			except AttributeError:
-				pass
-
-
-	__gestures = {
-		"kb:ALT+1": "readActiveTab",
-	}
-

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -56,7 +56,7 @@ class TCList(IAccessible):
 	def reportFocus(self):
 		if self.name:
 			currIndex = self.IAccessibleChildID
-			allIndex = len(self.parent.children)
+			allIndex = self.parent.childCount
 			indexString = (" %s of %s" % (currIndex, allIndex))
 			speakList=[]
 			if controlTypes.STATE_SELECTED in self.states:

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -11,27 +11,40 @@ import controlTypes
 import ui
 
 oldActivePannel=0
+x64trigger = 0
 
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if obj.windowClassName in ("TMyListBox", "TMyListBox.UnicodeClass"):
-			clsList.insert(0, TCList)
+		if self.is64BitProcess:
+			if obj.windowClassName in ("LCLListBox", "LCLListBox.UnicodeClass"):
+				clsList.insert(0, TCList)
+		else:
+			x64trigger = 0
+			if obj.windowClassName in ("TMyListBox", "TMyListBox.UnicodeClass"):
+				clsList.insert(0, TCList)
+
 
 class TCList(IAccessible):
 
 	def event_gainFocus(self):
 		global oldActivePannel
+		global x64trigger
 		if oldActivePannel !=self.windowControlID:
 			oldActivePannel=self.windowControlID
 			obj=self
 			while obj and obj.parent and obj.parent.windowClassName!="TTOTAL_CMD":
 				obj=obj.parent
 			counter=0
-			while obj and obj.previous and obj.windowClassName!="TPanel":
+			while obj and obj.previous and obj.windowClassName!="Window":
 				obj=obj.previous
 				if obj.windowClassName!="TDrivePanel":
 					counter+=1
+				if self.appModule.is64BitProcess:
+					if counter == 3:
+						x64trigger = 1
+			if x64trigger == 1:
+				counter-=1
 			if counter==2:
 				ui.message(_("left"))
 			else:

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -10,6 +10,8 @@ import speech
 import controlTypes
 import ui
 
+currIndex = 0
+allIndex = 0
 oldActivePannel=0
 x64trigger = 0
 
@@ -53,10 +55,14 @@ class TCList(IAccessible):
 
 	def reportFocus(self):
 		if self.name:
+			currIndex = self.IAccessibleChildID
+			allIndex = len(self.parent.children)
+			indexString = (" %s of %s" % (currIndex, allIndex))
 			speakList=[]
 			if controlTypes.STATE_SELECTED in self.states:
 				speakList.append(controlTypes.stateLabels[controlTypes.STATE_SELECTED])
 			speakList.append(self.name.split("\\")[-1])
+			speakList.append(indexString)
 			speech.speakMessage(" ".join(speakList))
 		else:
 			super(TCList,self).reportFocus()

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -50,7 +50,9 @@ class TCList(IAccessible):
 		if self.name:
 			currIndex = self.IAccessibleChildID
 			allIndex = self.parent.childCount
-			indexString = (" %s of %s" % (currIndex, allIndex))
+			if currIndex == 1: ui.message(_("Top"))
+			if allIndex == currIndex: ui.message(_("Bottom"))
+			indexString=_("{number} of {total}").format( number = currIndex, total = allIndex)
 			speakList=[]
 			if controlTypes.STATE_SELECTED in self.states:
 				speakList.append(controlTypes.stateLabels[controlTypes.STATE_SELECTED])

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -38,9 +38,11 @@ class TCList(IAccessible):
 			while obj and obj.previous and obj.windowClassName!="Window":
 				obj=obj.previous
 			try:
-				if obj2.parent.parent.previous.firstChild.role  == 14:
+				if obj2.parent.parent.previous.firstChild.role  == controlTypes.ROLE_LIST:
+					# Translators: the word left for the left window in your language (only the word left).
 					ui.message(_("left"))
 				else:
+					# Translators: the word right for the right window in your language (only the word right).
 					ui.message(_("right"))
 			except AttributeError:
 				pass
@@ -50,8 +52,13 @@ class TCList(IAccessible):
 		if self.name:
 			currIndex = self.IAccessibleChildID
 			allIndex = self.parent.childCount
-			if currIndex == 1: ui.message(_("Top"))
-			if allIndex == currIndex: ui.message(_("Bottom"))
+			if currIndex == 1:
+				# Translators: the word  Top for reaching the top of the list in your language (only the word Top).
+				ui.message(_("Top"))
+			if allIndex == currIndex:
+				# Translators: the word  Bottom for reaching the Bottom of the list in your language (only the word Bottom).
+				ui.message(_("Bottom"))
+			# Translators: the phrase "{number} of {total}" in an index like 1 of 32 in your language.
 			indexString=_("{number} of {total}").format( number = currIndex, total = allIndex)
 			speakList=[]
 			if controlTypes.STATE_SELECTED in self.states:


### PR DESCRIPTION

### Link to issue number:
> Please include the issue number here. This helps us to keep the information linked together. If this is a minor/trivial change an issue does not need to be created. If in doubt, please create one.

### Summary of the issue:
> A quick summary of the problem you are trying to solve.
TotalCMD.py does handle only 32bit of TC and TotalCMD64.py is linked to totalcmd.py what doesn't work for TC 64bit
### Description of how this pull request fixes the issue:
totalcmd.py is updated to handle 64bit TC, it checks if 32bit or 64bit TC is running and uses the required classes and controls. 
I also added a file index to the end of each list item (x of x)

### Testing performed:

### Known issues with pull request:
> Any known issues or downsides of this approach. For instance: _Will not work with python 3_

### Change log entry:
> The section and description of this change to use for the changes file. Valid sections are:
> 
> * New features
- added a file index to the end of each list item (x of x)
> * Changes
> * Bug fixes
>
> For examples see the changes file in your NVDA repo: `user_docs/en/changes.t2t` or on github: https://github.com/nvaccess/nvda/blob/master/user_docs/en/changes.t2t
