### PR TITLE
Speech and Braille: don't report many clickables in a row in browse mode.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,6 +33,7 @@ What's New in NVDA
 - NVDA no longer refuses to report the focus on web pages where the new focus replaces a control that no longer exists. (#6606, #8341)
 - In the new Gmail, when using quick navigation inside messages while reading them, the entire body of the message is no longer reported after the element to which you just navigated. (#8887)
 - After updating NVDA, Browsers such as Firefox and google Chrome should no longer crash, and browse mode should continue to correctly reflect updates to any currently loaded documents. (#7641) 
+- NVDA no longer reports clickable multiple times in a row when navigating clickable content in Browse Mode. (#7430)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #7430

### Summary of the issue:
NVDA reports certain fields in browse mode as 'clickable' if the author has provided an onclick handler and NVDA would not normally report anything else for that field (E.g. has no reportable role).
However, with the increased use of onclick handlers on web pages, there are many cases where NVDA will report multiple clickables in a row E.g. "clickable clickable clickable clickable". This is extremely annoying.
To make things worse, versions of Chrome earlier than 63 also propagated the existence of the click action to all descendant accessibles, meaning that NVDA would report clickable for every descendant of a clickable node. Although this was fixed in Chrome a while back, many 3rd party apps that use Chromium / Electron (such as Microsoft Teams) still have this issue as they are using an older version of Chromium.
 
### Description of how this pull request fixes the issue:
Several solutions were described in issue #7430. This PR goes with solution 3 (collapsing clickables).
Although it wasn't the most perfect solution, it was the easiest to implement, and probably the easiest to follow code-wise. It also hopefully provides a good balance between usability and predictability. It is certainly a major improvement over what we currently have, but also erring on the side of reporting more than less.
In short: in both speech and braille now, NVDA will never report multiple clickables in a row without any other intervening text. As NVDA enters one or more clickable fields, it will only report clickable once. However, if one or more of these fields are exited, and then 1 or more new clickable fields are entered, NVDA will again report clickable, but only once when entering those new fields. To put it another way, NVDA will only report clickable once for any run of field starts.

 ### Testing performed:
Tested example in #7430. Multiple clickables in a row are now only announced as one clickable.
Also tested 
[clickables.html.txt](https://github.com/nvaccess/nvda/files/2551843/clickables.html.txt)
which contains various different paragraphs and divs containing single and nested clickable spans.

### Known issues with pull request:
None known.

### Change log entry:
Bug fixes:
* NVDA no longer reports clickable multiple times in a row when navigating clickable content in Browse Mode. (#7430)