### PR TITLE
Report the presence of formulae in Lotus Symphony-based spreadsheets

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -220,7 +220,7 @@ class SymphonyTableCell(IAccessible):
 			# #8988: Cells in Libre Office do not have the selected state when a single cell is selected (i.e. has focus).
 			# Since #8898, the negative selected state is announced for table cells with the selectable state.
 			states.add(controlTypes.STATE_SELECTED)
-		if 'Formula' in self.IA2Attributes and self.IA2Attributes['Formula']:
+ 		if self.IA2Attributes.get('Formula'):
 			# #860: Recent versions of Calc expose has formula state via IAccessible 2.
 			states.add(controlTypes.STATE_HASFORMULA)
 		return states

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2010 Michael Curran <mick@kulgan.net>, James Teh <jamie@jantrid.net>
+#Copyright (C) 2006-2019 NV Access Limited, Bill Dengler
 
 from comtypes import COMError
 import IAccessibleHandler

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -220,6 +220,9 @@ class SymphonyTableCell(IAccessible):
 			# #8988: Cells in Libre Office do not have the selected state when a single cell is selected (i.e. has focus).
 			# Since #8898, the negative selected state is announced for table cells with the selectable state.
 			states.add(controlTypes.STATE_SELECTED)
+		if 'Formula' in self.IA2Attributes and self.IA2Attributes['Formula']:
+			# #860: Recent versions of Calc expose has formula state via IAccessible 2.
+			states.add(controlTypes.STATE_HASFORMULA)
 		return states
 
 class SymphonyTable(IAccessible):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,7 @@ What's New in NVDA
  - This will allow NVDA to track the mouse when a system is controlled remotely using TeamViewer or other remote control software.
 - Added the `--disable-start-on-logon` command line parameter to allow silent installations of NVDA that don't run at the logon screen by default. (#8574)
 - It is possible to turn off NVDA's logging features off by setting logging level to "disabled" from General settings panel. (#8516)
+- The presence of formulae in LibreOffice and Apache OpenOffice spreadsheets is now reported. (#860)
 
 
 == Changes ==


### PR DESCRIPTION



<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#860

### Summary of the issue:
Unlike in Excel, NVDA does not announce the presence of formulae in Lotus Symphony spreadsheets, such as in [LibreOffice](http://libreoffice.org) or [OpenOffice](http://openoffice.org).

### Description of how this pull request fixes the issue:
As documented in the issue, these applications now expose an IAccessible 2 attribute, Formula, which contains the formula of a given cell if present. I've added a check in `appModules.soffice.SymphonyTableCell._get_states` for this attribute: if it indicates a formula for the cell, its `ControlTypes.STATE_HASFORMULA` is set.

### Testing performed:
Read the [attached spreadsheet](https://github.com/nvaccess/nvda/files/2719061/plants.xlsx) using LibreOffice Calc on Windows 10 1809 before and after the patch. Noted that "has formula" is announced after the patch for cells containing formulae.

### Known issues with pull request:
None.

### Change log entry:

== New Features ==
- The presence of formulae in LibreOffice and Apache OpenOffice spreadsheets is now reported. (#860)