### PR TITLE
Add music symbols to the symbols dictionary

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -185,5 +185,10 @@ _	line	most
 ⅝	five eighths	none
 ⅞	seven eighths	none
 
+# Music signs
+♭	flat	none
+♮	natural	none
+♯	sharp	none
+
 # Miscellaneous Technical
 ⌘	Mac Command key	none


### PR DESCRIPTION
### Link to issue number:
Fixes #9138

### Summary of the issue:
Music symbols, such as ♭ (flat), ♮ (natural) and ♯ (sharp) aren't spoken by NVDA.

### Description of how this pull request fixes the issue:
Adds the mentioned symbols to the symbols list.

### Testing performed:
Tested by arrowing over the symbols.

### Known issues with pull request:
None

### Change log entry:
Unicode music symbols (such as natural, flat and sharp) are now spoken appropriately. (#9138)