### PR TITLE
Make sure that user symbols without a replacement are properly ignored

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -469,6 +469,13 @@ class SpeechSymbolProcessor(object):
 					symbol=symbol.identifier, locale=self.locale))
 				del symbols[symbol.identifier]
 				try:
+					if len(symbol.identifier) == 1:
+						characters.remove(symbol.identifier)
+					else:
+						multiChars.remove(symbol.identifier)
+				except ValueError:
+					pass
+				try:
 					complexSymbolsList.remove(symbol)
 				except ValueError:
 					pass


### PR DESCRIPTION
### Link to issue number:
Related to #8931. It does not yet fix it, but provides a fix for the error involved.

### Summary of the issue:
When adding a symbol without a replacement to the user symbols, an error is raised when this symbol is encountered in text. This is because the symbol is properly removed from the list of symbols, but it is still included in the regex that is created to extract symbols from text in order to replace them.

### Description of how this pull request fixes the issue:
Remove the symbol identifier for a symbol without a replacement from the list of characters before building the regular expression.

### Testing performed:
Tested the steps to reproduce as explained in #8931.

### Known issues with pull request:
It does not fix #8931, this will require additional work and is a bit lower in priority.

### Change log entry:
* Bug fixes
    + NVDA no longer fails reading text in case a defined user symbol is encountered for which a replacement pattern isn't specified.