### PR TITLE
Improve support for combo boxes in all browsers

### DIFF
--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -425,6 +425,18 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 	def __contains__(self,obj):
 		if not isinstance(obj,UIA):
 			return False
+		# Ensure that this object is a descendant of the document or is the document itself. 
+		runtimeID=VARIANT()
+		self.rootNVDAObject.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(UIAHandler.UIA_RuntimeIdPropertyId,byref(runtimeID))
+		UIACondition=UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_RuntimeIdPropertyId,runtimeID)
+		UIAWalker=UIAHandler.handler.clientObject.createTreeWalker(UIACondition)
+		try:
+			docUIAElement=UIAWalker.normalizeElement(obj.UIAElement)
+		except COMError:
+			docUIAElement=None
+		if not docUIAElement:
+			return False
+		# Ensure that this object also can be reached by the document's text pattern.
 		try:
 			self.rootNVDAObject.makeTextInfo(obj)
 		except LookupError:

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -421,15 +421,6 @@ class DocumentWindow(PaneClassDC):
 		finally:
 			self._isHandlingSelectionChange=False
 
-	def event_gainFocus(self):
-		"""Bounces focus to the currently selected slide, shape or Text frame."""
-		obj=self.selection
-		if obj:
-			eventHandler.queueEvent("focusEntered",self)
-			eventHandler.queueEvent("gainFocus",obj)
-		else:
-			super(DocumentWindow,self).event_gainFocus()
-
 	def script_selectionChange(self,gesture):
 		gesture.send()
 		if scriptHandler.isScriptWaiting():

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1282,7 +1282,6 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		elif not self.disableAutoPassThrough:
 			self.passThrough = False
 		reportPassThrough(self)
-	script_collapseOrExpandControl.ignoreTreeInterceptorPassThrough = True
 
 	def _tabOverride(self, direction):
 		"""Override the tab order if the virtual  caret is not within the currently focused node.

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1268,12 +1268,17 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 
 		scriptHandler.queueScript(script, gesture)
 
+	currentExpandedControl=None #: an NVDAObject representing the control that has just been expanded with the collapseOrExpandControl script.
 	def script_collapseOrExpandControl(self, gesture):
 		oldFocus = api.getFocusObject()
 		oldFocusStates = oldFocus.states
 		gesture.send()
 		if controlTypes.STATE_COLLAPSED in oldFocusStates:
 			self.passThrough = True
+			# When a control (such as a combo box) is expanded, we expect that its descendants will be classed as being outside the browseMode document.
+			# We save off the expanded control so that the next focus event within the browseMode document can see if it is for the control,
+			# and if so, it disables passthrough, as the control has obviously been collapsed again.
+			self.currentExpandedControl=oldFocus
 		elif not self.disableAutoPassThrough:
 			self.passThrough = False
 		reportPassThrough(self)
@@ -1378,6 +1383,16 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			if self.passThrough:
 				self._replayFocusEnteredEvents()
 				nextHandler()
+			return
+		# If a control has been expanded by the collapseOrExpandControl script, and this focus event is for it,
+		# disable passThrough and report the control, as the control has obviously been collapsed again.
+		# Note that whether or not this focus event was for that control, the last expanded control is forgotten, so that only the next focus event for the browseMode document can handle the collapsed control.
+		lastExpandedControl=self.currentExpandedControl
+		self.currentExpandedControl=None
+		if self.passThrough and obj==lastExpandedControl:
+			self.passThrough=False
+			reportPassThrough(self)
+			nextHandler()
 			return
 		if enteringFromOutside and not self.passThrough and self._lastFocusObj==obj:
 			# We're entering the document from outside (not returning from an inside object/application; #3145)
@@ -1511,7 +1526,12 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 				# We found a cached result.
 				return doResult(inApp)
 			objs.append(obj)
-			if obj.role in self.APPLICATION_ROLES:
+			if (
+				# roles such as application and dialog should be treated as being within a "application" and therefore outside of the browseMode document. 
+				obj.role in self.APPLICATION_ROLES 
+				# Anything inside a combo box should be treated as being outside a browseMode document.
+				or (obj.container and obj.container.role==controlTypes.ROLE_COMBOBOX)
+			):
 				return doResult(True)
 			# Cache container.
 			container = obj.container

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -143,6 +143,9 @@ def executeEvent(eventName,obj,**kwargs):
 	@param kwargs: Additional event parameters as keyword arguments.
 	"""
 	try:
+		# Allow NVDAObjects to redirect focus events to another object of their choosing.
+		if eventName=="gainFocus" and obj.focusRedirect:
+			obj=obj.focusRedirect
 		sleepMode=obj.sleepMode
 		if eventName=="gainFocus" and not doPreGainFocus(obj,sleepMode=sleepMode):
 			return

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -191,33 +191,9 @@ class MSHTML(VirtualBuffer):
 	def __contains__(self,obj):
 		if not obj.windowClassName.startswith("Internet Explorer_"):
 			return False
