### PR TITLE
wxPython 4: update deprecated items in settings, elements list, and submenu addition

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -887,7 +887,7 @@ class ElementsListDialog(wx.Dialog):
 	def filter(self, filterText, newElementType=False):
 		# If this is a new element type, use the element nearest the cursor.
 		# Otherwise, use the currently selected element.
-		defaultElement = self._initialElement if newElementType else self.tree.GetItemPyData(self.tree.GetSelection())
+		defaultElement = self._initialElement if newElementType else self.tree.GetItemData(self.tree.GetSelection())
 		# Clear the tree.
 		self.tree.DeleteChildren(self.treeRoot)
 
@@ -906,7 +906,7 @@ class ElementsListDialog(wx.Dialog):
 			if parent:
 				parent = elementsToTreeItems.get(parent)
 			item = self.tree.AppendItem(parent or self.treeRoot, label)
-			self.tree.SetItemPyData(item, element)
+			self.tree.SetItemData(item, element)
 			elementsToTreeItems[element] = item
 			if element == defaultElement:
 				defaultItem = item
@@ -951,7 +951,7 @@ class ElementsListDialog(wx.Dialog):
 		elif key == wx.WXK_F2:
 			item=self.tree.GetSelection()
 			if item:
-				selectedItemType=self.tree.GetItemPyData(item).item
+				selectedItemType=self.tree.GetItemData(item).item
 				self.tree.EditLabel(item)
 				evt.Skip()
 
@@ -975,14 +975,14 @@ class ElementsListDialog(wx.Dialog):
 
 	def onTreeLabelEditBegin(self,evt):
 		item=self.tree.GetSelection()
-		selectedItemType = self.tree.GetItemPyData(item).item
+		selectedItemType = self.tree.GetItemData(item).item
 		if not selectedItemType.isRenameAllowed:
 			evt.Veto()
 
 	def onTreeLabelEditEnd(self,evt):
 			selectedItemNewName=evt.GetLabel()
 			item=self.tree.GetSelection()
-			selectedItemType = self.tree.GetItemPyData(item).item
+			selectedItemType = self.tree.GetItemData(item).item
 			selectedItemType.rename(selectedItemNewName)
 
 	def _clearSearchText(self):
@@ -1030,7 +1030,7 @@ class ElementsListDialog(wx.Dialog):
 		# Save off the last selected element type on to the class so its used in initialization next time.
 		self.__class__.lastSelectedElementType=self.lastSelectedElementType
 		item = self.tree.GetSelection()
