### PR TITLE
Enable event coalescing and connection recovery for UI Automation when available

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -192,6 +192,11 @@ class UIAHandler(COMObject):
 						break
 					except COMError:
 						pass
+				# Windows 10 RS5 provides new performance features for UI Automation including event coalescing and connection recovery. 
+				# Enable all of these where available.
+				if isinstance(self.clientObject,IUIAutomation6):
+					self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
+					self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
 			log.info("UIAutomation: %s"%self.clientObject.__class__.__mro__[1].__name__)
 			self.windowTreeWalker=self.clientObject.createTreeWalker(self.clientObject.CreateNotCondition(self.clientObject.CreatePropertyCondition(UIA_NativeWindowHandlePropertyId,0)))
 			self.windowCacheRequest=self.clientObject.CreateCacheRequest()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,6 +42,7 @@ What's New in NVDA
 - NVDA no longer announces redundant keyboard layout changes. (#7383)
 - Mouse tracking is now much more accurate in Notepad and other plain text edit controls when in a document with more than 65535 characters. (#8397)
 - NVDA will recognize more dialogs in Windows 10 and other modern applications. (#7473)
+- On windows 10 rs5 and above, NVDA no longer fails to track the system focus when an application freezes or floods the system with events. (#8539)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Addresses #7345 and #8535 on Windows 10 RS5 and later.

### Summary of the issue:
UI Automation events are no longer detected by NVDA across the entire Operating system, when an app freezes, does not run its message pump fast enough after emmitting winEvents, or when an app floods the system with UI automation events.
Most notably, UIA focus events no longer fire which means that NVDA can no longer track focus in UI Automation applications, including the alt+tab task list, and Explorer.
 
### Description of how this pull request fixes the issue:
IUIAutomation6 (introduced in Windows 10 RS5) allows coalescing of UI Automation events, and black listing of UIA providers when they are not responding fast enough.
this PR enables both features.

### Testing performed:
Tested #8535: When launching the Open Crashdump dialog in windbg,  NVDA can now continue to track focus in other UI Automation applications.
Similarly,  opening an app such as Notepad, opening windbg, and breaking into Notepad (essentially freezing it) also no longer kills off focus events across the system.
And also, @jcsteh's slowProgress testcase app when running no longer seems to take out focus events on the system either.

 ### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
On windows 10 rs5 and above, NVDA no longer fails to track the system focus when an application freezes or floods the system with events.
Section: New features, Changes, Bug fixes

