### PR TITLE
Minhook sconscript: correct case of hde source files

### DIFF
--- a/nvdaHelper/minHook/sconscript
+++ b/nvdaHelper/minHook/sconscript
@@ -10,7 +10,7 @@ env=env.Clone(CPPPATH=minhookPath.Dir('include'))
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
-HDESourceFile='HDE/HDE64.c' if env['TARGET_ARCH']=='x86_64' else 'HDE/HDE32.c'
+HDESourceFile='hde/hde64.c' if env['TARGET_ARCH']=='x86_64' else 'hde/hde32.c'
 
 sourceFiles=[
 	HDESourceFile,


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
On recent Windows 10 insider builds, it seems that paths are now case-sensitive. NVDA's build system mostly uses case-sensitive paths, except for a reference to some hde source files in minHook, where 'hde' is incorrectly capitalized. This is causing  the building of NvDA to fail on recent Windows 10 insider builds.
 
### Description of how this pull request fixes the issue:
The two paths have been changed to reflect their proper case in the file system.

### Testing performed:
NVDA now builds on the affected builds of Windows 10, and also still builds on appveyor.

### Known issues with pull request:
None.

### Change log entry:
None.