-		item = self.tree.GetItemPyData(item).item
+		item = self.tree.GetItemData(item).item
 		if activate:
 			item.activate()
 		else:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -402,7 +402,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		item = subMenu_speechDicts.Append(wx.ID_ANY,_("&Temporary dictionary..."),_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box"))
 		self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
 		# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
-		menu_preferences.Append(wx.ID_ANY,_("Speech &dictionaries"),subMenu_speechDicts)
+		menu_preferences.AppendSubMenu(subMenu_speechDicts,_("Speech &dictionaries"))
 		if not globalVars.appArgs.secure:
 			# Translators: The label for the menu item to open Punctuation/symbol pronunciation dialog.
 			item = menu_preferences.Append(wx.ID_ANY, _("&Punctuation/symbol pronunciation..."))
@@ -411,7 +411,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			item = menu_preferences.Append(wx.ID_ANY, _("I&nput gestures..."))
 			self.Bind(wx.EVT_MENU, frame.onInputGesturesCommand, item)
 		# Translators: The label for Preferences submenu in NVDA menu.
-		self.menu.Append(wx.ID_ANY,_("&Preferences"),menu_preferences)
+		self.menu.AppendSubMenu(menu_preferences,_("&Preferences"))
 
 		menu_tools = self.toolsMenu = wx.Menu()
 		if not globalVars.appArgs.secure:
@@ -444,7 +444,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			item = menu_tools.Append(wx.ID_ANY, _("Reload plugins"))
 			self.Bind(wx.EVT_MENU, frame.onReloadPluginsCommand, item)
 		# Translators: The label for the Tools submenu in NVDA menu.
-		self.menu.Append(wx.ID_ANY, _("Tools"), menu_tools)
+		self.menu.AppendSubMenu(menu_tools,_("Tools"))
 
 		menu_help = self.helpMenu = wx.Menu()
 		if not globalVars.appArgs.secure:
@@ -477,7 +477,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		item = menu_help.Append(wx.ID_ABOUT, _("About..."), _("About NVDA"))
 		self.Bind(wx.EVT_MENU, frame.onAboutCommand, item)
 		# Translators: The label for the Help submenu in NVDA menu.
-		self.menu.Append(wx.ID_ANY,_("&Help"),menu_help)
+		self.menu.AppendSubMenu(menu_help,_("&Help"))
 		self.menu.AppendSeparator()
 		# Translators: The label for the menu item to open the Configuration Profiles dialog.
 		item = self.menu.Append(wx.ID_ANY, _("&Configuration profiles..."))

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2593,9 +2593,9 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.symbolsList.SetFocus()
 
 	def updateListItem(self, item, symbol):
-		self.symbolsList.SetStringItem(item, 1, symbol.replacement)
-		self.symbolsList.SetStringItem(item, 2, characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS[symbol.level])
-		self.symbolsList.SetStringItem(item, 3, characterProcessing.SPEECH_SYMBOL_PRESERVE_LABELS[symbol.preserve])
+		self.symbolsList.SetItem(item, 1, symbol.replacement)
+		self.symbolsList.SetItem(item, 2, characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS[symbol.level])
+		self.symbolsList.SetItem(item, 3, characterProcessing.SPEECH_SYMBOL_PRESERVE_LABELS[symbol.preserve])
 
 	def onSymbolEdited(self):
 		if self.editingItem is not None:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2064,11 +2064,11 @@ class DictionaryDialog(SettingsDialog):
 		entryDialog.setType(self.tempSpeechDict[editIndex].type)
 		if entryDialog.ShowModal()==wx.ID_OK:
 			self.tempSpeechDict[editIndex]=entryDialog.dictEntry
-			self.dictList.SetStringItem(editIndex,0,entryDialog.commentTextCtrl.GetValue())
-			self.dictList.SetStringItem(editIndex,1,entryDialog.patternTextCtrl.GetValue())
-			self.dictList.SetStringItem(editIndex,2,entryDialog.replacementTextCtrl.GetValue())
-			self.dictList.SetStringItem(editIndex,3,self.offOn[int(entryDialog.caseSensitiveCheckBox.GetValue())])
-			self.dictList.SetStringItem(editIndex,4,DictionaryDialog.TYPE_LABELS[entryDialog.getType()])
+			self.dictList.SetItem(editIndex,0,entryDialog.commentTextCtrl.GetValue())
+			self.dictList.SetItem(editIndex,1,entryDialog.patternTextCtrl.GetValue())
+			self.dictList.SetItem(editIndex,2,entryDialog.replacementTextCtrl.GetValue())
+			self.dictList.SetItem(editIndex,3,self.offOn[int(entryDialog.caseSensitiveCheckBox.GetValue())])
+			self.dictList.SetItem(editIndex,4,DictionaryDialog.TYPE_LABELS[entryDialog.getType()])
 			self.dictList.SetFocus()
 		entryDialog.Destroy()
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2747,10 +2747,10 @@ class InputGesturesDialog(SettingsDialog):
 					continue
 				treeCom = self.tree.AppendItem(treeCat, command)
 				commandInfo = commands[command]
-				self.tree.SetItemPyData(treeCom, commandInfo)
+				self.tree.SetItemData(treeCom, commandInfo)
 				for gesture in commandInfo.gestures:
 					treeGes = self.tree.AppendItem(treeCom, self._formatGesture(gesture))
-					self.tree.SetItemPyData(treeGes, gesture)
+					self.tree.SetItemData(treeGes, gesture)
 			if not self.tree.ItemHasChildren(treeCat):
 				self.tree.Delete(treeCat)
 			elif filter:
@@ -2777,7 +2777,7 @@ class InputGesturesDialog(SettingsDialog):
 			item = self.tree.Selection
 		except RuntimeError:
 			return
-		data = self.tree.GetItemPyData(item)
+		data = self.tree.GetItemData(item)
 		isCommand = isinstance(data, inputCore.AllGesturesScriptInfo)
 		isGesture = isinstance(data, basestring)
 		self.addButton.Enabled = isCommand or isGesture
@@ -2788,10 +2788,10 @@ class InputGesturesDialog(SettingsDialog):
 			return
 
 		treeCom = self.tree.Selection
-		scriptInfo = self.tree.GetItemPyData(treeCom)
+		scriptInfo = self.tree.GetItemData(treeCom)
 		if not isinstance(scriptInfo, inputCore.AllGesturesScriptInfo):
 			treeCom = self.tree.GetItemParent(treeCom)
-			scriptInfo = self.tree.GetItemPyData(treeCom)
+			scriptInfo = self.tree.GetItemData(treeCom)
 		# Translators: The prompt to enter a gesture in the Input Gestures dialog.
 		treeGes = self.tree.AppendItem(treeCom, _("Enter input gesture:"))
 		self.tree.SelectItem(treeGes)
@@ -2817,7 +2817,7 @@ class InputGesturesDialog(SettingsDialog):
 					lambda evt, gid=gid, disp=disp: self._addChoice(treeGes, scriptInfo, gid, disp),
 					item)
 			self.PopupMenu(menu)
