### PR TITLE
Fix up of: Don't announce 'selected' when the focus moves in Google sheets if the focused cell is the only cell selected

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -5,7 +5,7 @@
 
 from comtypes.automation import IEnumVARIANT, VARIANT
 from comtypes import COMError, IServiceProvider, GUID
-from comtypes.hresult import S_OK
+from comtypes.hresult import S_OK, S_FALSE
 import ctypes
 import os
 import re
@@ -1221,33 +1221,41 @@ the NVDAObject for IAccessible
 			return self.table
 		return super(IAccessible,self).selectionContainer
 
+	def _getSelectedItemsCount_accSelection(self,maxCount):
+		sel=self.IAccessibleObject.accSelection
+		if not sel:
+			raise NotImplementedError
+		enumObj=sel.QueryInterface(IEnumVARIANT)
+		if not enumObj:
+			raise NotImplementedError
+		# Call the rawmethod for IEnumVARIANT::Next as COMTypes' overloaded version does not allow limiting the amount of items returned
+		numItemsFetched=ctypes.c_ulong()
+		itemsBuf=(VARIANT*(maxCount+1))()
+		res=enumObj._IEnumVARIANT__com_Next(maxCount,itemsBuf,ctypes.byref(numItemsFetched))
+		# IEnumVARIANT returns S_FALSE  if the buffer is too small, although it still writes as many as it can.
+		# For our purposes, we can treat both S_OK and S_FALSE as success.
+		if res!=S_OK and res!=S_FALSE:
+			raise COMError(res,None,None)
+		return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxint
+
 	def getSelectedItemsCount(self,maxCount):
 		# To fetch the number of selected items, we first try MSAA's accSelection, but if that fails in any way, we fall back to using IAccessibleTable2's nSelectedCells, if we are on an IAccessible2 table.
 		# Currently Chrome does not implement accSelection, thus for Google Sheets we must use nSelectedCells when on a table.
 		try:
-			sel=self.IAccessibleObject.accSelection
-		except COMError as e:
-			log.debugWarning("Error fetching accSelection, %s"%e)
-			sel=None
-		if sel:
-			try:
-				enumObj=sel.QueryInterface(IEnumVARIANT)
-			except COMError as e:
-				enumObj=None
-			if enumObj:
-				numItemsFetched=ctypes.c_ulong()
-				itemsBuf=(VARIANT*(maxCount+1))()
-				res=enumObj._IEnumVARIANT__com_Next(maxCount,itemsBuf,ctypes.byref(numItemsFetched))
-				if res!=S_OK:
-					return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxint
-				else:
-					log.debugWarning("Error in IEnumVARIANT::Next, code %s"%res)
+			return self._getSelectedItemsCount_accSelection(maxCount)
+		except (COMError,NotImplementedError) as e:
+			log.debug("Cannot fetch selected items count using accSelection, %s"%e)
+			pass
 		if self.IAccessibleTable2Object:
 			try:
 				return self.IAccessibleTable2Object.nSelectedCells
 			except COMError as e:
-				log.debugWarning("Error calling IAccessibleTable2::nSelectedCells, %s"%e)
-		return 0
+				log.debug("Error calling IAccessibleTable2::nSelectedCells, %s"%e)
+			pass
+		else:
+			log.debug("No means of getting a selection count from this IAccessible")
+		return super(IAccessible,self).getSelectedItemsCount(maxCount)
+
 
 	def _get_table(self):
 		if not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1219,6 +1219,7 @@ the NVDAObject for IAccessible
 	def _get_selectionContainer(self):
 		if self.table:
 			return self.table
+		return super(IAccessible,self).selectionContainer
 
 	def getSelectedItemsCount(self,maxCount):
 		# To fetch the number of selected items, we first try MSAA's accSelection, but if that fails in any way, we fall back to using IAccessibleTable2's nSelectedCells, if we are on an IAccessible2 table.

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1225,6 +1225,10 @@ the NVDAObject for IAccessible
 		sel=self.IAccessibleObject.accSelection
 		if not sel:
 			raise NotImplementedError
+		# accSelection can return a child ID of a simple element, for instance in QT tree tables. 
+		# Therefore treet this as a single selection.
+		if isinstance(sel,int) and sel>0:
+			return 1
 		enumObj=sel.QueryInterface(IEnumVARIANT)
 		if not enumObj:
 			raise NotImplementedError

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -53,6 +53,14 @@ class Ia2Web(IAccessible):
 			return roleText
 		return super(Ia2Web,self).roleText
 
