### PR TITLE
Stop crashing hh.exe when passing strings to MSHTML

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,9 @@ init:
        $version = "alpha-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
       } else {
        $version = "$env:APPVEYOR_REPO_BRANCH-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
+       if($env:APPVEYOR_REPO_BRANCH.StartsWith("try-release-")) {
+        Set-AppveyorBuildVariable "release" "1"
+       }
       }
       # The version is unique even for rebuilds, so we can use it for the AppVeyor version.
       Update-AppveyorBuild -Version $version

--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -17,6 +17,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <windows.h>
 #include <oleacc.h>
 #include <oleidl.h>
+#include <atlcomcli.h>
 #include <mshtml.h>
 #include <set>
 #include <string>
@@ -401,8 +402,11 @@ inline void getCurrentStyleInfoFromHTMLDOMNode(IHTMLDOMNode* pHTMLDOMNode, bool&
 	if (pHTMLCurrentStyle) pHTMLCurrentStyle->Release();
 }
 
+// #8976: the string in the following macro  must be passed to the COM method as a BSTR 
+// otherwise the COM marshaller will try and read the BSTR length and hit either inaccessible memory or get back junk. 
+// This is seen in optimized builds of NVDA when accessing some CHM files in hh.exe.
 #define macro_addHTMLAttributeToMap(attribName,allowEmpty,attribsObj,attribsMap,tempVar,tempAttrObj) {\
-	attribsObj->getNamedItem(attribName,&tempAttrObj);\
+	attribsObj->getNamedItem(CComBSTR(attribName),&tempAttrObj);\
 	if(tempAttrObj) {\
 		VariantInit(&tempVar);\
 		tempAttrObj->get_nodeValue(&tempVar);\


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

Aiming for 2018.4rc2 as this is a crash.

### Link to issue number:
Closes #8976 

### Summary of the issue:
Similar to issue #8759 where Firefox was crashing when passing a string literal to a COM method, hh.exe when opening particular chm files would also crash.
Again, we are passing a string literal to a COM method, this time in the MSHTML vbufBackend.
Passing a string literal in place of a bstr is bad as the COM marshaller tries to look for the bstr prefix containing the length, and either causes a memory violation or finds junk.
This only however seems to cause a crash in optimized builds of NVDA, and only with very recent versions of Visual Studio 2017, as this particular crash has not been seen before beta1 of 2018.4.
 
### Description of how this pull request fixes the issue:
Similar to pr #8767, the string literal is first converted to a BSTR before passing to the COM method.
This PR also adds a rule to the appveyor config that allows us us to build optimized try builds  when a branch name starts with try-release-. This change made it easier to test this fix.

### Testing performed:
While running an optimized try build for this pr, opened the chm in issue #8759 and it did not crash.
Also opened several pages in Internet Explorer to ensure that generally NVDA was still getting all required information from MSHTML.
Try build has been provided on the issue, awaiting testing by original reporter. 

### Known issues with pull request:
None.

### Change log entry:
None.