### PR TITLE
Add support for Foxit Reader and Foxit PhantomPDF (#8944)

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -497,7 +497,7 @@ the NVDAObject for IAccessible
 		if windowClassName.startswith("Internet Explorer_"):
 			from . import MSHTML
 			MSHTML.findExtraIAccessibleOverlayClasses(self, clsList)
-		elif windowClassName == "AVL_AVView":
+		elif windowClassName in ("AVL_AVView", "FoxitDocWnd"):
 			from . import adobeAcrobat
 			adobeAcrobat.findExtraOverlayClasses(self, clsList)
 		elif windowClassName == "WebViewWindowClass":

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -61,6 +61,7 @@ badUIAWindowClassNames=[
 	# #7497: Windows 10 Fall Creators Update has an incomplete UIA implementation for console windows, therefore for now we should ignore it.
 	# It does not implement caret/selection, and probably has no new text events.
 	"ConsoleWindowClass",
+	"FoxitDocWnd",
 ]
 
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -61,6 +61,7 @@ badUIAWindowClassNames=[
 	# #7497: Windows 10 Fall Creators Update has an incomplete UIA implementation for console windows, therefore for now we should ignore it.
 	# It does not implement caret/selection, and probably has no new text events.
 	"ConsoleWindowClass",
+	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 	"FoxitDocWnd",
 ]
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -211,6 +211,7 @@ Highlights of this release include  support for charts in Microsoft word and Pow
  - NVDA's braille input functionality can be used with these as well as other BC6 displays with firmware 3.0.0 and above.
 - Early support for Google Sheets with Braille mode enabled. (#7935)
 - Support for Eurobraille Esys, Esytime and Iris braille displays. (#7488)
+- Added support for Foxit Reader and Foxit PhantomPDF. (#8944)
 
 
 == Changes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,7 @@ What's New in NVDA
 - NVDA is now able to read descriptions for emoji as well as other characters that are part of the Unicode Common Locale Data Repository. (#6523)
 - In Microsoft Word, the cursor's distance from the top and left edges of the page can be reported by pressing NVDA+numpadDelete. (#1939)
 - In Google Sheets with braille mode enabled, NVDA no longer announces 'selected' on every cell when moving focus between cells. (#8879)
+- Add support for Foxit Reader and Foxit Phantom PDF (#8944)
 
 
 == Changes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -211,7 +211,6 @@ Highlights of this release include  support for charts in Microsoft word and Pow
  - NVDA's braille input functionality can be used with these as well as other BC6 displays with firmware 3.0.0 and above.
 - Early support for Google Sheets with Braille mode enabled. (#7935)
 - Support for Eurobraille Esys, Esytime and Iris braille displays. (#7488)
-- Added support for Foxit Reader and Foxit PhantomPDF. (#8944)
 
 
 == Changes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #8944

### Summary of the issue:
It is currently not possible to read PDF files in Foxit Reader.

Foxit Reader has implemented MSAA and PDF Dom interface in version 9.3.
The UIA implementation is not complete yet. Out of process queries are quite slow due to some unknown reasons. But their developers have implemented both MSAA and PDDom for the document, the UIA implementation may be removed in future releases.

Foxit PhantomPDF exposed the same interface as Foxit Reader did.

### Description of how this pull request fixes the issue:
Use Adobe Acrobat code to make Foxit Reader accessible.
Ignore Foxit Reader's UIA implementation.

### Testing performed:
Tested with Foxit Reader 9.3 and Foxit PhantomPDF 9.3 by me.
Tested with several PDF documents and PDF forms by me.
The guys from Foxit have tested against NVDA for a few weeks.

### Known issues with pull request:
None

### Change log entry:

Section: New features

* Add support for Foxit Reader and Foxit Phantom PDF (#8944)