### PR TITLE
Speak ordinal and hex value of 32 bit unicode characters when pressing review current character three times

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1127,9 +1127,24 @@ class GlobalCommands(ScriptableObject):
 		else:
 			try:
 				c = ord(info.text)
+			except TypeError:
+				# This might be a character taking multiple code points.
+				# If it is a 32 bit character, encode it to UTF-32 and calculate the ord manually.
+				# In Python 3, this is no longer necessary.
+				try:
+					encoded = info.text.encode("utf_32_le")
+				except UnicodeEncodeError:
+					c = None
+				else:
+					if len(encoded)==4:
+						c = sum(ord(cp)<<i*8 for i, cp in enumerate(encoded))
+					else:
+						c = None
+			if c is not None:
 				speech.speakMessage("%d," % c)
 				speech.speakSpelling(hex(c))
-			except:
+			else:
+				log.debugWarning("Couldn't calculate ordinal for character %r" % info.text)
 				speech.speakTextInfo(info,unit=textInfos.UNIT_CHARACTER,reason=controlTypes.REASON_CARET)
 	# Translators: Input help mode message for report current character under review cursor command.
 	script_review_currentCharacter.__doc__=_("Reports the character of the current navigator object where the review cursor is situated. Pressing twice reports a description or example of that character. Pressing three times reports the numeric value of the character in decimal and hexadecimal")


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
STR:
1. Paste 🤦 into notepad and move to it.
2. Press read character 3 times.

I expect to get the unicode value of the character, but I only get the emoji repeated again.

_Originally posted by @tspivey in https://github.com/nvaccess/nvda/pull/8953#issuecomment-443030839_

### Description of how this pull request fixes the issue:
When the ord function fails on a character and the UTF-32 encoded character is 4 bytes in size (i.e. it is really just one character), calculate the ordinal value manually. This will no longer be necessary in Python 3.

### Testing performed:
Tested with several emoji

### Known issues with pull request:
None

### Change log entry:
None needed
