### PR TITLE
MS Word: allow reporting distance from left and top edges of page with report location of review cursor command

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -98,14 +98,14 @@ class WordDocumentTextInfo(UIATextInfo):
 		# Therefore for now, get the screen coordinates, and if the word object model is available, use our legacy code to get the location text.
 		om=self.obj.WinwordWindowObject
 		if not om:
-			return
+			return super(WordDocumentTextInfo,self).locationText
 		try:
 			r=om.rangeFromPoint(left,top)
 		except (COMError,NameError):
 			log.debugWarning("MS Word object model does not support rangeFromPoint")
-			return
-		from  NVDAObjects.window.winword import WordDocumentTextInfo
-		i=WordDocumentTextInfo(self.obj,None,_rangeObj=r)
+			return super(WordDocumentTextInfo,self).locationText
+		from  NVDAObjects.window.winword import WordDocumentTextInfo as WordObjectModelTextInfo
+		i=WordObjectModelTextInfo(self.obj,None,_rangeObj=r)
 		return i.locationText
 
 	def _getTextWithFields_text(self,textRange,formatConfig,UIAFormatUnits=None):

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -89,6 +89,25 @@ class CommentUIATextInfoQuickNavItem(TextAttribUIATextInfoQuickNavItem):
 
 class WordDocumentTextInfo(UIATextInfo):
 
+	def _get_locationText(self):
+		rects=self._rangeObj.getBoundingRectangles()
+		left=rects[0]
+		top=rects[1]
+		# UIA has no good way yet to convert coordinates into user-configured distances such as inches or centimetres.
+		# Nor can it give us specific distances from the edge of a page.
+		# Therefore for now, get the screen coordinates, and if the word object model is available, use our legacy code to get the location text.
+		om=self.obj.WinwordWindowObject
+		if not om:
+			raise NotImplementedError
+		try:
+			r=om.rangeFromPoint(left,top)
+		except (COMError,NameError):
+			log.debugWarning("MS Word object model does not support rangeFromPoint")
+			raise NotImplementedError
+		from  NVDAObjects.window.winword import WordDocumentTextInfo
+		i=WordDocumentTextInfo(self.obj,None,_rangeObj=r)
+		return i.locationText
+
 	def _getTextWithFields_text(self,textRange,formatConfig,UIAFormatUnits=None):
 		if UIAFormatUnits is None and self.UIAFormatUnits:
 			# Word documents must always split by a unit the first time, as an entire text chunk can give valid annotation types 

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -98,12 +98,12 @@ class WordDocumentTextInfo(UIATextInfo):
 		# Therefore for now, get the screen coordinates, and if the word object model is available, use our legacy code to get the location text.
 		om=self.obj.WinwordWindowObject
 		if not om:
-			raise NotImplementedError
+			return
 		try:
 			r=om.rangeFromPoint(left,top)
 		except (COMError,NameError):
 			log.debugWarning("MS Word object model does not support rangeFromPoint")
-			raise NotImplementedError
+			return
 		from  NVDAObjects.window.winword import WordDocumentTextInfo
 		i=WordDocumentTextInfo(self.obj,None,_rangeObj=r)
 		return i.locationText

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -568,7 +568,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		offset=self._rangeObj.information(wdHorizontalPositionRelativeToPage)
 		distance=self.obj.getLocalizedMeasurementTextForPointSize(offset)
 		# Translators: a distance from the left edge of the page in Microsoft Word
-		textList.append(_("{distance} from left  edge of page").format(distance=distance))
+		textList.append(_("{distance} from left edge of page").format(distance=distance))
 		offset=self._rangeObj.information(wdVerticalPositionRelativeToPage)
 		distance=self.obj.getLocalizedMeasurementTextForPointSize(offset)
 		# Translators: a distance from the left edge of the page in Microsoft Word

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -65,6 +65,7 @@ wdActiveEndAdjustedPageNumber=1
 wdActiveEndPageNumber=3
 wdNumberOfPagesInDocument=4
 wdHorizontalPositionRelativeToPage=5
+wdVerticalPositionRelativeToPage=6
 wdFirstCharacterLineNumber=10
 wdWithInTable=12
 wdStartOfRangeRowNumber=13
@@ -561,6 +562,20 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		if unit==textInfos.UNIT_LINE:
 			unit=textInfos.UNIT_SENTENCE
 		return unit
+
+	def _get_locationText(self):
+		textList=[]
+		offset=self._rangeObj.information(wdHorizontalPositionRelativeToPage)
+		distance=self.obj.getLocalizedMeasurementTextForPointSize(offset)
+		# Translators: a distance from the left edge of the page in Microsoft Word
+		textList.append(_("{distance} from left  edge of page").format(distance=distance))
+		offset=self._rangeObj.information(wdVerticalPositionRelativeToPage)
+		distance=self.obj.getLocalizedMeasurementTextForPointSize(offset)
+		# Translators: a distance from the left edge of the page in Microsoft Word
+		textList.append(_("{distance} from top edge of page").format(distance=distance))
+		return ", ".join(textList)
+
+
 
 	def copyToClipboard(self):
 		self._rangeObj.copy()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,7 @@ What's New in NVDA
 - New braille tables: Chinese (China, Mandarin) grade 1 and grade 2. (#5553)
 - Replied / Forwarded status is now reported on mail items in the Microsoft Outlook message list. (#6911)
 - NVDA is now able to read descriptions for emoji as well as other characters that are part of the Unicode Common Locale Data Repository. (#6523)
+- In Microsoft Word, the cursor's distance from the top and left edges of the page can be reported by pressing NVDA+numpadDelete. (#1939)
 
 
 == Changes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #1939 

### Summary of the issue:
When creating Word documents, it can be sometimes useful to know the distance from the edge of the page.
NVDA does not currently have any way to report this information.

### Description of how this pull request fixes the issue:
Provide an implementation of the locationText property on both Word document TextInfo classes (object model, and UIA) that returns a string stating the distance of the cursor from the left and top of the page, in user-configured units (E.g. inches, centimetres).
This allows the user to report the distances by pressing NVDA+numpadDelete (report review cursor location command).
 As UI Automation does not currently provide a way to find out the actual distance from the edge of a page, this code falls back to using the Word object model if available. Thus, this feature will not work in Windows 10 Mail for instance.

### Testing performed:
In a word document, moved the cursor to various lines and offsets within those lines, and reported the distances by pressing NVDA+numpadDelete.

### Known issues with pull request:
None.

### Change log entry:
Already in pr.
