### PR TITLE
OneCore speech: do not append silence at the end of every speech utterance

### DIFF
--- a/nvdaHelper/localWin10/oneCoreSpeech.cpp
+++ b/nvdaHelper/localWin10/oneCoreSpeech.cpp
@@ -37,7 +37,7 @@ OcSpeech* __stdcall ocSpeech_initialize() {
 	instance->synth = ref new SpeechSynthesizer();
 	// By default, OneCore speech appends a  large annoying chunk of silence at the end of every utterance.
 	// Newer versions of OneCore speech allow disabling this feature, so turn it off where possible.
-	if (ApiInformation::IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7, 0)) {
+	if (ApiInformation::IsApiContractPresent("Windows.Foundation.UniversalApiContract", 6, 0)) {
 		auto options = instance->synth->Options;
 		options->AppendedSilence = SpeechAppendedSilence::Min;
 	}

--- a/nvdaHelper/localWin10/oneCoreSpeech.cpp
+++ b/nvdaHelper/localWin10/oneCoreSpeech.cpp
@@ -30,10 +30,17 @@ using namespace Windows::Storage::Streams;
 using namespace Microsoft::WRL;
 using namespace Windows::Media;
 using namespace Windows::Foundation::Collections;
+using Windows::Foundation::Metadata::ApiInformation;
 
 OcSpeech* __stdcall ocSpeech_initialize() {
 	auto instance = new OcSpeech;
 	instance->synth = ref new SpeechSynthesizer();
+	// By default, OneCore speech appends a  large annoying chunk of silence at the end of every utterance.
+	// Newer versions of OneCore speech allow disabling this feature, so turn it off where possible.
+	if (ApiInformation::IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7, 0)) {
+		auto options = instance->synth->Options;
+		options->AppendedSilence = SpeechAppendedSilence::Min;
+	}
 	return instance;
 }
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,6 +12,7 @@ What's New in NVDA
 
 
 == Bug Fixes ==
+- OneCore speech synthesizer: On Windows 10 April 2018 and above, large chunks of silence are no longer inserted between speech utterances. (#8985)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
By default, OneCore speech appends a large annoying chunk of silence at the end of every speech utterance. For example, when NVDA announces a newly opened dialog, there is a large chunk of silence after announcing the dialog itself, and befor announcing the control with focus within the dialog.
Up until the Windows 10 Fall 2017 release, it was impossible to disable this feature.
As it is now possible to disable, NVDA should.

### Description of how this pull request fixes the issue:
Code taken directly from #8934.  If supported, this PR sets OneCore speech's appendSilence synth option to the minimum value (essentially disabling the feature). 

### Testing performed:
Tested NVDA using OneCore speech on Windows 10 Fall 2018: silence is no longer appended.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
OneCore speech synthesizer: On Windows 10 Fall 2017 and above, large chunks of silence are no longer inserted between  speech utterances.