### PR TITLE
Make UIA in MS Word optional again, through an Advanced Settings category

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -66,10 +66,6 @@ badUIAWindowClassNames=[
 	"FoxitDocWnd",
 ]
 
-Version=namedtuple('Version',('major','minor','build'))
-# The minimum version of Microsoft Word where we can trust that UI Automation is complete enough to use
-minMSWordUIAVersion=Version(16,0,9000)
-
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.
 UIADialogClassNames=[
 	"#32770",
@@ -366,9 +362,10 @@ class UIAHandler(COMObject):
 		res=windll.UIAutomationCore.UiaHasServerSideProvider(hwnd)
 		if res:
 			# the window does support UIA natively, but
-			# MS Word documents now have a very usable UI Automation implementation. However,
+			# MS Word documents now have a fairly usable UI Automation implementation. However,
 			# Builds of MS Office 2016 before build 9000 or so had bugs which we cannot work around.
-			# Therefore refuse to use UIA for builds earlier than this, if we can inject in-process.
+			# And even current builds of Office 2016 are still missing enough info from UIA that it is still impossible to switch to UIA completely.
+			# Therefore, if we can inject in-process, refuse to use UIA and instead fall back to the MS Word object model.
 			if (
 				# An MS Word document window 
 				windowClass=="_WwG" 
@@ -377,21 +374,7 @@ class UIAHandler(COMObject):
 				# Allow the user to explisitly force UIA support for MS Word documents no matter the Office version 
 				and not config.conf['UIA']['useInMSWordWhenAvailable']
 			):
-				# We can only safely check the version of known Office apps using the Word document control, as we know their versioning scheme.
-				# But if the Word Document control is used in other unknown apps we should just use UIA if it has been implemented.
-				if appModule.appName not in ('outlook','winword','excel'):
-					log.debugWarning("Unknown application using MS Word document control: %s"%appModule.appName)
-					return True
-				try:
-					versionMajor,versionMinor,versionBuild,versionPatch=[int(x) for x in appModule.productVersion.split('.')]
-				except Exception as e:
-					log.error("Error parsing version information %s, %s"%(appModule.productVersion,e))
-					return True
-				if (
-					versionMajor<minMSWordUIAVersion.major
-					or versionMajor==minMSWordUIAVersion.major and versionMinor==minMSWordUIAVersion.minor and versionBuild<minMSWordUIAVersion.build
-				):
-					return False
+				return False
 		return bool(res)
 
 	def isUIAWindow(self,hwnd):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1928,6 +1928,67 @@ class UwpOcrPanel(SettingsPanel):
 		lang = self.languageCodes[self.languageChoice.Selection]
 		config.conf["uwpOcr"]["language"] = lang
 
+class AdvancedPanel(SettingsPanel):
+	# Translators: This is the label for the Advanced settings panel.
+	title = _("Advanced")
+
+	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+
+		# Translators: This is a label appearing on the Advanced settings panel.
+		panelText =_("Warning! The following settings are for advanced users. Changing them may cause NVDA to function incorrectly. Please only change these if you know what you are doing or have been specifically instructed by NVDA  developers.")
+		sHelper.addItem(wx.StaticText(self, label=panelText))
+
+		# Translators: This is the label for a group of  Advanced options in the 
+		#  Advanced settings panel
+		groupText = _("Microsoft UI Automation")
+		UIAGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=groupText), wx.VERTICAL))
+		sHelper.addItem(UIAGroup)
+
+		# Translators: This is the label for a checkbox in the
+		#  Advanced settings panel.
+		label = _("Use UI Automation to access Microsoft &Word document controls when available")
+		self.UIAInMSWordCheckBox=UIAGroup.addItem(wx.CheckBox(self, label=label))
+		self.UIAInMSWordCheckBox.SetValue(config.conf["UIA"]["useInMSWordWhenAvailable"])
+
+		# Translators: This is the label for a group of  Advanced options in the 
+		#  Advanced settings panel
+		groupText = _("Editable Text")
+		editableTextGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=groupText), wx.VERTICAL))
+		sHelper.addItem(editableTextGroup)
+
+		# Translators: This is the label for a numeric control in the
+		#  Advanced settings panel.
+		label = _("Caret movement timeout (in ms)")
+		self.caretMoveTimeoutSpinControl=editableTextGroup.addLabeledControl(label,nvdaControls.SelectOnFocusSpinCtrl,
+			min=0, max=2000, 
+			initial=config.conf["editableText"]["caretMoveTimeoutMs"]
+		)
+
+		# Translators: This is the label for a group of  Advanced options in the 
+		#  Advanced settings panel
+		groupText = _("Debug logging categories")
+		debugLogGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=groupText), wx.VERTICAL))
+		sHelper.addItem(debugLogGroup)
+
+		self.debugLogCheckboxes={}
+		for key in (
+			"hwIo",
+			"audioDucking",
+			"gui",
+			"louis",
+			"timeSinceInput",
+		):
+			checkbox=debugLogGroup.addItem(wx.CheckBox(self, label=key))
+			checkbox.SetValue(config.conf["debugLog"][key])
+			self.debugLogCheckboxes[key]=checkbox
+
+	def onSave(self):
+		config.conf["UIA"]["useInMSWordWhenAvailable"]=self.UIAInMSWordCheckBox.IsChecked()
+		config.conf["editableText"]["caretMoveTimeoutMs"]=self.caretMoveTimeoutSpinControl.GetValue()
+		for k,v in self.debugLogCheckboxes.iteritems():
+			config.conf['debugLog'][k]=v.IsChecked()
+
 class DictionaryEntryDialog(wx.Dialog):
 	TYPE_LABELS = {
 		# Translators: This is a label for an Entry Type radio button in add dictionary entry dialog.
@@ -2481,6 +2542,8 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		categoryClasses.append(TouchInteractionPanel)
 	if winVersion.isUwpOcrAvailable():
 		categoryClasses.append(UwpOcrPanel)
+	# And finally the Advanced panel which should always be last.
+	categoryClasses.append(AdvancedPanel)
 
 	def makeSettings(self, settingsSizer):
 		# Ensure that after the settings dialog is created the name is set correctly

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1967,27 +1967,29 @@ class AdvancedPanel(SettingsPanel):
 
 		# Translators: This is the label for a group of  Advanced options in the 
 		#  Advanced settings panel
-		groupText = _("Debug logging categories")
+		groupText = _("Debug logging")
 		debugLogGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=groupText), wx.VERTICAL))
 		sHelper.addItem(debugLogGroup)
 
