### PR TITLE
Fix reading empty columns in Windows Explorer on Windows 7

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -174,7 +174,10 @@ class UIProperty(UIA):
 	
 	def _get_value(self):
 		value = super(UIProperty, self).value
-		return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
+		if value == None:
+			return value
+		else:
+			return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -174,10 +174,9 @@ class UIProperty(UIA):
 	
 	def _get_value(self):
 		value = super(UIProperty, self).value
-		if value == None:
+		if value is None:
 			return value
-		else:
-			return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
+		return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 
 
 class AppModule(appModuleHandler.AppModule):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
After Merging #5729 it was no longer possible to read empty columns Such as size for folders in Windows Explorer on Windows 7, because those columns haven't got value under this OS.

### Description of how this pull request fixes the issue:
I've added conditional, which checks if value exist, and if not simply returns it without removing LTR and RTL marks.

### Testing performed:
Successfully read size column for folder in Windows 7
### Known issues with pull request:
None
### Change log entry:
None needed, because #5729 wasn't in a release yet.