### PR TITLE
Don't announce 'selected' when the focus moves in Google sheets if the focused cell is the only cell selected

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -5,7 +5,7 @@
 
 from comtypes.automation import IEnumVARIANT, VARIANT
 from comtypes import COMError, IServiceProvider, GUID
-from comtypes.hresult import S_OK
+from comtypes.hresult import S_OK, S_FALSE
 import ctypes
 import os
 import re
@@ -1221,33 +1221,41 @@ the NVDAObject for IAccessible
 			return self.table
 		return super(IAccessible,self).selectionContainer
 
+	def _getSelectedItemsCount_accSelection(self,maxCount):
+		sel=self.IAccessibleObject.accSelection
+		if not sel:
+			raise NotImplementedError
+		enumObj=sel.QueryInterface(IEnumVARIANT)
+		if not enumObj:
+			raise NotImplementedError
+		# Call the rawmethod for IEnumVARIANT::Next as COMTypes' overloaded version does not allow limiting the amount of items returned
+		numItemsFetched=ctypes.c_ulong()
+		itemsBuf=(VARIANT*(maxCount+1))()
+		res=enumObj._IEnumVARIANT__com_Next(maxCount,itemsBuf,ctypes.byref(numItemsFetched))
+		# IEnumVARIANT returns S_FALSE  if the buffer is too small, although it still writes as many as it can.
+		# For our purposes, we can treat both S_OK and S_FALSE as success.
+		if res!=S_OK and res!=S_FALSE:
+			raise COMError(res,None,None)
+		return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxint
+
 	def getSelectedItemsCount(self,maxCount):
 		# To fetch the number of selected items, we first try MSAA's accSelection, but if that fails in any way, we fall back to using IAccessibleTable2's nSelectedCells, if we are on an IAccessible2 table.
 		# Currently Chrome does not implement accSelection, thus for Google Sheets we must use nSelectedCells when on a table.
 		try:
-			sel=self.IAccessibleObject.accSelection
-		except COMError as e:
-			log.debugWarning("Error fetching accSelection, %s"%e)
-			sel=None
-		if sel:
-			try:
-				enumObj=sel.QueryInterface(IEnumVARIANT)
-			except COMError as e:
-				enumObj=None
-			if enumObj:
-				numItemsFetched=ctypes.c_ulong()
-				itemsBuf=(VARIANT*(maxCount+1))()
-				res=enumObj._IEnumVARIANT__com_Next(maxCount,itemsBuf,ctypes.byref(numItemsFetched))
-				if res!=S_OK:
-					return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxint
-				else:
-					log.debugWarning("Error in IEnumVARIANT::Next, code %s"%res)
+			return self._getSelectedItemsCount_accSelection(maxCount)
+		except (COMError,NotImplementedError) as e:
+			log.debug("Cannot fetch selected items count using accSelection, %s"%e)
+			pass
 		if self.IAccessibleTable2Object:
 			try:
 				return self.IAccessibleTable2Object.nSelectedCells
 			except COMError as e:
-				log.debugWarning("Error calling IAccessibleTable2::nSelectedCells, %s"%e)
-		return 0
+				log.debug("Error calling IAccessibleTable2::nSelectedCells, %s"%e)
+			pass
+		else:
+			log.debug("No means of getting a selection count from this IAccessible")
+		return super(IAccessible,self).getSelectedItemsCount(maxCount)
+
 
 	def _get_table(self):
 		if not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1219,6 +1219,7 @@ the NVDAObject for IAccessible
 	def _get_selectionContainer(self):
 		if self.table:
 			return self.table
+		return super(IAccessible,self).selectionContainer
 
 	def getSelectedItemsCount(self,maxCount):
 		# To fetch the number of selected items, we first try MSAA's accSelection, but if that fails in any way, we fall back to using IAccessibleTable2's nSelectedCells, if we are on an IAccessible2 table.

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1181,3 +1181,15 @@ This code is executed if a gain focus event is received by this object.
 			return True
 		else:
 			return False
