### PR TITLE
Windows 10 emoji panel and cloud clipboard: allow NVDA to make announcements when opening it in May 2019 Update

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -5,7 +5,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-"""App module for Windows Explorer (aka Windows shell).
+"""App module for Windows Explorer (aka Windows shell and renamed to File Explorer in Windows 8).
 Provides workarounds for controls such as identifying Start button, notification area and others.
 """
 

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -304,7 +304,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	def event_UIA_window_windowOpen(self, obj, nextHandler):
 		# Send UIA window open event to input app window.
-		inputPanelWindow = obj.firstChild
-		if isinstance(obj, UIA) and obj.UIAElement.cachedClassName == "ApplicationFrameWindow" and inputPanelWindow and inputPanelWindow.appModule.appName == "windowsinternal_composableshell_experiences_textinput_inputapp":
-			inputPanelWindow.appModule.event_UIA_window_windowOpen(inputPanelWindow, nextHandler)
-		nextHandler()
+		if isinstance(obj, UIA) and obj.UIAElement.cachedClassName == "ApplicationFrameWindow":
+			inputPanelWindow = obj.firstChild
+			if inputPanelWindow and inputPanelWindow.appModule.appName == "windowsinternal_composableshell_experiences_textinput_inputapp":
+				eventHandler.executeEvent("UIA_window_windowOpen", inputPanelWindow)

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -308,3 +308,5 @@ class AppModule(appModuleHandler.AppModule):
 			inputPanelWindow = obj.firstChild
 			if inputPanelWindow and inputPanelWindow.appModule.appName == "windowsinternal_composableshell_experiences_textinput_inputapp":
 				eventHandler.executeEvent("UIA_window_windowOpen", inputPanelWindow)
+				return
+		nextHandler()

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -297,8 +297,8 @@ class AppModule(appModuleHandler.AppModule):
 		nextHandler()
 
 	def isGoodUIAWindow(self,hwnd):
-		# #9204: In build 18305 and later, it is the shell that raises window open event for emoji panel.
-		if winVersion.winVersion.build > 17763 and winUser.getClassName(hwnd) == "ApplicationFrameWindow":
+		# #9204: In build 18305 and later (including 1903/build 18362), it is the shell that raises window open event for emoji panel.
+		if winVersion.isWin10(version=1903) and winUser.getClassName(hwnd) == "ApplicationFrameWindow":
 			return True
 		return False
 

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -296,8 +296,8 @@ class AppModule(appModuleHandler.AppModule):
 
 		nextHandler()
 
-	def isGoodUIAWindow(self,hwnd):
-		# #9204: In build 18305 and later (including 1903/build 18362), it is the shell that raises window open event for emoji panel.
+	def isGoodUIAWindow(self, hwnd):
+		# #9204: shell raises window open event for emoji panel in build 18305 and later.
 		if winVersion.isWin10(version=1903) and winUser.getClassName(hwnd) == "ApplicationFrameWindow":
 			return True
 		return False
@@ -306,7 +306,8 @@ class AppModule(appModuleHandler.AppModule):
 		# Send UIA window open event to input app window.
 		if isinstance(obj, UIA) and obj.UIAElement.cachedClassName == "ApplicationFrameWindow":
 			inputPanelWindow = obj.firstChild
-			if inputPanelWindow and inputPanelWindow.appModule.appName == "windowsinternal_composableshell_experiences_textinput_inputapp":
+			inputPanelAppName = "windowsinternal_composableshell_experiences_textinput_inputapp"
+			if inputPanelWindow and inputPanelWindow.appModule.appName == inputPanelAppName:
 				eventHandler.executeEvent("UIA_window_windowOpen", inputPanelWindow)
 				return
 		nextHandler()

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -306,8 +306,13 @@ class AppModule(appModuleHandler.AppModule):
 		# Send UIA window open event to input app window.
 		if isinstance(obj, UIA) and obj.UIAElement.cachedClassName == "ApplicationFrameWindow":
 			inputPanelWindow = obj.firstChild
-			inputPanelAppName = "windowsinternal_composableshell_experiences_textinput_inputapp"
-			if inputPanelWindow and inputPanelWindow.appModule.appName == inputPanelAppName:
+			inputPanelAppName = (
+				# 19H2 and earlier
+				"windowsinternal_composableshell_experiences_textinput_inputapp",
+				# 20H1 and later
+				"textinputhost"
+			)
+			if inputPanelWindow and inputPanelWindow.appModule.appName in inputPanelAppName:
 				eventHandler.executeEvent("UIA_window_windowOpen", inputPanelWindow)
 				return
 		nextHandler()

--- a/source/appModules/textinputhost.py
+++ b/source/appModules/textinputhost.py
@@ -1,0 +1,11 @@
+# App module for Composable Shell (CShell) input panel
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""App module for Windows 10 Modern Keyboard aka new touch keyboard panel.
+This is for 20H1 text input host window."""
+
+# Flake8/F401: this is an alias, so no need to worry about lint issue.
+from .windowsinternal_composableshell_experiences_textinput_inputapp import * # noqa

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,12 +1,13 @@
 # App module for Composable Shell (CShell) input panel
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017-2018 NV Access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2017-2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """App module for Windows 10 Modern Keyboard aka new touch keyboard panel.
 The chief feature is allowing NVDA to announce selected emoji when using the keyboard to search for and select one.
 Other features include announcing candidates for misspellings if suggestions for hardware keyboard is selected, and managing cloud clipboard paste.
+In 20H1, it is also responsible for presenting input candidates for Chinese, Japanese, and Korean IME.
 This is applicable on Windows 10 Fall Creators Update and later."""
 
 import appModuleHandler

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -96,7 +96,9 @@ class AppModule(appModuleHandler.AppModule):
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
 		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
