### PR TITLE
Per foreground uia property change events

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -233,7 +233,10 @@ class UIAHandler(COMObject):
 		while True:
 			func=self.MTAThreadQueue.get()
 			if func:
-				func()
+				try:
+					func()
+				except:
+					log.error("Exception in function queued to UIA MTA thread",exc_info=True)
 			else:
 				break
 		self.clientObject.RemoveAllEventHandlers()
@@ -249,11 +252,13 @@ class UIAHandler(COMObject):
 				# The old UIAElement died as the window was closed.
 				# The system should forget the old event registration itself.
 				pass
-		self.currentForegroundUIAElement=pendingForegroundUIAElement
 		try:
-			self.clientObject.AddPropertyChangedEventHandler(self.currentForegroundUIAElement,TreeScope_Subtree,self.baseCacheRequest,self,UIAPropertyIdsToNVDAEventNames.keys())
+			self.clientObject.AddPropertyChangedEventHandler(pendingForegroundUIAElement,TreeScope_Subtree,self.baseCacheRequest,self,UIAPropertyIdsToNVDAEventNames.keys())
 		except COMError:
 			log.error("Could not register for UIA property change events for new foreground")
+			self.currentForegroundUIAElement=None
+		else:
+			self.currentForegroundUIAElement=pendingForegroundUIAElement
 
 	def onForegroundChange(self,hwnd):
 		try:

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -4,6 +4,10 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+try:
+	from Queue import Queue # Python 2.7 import
+except ImportError:
+	from queue import Queue # Python 3 import
 from ctypes import *
 from ctypes.wintypes import *
 import comtypes.client
@@ -156,8 +160,8 @@ class UIAHandler(COMObject):
 	def __init__(self):
 		super(UIAHandler,self).__init__()
 		self.MTAThreadInitEvent=threading.Event()
-		self.MTAThreadStopEvent=threading.Event()
 		self.MTAThreadInitException=None
+		self.MTAThreadQueue=Queue()
 		self.MTAThread=threading.Thread(target=self.MTAThreadFunc)
 		self.MTAThread.daemon=True
 		self.MTAThread.start()
@@ -167,7 +171,7 @@ class UIAHandler(COMObject):
 
 	def terminate(self):
 		MTAThreadHandle=HANDLE(windll.kernel32.OpenThread(winKernel.SYNCHRONIZE,False,self.MTAThread.ident))
-		self.MTAThreadStopEvent.set()
+		self.MTAThreadQueue.put_nowait(None)
 		#Wait for the MTA thread to die (while still message pumping)
 		if windll.user32.MsgWaitForMultipleObjects(1,byref(MTAThreadHandle),False,200,0)!=0:
 			log.debugWarning("Timeout or error while waiting for UIAHandler MTA thread")
@@ -194,7 +198,7 @@ class UIAHandler(COMObject):
 						pass
 				# Windows 10 RS5 provides new performance features for UI Automation including event coalescing and connection recovery. 
 				# Enable all of these where available.
-				if isinstance(self.clientObject,IUIAutomation6):
+				if False: #isinstance(self.clientObject,IUIAutomation6):
 					self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
 					self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
 			log.info("UIAutomation: %s"%self.clientObject.__class__.__mro__[1].__name__)
@@ -213,7 +217,8 @@ class UIAHandler(COMObject):
 			self.rootElement=self.clientObject.getRootElementBuildCache(self.baseCacheRequest)
 			self.reservedNotSupportedValue=self.clientObject.ReservedNotSupportedValue
 			self.ReservedMixedAttributeValue=self.clientObject.ReservedMixedAttributeValue
-			self.curForegroundUIAElement=None
+			self.pendingForegroundUIAElement=None
+			self.currentForegroundUIAElement=None
 			self.clientObject.AddFocusChangedEventHandler(self.baseCacheRequest,self)
 			#self.clientObject.AddPropertyChangedEventHandler(self.rootElement,TreeScope_Subtree,self.baseCacheRequest,self,UIAPropertyIdsToNVDAEventNames.keys())
 			for x in UIAEventIdsToNVDAEventNames.iterkeys():  
@@ -225,26 +230,39 @@ class UIAHandler(COMObject):
 			self.MTAThreadInitException=e
 		finally:
 			self.MTAThreadInitEvent.set()
-		self.MTAThreadStopEvent.wait()
+		while True:
+			func=self.MTAThreadQueue.get()
+			if func:
+				func()
+			else:
+				break
 		self.clientObject.RemoveAllEventHandlers()
 
-	def onForegroundChange(self,hwnd):
-		if self.curForegroundUIAElement:
+	def _onForegroundChange(self):
+		pendingForegroundUIAElement=self.pendingForegroundUIAElement
+		if pendingForegroundUIAElement==self.currentForegroundUIAElement:
+			return
+		if self.currentForegroundUIAElement:
 			try:
-				self.clientObject.removePropertyChangedEventHandler(self.curForegroundUIAElement,self)
+				self.clientObject.removePropertyChangedEventHandler(self.currentForegroundUIAElement,self)
 			except COMError:
 				# The old UIAElement died as the window was closed.
 				# The system should forget the old event registration itself.
 				pass
