### PR TITLE
Support aria-braille-input to allow web authors to accept unicode braille input

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -532,6 +532,9 @@ class MSHTML(IAccessible):
 			return virtualBuffers.MSHTML.MSHTML
 		return super(MSHTML,self).treeInterceptorClass
 
+	def _get_requiresUnicodeBrailleInput(self):
+		return self.HTMLAttributes['aria-braille-input']=="true"
+
 	def _get_isCurrent(self):
 		isCurrent = self.HTMLAttributes["aria-current"]
 		if isCurrent == "false":

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -47,6 +47,9 @@ class Ia2Web(IAccessible):
 			return False
 		return super(Ia2Web,self).isPresentableFocusAncestor
 
+	def _get_requiresUnicodeBrailleInput(self):
+		return self.IA2Attributes.get('braille-input')=="true"
+
 class Document(Ia2Web):
 	value = None
 

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -471,6 +471,9 @@ class EdgeNode(UIA):
 			return valueOfAriaCurrent
 		return None
 
+	def _get_requiresUnicodeBrailleInput(self):
+		return self.ariaProperties.get('braille-input')=="true"
+
 	def _get_placeholder(self):
 		ariaPlaceholder = self.ariaProperties.get('placeholder', None)
 		return ariaPlaceholder

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -400,6 +400,9 @@ class NVDAObject(documentBase.TextContainerObject,baseObject.ScriptableObject):
 		"""
 		return None
 
+	#: Whether this control requires that braille input from a braille display should be sent directly to the control as unicode braille, rather than translated into standard text first.
+	requiresUnicodeBrailleInput=False
+
 	def _get_value(self):
 		"""The value of this object (example: the current percentage of a scrollbar, the selected option in a combo box).
 		@rtype: basestring


### PR DESCRIPTION
### Link to issue number:
None.


### Summary of the issue:
Web authors have asked for a way to have their controls accept raw braille input. An example where this would be useful would be an online math editor that could allow the user to directly type in Nemeth braille input on a Braille display.

### Description of how this pull request fixes the issue:
A new aria-braille-input attribute is going to be proposed to the ARIA working group for consideration (see https://github.com/w3c/aria/issues/771). NVDA looks for this property in all web browsers, and maps it to a new requiresUnicodeBrailleInput property on NVDAObjects.
If this property is true on the control with focus, then NVDA will automatically use the unicode braille table for braille input rather than the currently configured input braille table.

### Testing performed:
Testcase: https://sinabahram.github.io/aria-playground/BrailleInput.html
The first control takes normal text, the second control takes braille input (as aria-braille-input has a value of "true").
Tested in Firefox and Internet Explorer.

### Known issues with pull request:
Although NVDA supports this property in IA2, MSHTML and UIA, it does not currently work in Edge or Chrome due to these browsers not exposing unknown ARIA properties.
 
### Change log entry:
