### PR TITLE
What's new: fixed capitalization problem in the word 'in' in changelog for 2018.4.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -18,7 +18,7 @@ Highlights of this release include performance improvements in recent Mozilla Fi
 
 == Changes ==
 - "Report help balloons" in the Object Presentations dialog has been renamed to "Report notifications" to include reporting of toast notifications in Windows 8 and later. (#5789)
-- IN NVDA's keyboard settings, the checkboxes to enable or disable NVDA modifier keys are now displayed in a list rather than as separate checkboxes.
+- In NVDA's keyboard settings, the checkboxes to enable or disable NVDA modifier keys are now displayed in a list rather than as separate checkboxes.
 - NVDA will no longer present redundant information when reading clock system tray on some versions of Windows. (#4364)
 - Updated liblouis braille translator to version 3.7.0. (#8697)
 - Updated eSpeak-NG to commit 919f3240cbb.


### PR DESCRIPTION
This is opened against Beta.
### Link to issue number:
None
### Summary of the issue:
The word 'in' in the entry:

> IN NVDA's keyboard settings, the checkboxes to enable or disable NVDA modifier keys are now displayed in a list rather than as separate checkboxes. 

was written with all caps.
### Description of how this pull request fixes the issue:
Replaced capital N with the small one.
### Testing performed:
Build documentation via SCons.
### Known issues with pull request:
None
### Change log entry:
None needed.