### PR TITLE
BrowseMode: don't refuse to report focus changes for replaced controls or focused ancestors

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,6 +29,7 @@ What's New in NVDA
 - Braille no longer shows font attributes  if they have been disabled in  Document Formatting settings. (#7615)
 - NVDA no longer fails to track focus in File Explorer and other applications using UI Automation when another app is busy (such as batch processing audio). (#7345)
 - In ARIA menus on the web, the Escape key will now be passed through to the menu and no longer turn off focus mode unconditionally. (#3215)
+- NVDA no longer refuses to report the focus on web pages where the new focus replaces a control that no longer exists. (#6606, #8341)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #6606 
Closes #8341 

### Summary of the issue:
NVDA sometimes fails to report focus in browseMode documents, as it is trying to filter out redundant focus events caused by moving the caret.
Particular cases:

#### Focus replacement
Custom checkboxes and expandable controls that draw a checkmark or + symbol using the content css property on the element's ::before selector, can cause CSS reframing in Firefox, meaning that the accessible representing the focus dies and is replaced with a new accessible. NVDA refuses in this case to announce the state change, and also the new focus. At very least, NVDA should announce the new focus.
A similar case (but this time deliberate on the part of the web author) is where the current focus is removed from the DOM completely, and a new element is inserted in its place and then focused. An example of this is the Edit title button on Github pull requests. When pressing the button, the Title edit field appears in its place, and NVDA reports nothing.

#### Focus moves to an ancestor
Sometimes web authors want to focus an ancestor of the previous focus. this is quite common for single-page web apps. In this case, NVDA reports nothing.

#### Current implementation
Currently, NVDA chooses to ignore any focus in browseMode that overlaps with the browseMode caret. This is so that any focus event that resalts from moving the caret is not reported as this would be redundant. However, this rule is clearly too limiting as it stops the above examples from working.
 
### Description of how this pull request fixes the issue:
This PR changes browseMode so that:
* When NVDA requests that an element be focused due to the caret moving, it remembers this object for later.
* In the gainFocus event for any object within the browseMode document, NVDA tries to lookup the offsets for the previous focus and or the queued focus (due to the caret moving). If it successfully gets the offsets, and the start offset is equal to the new focus's start offset, then the focus is ignored. However, if the offsets differ or NVDA could not lookup the offsets (the old focus died) then the focus is reported.
 
### Testing performed:
Tested all cases in #6606 and #8341 

### Known issues with pull request:
None known. Note though this does not address the underlying issue in #2039.

### Change log entry:
Bug fixes:
NVDA no longer refuses to report the focus on web pages where the new focus replaces a control that no longer exists. (#6606, #8341)
