### PR TITLE
Compatibility for the "Use Unicode UTF-8 for worldwide language support" feature

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -35,6 +35,10 @@ import api
 import guiHelper
 import winVersion
 
+# Temporary: #8599: add cp65001 codec
+#            #7105: upgrading to python 3 should fix this issue. See https://bugs.python.org/issue13216
+codecs.register(lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
+
 try:
 	import updateCheck
 except RuntimeError:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ What's New in NVDA
  - Reduced overly verbose focus presentation in both speech and braille when focusing a Word document. (#8407)
  - Cursor routing in braille now works correctly when in a list in a Word document. (#7971)
  - Newly inserted bullets/numbers in a Word document are correctly reported in both speech and braille. (#7970)
+- In Windows 10 1803 and later, it is now possible to install add-ons if the "Use Unicode UTF-8 for worldwide language support" feature is enabled. (#8599)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #8599

### Summary of the issue:
Windows 10 1803 (April 2018 Update) introduced a new feature, "Use Unicode UTF-8 for worldwide language support". When this feature is enabled, add-ons fail to install.

### Description of how this pull request fixes the issue:
The solution consists to alias cp65001 to UTF-8.

### Testing performed:
Tested with the feature enabled, NVDA portable and installed. I tried to install several add-ons with success.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:
* In Windows 10 1803 and later, it is now possible to install add-ons if "Use Unicode UTF-8 for worldwide language support" feature is enabled. (#8599)