### PR TITLE
Allow building with other Visual Studio 2017 editions (eg. Professional)

### DIFF
--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -44,7 +44,7 @@ localWin10Lib = env.SharedLibrary(
 # Therefore, we must include it.
 # VS 2017 keeps changing the path to reflect the latest major.minor.build version which we canot easily find out.
 # Therefore  Search these versioned directories from newest to oldest  to collect all the files we need.
-vcRedistDirs = glob.glob(os.path.join(progFilesX86, r"Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT"))
+vcRedistDirs = glob.glob(os.path.join(progFilesX86, r"Microsoft Visual Studio\2017\*\VC\Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT"))
 if len(vcRedistDirs)==0:
 	raise RuntimeError("Could not locate vc redistributables. Perhaps the Universal Windows Platform component in visual Studio is not installed") 
 vcRedistDirs.sort(reverse=True)

--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -15,6 +15,8 @@
 import os
 import glob
 
+from SCons.Tool.MSCommon.vc import find_vc_pdir
+
 Import(
 	'win10env',
 	'sourceDir',
@@ -22,11 +24,6 @@ Import(
 )
 
 env=win10env.Clone()
-
-progFilesX86 = os.getenv("ProgramFiles(x86)")
-if not progFilesX86:
-	# 32 bit system, so only one Program Files directory.
-	progFilesX86 = os.getenv("ProgramFiles")
 
 localWin10Lib = env.SharedLibrary(
 	target="nvdaHelperLocalWin10",
@@ -44,7 +41,8 @@ localWin10Lib = env.SharedLibrary(
 # Therefore, we must include it.
 # VS 2017 keeps changing the path to reflect the latest major.minor.build version which we canot easily find out.
 # Therefore  Search these versioned directories from newest to oldest  to collect all the files we need.
-vcRedistDirs = glob.glob(os.path.join(progFilesX86, r"Microsoft Visual Studio\2017\*\VC\Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT"))
+vcProductDir = find_vc_pdir("14.1")
+vcRedistDirs = glob.glob(os.path.join(vcProductDir, r"Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT"))
 if len(vcRedistDirs)==0:
 	raise RuntimeError("Could not locate vc redistributables. Perhaps the Universal Windows Platform component in visual Studio is not installed") 
 vcRedistDirs.sort(reverse=True)

--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -41,8 +41,10 @@ localWin10Lib = env.SharedLibrary(
 # Therefore, we must include it.
 # VS 2017 keeps changing the path to reflect the latest major.minor.build version which we canot easily find out.
 # Therefore  Search these versioned directories from newest to oldest  to collect all the files we need.
-vcProductDir = find_vc_pdir("14.1")
-vcRedistDirs = glob.glob(os.path.join(vcProductDir, r"Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT"))
+vcRedistDirs = glob.glob(os.path.join(
+    find_vc_pdir(env.get("MSVC_VERSION")),
+    r"Redist\MSVC\%s*\x86\Microsoft.VC141.CRT" % env.get("MSVC_VERSION")
+))
 if len(vcRedistDirs)==0:
 	raise RuntimeError("Could not locate vc redistributables. Perhaps the Universal Windows Platform component in visual Studio is not installed") 
 vcRedistDirs.sort(reverse=True)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,7 @@ What's New in NVDA
 
 
 == Changes for Developers ==
+- NVDA can now  be built with all editions of Microsoft Visual Studio 2017 (not just the Community edition). (#8939)
 
 
 = 2018.4 =


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8939

### Summary of the issue:
Currently, NVDA requires Visual Studio 2017 Community edition in order to build from source.
This PR allows to also build with other edition, like Professional.

### Description of how this pull request fixes the issue:
The build process requires the file `Microsoft.VC141.CRT`, which currently cannot be found with other editions of Visual Studio 2017.

In `nvdaHelper/localWin10/sconscript`, replace the glob `Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT` with `Microsoft Visual Studio\2017\*\VC\Redist\MSVC\14.1*\x86\Microsoft.VC141.CRT`, that is, replacing `Community` with `*`, to allow resolving the required file.

### Testing performed:
Successfully built using Visual Studio 2017 Professional version 15.6.1

### Known issues with pull request:
Could someone please validate the build using Visual Studio 2017 Community as well?
EDIT: Seems like AppVeyor volunteered…

### Change log entry:

Section: Changes for Developpers
NVDA can now also be built with other editions of Microsoft Visual Studio 2017 (used to require Community edition).