-		#'select' tag lists have MSAA list items which do not relate to real HTML nodes.
-		#Go up one parent for these and use it instead
-		if isinstance(obj,NVDAObjects.IAccessible.IAccessible) and not isinstance(obj,NVDAObjects.IAccessible.MSHTML.MSHTML) and obj.role==controlTypes.ROLE_LISTITEM:
-			parent=obj.parent
-			if parent and isinstance(parent,NVDAObjects.IAccessible.MSHTML.MSHTML):
-				obj=parent
-		#Combo box lists etc are popup windows, so rely on accessibility hierarchi instead of window hierarchi for those.
-		#However only helps in IE8.
-		if obj.windowStyle&winUser.WS_POPUP:
-			parent=obj.parent
-			obj.parent=parent
-			while parent and parent.windowHandle==obj.windowHandle:
-				newParent=parent.parent
-				parent.parent=newParent
-				parent=newParent
-			if parent and parent.windowClassName.startswith('Internet Explorer_'):
-				obj=parent
 		if not winUser.isDescendantWindow(self.rootDocHandle,obj.windowHandle) and obj.windowHandle!=self.rootDocHandle:
 			return False
-		newObj=obj
-		while  isinstance(newObj,NVDAObjects.IAccessible.MSHTML.MSHTML):
-			if newObj==self.rootNVDAObject:
-				return True
-			if newObj.role in (controlTypes.ROLE_APPLICATION,controlTypes.ROLE_DIALOG):
-				break
-			newObj=newObj.parent 
-		return False
+		return not self._isNVDAObjectInApplication(obj)
 
 	def _get_isAlive(self):
 		if self.isLoading:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -126,29 +126,7 @@ class Gecko_ia2(VirtualBuffer):
 			return False
 		return True
 
-	def _getExpandedComboBox(self, obj):
-		"""If obj is an item in an expanded combo box, get the combo box.
-		"""
-		if not (obj.windowClassName.startswith('Mozilla') and obj.windowStyle & winUser.WS_POPUP):
-			# This is not a Mozilla popup window, so it can't be an expanded combo box.
-			return None
-		if obj.role not in (controlTypes.ROLE_LISTITEM, controlTypes.ROLE_LIST):
-			return None
-		parent = obj.parent
-		# Try a maximum of 2 ancestors, since we might be on the list item or the list.
-		for i in xrange(2):
-			obj = obj.parent
-			if not obj:
-				return None
-			if obj.role == controlTypes.ROLE_COMBOBOX:
-				return obj
-		return None
-
 	def __contains__(self,obj):
-		# if this is a Mozilla combo box popup, we want to work with the combo box.
-		combo = self._getExpandedComboBox(obj)
-		if combo:
-			obj = combo
 		if not (isinstance(obj,NVDAObjects.IAccessible.IAccessible) and isinstance(obj.IAccessibleObject,IAccessibleHandler.IAccessible2)) or not obj.windowClassName.startswith('Mozilla') or not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle,obj.windowHandle):
 			return False
 		if self.rootNVDAObject.windowHandle==obj.windowHandle:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,7 @@ What's New in NVDA
 - In Outlook 2016/365, the category and flag status are reported for messages. (#8603)
 - When NVDA is set to languages such as Kirgyz, Mongolian or Macedonian, it no longer shows a dialog on start-up warning that the language is not supported by the Operating System. (#8064)
 - Moving the mouse to the navigator object will now much more accurately move the mouse to the browse mode position in Mozilla Firefox, Google Chrome and Acrobat Reader DC. (#6460)
+- Interacting with combo boxes on the web in Firefox, Chrome and Internet Explorer has been improved. (#8664)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8664 

### Summary of the issue:
Currently in NVDA, the user experience when using combo boxes on the web significantly differs by browser, plus some of the original code written to handle combo boxes has now broken in multiple browsers.
For example:
*In Firefox, collapsing a combo box works, but browseMode is not re-enabled.
* In Chrome 68, focusing a collapsed combo box ends up focusing the active list item within the combo box, even though it is collapsed.
* In Chrome 68 and 70, collapsing a combo box with escape/enter/alt+upArrow simply switches to browseMode and does not collapse the combo box.
* In Edge, Expanding the combo box and then arrowing through the options reports nothing and an exception occurs.
 
### Description of how this pull request fixes the issue:
This PR standardizes the way we handle combo boxes in browseMode, so that:
* Anything inside a combo box is treated as not being in the browseMode document. This means that if the combo box is expanded and focus is inside, browseMode completely ignores it.
* Alt+downArrow when in browseMode expands the combo box and switches to focus mode, but also remembers the combo box, so that the next focus event in browseMode (if it is for the combo box), switches back to browseMode again (as this means the combo box has been collapsed). Technically there is no need to toggle focus mode and browseMode at all, but this keeps UX compatible with previous NVDA versions.

This PR also partly works around a bug in Chrome 68 and below where focusing a collapsed combo box focuses the active list item within the combo box. This has been fixed in Chrome 70.

This PR also fixes an issue in Edge where list items in the combo box were being treated were being treated as part of the document but with a broken textRange.
 
### Testing performed:
Tested a standard HTML select (size=1) in Firefox 52, Firefox Nightly, Chrome 68 and Chrome 70.
Arrowed to the combo box in browse mode. Pressed alt+downArrow. Arrowed through the list. And closed the combo box with either enter, escape or alt+upArrow.

### Known issues with pull request:
Combo boxes in Chrome 68 and below are still not perfect, but no worse than what they were before this PR. 
 
### Change log entry:
Bug fixes:
* Interacting with combo boxes on the web in Firefox, Chrome and Internet Explorer has been improved.