+	def _get_states(self):
+		states=super(Ia2Web,self).states
+		# Ensure that ARIA gridcells always get the focusable state, even if the Browser fails to provide it.
+		# This is necessary for other code that calculates how selection of cells should be spoken.
+		if 'gridcell' in self.IA2Attributes.get('xml-roles','').split(' '):
+			states.add(controlTypes.STATE_FOCUSABLE)
+		return states
+
 class Document(Ia2Web):
 	value = None
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1181,3 +1181,15 @@ This code is executed if a gain focus event is received by this object.
 			return True
 		else:
 			return False
+
+	def _get_selectionContainer(self):
+		""" An ancestor NVDAObject which manages the selection for this object and other descendants."""
+		return None
+
+	def getSelectedItemsCount(self,maxCount=2):
+		"""
+		Fetches the number of descendants currently selected.
+		For performance, this method will only count up to the given maxCount number, and if there is one more above that, then sys.maxint is returned stating that many items are selected.
+		"""
+		return 0
+

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -727,7 +727,18 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 	# but only if it is either focused or this is something other than a change event.
 	# The condition stops "not selected" from being spoken in some broken controls
 	# when the state change for the previous focus is issued before the focus change.
-	if role in (ROLE_LISTITEM, ROLE_TREEVIEWITEM, ROLE_TABLEROW,ROLE_TABLECELL,ROLE_TABLECOLUMNHEADER,ROLE_TABLEROWHEADER) and STATE_SELECTABLE in states and (reason != REASON_CHANGE or STATE_FOCUSED in states):
+	if (
+		STATE_SELECTABLE in states 
+		and (reason != REASON_CHANGE or STATE_FOCUSED in states)
+		and role in (
+			ROLE_LISTITEM, 
+			ROLE_TREEVIEWITEM, 
+			ROLE_TABLEROW,
+			ROLE_TABLECELL,
+			ROLE_TABLECOLUMNHEADER,
+			ROLE_TABLEROWHEADER
+		)
+	):
 		speakNegatives.add(STATE_SELECTED)
 	# Restrict "not checked" in a similar way to "not selected".
 	if (role in (ROLE_CHECKBOX, ROLE_RADIOBUTTON, ROLE_CHECKMENUITEM) or STATE_CHECKABLE in states)  and (STATE_HALFCHECKED not in states) and (reason != REASON_CHANGE or STATE_FOCUSED in states):

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -724,12 +724,17 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 		raise TypeError("negativeStates must be a set for this reason")
 	speakNegatives = set()
 	# Add the negative selected state if the control is selectable,
