### PR TITLE
OffsetsTextInfo.boundingRects property: make sure there is a location to work with when calculating intersections

### DIFF
--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -99,7 +99,7 @@ class _EventExecuter(object):
 		try:
 			return func(*args, **self.kwargs)
 		except TypeError:
-			log.warning("Could not execute function {func} defined in {module} module due to unsupported kwargs: {kwargs}".format(
+			log.warning("Could not execute function {func} defined in {module} module; kwargs: {kwargs}".format(
 				func=func.__name__,
 				module=func.__module__ or "unknown",
 				kwargs=self.kwargs

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -13,6 +13,7 @@ import config
 import textInfos
 from locationHelper import RectLTWH
 from treeInterceptorHandler import TreeInterceptor
+import api
 
 HIGH_SURROGATE_FIRST = u"\uD800"
 HIGH_SURROGATE_LAST = u"\uDBFF"
@@ -208,7 +209,10 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			pass
 		# If the inclusive end offset is greater than the start offset, we are working with a range.
 		# If not, i.e. the range only contains one character, we have only one location to deal with.
-		objLocation = self.obj.rootNVDAObject.location if isinstance(self.obj, TreeInterceptor) else self.obj.location
+		obj = self.obj.rootNVDAObject if isinstance(self.obj, TreeInterceptor) else self.obj
+		objLocation = obj.location or api.getForegroundObject().location
+		if not objLocation:
+			raise LookupError
 		rects = [] 
 		if inclusiveEndOffset > startOffset:
 			offset = startOffset

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2018 NV Access Limited, Babbage B.V.
+#Copyright (C) 2006-2019 NV Access Limited, Babbage B.V.
 
 from abc import abstractmethod
 import re
@@ -14,6 +14,7 @@ import textInfos
 from locationHelper import RectLTWH
 from treeInterceptorHandler import TreeInterceptor
 import api
+from six.moves import range
 
 HIGH_SURROGATE_FIRST = u"\uD800"
 HIGH_SURROGATE_LAST = u"\uDBFF"
@@ -210,7 +211,11 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		# If the inclusive end offset is greater than the start offset, we are working with a range.
 		# If not, i.e. the range only contains one character, we have only one location to deal with.
 		obj = self.obj.rootNVDAObject if isinstance(self.obj, TreeInterceptor) else self.obj
-		objLocation = obj.location or api.getForegroundObject().location
+		for i in range(100):
+			objLocation = obj.location
+			if objLocation:
+				break
+			obj = obj.parent
 		if not objLocation:
 			raise LookupError
 		rects = [] 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
I received a bug reports where the boundingRects code for OffsetsTextInfo failed as follows:

<details>
<summary>Log snippet<?summary>
WARNING - eventHandler._EventExecuter.next (13:43:58.411):
Could not execute function event_gainFocus defined in NVDAObjects module due to unsupported kwargs: {}
Traceback (most recent call last):
  File "eventHandler.pyc", line 100, in next
  File "NVDAObjects\__init__.pyc", line 972, in event_gainFocus
  File "vision\__init__.pyc", line 541, in handleGainFocus
  File "vision\NVDAHighlighter.pyc", line 65, in updateContextRect
  File "vision\__init__.pyc", line 237, in updateContextRect
  File "vision\__init__.pyc", line 165, in getContextRect
  File "vision\__init__.pyc", line 176, in _getRectFromTextInfo
  File "baseObject.pyc", line 32, in __get__
  File "textInfos\offsets.pyc", line 233, in _get_boundingRects
  File "locationHelper.pyc", line 335, in intersection
TypeError: other should be one of locationHelper.RectLTRB, locationHelper.RectLTWH, ctypes.wintypes.RECT, textInfos.Rect
</details>

This was tested with Firefox with the NVDA highlighter in the vision framework (#9064)

### Description of how this pull request fixes the issue:
1. EventGandler tries to executes functions, and if they fails because of unsupported arguments (which is a type error), it  tries to use extensionPoints.callWithSupportedKwargs instead. However, locationHelper caused a TypeError as well, which triggered the exception handler. Therefore, I somewhat reworded the logged warning in the eventHandler.
2. The boundingRects property caused a TypeError because it tried to throw a None type object in locationHelper.RectLTWH.intersection. Now, if either the location of the NVDAObject or the foreground object it lives in is None, a LookupError is raised instead.

### Testing performed:
Unfortunately, I wasn't able to reproduce the issue myself, so it wasn't possible to test this particular case.

### Known issues with pull request:
NOne

### Change log entry:
None needed.