### PR TITLE
Fix accelerator conflict with apply button.

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -104,6 +104,7 @@ class SettingsDialog(wx.Dialog):
 			startTime = time.time()
 		windowStyle = wx.DEFAULT_DIALOG_STYLE | (wx.RESIZE_BORDER if resizeable else 0)
 		super(SettingsDialog, self).__init__(parent, title=self.title, style=windowStyle)
+		self.hasApply = hasApplyButton
 
 		# the wx.Window must be constructed before we can get the handle.
 		import windowUtils
@@ -115,22 +116,44 @@ class SettingsDialog(wx.Dialog):
 
 		self.mainSizer.Add(self.settingsSizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL | wx.EXPAND, proportion=1)
 		self.mainSizer.Add(wx.StaticLine(self), flag=wx.EXPAND)
-		buttonFlags = wx.OK|wx.CANCEL|(wx.APPLY if hasApplyButton else 0)
+
+		buttonSizer = guiHelper.ButtonHelper(wx.HORIZONTAL)
+		# Translators: The Ok button on a NVDA dialog. This button will accept any changes and dismiss the dialog.
+		buttonSizer.addButton(self, label=_("OK"), id=wx.ID_OK)
+		# Translators: The cancel button on a NVDA dialog. This button will discard any changes and dismiss the dialog.
+		buttonSizer.addButton(self, label=_("Cancel"), id=wx.ID_CANCEL)
+		if hasApplyButton:
+			# Translators: The Apply button on a NVDA dialog. This button will accept any changes but will not dismiss the dialog.
+			buttonSizer.addButton(self, label=_("Apply"), id=wx.ID_APPLY)
+
 		self.mainSizer.Add(
-			self.CreateButtonSizer(flags=buttonFlags),
+			buttonSizer.sizer,
 			border=guiHelper.BORDER_FOR_DIALOGS,
-			flag=wx.ALL|wx.ALIGN_RIGHT
+			flag=wx.ALL | wx.ALIGN_RIGHT
 		)
+
 		self.mainSizer.Fit(self)
 		self.SetSizer(self.mainSizer)
 
-		self.Bind(wx.EVT_BUTTON,self.onOk,id=wx.ID_OK)
-		self.Bind(wx.EVT_BUTTON,self.onCancel,id=wx.ID_CANCEL)
-		self.Bind(wx.EVT_BUTTON,self.onApply,id=wx.ID_APPLY)
+		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
+		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
+		self.Bind(wx.EVT_BUTTON, self.onApply, id=wx.ID_APPLY)
+		self.Bind(wx.EVT_CHAR_HOOK, self._enterTriggersOnOk_ctrlSTriggersOnApply)
+
 		self.postInit()
 		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)
 		if gui._isDebug():
 			log.debug("Loading %s took %.2f seconds"%(self.__class__.__name__, time.time() - startTime))
