### PR TITLE
Fix functionality of the last 16 routing keys on 80 cell eurobraille displays

### DIFF
--- a/source/brailleDisplayDrivers/eurobraille.py
+++ b/source/brailleDisplayDrivers/eurobraille.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2017-2018 NV Access Limited, Babbage B.V., Eurobraille
+#Copyright (C) 2017-2019 NV Access Limited, Babbage B.V., Eurobraille
 
 from collections import OrderedDict, defaultdict
 from cStringIO import StringIO
@@ -559,7 +559,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 				if groupKeysDown & 0x100:
 					names.append("backSpace")
 			if group == EB_KEY_INTERACTIVE: # Routing
-				self.routingIndex = (groupKeysDown & 0x3f)-1
+				self.routingIndex = (groupKeysDown & 0xff)-1
 				names.append("doubleRouting" if groupKeysDown>>8 ==ord(EB_KEY_INTERACTIVE_DOUBLE_CLICK) else "routing")
 			if group == EB_KEY_COMMAND:
 				for key, keyName in display.keys.iteritems():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -38,6 +38,7 @@ What's New in NVDA
 - Significant speed improvements when navigating documents in Microsoft Word and Outlook 2016 build 9000 or higher, due to NVDA's UI Automation support for Microsoft Word now being used by default for these builds. (#7409)
 - NVDA no longer fails to report the focus for some controls in the Microsoft Office 2016 ribbon when collapsed.
 - NVDA no longer fails to report the suggested contact when entering addresses in new messages in Outlook 2016. (#8502)
+- The last few cursor routing keys on 80 cell eurobraille displays no longer route the cursor to a position at or just after the start of the braille line. (#9160)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
On eurobraille displays with 80 cells, using the cursor routings of the last cursor routing keys routes the cursor to one of the first cells on the display.

### Description of how this pull request fixes the issue:
There was an incorrect bitmask in the driver, 0x3f had to be 0xff. I'm really not sure why I've made this mistake in the past, since 0x3f makes no sense at all.

### Testing performed:
Confirmed that all cursor routing keys on a 80 cell display work as expected.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + The last few cursor routing keys on 80 cell eurobraille displays no longer route the cursor to a position at or just after the start of the braille line.