### PR TITLE
Readme: mention that ATL is required to compile NVDA

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,8 +44,8 @@ The following dependencies need to be installed on your system:
 			* Desktop development with C++
 		* Then in the Summary list, under Desktop for C++, Optional grouping, ensure the following is selected:
 			* VC++ 2017 v141 toolset (x86,x64)
-			* Windows 10 SDK (10.0.15063.0) for Desktop C++ x86 and x64
-
+			* Windows 10 SDK (10.0.17134.0) for Desktop C++ x86 and x64
+			* Visual C++ ATL for x86 and x64
 
 ### Git Submodules
 Most of the dependencies are contained in Git submodules.

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ The following dependencies need to be installed on your system:
 			* Windows 10 SDK (10.0.17134.0) for Desktop C++ x86 and x64
 			* Visual C++ ATL for x86 and x64
 
+
 ### Git Submodules
 Most of the dependencies are contained in Git submodules.
 If you didn't pass the --recursive option to git clone, you will need to run `git submodule update --init`.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
For a few weeks now, ATL has been required to compile NVDAHelper.
This should be mentioned in readme.md.

### Description of how this pull request fixes the issue:
Mention that ATL should also be installed when installing Visual Studio 2017.