### PR TITLE
Python 3 imports: try importing Python 3 version before resorting to using Python 2 names

### DIFF
--- a/site_scons/site_tools/doxygen.py
+++ b/site_scons/site_tools/doxygen.py
@@ -23,12 +23,15 @@ import os
 import os.path
 import glob
 from fnmatch import fnmatch
-import _winreg
+try:
+	import winreg
+except:
+	import _winreg as winreg
 
 def fetchDoxygenPath():
 	try:
-		with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\doxygen_is1", 0, _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY) as doxygenKey:
-			doxygenPath= '"%s"'%os.path.join(_winreg.QueryValueEx(doxygenKey, "InstallLocation")[0], "Bin", "doxygen.exe")
+		with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\doxygen_is1", 0, winreg.KEY_READ | winreg.KEY_WOW64_64KEY) as doxygenKey:
+			doxygenPath= '"%s"'%os.path.join(winreg.QueryValueEx(doxygenKey, "InstallLocation")[0], "Bin", "doxygen.exe")
 	except WindowsError:
 		return 'doxygen'
 	return doxygenPath

--- a/site_scons/site_tools/doxygen.py
+++ b/site_scons/site_tools/doxygen.py
@@ -23,11 +23,10 @@ import os
 import os.path
 import glob
 from fnmatch import fnmatch
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except:
-	import _winreg as winreg
+	import winreg # python 3 import
 
 def fetchDoxygenPath():
 	try:

--- a/site_scons/site_tools/doxygen.py
+++ b/site_scons/site_tools/doxygen.py
@@ -23,6 +23,7 @@ import os
 import os.path
 import glob
 from fnmatch import fnmatch
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except:

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -5,6 +5,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+# #8527: Queue -> queue in Python 3.
 try:
 	import queue
 except ImportError:

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -5,11 +5,10 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-# #8527: Queue -> queue in Python 3.
 try:
-	import queue
+	import Queue as queue # Python 2.7 import
 except ImportError:
-	import Queue as queue
+	import queue # Python 3 import
 from ctypes import *
 from ctypes.wintypes import *
 import time

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -5,7 +5,10 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-import Queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 from ctypes import *
 from ctypes.wintypes import *
 import time
@@ -292,7 +295,7 @@ isRunning=False
 # the issue, we use this cache as a fallback when either getTopLevelObject or
 # getHWNDFromAccessibleContext fails.
 vmIDsToWindowHandles={}
-internalFunctionQueue=Queue.Queue(1000)
+internalFunctionQueue=queue.Queue(1000)
 internalFunctionQueue.__name__="JABHandler.internalFunctionQueue"
 
 def internalQueueFunction(func,*args,**kwargs):

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -6,11 +6,10 @@
 
 import os
 import sys
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import msvcrt
 import versionInfo
 import winKernel

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -6,7 +6,10 @@
 
 import os
 import sys
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import msvcrt
 import versionInfo
 import winKernel
@@ -78,7 +81,7 @@ def _lookupKeyboardLayoutNameWithHexString(layoutString):
 	buf=create_unicode_buffer(1024)
 	bufSize=c_int(2048)
 	key=HKEY()
