### PR TITLE
Ensure that  labels explicitly set on divs and spans are reported in braille and speech

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -660,10 +660,16 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	current=field.get('current', None)
 	placeholder=field.get('placeholder', None)
 	roleText=field.get('roleText')
+	name=field.get('name')
+	alwaysReportName=field.get('alwaysReportName')
 
 	if presCat == field.PRESCAT_LAYOUT:
 		text = []
-		# The only item we report for these fields is clickable, if present.
+		# Always braille the name of a field if it is forced.
+		# This is for the fallback case where a div or a span (which has no other presentation) has its name reported if explicitly set by the author using aria-label etc. 
+		if alwaysReportName and name and field.get("_startOfNode"):
+			text.append(name)
+		#  report  clickable if present.
 		if controlTypes.STATE_CLICKABLE in states:
 			text.append(getBrailleTextForProperties(states={controlTypes.STATE_CLICKABLE}))
 		if current:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1067,6 +1067,8 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 			name=attrs.get('name')
 			if name and attrs.getPresentationCategory(ancestorAttrs,formatConfig,reason) is None:
 				textList.append(name)
+				# As the name is being explicitly reported along with the landmark, we must ensure that it is not reported again generically
+				attrs['alwaysReportName']=False
 				if landmark == "region":
 					# The word landmark is superfluous for regions.
 					textList.append(aria.landmarkRoles[landmark])
@@ -1082,6 +1084,8 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 			# Ensure that the name of the field gets presented even if normally it wouldn't. 
 			name=field.get('name')
 			if name and field.getPresentationCategory(ancestors,formatConfig) is None:
+				# As the name is being explicitly reported along with the landmark, we must ensure that it is not reported again generically
+				field['alwaysReportName']=False
 				textList.append(name)
 				if landmark == "region":
 					# The word landmark is superfluous for regions.

--- a/source/speech.py
+++ b/source/speech.py
@@ -1109,7 +1109,10 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 
 	presCat=attrs.getPresentationCategory(ancestorAttrs,formatConfig, reason=reason)
 	childControlCount=int(attrs.get('_childcontrolcount',"0"))
-	if reason==controlTypes.REASON_FOCUS or attrs.get('alwaysReportName',False):
+	alwaysReportName=attrs.get('alwaysReportName',False)
+	alwaysReportDescription=attrs.get('alwaysReportDescription',False)
+	isBlock=attrs.get('_isBlock',False)
+	if reason==controlTypes.REASON_FOCUS or alwaysReportName:
 		name=attrs.get('name',"")
 	else:
 		name=""
@@ -1225,14 +1228,17 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 	# Special cases
 	elif not speakEntry and fieldType in ("start_addedToControlFieldStack","start_relative"):
 		out = []
+		# Always speak the name of a field if it is forced.
+		# This is for the fallback case where a div or a span (which has no other presentation) has its name announced if explicitly set by the author using aria-label etc. 
+		if alwaysReportName and nameText:
+			out.append(nameText)
 		if not extraDetail and controlTypes.STATE_CLICKABLE in states: 
 			# Clickable.
 			out.append(getSpeechTextForProperties(states=set([controlTypes.STATE_CLICKABLE])))
 		if ariaCurrent:
 			out.append(ariaCurrentText)
 		return CHUNK_SEPARATOR.join(out)
-	else:
-		return ""
+	return ""
 
 def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,unit=None,extraDetail=False , initialFormat=False, separator=CHUNK_SEPARATOR):
 	if not formatConfig:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -30,6 +30,7 @@ What's New in NVDA
 - NVDA no longer fails to track focus in File Explorer and other applications using UI Automation when another app is busy (such as batch processing audio). (#7345)
 - In ARIA menus on the web, the Escape key will now be passed through to the menu and no longer turn off focus mode unconditionally. (#3215)
 - NVDA no longer refuses to report the focus on web pages where the new focus replaces a control that no longer exists. (#6606, #8341)
+- In BrowseMode, NVDA will now always report labels on divs and spans explicitly set by the web author. (#8886)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
A web author can explicitly set the label of a node using aria-label or aria-labelledby. In BrowseMode, NvDA will in some cases use this label as the actual text content, and in some cases report it as extra meta information. However, in the case of a div or a span that is not presented in any other way, NVDA currently fails to report the label at all. It should at least be reported as meta info. As the web author rightfully expects that if they set a label, it will be exposed somewhere.
The following html fragment in Firefox demonstrates this:
```
data:text/html,<p>Span with label: <span aria-label="span label">span text</span></p><p>A div with a label:</p><div aria-label="div label">div text</div>
```
NVDA does not announce "span label" or "div label" anywhere.

### Description of how this pull request fixes the issue:
In both speech and braille, NVDA now reports the label (name) if explisitly set by the author (alwaysReportName). Note that in the case of landmarks where the label is already reported specifically as the landmark label, care is taken not to duplicate the label for both speech and braille.

### Testing performed:
In Firefox, read the above testcase in both speech and braille. "span label" was reported before "span text" and "div label" before "div text".

### Known issues with pull request:
None.

### Change log entry:
In BrowseMode, NVDA will now always report  labels on divs and spans explicitly set by the web author.