### PR TITLE
speech.speakObjectProperties: if removing the 'selected' state, make sure to copy the states set first as to not mutate the cache for future state change announcements

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -325,8 +325,12 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 			and obj.selectionContainer 
 			and obj.selectionContainer.getSelectedItemsCount(2)==1
 		):
+			# We must copy the states set and  put it back in newPropertyValues otherwise mutating the original states set in-place will wrongly change the cached states.
+			# This would then cause 'selected' to be announced as a change when any other state happens to change on this object in future.
+			states=states.copy()
 			states.discard(controlTypes.STATE_SELECTED)
 			states.discard(controlTypes.STATE_SELECTABLE)
+			newPropertyValues['states']=states
 	#Get the speech text for the properties we want to speak, and then speak it
 	text=getSpeechTextForProperties(reason,**newPropertyValues)
 	if text:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8903

### Summary of the issue:
With the merging of pr #8898, NVDA has started announcing 'selected' if the focused control has the selected state when another state changes.
For example, In Thunderbird when collapsing or expanding an email account in the mail folders treeview.
 
### Description of how this pull request fixes the issue:
This PR makes sure to copy the states set in speakObjectProperties before removing the 'selected' and 'selectable' states. This is so that the cached states are not affected. Otherwise, when a state change occurs, NVDA would think that selected and selectable were added back in.

### Testing performed:
Collapsed and expanded an email account in Thunderbird mail folders treeview.

### Known issues with pull request:
None.

### Change log entry:
None needed.

Section: New features, Changes, Bug fixes

