### PR TITLE
Python 3/six: from six.moves import xrange

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -1,6 +1,6 @@
 #IAccessibleHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -29,6 +29,7 @@ import mouseHandler
 import controlTypes
 import keyboardHandler
 import core
+from six.moves import xrange
 
 MAX_WINEVENTS=500
 MAX_WINEVENTS_PER_THREAD=10

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #javaAccessBridgeHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
+#Copyright (C) 2007-2018 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -22,6 +22,7 @@ import eventHandler
 import controlTypes
 import NVDAObjects.JAB
 import core
+from six.moves import xrange
 
 #Some utility functions to help with function defines
 

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -26,6 +26,7 @@ import globalVars
 from logHandler import log
 import time
 import globalVars
+from six.moves import xrange
 
 versionedLibPath='lib'
 versionedLib64Path='lib64'

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -34,6 +34,7 @@ import NVDAObjects.JAB
 import eventHandler
 from NVDAObjects.behaviors import ProgressBar, Dialog, EditableTextWithAutoSelectDetection, FocusableUnfocusableContainer, ToolTip, Notification
 from locationHelper import RectLTWH
+from six.moves import xrange
 
 def getNVDAObjectFromEvent(hwnd,objectID,childID):
 	try:

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -1,6 +1,6 @@
-#braille.py
+#NVDAObjects/IAccessible/adobeAcrobat.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2008-2014 NV Access Limited
+#Copyright (C) 2008-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -14,6 +14,7 @@ from NVDAObjects.behaviors import EditableText
 from comtypes import GUID, COMError, IServiceProvider
 from comtypes.gen.AcrobatAccessLib import IAccID, IGetPDDomNode, IPDDomElement
 from logHandler import log
+from six.moves import xrange
 
 SID_AccID = GUID("{449D454B-1F46-497e-B2B6-3357AED9912B}")
 SID_GetPDDomNode = GUID("{C0A1D5E9-1142-4cf3-B607-82FC3B96A4DF}")

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2015-2017 NV Access Limited
+#Copyright (C) 2015-2018 NV Access Limited
 
 """Support for the IAccessible2 rich text model first implemented by Mozilla.
 This is now used by other applications as well.
@@ -19,6 +19,7 @@ from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 from . import IA2TextTextInfo, IAccessible
 from compoundDocuments import CompoundTextInfo
 from locationHelper import RectLTWH
+from six.moves import xrange
 
 class FakeEmbeddingTextInfo(textInfos.offsets.OffsetsTextInfo):
 

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #NVDAObjects/IAccessible/sysListView32.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -23,6 +23,7 @@ import watchdog
 from NVDAObjects.behaviors import RowWithoutCellObjects, RowWithFakeNavigation
 import config
 from locationHelper import RectLTRB
+from six.moves import xrange
 
 #Window messages
 LVM_FIRST=0x1000

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NVDA Contributors
+#Copyright (C) 2006-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -21,6 +21,7 @@ from displayModel import EditableTextDisplayModelTextInfo
 from NVDAObjects.window import DisplayModelEditableText
 from ..behaviors import EditableTextWithoutAutoSelectDetection
 from NVDAObjects.window.winword import *
+from six.moves import xrange
 
 class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocument):
  

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -10,6 +10,7 @@ import textInfos.offsets
 from logHandler import log
 from .. import InvalidNVDAObject
 from locationHelper import RectLTWH
+from six.moves import xrange
 
 JABRolesToNVDARoles={
 	"alert":controlTypes.ROLE_DIALOG,

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -33,6 +33,7 @@ import braille
 import time
 from locationHelper import RectLTWH
 import ui
+from six.moves import xrange
 
 class UIATextInfo(textInfos.TextInfo):
 

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2015-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2015-2018 NV Access Limited, Babbage B.V.
 
 from comtypes import COMError
 from comtypes.automation import VARIANT
@@ -20,6 +20,7 @@ import UIAHandler
 from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, UIATextRangeQuickNavItem,UIAControlQuicknavIterator
 from UIAUtils import *
 from . import UIA, UIATextInfo
+from six.moves import xrange
 
 def splitUIAElementAttribs(attribsString):
 	"""Split an UIA Element attributes string into a dict of attribute keys and values.

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -1,7 +1,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2016 NV Access Limited
+#Copyright (C) 2016-2018 NV Access Limited
 
 from comtypes import COMError
 from collections import defaultdict
