### PR TITLE
Braille in UIA word documents: improve focus ancestry, cursor routing, and newly inserted bullets/numbers

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -441,7 +441,10 @@ class ProtectedDocumentPane(IAccessible):
 	"""The pane that gets focus in case a document opens in protected mode in word
 	This is mapped to the window class _WWB and role oleacc.ROLE_SYSTEM_CLIENT
 	"""
-	
+
+	# This object should not be presented in the focus ancestry as it is redundant.
+	isPresentableFocusAncestor=False
+
 	def event_gainFocus(self):
 		"""On gaining focus, simply set the focus on a child of type word document. 
 		This is just a container window.

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -438,7 +438,10 @@ class SpellCheckErrorField(IAccessible,WordDocument_WwN):
 		return False
 
 class ProtectedDocumentPane(IAccessible):
-	"""The pane that gets focus in case a document opens in protected mode in word
+	"""
+	The pane that directly contains a Word document control.
+	This pane exists no matter if the document is protected or not, but specifically gets focus when a document is opened in protected mode, and therefore handles moving focus back to the actual document.
+	This class also suppresses this pane from being presented in the focus ancestry as it contains  redundant information.
 	This is mapped to the window class _WWB and role oleacc.ROLE_SYSTEM_CLIENT
 	"""
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -422,13 +422,15 @@ class UIATextInfo(textInfos.TextInfo):
 		"""
 		return range.getText(-1)
 
-	def _getTextWithFields_text(self,textRange,formatConfig,UIAFormatUnits=None):
+	def _getTextWithFields_text(self,textRange,formatConfig,ignoreEmptyChunks=True,UIAFormatUnits=None):
 		"""
 		Yields format fields and text for the given UI Automation text range, split up by the first available UI Automation text unit that does not result in mixed attribute values.
 		@param textRange: the UI Automation text range to walk.
 		@type textRange: L{UIAHandler.IUIAutomationTextRange}
 		@param formatConfig: the types of formatting requested.
 		@ type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@param ignoreEmptyChunks: if true, textRanges where the text is empty will not be emitted nor the formatField directly before it. 
+		@param ignoreEmptyChunks: bool
 		@param UIAFormatUnits: the UI Automation text units (in order of resolution) that should be used to split the text so as to avoid mixed attribute values. This is None by default.
 			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter. 
 			If this parameter is an empty list, then formatting and text is fetched for the entire range, but any mixed attribute values are ignored and no splitting occures.
@@ -448,8 +450,8 @@ class UIATextInfo(textInfos.TextInfo):
 		log.debug("With further units of: %s"%furtherUIAFormatUnits)
 		rangeIter=iterUIARangeByUnit(textRange,unit) if unit is not None else [textRange]
 		for tempRange in rangeIter:
-			text=self._getTextFromUIARange(tempRange)
-			if text:
+			text=self._getTextFromUIARange(tempRange) or ""
+			if not ignoreEmptyChunks or text:
 				log.debug("Chunk has text. Fetching formatting")
 				try:
 					field=self._getFormatFieldAtRange(tempRange,formatConfig,ignoreMixedValues=len(furtherUIAFormatUnits)==0)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -8,12 +8,14 @@ from collections import defaultdict
 import textInfos
 import eventHandler
 import UIAHandler
+from logHandler import log
 import controlTypes
 import ui
 import speech
 import api
 import browseMode
 from UIABrowseMode import UIABrowseModeDocument, UIADocumentWithTableNavigation, UIATextAttributeQuicknavIterator, TextAttribUIATextInfoQuickNavItem
+from UIAUtils import *
 from . import UIA, UIATextInfo
 from NVDAObjects.window.winword import WordDocument as WordDocumentBase
 
@@ -146,6 +148,21 @@ class WordDocumentTextInfo(UIATextInfo):
 			return res
 		return super(WordDocumentTextInfo,self).move(unit,direction,endPoint)
 
