### PR TITLE
Compile liblouis with 32 bit widechars and add textUtils module to deal with py2/py3 unicode differences

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -1,7 +1,7 @@
 ###
 #This file is a part of the NVDA project.
 #URL: https://www.nvaccess.org/
-#Copyright 2011-2017 NV Access Limited, Joseph Lee
+#Copyright 2011-2018 NV Access Limited, Joseph Lee, Babbage B.V.
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License version 2.0, as published by
 #the Free Software Foundation.
@@ -59,6 +59,10 @@ env.Prepend(CPPPATH=[".", louisSourceDir])
 
 # Upstream liblouis compiles without UNICODE defined.
 env['CPPDEFINES'].remove("UNICODE")
+
+# When compling liblouis with UCS-4 widechars, several signed/unsigned missmatch warnings appear.
+# Ignore these for now.
+env['CCFLAGS'].remove("/WX")
 
 liblouisH = env.Substfile("liblouis.h", louisSourceDir.File("liblouis.h.in"),
 	SUBST_DICT={"@WIDECHAR_TYPE@": "unsigned int"})

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -51,7 +51,7 @@ env.Append(CPPDEFINES=[
 	# variants that start with an '_'. This removes those deprecation warnings. */
 	"_CRT_NONSTDC_NO_DEPRECATE",
 	("PACKAGE_VERSION", r'\"%s\"' % getLouisVersion()),
-	("UNICODE_BITS", 16),
+	"WIDECHARS_ARE_UCS4",
 	# Tell liblouis.h that we're exporting liblouis dll functions, not importing them.
 	"_EXPORTING",
 ])
@@ -61,7 +61,7 @@ env.Prepend(CPPPATH=[".", louisSourceDir])
 env['CPPDEFINES'].remove("UNICODE")
 
 liblouisH = env.Substfile("liblouis.h", louisSourceDir.File("liblouis.h.in"),
-	SUBST_DICT={"@WIDECHAR_TYPE@": "unsigned short int"})
+	SUBST_DICT={"@WIDECHAR_TYPE@": "unsigned int"})
 
 sourceFiles = [
 	"compileTranslationTable.c",

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -236,7 +236,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		except COMError:
 			pass
 		try:
-			start,end,text = self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_CHAR)[0:2]
+			start,end,text = self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_CHAR)
 		except COMError:
 			return super(IA2TextTextInfo,self)._getCharacterOffsets(offset)
 		if HIGH_SURROGATE_FIRST <= text <= HIGH_SURROGATE_LAST or LOW_SURROGATE_FIRST <= text <= LOW_SURROGATE_LAST:

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -14,6 +14,7 @@ from comInterfaces.tom import ITextDocument
 import tones
 import languageHandler
 import textInfos.offsets
+from textInfos.offsets import HIGH_SURROGATE_FIRST, HIGH_SURROGATE_LAST, LOW_SURROGATE_FIRST, LOW_SURROGATE_LAST
 import colors
 import time
 import displayModel
@@ -235,9 +236,14 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		except COMError:
 			pass
 		try:
-			return self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_CHAR)[0:2]
+			start,end,text = self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_CHAR)[0:2]
 		except COMError:
 			return super(IA2TextTextInfo,self)._getCharacterOffsets(offset)
+		if HIGH_SURROGATE_FIRST <= text <= HIGH_SURROGATE_LAST or LOW_SURROGATE_FIRST <= text <= LOW_SURROGATE_LAST:
+			# #8953: Some IA2 implementations, including Gecko and Chromium,
+			# erroneously report one offset for surrogates.
+			return super(IA2TextTextInfo,self)._getCharacterOffsets(offset)
+		return start, end
 
 	def _getWordOffsets(self,offset):
 		try:

--- a/source/braille.py
+++ b/source/braille.py
@@ -5,6 +5,7 @@
 #See the file COPYING for more details.
 #Copyright (C) 2008-2018 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
 
+from __future__ import unicode_literals
 import sys
 import itertools
 import os
@@ -24,6 +25,7 @@ from logHandler import log
 import controlTypes
 import api
 import textInfos
+import textUtils
 import brailleDisplayDrivers
 import inputCore
 import brailleTables
@@ -367,7 +369,7 @@ class Region(object):
 
 	def __init__(self):
 		#: The original, raw text of this region.
