### PR TITLE
Fix handling of table cells without a containing table in browse mode.

### DIFF
--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -59,7 +59,7 @@ class ControlField(Field):
 						break
 				else:
 					table = None
-			if table and ((not formatConfig["includeLayoutTables"] and table.get("table-layout", None)) or table.get('isHidden',False)):
+			if not table or (not formatConfig["includeLayoutTables"] and table.get("table-layout", None)) or table.get('isHidden',False):
 				return self.PRESCAT_LAYOUT
 		if reason in (controlTypes.REASON_CARET, controlTypes.REASON_SAYALL, controlTypes.REASON_FOCUS) and (
 			(role == controlTypes.ROLE_LINK and not formatConfig["reportLinks"])

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -30,6 +30,7 @@ What's New in NVDA
 - NVDA no longer fails to track focus in File Explorer and other applications using UI Automation when another app is busy (such as batch processing audio). (#7345)
 - In ARIA menus on the web, the Escape key will now be passed through to the menu and no longer turn off focus mode unconditionally. (#3215)
 - NVDA no longer refuses to report the focus on web pages where the new focus replaces a control that no longer exists. (#6606, #8341)
+- In the new Gmail, when using quick navigation inside messages while reading them, the entire body of the message is no longer reported after the element to which you just navigated. (#8887)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
When using browse mode quick navigation to move to anything inside a message body in the new Gmail, the entire message body is reported after the element to which you just navigated.

### Description of how this pull request fixes the issue:
In the new Gmail, message bodies are contained within a "gridcell" which does not have a containing grid. The gridcell's name is the entire body of the message. When using quick navigation to move to anything inside these "cells", NVDA reports information about the cell, including its name, after the element to which you just navigated.

To fix this, cells outside of tables are now treated as layout.

Having a gridcell outside of a grid is authoring error, violates the ARIA spec and really should be fixed by Gmail. (I've reported it to Google already.) However, it doesn't hurt us to handle this more gracefully and thus mitigate user pain in the interim.

### Testing performed:

All tests performed in Firefox.

1. Tested that navigating to a link in a Gmail message body no longer reports the entire message body afterwards.

2. With this test case:

    `data:text/html,<div role="cell" aria-label="unwanted">foo<h1>bar</h1></div>`

    verified that quick navigating to the heading with "h" does not report "unwanted  cell" after the heading.

3. With this test case:

    `data:text/html,<table><tr><th>foo<h1>bar</h1></th><td>baz</td></tr></table>`

    verified that quick navigating to the heading still just reports the heading, and that the column number is still reported when using the cursor keys and column navigation commands to move between cells.

4. With this test case:

    `data:text/html,<table><tr><td>foo<h1>bar</h1></td><td>baz</td></tr></table>`

    verified that quick navigating to the heading still just reports the heading. Verified that with include layout tables disabled (default), no table coordinates are reported. Verified that with include layout tables enabled, verified that the column number is still reported when using the cursor keys and column navigation commands to move between cells.

### Known issues with pull request:
None.

### Change log entry:

Section: Bug Fixes

`- In the new Gmail, when using quick navigation inside messages while reading them, the entire body of the message is no longer reported after the element to which you just navigated.`