### PR TITLE
UIA in MS Word: Again report spelling error on specific word rather than over whole line

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -423,15 +423,13 @@ class UIATextInfo(textInfos.TextInfo):
 		"""
 		return range.getText(-1)
 
-	def _getTextWithFields_text(self,textRange,formatConfig,ignoreEmptyChunks=True,UIAFormatUnits=None):
+	def _getTextWithFields_text(self,textRange,formatConfig,UIAFormatUnits=None):
 		"""
 		Yields format fields and text for the given UI Automation text range, split up by the first available UI Automation text unit that does not result in mixed attribute values.
 		@param textRange: the UI Automation text range to walk.
 		@type textRange: L{UIAHandler.IUIAutomationTextRange}
 		@param formatConfig: the types of formatting requested.
 		@ type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
-		@param ignoreEmptyChunks: if true, textRanges where the text is empty will not be emitted nor the formatField directly before it. 
-		@param ignoreEmptyChunks: bool
 		@param UIAFormatUnits: the UI Automation text units (in order of resolution) that should be used to split the text so as to avoid mixed attribute values. This is None by default.
 			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter. 
 			If this parameter is an empty list, then formatting and text is fetched for the entire range, but any mixed attribute values are ignored and no splitting occures.
@@ -452,7 +450,7 @@ class UIATextInfo(textInfos.TextInfo):
 		rangeIter=iterUIARangeByUnit(textRange,unit) if unit is not None else [textRange]
 		for tempRange in rangeIter:
 			text=self._getTextFromUIARange(tempRange) or ""
-			if not ignoreEmptyChunks or text:
+			if text:
 				log.debug("Chunk has text. Fetching formatting")
 				try:
 					field=self._getFormatFieldAtRange(tempRange,formatConfig,ignoreMixedValues=len(furtherUIAFormatUnits)==0)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8609 

### Summary of the issue:
With the merging of #8576, In MS Word with UIA: NVDA no longer announced spelling errors on specific words, rather reporting spelling error for the entire line if it had one.
The reason for this was that WordDocumentTextInfo._getTextWithFields_text was accidentally implemented twice, therefore overriding some needed existing code.

### Description of how this pull request fixes the issue:
Remove the second _getTextWithFields_text, which again allows the older code spelling errors on specific words to run.
Also remove the newly added ignoreEmptyChunks argument from UIATextInfo._getTextWithFields_text, and instead handle this specifically in WordDocumentTextInfo.getTextWithFields.
This argument was trying to ensure that  all controlFields would contain at least one formatfield and text string, as this is what speech expects.
Without this, left or right arrowing onto a graphic would cause a traceback in speech.speakTextInfo.
On further testing this however was causing other bugs such as heading levels to be announced on the blank line preceding a heading.
Now WordDocumentTextInfo.getTextWithFields adds in the needed empty formatField and empty text string for the first lot of controlStarts itself.
 
### Testing performed:
All tests that were done in #8576.
 Plus, left and right arrowing onto a graphic no longer causes a traceback, and the graphic is announced.
Plus, arrowing onto the blank line before a heading no longer announces the heading level for the heading.

### Known issues with pull request:
None.

### Change log entry:
None.