+	def expand(self,unit):
+		super(WordDocumentTextInfo,self).expand(unit)
+		# #7970: MS Word refuses to expand to line when on the final line and it is blank.
+		# This among other things causes a newly inserted bullet not to be spoken or brailled.
+		# Therefore work around this by detecting if the expand to line failed, and moving the end of the range to the end of the document manually.
+		if  self.isCollapsed:
+			if self.move(unit,1,endPoint="end")==0:
+				docInfo=self.obj.makeTextInfo(textInfos.POSITION_ALL)
+				self.setEndPoint(docInfo,"endToEnd")
+
+	def _getTextWithFields_text(self,textRange,formatConfig,ignoreEmptyChunks=False,UIAFormatUnits=None):
+		# This override just changes ignoreEmptyChunks to false by default.
+		# We need this so that graphics and other embeded objects in MS Word get exposed.
+		return super(WordDocumentTextInfo,self)._getTextWithFields_text(textRange,formatConfig,ignoreEmptyChunks,UIAFormatUnits)
+
 	def _get_isCollapsed(self):
 		res=super(WordDocumentTextInfo,self).isCollapsed
 		if res: 
@@ -155,10 +172,42 @@ class WordDocumentTextInfo(UIATextInfo):
 		return not bool(self.text)
 
 	def getTextWithFields(self,formatConfig=None):
+		if self.isCollapsed:
+			# #7652: We cannot fetch fields on collapsed ranges otherwise we end up with repeating controlFields in braille (such as list list list). 
+			return []
 		fields=super(WordDocumentTextInfo,self).getTextWithFields(formatConfig=formatConfig)
 		if len(fields)==0: 
 			# Nothing to do... was probably a collapsed range.
 			return fields
+		##7971: Microsoft Word exposes list bullets as part of the actual text.
+		# This then confuses NVDA's braille cursor routing as it expects that there is a one-to-one mapping between characters in the text string and   unit character moves.
+		# Therefore, detect when at the start of a list, and strip the bullet from the text string, placing it in the text's formatField as line-prefix.
+		listItemStarted=False
+		lastFormatField=None
+		for index in xrange(len(fields)):
+			field=fields[index]
+			if isinstance(field,textInfos.FieldCommand) and field.command=="controlStart":
+				if field.field.get('role')==controlTypes.ROLE_LISTITEM and field.field.get('_startOfNode'):
+					# We are in the start of a list item.
+					listItemStarted=True
+			elif isinstance(field,textInfos.FieldCommand) and field.command=="formatChange":
+				# This is the most recent formatField we have seen.
+				lastFormatField=field.field
+			elif listItemStarted and isinstance(field,basestring):
+				# This is the first text string within the list.
+				# Remove the text up to the first space, and store it as line-prefix which NVDA will appropriately speak/braille as a bullet.
+				try:
+					spaceIndex=field.index(' ')
+				except ValueError:
+					log.debugWarning("No space found in this text string")
+					break
+				prefix=field[0:spaceIndex]
+				fields[index]=field[spaceIndex+1:]
+				lastFormatField['line-prefix']=prefix
+				break
+			else:
+				# Not a controlStart, formatChange or text string. Nothing to do.
+				break
 		# Fill in page number attributes where NVDA expects
 		try:
 			page=fields[0].field['page-number']
@@ -178,6 +227,8 @@ class WordDocumentTextInfo(UIATextInfo):
 		for index,field in enumerate(fields):
 			if isinstance(field,textInfos.FieldCommand) and field.command=="controlStart":
 				runtimeID=field.field['runtimeID']
+				if not runtimeID:
+					continue
 				if runtimeID in seenStarts:
 					pendingRemoves.append(field.field)
 				else:

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -301,10 +301,8 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	shouldCreateTreeInterceptor=False
 	announceEntireNewLine=True
 
-	def _get_name(self):
-		# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.
-		# Translators: The name of a control that shows a Microsoft Word document.
-		return _("Microsoft Word")
+	# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.
+	name=u""
 
 	def script_reportCurrentComment(self,gesture):
 		caretInfo=self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -204,6 +204,8 @@ class WordDocumentTextInfo(UIATextInfo):
 				prefix=field[0:spaceIndex]
 				fields[index]=field[spaceIndex+1:]
 				lastFormatField['line-prefix']=prefix
+				# Let speech know that line-prefix is safe to be spoken always, as it will only be exposed on the very first formatField on the list item.
+				lastFormatField['line-prefix_speakAlways']=True
 				break
 			else:
 				# Not a controlStart, formatChange or text string. Nothing to do.

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -104,6 +104,9 @@ class WordDocumentTextInfo(UIATextInfo):
 		field=super(WordDocumentTextInfo,self)._getControlFieldForObject(obj,isEmbedded=isEmbedded,startOfNode=startOfNode,endOfNode=endOfNode)
 		if automationID.startswith('UIA_AutomationId_Word_Page_'):
 			field['page-number']=automationID.rsplit('_',1)[-1]
