### PR TITLE
Gecko vbufBackend: If a table row is invalidated, it should not require its parent to be updated

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -680,7 +680,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 			// For example, if this is a table row group, its rerendering may change the number of rows inside. 
 			// this in turn would affect the coordinates of all table cells in table rows after this row group.
 			// Thus, ensuring we rerender this node's parent, gives a chance to rerender other table rows.
-			// Note that we however do not want to set this on table rows as if this row alone is invalidated, none of the other row coodinates would be affected. 
+			// Note that we however do not want to set this on table rows as if this row alone is invalidated, none of the other row coordinates would be affected. 
 			if(role!=ROLE_SYSTEM_ROW) {
 				LOG_DEBUG(L"Setting node's requiresParentUpdate to true");
 				parentNode->requiresParentUpdate=true;

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -680,8 +680,11 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 			// For example, if this is a table row group, its rerendering may change the number of rows inside. 
 			// this in turn would affect the coordinates of all table cells in table rows after this row group.
 			// Thus, ensuring we rerender this node's parent, gives a chance to rerender other table rows.
-			LOG_DEBUG(L"Setting node's requiresParentUpdate to true");
-			parentNode->requiresParentUpdate=true;
+			// Note that we however do not want to set this on table rows as if this row alone is invalidated, none of the other row coodinates would be affected. 
+			if(role!=ROLE_SYSTEM_ROW) {
+				LOG_DEBUG(L"Setting node's requiresParentUpdate to true");
+				parentNode->requiresParentUpdate=true;
+			}
 			// Setting alwaysRerenderChildren ensures that if this node is rerendered, none of its children are reused.
 			// For example, if this is a table row that is rerendered (perhaps due to a previous table row being added),
 			// this row's cells can't be reused because their coordinates would now be out of date.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
The work to speed up dynamic updates in virtualBuffers in pr #8678  causes a major slowdown in the new Gmail interface.
Specifically:
When arrowing up and down the message list, a cell on one of the rows is changed in such a way that in Gecko its accessible is re-framed and therefore the row itself is marked in the virtualBuffer as being invalid. But as row nodes in the Gecko vbufBackend have their requiresParentUpdate property set to true, this causes the entire table to be re-rendered.
The comment where this property is set specifically talks about row groups needing this, not rows. But the code does not correctly exclude rows.
As we know that other row coordinates will not change just because a row was invalidated, it would be safe to exclude rows from having their requiresParentUpdate property set to true.

### Description of how this pull request fixes the issue:
This PR only sets requiresParentUpdate to true on nodes within tables that are not cells or rows. (In otherwords, probably just row groups).

### Testing performed:
* In New gmail, arrowed up and down an inbox. The lag no longer exists.
 * Tested German wikipedia page: No change in performance.
* Tested inserting rows at the top of a table: row coordinates for the entire table stayed correct.

### Known issues with pull request:
None.

### Change log entry:
None.