### PR TITLE
Remove duplicated functions from winKernel

### DIFF
--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -120,58 +120,6 @@ def setWaitableTimer(handle, dueTime, period=0, completionRoutine=None, arg=None
 		raise ctypes.WinError()
 	return True
 
-def createWaitableTimer(securityAttributes=None, manualReset=False, name=None):
-	"""Wrapper to the kernel32 CreateWaitableTimer function.
-	Consult https://msdn.microsoft.com/en-us/library/windows/desktop/ms682492.aspx for Microsoft's documentation.
-	In contrast with the original function, this wrapper assumes the following defaults.
-	@param securityAttributes: Defaults to C{None};
-		The timer object gets a default security descriptor and the handle cannot be inherited.
-		The ACLs in the default security descriptor for a timer come from the primary or impersonation token of the creator.
-	@type securityAttributes: pointer to L{SECURITY_ATTRIBUTES}
-	@param manualReset: Defaults to C{False} which means the timer is a synchronization timer.
-		If C{True}, the timer is a manual-reset notification timer.
-	@type manualReset: bool
-	@param name: Defaults to C{None}, the timer object is created without a name.
-	@type name: unicode
-	"""
-	res = kernel32.CreateWaitableTimerW(securityAttributes, manualReset, name)
-	if res==0:
-		raise ctypes.WinError()
-	return res
-
-def setWaitableTimer(handle, dueTime, period=0, completionRoutine=None, arg=None, resume=False):
-	"""Wrapper to the kernel32 SETWaitableTimer function.
-	Consult https://msdn.microsoft.com/en-us/library/windows/desktop/ms686289.aspx for Microsoft's documentation.
-	@param handle: A handle to the timer object.
-	@type handle: int
-	@param dueTime: Relative time (in miliseconds).
-		Note that the original function requires relative time to be supplied as a negative nanoseconds value.
-	@type dueTime: int
-	@param period: Defaults to 0, timer is only executed once.
-		Value should be supplied in miliseconds.
-	@type period: int
-	@param completionRoutine: The function to be executed when the timer elapses.
-	@type completionRoutine: L{PAPCFUNC}
-	@param arg: Defaults to C{None}; a pointer to a structure that is passed to the completion routine.
-	@type arg: L{ctypes.c_void_p}
-	@param resume: Defaults to C{False}; the system is not restored.
-		If this parameter is TRUE, restores a system in suspended power conservation mode 
-		when the timer state is set to signaled.
-	@type resume: bool
-	"""
-	res = kernel32.SetWaitableTimer(
-		handle,
-		# due time is in 100 nanosecond intervals, relative time should be negated.
-		byref(LARGE_INTEGER(dueTime*-10000)),
-		period,
-		completionRoutine,
-		arg,
-		resume
-	)
-	if res==0:
-		raise ctypes.WinError()
-	return True
-
 
 def openProcess(*args):
 	return kernel32.OpenProcess(*args)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In winKernel.py, the createWaitableTimer and setWaitableTimer functions are present twice. This is probably caused by a merge issue in #7741.

### Description of how this pull request fixes the issue:
Removed the duplicates from winKernel.py

### Testing performed:
Made sure that code using waitable timers still works.

### Known issues with pull request:
None

### Change log entry:
None
