### PR TITLE
Update liblouis to version 3.7, add new chinese tables

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -56,6 +56,9 @@ env.Append(CPPDEFINES=[
 ])
 env.Prepend(CPPPATH=[".", louisSourceDir])
 
+# Upstream liblouis compiles without UNICODE defined.
+env['CPPDEFINES'].remove("UNICODE")
+
 liblouisH = env.Substfile("liblouis.h", louisSourceDir.File("liblouis.h.in"),
 	SUBST_DICT={"@WIDECHAR_TYPE@": "unsigned short int"})
 
@@ -66,6 +69,7 @@ sourceFiles = [
 	"logging.c",
 	"pattern.c",
 	"commonTranslationFunctions.c",
+	"metadata.c",
 	"utils.c",
 ]
 objs = [env.Object("%s.obj" % f, louisSourceDir.File(f)) for f in sourceFiles]

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ For reference, the following dependencies are included in Git submodules:
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
-* [liblouis](http://www.liblouis.org/), version 3.6.0
+* [liblouis](http://www.liblouis.org/), version 3.7.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -380,6 +380,12 @@ addTable("unicode-braille.utb", _("Unicode braille"), output=False)
 addTable("vi-g1.ctb", _("Vietnamese grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("zhcn-g1.ctb", _("Chinese (China, Mandarin) grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("zhcn-g2.ctb", _("Chinese (China, Mandarin) grade 2"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,12 +6,14 @@ What's New in NVDA
 = 2018.4 =
 
 == New Features ==
+- New braille tables: Chinese (China, Mandarin) grade 1 and grade 2. (#5553)
 
 
 == Changes ==
 - "Report help balloons" in the Object Presentations dialog has been renamed to "Report notifications" to include reporting of toast notifications in Windows 8 and later. (#5789)
 - IN NVDA's keyboard settings, the checkboxes to enable or disable NVDA modifier keys are now displayed in a list rather than as separate checkboxes.
 - NVDA will no longer present redundant information when reading clock system tray on some versions of Windows. (#4364)
+- Updated liblouis braille translator to version 3.7.0. (#8697)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
### Link to issue number:
Closes #5553
Closes #8697 

### Summary of the issue:
Liblouis 3.7 has been released today.

### Description of how this pull request fixes the issue:
1. Updates liblouis to version 3.7
2. Add new Mandarin Chinese tables
3. In trying to make the NVDA build resemble upstream as much as possible, metadata.c is now also included in the build process. Also, Liblouis is no longer compiled with the UNICODE flag. There are two reasons for this:

    1. Upstream doesn't define UNICODE either.
    2. It causes signed/unsigned missmatch warnings when compiling with UCS-4 support. Though UCS-4 is not yet the default. I will publish try builds with this functionality whenever this pr is merged. Also, metadata.c doesn't build without warnings when UNICODE is defined.

### Testing performed:
Created try build, loaded the two new Chinese tables.

### Known issues with pull request:
None

### Change log entry:
* New features
    + New braille tables: Chinese (China, Mandarin) grade 1 and grade 2. (#5553)

* Changes
    + Updated liblouis braille translator to version 3.7.0. (#8697)