### PR TITLE
Display log viewer even there's no dev info for navigator object

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1447,7 +1447,10 @@ class GlobalCommands(ScriptableObject):
 
 	def script_navigatorObject_devInfo(self,gesture):
 		obj=api.getNavigatorObject()
-		log.info("Developer info for navigator object:\n%s" % "\n".join(obj.devInfo), activateLogViewer=True)
+		if hasattr(obj, "devInfo"):
+			log.info("Developer info for navigator object:\n%s" % "\n".join(obj.devInfo), activateLogViewer=True)
+		else:
+			log.info("No developer info for navigator object", activateLogViewer=True)
 	# Translators: Input help mode message for developer info for current navigator object command, used by developers to examine technical info on navigator object. This command also serves as a shortcut to open NVDA log viewer.
 	script_navigatorObject_devInfo.__doc__ = _("Logs information about the current navigator object which is useful to developers and activates the log viewer so the information can be examined.")
 	script_navigatorObject_devInfo.category=SCRCAT_TOOLS


### PR DESCRIPTION
### Link to issue number:
Fixes #8613

### Summary of the issue:
When there's no info developer for current navigator object, the log viewer cannot be displayed.

### Description of how this pull request fixes the issue:
This PR just adds a condition. If there's no dev info, a appropriate message is logged and the log is displayed.

### Testing performed:
Tested with a test build and through a small global plugin under my installed version.

### Known issues with pull request:
None

### Change log entry:

**Bug fixes**
- It is now possible to view log if there is no Dev info for navigator object. (#8613)