### PR TITLE
Work around frozen keyboard input while the NVDA core is frozen

### DIFF
--- a/source/winInputHook.py
+++ b/source/winInputHook.py
@@ -10,6 +10,7 @@ import time
 from ctypes import *
 from ctypes.wintypes import *
 from win32con import WM_QUIT, HC_ACTION, WH_KEYBOARD_LL, LLKHF_UP, LLKHF_EXTENDED, LLKHF_INJECTED, WH_MOUSE_LL, LLMHF_INJECTED
+import watchdog
 
 class KBDLLHOOKSTRUCT(Structure):
 	_fields_=[
@@ -35,7 +36,7 @@ mouseCallback=None
 
 @WINFUNCTYPE(c_long,c_int,WPARAM,LPARAM)
 def keyboardHook(code,wParam,lParam):
-	if code!=HC_ACTION:
+	if watchdog.isAttemptingRecovery or code!=HC_ACTION:
 		return windll.user32.CallNextHookEx(0,code,wParam,lParam)
 	kbd=KBDLLHOOKSTRUCT.from_address(lParam)
 	if keyUpCallback and kbd.flags&LLKHF_UP:
@@ -48,7 +49,7 @@ def keyboardHook(code,wParam,lParam):
 
 @WINFUNCTYPE(c_long,c_int,WPARAM,LPARAM)
 def mouseHook(code,wParam,lParam):
-	if code!=HC_ACTION:
+	if watchdog.isAttemptingRecovery or code!=HC_ACTION:
 		return windll.user32.CallNextHookEx(0,code,wParam,lParam)
 	msll=MSLLHOOKSTRUCT.from_address(lParam)
 	if mouseCallback:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,6 +39,7 @@ What's New in NVDA
 - NVDA no longer fails to report the focus for some controls in the Microsoft Office 2016 ribbon when collapsed.
 - NVDA no longer fails to report the suggested contact when entering addresses in new messages in Outlook 2016. (#8502)
 - The last few cursor routing keys on 80 cell eurobraille displays no longer route the cursor to a position at or just after the start of the braille line. (#9160)
+- NVDA is now less likely to freeze in such a way that the only way to escape is signing out from your current windows session. (#6291)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Improves #6291 

### Summary of the issue:
When large chunks of text are written to a terminal window, NVDA tends to freeze entirely. The freeze tends to lock up the keyboard in such a way that a user needs to sign out of his session and sign in back again, in which case it is likely that work is lost.

### Description of how this pull request fixes the issue:
This pr checks whether the core is attempting recovery way earlier than the current code does. The current code does the following:

1. Input is received
2. winInputHook executes the keyboardHandler.internal_keyDownEvent function
3. internal_keyDownEvent checks for pass through, sticky keys, etc.
4. It executes inputCore.manager.executeGesture
5. inputCore.manager.executeGesture checks whether the core is attempting recovery. If it is, it raises NoInputGestureAction
6. The finally block of internal_keyDownEvent is executed.

The code in this pull request checks the core's recovery state within the winInputHook module itself and doesn't execute keyboardHandler.internal_keyDown/UpEvent at all when the core is frozen. While it does not fix #6291, it does no longer break keyboard input entirely, allowing a user to restart NVDA by hand.

### Testing performed:
Tested by @lukaszgo1 

### Known issues with pull request:
This approach might be a bit aggressive. We could also check the state of the watchdog in keyboardHandler, for example. However, the current code where the keyboard hook executes a massive amount of code even when the core is frozen, is certainly not something we should keep as it is.

### Change log entry:
* Bug fixes
    + NVDA is now less likely to freeze in such a way that the only way to escape is signing out from your current windows session. (#6291)