### PR TITLE
NVDAObjects/UIA: treat looping selectors as combo boxes without value pattern

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -30,7 +30,6 @@ from NVDAObjects.window import Window
 from NVDAObjects import NVDAObjectTextInfo, InvalidNVDAObject
 from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDetection, Dialog, Notification, EditableTextWithSuggestions
 import braille
-import time
 from locationHelper import RectLTWH
 import ui
 
@@ -774,7 +773,7 @@ class UIA(Window):
 		elif self.windowClassName=="Windows.UI.Core.CoreWindow" and UIAControlType==UIAHandler.UIA_WindowControlTypeId and "ToastView" in self.UIAElement.cachedAutomationId: # Windows 10
 			clsList.append(Toast_win10)
 		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
-			import edge
+			from . import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
 				clsList.append(edge.EdgeHTMLRootContainer)
 			elif (self.UIATextPattern and
@@ -789,7 +788,7 @@ class UIA(Window):
 				clsList.append(edge.EdgeNode)
 		elif self.role==controlTypes.ROLE_DOCUMENT and self.UIAElement.cachedAutomationId=="Microsoft.Windows.PDF.DocumentView":
 				# PDFs
-				import edge
+				from . import edge
 				clsList.append(edge.EdgeHTMLRoot)
 		if UIAControlType==UIAHandler.UIA_ProgressBarControlTypeId:
 			clsList.append(ProgressBar)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -802,7 +802,10 @@ class UIA(Window):
 			clsList.append(SensitiveSlider) 
 		if UIAControlType==UIAHandler.UIA_TreeItemControlTypeId:
 			clsList.append(TreeviewItem)
-		elif UIAControlType==UIAHandler.UIA_ComboBoxControlTypeId:
+		# Some combo boxes and looping selectors do not expose value pattern.
+		elif (UIAControlType==UIAHandler.UIA_ComboBoxControlTypeId
+		# #5231: Announce values in time pickers by "transforming" them into combo box without value pattern objects.
+		or (UIAControlType==UIAHandler.UIA_ListControlTypeId and "LoopingSelector" in UIAClassName)):
 			try:
 				if not self._getUIACacheablePropertyValue(UIAHandler.UIA_IsValuePatternAvailablePropertyId):
 					clsList.append(ComboBoxWithoutValuePattern)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -30,6 +30,7 @@ What's New in NVDA
 - If a 3rd party speech synthesizer fails to load, NVDA will fall back to Windows OneCore speech on Windows 10, rather than espeak. (#9025)
 - Removed the "Welcome Dialog" entry in the NVDA menu while on secure screens. (#8520)
 - When tabbing or using quick navigation in browse mode, legends on tab panels are now reported more consistently. (#709)
+- NVDA will now announce selection changes for certain time pickers such as in the Alarms and Clock app. (#5231)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
Hi,

Finally resolving it after three years:

### Link to issue number:
Fixes #5231 

### Summary of the issue:
Looping selectors do not expose value pattern, causing NVDA to not announce currently selected item. This is prominent in Alarms and Clock app and other apps where time picker is involved.

### Description of how this pull request fixes the issue:
Looping selectors without value pattern is coerced into NVDAObjects.UIA.ComboBoxWithouValuePattern.

### Testing performed:
Tested with Alarms and Clock, Settings and other apps employing time pickers on various Windows 10 releases (builds 17134, 17763, 18305)

### Known issues with pull request:
None

### Change log entry:
Bug fixes: I advise copying the what's new entry for ComboBoxWithoutValuePattern fix (#6337), adopting the wording to say that the fix now applies to certain time pickers in Windows 10 apps.

Thanks.