### PR TITLE
Optional logging of time since input when speaking.

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -204,6 +204,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	audioDucking = boolean(default=false)
 	gui = boolean(default=false)
 	louis = boolean(default=false)
+	timeSinceInput = boolean(default=false)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2017 NV Access Limited, Babbage B.V.
+#Copyright (C) 2010-2019 NV Access Limited, Babbage B.V., Mozilla Corporation
 
 """Core framework for handling input from the user.
 Every piece of input from the user (e.g. a key press) is represented by an L{InputGesture}.
@@ -14,6 +14,7 @@ import sys
 import os
 import itertools
 import weakref
+import time
 import configobj
 import sayAllHandler
 import baseObject
@@ -403,6 +404,7 @@ class InputManager(baseObject.AutoPropertyObject):
 		self.userGestureMap = GlobalGestureMap()
 		self.loadLocaleGestureMap()
 		self.loadUserGestureMap()
+		self._lastInputTime = None
 
 	def executeGesture(self, gesture):
 		"""Perform the action associated with a gesture.
@@ -440,6 +442,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
+			self._lastInputTime = time.time()
 			log.io("Input: %s" % gesture.identifiers[0])
 
 		if self._captureFunc:
@@ -787,3 +790,14 @@ def terminate():
 	"""
 	global manager
 	manager=None
+
+def  logTimeSinceInput():
+	"""Log the time since the last input was received.
+	This does nothing if time since input logging is disabled.
+	"""
+	if (not log.isEnabledFor(log.IO)
+		or not config.conf["debugLog"]["timeSinceInput"]
+		or not manager or not manager._lastInputTime
+	):
+		return
+	log.io("Time since input: %.3f sec" % (time.time() - manager._lastInputTime))

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -800,4 +800,4 @@ def  logTimeSinceInput():
 		or not manager or not manager._lastInputTime
 	):
 		return
-	log.io("Time since input: %.3f sec" % (time.time() - manager._lastInputTime))
+	log.io("%.3f sec since input" % (time.time() - manager._lastInputTime))

--- a/source/speech.py
+++ b/source/speech.py
@@ -240,6 +240,8 @@ def _speakSpellingGen(text,locale,useCharacterDescriptions):
 				synth.pitch=max(0,min(oldPitch+synthConfig["capPitchChange"],100))
 			count = len(char)
 			index=count+1
+			import inputCore
+			inputCore.logTimeSinceInput()
 			log.io("Speaking character %r"%char)
 			speechSequence=[LangChangeCommand(locale)] if config.conf['speech']['autoLanguageSwitching'] else []
 			if len(char) == 1 and synthConfig["useSpellingFunctionality"]:
@@ -553,6 +555,8 @@ def speak(speechSequence,symbolLevel=None):
 		# After normalisation, the sequence is empty.
 		# There's nothing to speak.
 		return
+	import inputCore
+	inputCore.logTimeSinceInput()
 	log.io("Speaking %r" % speechSequence)
 	if symbolLevel is None:
 		symbolLevel=config.conf["speech"]["symbolLevel"]

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -49,6 +49,7 @@ What's New in NVDA
 - OffsetsTextInfo objects can now implement the _getBoundingRectFromOffset method to allow retrieval of bounding rectangles per characters instead of points. (#8572)
 - Added a boundingRect property to TextInfo objects to retrieve the bounding rectangle of a range of text. (#8371)
 - Properties and methods within classes can now be marked as abstract in NVDA. These classes will raise an error if instantiated. (#8294, #8652, #8658)
+- NVDA can log the time since input when text is spoken, which helps in measuring perceived responsiveness. This can be enabled by setting the timeSinceInput setting to True in the debugLog section of the NVDA configuration. (#9167)
 
 
 = 2018.4.1 =


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
When working on performance improvements or identifying performance regressions, it is useful to be able to measure perceived responsiveness. A starting point is to measure the time between input from the user (e.g. a key press) and when text is spoken. We already log times, so it's already possible to do this by subtracting the input log time from the speech log time, but that's fairly tedious at scale, especially given that there can be several log entries between the two relevant entries, the times are logged as full times (not just seconds) and the log times are at the end of the line. We want to make measuring perceived performance as simple as possible.

### Description of how this pull request fixes the issue:
This PR introduces optional logging of time since input when text is sent to to be spoken. It can be enabled in the debugLog section of the config using the timeSinceInput setting. It is logged at level IO if this setting is enabled.

Note that the last input time is not reset after the time since input is logged. That is, if a key press generates two spoken messages, the second will show the time since the last key press (>= the time since input for the first message). This can be useful if the first message isn't the primary information the user cares about or if, for example, speak command keys is enabled (in which case the first message will be the key being spoken).

### Testing performed:
Tested cursoring through the NVDA menu with the debugLog -> timeSinceInput setting set to False. Verified that time since input was not logged.

With the setting enabled, tested cursoring through the NVDA menu, using object navigation in Gmail, pressing control+o to bring up the Open dialog in Notepad, moving by line and character in Notepad.  Verified that the time since input logged seemed proportional to my perception of performance in these cases.

### Known issues with pull request:
None known.

### Change log entry:

Changes for Developers:
`- NVDA can log the time since input when text is spoken, which helps in measuring perceived responsiveness. This can be enabled by setting the timeSinceInput setting to True in the debugLog section of the NVDA configuration.`