### PR TITLE
Language handler: add Burmese manually as it is not recognized in Windows 7

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -81,6 +81,8 @@ def getLanguageDescription(language):
 			"ckb":pgettext("languageName","Central Kurdish"),
 			# Translators: The name of a language supported by NVDA.
 			"kmr":pgettext("languageName","Northern Kurdish"),
+			# Translators: The name of a language supported by NVDA.
+			"my":pgettext("languageName","Burmese"),
 		}.get(language,None)
 	return desc
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ What's New in NVDA
 - NVDA will recognize more dialogs in Windows 10 and other modern applications. (#7473)
 - On windows 10 rs5 and above, NVDA no longer fails to track the system focus when an application freezes or floods the system with events. (#8539)
 - Fix a case where the "not checked" state on controls is not reported in speech if the control has previously been half checked. (#6946)
+- In the list of languages in NVDA's General Settings, language name for Burmese is displayed correctly on Windows 7. (#8544)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #8544 

### Summary of the issue:
Burmese (my) is not recognized in Windows 7

### Description of how this pull request fixes the issue:
Burmese (my) is recognized starting with Windows 8. Because NVDA also runs on Windows 7, add this language manually.

### Testing performed:
Tested on Windows 7, 8,1 and 10 by compiling and running the launcher version of NVDA.

### Known issues with pull request:
None

### Change log entry:
Bug fixes: On Windows 7, language description for Burmese is shown in language combo box in general settings panel.

Thanks.