### PR TITLE
Save config after usage stats dialog on NVDA start-up

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -79,8 +79,21 @@ def doStartupDialogs():
 		gui.messageBox(_("Your gesture map file contains errors.\n"
 				"More details about the errors can be found in the log file."),
 			_("gesture map File Error"), wx.OK|wx.ICON_EXCLAMATION)
-	if not globalVars.appArgs.secure and not config.isAppX and not config.conf['update']['askedAllowUsageStats']:
-		gui.runScriptModalDialog(gui.AskAllowUsageStatsDialog(None))
+	try:
+		import updateCheck
+	except RuntimeError:
+		updateCheck=None
+	if updateCheck and not config.conf['update']['askedAllowUsageStats']:
+		# a callback to save config after the usage stats question dialog has been answered.
+		def onResult(ID):
+			import wx
+			if ID in (wx.ID_YES,wx.ID_NO):
+				try:
+					config.conf.save()
+				except:
+					pass
+		# Ask the user if usage stats can be collected.
+		gui.runScriptModalDialog(gui.AskAllowUsageStatsDialog(None),onResult)
 
 def restart(disableAddons=False, debugLogging=False):
 	"""Restarts NVDA by starting a new copy with -r."""


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #8688

### Summary of the issue:
In 2018.3 and later, at NVDA launch the user is asked if usage stats can be collected.
However, if the user has previously chosen not to save settings on exit, this dialog will appear every time NVDA is launched, no matter how the user answers the usage stats dialog.
It is expected that if the user answers yes or no, NVDA should no longer ask the user.

### Description of how this pull request fixes the issue:
When the Usage stats dialog is shown on NVDA launch, and the user answers either yes or no, configuration is now saved.
Also ensured that the usage stats dialog is not shown for builds of NVDA that does not support update checking (E.g. source copies, try builds).
Note that the if check used to explicitly check for secure copies has been removed. This is no longer necessary as update check is not supported on secure copies and therefore is implicit.

### Testing performed:
Tested with a fresh config:
* Launched NVDA.
* Usage stats dialog appeared. Activated the Not Now button.
* Set NvDA to not save settings on exit, and then saved configuration and restarted.
* NVDA again showed the Usage stats dialog. Activated the Yes button.
* Restarted NVDA.
* NVDA did not show the usage stats dialog.

 ### Known issues with pull request:
None.

### Change log entry:
None needed (fix to new feature in 2018.3).

Section: New features, Changes, Bug fixes

