### PR TITLE
Gecko vbuf: Render the selected item in list boxes and trees.

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -36,6 +36,8 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	bool isLabelVisible(IAccessible2* pacc2);
 	CComPtr<IAccessible2> getLabelElement(IAccessible2_2* element);
+	CComPtr<IAccessible2> getSelectedItem(IAccessible2* container,
+		const std::map<std::wstring, std::wstring>& attribs);
 
 	protected:
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -262,6 +262,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		controlTypes.ROLE_COMBOBOX,
 		controlTypes.ROLE_EDITABLETEXT,
 		controlTypes.ROLE_LIST,
+		controlTypes.ROLE_LISTITEM,
 		controlTypes.ROLE_SLIDER,
 		controlTypes.ROLE_TABCONTROL,
 		controlTypes.ROLE_MENUBAR,

--- a/source/speech.py
+++ b/source/speech.py
@@ -1210,7 +1210,11 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 
 	# Determine the order of speech.
 	# speakContentFirst: Speak the content before the control field info.
-	speakContentFirst = reason == controlTypes.REASON_FOCUS and presCat != attrs.PRESCAT_CONTAINER and role not in (controlTypes.ROLE_EDITABLETEXT, controlTypes.ROLE_COMBOBOX) and not tableID and controlTypes.STATE_EDITABLE not in states
+	speakContentFirst = (reason == controlTypes.REASON_FOCUS
+		and presCat != attrs.PRESCAT_CONTAINER
+		and role not in (controlTypes.ROLE_EDITABLETEXT, controlTypes.ROLE_COMBOBOX, controlTypes.ROLE_TREEVIEW, controlTypes.ROLE_LIST)
+		and not tableID
+		and controlTypes.STATE_EDITABLE not in states)
 	# speakStatesFirst: Speak the states before the role.
 	speakStatesFirst=role==controlTypes.ROLE_LINK
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,6 +12,9 @@ What's New in NVDA
 - Added the `--disable-start-on-logon` command line parameter to allow silent installations of NVDA that don't run at the logon screen by default. (#8574)
 - It is possible to turn off NVDA's logging features off by setting logging level to "disabled" from General settings panel. (#8516)
 - The presence of formulae in LibreOffice and Apache OpenOffice spreadsheets is now reported. (#860)
+- In Mozilla Firefox and Google Chrome, browse mode now reports the selected item in list boxes and trees.
+ - This works in Firefox 66 and later.
+ - This does not work for certain list boxes (HTML select controls) in Chrome.
 
 
 == Changes ==
@@ -40,6 +43,7 @@ What's New in NVDA
 - NVDA no longer fails to report the suggested contact when entering addresses in new messages in Outlook 2016. (#8502)
 - The last few cursor routing keys on 80 cell eurobraille displays no longer route the cursor to a position at or just after the start of the braille line. (#9160)
 - Fixed table navigation in threaded view in Mozilla Thunderbird. (#8396)
+- In Mozilla Firefox and Google Chrome, switching to focus mode now works correctly for certain list boxes and trees (where the list box/tree is not itself focusable but its items are) . (#3573, #9157)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #3573. Fixes #9157.

### Summary of the issue:
1. When an ARIA list box or tree isn't focusable but its items are (as permitted by the ARIA spec), it is currently impossible to focus the list box/tree in browse mode.
2. In browse mode, the selected item in a list box or tree is not reported. The user has to use the report focus command or similar to query for this information.

### Description of how this pull request fixes the issue:
In the Gecko vbuf backend, IAccessible::accSelection is used to retrieve the selected item in list boxes and trees. This is then rendered into the buffer. If there is no selected item, the first chlid is rendered.

This required changing speech.getControlFieldSpeech so that the content of lists and trees is spoken after the control field info for REASON_FOCUS. Otherwise, moving to a list box or tree with quick navigation would speak the selected item first.

List item also had to be added to the roles which always enable pass through, as this change means that a list item can now be under the cursor when enter is pressed. (Read only list items are still excluded by an earlier check.)

This is currently disabled for HTML select size>1 controls in Chrome. These list items get the focusable state but setting focus programmatically does nothing. Therefore, we don't want to render these in Chrome because a user wouldn't be able to focus these list boxes in browse mode if we did.

### Testing performed:
Test cases:

- HTML select, initially selected item should be "b":
    `data:text/html,<select size="2"><option>a</option><option selected>b</option></select>`
- ARIA tree, selected item should be "b":
    `data:text/html,<div role="tree"><div id="a" role="treeitem">a</div><div id="b" role="treeitem" aria-selected="true" tabindex="0">b</div></div><button onClick="a.setAttribute('aria-selected', 'true'); b.setAttribute('aria-selected', 'false');">Select a</button>`
    Use the "Select a" button to change the selection.

In Firefox, for each test case, verified the initial selection is reported in the buffer. Verified that when the selection is changed, the buffer is updated.
In Chrome, only the tree test case can be tested, since this is disabled for HTML select in Chrome.

### Known issues with pull request:
Disabled for HTML select in Chrome due to a Chrome bug.

### Change log entry:

New Features:
```
- In Mozilla Firefox and Google Chrome, browse mode now reports the selected item in list boxes and trees.
 - This works in Firefox 66 and later.
 - This does not work for certain list boxes (HTML select controls) in Chrome.
```

Bug Fixes:
`- In Mozilla Firefox and Google Chrome, switching to focus mode now works correctly for certain list boxes and trees (where the list box/tree is not itself focusable but its items are) . (#3573, #9157)`