+		self.currentForegroundUIAElement=pendingForegroundUIAElement
 		try:
-			self.curForegroundUIAElement=self.clientObject.ElementFromHandle(hwnd)
+			self.clientObject.AddPropertyChangedEventHandler(self.currentForegroundUIAElement,TreeScope_Subtree,self.baseCacheRequest,self,UIAPropertyIdsToNVDAEventNames.keys())
+		except COMError:
+			log.error("Could not register for UIA property change events for new foreground")
+
+	def onForegroundChange(self,hwnd):
+		try:
+			self.pendingForegroundUIAElement=self.clientObject.ElementFromHandle(hwnd)
 		except COMError:
 			log.error("Could not get a UIAElement from new foreground window")
 			return
-		try:
-			self.clientObject.AddPropertyChangedEventHandler(self.curForegroundUIAElement,TreeScope_Subtree,self.baseCacheRequest,self,UIAPropertyIdsToNVDAEventNames.keys())
-		except COMError:
-			log.error("Could not register for UIA property change events for new foreground")
+		# Event registration/unregistration must be always done from the MTA thread, otherwise deadlocks can occur with our UI.
+		self.MTAThreadQueue.put_nowait(self._onForegroundChange)
 
 	def IUIAutomationEventHandler_HandleAutomationEvent(self,sender,eventID):
 		if not self.MTAThreadInitEvent.isSet():

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -259,7 +259,7 @@ class UIAHandler(COMObject):
 		try:
 			self.pendingForegroundUIAElement=self.clientObject.ElementFromHandle(hwnd)
 		except COMError:
-			log.error("Could not get a UIAElement from new foreground window")
+			log.debugWarning("Could not get a UIAElement from new foreground window")
 			return
 		# Event registration/unregistration must be always done from the MTA thread, otherwise deadlocks can occur with our UI.
 		self.MTAThreadQueue.put_nowait(self._onForegroundChange)

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -198,7 +198,7 @@ class UIAHandler(COMObject):
 						pass
 				# Windows 10 RS5 provides new performance features for UI Automation including event coalescing and connection recovery. 
 				# Enable all of these where available.
-				if False: #isinstance(self.clientObject,IUIAutomation6):
+				if isinstance(self.clientObject,IUIAutomation6):
 					self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
 					self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
 			log.info("UIAutomation: %s"%self.clientObject.__class__.__mro__[1].__name__)

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -171,6 +171,10 @@ def doPreGainFocus(obj,sleepMode=False):
 			else:
 				newForeground=obj
 		api.setForegroundObject(newForeground)
+		import UIAHandler
+		if UIAHandler.isUIAAvailable:
+			# Notify UIAHandler of the new foreground so that it can deregister old events and register new ones 
+			UIAHandler.handler.onForegroundChange(newForeground.windowHandle)
 		executeEvent('foreground',newForeground)
 	if sleepMode: return True
 	#Fire focus entered events for all new ancestors of the focus if this is a gainFocus event

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -172,7 +172,7 @@ def doPreGainFocus(obj,sleepMode=False):
 				newForeground=obj
 		api.setForegroundObject(newForeground)
 		import UIAHandler
-		if UIAHandler.isUIAAvailable:
+		if UIAHandler.isUIAAvailable and UIAHandler.handler:
 			# Notify UIAHandler of the new foreground so that it can deregister old events and register new ones 
 			UIAHandler.handler.onForegroundChange(newForeground.windowHandle)
 		executeEvent('foreground',newForeground)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,7 @@ What's New in NVDA
 - When NVDA is set to languages such as Kirgyz, Mongolian or Macedonian, it no longer shows a dialog on start-up warning that the language is not supported by the Operating System. (#8064)
 - Moving the mouse to the navigator object will now much more accurately move the mouse to the browse mode position in Mozilla Firefox, Google Chrome and Acrobat Reader DC. (#6460)
 - Interacting with combo boxes on the web in Firefox, Chrome and Internet Explorer has been improved. (#8664)
+- NVDA no longer fails to track focus in File Explorer and other applications using UI Automation when another app is busy (such as when an application is batch processing audio). (#7345)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #7345 

### Summary of the issue:
Sometimes UI Automation focus events stop firing across the Operating System, if a background app is currently firing a lot of MSAA events and at the same time is slow to respond to window messages. An example would be trying to use File Explorer while another app  is showing a progress bar while processing audio.

### Description of how this pull request fixes the issue:
NVDA now registers for UIA propertyChange events per foreground change, rather than globally at NVDA startup.

### Testing performed:
Multiple users have been testing try build of this code on both Windows 7 and Windows 10. They have reported that the UIA focus events no longer disappear, and in some cases general performance has been improved.

### Known issues with pull request:
None known so far.

### Change log entry:
Bug fixes:
NVDA no longer fails to track focus in File Explorer and other applications using UI Automation when another app is busy (such as batch processing audio).