-	if windll.advapi32.RegOpenKeyExW(_winreg.HKEY_LOCAL_MACHINE,u"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\"+ layoutString,0,_winreg.KEY_QUERY_VALUE,byref(key))==0:
+	if windll.advapi32.RegOpenKeyExW(winreg.HKEY_LOCAL_MACHINE,u"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\"+ layoutString,0,winreg.KEY_QUERY_VALUE,byref(key))==0:
 		try:
 			if windll.advapi32.RegQueryValueExW(key,u"Layout Display Name",0,None,buf,byref(bufSize))==0:
 				windll.shlwapi.SHLoadIndirectString(buf.value,buf,1023,None)

--- a/source/NVDAObjects/inputComposition.py
+++ b/source/NVDAObjects/inputComposition.py
@@ -5,7 +5,7 @@ import characterProcessing
 import speech
 import config
 from NVDAObjects.window import Window
-from behaviors import EditableTextWithAutoSelectDetection, CandidateItem as CandidateItemBehavior 
+from .behaviors import EditableTextWithAutoSelectDetection, CandidateItem as CandidateItemBehavior 
 from textInfos.offsets import OffsetsTextInfo
 
 def calculateInsertedChars(oldComp,newComp):

--- a/source/NVDAObjects/window/akelEdit.py
+++ b/source/NVDAObjects/window/akelEdit.py
@@ -3,7 +3,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-import edit
+from . import edit
 import winUser
 import winKernel
 import ctypes

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -199,7 +199,7 @@ backgroundPatternLabels={
 		xlPatternRectangularGradient:_("rectangular gradient"),
 	}
 
-from excelCellBorder import getCellBorderStyleDescription
+from .excelCellBorder import getCellBorderStyleDescription
 
 re_RC=re.compile(r'R(?:\[(\d+)\])?C(?:\[(\d+)\])?')
 re_absRC=re.compile(r'^R(\d+)C(\d+)(?::R(\d+)C(\d+))?$')

--- a/source/appModules/digitaleditionspreview.py
+++ b/source/appModules/digitaleditionspreview.py
@@ -4,4 +4,4 @@
 #See the file COPYING for more details.
 #Copyright (C) 2012 NV Access Limited
 
-from digitaleditions import *
+from .digitaleditions import *

--- a/source/appModules/esybraille.py
+++ b/source/appModules/esybraille.py
@@ -8,4 +8,4 @@
 This imports the esysuite appModule,
 """
 
-from esysuite import *
+from .esysuite import *

--- a/source/appModules/hxoutlook.py
+++ b/source/appModules/hxoutlook.py
@@ -4,4 +4,4 @@
 #See the file COPYING for more details.
 
 # An alias for hxmail appModule
-from hxmail import *
+from .hxmail import *

--- a/source/appModules/miranda64.py
+++ b/source/appModules/miranda64.py
@@ -2,4 +2,4 @@
 This simply uses the miranda32 app module.
 """
 
-from miranda32 import *
+from .miranda32 import *

--- a/source/appModules/mpc-hc.py
+++ b/source/appModules/mpc-hc.py
@@ -1,1 +1,1 @@
-from mplayerc import AppModule
+from .mplayerc import AppModule

--- a/source/appModules/mpc-hc64.py
+++ b/source/appModules/mpc-hc64.py
@@ -4,5 +4,4 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-from mplayerc import *
-
+from .mplayerc import *

--- a/source/appModules/sts.py
+++ b/source/appModules/sts.py
@@ -2,4 +2,4 @@
 This simply uses the app module for Eclipse.
 """
 
-from eclipse import *
+from .eclipse import *

--- a/source/appModules/teamtalk3.py
+++ b/source/appModules/teamtalk3.py
@@ -1,1 +1,1 @@
-from teamtalk4classic import AppModule
+from .teamtalk4classic import AppModule

--- a/source/appModules/totalcmd64.py
+++ b/source/appModules/totalcmd64.py
@@ -1,2 +1,2 @@
 #Use the app module for Total Commander 32 bit version.
-from totalcmd import *
+from .totalcmd import *

--- a/source/appModules/win32calc.py
+++ b/source/appModules/win32calc.py
@@ -7,4 +7,4 @@
 """App module for Windows Calculator (desktop version) for Windows 10 LTSB (Long-Term Servicing Branch) and Server, only difference being executable name.
 """
 
-from calc import *
+from .calc import *

--- a/source/appModules/winmail.py
+++ b/source/appModules/winmail.py
@@ -1,2 +1,2 @@
 #Uses the Outlook Express app module
-from msimn import *
+from .msimn import *

--- a/source/appModules/wlmail.py
+++ b/source/appModules/wlmail.py
@@ -10,7 +10,7 @@ import api
 import winUser
 from keyboardHandler import KeyboardInputGesture
 from NVDAObjects.IAccessible.MSHTML import MSHTML
-import msimn 
+from . import msimn 
 
 class AboutBlankDocument(MSHTML):
 	"""A document called about:blank which hosts the HTML message composer document using viewlink.

--- a/source/appModules/zend-eclipse-php.py
+++ b/source/appModules/zend-eclipse-php.py
@@ -2,4 +2,4 @@
 This simply uses the app module for Eclipse.
 """
 
-from eclipse import *
+from .eclipse import *

--- a/source/appModules/zendstudio.py
+++ b/source/appModules/zendstudio.py
@@ -2,4 +2,4 @@
 This simply uses the app module for Eclipse.
 """
 
-from eclipse import *
+from .eclipse import *

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -27,7 +27,10 @@ import serial
 
 #for brxcom
 import ctypes as c
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import winUser
 
 #for scripting
@@ -206,9 +209,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def connectBrxCom(self):#connect to brxcom server (provided by papenmeier)
 		try:
-			brxcomkey=_winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\FHP\\BrxCom")
-			value, vtype = _winreg.QueryValueEx(brxcomkey, "InstallPath")
-			_winreg.CloseKey(brxcomkey)
+			brxcomkey=winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\FHP\\BrxCom")
+			value, vtype = winreg.QueryValueEx(brxcomkey, "InstallPath")
+			winreg.CloseKey(brxcomkey)
 			self._brxnvda = c.cdll.LoadLibrary(str(value+"\\brxnvda.dll"))
 			if(self._brxnvda.brxnvda_init(str(value+"\\BrxCom.dll").decode("mbcs"))==0):
 				self._baud=1 #prevent bluetooth from connecting

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -27,6 +27,7 @@ import serial
 
 #for brxcom
 import ctypes as c
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -27,11 +27,10 @@ import serial
 
 #for brxcom
 import ctypes as c
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import winUser
 
 #for scripting

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -12,7 +12,10 @@ For the latter two actions, one can perform actions prior to and/or after they t
 """ 
 
 import globalVars
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import ctypes
 import ctypes.wintypes
 import os
@@ -76,11 +79,11 @@ def saveOnExit():
 def isInstalledCopy():
 	"""Checks to see if this running copy of NVDA is installed on the system"""
 	try:
-		k=_winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA")
-		instDir=_winreg.QueryValueEx(k,"UninstallDirectory")[0]
+		k=winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA")
+		instDir=winreg.QueryValueEx(k,"UninstallDirectory")[0]
 	except WindowsError:
 		return False
-	_winreg.CloseKey(k)
+	winreg.CloseKey(k)
 	try:
 		return os.stat(instDir)==os.stat(os.getcwdu()) 
 	except WindowsError:
@@ -98,8 +101,8 @@ CONFIG_IN_LOCAL_APPDATA_SUBKEY=u"configInLocalAppData"
 
 def getInstalledUserConfigPath():
 	try:
-		k = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
-		configInLocalAppData = bool(_winreg.QueryValueEx(k, CONFIG_IN_LOCAL_APPDATA_SUBKEY)[0])
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
+		configInLocalAppData = bool(winreg.QueryValueEx(k, CONFIG_IN_LOCAL_APPDATA_SUBKEY)[0])
 	except WindowsError:
 		configInLocalAppData=False
 	configParent=shlobj.SHGetFolderPath(0, shlobj.CSIDL_LOCAL_APPDATA if configInLocalAppData else shlobj.CSIDL_APPDATA)
@@ -156,11 +159,11 @@ RUN_REGKEY = ur"SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
 
 def getStartAfterLogon():
 	if (easeOfAccess.isSupported and easeOfAccess.canConfigTerminateOnDesktopSwitch
-			and easeOfAccess.willAutoStart(_winreg.HKEY_CURRENT_USER)):
+			and easeOfAccess.willAutoStart(winreg.HKEY_CURRENT_USER)):
 		return True
 	try:
-		k = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER, RUN_REGKEY)
-		val = _winreg.QueryValueEx(k, u"nvda")[0]
+		k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_REGKEY)
+		val = winreg.QueryValueEx(k, u"nvda")[0]
 		return os.stat(val) == os.stat(sys.argv[0])
 	except (WindowsError, OSError):
 		return False
@@ -169,7 +172,7 @@ def setStartAfterLogon(enable):
 	if getStartAfterLogon() == enable:
 		return
 	if easeOfAccess.isSupported and easeOfAccess.canConfigTerminateOnDesktopSwitch:
-		easeOfAccess.setAutoStart(_winreg.HKEY_CURRENT_USER, enable)
+		easeOfAccess.setAutoStart(winreg.HKEY_CURRENT_USER, enable)
 		if enable:
 			return
 		# We're disabling, so ensure the run key is cleared,
@@ -177,12 +180,12 @@ def setStartAfterLogon(enable):
 		run = False
 	else:
 		run = enable
-	k = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER, RUN_REGKEY, 0, _winreg.KEY_WRITE)
+	k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_REGKEY, 0, winreg.KEY_WRITE)
 	if run:
-		_winreg.SetValueEx(k, u"nvda", None, _winreg.REG_SZ, sys.argv[0])
+		winreg.SetValueEx(k, u"nvda", None, winreg.REG_SZ, sys.argv[0])
 	else:
 		try:
-			_winreg.DeleteValue(k, u"nvda")
+			winreg.DeleteValue(k, u"nvda")
 		except WindowsError:
 			pass
 
@@ -223,11 +226,11 @@ SLAVE_FILENAME = u"nvda_slave.exe"
 NVDA_REGKEY = ur"SOFTWARE\NVDA"
 
 def getStartOnLogonScreen():
-	if easeOfAccess.isSupported and easeOfAccess.willAutoStart(_winreg.HKEY_LOCAL_MACHINE):
+	if easeOfAccess.isSupported and easeOfAccess.willAutoStart(winreg.HKEY_LOCAL_MACHINE):
 		return True
 	try:
-		k = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
-		return bool(_winreg.QueryValueEx(k, u"startOnLogonScreen")[0])
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
+		return bool(winreg.QueryValueEx(k, u"startOnLogonScreen")[0])
 	except WindowsError:
 		return False
 
@@ -235,10 +238,10 @@ def _setStartOnLogonScreen(enable):
 	if easeOfAccess.isSupported:
 		# The installer will have migrated service config to EoA if appropriate,
 		# so we only need to deal with EoA here.
-		easeOfAccess.setAutoStart(_winreg.HKEY_LOCAL_MACHINE, enable)
+		easeOfAccess.setAutoStart(winreg.HKEY_LOCAL_MACHINE, enable)
 	else:
-		k = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY, 0, _winreg.KEY_WRITE)
-		_winreg.SetValueEx(k, u"startOnLogonScreen", None, _winreg.REG_DWORD, int(enable))
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY, 0, winreg.KEY_WRITE)
+		winreg.SetValueEx(k, u"startOnLogonScreen", None, winreg.REG_DWORD, int(enable))
 
 def setSystemConfigToCurrentConfig():
 	fromPath=os.path.abspath(globalVars.appArgs.configPath)

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -35,7 +35,7 @@ import easeOfAccess
 from fileUtils import FaultTolerantFile
 import winKernel
 import extensionPoints
-import profileUpgrader
+from . import profileUpgrader
 from .configSpec import confspec
 
 #: True if NVDA is running as a Windows Store Desktop Bridge application

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -12,6 +12,7 @@ For the latter two actions, one can perform actions prior to and/or after they t
 """ 
 
 import globalVars
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -12,11 +12,10 @@ For the latter two actions, one can perform actions prior to and/or after they t
 """ 
 
 import globalVars
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import ctypes
 import ctypes.wintypes
 import os

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -7,6 +7,7 @@
 """Utilities for working with the Windows Ease of Access Center.
 """
 
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -7,7 +7,10 @@
 """Utilities for working with the Windows Ease of Access Center.
 """
 
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import ctypes
 import winUser
 from winVersion import winVersion
@@ -23,8 +26,8 @@ APP_KEY_PATH = r"%s\ATs\%s" % (ROOT_KEY, APP_KEY_NAME)
 
 def isRegistered():
 	try:
-		_winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, APP_KEY_PATH, 0,
-			_winreg.KEY_READ | _winreg.KEY_WOW64_64KEY)
+		winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, APP_KEY_PATH, 0,
+			winreg.KEY_READ | winreg.KEY_WOW64_64KEY)
 		return True
 	except WindowsError:
 		return False
@@ -32,8 +35,8 @@ def isRegistered():
 def notify(signal):
 	if not isRegistered():
 		return
-	with _winreg.CreateKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp") as rkey:
-		_winreg.SetValueEx(rkey, APP_KEY_NAME, None, _winreg.REG_DWORD, signal)
+	with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp") as rkey:
+		winreg.SetValueEx(rkey, APP_KEY_NAME, None, winreg.REG_DWORD, signal)
 	keys = []
 	# The user might be holding unwanted modifiers.
 	for vk in winUser.VK_SHIFT, winUser.VK_CONTROL, winUser.VK_MENU:
@@ -60,18 +63,18 @@ def notify(signal):
 
 def willAutoStart(hkey):
 	try:
-		k = _winreg.OpenKey(hkey, ROOT_KEY, 0,
-			_winreg.KEY_READ | _winreg.KEY_WOW64_64KEY)
+		k = winreg.OpenKey(hkey, ROOT_KEY, 0,
+			winreg.KEY_READ | winreg.KEY_WOW64_64KEY)
 		return (APP_KEY_NAME in
-			_winreg.QueryValueEx(k, "Configuration")[0].split(","))
+			winreg.QueryValueEx(k, "Configuration")[0].split(","))
 	except WindowsError:
 		return False
 
 def setAutoStart(hkey, enable):
-	k = _winreg.OpenKey(hkey, ROOT_KEY, 0,
-		_winreg.KEY_READ | _winreg.KEY_WRITE | _winreg.KEY_WOW64_64KEY)
+	k = winreg.OpenKey(hkey, ROOT_KEY, 0,
+		winreg.KEY_READ | winreg.KEY_WRITE | winreg.KEY_WOW64_64KEY)
 	try:
-		conf = _winreg.QueryValueEx(k, "Configuration")[0].split(",")
+		conf = winreg.QueryValueEx(k, "Configuration")[0].split(",")
 	except WindowsError:
 		conf = []
 	else:
@@ -89,5 +92,5 @@ def setAutoStart(hkey, enable):
 		except ValueError:
 			pass
 	if changed:
-		_winreg.SetValueEx(k, "Configuration", None, _winreg.REG_SZ,
+		winreg.SetValueEx(k, "Configuration", None, winreg.REG_SZ,
 			",".join(conf))

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -7,11 +7,10 @@
 """Utilities for working with the Windows Ease of Access Center.
 """
 
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import ctypes
 import winUser
 from winVersion import winVersion

--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -12,7 +12,7 @@ or allow modification of spoken messages before they are passed to the synthesiz
 See the L{Action}, L{Filter}, L{Decider} classes.
 """
 from logHandler import log
-from util import HandlerRegistrar, callWithSupportedKwargs, BoundMethodWeakref
+from .util import HandlerRegistrar, callWithSupportedKwargs, BoundMethodWeakref
 
 
 class Action(HandlerRegistrar):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -23,16 +23,16 @@ import versionInfo
 import speech
 import queueHandler
 import core
-import guiHelper
-from settingsDialogs import *
+from . import guiHelper
+from .settingsDialogs import *
 import speechDictHandler
 import languageHandler
 import keyboardHandler
-import logViewer
+from . import logViewer
 import speechViewer
 import winUser
 import api
-import guiHelper
+from . import guiHelper
 import winVersion
 
 # Temporary: #8599: add cp65001 codec

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -11,7 +11,7 @@ import gui
 from logHandler import log
 import appModuleHandler
 import globalVars
-import guiHelper
+from . import guiHelper
 
 class ProfilesDialog(wx.Dialog):
 	shouldSuspendConfigProfileTriggers = True

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -35,13 +35,13 @@ import brailleInput
 import core
 import keyboardHandler
 import characterProcessing
-import guiHelper
+from . import guiHelper
 try:
 	import updateCheck
 except RuntimeError:
 	updateCheck = None
 import inputCore
-import nvdaControls
+from . import nvdaControls
 import touchHandler
 import winVersion
 import weakref

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -9,6 +9,7 @@
 import itertools
 import ctypes
 from ctypes.wintypes import BOOL, WCHAR, HWND, DWORD, ULONG, WORD, USHORT
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -9,11 +9,10 @@
 import itertools
 import ctypes
 from ctypes.wintypes import BOOL, WCHAR, HWND, DWORD, ULONG, WORD, USHORT
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import winKernel
 from winKernel import SYSTEMTIME
 import config

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -9,7 +9,10 @@
 import itertools
 import ctypes
 from ctypes.wintypes import BOOL, WCHAR, HWND, DWORD, ULONG, WORD, USHORT
-import _winreg as winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import winKernel
 from winKernel import SYSTEMTIME
 import config

--- a/source/installer.py
+++ b/source/installer.py
@@ -6,11 +6,10 @@
 
 from ctypes import *
 from ctypes.wintypes import *
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import threading
 import time
 import os

--- a/source/installer.py
+++ b/source/installer.py
@@ -6,6 +6,7 @@
 
 from ctypes import *
 from ctypes.wintypes import *
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/installer.py
+++ b/source/installer.py
@@ -6,7 +6,10 @@
 
 from ctypes import *
 from ctypes.wintypes import *
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import threading
 import time
 import os
@@ -32,8 +35,8 @@ def _getWSH():
 	return _wsh
 
 defaultStartMenuFolder=versionInfo.name
-with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\Microsoft\Windows\CurrentVersion") as k: 
-	programFilesPath=_winreg.QueryValueEx(k, "ProgramFilesDir")[0] 
+with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\Microsoft\Windows\CurrentVersion") as k: 
+	programFilesPath=winreg.QueryValueEx(k, "ProgramFilesDir")[0] 
 defaultInstallPath=os.path.join(programFilesPath, versionInfo.name)
 
 def createShortcut(path,targetPath=None,arguments=None,iconLocation=None,workingDirectory=None,hotkey=None,prependSpecialFolder=None):
@@ -67,15 +70,15 @@ def createShortcut(path,targetPath=None,arguments=None,iconLocation=None,working
 
 def getStartMenuFolder(noDefault=False):
 	try:
-		with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,config.NVDA_REGKEY) as k:
-			return _winreg.QueryValueEx(k,u"Start Menu Folder")[0]
+		with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,config.NVDA_REGKEY) as k:
+			return winreg.QueryValueEx(k,u"Start Menu Folder")[0]
 	except WindowsError:
 		return defaultStartMenuFolder if not noDefault else None
 
 def getInstallPath(noDefault=False):
 	try:
-		k=_winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA")
-		return _winreg.QueryValueEx(k,"UninstallDirectory")[0]
+		k=winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA")
+		return winreg.QueryValueEx(k,"UninstallDirectory")[0]
 	except WindowsError:
 		return defaultInstallPath if not noDefault else None
 
@@ -212,16 +215,15 @@ uninstallerRegInfo={
 }
 
 def registerInstallation(installDir,startMenuFolder,shouldCreateDesktopShortcut,startOnLogonScreen,configInLocalAppData=False):
-	import _winreg
-	with _winreg.CreateKeyEx(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NVDA",0,_winreg.KEY_WRITE) as k:
+	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NVDA",0,winreg.KEY_WRITE) as k:
 		for name,value in uninstallerRegInfo.iteritems(): 
-			_winreg.SetValueEx(k,name,None,_winreg.REG_SZ,value.format(installDir=installDir))
-	with _winreg.CreateKeyEx(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\nvda.exe",0,_winreg.KEY_WRITE) as k:
-		_winreg.SetValueEx(k,"",None,_winreg.REG_SZ,os.path.join(installDir,"nvda.exe"))
-	with _winreg.CreateKeyEx(_winreg.HKEY_LOCAL_MACHINE,config.NVDA_REGKEY,0,_winreg.KEY_WRITE) as k:
-		_winreg.SetValueEx(k,"startMenuFolder",None,_winreg.REG_SZ,startMenuFolder)
+			winreg.SetValueEx(k,name,None,winreg.REG_SZ,value.format(installDir=installDir))
+	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\nvda.exe",0,winreg.KEY_WRITE) as k:
+		winreg.SetValueEx(k,"",None,winreg.REG_SZ,os.path.join(installDir,"nvda.exe"))
+	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE,config.NVDA_REGKEY,0,winreg.KEY_WRITE) as k:
+		winreg.SetValueEx(k,"startMenuFolder",None,winreg.REG_SZ,startMenuFolder)
 		if configInLocalAppData:
-			_winreg.SetValueEx(k,config.CONFIG_IN_LOCAL_APPDATA_SUBKEY,None,_winreg.REG_DWORD,int(configInLocalAppData))
+			winreg.SetValueEx(k,config.CONFIG_IN_LOCAL_APPDATA_SUBKEY,None,winreg.REG_DWORD,int(configInLocalAppData))
 	registerEaseOfAccess(installDir)
 	if startOnLogonScreen is not None:
 		config._setStartOnLogonScreen(startOnLogonScreen)
@@ -257,9 +259,9 @@ def isDesktopShortcutInstalled():
 
 def unregisterInstallation(keepDesktopShortcut=False):
 	try:
-		_winreg.DeleteKeyEx(_winreg.HKEY_LOCAL_MACHINE, easeOfAccess.APP_KEY_PATH,
-			_winreg.KEY_WOW64_64KEY)
-		easeOfAccess.setAutoStart(_winreg.HKEY_LOCAL_MACHINE, False)
+		winreg.DeleteKeyEx(winreg.HKEY_LOCAL_MACHINE, easeOfAccess.APP_KEY_PATH,
+			winreg.KEY_WOW64_64KEY)
+		easeOfAccess.setAutoStart(winreg.HKEY_LOCAL_MACHINE, False)
 	except WindowsError:
 		pass
 	wsh=_getWSH()
@@ -276,15 +278,15 @@ def unregisterInstallation(keepDesktopShortcut=False):
 		if os.path.isdir(startMenuPath):
 			shutil.rmtree(startMenuPath,ignore_errors=True)
 	try:
-		_winreg.DeleteKey(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\nvda")
+		winreg.DeleteKey(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\nvda")
 	except WindowsError:
 		pass
 	try:
-		_winreg.DeleteKey(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\nvda.exe")
+		winreg.DeleteKey(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\nvda.exe")
 	except WindowsError:
 		pass
 	try:
-		_winreg.DeleteKey(_winreg.HKEY_LOCAL_MACHINE,config.NVDA_REGKEY)
+		winreg.DeleteKey(winreg.HKEY_LOCAL_MACHINE,config.NVDA_REGKEY)
 	except WindowsError:
 		pass
 	unregisterAddonFileAssociation()
@@ -292,21 +294,21 @@ def unregisterInstallation(keepDesktopShortcut=False):
 def registerAddonFileAssociation(slaveExe):
 	try:
 		# Create progID for NVDA ad-ons
-		with _winreg.CreateKeyEx(_winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Classes\\%s" % addonHandler.NVDA_ADDON_PROG_ID, 0, _winreg.KEY_WRITE) as k:
+		with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Classes\\%s" % addonHandler.NVDA_ADDON_PROG_ID, 0, winreg.KEY_WRITE) as k:
 			# Translators: A file extension label for NVDA add-on package.
-			_winreg.SetValueEx(k, None, 0, _winreg.REG_SZ, _("NVDA add-on package"))
-			with _winreg.CreateKeyEx(k, "DefaultIcon", 0, _winreg.KEY_WRITE) as k2:
-				_winreg.SetValueEx(k2, None, 0, _winreg.REG_SZ, "@{slaveExe},1".format(slaveExe=slaveExe))
+			winreg.SetValueEx(k, None, 0, winreg.REG_SZ, _("NVDA add-on package"))
+			with winreg.CreateKeyEx(k, "DefaultIcon", 0, winreg.KEY_WRITE) as k2:
+				winreg.SetValueEx(k2, None, 0, winreg.REG_SZ, "@{slaveExe},1".format(slaveExe=slaveExe))
 			# Point the open verb to nvda_slave addons_installAddonPackage action
-			with _winreg.CreateKeyEx(k, "shell\\open\\command", 0, _winreg.KEY_WRITE) as k2:
-				_winreg.SetValueEx(k2, None, 0, _winreg.REG_SZ, u"\"{slaveExe}\" addons_installAddonPackage \"%1\"".format(slaveExe=slaveExe))
+			with winreg.CreateKeyEx(k, "shell\\open\\command", 0, winreg.KEY_WRITE) as k2:
+				winreg.SetValueEx(k2, None, 0, winreg.REG_SZ, u"\"{slaveExe}\" addons_installAddonPackage \"%1\"".format(slaveExe=slaveExe))
 		# Now associate addon extension to the created prog id.
-		with _winreg.CreateKeyEx(_winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Classes\\.%s" % addonHandler.BUNDLE_EXTENSION, 0, _winreg.KEY_WRITE) as k:
-			_winreg.SetValueEx(k, None, 0, _winreg.REG_SZ, addonHandler.NVDA_ADDON_PROG_ID)
-			_winreg.SetValueEx(k, "Content Type", 0, _winreg.REG_SZ, addonHandler.BUNDLE_MIMETYPE)
+		with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Classes\\.%s" % addonHandler.BUNDLE_EXTENSION, 0, winreg.KEY_WRITE) as k:
+			winreg.SetValueEx(k, None, 0, winreg.REG_SZ, addonHandler.NVDA_ADDON_PROG_ID)
+			winreg.SetValueEx(k, "Content Type", 0, winreg.REG_SZ, addonHandler.BUNDLE_MIMETYPE)
 			# Add NVDA to the "open With" list
-			k2 = _winreg.CreateKeyEx(k, "OpenWithProgids\\%s" % addonHandler.NVDA_ADDON_PROG_ID, 0, _winreg.KEY_WRITE)
-			_winreg.CloseKey(k2)
+			k2 = winreg.CreateKeyEx(k, "OpenWithProgids\\%s" % addonHandler.NVDA_ADDON_PROG_ID, 0, winreg.KEY_WRITE)
+			winreg.CloseKey(k2)
 		# Notify the shell that a file association has changed:
 		shellapi.SHChangeNotify(shellapi.SHCNE_ASSOCCHANGED, shellapi.SHCNF_IDLIST, None, None)
 	except WindowsError:
@@ -315,7 +317,7 @@ def registerAddonFileAssociation(slaveExe):
 def unregisterAddonFileAssociation():
 	try:
 		# As per MSDN recomendation, we only need to remove the prog ID.
-		_deleteKeyAndSubkeys(_winreg.HKEY_LOCAL_MACHINE, "Software\\Classes\\%s" % addonHandler.NVDA_ADDON_PROG_ID)
+		_deleteKeyAndSubkeys(winreg.HKEY_LOCAL_MACHINE, "Software\\Classes\\%s" % addonHandler.NVDA_ADDON_PROG_ID)
 	except WindowsError:
 		# This is probably the first install, so just ignore the error.
 		return
@@ -324,18 +326,18 @@ def unregisterAddonFileAssociation():
 
 # Windows API call regDeleteTree is only available on vist and above so rule our own.
 def _deleteKeyAndSubkeys(key, subkey):
-	with _winreg.OpenKey(key, subkey, 0, _winreg.KEY_WRITE|_winreg.KEY_READ) as k:
+	with winreg.OpenKey(key, subkey, 0, winreg.KEY_WRITE|winreg.KEY_READ) as k:
 		# Recursively delete subkeys (Depth first search order)
 		# So Pythonic... </rant>
 		for i in itertools.count():
 			try:
-				subkeyName = _winreg.EnumKey(k, i)
+				subkeyName = winreg.EnumKey(k, i)
 			except WindowsError:
 				break
 			# Recursive call.
 			_deleteKeyAndSubkeys(k, subkeyName)
 		# Delete this key
-		_winreg.DeleteKey(k, "")
+		winreg.DeleteKey(k, "")
 
 class RetriableFailure(Exception):
 	pass
@@ -392,8 +394,8 @@ def tryCopyFile(sourceFilePath,destFilePath):
 def install(shouldCreateDesktopShortcut=True,shouldRunAtLogon=True):
 	prevInstallPath=getInstallPath(noDefault=True)
 	try:
-		k = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, config.NVDA_REGKEY)
-		configInLocalAppData = bool(_winreg.QueryValueEx(k, config.CONFIG_IN_LOCAL_APPDATA_SUBKEY)[0])
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, config.NVDA_REGKEY)
+		configInLocalAppData = bool(winreg.QueryValueEx(k, config.CONFIG_IN_LOCAL_APPDATA_SUBKEY)[0])
 	except WindowsError:
 		configInLocalAppData = False
 	unregisterInstallation(keepDesktopShortcut=shouldCreateDesktopShortcut)
@@ -454,31 +456,31 @@ def createPortableCopy(destPath,shouldCopyUserConfig=True):
 	removeOldLibFiles(destPath,rebootOK=True)
 
 def registerEaseOfAccess(installDir):
-	with _winreg.CreateKeyEx(_winreg.HKEY_LOCAL_MACHINE, easeOfAccess.APP_KEY_PATH, 0,
-			_winreg.KEY_ALL_ACCESS | _winreg.KEY_WOW64_64KEY) as appKey:
-		_winreg.SetValueEx(appKey, "ApplicationName", None, _winreg.REG_SZ,
+	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE, easeOfAccess.APP_KEY_PATH, 0,
+			winreg.KEY_ALL_ACCESS | winreg.KEY_WOW64_64KEY) as appKey:
+		winreg.SetValueEx(appKey, "ApplicationName", None, winreg.REG_SZ,
 			versionInfo.name)
-		_winreg.SetValueEx(appKey, "Description", None, _winreg.REG_SZ,
+		winreg.SetValueEx(appKey, "Description", None, winreg.REG_SZ,
 			versionInfo.longName)
 		if easeOfAccess.canConfigTerminateOnDesktopSwitch:
-			_winreg.SetValueEx(appKey, "Profile", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "Profile", None, winreg.REG_SZ,
 				'<HCIModel><Accommodation type="severe vision"/></HCIModel>')
-			_winreg.SetValueEx(appKey, "SimpleProfile", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "SimpleProfile", None, winreg.REG_SZ,
 				"screenreader")
-			_winreg.SetValueEx(appKey, "ATExe", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "ATExe", None, winreg.REG_SZ,
 				"nvda.exe")
-			_winreg.SetValueEx(appKey, "StartExe", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "StartExe", None, winreg.REG_SZ,
 				os.path.join(installDir, u"nvda.exe"))
-			_winreg.SetValueEx(appKey, "StartParams", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "StartParams", None, winreg.REG_SZ,
 				"--ease-of-access")
-			_winreg.SetValueEx(appKey, "TerminateOnDesktopSwitch", None,
-				_winreg.REG_DWORD, 0)
+			winreg.SetValueEx(appKey, "TerminateOnDesktopSwitch", None,
+				winreg.REG_DWORD, 0)
 		else:
 			# We don't want NVDA to appear in EoA because
 			# starting NVDA from there won't work in this case.
 			# We can do this by not setting Profile and SimpleProfile.
 			# NVDA can still change the EoA logon settings.
-			_winreg.SetValueEx(appKey, "ATExe", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "ATExe", None, winreg.REG_SZ,
 				"nvda_eoaProxy.exe")
-			_winreg.SetValueEx(appKey, "StartExe", None, _winreg.REG_SZ,
+			winreg.SetValueEx(appKey, "StartExe", None, winreg.REG_SZ,
 				os.path.join(installDir, u"nvda_eoaProxy.exe"))

--- a/source/mathType.py
+++ b/source/mathType.py
@@ -7,6 +7,7 @@
 """Utilities for working with MathType.
 """
 
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/mathType.py
+++ b/source/mathType.py
@@ -7,7 +7,10 @@
 """Utilities for working with MathType.
 """
 
-import _winreg as winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import ctypes
 import mathPres
 

--- a/source/mathType.py
+++ b/source/mathType.py
@@ -7,11 +7,10 @@
 """Utilities for working with MathType.
 """
 
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import ctypes
 import mathPres
 

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -171,6 +171,7 @@ if not mutex or ctypes.windll.kernel32.GetLastError()==ERROR_ALREADY_EXISTS:
 
 isSecureDesktop = desktopName == "Winlogon"
 if isSecureDesktop:
+	# #8527: _winreg -> winreg in Python 3.
 	try:
 		import winreg
 	except ImportError:

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -171,10 +171,13 @@ if not mutex or ctypes.windll.kernel32.GetLastError()==ERROR_ALREADY_EXISTS:
 
 isSecureDesktop = desktopName == "Winlogon"
 if isSecureDesktop:
-	import _winreg
 	try:
-		k = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, ur"SOFTWARE\NVDA")
-		if not _winreg.QueryValueEx(k, u"serviceDebug")[0]:
+		import winreg
+	except ImportError:
+		import _winreg as winreg
+	try:
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, ur"SOFTWARE\NVDA")
+		if not winreg.QueryValueEx(k, u"serviceDebug")[0]:
 			globalVars.appArgs.secure = True
 	except WindowsError:
 		globalVars.appArgs.secure = True

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -171,11 +171,10 @@ if not mutex or ctypes.windll.kernel32.GetLastError()==ERROR_ALREADY_EXISTS:
 
 isSecureDesktop = desktopName == "Winlogon"
 if isSecureDesktop:
-	# #8527: _winreg -> winreg in Python 3.
 	try:
-		import winreg
+		import _winreg as winreg # Python 2.7 import
 	except ImportError:
-		import _winreg as winreg
+		import winreg # Python 3 import
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, ur"SOFTWARE\NVDA")
 		if not winreg.QueryValueEx(k, u"serviceDebug")[0]:

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -1,11 +1,14 @@
 #queueHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 import types
-from Queue import Queue
+try:
+	from queue import Queue
+except ImportError:
+	from Queue import Queue
 import globalVars
 from logHandler import log
 import watchdog

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -5,6 +5,7 @@
 #See the file COPYING for more details.
 
 import types
+# #8527: Queue -> queue in Python 3.
 try:
 	from queue import Queue
 except ImportError:

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -5,11 +5,10 @@
 #See the file COPYING for more details.
 
 import types
-# #8527: Queue -> queue in Python 3.
 try:
-	from queue import Queue
+	from Queue import Queue # Python 2.7 import
 except ImportError:
-	from Queue import Queue
+	from queue import Queue # Python 3 import
 import globalVars
 from logHandler import log
 import watchdog

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -8,6 +8,7 @@
 import time
 import nvwave
 import threading
+# #8527: Queue -> queue in Python 3.
 try:
 	import queue
 except ImportError:

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -8,7 +8,10 @@
 import time
 import nvwave
 import threading
-import Queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 from ctypes import *
 import config
 import globalVars
@@ -193,7 +196,7 @@ def stop():
 			if item[0] != _speak:
 				params.append(item)
 			bgQueue.task_done()
-	except Queue.Empty:
+	except queue.Empty:
 		# Let the exception break us out of this loop, as queue.empty() is not reliable anyway.
 		pass
 	for item in params:
@@ -290,7 +293,7 @@ def initialize():
 		raise OSError("espeak_Initialize %d"%sampleRate)
 	player = nvwave.WavePlayer(channels=1, samplesPerSec=sampleRate, bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"])
 	espeakDLL.espeak_SetSynthCallback(callback)
-	bgQueue = Queue.Queue()
+	bgQueue = queue.Queue()
 	bgThread=BgThread()
 	bgThread.start()
 

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -8,11 +8,10 @@
 import time
 import nvwave
 import threading
-# #8527: Queue -> queue in Python 3.
 try:
-	import queue
+	import Queue as queue # Python 2.7 import
 except ImportError:
-	import Queue as queue
+	import queue # Python 3 import
 from ctypes import *
 import config
 import globalVars

--- a/source/synthDrivers/audiologic.py
+++ b/source/synthDrivers/audiologic.py
@@ -7,11 +7,10 @@
 from collections import OrderedDict
 from . import _audiologic
 from synthDriverHandler import SynthDriver, VoiceInfo
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 
 class SynthDriver(SynthDriver):
 	supportedSettings=(SynthDriver.RateSetting(),SynthDriver.PitchSetting(minStep=5),SynthDriver.InflectionSetting(minStep=10),SynthDriver.VolumeSetting(minStep=2))

--- a/source/synthDrivers/audiologic.py
+++ b/source/synthDrivers/audiologic.py
@@ -7,6 +7,7 @@
 from collections import OrderedDict
 from . import _audiologic
 from synthDriverHandler import SynthDriver, VoiceInfo
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/synthDrivers/audiologic.py
+++ b/source/synthDrivers/audiologic.py
@@ -7,7 +7,10 @@
 from collections import OrderedDict
 import _audiologic
 from synthDriverHandler import SynthDriver, VoiceInfo
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 
 class SynthDriver(SynthDriver):
 	supportedSettings=(SynthDriver.RateSetting(),SynthDriver.PitchSetting(minStep=5),SynthDriver.InflectionSetting(minStep=10),SynthDriver.VolumeSetting(minStep=2))
@@ -19,7 +22,7 @@ class SynthDriver(SynthDriver):
 	@classmethod
 	def check(cls):
 		try:
-			r=_winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\Audiologic\Sintesi Audiologic")
+			r=winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\Audiologic\Sintesi Audiologic")
 			r.Close()
 			return True
 		except:

--- a/source/synthDrivers/audiologic.py
+++ b/source/synthDrivers/audiologic.py
@@ -5,7 +5,7 @@
 #Copyright (C) 2008-2010 Gianluca Casalino <gianluca@spazioausili.net>, James Teh <jamie@jantrid.net>
 
 from collections import OrderedDict
-import _audiologic
+from . import _audiologic
 from synthDriverHandler import SynthDriver, VoiceInfo
 try:
 	import winreg

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -7,7 +7,7 @@
 
 import os
 from collections import OrderedDict
-import _espeak
+from . import _espeak
 import Queue
 import threading
 import languageHandler

--- a/source/synthDrivers/mssp.py
+++ b/source/synthDrivers/mssp.py
@@ -4,7 +4,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-from sapi5 import SynthDriver
+from .sapi5 import SynthDriver
 
 class SynthDriver(SynthDriver):
 	COM_CLASS = "speech.SPVoice"

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -11,11 +11,10 @@ import os
 import sys
 from collections import OrderedDict
 import ctypes
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import wave
 import cStringIO
 from synthDriverHandler import SynthDriver, VoiceInfo

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -11,6 +11,7 @@ import os
 import sys
 from collections import OrderedDict
 import ctypes
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -11,7 +11,10 @@ import os
 import sys
 from collections import OrderedDict
 import ctypes
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import wave
 import cStringIO
 from synthDriverHandler import SynthDriver, VoiceInfo
@@ -272,15 +275,15 @@ class SynthDriver(SynthDriver):
 		@rtype: boolean
 		"""
 		IDParts = ID.split('\\')
-		rootKey = getattr(_winreg, IDParts[0])
+		rootKey = getattr(winreg, IDParts[0])
 		subkey = "\\".join(IDParts[1:])
 		try:
-			hkey = _winreg.OpenKey(rootKey, subkey)
+			hkey = winreg.OpenKey(rootKey, subkey)
 		except WindowsError as e:
 			log.debugWarning("Could not open registry key %s, %r" % (ID, e))
 			return False
 		try:
-			langDataPath = _winreg.QueryValueEx(hkey, 'langDataPath')
+			langDataPath = winreg.QueryValueEx(hkey, 'langDataPath')
 		except WindowsError as e:
 			log.debugWarning("Could not open registry value 'langDataPath', %r" % e)
 			return False
@@ -291,7 +294,7 @@ class SynthDriver(SynthDriver):
 			log.debugWarning("Missing language data file: %s" % langDataPath[0])
 			return False
 		try:
-			voicePath = _winreg.QueryValueEx(hkey, 'voicePath')
+			voicePath = winreg.QueryValueEx(hkey, 'voicePath')
 		except WindowsError as e:
 			log.debugWarning("Could not open registry value 'langDataPath', %r" % e)
 			return False

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -6,7 +6,10 @@
 
 import locale
 from collections import OrderedDict
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 from comtypes import COMObject, COMError
 from ctypes import *
 from synthDriverHandler import SynthDriver,VoiceInfo
@@ -42,7 +45,7 @@ class SynthDriver(SynthDriver):
 	@classmethod
 	def check(cls):
 		try:
-			_winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, r"CLSID\%s" % CLSID_TTSEnumerator).Close()
+			winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s" % CLSID_TTSEnumerator).Close()
 			return True
 		except WindowsError:
 			return False

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -6,11 +6,10 @@
 
 import locale
 from collections import OrderedDict
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 from comtypes import COMObject, COMError
 from ctypes import *
 from synthDriverHandler import SynthDriver,VoiceInfo

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -15,7 +15,7 @@ from ctypes import *
 from synthDriverHandler import SynthDriver,VoiceInfo
 from logHandler import log
 import speech
-from _sapi4 import *
+from ._sapi4 import *
 import config
 import nvwave
 

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -6,6 +6,7 @@
 
 import locale
 from collections import OrderedDict
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -13,11 +13,10 @@ import os
 from ctypes import *
 import comtypes.client
 from comtypes import COMError
-# #8527: _winreg -> winreg in Python 3.
 try:
-	import winreg
+	import _winreg as winreg # Python 2.7 import
 except ImportError:
-	import _winreg as winreg
+	import winreg # Python 3 import
 import audioDucking
 import NVDAHelper
 import globalVars

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -13,6 +13,7 @@ import os
 from ctypes import *
 import comtypes.client
 from comtypes import COMError
+# #8527: _winreg -> winreg in Python 3.
 try:
 	import winreg
 except ImportError:

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -13,7 +13,10 @@ import os
 from ctypes import *
 import comtypes.client
 from comtypes import COMError
-import _winreg
+try:
+	import winreg
+except ImportError:
+	import _winreg as winreg
 import audioDucking
 import NVDAHelper
 import globalVars
@@ -90,7 +93,7 @@ class SynthDriver(SynthDriver):
 	@classmethod
 	def check(cls):
 		try:
-			r=_winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT,cls.COM_CLASS)
+			r=winreg.OpenKey(winreg.HKEY_CLASSES_ROOT,cls.COM_CLASS)
 			r.Close()
 			return True
 		except:


### PR DESCRIPTION
Hi,

Part of preparation for Python 3 transition:

### Link to issue number:
Fixes #8527
Fixes #8590
Fixes #8649

### Summary of the issue:
Use Python 3 module names before resorting to using python 2 names.

### Description of how this pull request fixes the issue:
Python 3 has renamed several modules. These include _winreg to winreg and Queue to queue. At the moment some NVDA modules import affected modules directly or load one or two things from these. Thus a try/except block has been added to load Python 3 version first before resorting to Python 2 names, and for some, edited various code fragments to use Python 3 names.

### Testing performed:
Compiled and ran NVDA from source, along with running Python 2.7 and 3.7 interpreters to make sure names are correct.

### Known issues with pull request:
None

### Change log entry:
None

Thanks.