### PR TITLE
Fix case for outlook replied all status

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -42,7 +42,7 @@ executedVerbLabels={
 	# Translators: the last action taken on an Outlook mail message
 	VERB_REPLYTOSENDER:_("replied"),
 	# Translators: the last action taken on an Outlook mail message
-	VERB_REPLYTOALL:_("REPLIED ALL"),
+	VERB_REPLYTOALL:_("replied all"),
 	# Translators: the last action taken on an Outlook mail message
 	VERB_FORWARD:_("forwarded"),
 }


### PR DESCRIPTION
This pr is filed against beta.

### Link to issue number:
None

### Summary of the issue:
The outlook replied all status is presented in uppercase letters. This was probably a case of having the caps lock on by accident.

### Description of how this pull request fixes the issue:
Changed replied all to lower case
