### PR TITLE
Update liblouis to version 3.8, add debug logging functionality and cleanup old workarounds that are no longer necessary

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -23,6 +23,7 @@ Import([
 louisRootDir = env.Dir("#include/liblouis")
 louisSourceDir = louisRootDir.Dir("liblouis")
 outDir = sourceDir.Dir("louis")
+signExec=env['signExec'] if env['certFile'] else None
 
 RE_AC_INIT = re.compile(r"^AC_INIT\(\[(?P<package>.*)\], \[(?P<version>.*)\], \[(?P<bugReport>.*)\], \[(?P<tarName>.*)\], \[(?P<url>.*)\]\)")
 def getLouisVersion():
@@ -74,6 +75,8 @@ sourceFiles = [
 ]
 objs = [env.Object("%s.obj" % f, louisSourceDir.File(f)) for f in sourceFiles]
 louisLib = env.SharedLibrary("liblouis", objs)
+if signExec:
+	env.AddPostAction(louisLib[0],[signExec])
 env.Install(sourceDir, louisLib)
 
 louisPython = env.Substfile(outDir.File("__init__.py"), louisRootDir.File("python/louis/__init__.py.in"),

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ For reference, the following dependencies are included in Git submodules:
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
-* [liblouis](http://www.liblouis.org/), version 3.7.0
+* [liblouis](http://www.liblouis.org/), version 3.8.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 34.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ For reference, the following dependencies are included in Git submodules:
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
-* [liblouis](http://www.liblouis.org/), version 3.8.0
+* [liblouis](http://www.liblouis.org/), version 3.8.0, commit 90a808bf
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 34.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest

--- a/source/braille.py
+++ b/source/braille.py
@@ -13,6 +13,7 @@ import ctypes.wintypes
 import threading
 import time
 import wx
+import louisHelper
 import louis
 import gui
 import winKernel
@@ -1571,6 +1572,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	]
 
 	def __init__(self):
+		louisHelper.initialize()
 		self.display = None
 		self.displaySize = 0
 		self.mainBuffer = BrailleBuffer(self)
@@ -1604,6 +1606,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.display.terminate()
 			self.display = None
 		_BgThread.stop(timeout=bgThreadStopTimeout)
+		louisHelper.terminate()
 
 	def getTether(self):
 		return self._tether

--- a/source/braille.py
+++ b/source/braille.py
@@ -418,36 +418,14 @@ class Region(object):
 		mode = louis.dotsIO
 		if config.conf["braille"]["expandAtCursor"] and self.cursorPos is not None:
 			mode |= louis.compbrlAtCursor
-		text=unicode(self.rawText).replace('\0','')
-		braille, self.brailleToRawPos, self.rawToBraillePos, brailleCursorPos = louis.translate(
+		self.brailleCells, self.brailleToRawPos, self.rawToBraillePos, self.brailleCursorPos = louisHelper.translate(
 			[os.path.join(brailleTables.TABLES_DIR, config.conf["braille"]["translationTable"]),
 				"braille-patterns.cti"],
-			text,
-			# liblouis mutates typeform if it is a list.
-			typeform=tuple(self.rawTextTypeforms) if isinstance(self.rawTextTypeforms, list) else self.rawTextTypeforms,
-			mode=mode, cursorPos=self.cursorPos or 0)
-		# liblouis gives us back a character string of cells, so convert it to a list of ints.
-		# For some reason, the highest bit is set, so only grab the lower 8 bits.
-		self.brailleCells = [ord(cell) & 255 for cell in braille]
-		# #2466: HACK: liblouis incorrectly truncates trailing spaces from its output in some cases.
-		# Detect this and add the spaces to the end of the output.
-		if self.rawText and self.rawText[-1] == " ":
-			# rawToBraillePos isn't truncated, even though brailleCells is.
-			# Use this to figure out how long brailleCells should be and thus how many spaces to add.
-			correctCellsLen = self.rawToBraillePos[-1] + 1
-			currentCellsLen = len(self.brailleCells)
-			if correctCellsLen > currentCellsLen:
-				self.brailleCells.extend((0,) * (correctCellsLen - currentCellsLen))
-		if self.cursorPos is not None:
-			# HACK: The cursorPos returned by liblouis is notoriously buggy (#2947 among other issues).
-			# rawToBraillePos is usually accurate.
-			try:
-				brailleCursorPos = self.rawToBraillePos[self.cursorPos]
-			except IndexError:
-				pass
-		else:
-			brailleCursorPos = None
-		self.brailleCursorPos = brailleCursorPos
+			self.rawText,
+			typeform=self.rawTextTypeforms,
+			mode=mode,
+			cursorPos=self.cursorPos
+		)
 		if self.selectionStart is not None and self.selectionEnd is not None:
 			try:
 				# Mark the selection.

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -65,6 +65,9 @@ RENAMED_TABLES = {
 	"ar-fa.utb" : "fa-ir-g1.utb",
 	"da-dk-g16.utb":"da-dk-g16.ctb",
 	"da-dk-g18.utb":"da-dk-g18.ctb",
+	"de-de-g0.utb":"de-g0.utb",
+	"de-de-g1.ctb":"de-g1.ctb",
+	"de-de-g2.ctb":"de-g2.ctb",
 	"en-us-comp8.ctb" : "en-us-comp8-ext.utb",
 	"fr-ca-g1.utb":"fr-bfu-comp6.utb",
 	"Fr-Ca-g2.ctb":"fr-bfu-g2.ctb",
@@ -83,7 +86,13 @@ RENAMED_TABLES = {
 # Add builtin tables.
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("ar-ar-comp8.utb", _("Arabic 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("ar-ar-g1.utb", _("Arabic grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("ar-ar-g2.ctb", _("Arabic grade 2"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("as-in-g1.utb", _("Assamese grade 1"))
@@ -128,13 +137,13 @@ addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2"), contracted=True)
 addTable("de-de-comp8.ctb", _("German 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("de-de-g0.utb", _("German grade 0"))
+addTable("de-g0.utb", _("German grade 0"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("de-de-g1.ctb", _("German grade 1"))
+addTable("de-g1.ctb", _("German grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("de-de-g2.ctb", _("German grade 2"), contracted=True)
+addTable("de-g2.ctb", _("German grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("el.ctb", _("Greek (Greece)"))
@@ -174,6 +183,9 @@ addTable("Es-Es-G0.utb", _("Spanish 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("es-g1.ctb", _("Spanish grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("es-g2.ctb", _("Spanish grade 2"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("et-g0.utb", _("Estonian grade 0"))

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -202,6 +202,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	hwIo = boolean(default=false)
 	audioDucking = boolean(default=false)
 	gui = boolean(default=false)
+	louis = boolean(default=false)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -168,7 +168,7 @@ class Logger(logging.Logger):
 		self._log(log.IO, msg, args, **kwargs)
 
 	def exception(self, msg="", exc_info=True, **kwargs):
-		"""Log an exception at an appropriate levle.
+		"""Log an exception at an appropriate level.
 		Normally, it will be logged at level "ERROR".
 		However, certain exceptions which aren't considered errors (or aren't errors that we can fix) are expected and will therefore be logged at a lower level.
 		"""

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -1,0 +1,46 @@
+#louisHelper.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2018 NV Access Limited, Babbage B.V.
+
+"""Helper module to ease communication to and from liblouis."""
+
+import louis
+from logHandler import log
+
+LOUIS_TO_NVDA_LOG_LEVELS = {
+	louis.LOG_ALL: log.DEBUG,
+	louis.LOG_DEBUG: log.DEBUG,
+	louis.LOG_INFO: log.INFO,
+	louis.LOG_WARN: log.WARNING,
+	louis.LOG_ERROR: log.ERROR,
+	louis.LOG_FATAL: log.ERROR,
+}
+
+@louis.logcallback
+def louis_log(level, message):
+	if not _isDebug():
+		return
+	NVDALevel = LOUIS_TO_NVDA_LOG_LEVELS.get(level, log.DEBUG)
+	if not log.isEnabledFor(NVDALevel):
+		return
+	message = message.decode("ASCII")
+	codepath = "liblouis at internal log level %d" % level
+	log._log(NVDALevel, message, [], codepath=codepath)
+
+def _isDebug():
+	return config.conf["debugLog"]["louis"]
+
+def initialize():
+	# Register the liblouis logging callback.
+	louis.registerLogCallback(louis_log)
+	# Set the log level to debug.
+	# The NVDA logging callback will filter messages appropriately.
+	louis.setLogLevel(louis.LOG_DEBUG)
+
+def terminate():
+	# Set the log level to off.
+	louis.setLogLevel(louis.LOG_OFF)
+	# Unregister the liblouis logging callback.
+	louis.registerLogCallback(None)

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -69,15 +69,6 @@ def translate(tableList, inbuf, typeform=None, cursorPos=None, mode=0):
 	# liblouis gives us back a character string of cells, so convert it to a list of ints.
 	# For some reason, the highest bit is set, so only grab the lower 8 bits.
 	braille = [ord(cell) & 255 for cell in braille]
-	# #2466: HACK: liblouis incorrectly truncates trailing spaces from its output in some cases.
-	# Detect this and add the spaces to the end of the output.
-	if inbuf and inbuf[-1] == " ":
-		# rawToBraillePos isn't truncated, even though brailleCells is.
-		# Use this to figure out how long brailleCells should be and thus how many spaces to add.
-		correctCellsLen = rawToBraillePos[-1] + 1
-		currentCellsLen = len(braille)
-		if correctCellsLen > currentCellsLen:
-			braille.extend((0,) * (correctCellsLen - currentCellsLen))
 	if cursorPos is not None:
 		# HACK: The cursorPos returned by liblouis is notoriously buggy (#2947 among other issues).
 		# rawToBraillePos is usually accurate.

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -36,7 +36,7 @@ def _isDebug():
 def initialize():
 	# Register the liblouis logging callback.
 	louis.registerLogCallback(louis_log)
-	# Set the log level to all.
+	# Set the log level to debug.
 	# The NVDA logging callback will filter messages appropriately,
 	# i.e. error messages will be logged at the error level.
 	louis.setLogLevel(louis.LOG_DEBUG)

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -8,6 +8,7 @@
 
 import louis
 from logHandler import log
+import config
 
 LOUIS_TO_NVDA_LOG_LEVELS = {
 	louis.LOG_ALL: log.DEBUG,
@@ -18,7 +19,7 @@ LOUIS_TO_NVDA_LOG_LEVELS = {
 	louis.LOG_FATAL: log.ERROR,
 }
 
-@louis.logcallback
+@louis.LogCallback
 def louis_log(level, message):
 	if not _isDebug():
 		return
@@ -35,12 +36,15 @@ def _isDebug():
 def initialize():
 	# Register the liblouis logging callback.
 	louis.registerLogCallback(louis_log)
-	# Set the log level to debug.
-	# The NVDA logging callback will filter messages appropriately.
-	louis.setLogLevel(louis.LOG_DEBUG)
+	# Set the log level to all.
+	# The NVDA logging callback will filter messages appropriately,
+	# i.e. error messages will be logged at the error level.
+	louis.setLogLevel(louis.LOG_ALL)
 
 def terminate():
 	# Set the log level to off.
 	louis.setLogLevel(louis.LOG_OFF)
 	# Unregister the liblouis logging callback.
 	louis.registerLogCallback(None)
+	# Free liblouis resources
+	louis.liblouis.lou_free()

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -52,10 +52,8 @@ def terminate():
 def translate(tableList, inbuf, typeform=None, cursorPos=None, mode=0):
 	"""
 	Convenience wrapper for louis.translate that:
-	* returns a list of integers instead of an string with cells;
-	* uses an alternative approach to  calculate the cursor position;
-	* distinguishes between cursor position 0 (cursor at first character) and None (no cursor at all);
-	* Works around truncation of trailing spaces from the output
+	* returns a list of integers instead of an string with cells, and
+	* distinguishes between cursor position 0 (cursor at first character) and None (no cursor at all)
 	"""
 	text = unicode(inbuf).replace('\0','')
 	braille, brailleToRawPos, rawToBraillePos, brailleCursorPos = louis.translate(
@@ -69,13 +67,6 @@ def translate(tableList, inbuf, typeform=None, cursorPos=None, mode=0):
 	# liblouis gives us back a character string of cells, so convert it to a list of ints.
 	# For some reason, the highest bit is set, so only grab the lower 8 bits.
 	braille = [ord(cell) & 255 for cell in braille]
-	if cursorPos is not None:
-		# HACK: The cursorPos returned by liblouis is notoriously buggy (#2947 among other issues).
-		# rawToBraillePos is usually accurate.
-		try:
-			brailleCursorPos = rawToBraillePos[cursorPos]
-		except IndexError:
-			pass
-	else:
+	if cursorPos is None:
 		brailleCursorPos = None
 	return braille, brailleToRawPos, rawToBraillePos, brailleCursorPos

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -39,7 +39,7 @@ def initialize():
 	# Set the log level to all.
 	# The NVDA logging callback will filter messages appropriately,
 	# i.e. error messages will be logged at the error level.
-	louis.setLogLevel(louis.LOG_ALL)
+	louis.setLogLevel(louis.LOG_DEBUG)
 
 def terminate():
 	# Set the log level to off.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,9 +6,11 @@ What's New in NVDA
 = 2019.1 =
 
 == New Features ==
+- New braille tables: Arabic 8 dot computer braille, Arabic grade 2, Spanish grade 2. (#4435)
 
 
 == Changes ==
+- Updated liblouis braille translator to version 3.8.0. (#9013)
 
 
 == Bug Fixes ==
@@ -18,6 +20,7 @@ What's New in NVDA
 
 == Changes for Developers ==
 - NVDA can now  be built with all editions of Microsoft Visual Studio 2017 (not just the Community edition). (#8939)
+- You can now include log output from liblouis into the NVDA log by setting the louis boolean flag in the debugLogging section of the NVDA configuration. (#4554)
 
 
 = 2018.4 =


### PR DESCRIPTION
### Link to issue number:
Closes #9013 
Closes #4435
Closes #4554 

### Description of this pull request
1. Updates liblouis to version 3.8, thereby dealing with renamed tables. Also added grade 2 tables for Arabic and Spanish, and an Arabic 8 dot computer braille table.
2. Add the possibility to send liblouis' log output to the NVDA log. This is the reason why we are at liblouis commit 90a808bf, and not at 3.8.0 itself.
    The log output can be enabled by setting config.conf['debugLog']['louis'] to True. While @jcsteh suggested in https://github.com/nvaccess/nvda/issues/4554#issuecomment-315663267 to throw everything in at level debug, I think I've been able to come up with a sane mapping of louis levels to NVDA levels.
3. Now we are introducing more liblouis specific functionality into NVDA, I introduced a new louisHelper module. I added a translate method to that new module as well, to act as a convenience wrapper for louis.translate. The braille module now uses louisHelper.translate, and that function does the underlying magic to have NVDA work with the translation result in a correct way. I also investigated whether some workarounds needed to fix #2947 and #2466 were still necessary, and it looks like that they're fixed upstream. What also changed since then is that Liblouis now has a decent way of providing patches and getting assistance with bugs, thanks to github.
4. Something " I'd like to discuss and which is implemented in this pr as well, is signing liblouis dlls with the NV Access certificate. Now there are several liblouis dll builds in the wild, such as those from Microsoft, Freedom Scientific and even others, it might make sense to do this in order for NVDA specific liblouis builds to be recognized as such. Note that Microsoft also signs liblouis dlls that are included with Windows 10.

### Testing performed:
Unit tests, chose the new tables from the braille settings panel.

### Known issues with pull request:
* Once we agree that the fixes for #2947 and #2466 can be reverted, we should be alert for them returning
* I really wish we could have switched to UCS-4 builds of liblouis, however that's not yet possible and I doubt that that will ever make it into Python 2 builds of NVDA.

### Change log entry:
* New features
    + New braille tables: Arabic 8 dot computer braille, Arabic grade 2, Spanish grade 2. (#4435)

* Changes
    + Updated liblouis braille translator to version 3.8.0. (#9013)

* Changes for developers
    + You can now include log output from liblouis into the NVDA log by setting the louis boolean flag in the debugLogging section of the NVDA configuration. (#4554)