### PR TITLE
Expose the extended window style on Window objects

### DIFF
--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -1,6 +1,6 @@
 #NVDAObjects/window.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Babbage B.V.
+#Copyright (C) 2006-2019 NV Access Limited, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -287,6 +287,9 @@ An NVDAObject for a window
 	def _get_windowStyle(self):
 		return winUser.getWindowStyle(self.windowHandle)
 
+	def _get_extendedWindowStyle(self):
+		return winUser.getExtendedWindowStyle(self.windowHandle)
+
 	def _get_isWindowUnicode(self):
 		if not hasattr(self,'_isWindowUnicode'):
 			self._isWindowUnicode=bool(ctypes.windll.user32.IsWindowUnicode(self.windowHandle))
@@ -357,6 +360,11 @@ An NVDAObject for a window
 		except Exception as e:
 			ret = "exception: %s" % e
 		info.append("windowStyle: %s" % ret)
+		try:
+			ret = repr(self.extendedWindowStyle)
+		except Exception as e:
+			ret = "exception: %s" % e
+		info.append("extendedWindowStyle: %s" % ret)
 		try:
 			ret = repr(self.windowThreadID)
 		except Exception as e:

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -1,6 +1,6 @@
 #winUser.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2006-2019 NV Access Limited, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -487,6 +487,9 @@ def getGUIThreadInfo(threadID):
 
 def getWindowStyle(hwnd):
 	return user32.GetWindowLongW(hwnd,GWL_STYLE)
+
+def getExtendedWindowStyle(hwnd):
+	return user32.GetWindowLongW(hwnd,GWL_EXSTYLE)
 
 def getPreviousWindow(hwnd):
 	try:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
For application Windows, the window style can be fetched to find out whether the window has a title bar, is visible or unavailable. The extended window style wasn't yet available on Window objects. The [extended window style](https://www.google.com/search?client=firefox-b-d&q=extended+window+style+msdn) provides information like:

* Whether the window supports dragging and dropping of files
* Whether the window is a window within an MDI interface
* Whether the window text is displayed using right-to-left reading-order properties
* Whether the window is a floating toolbar
* Whether the window is transparent
* The window is always on top

### Description of how this pull request fixes the issue:
Implements the extendedWindowStyle property and adds it to the developer info

### Testing performed:
Tested using several windows. IN many cases, the extended window style is 0. However, not for the notepad foreground window, for example.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
    + The extended window style of a window is now exposed using the extendedWindowStyle property on Window objects and their derivatives.