### PR TITLE
Improve accuracy of caret location script in MS Word

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -565,17 +565,22 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 
 	def _get_locationText(self):
 		textList=[]
-		offset=self._rangeObj.information(wdHorizontalPositionRelativeToPage)
+		# #8994: MS Word can only give accurate distances (taking paragraph indenting into account) when directly querying the selection. 
+		r=self._rangeObj
+		s=self.obj.WinwordSelectionObject
+		if s.isEqual(r):
+			r=s
+		else:
+			return super(WordDocumentTextInfo,self).locationText
+		offset=r.information(wdHorizontalPositionRelativeToPage)
 		distance=self.obj.getLocalizedMeasurementTextForPointSize(offset)
 		# Translators: a distance from the left edge of the page in Microsoft Word
 		textList.append(_("{distance} from left edge of page").format(distance=distance))
-		offset=self._rangeObj.information(wdVerticalPositionRelativeToPage)
+		offset=r.information(wdVerticalPositionRelativeToPage)
 		distance=self.obj.getLocalizedMeasurementTextForPointSize(offset)
 		# Translators: a distance from the left edge of the page in Microsoft Word
 		textList.append(_("{distance} from top edge of page").format(distance=distance))
 		return ", ".join(textList)
-
-
 
 	def copyToClipboard(self):
 		self._rangeObj.copy()


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8994 

### Summary of the issue:
The reportLocation script (NVDA+numpadDelete) does not work accurately in MS Word as it does not take paragraph indenting into account.
It seems that in the MS Word object model: `range.information(wdHorizontalPositionRelativeToPage)` does not take paragraph indenting into account, yet `selection.information(wdHorizontalPositionRelativeToPage)` does.

### Description of how this pull request fixes the issue:
The implementation of the locationText property on WordDocumentTextInfo now uses `selection.information` to fetch the distances, rather than `range.information`, if the TextInfo's range is equal to the selection. If it is not equal, this property refuses to provide distances as they would be incorrect and there is no other way to find them out at this stage.

### Testing performed:
Tested with MS Word 2016/365, with both indented and normal paragraphs. The reportLocation script correctly took paragraph indenting into account.

### Known issues with pull request:
It is no longer possible to find out distances for the review position if moved away from the selection, or if the selection is not collapsed.
 
### Change log entry:
None needed.
