### PR TITLE
If running on the Japanese version of Windows XP or Vista, NVDA should displays the alert of OS version requirements

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -74,10 +74,7 @@ globalVars.startTime=time.time()
 # Check OS version requirements
 import winVersion
 if not winVersion.isSupportedOS():
-	msg = ctypes.FormatError(winUser.ERROR_OLD_WIN_VERSION)
-	if hasattr(msg, 'decode'):
-		msg = msg.decode('mbcs')
-	winUser.MessageBox(0, msg, None, winUser.MB_ICONERROR)
+	winUser.MessageBox(0, ctypes.FormatError(winUser.ERROR_OLD_WIN_VERSION), None, winUser.MB_ICONERROR)
 	sys.exit(1)
 
 def decodeMbcs(string):

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -74,7 +74,10 @@ globalVars.startTime=time.time()
 # Check OS version requirements
 import winVersion
 if not winVersion.isSupportedOS():
-	winUser.MessageBox(0, unicode(ctypes.FormatError(winUser.ERROR_OLD_WIN_VERSION)), None, winUser.MB_ICONERROR)
+	msg = ctypes.FormatError(winUser.ERROR_OLD_WIN_VERSION)
+	if hasattr(msg, 'decode'):
+		msg = msg.decode('mbcs')
+	winUser.MessageBox(0, msg, None, winUser.MB_ICONERROR)
 	sys.exit(1)
 
 def decodeMbcs(string):

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -514,6 +514,10 @@ IDRETRY=4
 IDCANCEL=3
 
 def MessageBox(hwnd, text, caption, type):
+	if hasattr(text, 'decode'):
+		text = text.decode('mbcs')
+	if caption and hasattr(caption, 'decode'):
+		caption = caption.decode('mbcs')
 	res = user32.MessageBoxW(hwnd, text, caption, type)
 	if res == 0:
 		raise WinError()

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -514,9 +514,9 @@ IDRETRY=4
 IDCANCEL=3
 
 def MessageBox(hwnd, text, caption, type):
-	if hasattr(text, 'decode'):
+	if isinstance(text, bytes):
 		text = text.decode('mbcs')
-	if caption and hasattr(caption, 'decode'):
+	if isinstance(caption, bytes):
 		caption = caption.decode('mbcs')
 	res = user32.MessageBoxW(hwnd, text, caption, type)
 	if res == 0:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,6 +22,7 @@ What's New in NVDA
 - When NVDA is set to languages such as Kirgyz, Mongolian or Macedonian, it no longer shows a dialog on start-up warning that the language is not supported by the Operating System. (#8064)
 - Moving the mouse to the navigator object will now much more accurately move the mouse to the browse mode position in Mozilla Firefox, Google Chrome and Acrobat Reader DC. (#6460)
 - Interacting with combo boxes on the web in Firefox, Chrome and Internet Explorer has been improved. (#8664)
+- If running on the Japanese version of Windows XP or Vista, NVDA now displays the alert of OS version requirements as expected. (#8771)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:

Closes #7586

### Summary of the issue:

If running on the Japanese version of Windows XP or Vista, NVDA raises error as follows.

```
See the logfile 'C:\Users\***\AppData\Local\Temp\***.tmp\app\nvda_noUIAccess.exe.log' for details
```

```
Traceback (most recent call last):
  File "nvda.pyw", line 77, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0x8e in position 0: ordinal not in range(128)
```

It makes difficult for supporters to solve the problem of the users.

### Description of how this pull request fixes the issue:

* if ctypes.FormatError() returns mbcs string, it should be decoded.
* the code is expected to work with both Python 2.7 and Python 3.7.

### Testing performed:

* this workaround is already done for NVDA Japanese version 2018.3.1jp.

### Known issues with pull request:

* similar workaround may be necessary for other parts of NVDA, so we should avoid the duplication.

### Change log entry:

Section: Bug fixes

If running on the Japanese version of Windows XP or Vista, NVDA now displays the alert of OS version requirements as expected.
