### PR TITLE
Fixing French translation for 'NVDA version is ready to be installed'.

### DIFF
--- a/source/locale/fr/LC_MESSAGES/nvda.po
+++ b/source/locale/fr/LC_MESSAGES/nvda.po
@@ -6,14 +6,14 @@ msgstr ""
 "Project-Id-Version: NVDA bzr main:11331\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-18 14:57+1000\n"
-"PO-Revision-Date: 2018-09-18 10:01+0200\n"
+"PO-Revision-Date: 2018-09-27 13:31+0200\n"
 "Last-Translator: Michel Such <michel.such@free.fr>\n"
 "Language-Team: fra <LL@li.org>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.8\n"
+"X-Generator: Poedit 2.1.1\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
 #. Translators: Message to indicate User Account Control (UAC) or other secure desktop screen is active.
@@ -6575,7 +6575,7 @@ msgstr "&Fermer"
 #. Translators: A message indicating that an updated version of NVDA is ready to be installed.
 #, python-brace-format
 msgid "NVDA version {version} is ready to be installed.\n"
-msgstr "NVDA version {version} est est prêt à être installé.\n"
+msgstr "NVDA version {version} est prêt à être installé.\n"
 
 #. Translators: The label of a button to install an NVDA update.
 msgid "&Install update"


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Summary of the issue:
On the French translation, the text displayed on the dialog that appears when NVDA is ready to install a newly downloaded version contained a typo.

### Description of how this pull request fixes the issue:
The translation file have been modified to delete the double "est" word.

First time contributing here, let me know if I did something wrong.