### PR TITLE
Emojis: build data for Vietnamese and Chinese variants.

### DIFF
--- a/cldrDict_sconscript
+++ b/cldrDict_sconscript
@@ -102,6 +102,7 @@ NVDAToCLDRLocales = {
 	"ru":("ru",),
 	"sk":("sk",),
 	"sl":("sl",),
+	#"so":(),
 	"sq":("sq",),
 	"sr":("sr",),
 	"sv":("sv",),
@@ -110,6 +111,10 @@ NVDAToCLDRLocales = {
 	"th":("th",),
 	"tr":("tr",),
 	"uk":("uk",),
+	"vi":("vi",),
+	"zh_cn":("zh",),
+	"zh_hk":("zh","zh_Hant_HK"),
+	"zh_tw":("zh","zh_Hant"),
 }
 
 annotationsDir = env.Dir("include/cldr-emoji-annotation/annotations")


### PR DESCRIPTION
### Link to issue number:
Fixes #8799

### Summary of the issue:
Emoji data are missing for Vietnamese and Chinese variants.

### Description of how this pull request fixes the issue:
CLDR sconscript has been edited to add emoji XML files for Vietnamese (vi) and Chinese (zh) variants.

### Testing performed:
Compiled and used nVDA in those languages.

### Known issues with pull request:
None

### Change log entry:
None

