### PR TITLE
Catch exceptions in initial focus after braille display load

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1695,7 +1695,14 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			else: # detected:
 				self._disableDetection()
 			log.info("Loaded braille display driver %s, current display has %d cells." %(name, self.displaySize))
-			self.initialDisplay()
+			try:
+				self.initialDisplay()
+			except:
+				# #8877: initialDisplay might fail because NVDA tries to focus
+				# an object for which property fetching raises an error.
+				# We should handle this more gracefully, since this is no reason
+				# to stop a display from loading successfully.
+				log.error("Error within initial focus after display load", exc_info=True)
 			return True
 		except:
 			# For auto display detection, logging an error for every failure is too obnoxious.

--- a/source/braille.py
+++ b/source/braille.py
@@ -1699,10 +1699,10 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				self.initialDisplay()
 			except:
 				# #8877: initialDisplay might fail because NVDA tries to focus
-				# an object for which property fetching raises an error.
+				# an object for which property fetching raises an exception.
 				# We should handle this more gracefully, since this is no reason
 				# to stop a display from loading successfully.
-				log.error("Error within initial focus after display load", exc_info=True)
+				log.debugWarning("Error in initial display after display load", exc_info=True)
 			return True
 		except:
 			# For auto display detection, logging an error for every failure is too obnoxious.


### PR DESCRIPTION
### Link to issue number:
Fixes #8877

### Summary of the issue:
When loading a braille display driver, the initialFocus method on the braille handler is called to fill the display with the current focus or review position. However, whenever this failed, NVDA treated this as being a failure in loading the display..

### Description of how this pull request fixes the issue:
When calling initialFocus, catch exceptions that might be raised.

### Testing performed:
Todo with try build

### Known issues with pull request:
None

### Change log entry:
Depends on whether this has to go into 2018.4. Strictly spoken, the regression is there since 2018.3, but the fix is pretty trivial. I leave it up to @michaeldcurran :)