@@ -18,6 +18,7 @@ from UIABrowseMode import UIABrowseModeDocument, UIADocumentWithTableNavigation,
 from UIAUtils import *
 from . import UIA, UIATextInfo
 from NVDAObjects.window.winword import WordDocument as WordDocumentBase
+from six.moves import xrange
 
 """Support for Microsoft Word via UI Automation."""
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,13 +1,14 @@
 # -*- coding: UTF-8 -*-
 #NVDAObjects/__init__.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V., Davy Kager
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V., Davy Kager
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 """Module that contains the base NVDA object type"""
 
 from six import with_metaclass
+from six.moves import xrange
 import time
 import re
 import weakref

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Joseph Lee
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Joseph Lee
 
 """Mix-in classes which provide common behaviour for particular types of controls across different APIs.
 Behaviors described in this mix-in include providing table navigation commands for certain table rows, terminal input and output support, announcing notifications and suggestion items and so on.
@@ -28,6 +28,7 @@ import api
 import ui
 import braille
 import nvwave
+from six.moves import xrange
 
 class ProgressBar(NVDAObject):
 

--- a/source/NVDAObjects/inputComposition.py
+++ b/source/NVDAObjects/inputComposition.py
@@ -7,6 +7,7 @@ import config
 from NVDAObjects.window import Window
 from .behaviors import EditableTextWithAutoSelectDetection, CandidateItem as CandidateItemBehavior 
 from textInfos.offsets import OffsetsTextInfo
+from six.moves import xrange
 
 def calculateInsertedChars(oldComp,newComp):
 	oldLen=len(oldComp)

--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #NVDAObjects/window/_msOfficeChartConstants.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2014-2017 NV Access Limited, NVDA India
+#Copyright (C) 2014-2018 NV Access Limited, NVDA India
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -16,6 +16,7 @@ import colors
 import inputCore
 import re
 from logHandler import log
+from six.moves import xrange
 
 #This file contains chart constants common to Chart Object for Microsoft Office.
 

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -32,6 +32,7 @@ from .. import NVDAObjectTextInfo
 from ..behaviors import EditableTextWithAutoSelectDetection
 import braille
 import watchdog
+from six.moves import xrange
 
 selOffsetsAtLastCaretEvent=None
 

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1,6 +1,6 @@
 #NVDAObjects/excel.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2016 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta
+#Copyright (C) 2006-2018 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -33,6 +33,7 @@ import scriptHandler
 import browseMode
 import inputCore
 import ctypes
+from six.moves import xrange
 
 excel2010VersionMajor=14
 

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,6 +1,6 @@
-#appModules/winword.py
+#NVDAObjects/window/winword.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V.
+#Copyright (C) 2006-2018 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -41,6 +41,7 @@ from . import Window
 from ..behaviors import EditableTextWithoutAutoSelectDetection
 from . import _msOfficeChart
 from textInfos import Point
+from six.moves import xrange
 
 #Word constants
 

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -1,7 +1,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2015-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2015-2018 NV Access Limited, Babbage B.V.
 
 from ctypes import byref
 from comtypes import COMError
@@ -16,6 +16,7 @@ import cursorManager
 import textInfos
 import browseMode
 from NVDAObjects.UIA import UIA
+from six.moves import xrange
 
 class UIADocumentWithTableNavigation(documentBase.DocumentWithTableNavigation):
 

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2015-2016 NV Access Limited
+#Copyright (C) 2015-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -7,6 +7,7 @@ import operator
 from comtypes import COMError
 import ctypes
 import UIAHandler
+from six.moves import xrange
 
 def createUIAMultiPropertyCondition(*dicts):
 	"""

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -23,6 +23,7 @@ import winUser
 import eventHandler
 from logHandler import log
 import UIAUtils
+from six.moves import xrange
 
 from comtypes.gen.UIAutomationClient import *
 

--- a/source/api.py
+++ b/source/api.py
@@ -1,6 +1,6 @@
 #api.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NVDA Contributors
+#Copyright (C) 2006-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -24,6 +24,7 @@ import eventHandler
 import braille
 import watchdog
 import appModuleHandler
+from six.moves import xrange
 
 #User functions
 

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016-2017 NV Access Limited
+#Copyright (C) 2016-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -29,6 +29,7 @@ import mouseHandler
 from logHandler import log
 import ui
 import config
