### PR TITLE
Support Win10 rs5 task switch list

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -233,8 +233,13 @@ class AppModule(appModuleHandler.AppModule):
 				clsList.insert(0, SuggestionListItem)
 			elif uiaClassName == "MultitaskingViewFrame" and role == controlTypes.ROLE_WINDOW:
 				clsList.insert(0, MultitaskingViewFrameWindow)
-			elif windowClass == "MultitaskingViewFrame" and role == controlTypes.ROLE_LISTITEM:
-				# Use windowClass here as there is no uiaClassName for these list items.
+			# Windows 10 task switch list
+			elif role == controlTypes.ROLE_LISTITEM and (
+				# RS4 and below we can match on a window class
+				windowClass == "MultitaskingViewFrame" or
+				# RS5 and above we must look for a particular UIA automationID on the list
+				isinstance(obj.parent,UIA) and obj.parent.UIAElement.cachedAutomationID=="SwitchItemListControl"
+			):
 				clsList.insert(0, MultitaskingViewFrameListItem)
 			elif uiaClassName == "UIProperty" and role == controlTypes.ROLE_EDITABLETEXT:
 				clsList.insert(0, UIProperty)


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In Windows 10 RS5, The Task switcher was re-written in XAML. Therefore this means ATs lost the ability to match on a particular window class in order to suppress reporting of the switch items' ancestry, thereby causing the switcher to be way too verbose.
Microsoft however did add a UIA automation ID to the switcher list for this purpose.

### Description of how this pull request fixes the issue:
Also look for the new UIA automation ID on the switcher list when choosing to use our task switcher item functionality.

### Testing performed:
Alt+tabbed around Windows with multiple apps open. Confirmed that only the app names were announced, rather than the task switching window itself also. Also confirmed that pressing windows+tab still correctly announced the task switch window as it should.
If someone could test on rs4 this would be great.


### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* In Windows 10 RS5, NVDA no longer reports extra redundant information when switching tasks with alt+tab.
