### PR TITLE
wxLang: only load language data if the given UI language has language info

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -385,8 +385,10 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 		locale.AddCatalogLookupPathPrefix(os.path.join(os.getcwdu(),"locale"))
 	# #8064: Wx might know the language, but may not actually contain a translation database for that language.
 	# If we try to initialize this language, wx will show a warning dialog.
-	# Therefore treat this situation like wx not knowing the language at all.
-	if not locale.IsAvailable(wxLang.Language):
+	# #9089: some languages (such as Aragonese) do not have language info, causing language getter to fail.
+	# In this case, wxLang is already set to None.
+	# Therefore treat these situations like wx not knowing the language at all.
+	if wxLang and not locale.IsAvailable(wxLang.Language):
 		wxLang=None
 	if wxLang:
 		try:


### PR DESCRIPTION
### Link to issue number:
Fixes #9089 

### Summary of the issue:
if wxLang is None, wxLang.Language raises AttributeError, seen if the given UI language does not have language info.

### Description of how this pull request fixes the issue:
wxLang.Language fails in Aragonese because wxLang itself is None. There might be other languages where this might be the case. Thus only obtain wxLang.Language if and only if wxLang is indeed not None, evidenced by presence of language info.

### Testing performed:
Tested on both source code and a portable copy with language set to Aragonese.

### Known issues with pull request:
None

### Change log entry:
Bug fixes for 2018.4.x: This release fixes a crash at start up if NVDA's user interface language is set to Aragonese.
