### PR TITLE
Don't throw an error when doing ui.message(None)

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1772,10 +1772,10 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		"""Display a message to the user which times out after a configured interval.
 		The timeout will be reset if the user scrolls the display.
 		The message will be dismissed immediately if the user presses a cursor routing key.
-		If a key is pressed the message will be dismissed by the next text being written to the display
+		If a key is pressed the message will be dismissed by the next text being written to the display.
 		@postcondition: The message is displayed.
 		"""
-		if not self.enabled or config.conf["braille"]["messageTimeout"] == 0:
+		if not self.enabled or config.conf["braille"]["messageTimeout"] == 0 or text is None:
 			return
 		if self.buffer is self.messageBuffer:
 			self.buffer.clear()


### PR DESCRIPTION
### Link to issue number:
Fixes #8055.
Or really, assures that if `ui.message()` is ever called with parameter `None`, this does not throw an error.

### Summary of the issue:
Apparently, Outlook 2013/2016 can sometimes have e-mail address auto-completion results where the corresponding `NVDAObject` has the name set to `None`. When sending this as a message to a braille display, an error was raised.

### Description of how this pull request fixes the issue:
Since especially Office 365 is constantly changing, this issue hardens `braille.BrailleHandler.message` a bit instead of trying to resolve the root cause of this particular issue. `speech.speakMessage`, which calls `speech.speakText`, already checks for the value `None`.

### Testing performed:
Called `ui.message(None)` from the Python console.

### Known issues with pull request:
This PR does not resolve the root cause in Outlook 2013/2016. However, few people were able to reproduce it. Auto-completion in Outlook 2016 is further covered by #8502.

### Change log entry:
None.