-			self.event_UIA_elementSelected(obj.children[-2], nextHandler)
+			# Under some cases, clipboard tip text isn't shown on screen, causing clipboard history title to be announced instead of most recently copied item.
+			clipboardItemsIndex = -2 if obj.children[-2].UIAElement.cachedAutomationID != childAutomationID else -1
+			self.event_UIA_elementSelected(obj.children[clipboardItemsIndex], nextHandler)
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -84,11 +84,10 @@ class AppModule(appModuleHandler.AppModule):
 			)
 		):
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
-		# Handle hardware keyboard and CJK IME suggestions.
+		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
-		# #10093: in fact, in 20H1, this is the CJK IME candidates window.
 		elif (
-			inputPanelAutomationID in ("CandidateWindowControl", "IME_Candidate_Window")
+			inputPanelAutomationID == "CandidateWindowControl"
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
@@ -129,8 +128,7 @@ class AppModule(appModuleHandler.AppModule):
 	def event_nameChange(self, obj, nextHandler):
 		# On some systems, touch keyboard keys keeps firing name change event.
 		# In build 17704, whenever skin tones are selected, name change is fired by emoji entries (GridViewItem).
-		# In build 18975, CJK IME candidates fire name change event.
-		if ((obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem", "ListViewItem"))
+		if ((obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem"))
 		# Just ignore useless clipboard status.
 		# Also top emoji search result must be announced for better user experience.
 		or (obj.UIAElement.cachedAutomationID in ("TEMPLATE_PART_ClipboardItemsList", "TEMPLATE_PART_Search_TextBlock"))

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -87,8 +87,10 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel in build 17666 and later (unless this changes).
 		elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
+			# On some systems, there is something else besides grouping controls, so another child control must be used.
+			emojisIndex = -3 if obj.firstChild.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView" else -2
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.children[-2].firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(obj.firstChild.children[emojisIndex].firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -84,10 +84,11 @@ class AppModule(appModuleHandler.AppModule):
 			)
 		):
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
-		# Handle hardware keyboard suggestions.
+		# Handle hardware keyboard and CJK IME suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
+		# #10093: in fact, in 20H1, this is the CJK IME candidates window.
 		elif (
-			inputPanelAutomationID == "CandidateWindowControl"
+			inputPanelAutomationID in ("CandidateWindowControl", "IME_Candidate_Window")
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
@@ -128,7 +129,8 @@ class AppModule(appModuleHandler.AppModule):
 	def event_nameChange(self, obj, nextHandler):
 		# On some systems, touch keyboard keys keeps firing name change event.
 		# In build 17704, whenever skin tones are selected, name change is fired by emoji entries (GridViewItem).
-		if ((obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem"))
+		# In build 18975, CJK IME candidates fire name change event.
+		if ((obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem", "ListViewItem"))
 		# Just ignore useless clipboard status.
 		# Also top emoji search result must be announced for better user experience.
 		or (obj.UIAElement.cachedAutomationID in ("TEMPLATE_PART_ClipboardItemsList", "TEMPLATE_PART_Search_TextBlock"))

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -99,7 +99,7 @@ class AppModule(appModuleHandler.AppModule):
 			self._emojiPanelJustOpened = True
 			# On some systems, there is something else besides grouping controls,
 			# so another child control must be used.
-			if obj.firstChild.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
+			if inputPanel.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
 				emojisIndex = -3
 			else:
 				emojisIndex = -2

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -68,24 +68,34 @@ class AppModule(appModuleHandler.AppModule):
 		# However, in build 17666 and later, child count is the same for both emoji panel and hardware keyboard candidates list.
 		# Thankfully first child automation ID's are different for each modern input technology.
 		# However this event is raised when the input panel closes.
-		if obj.firstChild is None:
+		inputPanel = obj.firstChild
+		if inputPanel is None:
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
-		childAutomationID = obj.firstChild.UIAElement.cachedAutomationID
+		inputPanelAutomationID = inputPanel.UIAElement.cachedAutomationID
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
-		if winVersion.winVersion.build <= 17134 and childAutomationID in ("TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl", "TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"):
+		if (
+			winVersion.winVersion.build <= 17134
+			and inputPanelAutomationID in (
+				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
+				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
+			)
+		):
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
-		elif childAutomationID == "CandidateWindowControl" and config.conf["inputComposition"]["autoReportAllCandidates"]:
+		elif (
+			inputPanelAutomationID == "CandidateWindowControl"
+			and config.conf["inputComposition"]["autoReportAllCandidates"]
+		):
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(inputPanel.firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# Because this is dictation window.
 				pass
 		# Emoji panel in build 17666 and later (unless this changes).
-		elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
+		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
 			# On some systems, there is something else besides grouping controls,
 			# so another child control must be used.
@@ -94,17 +104,20 @@ class AppModule(appModuleHandler.AppModule):
 			else:
 				emojisIndex = -2
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.children[emojisIndex].firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(inputPanel.children[emojisIndex].firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
 		# Clipboard history.
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
-		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
+		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
 			# Under some cases, clipboard tip text isn't shown on screen,
 			# causing clipboard history title to be announced instead of most recently copied item.
-			clipboardItemsIndex = -2 if obj.children[-2].UIAElement.cachedAutomationID != childAutomationID else -1
+			if obj.children[-2].UIAElement.cachedAutomationID != inputPanelAutomationID:
+				clipboardItemsIndex = -2
+			else:
+				clipboardItemsIndex = -1
 			self.event_UIA_elementSelected(obj.children[clipboardItemsIndex], nextHandler)
 		nextHandler()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -87,8 +87,12 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel in build 17666 and later (unless this changes).
 		elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
-			# On some systems, there is something else besides grouping controls, so another child control must be used.
-			emojisIndex = -3 if obj.firstChild.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView" else -2
+			# On some systems, there is something else besides grouping controls,
+			# so another child control must be used.
+			if obj.firstChild.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
+				emojisIndex = -3
+			else:
+				emojisIndex = -2
 			try:
 				self.event_UIA_elementSelected(obj.firstChild.children[emojisIndex].firstChild.firstChild, nextHandler)
 			except AttributeError:
@@ -98,7 +102,8 @@ class AppModule(appModuleHandler.AppModule):
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
 		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
-			# Under some cases, clipboard tip text isn't shown on screen, causing clipboard history title to be announced instead of most recently copied item.
+			# Under some cases, clipboard tip text isn't shown on screen,
+			# causing clipboard history title to be announced instead of most recently copied item.
 			clipboardItemsIndex = -2 if obj.children[-2].UIAElement.cachedAutomationID != childAutomationID else -1
 			self.event_UIA_elementSelected(obj.children[clipboardItemsIndex], nextHandler)
 		nextHandler()


### PR DESCRIPTION
Hi,

A continuation of #9112 but optimized for 19H1/May 2019 Update and later:

### Link to issue number:
Fixes #9204 
Fixes #10093

### Summary of the issue:
When emoji panel and/or cloud clipboard opens in Windows 10 Version 1903 (May 2019 Update) and later, NVDA won't announce selected emoji and/or clipboard status, caused by File Explorer firing UIA window open event instead of modern keyboard doing it. This also affects CJK IME support in 20H1.

### Description of how this pull request fixes the issue:
Adds the following in appModules/explorer.py:

* Allows ApplicationFrameWindow object in builds above 17763 to be recognized as good uIA window.
* If UIA window open event is fired by the newly classed good UIA object, check if the first child object is indeed part of modern keyboard, and if yes, allow modern keyboard app module to call window open event on this object instead.

Adds the following in modern keyboard app module:

* Support for CJK IME introduced in 20H1.

In addition, because modern keyboard executable has been renamed in 20H1 (textinputhost.exe), an alias app module has been added.

### Testing performed:
Tested on Windows 10 Version 1809 and 1903 (and later releases) from source code as well as via Windows 10 App Essentials add-on.

### Known issues with pull request:
This work is subject to change if Microsoft restores UIA window open event for modern keyboard to previous behavior (the modern keyboard firing this event instead of File Explorer).

### Change log entry:
Bug fixes:

NVDA will announce first selected emoji and clipboard history item when modern keyboard opens in Windows 10 May 2019 Update and later. (#9204)
NVDA will announce first selected candidate for modern Japanese IME introduced in Windows 10 20H1. (#10093)

Thanks.