### PR TITLE
Fix crash in 32 bit Mozilla Firefox

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -34,7 +34,8 @@ CComPtr<IAccessible2> getLabelElement(IAccessible2_2* element) {
 	IUnknown** ppUnk=nullptr;
 	long nTargets=0;
 	constexpr int numRelations=2;
-	HRESULT res=element->get_relationTargetsOfType(IA2_RELATION_LABELLED_BY,numRelations,&ppUnk,&nTargets);
+	// the relation type string *must* be passed correctly as a BSTR otherwise we can see crashes in 32 bit Firefox.
+	HRESULT res=element->get_relationTargetsOfType(CComBSTR(IA2_RELATION_LABELLED_BY),numRelations,&ppUnk,&nTargets);
 	if(res!=S_OK) return nullptr;
 	// Grab all the returned IUnknowns and store them as smart pointers within a smart pointer array 
 	// so that any further returns will correctly release all the objects. 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,10 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2018.3.1 =
+This is a minor release to fix a critical bug in NVDA which caused 32 bit versions of Mozilla Firefox to crash. (#8759)
+ 
+
 = 2018.3 =
 Highlights of this release include automatic detection of many Braille displays, support for new Windows 10 features including the Windows 10 Emoji input panel, and many other bug fixes.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8759 

### Summary of the issue:
With the release of NVDA 2018.3, we received many reports of Mozilla Firefox 32 bit crashing with NVDA.
This was tracked down to a call to IAccessible2_2::get_relationTargetsOfType, where COM failed to marshal the relation type BSTR argument.
This argument was passed in a a compile-time constant string literal, directly from the IAccessible2 IDLs. C++ allows this as BSTR is a typedef for wchar_t* (which is what the string literal is).
However, as COM things it is a BSTR, it looks in the two bytes before the string to find the size. However, this causes an access violation on optimized 32 bit builds of NVDA. No doubt even on other builds, there is a danger that it could read an invalid size.
Bug introduced by #8352 and then by #8586.
 
### Description of how this pull request fixes the issue:
This PR wraps the string literal in a CComBSTR when passing it to get_relationTargetsOfType.
Note: CComBSTR cannot take a BSTR at construction, thus it properly treats a wchar_t* as a wchar_t*so it does not suffer from the same issue as get_relationTargetsOfType.

### Testing performed:
Tested an optimized build of NVDA with both 32 bit and 64 bit Mozilla Firefox 62. Using the tests in #8352.
 
### Known issues with pull request:
None known.

### Change log entry:
Already in pr.
