### PR TITLE
Pending update installation: obtain version tuple from update tuple instead of going through version info module

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -214,10 +214,10 @@ class MainFrame(wx.Frame):
 	def onExecuteUpdateCommand(self, evt):
 		if updateCheck and updateCheck.isPendingUpdate():
 			updateTuple = updateCheck.getPendingUpdate()
-			newNVDAVersionTuple = versionInfo.getNVDAVersionTupleFromString(updateTuple[1])
+			newNVDAVersionTuple = updateTuple[2]
 			from addonHandler import getAddonsWithoutKnownCompatibility
 			if any(getAddonsWithoutKnownCompatibility(newNVDAVersionTuple)):
-				confirmUpdateDialog = updateCheck.UpdateAskInstallDialog(gui.mainFrame, updateTuple[0], updateTuple[1])
+				confirmUpdateDialog = updateCheck.UpdateAskInstallDialog(gui.mainFrame, updateTuple[0], updateTuple[1], newNVDAVersionTuple)
 				gui.runScriptModalDialog(confirmUpdateDialog)
 			else:
 				updateCheck.executePendingUpdate()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -861,10 +861,10 @@ class ExitDialog(wx.Dialog):
 		elif action == 4:
 			if updateCheck:
 				updateTuple = updateCheck.getPendingUpdate()
-				newNVDAVersionTuple = versionInfo.getNVDAVersionTupleFromString(updateTuple[1])
+				newNVDAVersionTuple = updateTuple[2]
 				from addonHandler import getAddonsWithoutKnownCompatibility
 				if any(getAddonsWithoutKnownCompatibility(newNVDAVersionTuple)):
-					confirmUpdateDialog = updateCheck.UpdateAskInstallDialog(gui.mainFrame, updateTuple[0], updateTuple[1])
+					confirmUpdateDialog = updateCheck.UpdateAskInstallDialog(gui.mainFrame, updateTuple[0], updateTuple[1], newNVDAVersionTuple)
 					confirmUpdateDialog.ShowModal()
 				else:
 					updateCheck.executePendingUpdate()


### PR DESCRIPTION
### Link to issue number:
Fixes #9075 

### Summary of the issue:
"Install pending update" fails with a traceback from version info complaining about incorrect version tuple for alpha builds.

### Description of how this pull request fixes the issue:
'install pending update' fails because version tuple is derived from version info module when in fact version tuple can be retrieved from update check/pending update state. Thus use the latter so confirmation dialog can work.

### Testing performed:
Tested with a source code version of NVDA through update checks and attempted installations.

### Known issues with pull request:
None

### Change log entry:
None
