### PR TITLE
Ensure spelling errors are still reported if IUIAutomationTextRange3 is unavailable

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -134,7 +134,7 @@ class UIATextInfo(textInfos.TextInfo):
 		formatField=textInfos.FormatField()
 		if not isinstance(textRange,UIAHandler.IUIAutomationTextRange):
 			raise ValueError("%s is not a text range"%textRange)
-		fetchAnnotationTypes=False
+		fetchAnnotationTypes=formatConfig["reportSpellingErrors"] or formatConfig["reportComments"] or formatConfig["reportRevisions"]
 		try:
 			textRange=textRange.QueryInterface(UIAHandler.IUIAutomationTextRange3)
 		except (COMError,AttributeError):
@@ -161,8 +161,7 @@ class UIATextInfo(textInfos.TextInfo):
 				IDs.add(UIAHandler.UIA_StyleNameAttributeId)
 			if formatConfig["reportHeadings"]:
 				IDs.add(UIAHandler.UIA_StyleIdAttributeId)
-			if formatConfig["reportSpellingErrors"] or formatConfig["reportComments"] or formatConfig["reportRevisions"]:
-				fetchAnnotationTypes=True
+			if fetchAnnotationTypes:
 				IDs.add(UIAHandler.UIA_AnnotationTypesAttributeId)
 			IDs.add(UIAHandler.UIA_CultureAttributeId)
 			fetcher=BulkUIATextRangeAttributeValueFetcher(textRange,IDs)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9176 

### Summary of the issue:
Spelling errors are not being reported in speech or braille in early Windows 10 builds. This was seen when testing UIA in Microsoft Word 2016 by default.
Further testing showed that spelling errors, and other annotation information (such as comments) were not being reported, in any build of Windows before IUIAutomationTextRange3 was introduced, which allowed bulk fetching of text attributes.
The code that checked if annotationTypes should be fetched is incorrectly positioned within the block specific to IUIAutomationTextRange3.

### Description of how this pull request fixes the issue:
This pr moves the config check to see if annotationTypes should be fetched, up so that  this variable can be used whether IUIAutomationTextRange3 is available or not.

### Testing performed:
Ensuring UIA was enabled, read a basic word document that contained some spelling errors, both on builds with IUIAutomationTextRange3 available and not available. In both cases spelling errors were properly reported.

### Known issues with pull request:
None.

### Change log entry:
None needed.