### PR TITLE
Update issue template with more instructions.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -11,7 +11,8 @@
 > **Please note:**
 > While we welcome images/screenshots to help explain a problem, be aware that many of the
 > developers of NVDA are blind and will greatly appreciate this image being described in text.
-> For example, to capture the output of the inspect.exe tool:
+> Rather than taking a screenshot showing the output of an accessibility tool, in many cases you
+> can directly copy the text. For instance when using the Inspect tool from the Windows SDK:
 > 1. In the tree-view focus the element which you are interested in.
 > 1. Press F6 to move focus to the properties pane on the right.
 > 1. Select all, then copy and paste this into the issue.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,12 +1,33 @@
+> Below you will find NVDA's Github issue template. You might consider swapping to the preview tab in order
+> to read through this template with the formatting applied before attempting to complete it. In all but
+> exceptional circumstances we require this to be completed. Your issue will likely be closed if this
+> template has not been followed. If you have trouble following this template, or with the initial investigation
+> that is required, please contact the fantastic community of people on the [NVDA users mailing list](https://github.com/nvaccess/nvda-community/wiki/Connect#international-users-mailing-list-english)
+> and politely ask for assistance.
+>
+> To complete the template please remove all lines that start with a greater than (>) symbol.
+> These lines are meant to provide an example of how you might complete this section of the issue template.
+>
+> **Please note:**
+> While we welcome images/screenshots to help explain a problem, be aware that many of the
+> developers of NVDA are blind and will greatly appreciate this image being described in text.
+> For example, to capture the output of the inspect.exe tool:
+> 1. In the tree-view focus the element which you are interested in.
+> 1. Press F6 to move focus to the properties pane on the right.
+> 1. Select all, then copy and paste this into the issue.
+>
+> This will contain all of the properties for the selected element, as well as the names/roles of
+> it's ancestors and children.
+
 ### Steps to reproduce:
-> A list of the steps you take to demonstrate the problem. 
+> A list of the steps you take to demonstrate the problem.
 >
 > Example:
 >
 > 1. Open Chrome
-> 2. Browse to www.google.com
-> 3. Type "Hello"
-> 4. Notice an error sound when enter is pressed.
+> 1. Browse to www.google.com
+> 1. Type "Hello"
+> 1. Notice an error sound when enter is pressed.
 
 > Please also remember to attach a zip of any files required to reproduce the issue.
 


### PR DESCRIPTION
* Include some instructions about how to fill in the issue template
* Explain that we will be more strict about closing issues that do not
follow the template.
* Give a suggestion for where to get help with the issue template
* Note that for some NVDA developers, images are not very helpful.

### Summary of the issue:
We regularly have to process github issues that do not describe an issue adequately, or have not demonstrated an appropriate level of initial investigation. This project currently does not have the resources to investigate every issue that is raised. In order to make the best use of resources let's try to limit the creation of issues to those that are well described. 

### Description of how this pull request fixes the issue:
This change adds instructions for how to fill in the template, and makes it clear that issues that do not follow the template are likely to be closed. Of course in reality, if an issue is clearly important and someone can easily fix up the issue to provide the required information, then fixing it may be a better course of action.

We occasionally have images attached to issues that provide helpful information, however often these images are not accompanied by a description. I have also added a note which will hopefully remedy some of the time.

### Testing performed:
Pasted the markdown into a new issue to inspect the preview tab.

### Known issues with pull request:
None

### Change log entry:
None required.