### PR TITLE
Allow pass through in ARIA menus, fixes #3215.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -481,9 +481,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			return gesture.send()
 		# #3215 ARIA menus should get the Escape key unconditionally so they can handle it without invoking browse mode first
 		obj = api.getFocusObject()
-		if obj:
-			if obj.role in self.IGNORE_DISABLE_PASS_THROUGH_WHEN_FOCUSED_ROLES:
-				return gesture.send()
+		if obj and obj.role in self.IGNORE_DISABLE_PASS_THROUGH_WHEN_FOCUSED_ROLES:
+			return gesture.send()
 		self.passThrough = False
 		self.disableAutoPassThrough = False
 		reportPassThrough(self)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -305,8 +305,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		# many controls that are read-only should not switch to passThrough. 
 		# However, certain controls such as combo boxes and readonly edits are read-only but still interactive.
 		# #5118: read-only ARIA grids should also be allowed (focusable table cells, rows and headers).
-		# #3215: Also allow ARIA menus
-		if controlTypes.STATE_READONLY in states and role not in (controlTypes.ROLE_EDITABLETEXT, controlTypes.ROLE_COMBOBOX, controlTypes.ROLE_TABLEROW, controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLEROWHEADER, controlTypes.ROLE_TABLECOLUMNHEADER, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_RADIOMENUITEM, controlTypes.ROLE_CHECKMENUITEM):
+		if controlTypes.STATE_READONLY in states and role not in (controlTypes.ROLE_EDITABLETEXT, controlTypes.ROLE_COMBOBOX, controlTypes.ROLE_TABLEROW, controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLEROWHEADER, controlTypes.ROLE_TABLECOLUMNHEADER):
 			return False
 		# Any roles or states for which we always switch to passThrough
 		if role in self.ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES or controlTypes.STATE_EDITABLE in states:
@@ -474,6 +473,11 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def script_disablePassThrough(self, gesture):
 		if not self.passThrough or self.disableAutoPassThrough:
 			return gesture.send()
+		# #3215 ARIA menus should get the Escape key unconditionally so they can handle it without invoking browse mode first
+		obj = api.getFocusObject()
+		if obj:
+			if obj.role in (controlTypes.ROLE_MENUITEM, controlTypes.ROLE_RADIOMENUITEM, controlTypes.ROLE_CHECKMENUITEM):
+				return gesture.send()
 		self.passThrough = False
 		self.disableAutoPassThrough = False
 		reportPassThrough(self)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -279,6 +279,12 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		controlTypes.ROLE_CHECKMENUITEM,
 		})
 
+	IGNORE_DISABLE_PASS_THROUGH_WHEN_FOCUSED_ROLES = frozenset({
+		controlTypes.ROLE_MENUITEM,
+		controlTypes.ROLE_RADIOMENUITEM,
+		controlTypes.ROLE_CHECKMENUITEM,
+		})
+
 	def shouldPassThrough(self, obj, reason=None):
 		"""Determine whether pass through mode should be enabled (focus mode) or disabled (browse mode) for a given object.
 		@param obj: The object in question.
@@ -476,7 +482,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		# #3215 ARIA menus should get the Escape key unconditionally so they can handle it without invoking browse mode first
 		obj = api.getFocusObject()
 		if obj:
-			if obj.role in (controlTypes.ROLE_MENUITEM, controlTypes.ROLE_RADIOMENUITEM, controlTypes.ROLE_CHECKMENUITEM):
+			if obj.role in self.IGNORE_DISABLE_PASS_THROUGH_WHEN_FOCUSED_ROLES:
 				return gesture.send()
 		self.passThrough = False
 		self.disableAutoPassThrough = False

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -305,7 +305,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		# many controls that are read-only should not switch to passThrough. 
 		# However, certain controls such as combo boxes and readonly edits are read-only but still interactive.
 		# #5118: read-only ARIA grids should also be allowed (focusable table cells, rows and headers).
-		if controlTypes.STATE_READONLY in states and role not in (controlTypes.ROLE_EDITABLETEXT, controlTypes.ROLE_COMBOBOX, controlTypes.ROLE_TABLEROW, controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLEROWHEADER, controlTypes.ROLE_TABLECOLUMNHEADER):
+		# #3215: Also allow ARIA menus
+		if controlTypes.STATE_READONLY in states and role not in (controlTypes.ROLE_EDITABLETEXT, controlTypes.ROLE_COMBOBOX, controlTypes.ROLE_TABLEROW, controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLEROWHEADER, controlTypes.ROLE_TABLECOLUMNHEADER, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_RADIOMENUITEM, controlTypes.ROLE_CHECKMENUITEM):
 			return False
 		# Any roles or states for which we always switch to passThrough
 		if role in self.ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES or controlTypes.STATE_EDITABLE in states:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -28,6 +28,7 @@ What's New in NVDA
 - Performance increases in Mozilla Firefox when navigating large pages with lots of dynamic changes. (#8678)
 - Braille no longer shows font attributes  if they have been disabled in  Document Formatting settings. (#7615)
 - NVDA no longer fails to track focus in File Explorer and other applications using UI Automation when another app is busy (such as batch processing audio). (#7345)
+- In ARIA menus on the web, the Escape key will now be passed through to the menu and no longer turn off focus mode unconditionally. (#3215)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

#3215

### Summary of the issue:

When in an ARIA menu on the web, pressing keys such as Escape immediately switches back to browse mode. It would be better if the Escape key was passed through in this case so the menu can handle it rather than requiring the user to press Escape twice to first turn on Browse mode and then passing the key through upon the second press.

### Description of how this pull request fixes the issue:

The script for the Escape key needs to check for the MENUITEM, RADIOMENUITEM, and CHECKMENUITEM roles to not invoke browse mode, but pass the gesture through so the web application can handle it.

### Testing performed:

* Navigated a mega menu such as the one found on [mortonarb.org](https://www.mortonarb.org), and confirmed that:
  * Tabbing to the menu,
  * Arrowing down into the first level sub menu bar,
  * Pressing Escape (which should not turn on browse mode,
  * Navigating to the first sub menu bar and opening one of the drop downs,
  * Pressing Escape to return to the main menu bar (which should not invoke browse mode),
  * Pressing escape from there (which should exit passThrough mode) all worked as expected.
* opened and closed popup menus from menu buttons such as the ones newly found on [mobile Twitter](https://mobile.twitter.com).
* Opened and closed the Settings menu in Gmail. Note that this exhibits a change now since a focus landing on the button no longer invokes browse mode, whereas previously it did. This is probably because when focus returns from a menu to a menu button, browse mode should not be enabled. I confirmed this with a regular NVDA build by passing the Escape key through from the menu via NVDA+F2, and focus mode stayed on when focus landed on the menu button.

### Known issues with pull request:

None.

### Change log entry:

In ARIA menus on the web, the Escape key will now be passed through to the menu and no longer turn off focus mode unconditionally.

Section: Changes