-		self.debugLogCheckboxes={}
-		for key in (
+		self.logCategories=[
 			"hwIo",
 			"audioDucking",
 			"gui",
 			"louis",
 			"timeSinceInput",
-		):
-			checkbox=debugLogGroup.addItem(wx.CheckBox(self, label=key))
-			checkbox.SetValue(config.conf["debugLog"][key])
-			self.debugLogCheckboxes[key]=checkbox
+		]
+		# Translators: This is the label for a list in the 
+		#  Advanced settings panel
+		logCategoriesLabel=_("Enabled logging categories")
+		self.logCategoriesList=debugLogGroup.addLabeledControl(logCategoriesLabel, nvdaControls.CustomCheckListBox, choices=self.logCategories)
+		self.logCategoriesList.CheckedItems=[index for index,x in enumerate(self.logCategories) if config.conf['debugLog'][x]]
+		self.logCategoriesList.Select(0)
 
 	def onSave(self):
 		config.conf["UIA"]["useInMSWordWhenAvailable"]=self.UIAInMSWordCheckBox.IsChecked()
 		config.conf["editableText"]["caretMoveTimeoutMs"]=self.caretMoveTimeoutSpinControl.GetValue()
-		for k,v in self.debugLogCheckboxes.iteritems():
-			config.conf['debugLog'][k]=v.IsChecked()
+		for index,key in enumerate(self.logCategories):
+			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 
 class DictionaryEntryDialog(wx.Dialog):
 	TYPE_LABELS = {

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,7 @@ What's New in NVDA
  - This does not work for certain list boxes (HTML select controls) in Chrome.
 - Added the Afrikaans braille table. (#9186)
 - Early support for apps such as Mozilla Firefox on computers with ARM64 (e.g. Qualcom Snapdragon) processors. (#9216)
+- A new Advanced Settings category has been added to NVDA's Settings dialog, including an option to try out NVDA's new support for Microsoft Word via the Microsoft UI Automation API. (#9200)
 
 
 == Changes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1603,6 +1603,26 @@ This category contains the following options:
 ==== Recognition language ====[Win10OcrSettingsRecognitionLanguage]
 This combo box allows you to choose the language to be used for text recognition.
 
++++ Advanced Settings +++
+Warning! The settings in this category are for advanced users and may cause NVDA to not function correctly if configured in the wrong way.
+Only make changes to these settings if you are sure you know what you are doing or if you have been specifically instrructed to by an NVDA developer.
+
+==== Use UI automation to access Microsoft Word document controls when available ====
+When this option is enabled, NVDA will try to use  the Microsoft UI Automation accessibility api in order to fetch information from Microsoft Word document controls.
+this includes in Microsoft Word itself, and also the Microsoft Outlook message viewer and composer.
+ For the most recent versions of Microsoft Office 2016/365 running on windows 10, UI Automation support is complete enough to provide access to Microsoft Word documents almost on par with NvDA's existing Microsoft Word support, with the added advantage that responsiveness is majorly increased.
+However, There may be some information which is either not exposed, or exposed incorrectly in some versions of Microsoft Office, which means this UI automation support cannot always be relied upon.
+We still do not recommend that  the majority of users turn this on by default, though we do welcome users of Office 2016/365 to test this feature and provide feedback.
+
+==== Caret move timeout (in MS) ====
+This option allows you to configure the number of mili seconds NVDA will wait for the caret (insertion point) to move in editable text controls.
+If you find that NVDA seems to be incorrectly tracking the caret E.g. it seems to be always one character behind or is repeating lines, then you may wish to try increasing this value.
+
+==== Debug logging categories ====
+The checkboxes in this group allow you to enable specific categories of debug messages in NVDA's log.
+Logging these messages can resort in decreased performance and large log files.
+Only turn one of these on if specifically instructed to by an NVDA developer e.g. when debugging why a braille display driver is not functioning correctly.
+
 ++ miscellaneous Settings ++[MiscSettings]
 Besides the [NVDA Settings #NVDASettings] dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1609,8 +1609,8 @@ Only make changes to these settings if you are sure you know what you are doing 
 
 ==== Use UI automation to access Microsoft Word document controls when available ====
 When this option is enabled, NVDA will try to use  the Microsoft UI Automation accessibility api in order to fetch information from Microsoft Word document controls.
-this includes in Microsoft Word itself, and also the Microsoft Outlook message viewer and composer.
- For the most recent versions of Microsoft Office 2016/365 running on windows 10, UI Automation support is complete enough to provide access to Microsoft Word documents almost on par with NvDA's existing Microsoft Word support, with the added advantage that responsiveness is majorly increased.
+This includes in Microsoft Word itself, and also the Microsoft Outlook message viewer and composer.
+ For the most recent versions of Microsoft Office 2016/365 running on windows 10, UI Automation support is complete enough to provide access to Microsoft Word documents almost equal to NVDA's existing Microsoft Word support, with the added advantage that responsiveness is majorly increased.
 However, There may be some information which is either not exposed, or exposed incorrectly in some versions of Microsoft Office, which means this UI automation support cannot always be relied upon.
 We still do not recommend that  the majority of users turn this on by default, though we do welcome users of Office 2016/365 to test this feature and provide feedback.
 
@@ -1619,7 +1619,7 @@ This option allows you to configure the number of mili seconds NVDA will wait fo
 If you find that NVDA seems to be incorrectly tracking the caret E.g. it seems to be always one character behind or is repeating lines, then you may wish to try increasing this value.
 
 ==== Debug logging categories ====
-The checkboxes in this group allow you to enable specific categories of debug messages in NVDA's log.
+The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.
 Logging these messages can resort in decreased performance and large log files.
 Only turn one of these on if specifically instructed to by an NVDA developer e.g. when debugging why a braille display driver is not functioning correctly.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1605,7 +1605,7 @@ This combo box allows you to choose the language to be used for text recognition
 
 +++ Advanced Settings +++
 Warning! The settings in this category are for advanced users and may cause NVDA to not function correctly if configured in the wrong way.
-Only make changes to these settings if you are sure you know what you are doing or if you have been specifically instrructed to by an NVDA developer.
+Only make changes to these settings if you are sure you know what you are doing or if you have been specifically instructed to by an NVDA developer.
 
 ==== Use UI automation to access Microsoft Word document controls when available ====
 When this option is enabled, NVDA will try to use  the Microsoft UI Automation accessibility api in order to fetch information from Microsoft Word document controls.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
NVDA switched to using UI Automation to access Microsoft Word document controls by default for Office 2016/365, however Office's UIA support is still not 100% complete.
This should be left optional for 2019.1 at least.

### Description of how this pull request fixes the issue:
UIA is no longer used by default in MS Word. However, there is now a new Advanced Settings category in NVDA's settings dialog which contains a checkbox to turn this on for testing this feature out.
The Advanced Settings category also contains all other config options previously not in the GUI. these include caret movement timeout, and the Debug log categories.

### Testing performed:
Tested each option in the Advanced settings category to ensure that their setting is remembered when opening the Settings dialog again, and that the option is truly activated / deactivated in NVDA itself.

### Known issues with pull request:
Although there is a panel caption warning the user to be careful with these settings, it is not automatically read by NVDA when tabbing from the categories list into the settings themselves. This is similar to the Document Formatting settings caption which is also not read.

### Change log entry:
New features:
A new Advanced Settings category has been added to NVDA's Settings dialog, including an option to try out NVDA's new support for Microsoft Word via the Microsoft UI Automation API.
