### PR TITLE
Elements list: catch wxPython::invalid item exception when text in the filter field yields no elements. Re #8753.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -887,7 +887,11 @@ class ElementsListDialog(wx.Dialog):
 	def filter(self, filterText, newElementType=False):
 		# If this is a new element type, use the element nearest the cursor.
 		# Otherwise, use the currently selected element.
-		defaultElement = self._initialElement if newElementType else self.tree.GetItemData(self.tree.GetSelection())
+		# #8753: wxPython 4 returns "invalid tree item" when the tree view is empty, so use initial element if appropriate.
+		try:
+			defaultElement = self._initialElement if newElementType else self.tree.GetItemData(self.tree.GetSelection())
+		except:
+			defaultElement = self._initialElement
 		# Clear the tree.
 		self.tree.DeleteChildren(self.treeRoot)
 


### PR DESCRIPTION
### Link to issue number:
Fixes #8753 

### Summary of the issue:
Regression: when a user enters text into the filter field and no elements are found, wxPython returns 'invalid item' when attempting to obtain selection from the search tree. Thus coerce this to default element (initial element).

### Description of how this pull request fixes the issue:
Via a try/except clause, catch invalid item exception and assign default element to initial element for the currently selected element type.

### Testing performed:
Tested on various websites and in browsers such as IE, Firefox and Edge.

### Known issues with pull request:
None

### Change log entry:
None