-		self.rawText = ""
+		self.rawText = textUtils.getEncodingAwareString("", louis.conversionEncoding)
 		#: The position of the cursor in L{rawText}, C{None} if the cursor is not in this region.
 		#: @type: int
 		self.cursorPos = None
@@ -463,7 +465,7 @@ class TextRegion(Region):
 
 	def __init__(self, text):
 		super(TextRegion, self).__init__()
-		self.rawText = text
+		self.rawText += text
 
 def getBrailleTextForProperties(**propertyValues):
 	textList = []
@@ -575,7 +577,7 @@ class NVDAObjectRegion(Region):
 		@param obj: The associated NVDAObject.
 		@type obj: L{NVDAObjects.NVDAObject}
 		@param appendText: Text which should always be appended to the NVDAObject text, useful if this region will always precede other regions.
-		@type appendText: str
+		@type appendText: unicode
 		"""
 		super(NVDAObjectRegion, self).__init__()
 		self.obj = obj
@@ -610,7 +612,10 @@ class NVDAObjectRegion(Region):
 						obj.mathMl)
 				except (NotImplementedError, LookupError):
 					pass
-		self.rawText = text + self.appendText
+		self.rawText = textUtils.getEncodingAwareString(
+			text + self.appendText,
+			louis.conversionEncoding
+		)
 		super(NVDAObjectRegion, self).update()
 
 	def routeTo(self, braillePos):
@@ -792,6 +797,7 @@ class TextInfoRegion(Region):
 		return typeform
 
 	def _addFieldText(self, text, contentPos, separate=True):
+		text = textUtils.getEncodingAwareString(text, louis.conversionEncoding)
 		if separate and self.rawText:
 			# Separate this field text from the rest of the text.
 			text = TEXT_SEPARATOR + text
@@ -909,7 +915,7 @@ class TextInfoRegion(Region):
 	def update(self):
 		formatConfig = config.conf["documentFormatting"]
 		unit = self._getReadingUnit()
-		self.rawText = ""
+		self.rawText = textUtils.getEncodingAwareString("", louis.conversionEncoding)
 		self.rawTextTypeforms = []
 		self.cursorPos = None
 		# The output includes text representing fields which isn't part of the real content in the control.

--- a/source/mathPres/mathPlayer.py
+++ b/source/mathPres/mathPlayer.py
@@ -86,7 +86,7 @@ class MathPlayerInteraction(mathPres.MathInteractionNVDAObject):
 			self.provider._language))
 
 	def getBrailleRegions(self, review=False):
-		yield braille.NVDAObjectRegion(self, appendText=" ")
+		yield braille.NVDAObjectRegion(self, appendText=u" ")
 		region = braille.Region()
 		region.focusToHardLeft = True
 		self.provider._mpBraille.SetBrailleWidth(braille.handler.displaySize)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,0 +1,57 @@
+#textUtils.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2018 NV Access Limited, Babbage B.V.
+
+from six import text_type
+import encodings
+
+class DuoString(text_type):
+	"""
+	Magic string object that holds a string in both its decoded and encoded forms.
+	"""
+	__slots__=("bytesPerIndex", "encoded", "encoding", "errors")
+	_encodingToBytes = {
+		"utf_8": 1,
+		"utf_16_le": 2,
+		"utf_32_le": 4,
+	}
+
+	@property
+	def decoded(self):
+		return text_type(self)
+
+	def __new__(cls, value="", encoding="utf-8", errors="strict"):
+		if isinstance(value, (bytes, bytearray)):
+			obj = super(DuoString, cls).__new__(cls, value, encoding. errors)
+			obj.encoded = value
+		else:
+			obj = super(DuoString, cls).__new__(cls, value)
+			obj.encoded = obj.encode(encoding, errors)
+		obj.encoding = encodings.normalize_encoding(encoding)
+		obj.bytesPerIndex = cls._encodingToBytes[obj.encoding]
+		obj.errors = errors
+		return obj
+
+	def __len__(self):
+		return len(self.encoded) / self.bytesPerIndex
+
+	def __getitem__(self, key):
+		if isinstance(key, int):
+			start = key * self.bytesPerIndex
+			stop = start + self.bytesPerIndex
+			step = None
+		elif isinstance(key, slice):
+			start = key.start
+			if start is not None:
+				start *= self.bytesPerIndex
+			stop = key.stop
+			if stop is not None:
+				stop *= self.bytesPerIndex
+			step = key.step
+		else:
+			return NotImplemented
+		key = slice(start, stop, step)
+		item = self.encoded[key].decode(self.encoding, self.errors)
+		return item

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -94,8 +94,10 @@ class EncodingAwareString(Sequence, text_type):
 	def __add__(self, value):
 		return EncodingAwareString(super(EncodingAwareString, self).__add__(value), self.encoding, self.errors)
 
-	def __radd__(self, value):
-		return EncodingAwareString(super(EncodingAwareString, self).__radd__(value), self.encoding, self.errors)
+	def __rad__(self, value):
+		# Python strings do not implement __radd__,
+		# however addition involving EncodingAwareStrings should always result in one.
+		return EncodingAwareString(value + self.decoded, self.encoding, self.errors)
 
 	def __mul__(self, value):
 		return EncodingAwareString(super(EncodingAwareString, self).__mul__(value), self.encoding, self.errors)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -219,8 +219,8 @@ def getEncodingAwareString(value, encoding, errors="replace"):
 	"""Creates a string that is encoding aware if necessary.
 	On python 2, UTF_16_le will result in an unicode object,
 	as it uses UCS-2/UTF-16 internally.
