### PR TITLE
Reduce the verbosity of the github templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,19 @@
+<!--
+Please fill in the following template, for an explanation of the sections see:
+https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
+-->
+
 ### Link to issue number:
-> Please include the issue number here. This helps us to keep the information linked together. If this is a minor/trivial change an issue does not need to be created. If in doubt, please create one.
 
 ### Summary of the issue:
-> A quick summary of the problem you are trying to solve.
 
 ### Description of how this pull request fixes the issue:
-> Please include a quick discussion of how this change addresses the issue. Please also include any links or external information you may have used in order to address the issue. This helps others to have the same background as you and learn from this work.
 
 ### Testing performed:
 
 ### Known issues with pull request:
-> Any known issues or downsides of this approach. For instance: _Will not work with python 3_
 
 ### Change log entry:
-> The section and description of this change to use for the changes file. Valid sections are:
-> 
-> * New features
-> * Changes
-> * Bug fixes
->
-> For examples see the changes file in your NVDA repo: `user_docs/en/changes.t2t` or on github: https://github.com/nvaccess/nvda/blob/master/user_docs/en/changes.t2t
+
+Section: New features, Changes, Bug fixes
+

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,34 +1,7 @@
 <!--
-Below you will find NVDA's Github issue template. You might consider swapping
-to the preview tab in order to read through the required sections in the
-template. This template uses github markdown, to provide formatting for
-headings, lists, quotes etc. If you are not familiar with github markdown,
-please read through: https://guides.github.com/features/mastering-markdown/
-
-This block is a HTML comment, it can be left in place and will not appear once
-the issue is saved. To verify that the issue will display as you expect, swap to
-the preview tab. For an explanation of these headings, and examples of the kind
-of information that might be included there, see:
+Please thoroughly read NVDA's wiki article on how to fill in this template, including how to provide the required files.
+Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
-
-In all but exceptional circumstances we require this template should be
-completed. Your issue will likely be closed if this template has not been
-followed.
-
-In most cases an NVDA log file is incredibly helpful when trying to
-understand/fix an issue, please remember to attach one. For assistance with
-this see: https://github.com/nvaccess/nvda/wiki/LogFilesAndCrashDumps
-
-If you have trouble following this template, or with the initial investigation
-that is required, please politely ask for assistance from the fantastic
-community of people on the NVDA users mailing list at
-https://github.com/nvaccess/nvda-community/wiki/Connect#international-users-mailing-list-english
-
-**Please note:**
-While we welcome images/screenshots to help explain a problem, be aware that
-many of the developers of NVDA are blind and will greatly appreciate this image
-being described in text.
-
 -->
 
 ### Steps to reproduce:

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,60 +1,57 @@
-> Below you will find NVDA's Github issue template. You might consider swapping to the preview tab in order
-> to read through this template with the formatting applied before attempting to complete it. In all but
-> exceptional circumstances we require this to be completed. Your issue will likely be closed if this
-> template has not been followed. If you have trouble following this template, or with the initial investigation
-> that is required, please contact the fantastic community of people on the [NVDA users mailing list](https://github.com/nvaccess/nvda-community/wiki/Connect#international-users-mailing-list-english)
-> and politely ask for assistance.
->
-> To complete the template please remove all lines that start with a greater than (>) symbol.
-> These lines are meant to provide an example of how you might complete this section of the issue template.
->
-> **Please note:**
-> While we welcome images/screenshots to help explain a problem, be aware that many of the
-> developers of NVDA are blind and will greatly appreciate this image being described in text.
-> Rather than taking a screenshot showing the output of an accessibility tool, in many cases you
-> can directly copy the text. For instance when using the Inspect tool from the Windows SDK:
-> 1. In the tree-view focus the element which you are interested in.
-> 1. Press F6 to move focus to the properties pane on the right.
-> 1. Select all, then copy and paste this into the issue.
->
-> This will contain all of the properties for the selected element, as well as the names/roles of
-> it's ancestors and children.
+<!--
+Below you will find NVDA's Github issue template. You might consider swapping
+to the preview tab in order to read through the required sections in the
+template. This template uses github markdown, to provide formatting for
+headings, lists, quotes etc. If you are not familiar with github markdown,
+please read through: https://guides.github.com/features/mastering-markdown/
+
+This block is a HTML comment, it can be left in place and will not appear once
+the issue is saved. To verify that the issue will display as you expect, swap to
+the preview tab. For an explanation of these headings, and examples of the kind
+of information that might be included there, see:
+https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
+
+In all but exceptional circumstances we require this template should be
+completed. Your issue will likely be closed if this template has not been
+followed.
+
+In most cases an NVDA log file is incredibly helpful when trying to
+understand/fix an issue, please remember to attach one. For assistance with
+this see: https://github.com/nvaccess/nvda/wiki/LogFilesAndCrashDumps
+
+If you have trouble following this template, or with the initial investigation
+that is required, please politely ask for assistance from the fantastic
+community of people on the NVDA users mailing list at
+https://github.com/nvaccess/nvda-community/wiki/Connect#international-users-mailing-list-english
+
+**Please note:**
+While we welcome images/screenshots to help explain a problem, be aware that
+many of the developers of NVDA are blind and will greatly appreciate this image
+being described in text.
+
+-->
 
 ### Steps to reproduce:
-> A list of the steps you take to demonstrate the problem.
->
-> Example:
->
-> 1. Open Chrome
-> 1. Browse to www.google.com
-> 1. Type "Hello"
-> 1. Notice an error sound when enter is pressed.
-
-> Please also remember to attach a zip of any files required to reproduce the issue.
-
-### Expected behavior:
-> Tell us what should happen.
 
 ### Actual behavior:
-> Tell us what happens instead.
+
+### Expected behavior:
 
 ### System configuration:
-NVDA version:
-> Example: next-14027,c80e529f
 
-NVDA Installed or portable:
+#### NVDA Installed/portable/running from source:
 
-Other information:
-> Example: Running in a VM
+#### NVDA version:
 
-Windows version:
-> Example: Windows 10 Version 1607 Build 14393.1066
+#### Windows version:
 
-Name and version of other software in use when reproducing the issue:
+#### Name and version of other software in use when reproducing the issue:
+
+#### Other information about your system:
 
 ### Other questions:
 
-Does the issue still occur after restarting your PC?
+#### Does the issue still occur after restarting your PC?
 
-Have you tried any other versions of NVDA?
-> Please list them and the result
+#### Have you tried any other versions of NVDA?
+


### PR DESCRIPTION
### Link to issue number:
See comments on #8417

### Summary of the issue:
Essentially we are trying to reduce the verbosity of the issue / PR templates, and reduce the effort of having to delete text in the template.

### Description of how this pull request fixes the issue:

The explanations and examples that were in the templates have been moved out to two wiki pages:
https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples

The description at the top of the file has been reworded and shortened, it is now in a HTML comment so that it can be left in place without polluting the rendered issue.

### Testing performed:
Used the Github preview to ensure that the template renders as expected.

### Known issues with pull request:
Some users may find it difficult to provide the required information or follow the formatting of the template. 

### Change log entry:
None

