### PR TITLE
Fixes list item numbers for ordered lists in Internet Explorer.

### DIFF
--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -461,6 +461,9 @@ inline void getAttributesFromHTMLDOMNode(IHTMLDOMNode* pHTMLDOMNode,wstring& nod
 		macro_addHTMLAttributeToMap(L"colspan",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 		macro_addHTMLAttributeToMap(L"rowspan",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 		macro_addHTMLAttributeToMap(L"scope",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
+	} else if (nodeName.compare(L"OL") == 0) {
+		macro_addHTMLAttributeToMap(L"start", false, pHTMLAttributeCollection2, attribsMap, tempVar, tempAttribNode);
+		macro_addHTMLAttributeToMap(L"type", false, pHTMLAttributeCollection2, attribsMap, tempVar, tempAttribNode);
 	}
 	macro_addHTMLAttributeToMap(L"longdesc",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"alt",true,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
@@ -1007,6 +1010,13 @@ if(!(formatState&FORMATSTATE_INSERTED)&&nodeName.compare(L"INS")==0) {
 	if(nodeName.compare(L"OL")==0||nodeName.compare(L"UL")==0) {
 		//Ordered lists should number their list items
 		LIIndex=1;
+		// set the list index if list has start attribute
+		if ((tempIter = attribsMap.find(L"HTMLAttrib::start")) != attribsMap.end()) {
+			if (!tempIter->second.empty()) {
+				LIIndex = stoi(tempIter->second);
+			}
+		}
+
 		LIIndexPtr=&LIIndex;
 	} else if(nodeName.compare(L"DL")==0) {
 		//Unordered lists should not be numbered


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8438
### Summary of the issue:
NVDA is not reading list item numbers for ordered list if the number is specified in start attribute of a ol tag. 

NVDA also does not handle type attribute that specifies what type of numbers should be shown. For example, if type attribute specifies "A" then NVDA should read alphabets.

### Description of how this pull request fixes the issue:

This pull request fixes the handling of start attribute for MSHTML. 

### Testing performed:

Tested with the file attached.

### Known issues with pull request:

We still need to work on type attribute. A big challenge is generating numbers in A,B,C format and also generating those numbers in roman format as type attribute could specify roman numerals as well.

Another problem is that the fix is not working for MSHTML control embedded in applications such as vital source.

### Change log entry:

Section: Bug fixes

In Internet Explorer, Fixes reading of numbers for ordered lists if the number does not start with 1.
[OLHTML.zip](https://github.com/nvaccess/nvda/files/2155125/OLHTML.zip)
