### PR TITLE
Revert announcement of replied and forwarded state in Outlook

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,7 +21,6 @@ Highlights of this release include Support for tables in Kindle for PC, support 
  - You can assign these new modifier toggles using the commands found under Emulated system keyboard keys in the Input gestures dialog.
 - Restored support for Handy Tech Braillino and Modular (with old firmware) displays. (#8016)
 - Date and time for supported Handy Tech devices (such as Active Braille and Active Star) will now automatically be synchronized by NVDA when out of sync more than five seconds. (#8016)
-- In Microsoft Outlook message lists, NVDA now reports if a message has been replied to or forwarded. (#6911)
 - An input gesture can be assigned to temporarily disable all configuration profile triggers. (#4935)
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #8351

### Summary of the issue:
For German version if Outlook, when replying to an e-mail, the read state is announced instead of the answered state. It turns out that the German version of Outlook (and probably other languages) expose the message parameters in the UIA value in a different order.

### Description of how this pull request fixes the issue:
Reverts the Outlook message list behavior to the 2018.1 state, with the following exceptions:

* Associated drafts are still reported
* There is still a safety check in case UIA doesn't expose children to build the message object's name.

### Testing performed:
Tested whether the messages reporting behavior is equal to NVDA 2018.1

### Known issues with pull request:
None

### Change log entry:
None. However, I removed the replied to and forwarded change from the English changes file. We might have to discuss what to do with translations. May be do an announcement on the translations list for a two days window of reverting the change? Note that Master is still equal to RC, as far as I can see.