### PR TITLE
Automatically announce selection changes in Delphi Grids and other inaccessible controls

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -13,7 +13,7 @@ import itertools
 from comInterfaces.tom import ITextDocument
 import tones
 import languageHandler
-import textInfos.offsets
+import textInfos
 import colors
 import time
 import displayModel
@@ -28,7 +28,7 @@ import braille
 import api
 import config
 import controlTypes
-from NVDAObjects.window import Window
+from NVDAObjects.window import Window, DisplayModelSelectionChangeMonitor
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo, InvalidNVDAObject
 import NVDAObjects.JAB
 import eventHandler
@@ -543,6 +543,14 @@ the NVDAObject for IAccessible
 			#Generic client IAccessibles with no children should be classed as content and should use displayModel 
 			if clsList[0]==IAccessible and len(clsList)==3 and self.IAccessibleRole==oleacc.ROLE_SYSTEM_CLIENT and self.childCount==0:
 				clsList.insert(0,ContentGenericClient)
+				# The text of this window might expose relevant selection changes.
+				try:
+					displayModel.DisplayModelTextInfo(self, textInfos.POSITION_SELECTION)
+				except LookupError:
+					pass
+				else:
+					# Monitor for selection changes on this object
+					clsList.insert(0, DisplayModelSelectionChangeMonitor)
 
 	def __init__(self,windowHandle=None,IAccessibleObject=None,IAccessibleChildID=None,event_windowHandle=None,event_objectID=None,event_childID=None):
 		"""
@@ -1898,6 +1906,8 @@ _staticMap={
 	("TRichView",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TRichView",
 	("TRichViewEdit",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TRichViewEdit",
 	("TTntDrawGrid.UnicodeClass",oleacc.ROLE_SYSTEM_CLIENT):"List",
+	("TGrid",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TGrid",
+	("TDBGrid",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TGrid",
 	("SysListView32",oleacc.ROLE_SYSTEM_LIST):"sysListView32.List",
 	("SysListView32",oleacc.ROLE_SYSTEM_GROUPING):"sysListView32.List",
 	("SysListView32",oleacc.ROLE_SYSTEM_LISTITEM):"sysListView32.ListItem",

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1907,8 +1907,6 @@ _staticMap={
 	("TRichView",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TRichView",
 	("TRichViewEdit",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TRichViewEdit",
 	("TTntDrawGrid.UnicodeClass",oleacc.ROLE_SYSTEM_CLIENT):"List",
-	("TGrid",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TGrid",
-	("TDBGrid",oleacc.ROLE_SYSTEM_CLIENT):"delphi.TGrid",
 	("SysListView32",oleacc.ROLE_SYSTEM_LIST):"sysListView32.List",
 	("SysListView32",oleacc.ROLE_SYSTEM_GROUPING):"sysListView32.List",
 	("SysListView32",oleacc.ROLE_SYSTEM_LISTITEM):"sysListView32.ListItem",

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -34,6 +34,7 @@ import NVDAObjects.JAB
 import eventHandler
 from NVDAObjects.behaviors import ProgressBar, Dialog, EditableTextWithAutoSelectDetection, FocusableUnfocusableContainer, ToolTip, Notification
 from locationHelper import RectLTWH
+from documentBase import SelectableTextContainerObject
 
 def getNVDAObjectFromEvent(hwnd,objectID,childID):
 	try:
@@ -1396,7 +1397,7 @@ the NVDAObject for IAccessible
 		return self._getIA2RelationFirstTarget(IAccessibleHandler.IA2_RELATION_FLOWS_FROM)
 
 	def event_valueChange(self):
-		if isinstance(self, EditableTextWithAutoSelectDetection):
+		if isinstance(self, SelectableTextContainerObject):
 			self.hasContentChangedSinceLastSelection = True
 			return
 		return super(IAccessible, self).event_valueChange()

--- a/source/NVDAObjects/IAccessible/delphi.py
+++ b/source/NVDAObjects/IAccessible/delphi.py
@@ -1,6 +1,7 @@
 from NVDAObjects import behaviors
 import controlTypes
 from . import IAccessible
+from NVDAObjects.window import DisplayModelDrawFocusRectProcessor
 
 class TRichView(IAccessible):
 
@@ -35,3 +36,6 @@ class TRxRichEdit(IAccessible):
 
 	def _get_name(self):
 		return None
+
+class TGrid(DisplayModelDrawFocusRectProcessor, IAccessible):
+	pass

--- a/source/NVDAObjects/IAccessible/delphi.py
+++ b/source/NVDAObjects/IAccessible/delphi.py
@@ -36,6 +36,3 @@ class TRxRichEdit(IAccessible):
 
 	def _get_name(self):
 		return None
-
-class TGrid(DisplayModelDrawFocusRectProcessor, IAccessible):
-	pass

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -28,6 +28,7 @@ import api
 import ui
 import braille
 import nvwave
+from documentBase import SelectableTextContainerObject
 
 class ProgressBar(NVDAObject):
 

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -262,8 +262,6 @@ class LiveText(TextMonitor):
 	"""An object for which new text should be reported automatically.
 	These objects present text as a single chunk
 	and only fire an event indicating that some part of the text has changed; i.e. they don't provide the new text.
