### PR TITLE
Work around crash in Google Chrome when navigating tweets on twitter.com

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -30,10 +30,18 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 using namespace std;
 
-CComPtr<IAccessible2> getLabelElement(IAccessible2_2* element) {
+CComPtr<IAccessible2> GeckoVBufBackend_t::getLabelElement(IAccessible2_2* element) {
 	IUnknown** ppUnk=nullptr;
 	long nTargets=0;
-	constexpr int numRelations=2;
+	// We only need to request one relation target
+	int numRelations=1;
+	// However, a bug in Chrome causes a buffer overrun if numRelations is less than the total number of targets the node has.
+	// Therefore, If this is Chrome, request all targets (by setting numRelations to 0) as this works around the bug.
+	// There is no major performance hit to fetch all targets in Chrome as Chrome is already fetching all targets either way.
+	// In Firefox there would be extra cross-proc calls.
+	if(this->toolkitName.compare(L"Chrome")==0) {
+		numRelations=0;
+	}
 	// the relation type string *must* be passed correctly as a BSTR otherwise we can see crashes in 32 bit Firefox.
 	HRESULT res=element->get_relationTargetsOfType(CComBSTR(IA2_RELATION_LABELLED_BY),numRelations,&ppUnk,&nTargets);
 	if(res!=S_OK) return nullptr;
@@ -275,6 +283,9 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 		iaApp->Release();
 		return;
 	}
+	if(toolkitName) {
+		this->toolkitName=toolkitName;
+	}
 	BSTR toolkitVersion = NULL;
 	if (iaApp->get_toolkitVersion(&toolkitVersion) != S_OK) {
 		iaApp->Release();
@@ -306,7 +317,7 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 	SysFreeString(toolkitVersion);
 }
 
-bool isLabelVisible(IAccessible2* pacc2) {
+bool GeckoVBufBackend_t::isLabelVisible(IAccessible2* pacc2) {
 	CComQIPtr<IAccessible2_2> pacc2_2=pacc2;
 	if(!pacc2_2) return false;
 	auto targetAcc=getLabelElement(pacc2_2);

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -284,7 +284,7 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 		return;
 	}
 	if(toolkitName) {
-		this->toolkitName=toolkitName;
+		this->toolkitName = std::wstring(toolkitName, SysStringLen(toolkitName));
 	}
 	BSTR toolkitVersion = NULL;
 	if (iaApp->get_toolkitVersion(&toolkitVersion) != S_OK) {

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -32,6 +32,10 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	bool shouldDisableTableHeaders;
 	bool hasEncodedAccDescription;
+	std::wstring toolkitName;
+
+	bool isLabelVisible(IAccessible2* pacc2);
+	CComPtr<IAccessible2> getLabelElement(IAccessible2_2* element);
 
 	protected:
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,10 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2018.3.2 =
+This is a minor release to work around a crash in Google Chrome when navigating tweetts on www.twitter.com/
+ 
+
 = 2018.3.1 =
 This is a minor release to fix a critical bug in NVDA which caused 32 bit versions of Mozilla Firefox to crash. (#8759)
  


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8777 

### Summary of the issue:
Google Chrome crashes when navigating tweets in twitter.com due to a buffer overrun in Chrome's implementation of IAccessible2_2::relationTargetsOfType.
NVDA started calling relationTargetsOfType in pr #8352. 

### Description of how this pull request fixes the issue:
This PR works around the crash by making use of the fact that chrome's relationTargetsOftype works okay when requesting all targets (numRelations is 0) rather than a specific number of them that may be smaller than the total amount.

### Testing performed:
Tested NVDA and Chrome using the testcases in #8777.
And again with tests in pr #8352  

 ### Known issues with pull request:
None.

### Change log entry:
Already in PR.
