### PR TITLE
Fix crash in VBufStorage_buffer_t::getTextInRange when at the end of a buffer

### DIFF
--- a/nvdaHelper/remote/vbufRemote.cpp
+++ b/nvdaHelper/remote/vbufRemote.cpp
@@ -152,7 +152,8 @@ int VBufRemote_getTextLength(VBufRemote_bufferHandle_t buffer) {
 int VBufRemote_getTextInRange(VBufRemote_bufferHandle_t buffer, int startOffset, int endOffset, wchar_t** text, boolean useMarkup) {
 	VBufBackend_t* backend=(VBufBackend_t*)buffer;
 	backend->lock.acquire();
-	 wstring textString=backend->getTextInRange(startOffset,endOffset,useMarkup!=false);
+	 wstring textString;
+	 backend->getTextInRange(startOffset,endOffset,textString,useMarkup!=false);
 	backend->lock.release();
 	if(textString.empty()) {
 		return false;

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -912,19 +912,18 @@ int VBufStorage_buffer_t::getTextLength() const {
 	return length;
 }
 
-wstring  VBufStorage_buffer_t::getTextInRange(int startOffset, int endOffset, bool useMarkup) {
+bool VBufStorage_buffer_t::getTextInRange(int startOffset, int endOffset, wstring& text, bool useMarkup) {
 	if(this->rootNode==NULL) {
 		LOG_DEBUGWARNING(L"buffer is empty, returning NULL");
-		return NULL;
+		return false;
 	}
 	if(startOffset<0||startOffset>=endOffset||endOffset>this->rootNode->length) {
 		LOG_DEBUGWARNING(L"Bad offsets of "<<startOffset<<L" and "<<endOffset<<L", returning NULL");
-		return NULL;
+		return false;
 	}
-	wstring text;
 	this->rootNode->getTextInRange(startOffset,endOffset,text,useMarkup);
 	LOG_DEBUG(L"Got text between offsets "<<startOffset<<L" and "<<endOffset<<L", returning true");
-	return text;
+	return true;
 }
 
 VBufStorage_fieldNode_t* VBufStorage_buffer_t::findNodeByAttributes(int offset, VBufStorage_findDirection_t direction, const std::wstring& attribs, const std::wstring &regexp, int *startOffset, int *endOffset) {

--- a/nvdaHelper/vbufBase/storage.h
+++ b/nvdaHelper/vbufBase/storage.h
@@ -639,7 +639,7 @@ class VBufStorage_buffer_t {
  * @param useMarkup if true then markup is included in the text denoting field starts and ends.
  * @return the text.
  */
-	virtual std::wstring  getTextInRange(int startOffset, int endOffset, bool useMarkup=false);
+	virtual bool getTextInRange(int startOffset, int endOffset, std::wstring& text, bool useMarkup=false);
 
 /**
  * Expands the given offset to the start and end offsets of the containing line.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
PR #8866 (merging of VBufBackends into nvdaHelperRemote) introduced a crash in VBufStorage_buffer_t::getTextInRange.
To reproduce:
* Open Firefox
* Go to  URL: ``` data:text/html,<p></p> ```
* When focused in the document in browse mode, press right arrow and Firefox will crash.
This is because VBufStorage_buffer_t::getTextInRange is declaired as returning a wstring, but on some errors it returns NULL. I am very surprised the compiler allows this.

### Description of how this pull request fixes the issue:
This PR changes getTextInRange so that it takes a string by reference which it copies the text into, and it returns a bool communicating success or failure. Note that this is the way that the node-specific getTextInRange methods work already.

### Testing performed:
In Firefox:
* Arrowed up and down a standard html page with content.
* Pressed right arrow on a completely blank page. There was no crash.

### Known issues with pull request:
None.

### Change log entry:
None needed.
