### PR TITLE
Remove circuluar reference from MultiCategorySettings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -381,7 +381,6 @@ class MultiCategorySettingsDialog(SettingsDialog):
 
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
-		self.sHelper = sHelper
 
 		# Translators: The label for the list of categories in a multi category settings dialog.
 		categoriesLabelText=_("&Categories:")


### PR DESCRIPTION
### Link to issue number:
Described in https://github.com/nvaccess/nvda/pull/7104#pullrequestreview-126254699

### Summary of the issue:
The upgrade to WX Python 4 revealed a circular reference caused by a BoxSizerHelper stored on the MultiCategorySettingsDialog instances. This BoxSizerHelper was unnecessarily stored as object attribute.

### Description of how this pull request fixes the issue:
No longer store the BoxSizerHelper on the object.

### Testing performed:
Testing performed by @josephsl as part of #7104

### Known issues with pull request:
None

### Change log entry:
None