### PR TITLE
Support the custom aria-goog-editable attribute to improve support for Google Slides 

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -59,6 +59,9 @@ class Ia2Web(IAccessible):
 		# This is necessary for other code that calculates how selection of cells should be spoken.
 		if 'gridcell' in self.IA2Attributes.get('xml-roles','').split(' '):
 			states.add(controlTypes.STATE_FOCUSABLE)
+		# Google has a custom ARIA attribute to force a node's editable state off (such as in Google Slides).
+		if self.IA2Attributes.get('goog-editable')=="false":
+			states.discard(controlTypes.STATE_EDITABLE)
 		return states
 
 class Document(Ia2Web):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -38,6 +38,7 @@ Highlights of this release include performance improvements in recent Mozilla Fi
 - After updating NVDA, Browsers such as Firefox and google Chrome should no longer crash, and browse mode should continue to correctly reflect updates to any currently loaded documents. (#7641) 
 - NVDA no longer reports clickable multiple times in a row when navigating clickable content in Browse Mode. (#7430)
 - Gestures performed on baum Vario 40 braille displays will no longer fail to execute. (#8894)
+- In Google Slides with Mozilla Firefox, NVDA no longer reports selected text on every control with focus. (#8964)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
In Google Slides, Google makes use of contenteditable for technical reasons, even when the content in question is read-only as far as the user is concerned.
This means that when moving focus around a slide, NVDA sees the focused node is editable and therefore tries to read it like it would an edit field (I.e. announces he current line of text where the caret is, or in many cases, what is selected).
Google has fixed this internally in Google Chrome by not exposing the editable state on IAccessible2 objects in this specific situation, but in Firefox, they expose a custom aria-goog-editable attribute set to False, denoting that although contenteditable is used, accessibility should reflect that it is not editable.
NVDA should honor this attribute and drop the editable state itself.
 In future, this attribute could be standardized by ARIA as aria-editable.

### Description of how this pull request fixes the issue:
This PR detects aria-goog-editable, and if false, discards the editable state from NVDAObjects. Thus, when moving around Google Slides, focus is announced like a normal non-editable control, rather than an edit field.


### Testing performed:
Opened an existing slide dec in Google Slides. Moved focus around a slide using tab and shift+tab. Current line / selection was not announced, rather  just the control itself.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* In Google Slides, NVDA no longer reports selected text on each control.