### PR TITLE
Ensure browse mode is used when reading Outlook messages with UI automation enabled 

### DIFF
--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -155,7 +155,7 @@ def UIAHeadingQuicknavIterator(itemType,document,position,direction="next"):
 	while not stop:
 		tempInfo=curPosition.copy()
 		tempInfo.expand(textInfos.UNIT_CHARACTER)
-		styleIDValue=getUIATextAttributeValueFromRange(tempInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId)
+		styleIDValue=getUIATextAttributeValueFromRange(tempInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId,ignoreMixedValues=True)
 		if (UIAHandler.StyleId_Heading1<=styleIDValue<=UIAHandler.StyleId_Heading9):
 			foundLevel=(styleIDValue-UIAHandler.StyleId_Heading1)+1
 			wantedLevel=int(itemType[7:]) if len(itemType)>7 else None

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -166,6 +166,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if UIAWordDocument in clsList:
+			# Overlay class for Outlook message viewer when UI Automation for MS Word is enabled.
 			clsList.insert(0,OutlookUIAWordDocument)
 		if isinstance(obj,UIA) and obj.UIAElement.cachedClassName in ("LeafRow","ThreadItem","ThreadHeader"):
 			clsList.insert(0,UIAGridRow)
@@ -630,6 +631,7 @@ class OutlookWordDocument(WordDocument):
 	ignorePageNumbers=True # This includes page sections, and page columns. None of which are appropriate for outlook.
 
 class OutlookUIAWordDocument(UIAWordDocument):
+	""" Forces browse mode to be used on the UI Automation Outlook message viewer if the message is being read)."""
 
 	def _get_isReadonlyViewer(self):
 		# #2975: The only way we know an email is read-only is if the underlying email has been sent.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ What's New in NVDA
 - The last few cursor routing keys on 80 cell eurobraille displays no longer route the cursor to a position at or just after the start of the braille line. (#9160)
 - Fixed table navigation in threaded view in Mozilla Thunderbird. (#8396)
 - In Mozilla Firefox and Google Chrome, switching to focus mode now works correctly for certain list boxes and trees (where the list box/tree is not itself focusable but its items are) . (#3573, #9157)
+- Browse mode is now correctly turned on by default when reading messages in Outlook 2016/365 if using NVDA's experimental UI Automation support for Word Documents. (#9188)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fall out from #8919 

### Summary of the issue:
With UI automation used for accessing Microsoft Word Documents when reading messages in Outlook, browse mode is not on by default.
This means that arrowing up and down the message can miss content a lot of the time if the content contains tables with more than one column.

### Description of how this pull request fixes the issue:
Create an overlay class for Outlook word documents using UIA, that uses the treeInterceptor by default if the current message being viewed has been 'sent', I.e. it is being read, not composed.
This PR also catches a UIAMixedAttribute error sometimes seen when trying to quick navigate to headings in Outlook messages.

### Testing performed:
Using Outlook 16.0.1231, Opened some messages from the inpox. Browse mdoe was correctly enabled for all of them. Also Created a new email and focused in the document. Browse mode was not enabled by default.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* Browse mode is now correctly turned on by default when reading messages in Outlook 2016/365 if using the NVDA's experimental UI Automation support for Word Documents.