### PR TITLE
Update CLDR annotations to version 34.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ For reference, the following dependencies are included in Git submodules:
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [liblouis](http://www.liblouis.org/), version 3.7.0
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 34.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)


### PR DESCRIPTION
### Link to issue number:
None

### Description of this pull request
This updates the CLDR emoji annotations from version 33.1 to 34.0. The new annotations include new emoji,
* [Release notes](http://cldr.unicode.org/index/downloads/cldr-34)

Relevant entries:

> * Many new emoji keywords and corrections/refinements of previous keywords and names
> * Updates from Emoji Subcommittee for collation and grouping, bringing similar emoji closer together — especially affecting smileys.
> * Reviewed and revised emoji names and keywords for most languages
> * Updated the emoji ordering to group characters more naturally [
> * Revised the derived name generation (for complex emoji) for more consistency with the new hair styles

### Testing performed:
Made sure that emoji still speak

### Known issues with pull request:
None

### Change log entry:
None