### PR TITLE
ia2utils HyperlinkGetter: Switch to CComPtr

### DIFF
--- a/nvdaHelper/common/ia2utils.h
+++ b/nvdaHelper/common/ia2utils.h
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2007-2017 NV Access Limited, Mozilla Corporation
+Copyright 2007-2019 NV Access Limited, Mozilla Corporation
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -15,8 +15,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #ifndef _VBUF_IA2UTILS_H
 #define _VBUF_IA2UTILS_H
 
-#include <comdef.h>
-#include <comip.h>
+#include <atlcomcli.h>
 #include <string>
 #include <map>
 #include <memory>
@@ -33,11 +32,6 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
 void IA2AttribsToMap(const std::wstring &attribsString, std::map<std::wstring, std::wstring> &attribsMap);
 
-_COM_SMARTPTR_TYPEDEF(IAccessible2, IID_IAccessible2);
-_COM_SMARTPTR_TYPEDEF(IAccessibleHypertext, IID_IAccessibleHypertext);
-_COM_SMARTPTR_TYPEDEF(IAccessibleHypertext2, IID_IAccessibleHypertext2);
-_COM_SMARTPTR_TYPEDEF(IAccessibleHyperlink, IID_IAccessibleHyperlink);
-
 /**
  * Base class to support retrieving hyperlinks (embedded objects) from
  * IAccessibleHypertext or IAccessibleHypertext2.
@@ -50,38 +44,38 @@ class HyperlinkGetter {
 
 	/** Get the next hyperlink.
 	 */
-	virtual IAccessibleHyperlinkPtr next();
+	virtual CComPtr<IAccessibleHyperlink> next();
 
 	protected:
 	long index = 0;
-	virtual IAccessibleHyperlinkPtr get(const unsigned long index) = 0;
+	virtual CComPtr<IAccessibleHyperlink> get(const unsigned long index) = 0;
 };
 
 /** Supports retrieval of hyperlinks from IAccessibleHypertext.
  */
 class HtHyperlinkGetter: public HyperlinkGetter {
 	public:
-	HtHyperlinkGetter(IAccessibleHypertextPtr hypertext);
+	HtHyperlinkGetter(CComPtr<IAccessibleHypertext> hypertext);
 
 	protected:
-	virtual IAccessibleHyperlinkPtr get(const unsigned long index) override;
+	virtual CComPtr<IAccessibleHyperlink> get(const unsigned long index) override;
 
 	private:
-	IAccessibleHypertextPtr hypertext;
+	CComPtr<IAccessibleHypertext> hypertext;
 };
 
 /** Supports retrieval of hyperlinks from IAccessibleHypertext2.
  */
 class Ht2HyperlinkGetter: public HyperlinkGetter {
 	public:
-	Ht2HyperlinkGetter(IAccessibleHypertext2Ptr hypertext);
+	Ht2HyperlinkGetter(CComPtr<IAccessibleHypertext2> hypertext);
 	virtual ~Ht2HyperlinkGetter();
 
 	protected:
-	virtual IAccessibleHyperlinkPtr get(const unsigned long index) override;
+	virtual CComPtr<IAccessibleHyperlink> get(const unsigned long index) override;
 
 	private:
-	IAccessibleHypertext2Ptr hypertext;
+	CComPtr<IAccessibleHypertext2> hypertext;
 	IAccessibleHyperlink** rawLinks = nullptr;
 	long count;
 	void maybeFetch();

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -854,8 +854,8 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 					chunkStart=i+1;
 					// In Gecko, hyperlinks correspond to embedded object chars,
 					// so there's no need to call IAHyperlink::hyperlinkIndex.
-					IAccessibleHyperlinkPtr link = move(linkGetter->next());
-					IAccessible2Ptr childPacc = link;
+					CComPtr<IAccessibleHyperlink> link = linkGetter->next();
+					CComQIPtr<IAccessible2> childPacc = link;
 					if(!childPacc) {
 						continue;
 					}

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -34,6 +34,7 @@ What's New in NVDA
 - In Windows 10's Action Center, NVDA will announce status messages when toggling quick actions such as brightness and focus assist. (#8954)
 - In action Center in Windows 10 October 2018 Update and earlier, NVDA will recognize brightness quick action control as a button instead of a toggle button. (#8845)
 - NVDA will again track cursor and announce deleted characters in the Microsoft Excel  go to and find edit fields. (#9042)
+- Fixed a rare browse mode crash in Firefox. (#9152)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Addresses part of #9133.

### Summary of the issue:
When rendering a document for browse mode in Firefox, failure in retrieving an embedded object causes an uncaught exception, thus crashing Firefox. See [this Firefox crash report](https://crash-stats.mozilla.org/report/index/39516d12-2e98-4620-8d3f-dccde0190107).

### Description of how this pull request fixes the issue:
HyperlinkGetter (in nvdaHelper/common/ia2utils) uses the `_com_ptr_t` smart pointer for COM objects. `_com_ptr_t` throws C++ exceptions for COM errors (other than E_NOINTERFACE) when doing a QueryInterface. Normally, there should not be any COM errors when doing a QI to IAccessible2 on an IAccessibleHyperlink for an embedded object in Firefox. However, it has happened (it's the cause of the above crash) and it is theoretically possible; e.g. if the object died after being retrieved but before QI, since a11y calls do not block the content main thread in Firefox.

We had the choice to switch to CComPtr (which guarantees not to throw exceptions) or catch the exceptions. Since we're moving to CComPtr in newer code anyway, I went with the former.

### Testing performed:
Tested rendering World War I in Firefox and compared the load times to check they were in the same ballpark. I can't test for the crash, since I can't reproduce it and it is very rare.

### Known issues with pull request:
None known.

### Change log entry:

Bug fixes:

`- Fixed a rare browse mode crash in Firefox.`