### PR TITLE
Remove duplicate section heading from change log.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,9 +29,6 @@ What's New in NVDA
  - AutoWidthColumnCheckListCtrl adds accessible check boxes to an AutoWidthColumnListCtrl, which itself is based on wx.ListCtrl.
 - If you need to make a wx widget accessible which isn't already, it is possible to do so by using an instance of gui.accPropServer.IAccPropServer_impl. (#7491)
  - See the implementation of gui.nvdaControls.ListCtrlAccPropServer for more info.
-
-
-== Changes for Developers ==
 - Updated configobj to 5.1.0dev commit 5b5de48a. (#4470)
 
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
N/A

### Summary of the issue:
There are 2 changes for developers headings for 2018.4.

### Description of how this pull request fixes the issue:
Delete the second heading.