-	On python 3, UTF_32_le will result in astring object,
-	as one index corresponds to one code point.
+	On python 3, UTF_32_le will result in a str object,
+	as 1 index corresponds to 1 code point.
 	Other encodings will result in a L{EncodeAwareString} object.
 	"""
 	encoding = encodings.normalize_encoding(encoding)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,8 +1,14 @@
+# -*- coding: UTF-8 -*-
+
 #textUtils.py
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 #Copyright (C) 2018 NV Access Limited, Babbage B.V.
+
+"""
+Classes and utilities to deal with strings.
+"""
 
 from six import text_type
 import encodings
@@ -16,9 +22,43 @@ byteTypes = (bytes, bytearray)
 defaultStringEncoding = "utf_16_le" if sys.version_info.major == 2 else "utf_32_le"
 
 class EncodingAwareString(Sequence, text_type):
+	u"""
+	Magic string object that holds a string in both its decoded and its UTF-x encoded form.
+	The indexes and length of the resulting objects are based on the byte size of the given encoding.
+
+	First, an instance is created:
+
+	>> string = EncodingAwareString(u'\U0001f609', encoding="utf_32_le")
+
+	Then, the length of the string can be fetched:
+
+	>>> len(string)
+	1
+
+	And the object can be indexed and sliced:
+
+	>>> string[0]
+	EncodingAwareString(u'\U0001f609')
+
+	This example string behaves exactly the same as a Python 3 string, where 1 index is 1 code point.
+	Therefore, the following happens on Python 3:
+
+	>>> len(string.decoded)
+	1
+
+	However, on Python 2, the result differs:
+
+	>>> len(string.decoded)
+	2
+
+	This is because Python 2 on Windows uses a 2 byte encoding to store the string.
+	The oposite is accomplished with an instance like this:
+
+	>> string = EncodingAwareString(u"\U0001f609", encoding="utf_16_le")
+	>>> len(string)
+	2
 	"""
-	Magic string object that holds a string in both its decoded and encoded forms.
-	"""
+
 	__slots__=("bytesPerIndex", "encoded", "encoding", "errors")
 	_encodingToBytes = {
 		"utf_8": 1,
@@ -27,13 +67,19 @@ class EncodingAwareString(Sequence, text_type):
 	}
 
 	def __new__(cls, value, encoding, errors="replace"):
+		encoding = encodings.normalize_encoding(encoding)
+		if encoding not in cls._encodingToBytes:
+			raise ValueError("Encoding %s not supported. Supported values are %s" % (
+				encoding,
+				", ".join(cls._encodingToBytes)
+			))
 		if isinstance(value, byteTypes):
 			obj = super(EncodingAwareString, cls).__new__(cls, value, encoding, errors)
 			obj.encoded = value
 		else:
 			obj = super(EncodingAwareString, cls).__new__(cls, value)
 			obj.encoded = obj.encode(encoding, errors)
-		obj.encoding = encodings.normalize_encoding(encoding)
+		obj.encoding = encoding
 		obj.bytesPerIndex = cls._encodingToBytes[obj.encoding]
 		obj.errors = errors
 		return obj