-			if not self.tree.GetItemPyData(treeGes):
+			if not self.tree.GetItemData(treeGes):
 				# No item was selected, so use the first.
 				self._addChoice(treeGes, scriptInfo, gids[0],
 					self._formatGesture(gids[0]))
@@ -2834,15 +2834,15 @@ class InputGesturesDialog(SettingsDialog):
 		except KeyError:
 			self.pendingAdds.add(entry)
 		self.tree.SetItemText(treeGes, disp)
-		self.tree.SetItemPyData(treeGes, gid)
+		self.tree.SetItemData(treeGes, gid)
 		scriptInfo.gestures.append(gid)
 		self.onTreeSelect(None)
 
 	def onRemove(self, evt):
 		treeGes = self.tree.Selection
-		gesture = self.tree.GetItemPyData(treeGes)
+		gesture = self.tree.GetItemData(treeGes)
 		treeCom = self.tree.GetItemParent(treeGes)
-		scriptInfo = self.tree.GetItemPyData(treeCom)
+		scriptInfo = self.tree.GetItemData(treeCom)
 		entry = (gesture, scriptInfo.moduleName, scriptInfo.className, scriptInfo.scriptName)
 		try:
 			# If this was just added, just undo it.


### PR DESCRIPTION
Hi,

Continuation of wxPython 4 updates.

### Link to issue number:
None

### Summary of the issue:
wxPython 4 raises deprecation warning for various items, so catch them and use suggested code paths.

### Description of how this pull request fixes the issue:
Handles the following deprecated code paths:

1. NVDA menu: wx.Menu.Append -> wx.Menu.AppendSubMenu for submenus.
2. Browse mode/elements list: wx.TreeCtrl.{Get/Set}ItemPyData -> wx.TreeCtrl.{Get/Set}ItemData for elements list tree, and in case of changing sheet names in Excel, also for edit begin/end events.
3. Input gestures dialog: same as item 2.
4. Speech dictionaries: wx.ListCtrl.SetStringItem -> wx.ListCtrl.SetItem for entries.
5. Punctuation/symbol pronunciation dialog: same as item 4.

Also, wx.Yield is deprecated, with numerous replacements, including wx.SafeYield and/or wx.YieldIfNeeded. However, this should be done as a separate issue/pull request pair due to risk of introducing regressions and breaking things.

### Testing performed:
For each change, tested with NVDA run from source.

### Known issues with pull request:
None

### Change log entry:
N/A

Thanks.