### PR TITLE
Increase eurobraille timeout when connecting

### DIFF
--- a/source/brailleDisplayDrivers/eurobraille.py
+++ b/source/brailleDisplayDrivers/eurobraille.py
@@ -188,7 +188,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 				self._sendPacket(EB_VISU, EB_VISU_DOT, '0')
 				# A device identification results in multiple packets.
 				# Make sure we've received everything before we continue
-				while self._dev.waitForRead(self.timeout):
+				while self._dev.waitForRead(self.timeout*2):
 					continue
 				if self.numCells and self.deviceType:
 					break


### PR DESCRIPTION
Note: this pr is based on beta.

### Link to issue number:
None

### Summary of the issue:
Normally, eurobraille Esys  devices have no problems when connecting over USB. However, braille display auto detection introduced the following case:

1. Connect a powered off Esys to a pc
2. The device is connected and auto display detection is triggered.
3. NVDA is able to the detect the device and connect to it, however it does not reply to its requests.
4. Auto detection fails.

### Description of how this pull request fixes the issue:
Instead of doing three connection attempts taking 0.2 seconds each, the timeout when connecting has been increased to timeout*2 (i.e. 0.4 seconds). The number of attempts is still 3.

### Testing performed:
Testing the above steps to reproduce succeeded in all my attempts.

### Known issues with pull request:
None

### Change log entry:
None, as this issue is related to braille display auto detection (#1271), which is a new feature.