### PR TITLE
Update eSpeak-ng to latest master (commit 919f3240cbb).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ For reference, the following dependencies are included in Git submodules:
 * [wxPython](http://www.wxpython.org/), version 4.0.3
 * [Six](https://pypi.python.org/pypi/six), version 1.10.0, required by wxPython
 * [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 218
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 910f4c2
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 348e7ecbd6274
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ For reference, the following dependencies are included in Git submodules:
 * [wxPython](http://www.wxpython.org/), version 4.0.3
 * [Six](https://pypi.python.org/pypi/six), version 1.10.0, required by wxPython
 * [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 218
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 348e7ecbd6274
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 919f3240cbb
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,7 +17,7 @@ What's New in NVDA
 - IN NVDA's keyboard settings, the checkboxes to enable or disable NVDA modifier keys are now displayed in a list rather than as separate checkboxes.
 - NVDA will no longer present redundant information when reading clock system tray on some versions of Windows. (#4364)
 - Updated liblouis braille translator to version 3.7.0. (#8697)
-
+- Updated eSpeak-NG to commit 919f3240cbb
 
 == Bug Fixes ==
 - In Outlook 2016/365, the category and flag status are reported for messages. (#8603)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
NVDA 2018.3 contained a copy of espeak-ng with several regressions for Russian and Portuguese.
These regressions have been addressed in later eSpeak-ng commits but are not yet in NVDA.

### Description of how this pull request fixes the issue:
Update eSpeak-ng to commit 919f3240cbb 

### Testing performed:
Ran NVDA in English using this eSpeak commit. 
Try builds have been provided to both Russian and Portuguese users.
* Portuguese have reported the issues are solved.

 ### Known issues with pull request:
None.

### Change log entry:
Changes:
* eSpeak-ng has been updated to commit 348e7ecbd6274.
