### PR TITLE
VBufStorage: Fix crash by not allowing the reusing of nodes with differing parents.

### DIFF
--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -276,8 +276,8 @@ VBufStorage_controlFieldNode_t* VBufBackend_t::reuseExistingNodeInRender(VBufSto
 		LOG_DEBUG(L"Existing node refuses to be reused");
 		return nullptr;
 	}
-	// We only allow reusing nodes that remain at the same position in the tree.
-	// I.e. We never reuse a node that is from  a different parent.
+	// We only allow reusing nodes that share the same parent. 
+	// I.e. we don't allow reusing a node that existed in an entirely different part of the tree. 
 	// If we did, this could possibly cause corruption in the virtualBuffer as a node might move between two unrelated updates.
 	auto existingParent=existingNode->getParent();
 	if(!existingParent) {

--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -257,6 +257,10 @@ VBufBackend_t::~VBufBackend_t() {
 
 VBufStorage_controlFieldNode_t* VBufBackend_t::reuseExistingNodeInRender(VBufStorage_controlFieldNode_t* parent, VBufStorage_fieldNode_t* previous, int docHandle, int ID) {
 	LOG_DEBUG(L"Try to reuse node with docHandle "<<docHandle<<L", and ID "<<ID);
+	if(!parent) {
+		LOG_DEBUG(L"Cannot reuse a node at the root");
+		return nullptr;
+	}
 	if(parent->alwaysRerenderDescendants||parent->alwaysRerenderChildren) {
 		LOG_DEBUG(L"Won't  find a node to reuse as parent says always rerender children");
 		return nullptr;
@@ -270,6 +274,18 @@ VBufStorage_controlFieldNode_t* VBufBackend_t::reuseExistingNodeInRender(VBufSto
 	// Ensure the node allows us to reuse it
 	if(!existingNode->allowReuseInAncestorUpdate) {
 		LOG_DEBUG(L"Existing node refuses to be reused");
+		return nullptr;
+	}
+	// We only allow reusing nodes that remain at the same position in the tree.
+	// I.e. We never reuse a node that is from  a different parent.
+	// If we did, this could possibly cause corruption in the virtualBuffer as a node might move between two unrelated updates.
+	auto existingParent=existingNode->getParent();
+	if(!existingParent) {
+		LOG_DEBUG(L"existing node has no parent. Not reusing.");
+		return nullptr;
+	}
+	if(existingParent->identifier!=parent->identifier) {
+		LOG_DEBUG(L"Cannot reuse a node moved from within another parent.");
 		return nullptr;
 	}
 	if(existingNode->denyReuseIfPreviousSiblingsChanged) {

--- a/nvdaHelper/vbufBase/storage.h
+++ b/nvdaHelper/vbufBase/storage.h
@@ -312,12 +312,12 @@ class VBufStorage_controlFieldNode_t : public VBufStorage_fieldNode_t {
 
 	friend class VBufStorage_buffer_t;
 
+	public:
+
 /**
  * uniquely identifies this control in its buffer.
  */
-	VBufStorage_controlFieldNodeIdentifier_t identifier;
-
-	public:
+	const VBufStorage_controlFieldNodeIdentifier_t identifier;
 
 /**
  * If true, When this node is invalidated in a backend, its parent will be invalidated instead. 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #8924 

### Summary of the issue:
A web author can move a node from one place to another in the DOM. A web author can also move an accessible from one place to another within the accessibility tree, by dynamically changing aria-owns.
With the merging of pr #8678 this can in some cases cause NVDA to crash the web browser if NVDA's virtualBuffer for the document tries to reusethe moved node, as two separate updates may try to touch the same thing.
Examples of this are in #8924 including a real-life testcase in Gmail, and a specific code fragment.

### Description of how this pull request fixes the issue:
NVDA's virtualBuffer code now refuses to reuse an existing node when re-rendering a parent if the existing node has a different parent to what is being re-rendered. 
However, it still allows nodes to change ordering within a given parent (if the existing node does not directly disallow this, such as in tables). If we do not keep this, the German wikipedia page becomes as slow as it used to be in NVDA 2018.3.
 
### Testing performed:
Tested the speed of the German wikipedia page. Tested the speed of moving up and down the inbox in Gmail.
Tested the code fragment in #8924.
However, waiting on @marcoZehe to report if the try build in #8924 successfully fixes the crash for him.
I was never able to reproduce the crash.
 
### Known issues with pull request:
None.

### Change log entry:
None needed.