### PR TITLE
Catch LookupError when getting NVDAObject from offset in virtual buffers

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -178,7 +178,11 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		return textInfos.Point(left + width / 2, top + height / 2)
 
 	def _getNVDAObjectFromOffset(self,offset):
-		docHandle,ID=self._getFieldIdentifierFromOffset(offset)
+		try:
+			docHandle,ID=self._getFieldIdentifierFromOffset(offset)
+		except LookupError:
+			log.debugWarning("Couldn't get NVDAObject from offset %d" % offset)
+			return None
 		return self.obj.getNVDAObjectFromIdentifier(docHandle,ID)
 
 	def _getOffsetsFromNVDAObjectInBuffer(self,obj):


### PR DESCRIPTION
### Link to issue number:
Fixes #8667, regression caused by #8479. Originally reported by @ruifontes via mail

### Summary of the issue (steps to reproduce):
1. Open the following in Firefox:

    `data:text/html, <p></p>`

2. Navigate through the empty buffer.

### Actual result
An error sound is played. The following is printed in the log:

<details>
<summary>Log snippet</summary>
<pre>
ERROR - scriptHandler.executeScript (07:13:10.999):
error executing script: <bound method Gecko_ia2.script_moveByLine_forward of <virtualBuffers.gecko_ia2.Gecko_ia2 object at 0x0540E1B0>> with gesture u'down arrow'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 187, in executeScript
  File "cursorManager.pyc", line 210, in script_moveByLine_forward
  File "cursorManager.pyc", line 140, in _caretMovementScriptHelper
  File "browseMode.pyc", line 1210, in _set_selection
  File "baseObject.pyc", line 21, in __get__
  File "textInfos\offsets.pyc", line 311, in _get_NVDAObjectAtStart
  File "virtualBuffers\__init__.pyc", line 181, in _getNVDAObjectFromOffset
  File "virtualBuffers\__init__.pyc", line 160, in _getFieldIdentifierFromOffset
LookupError: Neither docHandle nor ID found for offset 0
</pre>
</details>

### Expected result
NVDA just says blank.

### Description of how this pull request fixes the issue:
With #8479, I introduced raising a LookupError for cases where both the vbuf handle and id of for an offset are 0 when executing _getFieldIdentifierFromOffset, since this is an invalid case. However, LookupErrors wheren't caught in _getNVDAObjectFromOffset. With this pr, they are, and an additional debugWarning is logged.

Note that the old path (pre #8479) was as follows:

1. Call _getNVDAObjectFromOffset with an offset
2. This calls _getFieldIdentifierFromOffset, which returns (0, 0)
3. _getNVDAObjectFromOffset calls getNVDAObjectFromIdentifier on the virtual buffer with parameters (0, 0). This returns None.
4. Therefore, we now return None early in _getNVDAObjectFromOffset.

### Testing performed:
Tested the case as described above. Also made sure that _get_fieldIdentifierFromOffset isn't called elsewhere where this could cause an issue due to a not caught LookupError.

### Known issues with pull request:
None

### Change log entry:
None
