### PR TITLE
nvwave.playWaveFile: async > asynchronous

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -274,7 +274,7 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 		speech.cancelSpeech()
 		if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:
 			try:
-				nvwave.playWaveFile("waves\\exit.wav",async=False)
+				nvwave.playWaveFile("waves\\exit.wav",asynchronous=False)
 			except:
 				pass
 		log.info("Windows session ending")
@@ -557,7 +557,7 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 
 	if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:
 		try:
-			nvwave.playWaveFile("waves\\exit.wav",async=False)
+			nvwave.playWaveFile("waves\\exit.wav",asynchronous=False)
 		except:
 			pass
 	# #5189: Destroy the message window as late as possible

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -383,7 +383,7 @@ def outputDeviceNameToID(name, useDefaultIfInvalid=False):
 
 fileWavePlayer = None
 fileWavePlayerThread=None
-def playWaveFile(fileName, async=True):
+def playWaveFile(fileName, asynchronous=True):
 	"""plays a specified wave file.
 """
 	global fileWavePlayer, fileWavePlayerThread
@@ -393,7 +393,7 @@ def playWaveFile(fileName, async=True):
 		fileWavePlayer.stop()
 	fileWavePlayer = WavePlayer(channels=f.getnchannels(), samplesPerSec=f.getframerate(),bitsPerSample=f.getsampwidth()*8, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
 	fileWavePlayer.feed(f.readframes(f.getnframes()))
-	if async:
+	if asynchronous:
 		if fileWavePlayerThread is not None:
 			fileWavePlayerThread.join()
 		fileWavePlayerThread=threading.Thread(target=fileWavePlayer.idle)

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -385,7 +385,9 @@ fileWavePlayer = None
 fileWavePlayerThread=None
 def playWaveFile(fileName, asynchronous=True):
 	"""plays a specified wave file.
-"""
+	@param asynchronous: whether the wave file should be played asynchronously
+	@type hz: bool
+	"""
 	global fileWavePlayer, fileWavePlayerThread
 	f = wave.open(fileName,"r")
 	if f is None: raise RuntimeError("can not open file %s"%fileName)

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -386,7 +386,7 @@ fileWavePlayerThread=None
 def playWaveFile(fileName, asynchronous=True):
 	"""plays a specified wave file.
 	@param asynchronous: whether the wave file should be played asynchronously
-	@type hz: bool
+	@type asynchronous: bool
 	"""
 	global fileWavePlayer, fileWavePlayerThread
 	f = wave.open(fileName,"r")

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -287,7 +287,7 @@ class WaveFileCommand(BaseCallbackCommand):
 
 	def run(self):
 		import nvwave
-		nvwave.playWaveFile(self.fileName, async=True)
+		nvwave.playWaveFile(self.fileName, asynchronous=True)
 
 	def __repr__(self):
 		return "WaveFileCommand(%r)" % self.fileName


### PR DESCRIPTION
### Link to issue number:
Fixes #8607
### Summary of the issue:
Change async argument in nvwave.playWaveFile to asynchronous.

### Description of how this pull request fixes the issue:
Python 3.5 introduces 'async' and 'await' keywords to deal with asynchronous generators and other possibilities. Since Python 3.7, use of these keywords as variable names is no longer allowed. In NVDA code, nvWave.playWaveFile is affected, so rename 'async' to 'asynchronous'.

### Testing performed:
Compiled and tested various code paths that calls nvwave.playWaveFile with the new keyword arguments.

### Known issues with pull request:
Any add-on that sets "async" argument to True will be affected.

### Change log entry:
Changes for developers:
The "async" argument in nvwave.playWaveFile has been renamed to "asynchronous". Add-ons that relied on this name should be modified to use the new argument name. (#8607)

