### PR TITLE
Implement an ActionContainer class in extensionPoints

### DIFF
--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -1,6 +1,6 @@
 #extensionPoints.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017 NV Access Limited
+#Copyright (C) 2017-2019 NV Access Limited, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -88,8 +88,8 @@ class ActionContainer(MutableMapping):
 		return key in self._actions
 
 	def __setitem__(self, key, val):
-		if not isinstance(key, basestring):
-			raise TypeError("Keys in an ActionContainer should be of type basestring")
+		if not isinstance(key, str):
+			raise TypeError("Keys in an ActionContainer should be of type str")
 		if not isinstance(val, Action):
 			raise TypeError("You can only add items of type Action to an ActionContainer")
 		self._actions[key] = val


### PR DESCRIPTION
### Description of this pull request
This pr implements an ActionContainer class in extensionPoints. This does what it says, it can bundle multiple Actions in a container. As a bonus, it supports wildcard actions. The concept of the action container is heavily inspired by the callbackManager system in @nvdaremote.

First, an ActionContainer is created:

`>>> actions= extensionPoints.ActionContainer()`

Interested parties then register to be notified about an action

```
>>> def onSomethingHappened(someArg=None):
... 	print(someArg)
...
>>> actions.register('somethingHappened', onSomethingHappened)
```

When the action is performed, register handlers are notified.

`>>> actions.notify('somethingHappened', someArg=42)`

Alternatively, you can use Unix filename pattern matching rules
to create an action that will be notified for multiple action names.

`>>> actions.register('something*', onSomethingRandom)`

Then, Calling notify for 'somethingHappened' will trigger both 'somethingHappened' and 'something*'

### Testing performed:
Tested in a python console.

### Known issues with pull request:
None

### Change log entry:
+ Changes for developers
    * The extensionPoints module now contains a new ActionContainer class that can be used to group actions together.