### PR TITLE
Treat documents as being multiline in Braille

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -766,8 +766,11 @@ class TextInfoRegion(Region):
 		from treeInterceptorHandler import TreeInterceptor
 		if isinstance(self.obj, TreeInterceptor):
 			return True
-		# Terminals are inherently multiline, so they don't have the multiline state.
-		return (self.obj.role == controlTypes.ROLE_TERMINAL or controlTypes.STATE_MULTILINE in self.obj.states)
+		# Terminals and documents are inherently multiline, so they don't have the multiline state.
+		return (
+			self.obj.role in (controlTypes.ROLE_TERMINAL,controlTypes.ROLE_DOCUMENT)
+			or controlTypes.STATE_MULTILINE in self.obj.states
+		)
 
 	def _getSelection(self):
 		"""Retrieve the selection.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -47,6 +47,7 @@ What's New in NVDA
 - Fix a case where the "not checked" state on controls is not reported in speech if the control has previously been half checked. (#6946)
 - In the list of languages in NVDA's General Settings, language name for Burmese is displayed correctly on Windows 7. (#8544)
 - In Microsoft Edge, NVDA will announce notifications such as reading view availability and page load progress. (#8423)
+- Similar to other multiline text fields, When positioned at the start of a document in Braille, the display is now panned such that the first character of the document is at the start of the display. (#8406)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8406  

### Summary of the issue:
Multiline text fields in braille should appear hard left on the braille display to allow as much room as possible for the content of the first line.
NVDA already does this for terminals, and anything with the multiline state. However, it does not do it for documents.
This is now a noticeable problem when using UI automation in MS Word, where the controlType for the UIA element for the document is in deed document. When previously using the object model, it was edit, but did have the multiline state.
 
### Description of how this pull request fixes the issue:
Braille now treats documents as being multiline.

### Testing performed:
Using NVDA with braille:
* Opened MS Word with UIA enabled.
* Confirmed that the braille display was showing the document's textInfo region hard left. I.e. for a new document there was just a flashing cursor at the start of the display and nothing else.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* Similar to other multiline text fields, When positioned at the start of a document in Braille, the display is now panned such that the first character of the document is at the start of the display. (#8406)