### PR TITLE
Catch KeyError when creating a deep copy dictionary from an aggregated config section

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -937,17 +937,16 @@ class AggregatedSection(object):
 		Adapted from L{configobj.Section.dict}.
 		"""
 		newdict = {}
-		for entry in self:
-			this_entry = self[entry]
-			if isinstance(this_entry, AggregatedSection):
-				this_entry = this_entry.dict()
-			elif isinstance(this_entry, list):
+		for key, value in self.iteritems():
+			if isinstance(value, AggregatedSection):
+				value = value.dict()
+			elif isinstance(value, list):
 				# create a copy rather than a reference
-				this_entry = list(this_entry)
-			elif isinstance(this_entry, tuple):
+				value = list(value)
+			elif isinstance(value, tuple):
 				# create a copy rather than a reference
-				this_entry = tuple(this_entry)
-			newdict[entry] = this_entry
+				value = tuple(value)
+			newdict[key] = value
 		return newdict
 
 	def __setitem__(self, key, val):


### PR DESCRIPTION
### Link to issue number:
Fixes #8778

### Summary of the issue:
Switching config profiles didn't work in many cases. This was because the new dict method on aggregated config sections didn't catch a KeyError.

### Description of how this pull request fixes the issue:
The dict method is now based on iteritems, similar to copy. iteritems properly catches this error.

### Testing performed:
There is a try build being created to be tested by people who suffer from this.

### Known issues with pull request:
None

### Change log entry:
None needed