### PR TITLE
Second attempt to update to configobj 5.1.0dev

### DIFF
--- a/source/addonHandler.py
+++ b/source/addonHandler.py
@@ -20,7 +20,7 @@ from cStringIO import StringIO
 import zipfile
 
 from configobj import ConfigObj, ConfigObjError
-from validate import Validator
+from configobj.validate import Validator
 
 import config
 import globalVars

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -23,7 +23,7 @@ import contextlib
 from copy import deepcopy
 from collections import OrderedDict
 from configobj import ConfigObj, ConfigObjError
-from validate import Validator
+from configobj.validate import Validator
 from logHandler import log, levelNames
 from logging import DEBUG
 import shlobj

--- a/source/core.py
+++ b/source/core.py
@@ -211,6 +211,8 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 	log.info("Using Windows version %s" % winVersion.winVersionText)
 	log.info("Using Python version %s"%sys.version)
 	log.info("Using comtypes version %s"%comtypes.__version__)
+	import configobj
+	log.info("Using configobj version %s with validate version %s"%(configobj.__version__,configobj.validate.__version__))
 	# Set a reasonable timeout for any socket connections NVDA makes.
 	import socket
 	socket.setdefaulttimeout(10)

--- a/source/sourceEnv.py
+++ b/source/sourceEnv.py
@@ -17,7 +17,7 @@ PYTHON_DIRS = (
 	os.path.join(TOP_DIR, "include", "scons", "src", "engine"),
 	os.path.join(TOP_DIR, "include", "pyserial"),
 	os.path.join(TOP_DIR, "include", "comtypes"),
-	os.path.join(TOP_DIR, "include", "configobj", "src", "configobj"),
+	os.path.join(TOP_DIR, "include", "configobj", "src"),
 	os.path.join(TOP_DIR, "include", "wxPython"),
 	os.path.join(TOP_DIR, "miscDeps", "python"),
 )

--- a/source/validate.py
+++ b/source/validate.py
@@ -1,0 +1,15 @@
+#validate.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2018 NV Access Limited, Babbage B.V., Joseph Lee
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+"""
+Module to provide backwards compatibility with add-ons that use the configobj validate module.
+Add-ons should be changed to use configobj.validate instead.
+"""
+
+from configobj.validate import *
+import warnings
+
+warnings.warn("Importing validate directly is deprecated. Please use configobj.validate instead", DeprecationWarning)

--- a/source/validate.py
+++ b/source/validate.py
@@ -12,4 +12,4 @@ Add-ons should be changed to use configobj.validate instead.
 from configobj.validate import *
 import warnings
 
-warnings.warn("Importing validate directly is deprecated. Please use configobj.validate instead", DeprecationWarning)
+warnings.warn("Importing validate directly is deprecated. Please use configobj.validate instead", DeprecationWarning, stacklevel=2)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,13 +6,17 @@ What's New in NVDA
 = 2018.4 =
 
 == New Features ==
- 
- 
+
+
 == Changes ==
 - "Report help balloons" in the Object Presentations dialog has been renamed to "Report notifications" to include reporting of toast notifications in Windows 8 and later. (#5789)
 
 
 == Bug Fixes ==
+
+
+== Changes for Developers ==
+- Updated configobj to 5.1.0dev commit 5b5de48a. (#4470)
 
 
 = 2018.3 =


### PR DESCRIPTION
### Link to issue number:
Closes #4470
Implements #7945
Supersedes #8622

### Summary of the issue:
The previous attempt to update configobj did not really update to the new configobj, but was accidentally still using the configobj from misc-deps.

### Description of how this pull request fixes the issue:
This time, we really updated to configobj 5.1.0dev.

1. I added logging to the core module that will print the configobj and validate versions.
2. validate is now considered a part of the configobj package. Add-ons should use configobj.validate instead of validate directly.
3. To facilitate a smooth upgrade path, I added a validate.py module to NVDA's source tree that imports configobj.validate.*. It will also raise a proper deprecation warning, like this:

```DEBUGWARNING - Python warning (15:46:42.430):
C:\Users\Leonard de Ruijter\AppData\Roaming\nvda\addons\vocalizer_expressive_driver\synthDrivers\vocalizer_expressive\_config.py:11: DeprecationWarning: Importing validate directly is deprecated. Please use configobj.validate instead
  from validate import Validator
```

### Testing performed:
As @feerrenrut proposed earlier, testing should include an upgrade path of an old config file without a schema version from NVDA 2016.4 or older. [These are the results](https://github.com/nvaccess/nvda/files/2283170/configobjtestconf.zip).

### Known issues with pull request:
NOne

### Change log entry:
Included in changes.t2t