### PR TITLE
Report  label of lists in browseMode

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -1166,12 +1166,16 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 	# speakStatesFirst: Speak the states before the role.
 	speakStatesFirst=role==controlTypes.ROLE_LINK
 
+	containerContainsText="" #: used for item counts for lists
+
 	# Determine what text to speak.
 	# Special cases
 	if speakEntry and childControlCount and fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_LIST and controlTypes.STATE_READONLY in states:
 		# List.
-		# Translators: Speaks number of items in a list (example output: list with 5 items).
-		return roleText+" "+_("with %s items")%childControlCount
+		# #7652: containerContainsText variable is set here, but the actual generation of all other output is handled further down in the general cases section.
+		# This ensures that properties such as name, states and level etc still get reported appropriately.
+		# Translators: Number of items in a list (example output: list with 5 items).
+		containerContainsText=_("with %s items")%childControlCount
 	elif fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_TABLE and tableID:
 		# Table.
 		return " ".join((nameText,roleText,stateText, getSpeechTextForProperties(_tableID=tableID, rowCount=attrs.get("table-rowcount"), columnCount=attrs.get("table-columncount")),levelText))
@@ -1196,8 +1200,8 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 			+ (" %s" % stateText if stateText else "")
 			+ (" %s" % ariaCurrentText if ariaCurrent else ""))
 
-	# General cases
-	elif (
+	# General cases.
+	if (
 		(speakEntry and ((speakContentFirst and fieldType in ("end_relative","end_inControlFieldStack")) or (not speakContentFirst and fieldType in ("start_addedToControlFieldStack","start_relative"))))
 		or (speakWithinForLine and not speakContentFirst and not extraDetail and fieldType=="start_inControlFieldStack")
 	):
@@ -1209,7 +1213,7 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 			if valueText:
 				log.error("valueText exists when expected none: valueText:'%s' placeholderText:'%s'"%(valueText,placeholderText))
 			valueText = placeholderText
-		out.extend(x for x in (nameText,(stateText if speakStatesFirst else roleText),(roleText if speakStatesFirst else stateText),ariaCurrentText,valueText,descriptionText,levelText,keyboardShortcutText) if x)
+		out.extend(x for x in (nameText,(stateText if speakStatesFirst else roleText),(roleText if speakStatesFirst else stateText),containerContainsText,ariaCurrentText,valueText,descriptionText,levelText,keyboardShortcutText) if x)
 		if content and not speakContentFirst:
 			out.append(content)
 		return CHUNK_SEPARATOR.join(out)

--- a/source/speech.py
+++ b/source/speech.py
@@ -1170,7 +1170,7 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 
 	# Determine what text to speak.
 	# Special cases
-	if speakEntry and childControlCount and fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_LIST and controlTypes.STATE_READONLY in states:
+	if childControlCount and fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_LIST and controlTypes.STATE_READONLY in states:
 		# List.
 		# #7652: containerContainsText variable is set here, but the actual generation of all other output is handled further down in the general cases section.
 		# This ensures that properties such as name, states and level etc still get reported appropriately.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -49,6 +49,7 @@ What's New in NVDA
 - In the list of languages in NVDA's General Settings, language name for Burmese is displayed correctly on Windows 7. (#8544)
 - In Microsoft Edge, NVDA will announce notifications such as reading view availability and page load progress. (#8423)
 - Similar to other multiline text fields, When positioned at the start of a document in Braille, the display is now panned such that the first character of the document is at the start of the display. (#8406)
+- When navigating into a list on the web, NvDA will now report its label if the web author has provided one. (#7652)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #7652 

### Summary of the issue:
Web authors can label ul/ol lists with aria-label or aria-labelledby. However, NVDA does not currently speak these labels when entering the list with quicknav, or arrowing (when the label does not appear anywhere else on the page).
 
### Description of how this pull request fixes the issue:
The information spoken when entering a list has now been generlized so that it includes  all the standard properties such as name, states, level etc, which were previously being completely ignored.

### Testing performed:
Using Firefox, Tested the testcase in #7652. NVDA announced the name of both lists.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* When navigating into a list on the web, NvDA will now report its label if the web author has provided one.