### PR TITLE
Fix mistake in freedomScientific keymap assignment

### DIFF
--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -248,7 +248,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver,ScriptableObject):
 			"kb:alt" : ("br(freedomScientific):dot1+dot3+dot4+brailleSpaceBar",),
 			"kb:alt+tab" : ("br(freedomScientific):dot2+dot3+dot4+dot5+brailleSpaceBar",),
 			"kb:alt+shift+tab" : ("br(freedomScientific):dot1+dot2+dot5+dot6+brailleSpaceBar",),
-			"kb:win+tab" : ("br(freedomScientific):dot2+dot3+dot4+brailleSpaceBar",),
+			"kb:windows+tab" : ("br(freedomScientific):dot2+dot3+dot4+brailleSpaceBar",),
 			"kb:escape" : ("br(freedomScientific):dot1+dot5+brailleSpaceBar",),
 			"kb:windows" : ("br(freedomScientific):dot2+dot4+dot5+dot6+brailleSpaceBar",),
 			"kb:windows+d" : ("br(freedomScientific):dot1+dot2+dot3+dot4+dot5+dot6+brailleSpaceBar",),


### PR DESCRIPTION
### Link to issue number:
Reported in https://github.com/nvaccess/nvda/pull/7387#discussion_r200442523

### Summary of the issue:
One of the new Freedom Scientific gestures is mapped to win+tab instead of windows+tab. This is wrong.

### Description of how this pull request fixes the issue:
Fixed the mistake.

### Testing performed:
I'm not able to test this, as I don't have a display.

### Known issues with pull request:
None

### Change log entry:
None