### PR TITLE
Add `class` to MSHTML attributes (#8941)

### DIFF
--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -459,6 +459,7 @@ inline void getAttributesFromHTMLDOMNode(IHTMLDOMNode* pHTMLDOMNode,wstring& nod
 	macro_addHTMLAttributeToMap(L"onmousedown",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"onmouseup",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"required",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
+	macro_addHTMLAttributeToMap(L"class",true,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	//ARIA properties:
 	macro_addHTMLAttributeToMap(L"role",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"aria-roledescription",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8941

### Summary of the issue:
Discussed this issue with @michaelDCurran and @leonardder in Frankfurt during SightCity.
The goal is here to ease the development of adaptations for complex web sites and business web applications.
Even if Microsoft has dropped mainstream support for Internet Explorer, it is still a widely used industry standard, and a lot of business web applications are still exclusively targeted to it.

When browsing with Firefox or Chrome, NVDA provides access to the HTML class attribute through IAccessible2.
When browsing with Internet Explorer, this information is not provided through MSHTML.

### Description of how this pull request fixes the issue:
Add the HTML class to the MSHTML attributes.

### Testing performed:
We are already using this small patch in production with custom builds since 2016.4 up to current 2018.3.2

### Known issues with pull request:

### Change log entry:

Probably too specific to be mentioned?

