### PR TITLE
Announce context menus in Outlook 2016 and existance of submenus

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -765,7 +765,10 @@ class UIA(Window):
 	def findOverlayClasses(self,clsList):
 		UIAControlType=self.UIAElement.cachedControlType
 		UIAClassName=self.UIAElement.cachedClassName
-		if UIAClassName=="WpfTextView":
+		if UIAClassName=="NetUITWMenuItem" and UIAControlType==UIAHandler.UIA_MenuItemControlTypeId and not self.name and not self.previous:
+			# Bounces focus from a netUI dead placeholder menu item when no item is selected up to the menu itself.
+			clsList.append(PlaceholderNetUITWMenuItem)
+		elif UIAClassName=="WpfTextView":
 			clsList.append(WpfTextView)
 		elif UIAClassName=="NetUIDropdownAnchor":
 			clsList.append(NetUIDropdownAnchor)
@@ -1659,3 +1662,18 @@ class NetUIDropdownAnchor(UIA):
 		if not name and self.previous and self.previous.role==controlTypes.ROLE_STATICTEXT:
 			name=self.previous.name
 		return name
+
+class PlaceholderNetUITWMenuItem(UIA):
+	""" Bounces focus from a netUI dead placeholder menu item when no item is selected up to the menu itself."""
+
+	shouldAllowUIAFocusEvent=True
+
+	def _get_focusRedirect(self):
+		# Locate the containing menu and focus that instead.
+		parent=self.parent
+		for count in xrange(4):
+			if not parent:
+				return
+			if parent.role==controlTypes.ROLE_POPUPMENU:
+				return parent
+			parent=parent.parent

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -698,8 +698,8 @@ def processPositiveStates(role, states, reason, positiveStates=None):
 		positiveStates.discard(STATE_READONLY)
 	if role == ROLE_CHECKBOX:
 		positiveStates.discard(STATE_PRESSED)
-	if role == ROLE_MENUITEM:
-		# The user doesn't usually care if a menu item is expanded or collapsed.
+	if role == ROLE_MENUITEM and STATE_HASPOPUP in positiveStates:
+		# The user doesn't usually care if a submenu is expanded or collapsed.
 		positiveStates.discard(STATE_COLLAPSED)
 		positiveStates.discard(STATE_EXPANDED)
 	if STATE_FOCUSABLE not in states:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9171 

### Summary of the issue:
With the merging of #8919 context menus in Outlook started using UI Automation. However, this caused them not to be announced when they first appeared.
The UIA implementation for NetUI context menus does some strange things like focusing a fake unlabeled menu item when the menu first appears. This fake menu item does not have the focused state.
Also, menu items in these menus that have a submenu is not conveyed to the user, as they expose the collapsed/expanded states, rather than the haspopup state.
But, NVDA currently filters out collapsed/expanded states on all menu items.

### Description of how this pull request fixes the issue:
Create an overlay class for the special UIA fake placeholder NetUI menu item, which bounces focus up to the menu itself so that it is better presented.
Also, now only suppress collapsed/expanded states from menu items if the menu item has the haspopup state.

### Testing performed:
Opened a context menu in the Outlook inbox. NVDA announced the context menu. Arrow3ed down the menu listening to the options. NVDA announced collapsed for all menu items with submenus.

### Known issues with pull request:
None.

### Change log entry:
None needed.