-	Monitoring must be explicitly started and stopped using the L{startMonitoring} and L{stopMonitoring} methods.
-	The object should notify of text changes using the textChange event.
 	"""
 	# If the text is live, this is definitely content.
 	presentationType = NVDAObject.presType_content
@@ -367,7 +365,7 @@ class LiveText(TextMonitor):
 class Terminal(LiveText, EditableText):
 	"""An object which both accepts text input and outputs text which should be reported automatically.
 	This is an L{EditableText} object,
-	as well as a L{liveText} object for which monitoring is automatically enabled and disabled based on whether it has focus.
+	as well as a L{LiveText} object for which monitoring is automatically enabled and disabled based on whether it has focus.
 	"""
 	role = controlTypes.ROLE_TERMINAL
 
@@ -697,6 +695,8 @@ class WebDialog(NVDAObject):
 
 class SelectionChangeMonitor(TextMonitor, SelectableTextContainerObject):
 	"""Reports selection changes based on text monitoring.
+	This inherrits from L{documentBase.SelectableTextContainerObject} which facilitates the detection of selection changesusing the L{TextInfo}.
+	This is also a L{TextMonitor} object for which monitoring is automatically enabled and disabled based on whether it has focus.
 	"""
 
 	def startMonitoring(self):

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -699,6 +699,8 @@ class SelectionChangeMonitor(TextMonitor, SelectableTextContainerObject):
 	This is also a L{TextMonitor} object for which monitoring is automatically enabled and disabled based on whether it has focus.
 	"""
 
