### PR TITLE
Change report balloons to report notifications

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1464,7 +1464,7 @@ class ObjectPresentationPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings panel.
-		balloonText = _("Report &help balloons")
+		balloonText = _("Report &notifications")
 		self.balloonCheckBox=sHelper.addItem(wx.CheckBox(self,label=balloonText))
 		self.balloonCheckBox.SetValue(config.conf["presentation"]["reportHelpBalloons"])
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,18 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2018.4 =
+
+== New Features ==
+ 
+ 
+== Changes ==
+- "Report help balloons" in the Object Presentations dialog has been renamed to "Report notifications" to include reporting of toast notifications in Windows 8 and later. (#5789)
+
+
+== Bug Fixes ==
+
+
 = 2018.3 =
 
 == New Features ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #5789
### Summary of the issue:
Help balloons are not used in Windows 8 and later. To a new computer user using Windows 8 or later, this would be confusing. Having this option disabled does not read toast notifications as well as help balloons.
### Description of how this pull request fixes the issue:
Changes the text presented in object presentations dialog from "Report balloons to "Report notifications" as suggested in https://github.com/nvaccess/nvda/issues/5789#issuecomment-191470075
### Testing performed:

### Known issues with pull request:
None
### Change log entry:
Changes
"Report help balloons" in the Object Presentations dialog has been renamed to "Report notifications" to include reporting of toast notifications in Windows 8 and later.