### PR TITLE
Fix small bug in IA2TextInfo.getTextRange when retrieving an empty range

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -199,7 +199,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getTextRange(self,start,end):
 		try:
-			return self.obj.IAccessibleTextObject.text(start,end)
+			return self.obj.IAccessibleTextObject.text(start,end) or u""
 		except COMError:
 			return u""
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -148,6 +148,8 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		super(IA2TextTextInfo,self).expand(unit)
 		if isMouseChunkUnit:
 			text=self._getTextRange(self._startOffset,self._endOffset)
+			if not text:
+				return
 			try:
 				self._startOffset=text.rindex(u'\ufffc',0,oldStart-self._startOffset)
 			except ValueError:


### PR DESCRIPTION
### Link to issue number:
Fixes #3654

### Summary of the issue:
When moving the mouse in some applications exposing IA2TextInfo instances, such as in SKype 8 or Firefox, an error can be generated occasionally.

```
ERROR - eventHandler.executeEvent (16:50:48.926):
error executing event: mouseMove on <NVDAObjects.IAccessible.mozilla.Mozilla object at 0x05583B90> with extra args of {'y': 0, 'x': 752}
Traceback (most recent call last):
  File "eventHandler.pyc", line 155, in executeEvent
  File "eventHandler.pyc", line 92, in __init__
  File "eventHandler.pyc", line 100, in next
  File "NVDAObjects\__init__.pyc", line 937, in event_mouseMove
  File "NVDAObjects\IAccessible\__init__.pyc", line 165, in expand
AttributeError: 'NoneType' object has no attribute 'rindex'
```

The problem is that, when getting an empty text range from IAccessibleTextObjects, the result is None rather than an empty string.

### Description of how this pull request fixes the issue:
Return an empty unicode string instead of a None. Also, in the expand method, return early instead of executing index and rindex on an empty string.

### Testing performed:
Honestly, None, as I couldn't reproduce the issue myself.

### Known issues with pull request:
None

### Change log entry:
None needed, pretty trivial, though annoying on test builds.