### PR TITLE
Upgrade eSpeak-ng to latest master

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ For reference, the following dependencies are included in Git submodules:
 * [wxPython](http://www.wxpython.org/), version 4.0.3
 * [Six](https://pypi.python.org/pypi/six), version 1.10.0, required by wxPython
 * [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 218
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit e7e59f9
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 910f4c2
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](http://www.voidspace.org.uk/python/configobj.html), version 4.6.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,7 +29,7 @@ What's New in NVDA
 - When checking for updates, if the user has agreed to allow sending usage statistics to NV Access, NVDA will now send the name of the current synth driver and braille display in use, to aide in better prioritization for future work on these drivers. (#8217)
 - Updated liblouis braille translator to version 3.6.0. (#8365)
 - updated the path to the correct russian eight-dots Braille table. (#8446)
-- Updated eSpeak-ng to 1.49.3dev commit e7e59f9. (#7846)
+- Updated eSpeak-ng to 1.49.3dev commit 910f4c2 (#8561)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
With the merging of #7846, NVDA users complained of several issues in espeak-ng:
* espeak-ng/espeak-ng#523: Macedonian spoke junk characters after each string, and 0s before speaking each character.
 * espeak-ng/espeak-ng#520: issues speaking in Serbian
* espeak-ng/espeak-ng#518: Bad pronounciations in bulgarian

### Description of how this pull request fixes the issue:
Upgrade to latest master of espeak-ng which addresses these issues.

### Testing performed:
* Ran NVDA with this version of eSpeak-ng. 
* espeak-ng now has tests which should cover these kinds of breaks in the future.

### Known issues with pull request:
None.

### Change log entry:
Upgrade to espeak-ng commit xxxx