### PR TITLE
Fix module of dynamic NVDAObject classes

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -112,7 +112,7 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 			newCls=self._dynamicClassCache.get(bases,None)
 			if not newCls:
 				name="Dynamic_%s"%"".join([x.__name__ for x in clsList])
-				newCls=type(name,bases,{})
+				newCls=type(name,bases,{"__module__": __name__})
 				self._dynamicClassCache[bases]=newCls
 
 		oldMro=frozenset(obj.__class__.__mro__)


### PR DESCRIPTION
### Link to issue number:
Fixes trivial regression caused by #8393.

### Summary of the issue:
Dynamic NVDA Objects are considered to belong to the abc module, i.e. `abc.Dynamic_IAccessibleEditWindowNVDAObject`. This, although a trivial issue, is a bit confusing and its module was NVDAObjects before.

### Str
Do the following in a Python console when Notepad has focus before opening the console:
```
>>> nav
<abc.Dynamic_IAccessibleEditWindowNVDAObject object at 0x05705650>
>>> nav.__module__
'abc'
```

### Description of how this pull request fixes the issue:
When creating a new type, override the __module__ property on the dynamic class.

### Testing performed:
Tested in notepad, the module was NVDAObjects again.

```
>>> nav
<NVDAObjects.Dynamic_IAccessibleEditWindowNVDAObject object at 0x05705650>
>>> nav.__module__
'NVDAObjects'
```

### Known issues with pull request:
None

### Change log entry:
None needed