### PR TITLE
Work around iTunes 12.9 being completely broken with NVDA

### DIFF
--- a/source/appModules/itunes.py
+++ b/source/appModules/itunes.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2015 NV Access Limited
+#Copyright (C) 2009-2018 NV Access Limited, Leonard de Ruijter
 
 """App module for iTunes
 """
@@ -17,6 +17,7 @@ import treeInterceptorHandler
 import api
 import eventHandler
 import NVDAObjects.IAccessible
+import NVDAObjects.UIA
 from NVDAObjects.IAccessible import webKit
 
 class AppModule(appModuleHandler.AppModule):
@@ -39,6 +40,10 @@ class AppModule(appModuleHandler.AppModule):
 				obj.presentationType = obj.presType_layout
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if isinstance(obj,NVDAObjects.UIA.UIA):
+			# iTunes 12.9 implements UIA for many controls.
+			# Just leave them untouched for now.
+			return
 		windowClassName=obj.windowClassName
 		role=obj.role
 		if windowClassName in ('iTunesList','iTunesSources','iTunesTrackList') and role in (controlTypes.ROLE_LISTITEM,controlTypes.ROLE_TREEVIEWITEM):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -58,6 +58,7 @@ Highlights of this release include automatic detection of many Braille displays,
  - Cursor routing in braille now works correctly when in a list in a Word document. (#7971)
  - Newly inserted bullets/numbers in a Word document are correctly reported in both speech and braille. (#7970)
 - In Windows 10 1803 and later, it is now possible to install add-ons if the "Use Unicode UTF-8 for worldwide language support" feature is enabled. (#8599)
+- NVDA will no longer make iTunes 12.9 and newer completely unusable to interact with. (#8744)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #8744 

### Summary of the issue:
For many people, iTunes is an essential piece of software to control their Apple devices. iTunes 12.9 switched to UIA for many controls, including the foreground window. The current appModule isn't expecting UIA and therefore not UIA proof, making iTunes completely unusable.

### Description of how this pull request fixes the issue:
This patch adds a check to the choose overlay classes method to return early for UIA objects.

### Testing performed:
Did some basic tasks in iTunes, all seemed to work in an acceptable fashion.

### Known issues with pull request:
* The volume slider values seem to be multiplied by 100, so 100% is reported as 10000. This is really a bug in iTunes.
* I consider this a temporary work around. Since it is a fix with minimum amounts of code and maximum improvement for the end user, I propose adding this to NVDA 2018.3 as an emergency fix.

### Change log entry:
* Bug Fixes
    + NVDA will no longer make iTunes 12.9 and newer completely unusable to interact with. (#8744)