### PR TITLE
add braille tables for some languages

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -100,6 +100,9 @@ addTable("cy-cy-g1.utb", _("Welsh grade 1"))
 addTable("cy-cy-g2.ctb", _("Welsh grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("cs-comp8.utb", _("Czech 8-dots computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("cs-g1.ctb", _("Czech grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -74,6 +74,7 @@ RENAMED_TABLES = {
 	"nl-BE-g1.ctb":"nl-BE-g0.utb",
 	"nl-NL-g1.ctb":"nl-NL-g0.utb",
 	"no-no.ctb":"no-no-comp8.ctb",
+	"ru-compbrl.ctb":"ru.ctb",
 	"sk-sk-g1.utb":"sk-g1.ctb",
 	"UEBC-g1.ctb":"en-ueb-g1.ctb",
 	"UEBC-g2.ctb":"en-ueb-g2.ctb",
@@ -103,7 +104,7 @@ addTable("cy-cy-g1.utb", _("Welsh grade 1"))
 addTable("cy-cy-g2.ctb", _("Welsh grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("cs-comp8.utb", _("Czech 8-dots computer braille"))
+addTable("cs-comp8.utb", _("Czech 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("cs-g1.ctb", _("Czech grade 1"))
@@ -334,7 +335,7 @@ addTable("pu-in-g1.utb", _("Punjabi grade 1"))
 addTable("ro.ctb", _("Romanian"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru.ctb", _("Russian computer braille"))
+addTable("ru-compbrl.ctb", _("Russian braille for computer code"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ru-ru-g1.utb", _("Russian grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -94,6 +94,9 @@ addTable("be-in-g1.utb", _("Bengali grade 1"))
 addTable("bg.ctb", _("Bulgarian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("ckb-g1.ctb", _("Central kurdish grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("cy-cy-g1.utb", _("Welsh grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -161,6 +164,9 @@ addTable("en-us-g1.ctb", _("English (U.S.) grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("en-us-g2.ctb", _("English (U.S.) grade 2"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("eo-g1.ctb", _("Esperanto grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("Es-Es-G0.utb", _("Spanish 8 dot computer braille"))
@@ -328,7 +334,7 @@ addTable("pu-in-g1.utb", _("Punjabi grade 1"))
 addTable("ro.ctb", _("Romanian"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru-compbrl.ctb", _("Russian braille for computer code"))
+addTable("ru.ctb", _("Russian computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ru-ru-g1.utb", _("Russian grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -335,7 +335,7 @@ addTable("pu-in-g1.utb", _("Punjabi grade 1"))
 addTable("ro.ctb", _("Romanian"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru-compbrl.ctb", _("Russian braille for computer code"))
+addTable("ru.ctb", _("Russian braille for computer code"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ru-ru-g1.utb", _("Russian grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -226,6 +226,9 @@ addTable("hu-hu-comp8.ctb", _("Hungarian 8 dot computer braille"))
 addTable("hu-hu-g1.ctb", _("Hungarian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("hu-hu-g2.ctb", _("Hungarian grade 2"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("is.ctb", _("Icelandic 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -95,7 +95,7 @@ addTable("be-in-g1.utb", _("Bengali grade 1"))
 addTable("bg.ctb", _("Bulgarian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ckb-g1.ctb", _("Central kurdish grade 1"))
+addTable("ckb-g1.ctb", _("Central Kurdish grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("cy-cy-g1.utb", _("Welsh grade 1"))


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/8437
### Summary of the issue:
In the liblouis 3.6.0, there are some new braille tables for some languages, and others, which were not added in the past.

### Description of how this pull request fixes the issue:
This pull request adds new braille tables mentioned in the issue above, and corrects the russian braille table to the proper eight'dot table.
the table for russian whic was used in the past is not a proper russian eight'dot standardised table.
The table in the past was a representation for printing braille.
This pull request adds the following tables:
1. central Kurdish
2. czech,
3. esperanto grade 1,
4. hungarian grade 2
5. corrects russian braille table.

### Testing performed:
tested using latest master snapshot running from source
### Known issues with pull request:
Bo known issues, all braille tables load properly on imput and output
### Change log entry:
=== new features ===
- added czech eight dots, central kurdish, esperanto and hungarian braille tables

=== changes===
- updated the path to the correct russian eight-dots table
Section: New features, Changes, Bug fixes