@@ -46,14 +92,22 @@ class EncodingAwareString(Sequence, text_type):
 		return "{}({})".format(self.__class__.__name__, repr(self.decoded))
 
 	def __add__(self, value):
-		if isinstance(value, byteTypes):
-			return self.__class__(self.encoded + value, self.encoding, self.errors)
-		return self.__class__(self.decoded + value, self.encoding, self.errors)
+		return EncodingAwareString(super(EncodingAwareString, self).__add__(value), self.encoding, self.errors)
 
 	def __radd__(self, value):
-		if isinstance(value, byteTypes):
-			return self.__class__(value + self.encoded, self.encoding, self.errors)
-		return self.__class__(value + self.decoded, self.encoding, self.errors)
+		return EncodingAwareString(super(EncodingAwareString, self).__radd__(value), self.encoding, self.errors)
+
+	def __mul__(self, value):
+		return EncodingAwareString(super(EncodingAwareString, self).__mul__(value), self.encoding, self.errors)
+
+	def __rmul__(self, value):
+		return EncodingAwareString(super(EncodingAwareString, self).__rmul__(value), self.encoding, self.errors)
+
+	def __mod__(self, args):
+		return EncodingAwareString(super(EncodingAwareString, self).__mod__(args), self.encoding, self.errors)
+
+	def __rmod__(self, args):
+		return EncodingAwareString(super(EncodingAwareString, self).__rmod__(args), self.encoding, self.errors)
 
 	def __len__(self):
 		return len(self.encoded) // self.bytesPerIndex
@@ -63,7 +117,7 @@ class EncodingAwareString(Sequence, text_type):
 			newKey = key
 		elif isinstance(key, int):
 			if key >= len(self):
-				raise IndexError("%s index out of range" % self.__class__.__name__)
+				raise IndexError("%s index out of range" % EncodingAwareString.__name__)
 			start = key * self.bytesPerIndex
 			stop = start + self.bytesPerIndex
 			newKey = slice(start, stop)
@@ -76,7 +130,7 @@ class EncodingAwareString(Sequence, text_type):
 					stop = min(key.stop, len(self) - 1)
 				step = key.step
 				keys = range(start, stop, step)
-				return self.__class__("".join(self[i] for i in keys), self.encoding, self.errors)
+				return EncodingAwareString("".join(self[i] for i in keys), self.encoding, self.errors)
 			start = key.start
 			if start is not None:
 				start *= self.bytesPerIndex
@@ -87,45 +141,79 @@ class EncodingAwareString(Sequence, text_type):
 			newKey = slice(start, stop, step)
 		else:
 			return NotImplemented
-		return self.__class__(self.encoded[newKey], self.encoding, self.errors)
+		return EncodingAwareString(self.encoded[newKey], self.encoding, self.errors)
+
+	def __contains__(self, char):
+		if isinstance(char, byteTypes):
+			return char in self.encoded
+		return super(EncodingAwareString, self).__contains__(char)
+
+	def count(self, sub, start=0, end=sys.maxsize):
+		if isinstance(sub, text_type):
+			sub = sub.encode(self.encoding, self.errors)
+		if isinstance(sub, byteTypes):
+			start *= self.bytesPerIndex
+			end = min(end * self.bytesPerIndex, sys.maxsize)
+			return self.encoded.count(sub, start, end) / self.bytesPerIndex
+		return super(EncodingAwareString, self).count(sub, start, end)
+
+	def format(self, *args, **kwargs):
+		return EncodingAwareString(super(EncodingAwareString, self).format(*args, **kwargs), self.encoding, self.errors)
+
 
 	def find(self, sub, start=0, end=sys.maxsize):
 		if isinstance(sub, text_type):
 			sub = sub.encode(self.encoding, self.errors)
 		if isinstance(sub, byteTypes):
-			return self.encoded.find(sub) / self.bytesPerIndex
-		return super(EncodingAwareString, self).find(sub)
+			start *= self.bytesPerIndex
+			end = min(end * self.bytesPerIndex, sys.maxsize)
+			return self.encoded.find(sub, start, end) / self.bytesPerIndex
+		return super(EncodingAwareString, self).find(sub, start, end)
 
 	def index(self, sub, start=0, end=sys.maxsize):
 		if isinstance(sub, text_type):
 			sub = sub.encode(self.encoding, self.errors)
 		if isinstance(sub, byteTypes):