+from six.moves import xrange
 
 class ElementsListDialog(browseMode.ElementsListDialog):
 	ELEMENT_TYPES = (

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -1,6 +1,6 @@
 #appModules/miranda32.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NVDA Contributors
+#Copyright (C) 2006-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -21,6 +21,7 @@ import mouseHandler
 import oleacc
 from keyboardHandler import KeyboardInputGesture
 import watchdog
+from six.moves import xrange
 
 #contact list window messages
 CLM_FIRST=0x1000    #this is the same as LVM_FIRST

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -33,6 +33,7 @@ from NVDAObjects.IAccessible.winword import WordDocument, WordDocumentTreeInterc
 from NVDAObjects.IAccessible.MSHTML import MSHTML
 from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA
+fro msix.moves import xrange
 
 PR_LAST_VERB_EXECUTED=0x10810003
 VERB_REPLYTOSENDER=102

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -33,7 +33,7 @@ from NVDAObjects.IAccessible.winword import WordDocument, WordDocumentTreeInterc
 from NVDAObjects.IAccessible.MSHTML import MSHTML
 from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA
-fro msix.moves import xrange
+from six.moves import xrange
 
 PR_LAST_VERB_EXECUTED=0x10810003
 VERB_REPLYTOSENDER=102

--- a/source/appModules/skype.py
+++ b/source/appModules/skype.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #appModules/skype.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2015 Peter Vágner, NV Access Limited
+#Copyright (C) 2007-2018 Peter Vágner, NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -21,6 +21,7 @@ import config
 import NVDAObjects.behaviors
 import api
 from logHandler import log
+from six.moves import xrange
 
 # Translators: The name of the NVDA command category for Skype specific commands.
 SCRCAT_SKYPE = _("Skype")

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -1,6 +1,6 @@
 #appModules/vipmud.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2011 Willem Venter and Rynhardt Kruger
+#Copyright (C) 2011-2018 NV Access Limited, Willem Venter and Rynhardt Kruger
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -8,6 +8,7 @@ from NVDAObjects.window import edit
 import ui
 import appModuleHandler
 import controlTypes
+from six.moves import xrange
 
 """
 App module for VIP Mud

--- a/source/braille.py
+++ b/source/braille.py
@@ -34,6 +34,7 @@ import extensionPoints
 import hwPortUtils
 import bdDetect
 import winUser
+from six.moves import xrange
 
 roleLabels = {
 	# Translators: Displayed in braille for an object which is a

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -17,6 +17,7 @@ import ui
 from baseObject import ScriptableObject
 import time
 import datetime
+from six.moves import xrange
 
 ALVA_RELEASE_MASK = 0x80
 ALVA_2ND_CR_MASK = 0x80

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2010-2018 NV Access Limited, Babbage B.V.
 
 import time
 from collections import OrderedDict
@@ -14,6 +14,7 @@ from logHandler import log
 import brailleInput
 import bdDetect
 import hwIo
+from six.moves import xrange
 
 TIMEOUT = 0.2
 BAUD_RATE = 19200

--- a/source/brailleDisplayDrivers/brailleNote.py
+++ b/source/brailleDisplayDrivers/brailleNote.py
@@ -18,6 +18,7 @@ import inputCore
 from logHandler import log
 import hwIo
 import bdDetect
+from six.moves import xrange
 
 BAUD_RATE = 38400
 TIMEOUT = 0.1

--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2012-2018 NV Access Limited, Babbage B.V.
 
 import time
 import serial
@@ -12,6 +12,7 @@ from logHandler import log
 import brailleInput
 import bdDetect
 import hwIo
+from six.moves import xrange
 
 TIMEOUT = 0.2
 BAUD_RATE = 115200

--- a/source/brailleDisplayDrivers/eurobraille.py
+++ b/source/brailleDisplayDrivers/eurobraille.py
@@ -20,6 +20,7 @@ import threading
 from globalCommands import SCRCAT_BRAILLE
 import ui
 import time
+from six.moves import xrange
 
 BAUD_RATE = 9600
 

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited
+#Copyright (C) 2008-2018 NV Access Limited
 
 from ctypes import *
 from ctypes.wintypes import *
@@ -15,6 +15,7 @@ from baseObject import ScriptableObject
 from winUser import WNDCLASSEXW, WNDPROC, LRESULT, HCURSOR
 from logHandler import log
 import brailleInput
+from six.moves import xrange
 
 #Try to load the fs braille dll
 try:

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -24,6 +24,7 @@ from logHandler import log
 import bdDetect
 import time
 import datetime
+from six.moves import xrange
 
 BAUD_RATE = 19200
 PARITY = serial.PARITY_ODD

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -18,6 +18,7 @@ from baseObject import AutoPropertyObject
 import weakref
 import time
 import bdDetect
+from six.moves import xrange
 
 BAUD_RATE = 115200
 PARITY = serial.PARITY_NONE

--- a/source/brailleDisplayDrivers/lilli.py
+++ b/source/brailleDisplayDrivers/lilli.py
@@ -2,13 +2,14 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited, Gianluca Casalino, Alberto Benassati, Babbage B.V.
+#Copyright (C) 2008-2018 NV Access Limited, Gianluca Casalino, Alberto Benassati, Babbage B.V.
 
 from logHandler import log
 from ctypes import *
 import inputCore
 import wx
 import braille
+from six.moves import xrange
 
 try:
 	lilliDll=windll.LoadLibrary("brailleDisplayDrivers\\lilli.dll")

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 Tobias Platen, Halim Sahin, Ali-Riza Ciftcioglu, NV Access Limited, Davy Kager
+#Copyright (C) 2012-2018 Tobias Platen, Halim Sahin, Ali-Riza Ciftcioglu, NV Access Limited, Davy Kager
 #Author: Tobias Platen (nvda@lists.thm.de)
 #minor changes by Halim Sahin (nvda@lists.thm.de), Ali-Riza Ciftcioglu <aliminator83@googlemail.com>, James Teh and Davy Kager
 
@@ -11,6 +11,7 @@ import itertools
 import wx
 import braille
 from logHandler import log
+from six.moves import xrange
 
 import inputCore
 import brailleInput

--- a/source/brailleDisplayDrivers/papenmeier_serial.py
+++ b/source/brailleDisplayDrivers/papenmeier_serial.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 Tobias Platen, Halim Sahin, Ali-Riza Ciftcioglu, NV Access Limited, Davy Kager
+#Copyright (C) 2012-2018 Tobias Platen, Halim Sahin, Ali-Riza Ciftcioglu, NV Access Limited, Davy Kager
 #Author: Tobias Platen (nvda@lists.thm.de)
 #minor changes by Halim Sahin (nvda@lists.thm.de), Ali-Riza Ciftcioglu <aliminator83@googlemail.com>, James Teh and Davy Kager
 #used braille port selection code from braillenote driver
@@ -20,6 +20,7 @@ import globalCommands
 import scriptHandler
 import struct
 import serial
+from six.moves import xrange
 
 #Control Flow
 STX = 0x02 #Start of Text

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 NV Access Limited, Rui Batista, Babbage B.V.
+#Copyright (C) 2012-2018 NV Access Limited, Rui Batista, Babbage B.V.
 
 import os.path
 import time
@@ -19,6 +19,7 @@ import keyboardHandler
 import api
 from baseObject import AutoPropertyObject
 import keyLabels
+from six.moves import xrange
 
 """Framework for handling braille input from the user.
 All braille input is represented by a {BrailleInputGesture}.

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -37,6 +37,7 @@ import winKernel
 import extensionPoints
 from . import profileUpgrader
 from .configSpec import confspec
+from six.moves import xrange
 
 #: True if NVDA is running as a Windows Store Desktop Bridge application
 isAppX=False

--- a/source/config/profileUpgrader.py
+++ b/source/config/profileUpgrader.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016 NV Access Limited
+#Copyright (C) 2016-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -9,6 +9,7 @@ from .configSpec import latestSchemaVersion, confspec
 from configobj import flatten_errors
 from copy import deepcopy
 from . import profileUpgradeSteps
+from six.moves import xrange
 
 SCHEMA_VERSION_KEY = "schemaVersion"
 

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2006-2018 NV Access Limited, Babbage B.V.
 
 from ctypes import *
 from ctypes.wintypes import RECT
@@ -21,6 +21,7 @@ import watchdog
 from logHandler import log
 import windowUtils
 from locationHelper import RectLTRB, RectLTWH
+from six.moves import xrange
 
 def wcharToInt(c):
 	i=ord(c)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -20,6 +20,7 @@ import buildVersion
 from . import guiHelper
 from . import nvdaControls
 from .dpiScalingHelper import DpiScalingHelperMixin
+from six.moves import xrange
 
 def promptUserForRestart():
 	# Translators: A message asking the user if they wish to restart NVDA as addons have been added, enabled/disabled or removed.

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -11,6 +11,7 @@ import oleacc
 import winUser
 import comtypes
 from ctypes import c_int
+from six.moves import xrange
 
 class AutoWidthColumnListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
 	"""

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -17,6 +17,7 @@ import winKernel
 from winKernel import SYSTEMTIME
 import config
 from logHandler import log
+from six.moves import xrange
 
 def ValidHandle(value):
 	if value == 0:

--- a/source/installer.py
+++ b/source/installer.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2011-2017 NV Access Limited, Joseph Lee, Babbage B.V.
+#Copyright (C) 2011-2018 NV Access Limited, Joseph Lee, Babbage B.V.
 
 from ctypes import *
 from ctypes.wintypes import *
@@ -25,6 +25,7 @@ from logHandler import log
 import addonHandler
 import easeOfAccess
 import COMRegistrationFixes
+from six.moves import xrange
 
 _wsh=None
 def _getWSH():

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V.
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V.
 
 """Keyboard support"""
 
@@ -29,6 +29,7 @@ import tones
 import core
 from contextlib import contextmanager
 import threading
+from six.moves import xrange
 
 ignoreInjected=False
 

--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -23,6 +23,7 @@ import ui
 from math import floor
 from contextlib import contextmanager
 import threading
+from six.moves import xrange
 
 WM_MOUSEMOVE=0x0200
 WM_LBUTTONDOWN=0x0201

--- a/source/nvda_eoaProxy.pyw
+++ b/source/nvda_eoaProxy.pyw
@@ -1,6 +1,6 @@
 #nvda_eoaProxy.pyw
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2014 NV Access Limited
+#Copyright (C) 2014-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -16,6 +16,7 @@ import os
 import ctypes
 import winUser
 import winKernel
+from six.moves import xrange
 
 def getNvdaProcess():
 	try:

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1,6 +1,6 @@
 #nvwave.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
+#Copyright (C) 2007-2018 NV Access Limited, Aleksey Sadovoy
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -17,6 +17,7 @@ import winKernel
 import wave
 import config
 from logHandler import log
+from six.moves import xrange
 
 __all__ = (
 	"WavePlayer", "getOutputDeviceNames", "outputDeviceIDToName", "outputDeviceNameToID",

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited
+#Copyright (C) 2008-2018 NV Access Limited
 
 import watchdog
 
@@ -26,6 +26,7 @@ import api
 import gui
 from logHandler import log
 import braille
+from six.moves import xrange
 
 class HelpCommand(object):
 	"""

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -13,6 +13,7 @@ import globalVars
 from logHandler import log
 import watchdog
 import core
+from six.moves import xrange
 
 eventQueue=Queue()
 eventQueue.__name__="eventQueue"

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -1,6 +1,6 @@
 #sayAllHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NVDA Contributors
+#Copyright (C) 2006-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -14,6 +14,7 @@ import api
 import tones
 import time
 import controlTypes
+from six.moves import xrange
 
 CURSOR_CARET=0
 CURSOR_REVIEW=1

--- a/source/speech.py
+++ b/source/speech.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V.
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V.
 
 """High-level functions to speak information.
 """ 
@@ -27,6 +27,7 @@ import queueHandler
 import speechDictHandler
 import characterProcessing
 import languageHandler
+from six.moves import xrange
 
 speechMode_off=0
 speechMode_beeps=1

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -8,6 +8,7 @@ import wx
 import gui
 import config
 from logHandler import log
+from six.moves import xrange
 
 class SpeechViewerFrame(wx.Dialog):
 

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #synthDrivers/sapi5.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2014 NV Access Limited, Peter Vágner, Aleksey Sadovoy
+#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -25,6 +25,7 @@ from synthDriverHandler import SynthDriver,VoiceInfo
 import config
 import nvwave
 from logHandler import log
+from six.moves import xrange
 
 # SPAudioState enumeration
 SPAS_CLOSED=0

--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -2,12 +2,13 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012 NV Access Limited
+#Copyright (C) 2012-2018 NV Access Limited
 
 import threading
 import time
 from collections import OrderedDict
 from logHandler import log
+from six.moves import xrange
 
 #Possible actions (single trackers)
 action_tap="tap"

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2009-2018 NV Access Limited, Babbage B.V.
 
 from comtypes import COMError
 import eventHandler
@@ -21,6 +21,7 @@ import api
 import aria
 import config
 import watchdog
+from six.moves import xrange
 
 FORMATSTATE_INSERTED=1
 FORMATSTATE_DELETED=2

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2007-2017 NV Access Limited, Peter Vágner
+#Copyright (C) 2007-2018 NV Access Limited, Peter Vágner
 
 import time
 import threading
@@ -37,6 +37,7 @@ import nvwave
 import treeInterceptorHandler
 import watchdog
 from abc import abstractmethod
+from six.moves import xrange
 
 VBufStorage_findDirection_forward=0
 VBufStorage_findDirection_back=1

--- a/source/virtualBuffers/adobeAcrobat.py
+++ b/source/virtualBuffers/adobeAcrobat.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2012 NV Access Limited, Aleksey Sadovoy
+#Copyright (C) 2009-2018 NV Access Limited, Aleksey Sadovoy
 
 from . import VirtualBuffer, VirtualBufferTextInfo
 import browseMode
@@ -15,6 +15,7 @@ import oleacc
 from logHandler import log
 import textInfos
 import languageHandler
+from six.moves import xrange
 
 class AdobeAcrobat_TextInfo(VirtualBufferTextInfo):
 

--- a/source/virtualBuffers/adobeFlash.py
+++ b/source/virtualBuffers/adobeFlash.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2013 NV Access Limited
+#Copyright (C) 2010-2018 NV Access Limited
 
 from comtypes import COMError
 from . import VirtualBuffer, VirtualBufferTextInfo
@@ -14,6 +14,7 @@ import IAccessibleHandler
 import oleacc
 from logHandler import log
 import textInfos
+from six.moves import xrange
 
 class AdobeFlash_TextInfo(VirtualBufferTextInfo):
 

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited, Babbage B.V., Mozilla Corporation
+#Copyright (C) 2008-2018 NV Access Limited, Babbage B.V., Mozilla Corporation
 
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
@@ -20,6 +20,7 @@ from comtypes import COMError
 import aria
 import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
+from six.moves import xrange
 
 class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 

--- a/source/virtualBuffers/lotusNotes.py
+++ b/source/virtualBuffers/lotusNotes.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2012 NV Access Limited
+#Copyright (C) 2010-2018 NV Access Limited
 
 from . import VirtualBuffer, VirtualBufferTextInfo
 import controlTypes
@@ -14,6 +14,7 @@ import oleacc
 from logHandler import log
 import textInfos
 from virtualBuffers import VirtualBufferTextInfo
+from six.moves import xrange
 
 class LotusNotesRichText_TextInfo(VirtualBufferTextInfo):
 

--- a/source/virtualBuffers/webKit.py
+++ b/source/virtualBuffers/webKit.py
@@ -1,6 +1,6 @@
 #virtualBuffers/webKit.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2011-2016 NV Access Limited
+#Copyright (C) 2011-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -15,6 +15,7 @@ import oleacc
 from logHandler import log
 import textInfos
 import NVDAHelper
+from six.moves import xrange
 
 class WebKit_TextInfo(VirtualBufferTextInfo):
 

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -15,6 +15,7 @@ import speech
 import textInfos
 import api
 import config
+from six.moves import xrange
 
 #: How often to check whether the console is dead (in ms).
 CHECK_DEAD_INTERVAL = 100


### PR DESCRIPTION
Hi,

This pull request is an optional PR but might be useful for compatibility purposes:

### Link to issue number:
Fixes #9078

### Summary of the issue:
Python 2 includes xrange, but Python 3 doesn't, so add compatibility import.

### Description of how this pull request fixes the issue:
Six module includes:

from six.moves import xrange

In Python 2, this is alias for xrange() function, and in Python 3, it will call range() function.

### Testing performed:
Tested on both Python 2 and 3 versions of NVDA, as well as on at least two add-ons ported from Python 2 to 3.

### Known issues with pull request:
None

### Change log entry:
None

### Python 3 compatibility note:
If adopted, a note must be placed in the log stating that this will be converted to Python 3 native range() function in the near future.

Thanks.