### PR TITLE
NvDA/AppX: do not present 'restart with add-ons disabled' in exit dialog as this edition does not support add-ons yet

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -23,7 +23,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.15063.0" 
-			MaxVersionTested="10.0.16278.100" 
+			MaxVersionTested="10.0.17134.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -800,12 +800,14 @@ class ExitDialog(wx.Dialog):
 			# Translators: An option in the combo box to choose exit action.
 			_("Exit"),
 			# Translators: An option in the combo box to choose exit action.
-			_("Restart"),
-			# Translators: An option in the combo box to choose exit action.
-			_("Restart with add-ons disabled"),
-			# Translators: An option in the combo box to choose exit action.
-			_("Restart with debug logging enabled")
+			_("Restart")
 		]
+		# Windows Store version of NVDA does not support add-ons yet.
+		if not config.isAppX:
+			# Translators: An option in the combo box to choose exit action.
+			self.actions.append(_("Restart with add-ons disabled"))
+		# Translators: An option in the combo box to choose exit action.
+		self.actions.append(_("Restart with debug logging enabled"))
 		if updateCheck and updateCheck.isPendingUpdate():
 			# Translators: An option in the combo box to choose exit action.
 			self.actions.append(_("Install pending update"))
@@ -825,6 +827,9 @@ class ExitDialog(wx.Dialog):
 
 	def onOk(self, evt):
 		action=self.actionsList.GetSelection()
+		# Because Windows Store version of NVDA does not support add-ons yet, add 1 if action is 2 or above if this is such a case.
+		if action >= 2 and config.isAppX:
+			action += 1
 		if action == 0:
 			wx.GetApp().ExitMainLoop()
 		elif action == 1:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Do not show "restart with add-ons disabled" option when exiting NVDA/AppX.

### Description of how this pull request fixes the issue:
Possible oversight: when exiting Windows Store version of NVDA (config.IsAppX is True), NVDA will present ability to disable add-ons when in fact this edition does not support add-ons just yet. Thus remove this option.
Also, in case exit action is 2 (disable add-ons in desktop mode), add a 1 so it points to debug logging instead.

### Testing performed:
Tested with source code version with config.isAppX turned on, along with a custom Windows Store version try build.

### Known issues with pull request:
None

### Change log entry:
N/A
