### PR TITLE
Report legends on tab pages when tabbing or using quick navigation

### DIFF
--- a/source/speech.py
+++ b/source/speech.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V.
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler
 
 """High-level functions to speak information.
 """ 
@@ -1227,8 +1227,8 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 	elif fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_TABLE and tableID:
 		# Table.
 		return " ".join((nameText,roleText,stateText, getSpeechTextForProperties(_tableID=tableID, rowCount=attrs.get("table-rowcount"), columnCount=attrs.get("table-columncount")),levelText))
-	elif nameText and reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role==controlTypes.ROLE_GROUPING:
-		# #3321: Report the name of groupings (such as fieldsets) for quicknav and focus jumps
+	elif nameText and reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role in (controlTypes.ROLE_GROUPING, controlTypes.ROLE_PROPERTYPAGE):
+		# #3321, #709: Report the name of groupings (such as fieldsets) and tab pages for quicknav and focus jumps
 		return " ".join((nameText,roleText))
 	elif fieldType in ("start_addedToControlFieldStack","start_relative") and role in (controlTypes.ROLE_TABLECELL,controlTypes.ROLE_TABLECOLUMNHEADER,controlTypes.ROLE_TABLEROWHEADER) and tableID:
 		# Table cell.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -28,6 +28,7 @@ What's New in NVDA
 - Improved restart confirmation dialog after changing interface language. The text and the button labels are now more concise and less confusing. (#6416)
 - If a 3rd party speech synthesizer fails to load, NVDA will fall back to Windows OneCore speech on Windows 10, rather than espeak. (#9025)
 - Removed the "Welcome Dialog" entry in the NVDA menu while on secure screens. (#8520)
+- When tabbing or using quick navigation in browse mode, legends on tab panels are now reported more consistently. (#709)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#709

### Summary of the issue:
NVDA does not report legends on tab panels when tabbing or using quick navigation.

### Description of how this pull request fixes the issue:
This PR expands the check added in #7435 for property pages, so that we now check for either `controlTypes.ROLE_GROUPING` or `controlTypes.ROLE_PROPERTYPAGE`.

### Testing performed:
Visited the following URL:

    data:text/html,<div id="tab" role="tab" tabindex="0">Foo</div><a href="https://www.nvaccess.org/">Intervening link</a><div role="tabpanel" aria-labelledby="tab"><button>Button inside the tab panel</button></div>

before and after the patch, using Google Chrome 64-bit version 72.0.3626.28 on Windows 10 version 1809. Noticed that when tabbing through the elements, "foo property page" is now reported.

### Known issues with pull request:
None.

### Change log entry:
== Bug Fixes ==
- When tabbing or using quick navigation in browse mode, legends on tab panels are now reported more consistently. (#709)