### PR TITLE
Incompatible add-ons dialog: center the screen, hot keys for Yes/No buttons, python 3 compatible imports

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -91,7 +91,7 @@ class ConfirmAddonInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 				id=wx.ID_YES,
 				# Translators: A button in the addon installation warning dialog which allows the user to agree to installing
 				#  the add-on
-				label=_("Yes")
+				label=_("&Yes")
 			)
 			yesButton.SetDefault()
 			yesButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.YES))
@@ -103,7 +103,7 @@ class ConfirmAddonInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 				id=wx.ID_NO,
 				# Translators: A button in the addon installation warning dialog which allows the user to decide not to
 				# install the add-on
-				label=_("No")
+				label=_("&No")
 			)
 			noButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.NO))
 		contentsSizer.addDialogDismissButtons(buttonHelper)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -17,9 +17,9 @@ from logHandler import log
 import addonHandler
 import globalVars
 import buildVersion
-import guiHelper
-import nvdaControls
-from dpiScalingHelper import DpiScalingHelperMixin
+from . import guiHelper
+from . import nvdaControls
+from .dpiScalingHelper import DpiScalingHelperMixin
 
 def promptUserForRestart():
 	# Translators: A message asking the user if they wish to restart NVDA as addons have been added, enabled/disabled or removed.

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -115,6 +115,7 @@ class ConfirmAddonInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 		)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
+		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)
 
 	def _toggleEnabledStateOfAffirmativeAction(self, evt):
 		self.yesButton.Enable(self.confirmedCheckbox.IsChecked())


### PR DESCRIPTION
### Link to issue number:
Fixes #9030

### Summary of the issue:
Incompatible add-ons dialog: center the dialog. Also take care of adding hot keys for Yes/No buttons and use proper relative imports to make it Python 3 compatible.

### Description of how this pull request fixes the issue:
Adds:

* self.Center function to center the whole dialog.
* Adds hot keys for Yes/No buttons.
* Because of Python 3 transition is being planned, use proper relative import form compatible with both Python 2 and 3.

### Testing performed:
Installed various add-ons known to be compatible and incompatible, along with testing it on a personal copy of Python 3 NVDA.

### Known issues with pull request:
None

### Change log entry:
None
