### PR TITLE
UIA in MS Word: don't ignore tables with blank cells

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -342,8 +342,12 @@ class UIATextInfo(textInfos.TextInfo):
 		# Thus we must check getChildren before getEnclosingElement.
 		tempInfo.expand(textInfos.UNIT_CHARACTER)
 		tempRange=tempInfo._rangeObj
-		children=getChildrenWithCacheFromUIATextRange(tempRange,UIAHandler.handler.baseCacheRequest)
-		if children.length==1:
+		try:
+			children=getChildrenWithCacheFromUIATextRange(tempRange,UIAHandler.handler.baseCacheRequest)
+		except COMError as e:
+			log.debugWarning("Could not get children from UIA text range, %s"%e)
+			children=None
+		if children and children.length==1:
 			child=children.getElement(0)
 		else:
 			child=getEnclosingElementWithCacheFromUIATextRange(tempRange,UIAHandler.handler.baseCacheRequest)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -180,14 +180,6 @@ class WordDocumentTextInfo(UIATextInfo):
 				docInfo=self.obj.makeTextInfo(textInfos.POSITION_ALL)
 				self.setEndPoint(docInfo,"endToEnd")
 
-	def _get_isCollapsed(self):
-		res=super(WordDocumentTextInfo,self).isCollapsed
-		if res: 
-			return True
-		# MS Word does not seem to be able to fully collapse ranges when on links and tables etc.
-		# Therefore class a range as collapsed if it has no text
-		return not bool(self.text)
-
 	def getTextWithFields(self,formatConfig=None):
 		if self.isCollapsed:
 			# #7652: We cannot fetch fields on collapsed ranges otherwise we end up with repeating controlFields in braille (such as list list list). 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #8692 

### Summary of the issue:
When navigating in MS Word with NVDA's experimental UI Automation support, blank table cells atre treated as not existing at all.

### Description of how this pull request fixes the issue:
This was fixed in the UIAInMSWordByDefault branch a little while ago. the two relevant commits have been cherry-picked from there.
Those commits are isolated from the rest of the UIAInMSWordByDefault work and are safe to bring in to 2018.4. Stock standard NVDA will never run this code, but for those testing uIA with MS Word, this is very important.
 
### Testing performed:
Arrowed and table navigated around both tables with and with out content in their cells.

### Known issues with pull request:
None.

### Change log entry:
None as the UIA code is still behind a hidden config option.