+
+	def _get_selectionContainer(self):
+		""" An ancestor NVDAObject which manages the selection for this object and other descendants."""
+		return None
+
+	def getSelectedItemsCount(self,maxCount=2):
+		"""
+		Fetches the number of descendants currently selected.
+		For performance, this method will only count up to the given maxCount number, and if there is one more above that, then sys.maxint is returned stating that many items are selected.
+		"""
+		return 0
+

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -727,7 +727,18 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 	# but only if it is either focused or this is something other than a change event.
 	# The condition stops "not selected" from being spoken in some broken controls
 	# when the state change for the previous focus is issued before the focus change.
-	if role in (ROLE_LISTITEM, ROLE_TREEVIEWITEM, ROLE_TABLEROW,ROLE_TABLECELL,ROLE_TABLECOLUMNHEADER,ROLE_TABLEROWHEADER) and STATE_SELECTABLE in states and (reason != REASON_CHANGE or STATE_FOCUSED in states):
+	if (
+		STATE_SELECTABLE in states 
+		and (reason != REASON_CHANGE or STATE_FOCUSED in states)
+		and role in (
+			ROLE_LISTITEM, 
+			ROLE_TREEVIEWITEM, 
+			ROLE_TABLEROW,
+			ROLE_TABLECELL,
+			ROLE_TABLECOLUMNHEADER,
+			ROLE_TABLEROWHEADER
+		)
+	):
 		speakNegatives.add(STATE_SELECTED)
 	# Restrict "not checked" in a similar way to "not selected".
 	if (role in (ROLE_CHECKBOX, ROLE_RADIOBUTTON, ROLE_CHECKMENUITEM) or STATE_CHECKABLE in states)  and (STATE_HALFCHECKED not in states) and (reason != REASON_CHANGE or STATE_FOCUSED in states):

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -727,7 +727,7 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 	# but only if it is either focused or this is something other than a change event.
 	# The condition stops "not selected" from being spoken in some broken controls
 	# when the state change for the previous focus is issued before the focus change.
-	if role in (ROLE_LISTITEM, ROLE_TREEVIEWITEM, ROLE_TABLEROW) and STATE_SELECTABLE in states and (reason != REASON_CHANGE or STATE_FOCUSED in states):
+	if role in (ROLE_LISTITEM, ROLE_TREEVIEWITEM, ROLE_TABLEROW,ROLE_TABLECELL,ROLE_TABLECOLUMNHEADER,ROLE_TABLEROWHEADER) and STATE_SELECTABLE in states and (reason != REASON_CHANGE or STATE_FOCUSED in states):
 		speakNegatives.add(STATE_SELECTED)
 	# Restrict "not checked" in a similar way to "not selected".
 	if (role in (ROLE_CHECKBOX, ROLE_RADIOBUTTON, ROLE_CHECKMENUITEM) or STATE_CHECKABLE in states)  and (STATE_HALFCHECKED not in states) and (reason != REASON_CHANGE or STATE_FOCUSED in states):

--- a/source/speech.py
+++ b/source/speech.py
@@ -313,6 +313,15 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 	newPropertyValues['current']=obj.isCurrent
 	if allowedProperties.get('placeholder', False):
 		newPropertyValues['placeholder']=obj.placeholder
+	# When speaking an object due to a focus change, the 'selected' state should not be reported if only one item is selected.
+	# This is because that one item will be the focused object, and saying selected is redundant.
+	# Rather, 'unselected' will be spoken for an unselected object if 1 or more items are selected. 
+	
+	states=newPropertyValues.get('states')
+	if states is not None and reason==controlTypes.REASON_FOCUS:
+		if controlTypes.STATE_SELECTABLE in states and controlTypes.STATE_SELECTED in states and obj.selectionContainer and obj.selectionContainer.getSelectedItemsCount(2)==1:
+			states.discard(controlTypes.STATE_SELECTED)
+			states.discard(controlTypes.STATE_SELECTABLE)
 	#Get the speech text for the properties we want to speak, and then speak it
 	text=getSpeechTextForProperties(reason,**newPropertyValues)
 	if text:

