### PR TITLE
Expose grammar errors from IAccessible2 text.

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -79,8 +79,12 @@ def normalizeIA2TextFormatField(formatField):
 		invalid=formatField.pop("invalid")
 	except KeyError:
 		invalid=None
-	if invalid and invalid.lower()=="spelling":
-		formatField["invalid-spelling"]=True
+	if invalid:
+		invalid=invalid.lower()
+		if invalid=="spelling":
+			formatField["invalid-spelling"]=True
+		elif invalid=="grammar":
+			formatField["invalid-grammar"]=True
 	color=formatField.get('color')
 	if color:
 		try:


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
As well as spelling errors, IAccessible2 implementstions can also expose grammar errors. This may be through built-in support in the app itself, or  conveyed by the author via aria-invalid="grammar".
However, NVDA only looks for spelling errors from IAccessible2, not grammar errors.
Grammar errors in UIA are already supported.

### Description of how this pull request fixes the issue:
NVDA now supports the IAccessible2 text attribute: invalid:grammar, and maps it appropriately as the invalid-grammar=True attribute on formatFields so that it is spoken similar to spelling errors.
 
### Testing performed:
Using following html testcase: 
[invalidText.html.txt](https://github.com/nvaccess/nvda/files/2007663/invalidText.html.txt)
Tested in Firefox to ensure that NVDA announced grammar error at the appropriate place. (at the position of the second "to ").
Chrome does not yet expose grammar errors.

### Known issues with pull request:
None.

### Change log entry:
New features:
NVDA will report grammar errors when appropriately exposed by web pages in Mozilla Firefox.
