### PR TITLE
Basic implementation for Foxit Reader

### DIFF
--- a/source/appModules/foxitreader.py
+++ b/source/appModules/foxitreader.py
@@ -1,0 +1,23 @@
+#foxitreader.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2018 NV Access Limited, Babbage B.V.
+
+import appModuleHandler
+from NVDAObjects.UIA import UIA
+import cursorManager
+from UIABrowseMode import UIABrowseModeDocument
+import controlTypes
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if isinstance(obj,UIA) and obj.UIAElement.cachedClassName == "FoxitPDFDocument":
+			clsList.insert(0, FoxitRoot)
+
+class FoxitRoot(UIA):
+	treeInterceptorClass = UIABrowseModeDocument
+
+	def _get_shouldCreateTreeInterceptor(self):
+		return self.role==controlTypes.ROLE_DOCUMENT


### PR DESCRIPTION
### Link to issue number:
Fixes #8944

### Summary of the issue:
It is currently not possible to read PDF files in Foxit Reader.

According to @gauldoth:

> Foxit Reader has implemented MSAA and PDF Dom interface in version 9.3.
> The UIA implementation is not complete yet. Out of process queries are quite slow due to some unknown reasons. But their developers have implemented both MSAA and PDDom for the document, the UIA implementation may be removed in future releases.

### Description of how this pull request fixes the issue:
Added a pretty simple appModule that uses the Adobe Acrobat code to make Foxit Reader accessible.

### Testing performed:
Opened several documents in Foxit Reader 9.3, they all read properly.

### Known issues with pull request:
None

### Change log entry:
* New features
    + NVDA is now able to read PDF documents when using Foxit Reader. (#8944) 