--- a/source/speech.py
+++ b/source/speech.py
@@ -316,10 +316,14 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 	# When speaking an object due to a focus change, the 'selected' state should not be reported if only one item is selected.
 	# This is because that one item will be the focused object, and saying selected is redundant.
 	# Rather, 'unselected' will be spoken for an unselected object if 1 or more items are selected. 
-	
 	states=newPropertyValues.get('states')
 	if states is not None and reason==controlTypes.REASON_FOCUS:
-		if controlTypes.STATE_SELECTABLE in states and controlTypes.STATE_SELECTED in states and obj.selectionContainer and obj.selectionContainer.getSelectedItemsCount(2)==1:
+		if (
+			controlTypes.STATE_SELECTABLE in states 
+			and controlTypes.STATE_SELECTED in states
+			and obj.selectionContainer 
+			and obj.selectionContainer.getSelectedItemsCount(2)==1
+		):
 			states.discard(controlTypes.STATE_SELECTED)
 			states.discard(controlTypes.STATE_SELECTABLE)
 	#Get the speech text for the properties we want to speak, and then speak it

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,7 @@ What's New in NVDA
 - Replied / Forwarded status is now reported on mail items in the Microsoft Outlook message list. (#6911)
 - NVDA is now able to read descriptions for emoji as well as other characters that are part of the Unicode Common Locale Data Repository. (#6523)
 - In Microsoft Word, the cursor's distance from the top and left edges of the page can be reported by pressing NVDA+numpadDelete. (#1939)
+- In Google Sheets with braille mode enabled, NVDA no longer announces 'selected' on every cell when moving focus between cells. (#8879)
 
 
 == Changes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8766 

### Summary of the issue:
When navigating cells in Google Sheets with GoogleShets Braille mode enabled, NVDA reports 'selected' for every cell the focus moves to.
Although this is technically correct (the cell is selected), it is not at all practical. Most if not all cells that are focused will be selected. So it ends up being redundant information.
We should change the experience so that:
* If the focused cell is the only cell selected, then NvDA should not announce that it is selected.
* If the focused cell is selected and more than one cell is selected, NVDA should announce that the focused cell is selected.
* If the focused cell is not selected, NVDA should announce that the focused cell is 'not selected'.

### Description of how this pull request fixes the issue:
This PR implements these rules by the following:
* NvDAObjects now have a selectionContainer property, which should return the ancestor NVDAObject that manages the selection. E.g. for a table cell it would be the table. For a list item it would be the list. By default this property returns None.
* Implement the selectionContainer property on IAccessible NVDAObjects. This implementation currently just returns the table NVDAObject if the NVDAObject has an ancestor table. In the future, other NVDAObjects such as UIA should implement this to make use of the UIA selection pattern etc.
* Implement a getSelectedItemsCount method on NVDAObjects. This method should return the number of descendants currently selected. For performance reasons, the method takes a maxCount argument, which can be used to limet the amount of items counted, if an implementation has to literally fetch the items using a preallocated buffer in order to get the number of them. Implementations should try and fetch one more than maxCount, and if there are more items than maxCount, then sys.maxint should be returned, to denote many items.
* Implemented getSelectedItemsCount on IAccessible NVDAObject. This implementation tries to fetch and count items with IAccessible::accSelect, and if that fails or is not available, then if the IAccessible supports IAccessibleTable2, IAccessibleTable2::nSelectedCells is used instead. Note that As Chrome does not implement accSelection on tables, it is necessary to fall back to nSelectedCells.
* speech.speakObjectProperties: When speaking object properties for the reason of focus, remove the selected and selectable states from the object's states to be spoken, if the selectable state is present, the object has a selectionContainer, and its selectionContainer's getSelectedItemsCount is equal to 1.
 * controlTypes.processNegativeStates:  report 'not selected' when there is the selectable state but not the selected state, if the role is tableCell, tableColumnHeader or tableRowHeader. Previously we were already doing this for tableRow.

 
 
### Testing performed:
Created a new sheet in Google Sheets. Moved focus around the cells. NVDA no longer announced 'selected' if the focused cell was the only cell selected.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* In Google Sheets with braille mode enabled, NVDA no longer announces 'selected' on every cell when moving focus between cells.
