### PR TITLE
Fix a case where the "not checked" state is not reported in speech

### DIFF
--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -735,6 +735,9 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 		# Return only those supplied negative states which should be spoken;
 		# i.e. the states in both sets.
 		speakNegatives &= negativeStates
+		# #6946: if HALFCHECKED is present but CHECKED isn't, we should make sure we add CHECKED to speakNegatives.
+		if (STATE_HALFCHECKED in negativeStates and STATE_HALFCHECKED not in states):
+			speakNegatives.add(STATE_CHECKED)
 		if STATES_SORTED & negativeStates and not STATES_SORTED & states:
 			# If the object has just stopped being sorted, just report not sorted.
 			# The user doesn't care how it was sorted before.

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -736,7 +736,7 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 		# i.e. the states in both sets.
 		speakNegatives &= negativeStates
 		# #6946: if HALFCHECKED is present but CHECKED isn't, we should make sure we add CHECKED to speakNegatives.
-		if (STATE_HALFCHECKED in negativeStates and STATE_HALFCHECKED not in states):
+		if (STATE_HALFCHECKED in negativeStates and STATE_CHECKED not in states):
 			speakNegatives.add(STATE_CHECKED)
 		if STATES_SORTED & negativeStates and not STATES_SORTED & states:
 			# If the object has just stopped being sorted, just report not sorted.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,6 +43,7 @@ What's New in NVDA
 - Mouse tracking is now much more accurate in Notepad and other plain text edit controls when in a document with more than 65535 characters. (#8397)
 - NVDA will recognize more dialogs in Windows 10 and other modern applications. (#7473)
 - On windows 10 rs5 and above, NVDA no longer fails to track the system focus when an application freezes or floods the system with events. (#8539)
+- Fix a case where the "not checked" state on controls is not reported in speech if the control has previously been half checked. (#6946)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #6946

### Summary of the issue:
In a specific context, NVDA doesn't report the "not checked" state.

### Description of how this pull request fixes the issue:
In `controlTypes.py` then `processNegativeStates()` function, for REASON_CHANGE, if HALFCHECKED is present but CHECKED isn't, we add CHECKED to speakNegatives.

### Testing performed:
Tested with examples provided in #6946 comments and other HTML code. Works for me.

### Known issues with pull request:
None known.

### Change log entry:

Section: Bug fixes
> Fix a case where the "not checked" state is not reported in speech. (#6946)