### PR TITLE
Add validate to setup.py

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -204,10 +204,17 @@ setup(
 		"excludes": ["Tkinter",
 			"serial.loopback_connection", "serial.rfc2217", "serial.serialcli", "serial.serialjava", "serial.serialposix", "serial.socket_connection"],
 		"packages": ["NVDAObjects","virtualBuffers","appModules","comInterfaces","brailleDisplayDrivers","synthDrivers"],
-		# #3368: bisect was implicitly included with Python 2.7.3, but isn't with 2.7.5.
-		# Also, the service executable used win32api, which some add-ons use for various purposes.
-		# Explicitly include them so we don't break some add-ons.
-		"includes": ["nvdaBuiltin", "bisect", "win32api"],
+		"includes": [
+			"nvdaBuiltin",
+			# #3368: bisect was implicitly included with Python 2.7.3, but isn't with 2.7.5.
+			"bisect",
+			# Also, the previous service executable used win32api, which some add-ons use for various purposes.
+			"win32api",
+			# #8628: include an import module for validate, which older add-ons import directly.
+			# Since configobj 5.1.0, validate is a part of the configobj package
+			# and should be imported as configobj.validate instead
+			"validate",
+		],
 	}},
 	data_files=[
 		(".",glob("*.dll")+glob("*.manifest")+["builtin.dic"]),


### PR DESCRIPTION
### Link to issue number:
Follow up of #8626 
Fixes #8628

### Summary of the issue:
#8626 includes a new validate module to facilitate compatibility with older add-ons. The validate.py module wasn't added to the included modules in setup.py, and since this module is used nowhere within NVDA, it wsn't included in distribution builds.

### Description of how this pull request fixes the issue:
Added validate to the list of included modules in setup.py, splitting the code into multiple lines while at it.

### Testing performed:
Try build tested by @lukaszgo1.

### Known issues with pull request:
None

### Change log entry:
None
