### PR TITLE
Support IA2_ROLE_BLOCK_QUOTE.

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -254,6 +254,7 @@ IAccessibleRolesToNVDARoles={
 	IA2_ROLE_VIEW_PORT:controlTypes.ROLE_VIEWPORT,
 	IA2_ROLE_CONTENT_DELETION:controlTypes.ROLE_DELETED_CONTENT,
 	IA2_ROLE_CONTENT_INSERTION:controlTypes.ROLE_INSERTED_CONTENT,
+	IA2_ROLE_BLOCK_QUOTE:controlTypes.ROLE_BLOCKQUOTE,
 	#some common string roles
 	"frame":controlTypes.ROLE_FRAME,
 	"iframe":controlTypes.ROLE_INTERNALFRAME,

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -269,7 +269,12 @@ class Gecko_ia2(VirtualBuffer):
 		elif nodeType=="graphic":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_GRAPHIC]}
 		elif nodeType=="blockQuote":
-			attrs={"IAccessible2::attribute_tag":self._searchableTagValues(["blockquote"])}
+			attrs=[
+				# Search for a tag of blockquote for older implementations before the blockquote IAccessible2 role existed.
+				{"IAccessible2::attribute_tag":self._searchableTagValues(["blockquote"])},
+				# Also support the new blockquote IAccessible2 role
+				{"IAccessible::role":[IAccessibleHandler.IA2_ROLE_BLOCK_QUOTE]},
+			]
 		elif nodeType=="focusable":
 			attrs={"IAccessible::state_%s"%oleacc.STATE_SYSTEM_FOCUSABLE:[1]}
 		elif nodeType=="landmark":

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
  - You can enable this feature by selecting the automatic option from the list of braille displays in NVDA's braille display selection dialog.
  - Please consult the documentation for additional details.
 - Added support for various modern input features introduced in recent Windows 10 releases. These include emoji panel (Fall Creators Update), dictation (Fall Creators Update), hardware keyboard input suggestions (April 2018 Update), and cloud clipboard (RS5). (#7273)
+- Content marked as a block quote using ARIA (role blockquote) is now supported in Mozilla Firefox 63. (#8577)
 
 
 == Changes ==


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
1. The new ARIA role="blockquote" is exposed by Firefox 63, but NVDA does not report it.
2. HTML blockquote in Firefox 63 is reported as "unknown" when using object navigation.

### Description of how this pull request fixes the issue:
This PR adds support for the new IA2_ROLE_BLOCK_QUOTE, which is used by Firefox 63.

### Testing performed:
1. Tested that with `data:text/html,<div role="blockquote">ARIA</div>`, the presence of a block quote is reported in Firefox Nightly in both browse mode and focus mode.
2. Tested that with `data:text/html,<blockquote>HTML</blockquote>`, the presence of a block quote is reported in Firefox Nightly in both browse mode and focus mode.
3. Tested that with `data:text/html,<blockquote>HTML</blockquote>`, the presence of a block quote is reported in Chrome Canary in both browse mode and focus mode.

Note that Chrome doesn't currently use this role, so the third test verifies backwards compatibility. role="blockquote" is not yet supported in Chrome, so this wasn't tested.

### Known issues with pull request:
None.

### Change log entry:

Section: New features

`- Content marked as a block quote using ARIA (role blockquote) is now supported in Mozilla Firefox 63. (#8577)`