### PR TITLE
Ignore UIA notification events with no valid NVDAObject

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -70,8 +70,8 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 			obj.APIClass=APIClass
 			if isinstance(obj,self):
 				obj.__init__(**kwargs)
-		except InvalidNVDAObject, e:
-			log.debugWarning("Invalid NVDAObject: %s" % e, stack_info=True)
+		except InvalidNVDAObject as e:
+			log.debugWarning("Invalid NVDAObject: %s" % e, exc_info=True)
 			return None
 
 		clsList = []

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -305,6 +305,10 @@ class UIAHandler(COMObject):
 			return
 		import NVDAObjects.UIA
 		obj=NVDAObjects.UIA.UIA(UIAElement=sender)
+		if not obj:
+			# Sometimes notification events can be fired on a UIAElement that has no windowHandle and does not connect through parents back to the desktop.
+			# There is nothing we can do with these.
+			return
 		eventHandler.queueEvent("UIA_notification",obj, notificationKind=NotificationKind, notificationProcessing=NotificationProcessing, displayString=displayString, activityId=activityId)
 
 	def _isUIAWindowHelper(self,hwnd):


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In windows 10 RS5 builds, Windows has started firing some UIA notification events with a UIAElement  that has no valid windowHandle and seems to not be connected via its ancestry back to the Desktop. Specifically  this has been seen for "tab closed" notification events.
We can't do anything useful with these events due to the missing windowHandle, yet they are logging as errors.
This was seen as an error in the log complaining that NoneType had no attribute sleepMode in executeEvent.

### Description of how this pull request fixes the issue:
1. In the UIA notification event handler method, don't que an NVDA event if we can't get a valid NVDAObject for the UIAElement.
2. When logging InvalidNVDAObject exceptions, make sure to log the actual exception traceback rather than the outer stack where the log call is being made. the stack was totally useless for debugging why InvalidNvDAObject exceptions were being raised.
This was noticed when debugging the UIA notification event.

### Testing performed:
Performed a task such as closing a message window in Thunderbird which causes the tab closed notification event to fire. Made sure that the original error about sleepMode is no longer logged.

### Known issues with pull request:
None.

### Change log entry:
None needed, it just suppresses a logged error.
