### PR TITLE
Stop recursive wx.Yield calls in browseMode

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -10,6 +10,7 @@ import winsound
 import time
 import weakref
 import wx
+import core
 from logHandler import log
 import documentBase
 import review
@@ -1042,7 +1043,9 @@ class ElementsListDialog(wx.Dialog):
 				speech.cancelSpeech()
 				item.moveTo()
 				item.report()
-			wx.CallLater(100, move)
+			# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
+			# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
+			core.callLater(100, move)
 
 class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -10,6 +10,7 @@ A cursor manager provides caret navigation and selection commands for a virtual 
 """
 
 import wx
+import core
 import baseObject
 import documentBase
 import gui
@@ -61,7 +62,9 @@ class FindDialog(wx.Dialog):
 	def onOk(self, evt):
 		text = self.findTextField.GetValue()
 		caseSensitive = self.caseSensitiveCheckBox.GetValue()
-		wx.CallLater(100, self.activeCursorManager.doFindText, text, caseSensitive=caseSensitive)
+		# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
+		# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
+		core.callLater(100, self.activeCursorManager.doFindText, text, caseSensitive=caseSensitive)
 		self.Destroy()
 
 	def onCancel(self, evt):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1203,7 +1203,9 @@ class GlobalCommands(ScriptableObject):
 			parent.treeInterceptor.rootNVDAObject.setFocus()
 			import eventHandler
 			import wx
-			wx.CallLater(50,eventHandler.executeEvent,"gainFocus",parent.treeInterceptor.rootNVDAObject)
+			# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
+			# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
+			core.callLater(50,eventHandler.executeEvent,"gainFocus",parent.treeInterceptor.rootNVDAObject)
 	# Translators: Input help mode message for move to next document with focus command, mostly used in web browsing to move from embedded object to the webpage document.
 	script_moveToParentTreeInterceptor.__doc__=_("Moves the focus to the next closest document that contains the focus")
 	script_moveToParentTreeInterceptor.category=SCRCAT_FOCUS


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8787 

### Summary of the issue:
Quickly pressing keys after pressing enter in NvDA's browseMode Find dialog can cause wx.Yield recursion exceptions. 
This is because:
1. The callback the Find dialog runs after the dialog is dismissed is run outside of NVDA's core pump (using wx.CallLater).
2. Code in the callback may directily or indirectly call wx.Yield.
3. Inside wx.Yield, NVDA's core pump may bu run recursively.
4. A script or event run in NVDA's core pump may directly or indirectly call wx.Yield.

This bug has been possible for a long time, but was made very easy to reproduce with the merging of #8678, as  Mozilla NVDAObject's setFocus now does an api.processPendingEvents, which internally calls wx.Yield.
Similar issues can be seen with the callback for move to in the Elements List, and also the script to move to the parent treeInterceptor.

### Description of how this pull request fixes the issue:
The wxCallLater calls for the Find callback, Elements list move to callback, and in the move to parent treeInterceptor script have been changed to core.callLater. core.callLater always queues the callback to NVDA's event queue, ensureing that it is executed within NVDA's core pump.

### Testing performed:
In Firefox:
* Go to www.google.com/
* Use NVDA Find to find "apps".
* Press enter and start pressing down arrow very fast.
This used to cause the issue, where it does not now.
Similarly in Firefox on google.com:
* Open the NVDA Elements list
* highlight the "images" link, and press the move to button.
* Then press down arrow very fast.
This used to cause the issue, where it does not now.


### Known issues with pull request:
None.

### Change log entry:
None needed as regression never reached a stable version.
