### PR TITLE
Merge all vbufBackend dlls into nvdaHelperRemote.dll

### DIFF
--- a/appveyor/mozillaSyms.py
+++ b/appveyor/mozillaSyms.py
@@ -29,8 +29,6 @@ DLL_NAMES = [
 	"ISimpleDOM.dll",
 	"minHook.dll",
 	"nvdaHelperRemote.dll",
-	"VBufBackend_adobeFlash.dll",
-	"VBufBackend_gecko_ia2.dll",
 ]
 DLL_FILES = [f
 	for dll in DLL_NAMES

--- a/appx/sconscript
+++ b/appx/sconscript
@@ -51,12 +51,6 @@ excludedDistFiles=[
 	'lib/ISimpleDOM.dll',
 	'lib/minHook.dll',
 	'lib/NVDAHelperRemote.dll',
-	'lib/VBufBackend_adobeAcrobat.dll',
-	'lib/VBufBackend_adobeFlash.dll',
-	'lib/VBufBackend_gecko_ia2.dll',
-	'lib/VBufBackend_lotusNotesRichText.dll',
-	'lib/VBufBackend_mshtml.dll',
-	'lib/VBufBackend_webKit.dll',
 	'lib64/',
 	'uninstall.exe',
 ]

--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -203,39 +203,6 @@ if TARGET_ARCH=='x86_64':
 		env.AddPostAction(remoteLoaderProgram,[signExec])
 	env.Install(libInstallDir,remoteLoaderProgram)
 
-vbufBaseStaticLib=env.SConscript('vbufBase/sconscript')
-Export('vbufBaseStaticLib')
-
-adobeAcrobatVBufBackend=env.SConscript('vbufBackends/adobeAcrobat/sconscript')
-if signExec:
-	env.AddPostAction(adobeAcrobatVBufBackend[0],[signExec])
-env.Install(libInstallDir,adobeAcrobatVBufBackend)
-
-adobeFlashVBufBackend=env.SConscript('vbufBackends/adobeFlash/sconscript')
-if signExec:
-	env.AddPostAction(adobeFlashVBufBackend[0],[signExec])
-env.Install(libInstallDir,adobeFlashVBufBackend)
-
-lotusNotesRichTextVBufBackend=env.SConscript('vbufBackends/lotusNotesRichText/sconscript')
-if signExec:
-	env.AddPostAction(lotusNotesRichTextVBufBackend[0],[signExec])
-env.Install(libInstallDir,lotusNotesRichTextVBufBackend)
-
-geckoVBufBackend=env.SConscript('vbufBackends/gecko_ia2/sconscript')
-if signExec:
-	env.AddPostAction(geckoVBufBackend[0],[signExec])
-env.Install(libInstallDir,geckoVBufBackend)
-
-mshtmlVBufBackend=env.SConscript('vbufBackends/mshtml/sconscript')
-if signExec:
-	env.AddPostAction(mshtmlVBufBackend[0],[signExec])
-env.Install(libInstallDir,mshtmlVBufBackend)
-
-webKitVBufBackend=env.SConscript('vbufBackends/webKit/sconscript')
-if signExec:
-	env.AddPostAction(webKitVBufBackend[0],[signExec])
-env.Install(libInstallDir,webKitVBufBackend)
-
 if TARGET_ARCH=='x86':
 	env.SConscript('espeak/sconscript')
 	env.SConscript('liblouis/sconscript')

--- a/nvdaHelper/remote/sconscript
+++ b/nvdaHelper/remote/sconscript
@@ -20,6 +20,16 @@ Import([
 
 winIPCUtilsObj=env.Object("./winIPCUtils","../common/winIPCUtils.cpp")
 
+vbufBackendLibs=[
+	env.SConscript('../vbufBase/sconscript'),
+	env.SConscript('../vbufBackends/adobeAcrobat/sconscript'),
+	env.SConscript('../vbufBackends/adobeFlash/sconscript'),
+	env.SConscript('../vbufBackends/lotusNotesRichText/sconscript'),
+	env.SConscript('../vbufBackends/gecko_ia2/sconscript'),
+	env.SConscript('../vbufBackends/mshtml/sconscript'),
+	env.SConscript('../vbufBackends/webKit/sconscript'),
+]
+
 controllerRPCHeader,controllerRPCClientSource=env.MSRPCStubs(
 	target="./nvdaController",
 	source=[
@@ -105,6 +115,7 @@ remoteLib=env.SharedLibrary(
 		displayModelRPCServerSource,
 		nvdaInProcUtilsRPCServerSource,
 		"nvdaHelperRemote.def",
+		vbufBackendLibs,
 	],
 	LIBS=[
 		"user32",

--- a/nvdaHelper/remote/vbufRemote.cpp
+++ b/nvdaHelper/remote/vbufRemote.cpp
@@ -16,30 +16,39 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include "vbufRemote.h"
 #include <vbufBase/backend.h>
 #include "dllmain.h"
+#include <common/log.h>
 
 using namespace std;
 
-map<VBufBackend_t*,HINSTANCE> backendLibHandles;
+const map<wstring,VBufBackend_create_proc> VBufBackendFactoryMap {
+	{L"adobeAcrobat",AdobeAcrobatVBufBackend_t_createInstance},
+	{L"adobeFlash",AdobeFlashVBufBackend_t_createInstance},
+	{L"gecko_ia2",GeckoVBufBackend_t_createInstance},
+	{L"mshtml",MshtmlVBufBackend_t_createInstance},
+	{L"lotusNotesRichText",lotusNotesRichTextVBufBackend_t_createInstance},
+	{L"webKit",WebKitVBufBackend_t_createInstance}
+};
 
 extern "C" {
 
 VBufRemote_bufferHandle_t VBufRemote_createBuffer(handle_t bindingHandle, int docHandle, int ID, const wchar_t* backendName) {
-	wchar_t backendPath[MAX_PATH];
-	wsprintf(backendPath,L"%s\\VBufBackend_%s.dll",dllDirectory,backendName);
-	HINSTANCE backendLibHandle=LoadLibrary(backendPath);
-	if(backendLibHandle==NULL) return NULL;
-	VBufBackend_create_proc createBackend=(VBufBackend_create_proc)GetProcAddress((HMODULE)(backendLibHandle),"VBufBackend_create");
-	if(createBackend==NULL) {
-		FreeLibrary(backendLibHandle);
-		return NULL;
-	} 
+
+	auto i=VBufBackendFactoryMap.find(backendName);
+	if(i==VBufBackendFactoryMap.end()) {
+		LOG_ERROR(L"Unknown backend: "<<backendName);
+		return nullptr;
+	}
+	VBufBackend_create_proc createBackend=i->second;
 	VBufBackend_t* backend=createBackend(docHandle,ID);
 	if(backend==NULL) {
-		FreeLibrary(backendLibHandle);
 		return NULL;
 	}
-	backendLibHandles[backend]=backendLibHandle;
 	backend->initialize();
+	// Stop nvdaHelperRemote from being unloaded while a backend exists.
+	HINSTANCE tempHandle=nullptr;
+	if(!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,(LPCTSTR)dllHandle,&tempHandle)) {
+		LOG_ERROR(L"Could not keep nvdaHelperRemote loaded for backend!");
+	}
 	return (VBufRemote_bufferHandle_t)backend;
 }
 
@@ -49,13 +58,9 @@ void VBufRemote_destroyBuffer(VBufRemote_bufferHandle_t* buffer) {
 	#endif
 	VBufBackend_t* backend=(VBufBackend_t*)*buffer;
 	backend->terminate();
-	map<VBufBackend_t*,HINSTANCE>::iterator i=backendLibHandles.find(backend);
-	if(i==backendLibHandles.end()) return;
-	HINSTANCE backendLibHandle=i->second;
-	backendLibHandles.erase(i); 
 	backend->lock.acquire();
 	backend->destroy();
-	FreeLibrary(backendLibHandle);
+	FreeLibrary(dllHandle);
 	*buffer=NULL;
 }
 
@@ -144,13 +149,12 @@ int VBufRemote_getTextLength(VBufRemote_bufferHandle_t buffer) {
 int VBufRemote_getTextInRange(VBufRemote_bufferHandle_t buffer, int startOffset, int endOffset, wchar_t** text, boolean useMarkup) {
 	VBufBackend_t* backend=(VBufBackend_t*)buffer;
 	backend->lock.acquire();
-	VBufStorage_textContainer_t* textContainer=backend->getTextInRange(startOffset,endOffset,useMarkup!=false);
+	 wstring textString=backend->getTextInRange(startOffset,endOffset,useMarkup!=false);
 	backend->lock.release();
-	if(textContainer==NULL) {
+	if(textString.empty()) {
 		return false;
 	}
-	*text=SysAllocString(textContainer->getString().c_str());
-	textContainer->destroy();
+	*text=SysAllocString(textString.c_str());
 	return true;
 }
 

--- a/nvdaHelper/remote/vbufRemote.cpp
+++ b/nvdaHelper/remote/vbufRemote.cpp
@@ -32,7 +32,10 @@ const map<wstring,VBufBackend_create_proc> VBufBackendFactoryMap {
 extern "C" {
 
 VBufRemote_bufferHandle_t VBufRemote_createBuffer(handle_t bindingHandle, int docHandle, int ID, const wchar_t* backendName) {
-
+	if(!backendName) {
+		LOG_ERROR(L"backendName is NULL");
+		return nullptr;
+	}
 	auto i=VBufBackendFactoryMap.find(backendName);
 	if(i==VBufBackendFactoryMap.end()) {
 		LOG_ERROR(L"Unknown backend: "<<backendName);
@@ -46,7 +49,7 @@ VBufRemote_bufferHandle_t VBufRemote_createBuffer(handle_t bindingHandle, int do
 	backend->initialize();
 	// Stop nvdaHelperRemote from being unloaded while a backend exists.
 	HINSTANCE tempHandle=nullptr;
-	if(!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,(LPCTSTR)dllHandle,&tempHandle)) {
+	if(!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,reinterpret_cast<LPCWSTR>(dllHandle),&tempHandle)) {
 		LOG_ERROR(L"Could not keep nvdaHelperRemote loaded for backend!");
 	}
 	return (VBufRemote_bufferHandle_t)backend;

--- a/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
+++ b/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
@@ -864,15 +864,9 @@ AdobeAcrobatVBufBackend_t::~AdobeAcrobatVBufBackend_t() {
 	LOG_DEBUG(L"AdobeAcrobat backend destructor");
 }
 
-extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {
+VBufBackend_t* AdobeAcrobatVBufBackend_t_createInstance(int docHandle, int ID) {
 	VBufBackend_t* backend=new AdobeAcrobatVBufBackend_t(docHandle,ID);
 	LOG_DEBUG(L"Created new backend at "<<backend);
 	return backend;
 }
 
-BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
-	if(reason==DLL_PROCESS_ATTACH) {
-		_CrtSetReportHookW2(_CRT_RPTHOOK_INSTALL,(_CRT_REPORT_HOOKW)NVDALogCrtReportHook);
-	}
-	return true;
-}

--- a/nvdaHelper/vbufBackends/adobeAcrobat/sconscript
+++ b/nvdaHelper/vbufBackends/adobeAcrobat/sconscript
@@ -14,24 +14,12 @@
 
 Import([
 	'env',
-	'vbufBaseStaticLib',
 	'acrobatAccessRPCStubs',
 ])
 
-adobeAcrobatBackendLib=env.SharedLibrary(
-	target="VBufBackend_adobeAcrobat",
-	source=[
-		env['projectResFile'],
-		"adobeAcrobat.cpp",
-		env.Object('_acrobatAccess_i',acrobatAccessRPCStubs[2]),
-	],
-	LIBS=[
-		vbufBaseStaticLib,
-		"user32",
-		"kernel32",
-		"oleacc",
-		"oleaut32",
-	],
-)
+adobeAcrobatBackendLib=[
+	env.Object("adobeAcrobat.cpp"),
+	env.Object('_acrobatAccess_i',acrobatAccessRPCStubs[2]),
+]
 
 Return('adobeAcrobatBackendLib')

--- a/nvdaHelper/vbufBackends/adobeFlash/adobeFlash.cpp
+++ b/nvdaHelper/vbufBackends/adobeFlash/adobeFlash.cpp
@@ -302,14 +302,7 @@ void AdobeFlashVBufBackend_t::render(VBufStorage_buffer_t* buffer, int docHandle
 AdobeFlashVBufBackend_t::AdobeFlashVBufBackend_t(int docHandle, int ID): VBufBackend_t(docHandle,ID), accPropServices(NULL) {
 }
 
-extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {
+VBufBackend_t* AdobeFlashVBufBackend_t_createInstance(int docHandle, int ID) {
 	VBufBackend_t* backend=new AdobeFlashVBufBackend_t(docHandle,ID);
 	return backend;
-}
-
-BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
-	if(reason==DLL_PROCESS_ATTACH) {
-		_CrtSetReportHookW2(_CRT_RPTHOOK_INSTALL,(_CRT_REPORT_HOOKW)NVDALogCrtReportHook);
-	}
-	return true;
 }

--- a/nvdaHelper/vbufBackends/adobeFlash/sconscript
+++ b/nvdaHelper/vbufBackends/adobeFlash/sconscript
@@ -14,23 +14,8 @@
 
 Import([
 	'env',
-	'vbufBaseStaticLib',
 ])
 
-adobeFlashBackendLib=env.SharedLibrary(
-	target="VBufBackend_adobeFlash",
-	source=[
-		env['projectResFile'],
-		"adobeFlash.cpp",
-	],
-	LIBS=[
-		vbufBaseStaticLib,
-		"user32",
-		"kernel32",
-		"oleacc",
-		"oleaut32",
-		"ole32",
-	],
-)
+adobeFlashBackendLib=env.Object("adobeFlash.cpp")
 
 Return('adobeFlashBackendLib')

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -84,7 +84,7 @@ HWND findRealMozillaWindow(HWND hwnd) {
 	return hwnd;
 }
 
-IAccessible2* IAccessible2FromIdentifier(int docHandle, int ID) {
+static IAccessible2* IAccessible2FromIdentifier(int docHandle, int ID) {
 	IAccessible* pacc=NULL;
 	IServiceProvider* pserv=NULL;
 	IAccessible2* pacc2=NULL;
@@ -1128,14 +1128,7 @@ GeckoVBufBackend_t::GeckoVBufBackend_t(int docHandle, int ID): VBufBackend_t(doc
 GeckoVBufBackend_t::~GeckoVBufBackend_t() {
 }
 
-extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {
+VBufBackend_t* GeckoVBufBackend_t_createInstance(int docHandle, int ID) {
 	VBufBackend_t* backend=new GeckoVBufBackend_t(docHandle,ID);
 	return backend;
-}
-
-BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
-	if(reason==DLL_PROCESS_ATTACH) {
-		_CrtSetReportHookW2(_CRT_RPTHOOK_INSTALL,(_CRT_REPORT_HOOKW)NVDALogCrtReportHook);
-	}
-	return true;
 }

--- a/nvdaHelper/vbufBackends/gecko_ia2/sconscript
+++ b/nvdaHelper/vbufBackends/gecko_ia2/sconscript
@@ -14,28 +14,8 @@
 
 Import([
 	'env',
-	'vbufBaseStaticLib',
-	'ia2RPCStubs',
 ])
 
-ia2utilsObj=env.Object("./ia2utils","../../common/ia2utils.cpp")
-
-geckoBackendLib=env.SharedLibrary(
-	target="VBufBackend_gecko_ia2",
-	source=[
-		env['projectResFile'],
-		"gecko_ia2.cpp",
-		ia2utilsObj,
-		env.Object('_ia2_i',ia2RPCStubs[3]),
-	],
-	LIBS=[
-		vbufBaseStaticLib,
-		"user32",
-		"kernel32",
-		"oleacc",
-		"oleaut32",
-		"ole32",
-	],
-)
+geckoBackendLib=env.Object("gecko_ia2.cpp")
 
 Return('geckoBackendLib')

--- a/nvdaHelper/vbufBackends/lotusNotesRichText/lotusNotesRichText.cpp
+++ b/nvdaHelper/vbufBackends/lotusNotesRichText/lotusNotesRichText.cpp
@@ -187,14 +187,7 @@ void lotusNotesRichTextVBufBackend_t::render(VBufStorage_buffer_t* buffer, int d
 lotusNotesRichTextVBufBackend_t::lotusNotesRichTextVBufBackend_t(int docHandle, int ID): VBufBackend_t(docHandle,ID) {
 }
 
-extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {
+VBufBackend_t* lotusNotesRichTextVBufBackend_t_createInstance(int docHandle, int ID) {
 	VBufBackend_t* backend=new lotusNotesRichTextVBufBackend_t(docHandle,ID);
 	return backend;
-}
-
-BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
-	if(reason==DLL_PROCESS_ATTACH) {
-		_CrtSetReportHookW2(_CRT_RPTHOOK_INSTALL,(_CRT_REPORT_HOOKW)NVDALogCrtReportHook);
-	}
-	return true;
 }

--- a/nvdaHelper/vbufBackends/lotusNotesRichText/sconscript
+++ b/nvdaHelper/vbufBackends/lotusNotesRichText/sconscript
@@ -14,22 +14,8 @@
 
 Import([
 	'env',
-	'vbufBaseStaticLib',
 ])
 
-lotusNotesRichTextBackendLib=env.SharedLibrary(
-	target="VBufBackend_lotusNotesRichText",
-	source=[
-		env['projectResFile'],
-		"lotusNotesRichText.cpp",
-	],
-	LIBS=[
-		vbufBaseStaticLib,
-		"user32",
-		"kernel32",
-		"oleacc",
-		"oleaut32",
-	],
-)
+lotusNotesRichTextBackendLib=env.Object("lotusNotesRichText.cpp")
 
 Return('lotusNotesRichTextBackendLib')

--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -23,35 +23,26 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <sstream>
 #include <vbufBase/backend.h>
 #include <vbufBase/utils.h>
+#include <remote/dllmain.h>
 #include <common/log.h>
 #include "node.h"
 #include "mshtml.h"
 
 using namespace std;
 
-HINSTANCE backendLibHandle=NULL;
-UINT WM_HTML_GETOBJECT;
-
-BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
-	if(reason==DLL_PROCESS_ATTACH) {
-		_CrtSetReportHookW2(_CRT_RPTHOOK_INSTALL,(_CRT_REPORT_HOOKW)NVDALogCrtReportHook);
-		backendLibHandle=hModule;
-		WM_HTML_GETOBJECT=RegisterWindowMessage(L"WM_HTML_GETOBJECT");
-	}
-	return TRUE;
-}
+UINT WM_HTML_GETOBJECT=RegisterWindowMessage(L"WM_HTML_GETOBJECT");
 
 void incBackendLibRefCount() {
 	HMODULE h=NULL;
-	BOOL res=GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,(LPCTSTR)backendLibHandle,&h);
+	BOOL res=GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,(LPCTSTR)dllHandle,&h);
 	nhAssert(res); //Result of upping backend lib ref count
-	LOG_DEBUG(L"Increased backend lib ref count");
+	LOG_DEBUG(L"Increased  remote lib ref count");
 }
 
 void decBackendLibRefCount() {
-	BOOL res=FreeLibrary(backendLibHandle);
+	BOOL res=FreeLibrary(dllHandle);
 	nhAssert(res); //Result of freeing backend lib
-	LOG_DEBUG(L"Decreased backend lib ref count");
+	LOG_DEBUG(L"Decreased remote lib ref count");
 }
 
 VBufStorage_controlFieldNode_t* MshtmlVBufBackend_t::getDeepestControlFieldNodeForHTMLElement(IHTMLElement* pHTMLElement) {
@@ -1369,7 +1360,7 @@ MshtmlVBufBackend_t::~MshtmlVBufBackend_t() {
 	LOG_DEBUG(L"Mshtml backend destructor");
 }
 
-extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {
+VBufBackend_t* MshtmlVBufBackend_t_createInstance(int docHandle, int ID) {
 	VBufBackend_t* backend=new MshtmlVBufBackend_t(docHandle,ID);
 	LOG_DEBUG(L"Created new backend at "<<backend);
 	return backend;

--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -30,8 +30,6 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 using namespace std;
 
-UINT WM_HTML_GETOBJECT=RegisterWindowMessage(L"WM_HTML_GETOBJECT");
-
 void incBackendLibRefCount() {
 	HMODULE h=NULL;
 	BOOL res=GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,(LPCTSTR)dllHandle,&h);
@@ -1307,10 +1305,15 @@ if(!(formatState&FORMATSTATE_INSERTED)&&nodeName.compare(L"INS")==0) {
 	return parentNode;
 }
 
+UINT getHTMLWindowMessage() {
+	static UINT wm=RegisterWindowMessage(L"WM_HTML_GETOBJECT");
+	return wm;
+}
+
 void MshtmlVBufBackend_t::render(VBufStorage_buffer_t* buffer, int docHandle, int ID, VBufStorage_controlFieldNode_t* oldNode) {
 	LOG_DEBUG(L"Rendering from docHandle "<<docHandle<<L", ID "<<ID<<L", in to buffer at "<<buffer);
 	LOG_DEBUG(L"Getting document from window "<<docHandle);
-	LRESULT res=SendMessage((HWND)UlongToHandle(docHandle),WM_HTML_GETOBJECT,0,0);
+	LRESULT res=SendMessage((HWND)UlongToHandle(docHandle),getHTMLWindowMessage(),0,0);
 	if(res==0) {
 		LOG_DEBUG(L"Error getting document using WM_HTML_GETOBJECT");
 		return;

--- a/nvdaHelper/vbufBackends/mshtml/mshtml.h
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.h
@@ -44,6 +44,9 @@ typedef struct {
 void incBackendLibRefCount();
 void decBackendLibRefCount();
 
+// gets the window message registered by MSHTML which is used to fetch the MSHTML object model from its window. 
+UINT getHTMLWindowMessage();
+
 class MshtmlVBufBackend_t: public VBufBackend_t {
 	protected:
 

--- a/nvdaHelper/vbufBackends/mshtml/sconscript
+++ b/nvdaHelper/vbufBackends/mshtml/sconscript
@@ -14,23 +14,11 @@
 
 Import([
 	'env',
-	'vbufBaseStaticLib',
 ])
 
-mshtmlBackendLib=env.SharedLibrary(
-	target="VBufBackend_mshtml",
-	source=[
-		env['projectResFile'],
-		"mshtml.cpp",
-		"node.cpp",
-	],
-	LIBS=[
-		vbufBaseStaticLib,
-		"user32",
-		"kernel32",
-		"oleacc",
-		"oleaut32",
-	],
-)
+mshtmlBackendLib=[
+	env.Object("mshtml.cpp"),
+	env.Object("node.cpp"),
+]
 
 Return('mshtmlBackendLib')

--- a/nvdaHelper/vbufBackends/webKit/sconscript
+++ b/nvdaHelper/vbufBackends/webKit/sconscript
@@ -14,24 +14,8 @@
 
 Import([
 	'env',
-	'vbufBaseStaticLib',
-	'ia2RPCStubs',
 ])
 
-webKitBackendLib=env.SharedLibrary(
-	target="VBufBackend_webKit",
-	source=[
-		env['projectResFile'],
-		"webKit.cpp",
-		env.Object('_ia2_i',ia2RPCStubs[3]),
-	],
-	LIBS=[
-		vbufBaseStaticLib,
-		"user32",
-		"kernel32",
-		"oleacc",
-		"oleaut32",
-	],
-)
+webKitBackendLib=env.Object("webKit.cpp")
 
 Return('webKitBackendLib')

--- a/nvdaHelper/vbufBackends/webKit/webKit.cpp
+++ b/nvdaHelper/vbufBackends/webKit/webKit.cpp
@@ -29,7 +29,7 @@ using namespace std;
 _COM_SMARTPTR_TYPEDEF(IAccessible, __uuidof(IAccessible));
 _COM_SMARTPTR_TYPEDEF(IServiceProvider, __uuidof(IServiceProvider));
 
-IAccessible2* IAccessible2FromIdentifier(int docHandle, int id) {
+static IAccessible2* IAccessible2FromIdentifier(int docHandle, int id) {
 	IAccessiblePtr acc = NULL;
 	VARIANT varChild;
 	// WebKit returns a positive value for uniqueID,
@@ -244,14 +244,7 @@ void WebKitVBufBackend_t::render(VBufStorage_buffer_t* buffer, int docHandle, in
 WebKitVBufBackend_t::WebKitVBufBackend_t(int docHandle, int ID): VBufBackend_t(docHandle,ID) {
 }
 
-extern "C" __declspec(dllexport) VBufBackend_t* VBufBackend_create(int docHandle, int ID) {
+VBufBackend_t* WebKitVBufBackend_t_createInstance(int docHandle, int ID) {
 	VBufBackend_t* backend=new WebKitVBufBackend_t(docHandle,ID);
 	return backend;
-}
-
-BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
-	if(reason==DLL_PROCESS_ATTACH) {
-		_CrtSetReportHookW2(_CRT_RPTHOOK_INSTALL,(_CRT_REPORT_HOOKW)NVDALogCrtReportHook);
-	}
-	return true;
 }

--- a/nvdaHelper/vbufBase/backend.h
+++ b/nvdaHelper/vbufBase/backend.h
@@ -182,4 +182,12 @@ static LRESULT CALLBACK destroy_callWndProcHook(int code, WPARAM wParam, LPARAM 
  */
 typedef VBufBackend_t*(*VBufBackend_create_proc)(int,int);
 
+// The backend creation functions
+VBufBackend_t* AdobeAcrobatVBufBackend_t_createInstance(int docHandle, int ID);
+VBufBackend_t* AdobeFlashVBufBackend_t_createInstance(int docHandle, int ID);
+VBufBackend_t* GeckoVBufBackend_t_createInstance(int docHandle, int ID);
+VBufBackend_t* lotusNotesRichTextVBufBackend_t_createInstance(int docHandle, int ID);
+VBufBackend_t* MshtmlVBufBackend_t_createInstance(int docHandle, int ID);
+VBufBackend_t* WebKitVBufBackend_t_createInstance(int docHandle, int ID);
+
 #endif

--- a/nvdaHelper/vbufBase/sconscript
+++ b/nvdaHelper/vbufBase/sconscript
@@ -1,6 +1,5 @@
 Import([
 	'env',
-	'remoteLib',
 ])
 
 vbufBaseObjs=[env.Object(x) for x in (
@@ -8,6 +7,5 @@ vbufBaseObjs=[env.Object(x) for x in (
 		"utils.cpp",
 		"backend.cpp",
 )]
-vbufBaseObjs.append(remoteLib[2])
 
 Return('vbufBaseObjs')

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -30,18 +30,6 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 using namespace std;
 
-VBufStorage_textContainer_t::VBufStorage_textContainer_t(wstring str): wstring(str) {}
-
-VBufStorage_textContainer_t::~VBufStorage_textContainer_t() {}
-
-const wstring& VBufStorage_textContainer_t::getString() {
-	return *this;
-}
-
-void VBufStorage_textContainer_t::destroy() {
-	delete this;
-}
-
 //controlFieldNodeIdentifier implementation
 
 VBufStorage_controlFieldNodeIdentifier_t::VBufStorage_controlFieldNodeIdentifier_t(int docHandleArg, int IDArg) : docHandle(docHandleArg), ID(IDArg) {
@@ -924,7 +912,7 @@ int VBufStorage_buffer_t::getTextLength() const {
 	return length;
 }
 
-VBufStorage_textContainer_t*  VBufStorage_buffer_t::getTextInRange(int startOffset, int endOffset, bool useMarkup) {
+wstring  VBufStorage_buffer_t::getTextInRange(int startOffset, int endOffset, bool useMarkup) {
 	if(this->rootNode==NULL) {
 		LOG_DEBUGWARNING(L"buffer is empty, returning NULL");
 		return NULL;
@@ -936,7 +924,7 @@ VBufStorage_textContainer_t*  VBufStorage_buffer_t::getTextInRange(int startOffs
 	wstring text;
 	this->rootNode->getTextInRange(startOffset,endOffset,text,useMarkup);
 	LOG_DEBUG(L"Got text between offsets "<<startOffset<<L" and "<<endOffset<<L", returning true");
-	return new VBufStorage_textContainer_t(text);
+	return text;
 }
 
 VBufStorage_fieldNode_t* VBufStorage_buffer_t::findNodeByAttributes(int offset, VBufStorage_findDirection_t direction, const std::wstring& attribs, const std::wstring &regexp, int *startOffset, int *endOffset) {

--- a/nvdaHelper/vbufBase/storage.h
+++ b/nvdaHelper/vbufBase/storage.h
@@ -40,17 +40,6 @@ typedef enum {
 	TREEDIRECTION_SYMMETRICAL_BACK
 } TreeDirection;
 
-class VBufStorage_textContainer_t: protected std::wstring {
-	protected:
-	~VBufStorage_textContainer_t();
-
-	public:
-	VBufStorage_textContainer_t(std::wstring str);
-	virtual const std::wstring& getString();
-	virtual void destroy();
-
-};
-
 class VBufStorage_buffer_t;
 class VBufStorage_fieldNode_t;
 class VBufStorage_controlFieldNode_t;
@@ -650,7 +639,7 @@ class VBufStorage_buffer_t {
  * @param useMarkup if true then markup is included in the text denoting field starts and ends.
  * @return the text.
  */
-	virtual VBufStorage_textContainer_t*  getTextInRange(int startOffset, int endOffset, bool useMarkup=false);
+	virtual std::wstring  getTextInRange(int startOffset, int endOffset, bool useMarkup=false);
 
 /**
  * Expands the given offset to the start and end offsets of the containing line.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -32,6 +32,7 @@ What's New in NVDA
 - NVDA no longer refuses to report the focus on web pages where the new focus replaces a control that no longer exists. (#6606, #8341)
 - In the new Gmail, when using quick navigation inside messages while reading them, the entire body of the message is no longer reported after the element to which you just navigated. (#8887)
 - In BrowseMode, NVDA will now always report labels on divs and spans explicitly set by the web author. (#8886)
+- After updating NVDA, Browsers such as Firefox and google Chrome should no longer crash, and browse mode should continue to correctly reflect updates to any currently loaded documents. (#7641) 
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #7641

### Summary of the issue:
After updating NVDA while Firefox or Chrome web browsers are open, NVDA's virtualBuffers in these browsers fail to reflect further updates to web pages, and in some cases the browser crashes.
This is caused by:
1.  Although the old NVDA has quit, and the new NVDA has started, Windows may be slow at unloading the old NVDA's nvdaHelperRemote.dll. The old dll is fully terminated, but still resides in memory for a while.
2. Focus moves into the web browser, and Windows loads the new NVDA's nvdaHelperRemote.dll into the browser, via an in-process winEvent.
3. The new NVDA detects a document in a web browser and prepairs to create a virtualBuffer, by making an rpc call to the new nvdaHelperRemote.dll, requesting it to load the correct vbufBackend dll and create the virtualBuffer.
4. The vbufBackend dll is linked against nvdaHelperRemote, so Windows tries to resolve this linkage by newly loading, or reusing an existing loaded nvdaHelperRemote.dll.
5. As Two different nvdaHelperRemote dlls are loaded, Windows seems to choose the oldest one.
6. In this case, Windows chooses the old NVDA's nvdaHelperRemote.dll.
7. From now on, the virtualBuffer makes calls to the wrong nvdaHelperRemote, which is in fact terminated, and therefore it cannot make use of features such as nvdaHelperRemote's winEvent registrations etc. In deed, it is likely that one of the calls may completely crash the app, if for instance Windows does eventually unload the old NVDAHelperRemote.dll.

### Description of how this pull request fixes the issue:
This PR removes the possibility of loading the wrong nvdaHelperRemote.dll by moving all the virtualBuffer code into nvdaHelperRemote.dll itself, which removes the need for the vbufBackend dlls all together.
The vbufBackend dls were origianlly separate as there was some hope that perhaps one day we might allow custom backends. However, in truth this was never fully possible due to other limitations in NVDA. Another reason was that vbufBackend dlls may link against some specific heavy-weight libraries, which in many cases would not be required in all apps except the ones that actually required that specifica virtualBuffer. In truth though, none of the vbufBackend dlls link against anything else other than what nvdaHelperRemote already links against.
A part from solving the dynamic changes dying, and the crashes, a further advantage is that NvDA's size shrinks significantly as  we were carrying around about 12 vbufBackend dlls, all containing their own static copy of the CRT. Now, the virtualBuffers all share the one crt in nvdaHelperRemote.dll.
 
### Testing performed:
Ran NVDA. Opened documents that require virtualBuffers in Firefox, Chrome, Internet Explorer, and webKit (iTunes). AdobeAcrobat, AdobeFlash and LotusNotes are yet to be tested. However, the only way these could fail is if the name if the virtualBuffer has been typed incorrectly in the source code. The rest of the code stays the same.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
After updating NVDA, NvDA no longer fails to notice updates to document in Firefox and these browsers should no longer crash after the NVDA update. (#7641)