### PR TITLE
Add Somali to the languageHandler manually, because it is not recognized on Windows 7

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -83,6 +83,8 @@ def getLanguageDescription(language):
 			"kmr":pgettext("languageName","Northern Kurdish"),
 			# Translators: The name of a language supported by NVDA.
 			"my":pgettext("languageName","Burmese"),
+			# Translators: The name of a language supported by NVDA.
+			"so":pgettext("languageName","Somali"),
 		}.get(language,None)
 	return desc
 


### PR DESCRIPTION
This pr is based on beta.
### Link to issue number:
Fixes #8984
### Summary of the issue:
On Windows 7 Somali is not  recognized by default.
### Description of how this pull request fixes the issue:
Add Somali to the languageHandler manually.
### Testing performed:
Tested, that Somali is shown as Somali and not as So on Windows 7.
### Known issues with pull request:
None
### Change log entry:
If it would be included in 2018.4 there is no need for change log entry, because Somali is added in this version.