-			return self.encoded.index(sub) / self.bytesPerIndex
-		return super(EncodingAwareString, self).index(sub)
+			start *= self.bytesPerIndex
+			end = min(end * self.bytesPerIndex, sys.maxsize)
+			return self.encoded.index(sub, start, end) / self.bytesPerIndex
+		return super(EncodingAwareString, self).index(sub, start, end)
 
-	def strip(self, chars=None):
+	def join(self, seq):
+		return EncodingAwareString(super(EncodingAwareString, self).join(seq), self.encoding, self.errors)
+
+	def lstrip(self, chars=None):
 		if isinstance(chars, byteTypes):
-			return self.__class__(self.encoded.rstrip(chars), self.encoding, self.errors)
-		return self.__class__(self.decoded.rstrip(chars), self.encoding, self.errors)
+			return EncodingAwareString(self.encoded.lstrip(chars), self.encoding, self.errors)
+		return EncodingAwareString(self.decoded.lstrip(chars), self.encoding, self.errors)
 
 	def rfind(self, sub, start=0, end=sys.maxsize):
 		if isinstance(sub, text_type):
 			sub = sub.encode(self.encoding, self.errors)
 		if isinstance(sub, byteTypes):
-			return self.encoded.rfind(sub) / self.bytesPerIndex
-		return super(EncodingAwareString, self).rrfind(sub)
+			start *= self.bytesPerIndex
+			end = min(end * self.bytesPerIndex, sys.maxsize)
+			return self.encoded.rfind(sub, start, end) / self.bytesPerIndex
+		return super(EncodingAwareString, self).rrfind(sub, start, end)
 
 	def rindex(self, sub, start=0, end=sys.maxsize):
 		if isinstance(sub, text_type):
 			sub = sub.encode(self.encoding, self.errors)
 		if isinstance(sub, byteTypes):
-			return self.encoded.rindex(sub) / self.bytesPerIndex
-		return super(EncodingAwareString, self).rindex(sub)
+			start *= self.bytesPerIndex
+			end = min(end * self.bytesPerIndex, sys.maxsize)
+			return self.encoded.rindex(sub, start, end) / self.bytesPerIndex
+		return super(EncodingAwareString, self).rindex(sub, start, end)
 
 	def rstrip(self, chars=None):
 		if isinstance(chars, byteTypes):
-			return self.__class__(self.encoded.strip(chars), self.encoding, self.errors)
-		return self.__class__(self.decoded.strip(chars), self.encoding, self.errors)
+			return EncodingAwareString(self.encoded.strip(chars), self.encoding, self.errors)
+		return EncodingAwareString(self.decoded.strip(chars), self.encoding, self.errors)
+
+	def strip(self, chars=None):
+		if isinstance(chars, byteTypes):
+			return EncodingAwareString(self.encoded.strip(chars), self.encoding, self.errors)
+		return EncodingAwareString(self.decoded.strip(chars), self.encoding, self.errors)
 
 def getEncodingAwareString(value, encoding, errors="replace"):
 	"""Creates a string that is encoding aware if necessary.

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -106,7 +106,7 @@ class EncodingAwareString(Sequence, text_type):
 	def strip(self, chars=None):
 		if isinstance(chars, byteTypes):
 			return self.__class__(self.encoded.rstrip(chars), self.encoding, self.errors)
-		return self.__class__(self.rstrip(chars), self.encoding, self.errors)
+		return self.__class__(self.decoded.rstrip(chars), self.encoding, self.errors)
 
 	def rfind(self, sub, start=0, end=sys.maxsize):
 		if isinstance(sub, text_type):
@@ -125,7 +125,7 @@ class EncodingAwareString(Sequence, text_type):
 	def rstrip(self, chars=None):
 		if isinstance(chars, byteTypes):
 			return self.__class__(self.encoded.strip(chars), self.encoding, self.errors)
-		return self.__class__(self.strip(chars), self.encoding, self.errors)
+		return self.__class__(self.decoded.strip(chars), self.encoding, self.errors)
 
 def getEncodingAwareString(value, encoding, errors="replace"):
 	"""Creates a string that is encoding aware if necessary.

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -103,6 +103,11 @@ class EncodingAwareString(Sequence, text_type):
 			return self.encoded.index(sub) / self.bytesPerIndex
 		return super(EncodingAwareString, self).index(sub)
 
