### PR TITLE
Update to pyserial 3.4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ For reference, the following dependencies are included in Git submodules:
 * brlapi Python bindings, version 0.5.7 or later, distributed with [BRLTTY for Windows](http://brl.thefreecat.org/brltty/), version 4.2-2
 * ALVA BC6 generic dll, version 3.0.4.1
 * lilli.dll, version 2.1.0.0
-* [pyserial](http://pypi.python.org/pypi/pyserial), version 2.7
+* [pySerial](http://pypi.python.org/pypi/pyserial), version 3.4
 * [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)
 * [Py2Exe](http://sourceforge.net/projects/py2exe/), version 0.6.9
 * [Nulsoft Install System](http://nsis.sourceforge.net/), version 2.51

--- a/source/braille.py
+++ b/source/braille.py
@@ -2119,6 +2119,8 @@ def initialize():
 	global handler
 	config.addConfigDirsToPythonPackagePath(brailleDisplayDrivers)
 	log.info("Using liblouis version %s" % louis.version())
+	import serial
+	log.info("Using pySerial version %s"%serial.VERSION)
 	# #6140: Migrate to new table names as smoothly as possible.
 	oldTableName = config.conf["braille"]["translationTable"]
 	newTableName = brailleTables.RENAMED_TABLES.get(oldTableName)

--- a/source/brailleDisplayDrivers/ecoBraille.py
+++ b/source/brailleDisplayDrivers/ecoBraille.py
@@ -171,10 +171,10 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		# Try to open port
 		self._dev = serial.Serial(self._port, baudrate = 19200,  bytesize = serial.EIGHTBITS, parity = serial.PARITY_NONE, stopbits = serial.STOPBITS_ONE)
 		# Use a longer timeout when waiting for initialisation.
-		self._dev.timeout = self._dev.writeTimeout = 2.7
+		self._dev.timeout = self._dev.write_timeout = 2.7
 		self._ecoType  = eco_in_init(self._dev)
 		# Use a shorter timeout hereafter.
-		self._dev.timeout = self._dev.writeTimeout = TIMEOUT
+		self._dev.timeout = self._dev.write_timeout = TIMEOUT
 		# Always send the protocol answer.
 		self._dev.write("\x61\x10\x02\xf1\x57\x57\x57\x10\x03")
 		self._dev.write("\x10\x02\xbc\x00\x00\x00\x00\x00\x10\x03")
@@ -202,7 +202,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			pass
 
 	def _handleResponses(self):
-		if self._dev.inWaiting():
+		if self._dev.in_waiting:
 			command = eco_in(self._dev)
 			if command:
 				try:

--- a/source/brailleDisplayDrivers/hedoMobilLine.py
+++ b/source/brailleDisplayDrivers/hedoMobilLine.py
@@ -100,7 +100,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self._ser.write(line)
 
 	def handleResponses(self, wait=False):
-		while wait or self._ser.inWaiting():
+		while wait or self._ser.in_waiting:
 			data = self._ser.read(1)
 			if data:
 				# do not handle acknowledge bytes

--- a/source/brailleDisplayDrivers/hedoProfiLine.py
+++ b/source/brailleDisplayDrivers/hedoProfiLine.py
@@ -124,7 +124,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self._ser.write(line)
 
 	def handleResponses(self, wait=False):
-		while wait or self._ser.inWaiting():
+		while wait or self._ser.in_waiting:
 			data = self._ser.read(1)
 			if data:
 				# do not handle acknowledge bytes

--- a/source/brailleDisplayDrivers/papenmeier_serial.py
+++ b/source/brailleDisplayDrivers/papenmeier_serial.py
@@ -47,9 +47,9 @@ def brl_out(offset, data):
 
 def brl_poll(dev):
 	"""read data from braille display, used by keypress handler"""
-	if dev.inWaiting() < 10: return ""
+	if dev.in_waiting < 10: return ""
 	ret = []
-	ret.append(dev.read(dev.inWaiting()))
+	ret.append(dev.read(dev.in_waiting))
 	if ret[0][0] == chr(STX) and ret[0][9] == chr(ETX):
 		return "".join(ret)
 	return ""

--- a/source/brailleDisplayDrivers/seika.py
+++ b/source/brailleDisplayDrivers/seika.py
@@ -100,7 +100,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self._ser.write(line)
 
 	def handleResponses(self):
-		if not self._ser.inWaiting():
+		if not self._ser.in_waiting:
 			return
 		chars = [0,0]
 		key = 0

--- a/source/hwIo.py
+++ b/source/hwIo.py
@@ -175,8 +175,7 @@ class Serial(IoBase):
 		self._origTimeout = self._ser.timeout
 		# We don't want a timeout while we're waiting for data.
 		self._setTimeout(None)
-		self.inWaiting = self._ser.inWaiting
-		super(Serial, self).__init__(self._ser.hComPort, onReceive)
+		super(Serial, self).__init__(self._ser._port_handle, onReceive)
 
 	def read(self, size=1):
 		data = self._ser.read(size)
@@ -205,21 +204,21 @@ class Serial(IoBase):
 		# #6035: pyserial reconfigures all settings of the port when setting a timeout.
 		# This can cause error 'Cannot configure port, some setting was wrong.'
 		# Therefore, manually set the timeouts using the Win32 API.
-		# Adapted from pyserial 3.1.1.
+		# Adapted from pyserial 3.4.
 		timeouts = COMMTIMEOUTS()
 		if timeout is not None:
 			if timeout == 0:
 				timeouts.ReadIntervalTimeout = win32.MAXDWORD
 			else:
 				timeouts.ReadTotalTimeoutConstant = max(int(timeout * 1000), 1)
-		if timeout != 0 and self._ser._interCharTimeout is not None:
-			timeouts.ReadIntervalTimeout = max(int(self._ser._interCharTimeout * 1000), 1)
-		if self._ser._writeTimeout is not None:
-			if self._ser._writeTimeout == 0:
+		if timeout != 0 and self._ser._inter_byte_timeout is not None:
+			timeouts.ReadIntervalTimeout = max(int(self._ser._inter_byte_timeout * 1000), 1)
+		if self._ser._write_timeout is not None:
+			if self._ser._write_timeout == 0:
 				timeouts.WriteTotalTimeoutConstant = win32.MAXDWORD
 			else:
-				timeouts.WriteTotalTimeoutConstant = max(int(self._ser._writeTimeout * 1000), 1)
-		SetCommTimeouts(self._ser.hComPort, ctypes.byref(timeouts))
+				timeouts.WriteTotalTimeoutConstant = max(int(self._ser._write_timeout * 1000), 1)
+		SetCommTimeouts(self._ser._port_handle, ctypes.byref(timeouts))
 
 class HIDP_CAPS (ctypes.Structure):
 	_fields_ = (


### PR DESCRIPTION
### Link to issue number:
None. However, there is some discussion in #6035

### Summary of the issue:
We've been on an old version of pyserial for some time now. Currently, pyserial is at version 3.4. Most notably, this version includes some API changes, however there is still backwards compatibility for almost all of them. Though there is not very much information about Python 3 support of older versions, this version should ensure that full and up to date Python 3 support is covered.

### Description of how this pull request fixes the issue:
1. Updates to pyserial 3.4
2. Changes Serial.hComPort to Serial._port_handle
3. In all drivers, change Serial.inWaiting calls to the in_waiting property. Note that there is still an inWaiting method for backwards compatibility. The papenmeier driver uses FTDI2 which has a get_queue_status function. Therefore, we still use the inWaiting method here, which is still supported.
4. _interCharTimeout is now _inter_byte_timeout 
5. _writeTimeout is now _write_timeout

### Testing performed:
Tested auto and manual detection of a Handy Tech Modular Evolution. more testing would be appreciated, especially with regard to the papenmeier driver. I don't expect much trouble, though.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
    + Updated pySerial to version 3.4