-	# but only if it is either focused or this is something other than a change event.
+	# but only if it is reported for the reason of focus, or this is a change to the focused object. 
 	# The condition stops "not selected" from being spoken in some broken controls
 	# when the state change for the previous focus is issued before the focus change.
 	if (
-		STATE_SELECTABLE in states 
-		and (reason != REASON_CHANGE or STATE_FOCUSED in states)
+		# Only include if the object is actually selectable
+		STATE_SELECTABLE in states
+		# Only include if the object is focusable (E.g. ARIA grid cells, but not standard html tables)
+		and STATE_FOCUSABLE in states
+		# Only include  if reporting the focus or when states are changing on the focus.
+		# This is to avoid exposing it for things like caret movement in browse mode. 
+		and (reason == REASON_FOCUS or (reason == REASON_CHANGE and STATE_FOCUSED in states))
 		and role in (
 			ROLE_LISTITEM, 
 			ROLE_TREEVIEWITEM, 

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -727,7 +727,7 @@ def processNegativeStates(role, states, reason, negativeStates=None):
 	# but only if it is either focused or this is something other than a change event.
 	# The condition stops "not selected" from being spoken in some broken controls
 	# when the state change for the previous focus is issued before the focus change.
-	if role in (ROLE_LISTITEM, ROLE_TREEVIEWITEM, ROLE_TABLEROW) and STATE_SELECTABLE in states and (reason != REASON_CHANGE or STATE_FOCUSED in states):
+	if role in (ROLE_LISTITEM, ROLE_TREEVIEWITEM, ROLE_TABLEROW,ROLE_TABLECELL,ROLE_TABLECOLUMNHEADER,ROLE_TABLEROWHEADER) and STATE_SELECTABLE in states and (reason != REASON_CHANGE or STATE_FOCUSED in states):
 		speakNegatives.add(STATE_SELECTED)
 	# Restrict "not checked" in a similar way to "not selected".
 	if (role in (ROLE_CHECKBOX, ROLE_RADIOBUTTON, ROLE_CHECKMENUITEM) or STATE_CHECKABLE in states)  and (STATE_HALFCHECKED not in states) and (reason != REASON_CHANGE or STATE_FOCUSED in states):

--- a/source/speech.py
+++ b/source/speech.py
@@ -320,6 +320,7 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 	if states is not None and reason==controlTypes.REASON_FOCUS:
 		if (
 			controlTypes.STATE_SELECTABLE in states 
+			and controlTypes.STATE_FOCUSABLE in states
 			and controlTypes.STATE_SELECTED in states
 			and obj.selectionContainer 
 			and obj.selectionContainer.getSelectedItemsCount(2)==1

--- a/source/speech.py
+++ b/source/speech.py
@@ -313,6 +313,15 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 	newPropertyValues['current']=obj.isCurrent
 	if allowedProperties.get('placeholder', False):
 		newPropertyValues['placeholder']=obj.placeholder
+	# When speaking an object due to a focus change, the 'selected' state should not be reported if only one item is selected.
+	# This is because that one item will be the focused object, and saying selected is redundant.
+	# Rather, 'unselected' will be spoken for an unselected object if 1 or more items are selected. 
+	
+	states=newPropertyValues.get('states')
+	if states is not None and reason==controlTypes.REASON_FOCUS:
+		if controlTypes.STATE_SELECTABLE in states and controlTypes.STATE_SELECTED in states and obj.selectionContainer and obj.selectionContainer.getSelectedItemsCount(2)==1:
+			states.discard(controlTypes.STATE_SELECTED)
+			states.discard(controlTypes.STATE_SELECTABLE)
 	#Get the speech text for the properties we want to speak, and then speak it
 	text=getSpeechTextForProperties(reason,**newPropertyValues)
 	if text:

--- a/source/speech.py
+++ b/source/speech.py
@@ -316,10 +316,14 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 	# When speaking an object due to a focus change, the 'selected' state should not be reported if only one item is selected.
 	# This is because that one item will be the focused object, and saying selected is redundant.
 	# Rather, 'unselected' will be spoken for an unselected object if 1 or more items are selected. 
-	
 	states=newPropertyValues.get('states')
 	if states is not None and reason==controlTypes.REASON_FOCUS:
-		if controlTypes.STATE_SELECTABLE in states and controlTypes.STATE_SELECTED in states and obj.selectionContainer and obj.selectionContainer.getSelectedItemsCount(2)==1:
+		if (
+			controlTypes.STATE_SELECTABLE in states 
+			and controlTypes.STATE_SELECTED in states
+			and obj.selectionContainer 
+			and obj.selectionContainer.getSelectedItemsCount(2)==1
+		):
 			states.discard(controlTypes.STATE_SELECTED)
 			states.discard(controlTypes.STATE_SELECTABLE)
 	#Get the speech text for the properties we want to speak, and then speak it

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,7 @@ What's New in NVDA
 - Replied / Forwarded status is now reported on mail items in the Microsoft Outlook message list. (#6911)
 - NVDA is now able to read descriptions for emoji as well as other characters that are part of the Unicode Common Locale Data Repository. (#6523)
 - In Microsoft Word, the cursor's distance from the top and left edges of the page can be reported by pressing NVDA+numpadDelete. (#1939)
+- In Google Sheets with braille mode enabled, NVDA no longer announces 'selected' on every cell when moving focus between cells. (#8879)
 
 
 == Changes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

Fix up of pr #8879.
Contains one last commit which ensures this change is only limited to focusable items, such as ARIA gridcells. This is necessary as otherwise 'not selected' is reported for standard html tables both in focus and browse modes.

## Testing performed:
Same as PR #8879, but also:
* Arrowing up and down a standard html table in browse mode
* Object navigation between cells in a standard html table
* Moving focus up and down a list (NVDA punctuation settings dialog
* Moving up and down a treeview (File Explorer)

 