+	def strip(self, chars=None):
+		if isinstance(chars, byteTypes):
+			return self.__class__(self.encoded.rstrip(chars), self.encoding, self.errors)
+		return self.__class__(self.rstrip(chars), self.encoding, self.errors)
+
 	def rfind(self, sub, start=0, end=sys.maxsize):
 		if isinstance(sub, text_type):
 			sub = sub.encode(self.encoding, self.errors)
@@ -117,8 +122,19 @@ class EncodingAwareString(Sequence, text_type):
 			return self.encoded.rindex(sub) / self.bytesPerIndex
 		return super(EncodingAwareString, self).rindex(sub)
 
-def getString(value, encoding, errors="replace"):
-	"""Creates a string that is encoding aware if necessary."""
+	def rstrip(self, chars=None):
+		if isinstance(chars, byteTypes):
+			return self.__class__(self.encoded.strip(chars), self.encoding, self.errors)
+		return self.__class__(self.strip(chars), self.encoding, self.errors)
+
+def getEncodingAwareString(value, encoding, errors="replace"):
+	"""Creates a string that is encoding aware if necessary.
+	On python 2, UTF_16_le will result in an unicode object,
+	as it uses UCS-2/UTF-16 internally.
+	On python 3, UTF_32_le will result in astring object,
+	as one index corresponds to one code point.
+	Other encodings will result in a L{EncodeAwareString} object.
+	"""
 	encoding = encodings.normalize_encoding(encoding)
 	if encoding == defaultStringEncoding:
 		stringType = text_type
@@ -131,4 +147,3 @@ def getString(value, encoding, errors="replace"):
 	else:
 		return EncodingAwareString(value, encoding, errors)
 
-	


### PR DESCRIPTION
### Link to issue number:
Closes #9034 
Closes #6695 

### Summary of the issue:
Liblouis currently uses a 2 byte encoding to process braille. This is pretty annoying when displaying emoji, as they are 32 bit unicode characters. For example, 😉 is usually printed as '\xd83d''\xde09'.

### Description of how this pull request fixes the issue:
This pr does the following.

1. Compiles liblouis with 32 bit wide characters instead of 16. This means only one replacement pattern is printed for 32 bit characters instead of two.
2. Furthermore, it adds a textUtils module that deals with the differences between python 2 and 3 unicode strings. In python 2, unicode strings are internally saved with a two byte encoding. Therefore, 32 bit unicode characters take two indexes or offsets in a string. In python 3, one index/offset corresponds with a code point. Liblouis 2 byte wide characters played pretty nicely with Python 2 unicode strings, but with 32 bit wide characters, the rawToBraillePos and brailleToRawPos mappings do no longer match, as liblouis reads 😉 as one character whether Python 2 reads them as two. Python 3 would instantly fix this, but causes the same problem the other way around with several offset based TextInfos. For example, uniscribe uses 2 byte wide characters, and therefore 😉 is treated as two characters by uniscribe whereas Python 3 treats it as one.
    This is where textUtils.ENcodingAwareString comes into view. This new str subclass of unicode in python 2/str in python 3 keeps the decoded and encoded form of a string in one object. Indexing/slicing/length checking is based on the smallest with of the encoding used. For example, utf-16 is two bytes, so every index in the string corresponds with two bytes. Utf-32 uses four bytes for one character, so every index corresponds with four bytes in the string. This basically means that we have strings that behave like python 3 strings on python 2, and strings that behave like python 2 strings on python 3.
3. Since #9034 describes a possible regression that would be caused by switching liblouis to UCS-4, this possible regression has been neutralized. When fetching character offsets in IA2 and the implementation returns a surrogate character, the implementation falls back to the OffsetsTextInfos character offset mechanism, which takes 32 bit unicode characters based on surrogates into account.
4. the braille module is the first module to utilize the unicode_literals feature, i.e. all strings without the unicode literal are yet treated as such. This makes the braille module mimic Python 3 behavior more closely.

### Testing performed:
Tested a try build with braille, routing worked well, no unexpected errors in the log so far.

### Known issues with pull request:
No unit tests, and we really want them, I'm sure. however, first I want to make sure that we agree about the approach of the textUtils module.

### Change log entry:
* Bug fixes
    + Emoji and other 32 bit unicode characters now take less space on a braille display when they are undefined in a braille translation table. (#6695)
   + Cursor routing no longer moves the cursor one or more characters ahead when used on a line containing emoji. (#9034)