### PR TITLE
proof of concept wrt issue #8563

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -183,6 +183,10 @@ class EditableTextWithAutoSelectDetection(EditableText):
 	def event_textRemove(self):
 		self.hasContentChangedSinceLastSelection = True
 
+	def _caretScriptPostMovedHelper(self, speakUnit, gesture, info=None):
+                super(EditableTextWithAutoSelectDetection,self)._caretScriptPostMovedHelper(speakUnit, gesture, info=None)
+                self.detectPossibleSelectionChange()
+
 class EditableTextWithoutAutoSelectDetection(editableText.EditableTextWithoutAutoSelectDetection, EditableText):
 	"""In addition to L{EditableText}, provides scripts to report appropriately when the selection changes.
 	This should be used when an object does not notify of selection changes.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -248,6 +248,9 @@ class EditableText(TextContainerObject,ScriptableObject):
 		self._caretScriptPostMovedHelper(textInfos.UNIT_CHARACTER,gesture,newInfo)
 		braille.handler.handleCaretMove(self)
 
+        def script_selectAll (self,gesture):
+		self._caretMovementScriptHelper(gesture, textInfos.UNIT_LINE)                
+
 	__gestures = {
 		"kb:upArrow": "caret_moveByLine",
 		"kb:downArrow": "caret_moveByLine",
@@ -269,6 +272,7 @@ class EditableText(TextContainerObject,ScriptableObject):
 		"kb:numpadDelete": "caret_delete",
 		"kb:backspace": "caret_backspaceCharacter",
 		"kb:control+backspace": "caret_backspaceWord",
+                "kb:control+a": "selectAll",
 	}
 
 	def initAutoSelectDetection(self):


### PR DESCRIPTION
### Link to issue number:
  #8563 
### Summary of the issue:

### Description of how this pull request fixes the issue:
Added in EditableText an entry and script for ctrl+a gesture
Have _caretScriptPostMovedHelper in EditableTextWithAutoSelectDetection afterwards also check for possible selection changes.
### Testing performed:

### Known issues with pull request:
It is just a proof of concept.
What other gestures to add?
Now for ctrl+a caret movement considers line unit, not sure what most sensible unit would be in this case. In addition to that spoken output wrt selection comes immediately after spoken output wrt caret movement: how should the spoken output look like in order to become less confusing/more clear?
### Change log entry:

Section: New features, Changes, Bug fixes