+		elif obj.UIAElement.cachedControlType==UIAHandler.UIA_GroupControlTypeId and obj.name:
+			field['role']=controlTypes.ROLE_EMBEDDEDOBJECT
+			field['alwaysReportName']=True
 		elif obj.UIAElement.cachedControlType==UIAHandler.UIA_CustomControlTypeId and obj.name:
 			# Include foot note and endnote identifiers
 			field['content']=obj.name

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -301,6 +301,11 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	shouldCreateTreeInterceptor=False
 	announceEntireNewLine=True
 
+	def _get_name(self):
+		# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.
+		# Translators: The name of a control that shows a Microsoft Word document.
+		return _("Microsoft Word")
+
 	def script_reportCurrentComment(self,gesture):
 		caretInfo=self.makeTextInfo(textInfos.POSITION_CARET)
 		caretInfo.expand(textInfos.UNIT_CHARACTER)

--- a/source/speech.py
+++ b/source/speech.py
@@ -1635,7 +1635,12 @@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni
 				text=""
 			if text:
 				textList.append(text)
-	if unit in (textInfos.UNIT_LINE,textInfos.UNIT_SENTENCE,textInfos.UNIT_PARAGRAPH,textInfos.UNIT_READINGCHUNK):
+	# The line-prefix formatField attribute contains the text for a bullet or number for a list item, when the bullet or number does not appear in the actual text content.
+	# Normally this attribute could be repeated across formatFields within a list item and therefore is not safe to speak when the unit is word or character.
+	# However, some implementations (such as MS Word with UIA) do limit its useage to the very first formatField of the list item.
+	# Therefore, they also expose a line-prefix_speakAlways attribute to allow its usage for any unit.
+	linePrefix_speakAlways=attrs.get('line-prefix_speakAlways',False)
+	if linePrefix_speakAlways or unit in (textInfos.UNIT_LINE,textInfos.UNIT_SENTENCE,textInfos.UNIT_PARAGRAPH,textInfos.UNIT_READINGCHUNK):
 		linePrefix=attrs.get("line-prefix")
 		if linePrefix:
 			textList.append(linePrefix)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,6 +51,10 @@ What's New in NVDA
 - Similar to other multiline text fields, When positioned at the start of a document in Braille, the display is now panned such that the first character of the document is at the start of the display. (#8406)
 - When manually assigning functions to gestures for a particular braille display, these gestures now always show up as being assigned to that display. Previously, they showed up as if they were assigned to the currently active display. (#8108)
 - The 64-bit version of Media Player Classic is now supported. (#6066)
+- Several improvements to braille support in Microsoft Word with UI Automation enabled:
+ - Reduced overly verbose focus presentation in both speech and braille when focusing a Word document. (#8407)
+ - Cursor routing in braille now works correctly when in a list in a Word document. (#7971)
+ - Newly inserted bullets/numbers in a Word document are correctly reported in both speech and braille. (#7970)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8407 
Fixes #7971 
Fixes #7970 

### Summary of the issue:
There are several issues with braille support for Microsoft word when using UI automation:
* Focus ancestry for both speech and braille is overly redundant. The title of the document is reported at least 3 times.
* Braille cursor routing is incorrect when on list items due to the bullet/number text taking up cells in the wrong way.
 * When inserting a new bullet/number in Ms Word, the bullet/number is neither spoken nor brailled.

### Description of how this pull request fixes the issue:
* The focus ancestry has been improved by ignoring one of the redundant objects above the document, and the name of the document itself has been changed back to what it was pre UIA (namely "Microsoft word") rather than repeating the full title of the document again.
* Braille cursor routing has been fixed when on list items in MS Word by  stripping the nullet/number off the start of the actual text, and instead exposing it as the line-prefix formatField attribute that braille/speech knows how to handle.
* works around a bug in MS word where expanding to line on the last line of a document (that is blank) fails. In this case we manually move the end of the text range to the end of the document. This addresses the reporting of newly inserted bullets/numbers and also stops the page number from inappropriately being announced when arrowing up from this blank line into other content.
 
 ### Testing performed:
Tested several complex documents with Microsoft word with UIA support enabled. Tested with both speech and braille.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* Several improvements to braille support in Microsoft Word with UI Automation enabled:
 * Reduced overly verbose focus presentation in both speech and braille when focusing a Word document. (#8407)
 * Cursor routing in braille now works correctly when in a list in a Word document. (#7971)
 * Newly inserted bullets/numbers in a Word document are correctly reported in both speech and braille. (#7970)
