### PR TITLE
Find dialog: NVDA will no longer appear to do nothing when trying to find something while NVDA's About dialog is open

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -203,10 +203,13 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 		CursorManager._lastCaseSensitivity=caseSensitive
 
 	def script_find(self,gesture):
-		d = FindDialog(gui.mainFrame, self, self._lastCaseSensitivity, self._searchEntries)
-		gui.mainFrame.prePopup()
-		d.Show()
-		gui.mainFrame.postPopup()
+		# #8566: We need this to be a modal dialog, but it mustn't block this script.
+		def run():
+			gui.mainFrame.prePopup()
+			d = FindDialog(gui.mainFrame, self, self._lastCaseSensitivity, self._searchEntries)
+			d.ShowModal()
+			gui.mainFrame.postPopup()
+		wx.CallAfter(run)
 	# Translators: Input help message for NVDA's find command.
 	script_find.__doc__ = _("find a text string from the current cursor position")
 


### PR DESCRIPTION
### Link to issue number:
Fixes #8566 

### Summary of the issue:
NVDA's Find dialog (Control+NVDA+F) appeared to do nothing when NVDA's About dialog is open. As a result, find functionality doesn't work when Enter is pressed.

### Description of how this pull request fixes the issue:
wxPython 4: somehow, Find dialog (Control+NVDA+F) doesn't work if NVDA's About dialog is opened. Mitigate this by giving this dialog the same treattment as elements list - creating a run callback.

### Testing performed:
Ran Find dialog with or without NVDA's About dilaog opened. This was tested on Microsoft Edge, Firefox, and Internet Explorer.

### Known issues with pull request:
None

### Change log entry:
N/A (because this is a change brought by wxPython 4)