+
+	def _enterTriggersOnOk_ctrlSTriggersOnApply(self, evt):
+		"""Listens for keyboard input and triggers ok button on enter and triggers apply button when control + S is
+		pressed. Cancel behavior is built into wx"""
+		if evt.KeyCode == wx.WXK_RETURN:
+			self.onOk(evt)
+		elif self.hasApply and evt.UnicodeKey == ord(u'S') and evt.controlDown:
+			self.onApply(evt)
+		else:
+			evt.Skip()
 
 	def makeSettings(self, sizer):
 		"""Populate the dialog with settings controls.
@@ -724,7 +747,8 @@ class SpeechSettingsPanel(SettingsPanel):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: A label for the synthesizer on the speech panel.
 		synthLabel = _("&Synthesizer")
-		synthGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=synthLabel), wx.HORIZONTAL))
+		synthBox = wx.StaticBox(self, label=synthLabel)
+		synthGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(synthBox, wx.HORIZONTAL))
 		settingsSizerHelper.addItem(synthGroup)
 
 		# Use a ExpandoTextCtrl because even when readonly it accepts focus from keyboard, which
@@ -734,6 +758,7 @@ class SpeechSettingsPanel(SettingsPanel):
 		# display here.
 		synthDesc = getSynth().description
 		self.synthNameCtrl = ExpandoTextCtrl(self, size=(self.scaleSize(250), -1), value=synthDesc, style=wx.TE_READONLY)
+		self.synthNameCtrl.Bind(wx.EVT_CHAR_HOOK, self._enterTriggersOnChangeSynth)
 
 		# Translators: This is the label for the button used to change synthesizer,
 		# it appears in the context of a synthesizer group on the speech settings panel.
@@ -748,6 +773,12 @@ class SpeechSettingsPanel(SettingsPanel):
 
 		self.voicePanel = VoiceSettingsPanel(self)
 		settingsSizerHelper.addItem(self.voicePanel)
+
+	def _enterTriggersOnChangeSynth(self, evt):
+		if evt.KeyCode == wx.WXK_RETURN:
+			self.onChangeSynth(evt)
+		else:
+			evt.Skip()
 
 	def onChangeSynth(self, evt):
 		changeSynth = SynthesizerSelectionDialog(self, multiInstanceAllowed=True)
@@ -2033,10 +2064,17 @@ class BrailleSettingsPanel(SettingsPanel):
 				changeDisplayBtn
 			)
 		)
+		self.displayNameCtrl.Bind(wx.EVT_CHAR_HOOK, self._enterTriggersOnChangeDisplay)
 		changeDisplayBtn.Bind(wx.EVT_BUTTON,self.onChangeDisplay)
 
 		self.brailleSubPanel = BrailleSettingsSubPanel(self)
 		settingsSizerHelper.addItem(self.brailleSubPanel)
+
+	def _enterTriggersOnChangeDisplay(self, evt):
+		if evt.KeyCode == wx.WXK_RETURN:
+			self.onChangeDisplay(evt)
+		else:
+			evt.Skip()
 
 	def onChangeDisplay(self, evt):
 		changeDisplay = BrailleDisplaySelectionDialog(self, multiInstanceAllowed=True)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2050,7 +2050,9 @@ class BrailleSettingsPanel(SettingsPanel):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: A label for the braille display on the braille panel.
 		displayLabel = _("Braille &display")
-		displayGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=displayLabel), wx.HORIZONTAL))
+
+		displayBox = wx.StaticBox(self, label=displayLabel)
+		displayGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(displayBox, wx.HORIZONTAL))
 		settingsSizerHelper.addItem(displayGroup)
 		
 		displayDesc = braille.handler.display.description


### PR DESCRIPTION





### Link to issue number:
#8249 

### Summary of the issue:
The apply button shares an accelerator (in English, "alt+a") with other controls, when this accelerator is triggered for a button the button is activated. The only feedback that a user gets that this is the case is that the focus shifts to the categories list.

Since ok can be triggered with enter, and cancel with esc, it seems that apply should also have a keyboard shortcut.

### Description of how this pull request fixes the issue:
One considered idea was to remove the apply button, however we expect that some users use the apply button to test out different settings without having to reopen the settings dialog and find the settings that they were up to again. In the future we may move to a settings dialog that allows you to preview settings as soon as they are changed, only committing to the change when ok or cancel. This would allow us to remove the apply button and still support this use-case.

This commit stops the settings dialogs from using the "CreateButtonSizer" method, and instead we create the buttons manually. We add a binding for the "enter" key so that enter will still trigger the OK button. We also add a binding for "control + S" to trigger the apply button.

Also included is a change to resolve the annoying windows chime when pressing enter on the synthesiser name, or braille display name, the "...Change" button is now
triggered.

Because we are creating these buttons manually, we are able to translate the OK, Cancel, Apply for all our users.

### Testing performed:
* Enter / esc from categories list still accepts / discards changes 
* Enter on a button (such as synthesizer change button) still triggers the button
* Enter / esc on a checkbox item still accepts / discards changes
* Enter in an expanded dropdown list selects the current item
* Ctrl + s from a checkbox item applies settings and moves focus to the categories list
* Ctrl + s from the categories list applies settings
* Ctrl + s from the ok/cancel/apply buttons does apply settings
* Ctrl + tab shifts categories
* Enter on the synth label opens change synth dialog
* Enter on the braille display label opens the change braille display dialog

### Known issues with pull request:
There is still no explicit notification that settings have been applied other than focus shifting to the categories list.

### Change log entry:
**Changes**
`Settings can now be applied by using 'control + s' in the NVDA settings dialog. (#8249)`