+	speakUnselected = False
+
 	def startMonitoring(self):
 		self.initAutoSelectDetection()
 		super(SelectionChangeMonitor, self).startMonitoring()

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -190,19 +190,14 @@ class EditableTextWithoutAutoSelectDetection(editableText.EditableTextWithoutAut
 
 	initOverlayClass = editableText.EditableTextWithoutAutoSelectDetection.initClass
 
-class LiveText(NVDAObject):
-	"""An object for which new text should be reported automatically.
-	These objects present text as a single chunk
-	and only fire an event indicating that some part of the text has changed; i.e. they don't provide the new text.
+class TextMonitor(NVDAObject):
+	"""A basic object class which facilitates monitoring of changes in text or text formatting.
+	These objects only fire an event indicating that some part of the text or text formatting has changed; i.e. they don't provide the new text.
 	Monitoring must be explicitly started and stopped using the L{startMonitoring} and L{stopMonitoring} methods.
 	The object should notify of text changes using the textChange event.
 	"""
 	#: The time to wait before fetching text after a change event.
 	STABILIZE_DELAY = 0
-	# If the text is live, this is definitely content.
-	presentationType = NVDAObject.presType_content
-
-	announceNewLineText=False
 
 	def initOverlayClass(self):
 		self._event = threading.Event()
@@ -210,8 +205,7 @@ class LiveText(NVDAObject):
 		self._keepMonitoring = False
 
 	def startMonitoring(self):
-		"""Start monitoring for new text.
-		New text will be reported when it is detected.
+		"""Start monitoring for changes in text.
 		@note: If monitoring has already been started, this will have no effect.
 		@see: L{stopMonitoring}
 		"""
@@ -239,6 +233,25 @@ class LiveText(NVDAObject):
 		@note: It is safe to call this directly from threads other than the main thread.
 		"""
 		self._event.set()
+
+	def _monitor(self):
+		"""The monitoring method.
+		This is run in a separate thread using the L{startMonitoring} method.
+		Subclasses should override this method.
+		"""
+		raise NotImplementedError()
+
+class LiveText(TextMonitor):
+	"""An object for which new text should be reported automatically.
+	These objects present text as a single chunk
+	and only fire an event indicating that some part of the text has changed; i.e. they don't provide the new text.
+	Monitoring must be explicitly started and stopped using the L{startMonitoring} and L{stopMonitoring} methods.
+	The object should notify of text changes using the textChange event.
+	"""
+	# If the text is live, this is definitely content.
+	presentationType = NVDAObject.presType_content
+
+	announceNewLineText=False
 
 	def _getTextLines(self):
 		"""Retrieve the text of this object in lines.
@@ -671,3 +684,4 @@ class WebDialog(NVDAObject):
 		if self.parent.treeInterceptor:
 			return True
 		return False
+

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -15,7 +15,7 @@ import api
 import displayModel
 import eventHandler
 from NVDAObjects import NVDAObject
-from NVDAObjects.behaviors import EditableText, LiveText
+from NVDAObjects.behaviors import EditableText, TextMonitor, LiveText
 import watchdog
 from locationHelper import RectLTWH
 
@@ -392,18 +392,21 @@ class DisplayModelEditableText(EditableText, Window):
 		# Don't report value changes for editable text fields.
 		pass
 
-class DisplayModelLiveText(LiveText, Window):
-	TextInfo = displayModel.EditableTextDisplayModelTextInfo
+class DisplayModelTextMonitor(TextMonitor, Window):
+	TextInfo = displayModel.DisplayModelTextInfo
 
 	def startMonitoring(self):
 		# Force the window to be redrawn, as our display model might be out of date.
 		self.redraw()
 		displayModel.requestTextChangeNotifications(self, True)
-		super(DisplayModelLiveText, self).startMonitoring()
+		super(DisplayModelTextMonitor, self).startMonitoring()
 
 	def stopMonitoring(self):
-		super(DisplayModelLiveText, self).stopMonitoring()
+		super(DisplayModelTextMonitor, self).stopMonitoring()
 		displayModel.requestTextChangeNotifications(self, False)
+
+class DisplayModelLiveText(LiveText, DisplayModelTextMonitor):
+	TextInfo = displayModel.EditableTextDisplayModelTextInfo
 
 windowClassMap={
 	"EDIT":"Edit",

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -411,6 +411,34 @@ class DisplayModelLiveText(LiveText, DisplayModelTextMonitor):
 class DisplayModelSelectionChangeMonitor(SelectionChangeMonitor, DisplayModelTextMonitor):
 	pass
 
+class DisplayModelDrawFocusRectProcessor(Window):
+	"""
+	This object facilitates focus reporting when a focus rectangle is drawn,
+	but the focused rectangle does not correspond with an unique object and therefore no focus change is reported by NVDA.
+	For example, this can be used as an overlay class for objects (such as grids)
+	which don't expose child objects but fire displayModel_drawFocusRectNotify events for cell selection instead.
+	It should only be used as overlay class on an object which content is otherwise inaccessible.
+
+	When a displayModel_drawFocusRectNotify event is received,
+	the content of the given rectangle is set as the value of the object,
+	and event_valueChange is fired.
+	"""
+
+	TextInfo = displayModel.DisplayModelTextInfo
+
+	def _get_value(self):
+		# The initial value when this object is created is based on the selection.
+		import textInfos
+		try:
+			return self.makeTextInfo(textInfos.POSITION_SELECTION).text
+		except LookupError:
+			return None
+
+	def event_displayModel_drawFocusRectNotify(self, rect):
+		from textInfos import Rect
+		self.value = self.makeTextInfo(Rect(*rect)).text
+		self.event_valueChange()
+
 windowClassMap={
 	"EDIT":"Edit",
 	"TTntEdit.UnicodeClass":"Edit",

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -421,7 +421,7 @@ class DisplayModelDrawFocusRectProcessor(Window):
 
 	When a displayModel_drawFocusRectNotify event is received,
 	the content of the given rectangle is set as the value of the object,
-	and event_valueChange is fired.
+	and a valueChange event is fired.
 	"""
 
 	TextInfo = displayModel.DisplayModelTextInfo
@@ -437,7 +437,7 @@ class DisplayModelDrawFocusRectProcessor(Window):
 	def event_displayModel_drawFocusRectNotify(self, rect):
 		from textInfos import Rect
 		self.value = self.makeTextInfo(Rect(*rect)).text
-		self.event_valueChange()
+		eventHandler.queueEvent("valueChange", self)
 
 windowClassMap={
 	"EDIT":"Edit",

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -408,7 +408,7 @@ class DisplayModelTextMonitor(TextMonitor, Window):
 class DisplayModelLiveText(LiveText, DisplayModelTextMonitor):
 	TextInfo = displayModel.EditableTextDisplayModelTextInfo
 
-class DisplayModelSelectionChangeMonitor(DisplayModelTextMonitor, SelectionChangeMonitor):
+class DisplayModelSelectionChangeMonitor(SelectionChangeMonitor, DisplayModelTextMonitor):
 	pass
 
 windowClassMap={

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -435,6 +435,9 @@ class DisplayModelDrawFocusRectProcessor(Window):
 			return None
 
 	def event_displayModel_drawFocusRectNotify(self, rect):
+		# Filter out duplicate events
+		if eventHandler.isPendingEvents("displayModel_drawFocusRectNotify"):
+			return
 		from textInfos import Rect
 		self.value = self.makeTextInfo(Rect(*rect)).text
 		eventHandler.queueEvent("valueChange", self)

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -15,7 +15,7 @@ import api
 import displayModel
 import eventHandler
 from NVDAObjects import NVDAObject
-from NVDAObjects.behaviors import EditableText, TextMonitor, LiveText
+from NVDAObjects.behaviors import EditableText, TextMonitor, LiveText, SelectionChangeMonitor
 import watchdog
 from locationHelper import RectLTWH
 
@@ -407,6 +407,9 @@ class DisplayModelTextMonitor(TextMonitor, Window):
 
 class DisplayModelLiveText(LiveText, DisplayModelTextMonitor):
 	TextInfo = displayModel.EditableTextDisplayModelTextInfo
+
+class DisplayModelSelectionChangeMonitor(DisplayModelTextMonitor, SelectionChangeMonitor):
+	pass
 
 windowClassMap={
 	"EDIT":"Edit",

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -154,7 +154,7 @@ def processFieldsAndRectsRangeReadingdirection(commandList,rects,startIndex,star
 _getWindowTextInRect=None
 _requestTextChangeNotificationsForWindow=None
 #: Objects that have registered for text change notifications.
-_textChangeNotificationObjs=[]
+_textChangeNotificationObjs=set()
 
 def initialize():
 	global _getWindowTextInRect,_requestTextChangeNotificationsForWindow, _getFocusRect
@@ -206,7 +206,7 @@ def requestTextChangeNotifications(obj, enable):
 		_textChangeNotificationObjs.remove(obj)
 	watchdog.cancellableExecute(_requestTextChangeNotificationsForWindow, obj.appModule.helperLocalBindingHandle, obj.windowHandle, enable)
 	if enable:
-		_textChangeNotificationObjs.append(obj)
+		_textChangeNotificationObjs.add(obj)
 
 def textChangeNotify(windowHandle, left, top, right, bottom):
 	for obj in _textChangeNotificationObjs:

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -20,7 +20,7 @@ class TextContainerObject(AutoPropertyObject):
 
 	def _get_TextInfo(self):
 		raise NotImplementedError
- 
+
 	def makeTextInfo(self,position):
 		return self.TextInfo(self,position)
 
@@ -225,9 +225,10 @@ class SelectableTextContainerObject(TextContainerObject):
 	"""
 
 	#: Whether to speak the unselected content after new content has been selected.
-	#: If C{False}, the new selection is always spoken.
+	#: If C{False}, the old selection is ignored,
+	#: and the new selection is reported without the redundant selected state.
 	#: @type: bool
-	speakUnselected = False
+	speakUnselected = True
 
 	def initAutoSelectDetection(self):
 		"""Initialise automatic detection of selection changes.

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -261,7 +261,7 @@ class SelectableTextContainerObject(TextContainerObject):
 		if not self.speakUnselected:
 			# As the unselected state is not relevant here and all spoken content is selected,
 			# use speech.speakTextInfo to make sure the new selection is spoken.
-			speech.speakTextInfo(newInfo,unit=textInfos.UNIT_LINE,reason=controlTypes.REASON_CARET)
+			speech.speakTextInfo(newInfo,reason=controlTypes.REASON_CARET)
 		else:
 			speech.speakSelectionChange(oldInfo,newInfo,generalize=hasContentChanged)
 

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -10,6 +10,7 @@ import textInfos
 import speech
 import ui
 import controlTypes
+import braille
 
 class TextContainerObject(AutoPropertyObject):
 	"""
@@ -259,9 +260,15 @@ class SelectableTextContainerObject(TextContainerObject):
 		if not self.speakUnselected:
 			# As the unselected state is not relevant here and all spoken content is selected,
 			# use speech.speakTextInfo to make sure the new selection is spoken.
-			speech.speakTextInfo(newInfo,unit=textInfos.UNIT_LINE,reason=controlsTypes.REASON_CARET)
+			speech.speakTextInfo(newInfo,unit=textInfos.UNIT_LINE,reason=controlTypes.REASON_CARET)
 		else:
 			speech.speakSelectionChange(oldInfo,newInfo,generalize=hasContentChanged)
+
+		# Import late to avoid circular import
+		from editableText import EditableText
+		if not isinstance(self, EditableText):
+			# This object has no caret, manually trigger a braille update.
+			braille.handler.handleUpdate(self)
 
 	def _updateSelectionAnchor(self,oldInfo,newInfo):
 		# Only update the value if the selection changed.

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -224,6 +224,7 @@ class SelectableTextContainerObject(TextContainerObject):
 	"""
 
 	#: Whether to speak the unselected content after new content has been selected.
+	#: If C{False}, the new selection is always spoken.
 	#: @type: bool
 	speakUnselected = False
 
@@ -255,7 +256,12 @@ class SelectableTextContainerObject(TextContainerObject):
 		self._updateSelectionAnchor(oldInfo,newInfo)
 		hasContentChanged=getattr(self,'hasContentChangedSinceLastSelection',False)
 		self.hasContentChangedSinceLastSelection=False
-		speech.speakSelectionChange(oldInfo,newInfo,speakUnselected=speakUnselected,generalize=hasContentChanged)
+		if not self.speakUnselected:
+			# As the unselected state is not relevant here and all spoken content is selected,
+			# use speech.speakTextInfo to make sure the new selection is spoken.
+			speech.speakTextInfo(newInfo,unit=textInfos.UNIT_LINE,reason=controlsTypes.REASON_CARET)
+		else:
+			speech.speakSelectionChange(oldInfo,newInfo,generalize=hasContentChanged)
 
 	def _updateSelectionAnchor(self,oldInfo,newInfo):
 		# Only update the value if the selection changed.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -41,8 +41,6 @@ class EditableText(SelectableTextContainerObject,ScriptableObject):
 
 	_hasCaretMoved_minWordTimeoutMs=30 #: The minimum amount of time that should elapse before checking if the word under the caret has changed
 
-	speakUnselected = True
-
 	def _hasCaretMoved(self, bookmark, retryInterval=0.01, timeout=None, origWord=None):
 		"""
 		Waits for the caret to move, for a timeout to elapse, or for a new focus event or script to be queued.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -14,7 +14,7 @@ import sayAllHandler
 import api
 import review
 from baseObject import ScriptableObject
-from documentBase import TextContainerObject
+from documentBase import SelectableTextContainerObject
 import braille
 import speech
 import config
@@ -24,18 +24,11 @@ import textInfos
 import controlTypes
 from logHandler import log
 
-class EditableText(TextContainerObject,ScriptableObject):
+class EditableText(SelectableTextContainerObject,ScriptableObject):
 	"""Provides scripts to report appropriately when moving the caret in editable text fields.
 	This does not handle the selection change keys.
 	To have selection changes reported, the object must notify of selection changes.
 	If the object supports selection but does not notify of selection changes, L{EditableTextWithoutAutoSelectDetection} should be used instead.
-	
-	If the object notifies of selection changes, the following should be done:
-		* When the object gains focus, L{initAutoSelectDetection} must be called.
-		* When the object notifies of a possible selection change, L{detectPossibleSelectionChange} must be called.
-		* Optionally, if the object notifies of changes to its content, L{hasContentChangedSinceLastSelection} should be set to C{True}.
-	@ivar hasContentChangedSinceLastSelection: Whether the content has changed since the last selection occurred.
-	@type hasContentChangedSinceLastSelection: bool
 	"""
 
 	#: Whether to fire caretMovementFailed events when the caret doesn't move in response to a caret movement key.
@@ -47,6 +40,8 @@ class EditableText(TextContainerObject,ScriptableObject):
 	announceEntireNewLine=False
 
 	_hasCaretMoved_minWordTimeoutMs=30 #: The minimum amount of time that should elapse before checking if the word under the caret has changed
+
+	speakUnselected = True
 
 	def _hasCaretMoved(self, bookmark, retryInterval=0.01, timeout=None, origWord=None):
 		"""
@@ -270,43 +265,6 @@ class EditableText(TextContainerObject,ScriptableObject):
 		"kb:backspace": "caret_backspaceCharacter",
 		"kb:control+backspace": "caret_backspaceWord",
 	}
-
-	def initAutoSelectDetection(self):
-		"""Initialise automatic detection of selection changes.
-		This should be called when the object gains focus.
-		"""
-		try:
-			self._lastSelectionPos=self.makeTextInfo(textInfos.POSITION_SELECTION)
-		except:
-			self._lastSelectionPos=None
-		self.isTextSelectionAnchoredAtStart=True
-		self.hasContentChangedSinceLastSelection=False
-
-	def detectPossibleSelectionChange(self):
-		"""Detects if the selection has been changed, and if so it speaks the change.
-		"""
-		try:
-			newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
-		except:
-			# Just leave the old selection, which is usually better than nothing.
-			return
-		oldInfo=getattr(self,'_lastSelectionPos',None)
-		self._lastSelectionPos=newInfo.copy()
-		if not oldInfo:
-			# There's nothing we can do, but at least the last selection will be right next time.
-			self.isTextSelectionAnchoredAtStart=True
-			return
-		self._updateSelectionAnchor(oldInfo,newInfo)
-		hasContentChanged=getattr(self,'hasContentChangedSinceLastSelection',False)
-		self.hasContentChangedSinceLastSelection=False
-		speech.speakSelectionChange(oldInfo,newInfo,generalize=hasContentChanged)
-
-	def _updateSelectionAnchor(self,oldInfo,newInfo):
-		# Only update the value if the selection changed.
-		if newInfo.compareEndPoints(oldInfo,"startToStart")!=0:
-			self.isTextSelectionAnchoredAtStart=False
-		elif newInfo.compareEndPoints(oldInfo,"endToEnd")!=0:
-			self.isTextSelectionAnchoredAtStart=True
 
 class EditableTextWithoutAutoSelectDetection(EditableText):
 	"""In addition to L{EditableText}, provides scripts to report appropriately when the selection changes.

--- a/source/speech.py
+++ b/source/speech.py
@@ -755,7 +755,7 @@ def speakTextInfo(info,useCache=True,formatConfig=None,unit=None,reason=controlT
 	if isinstance(useCache,SpeakTextInfoState):
 		speakTextInfoState=useCache
 	elif useCache:
-		 speakTextInfoState=SpeakTextInfoState(info.obj)
+		speakTextInfoState=SpeakTextInfoState(info.obj)
 	else:
 		speakTextInfoState=None
 	autoLanguageSwitching=config.conf['speech']['autoLanguageSwitching']

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -22,10 +22,16 @@ class Field(dict):
 	def evaluateCondition(self, *dicts):
 		"""
 		A function that evaluates whether the provided condition is met for this L{Field}.
-		The arguments to this function are dicts whose keys are field attributes, and whose values are a list of possible values for the attribute.
+		The arguments to this function are dicts whose keys are field attributes, and whose values are either:
+			* A list of possible values for the attribute.
+			* a boolean value, indicating that the condition for the key matches if the key is or is not in the field with whatever value.
 		The dicts are joined with 'or', the keys in each dict are joined with 'and', and the values  for each key are joined with 'or'.
 		For example,  to create a condition that matches on a format field with a white or black foreground color, you would provide the following condition argument:
-		{'color': [colors.RGB(255, 255, 255), colors.RGB(0, 0, 0)]}
+			{'color': [colors.RGB(255, 255, 255), colors.RGB(0, 0, 0)]}
+		To create a condition that matches on a format field with whatever foreground color, you would provide the following condition argument:
+			{'color': True}
+		To create a condition that matches on a format field without a foreground color, you would provide the following condition argument:
+			{'color': False}
 		"""
 		if len(dicts) == 1 and isinstance(dicts[0], (list, set, tuple)):
 			dicts = dicts[0]
@@ -33,8 +39,13 @@ class Field(dict):
 			# Dicts are joined with or, therefore return early if a dict matches.
 			for key,values in dict.iteritems():
 				if key not in self:
-					# Go to the next dict
-					break
+					if values is False:
+						continue
+					else:
+						# Go to the next dict
+						break
+				elif values is True:
+					continue
 				if not isinstance(values, (list, set, tuple)):
 					values=[values]
 				if not self[key] in values:
@@ -42,8 +53,8 @@ class Field(dict):
 					break
 			else:
 				# This dict matches.
-				return True
-		return False
+				return dict
+		return None
 
 class FormatField(Field):
 	"""Provides information about the formatting of text; e.g. font information and hyperlinks."""

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -19,6 +19,32 @@ import controlTypes
 class Field(dict):
 	"""Provides information about a piece of text."""
 
+	def evaluateCondition(self, *dicts):
+		"""
+		A function that evaluates whether the provided condition is met for this L{Field}.
+		The arguments to this function are dicts whose keys are field attributes, and whose values are a list of possible values for the attribute.
+		The dicts are joined with 'or', the keys in each dict are joined with 'and', and the values  for each key are joined with 'or'.
+		For example,  to create a condition that matches on a format field with a white or black foreground color, you would provide the following condition argument:
+		{'color': [colors.RGB(255, 255, 255), colors.RGB(0, 0, 0)]}
+		"""
+		if len(dicts) == 1:
+			dicts = dicts[0]
+		for dict in dicts:
+			# Dicts are joined with or, therefore return early if a dict matches.
+			for key,values in dict.iteritems():
+				if key not in self:
+					# Go to the next dict
+					break
+				if not isinstance(values,(list,set,tuple)):
+					values=[values]
+				if not self[key] in values:
+					# Key does not match.
+					break
+			else:
+				# This dict matches.
+				return True
+		return False
+
 class FormatField(Field):
 	"""Provides information about the formatting of text; e.g. font information and hyperlinks."""
 

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -27,7 +27,7 @@ class Field(dict):
 		For example,  to create a condition that matches on a format field with a white or black foreground color, you would provide the following condition argument:
 		{'color': [colors.RGB(255, 255, 255), colors.RGB(0, 0, 0)]}
 		"""
-		if len(dicts) == 1:
+		if len(dicts) == 1 and isinstance(dicts[0], (list, set, tuple)):
 			dicts = dicts[0]
 		for dict in dicts:
 			# Dicts are joined with or, therefore return early if a dict matches.
@@ -35,7 +35,7 @@ class Field(dict):
 				if key not in self:
 					# Go to the next dict
 					break
-				if not isinstance(values,(list,set,tuple)):
+				if not isinstance(values, (list, set, tuple)):
 					values=[values]
 				if not self[key] in values:
 					# Key does not match.


### PR DESCRIPTION
### Link to issue number:
Closes #7418

### Summary of the issue:
In many legacy applications that have a bad accessibility implementation, we can still make these applications quite accessible using the display model. Even when an application does not fire focus events or doesn't implement accessibility API support, the display model can be used to find out what part of a window is relevant to report. An example of this is a Delphi Grid, where all information in the grid is only accessible by means of the display model, and in which case we can track the focus based on DrawFocusRect API calls. Even if DrawFocusRect isn't called, we can use the display model text info to find out what part of the window is considered selected and should therefore be reported.

### Description of how this pull request fixes the issue:
This pr is split up into several area's which are more or less related to each other.

#### Changed behaviors structure
1. The monitoring specific stuff in behaviors.LiveText is now abstracted into behaviors.TextMonitor. LiveText inherrits from TextMonitor
2. Based on this change, there is now a DisplayModelTextMonitor class. DisplayModelLiveText now inherrits from LiveText and DisplayModelTextMonitor

#### changes to documentBase and editableText
1. The selection support from editableText.EditableText has been abstracted into documentBase.SelectableTextContainer. editableText.EditableText now inherrits from SelectableTextContainer. The major reason why I did this, is that the fact that selectable text in a container doesn't necessarily mean that the window contains a caret.
2. While most functionality from SelectableTextContainer is coming from editableText.EditableText, I've made an additional change which allows unselected text not to be spoken. IN this case, the selected text is spoken with speech.SpeakTextInfo, which avoids unnecessarily calculation of what text has to be spoken. It also doesn't speak the redundant "selected" word every time a new selection is spoken.

#### New behaviors
1. As behaviors.TextMonitor is now abstract, we can build more types of monitors upon its functionality. the SelectionChangeMonitor combines the TextMonitor with the new SelectableTextContainer to automatically announce selection changes when there is a change in the text.
2. Based on this, there is window.DisplayModelSelectionChangeMonitor that announces the selection when the display model detects a change in the text.
3. There is also window.DisplayModelDrawFocusRectProcessor, which is meant to be used on windows which have no focusable children, yet communicate focus changes in the window with the displayModel_drawFocusRectNotify event. This is applicable to delphi grids, for example, but also to several inaccessible list controls.

#### Enhanced display model selection offsets detection
Display model text info selection offsets detection was based on the background and foreground selection colors reported by Windows. This can give excelent results, but is somewhat limited as it doesn't allow detection of selection when the selection is communicated to the visual user in a different way, either by different colors or font attributes. Therefore, I borrowed the idea of property conditions from UIAUtils to create one or more conditions that should be met in order to have selection to be reported. To evaluate a condition, you can simply throw one or more condition dicts at the evaluateCondition method of a textInfos.Field instance.

To give some real life examples. I've seen several situations in the wild where selection had to be detected based on two different combinations of foreground and background color. There are also cases where the selection can be detected based on only the foreground color.

### User visible changes
1. NVDA will now speak selection updates in Delphi grids
2. A change that we'll have to debate on, NVDA will now add the DisplayModelSelectionChangeMonitor overlay class for ContentGenericClient objects when the selection can be detected within these object's windows. This is intended to improve the base line level of accessibility within ContentGenericClient windows.

### Testing performed:
1. Tested focus rectangle behavior in Delphi Grids
2. Tested the selection based focus container in several work place specific applications

### Known issues with pull request:
Similar to terminal announcement behavior, the Selection based monitor is a bit limited in how it detects new selections and announces them. For example, when you select a list item that is continuously updating its value (e.g. when the selected item contains a counter) the whole item is repeated when the counter updates.

### Change log entry:
* Changes
    + NVDA will now try to speak selection changes in controls that were previously only accessible by means of the review cursor. (#8414)
    + NVDA will now announce the selection in many grids in Delphi applications. (#7418). 
