### PR TITLE
wxPython 4/deprecated items: use TextEntryDialog.Value, use Menu.Insert/Menu.Remove

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1403,7 +1403,7 @@ class ExcelCell(ExcelBase):
 			_("Editing comment for cell {address}").format(address=self.cellCoordsText),
 			# Translators: Title of a dialog edit an Excel comment 
 			_("Comment"),
-			defaultValue=commentObj.text() if commentObj else u"",
+			value=commentObj.text() if commentObj else u"",
 			style=wx.TE_MULTILINE|wx.OK|wx.CANCEL)
 		def callback(result):
 			if result == wx.ID_OK:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -213,12 +213,12 @@ class MainFrame(wx.Frame):
 
 	def evaluateUpdatePendingUpdateMenuItemCommand(self):
 		try:
-			self.sysTrayIcon.menu.RemoveItem(self.sysTrayIcon.installPendingUpdateMenuItem)
+			self.sysTrayIcon.menu.Remove(self.sysTrayIcon.installPendingUpdateMenuItem)
 		except:
 			log.debug("Error while removing  pending update menu item", exc_info=True)
 			pass
 		if not globalVars.appArgs.secure and updateCheck and updateCheck.isPendingUpdate():
-			self.sysTrayIcon.menu.InsertItem(self.sysTrayIcon.installPendingUpdateMenuItemPos,self.sysTrayIcon.installPendingUpdateMenuItem)
+			self.sysTrayIcon.menu.Insert(self.sysTrayIcon.installPendingUpdateMenuItemPos,self.sysTrayIcon.installPendingUpdateMenuItem)
 
 	def onExitCommand(self, evt):
 		if config.conf["general"]["askToExit"]:

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -218,7 +218,7 @@ class ProfilesDialog(wx.Dialog):
 		# Translators: The label of a field to enter a new name for a configuration profile.
 		with wx.TextEntryDialog(self, _("New name:"),
 				# Translators: The title of the dialog to rename a configuration profile.
-				_("Rename Profile"), defaultValue=oldName) as d:
+				_("Rename Profile"), value=oldName) as d:
 			if d.ShowModal() == wx.ID_CANCEL:
 				return
 			newName = api.filterFileName(d.Value)


### PR DESCRIPTION
### Link to issue number:
Fixes #8523.

### Summary of the issue:
wxPython 4/TextEntryDialog: use value instead of defaultValue keyword argument.

### Description of how this pull request fixes the issue:
Regression: wx.TextEntryDialog no longer accepts defaultValue kwarg, replaced by just 'value'. This affected edit command dialog in Excel and rename function in config profiles dialog (Control+NVDA+P).

### Testing performed:
Attempting to edit comments for cells in Excel, rename profiles in config profiles dialog.

### Known issues with pull request:
None

### Change log entry:
N/A

Thanks.