### PR TITLE
Baum braille displays: fix broken input when no model identifier is set for a display

### DIFF
--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -225,8 +225,9 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 	def __init__(self, model, keysDown):
 		super(InputGesture, self).__init__()
 		# Model identifiers should not contain spaces.
-		self.model = model.replace(" ", "")
-		assert(self.model.isalnum())
+		if model:
+			self.model = model.replace(" ", "")
+			assert(self.model.isalnum())
 		self.keysDown = dict(keysDown)
 
 		self.keyNames = names = []

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -34,6 +34,7 @@ What's New in NVDA
 - In the new Gmail, when using quick navigation inside messages while reading them, the entire body of the message is no longer reported after the element to which you just navigated. (#8887)
 - After updating NVDA, Browsers such as Firefox and google Chrome should no longer crash, and browse mode should continue to correctly reflect updates to any currently loaded documents. (#7641) 
 - NVDA no longer reports clickable multiple times in a row when navigating clickable content in Browse Mode. (#7430)
+- Gestures performed on baum Vario 40 braille displays will no longer fail to execute. (#8894)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #8894 

### Summary of the issue:
Some Baum braille displays, such as the Vario 40, seem to provide no model identifier. The current baum driver requires a model identifier to execute gestures.

### Description of how this pull request fixes the issue:
Allow creating gesture objects without a model identifier.

### Testing performed:
Tests performed by @nishimotz erikpro 

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + Gestures performed on baum Vario 40 braille displays will no longer fail to execute. (#8894)
