### PR TITLE
Fix possible freeze related to custom checklistboxes

### DIFF
--- a/source/gui/accPropServer.py
+++ b/source/gui/accPropServer.py
@@ -54,7 +54,11 @@ class IAccPropServer_Impl(with_metaclass(ABCMeta, COMObject)):
 			pServer=self,
 			AnnoScope=ANNO_CONTAINER if annotateChildren else ANNO_THIS
 		)
-		# clean up of the accPropServices needs to happen when the control is destroyed.
+		# clean up of accPropServices needs to happen when the control is destroyed. We can't rely on 
+		# pythons `__del__` method to be called, and the wx framework does not call Destroy on child controls,
+		# automatically. Instead we can bind to the "window destroy" event for the control to do necessary 
+		# cleanup (wxWidgets/Phoenix/#630). Not performing this cleanup results in a reference to the parent
+		# window, keeping it from being deleted correctly. This can cause a freeze on exit of NVDA.
 		control.Bind(wx.EVT_WINDOW_DESTROY, self._onDestroyControl, source=control)
 
 	@abstractmethod

--- a/source/gui/accPropServer.py
+++ b/source/gui/accPropServer.py
@@ -9,29 +9,53 @@
 from logHandler import log
 from  comtypes.automation import VT_EMPTY
 from  comtypes import COMObject
-from comInterfaces.Accessibility import IAccPropServer
-from abc import ABCMeta, abstractmethod
+from comInterfaces.Accessibility import IAccPropServer, ANNO_CONTAINER, ANNO_THIS
+from abc import ABCMeta, abstractmethod, abstractproperty
 from six import with_metaclass
 import weakref
+import winUser
+import wx
 
 class IAccPropServer_Impl(with_metaclass(ABCMeta, COMObject)):
-	"""Base class for implementing a COM interface for AccPropServer.
-	Please override the _GetPropValue method, not GetPropValue.
-	GetPropValue wraps _getPropValue to catch and log exceptions (Which for some reason NVDA's logger misses when they occur in GetPropValue).
+	"""Base class for implementing a COM interface for a hwnd based AccPropServer\
+	to annotate a WX control.
+	The AccPropServer registers itself using the window handle of the WX control.
+	When the WX control is destroyed, the instance is automatically unregistered.
+	This should eventually be dropped in favor of WX' own annotation support,
+	blocked by wxWidgets/Phoenix#1129.
+	Please override the L{_GetPropValue} method, not L{GetPropValue}.
+	L{GetPropValue} wraps L{_getPropValue} to catch and log exceptions (Which for some reason NVDA's logger misses when they occur in GetPropValue).
+	You must also provide the L{properties} property.
 	"""
 
 	_com_interfaces_ = [
 		IAccPropServer
 	]
 
-	def __init__(self, control, *args, **kwargs):
+	def __init__(self, control, annotateChildren=True):
 		"""Initialize the instance of AccPropServer. 
 		@param control: the WX control instance, so you can look up things in the _getPropValue method.
 			It's available on self.control.
 		@Type control: Subclass of wx.Window
+		@param annotateChildren: whether the WX control is a container which children should be annotated.
+		@type annotateChildren: bool
 		"""
 		self.control = weakref.ref(control)
-		super(IAccPropServer_Impl, self).__init__(*args, **kwargs)
+		self.hwnd = control.GetHandle()
+		super(IAccPropServer_Impl, self).__init__()
+		# Import late to avoid circular import
+		from IAccessibleHandler import accPropServices
+		accPropServices.SetHwndPropServer(
+			hwnd=self.hwnd,
+			idObject=winUser.OBJID_CLIENT,
+			idChild=0,
+			paProps=self.properties,
+			cProps=len(self.properties),
+			pServer=self,
+			AnnoScope=ANNO_CONTAINER if annotateChildren else ANNO_THIS
+		)
+		# clean up of the accPropServices needs to happen when the control is destroyed.
+		control.Bind(wx.EVT_WINDOW_DESTROY, self._onDestroyControl, source=control)
 
 	@abstractmethod
 	def _getPropValue(self, pIDString, dwIDStringLen, idProp):
@@ -44,6 +68,8 @@ class IAccPropServer_Impl(with_metaclass(ABCMeta, COMObject)):
 			If the accessible element is HWND-based,
 			IAccessibleHandler.accPropServices.DecomposeHwndIdentityString can be used
 			to extract the HWND/idObject/idChild from the identity string.
+			Note that, while one IAccPropServer implementation can annotate
+			multiple accessible elements, it is still bound to one wx.Control.
 		@type pIDString: str
 		@param dwIDStringLen: Specifies the length of the identity string specified by the pIDString parameter.
 		@type dwIDStringLen: int
@@ -59,3 +85,24 @@ class IAccPropServer_Impl(with_metaclass(ABCMeta, COMObject)):
 			log.exception()
 			return VT_EMPTY, 0
 
+	@abstractproperty
+	def properties(self):
+		""" Returns an array of properties that should be handled by this instance.
+		@rtype: L{comtypes.GUID}*n
+		"""
+		raise NotImplementedError
+
+	def _onDestroyControl(self, evt):
+		evt.Skip() # Allow other handlers to process this event.
+		self._cleanup()
+
+	def _cleanup(self):
+		# Import late to avoid circular import
+		from IAccessibleHandler import accPropServices
+		accPropServices.ClearHwndProps(
+			hwnd=self.hwnd,
+			idObject=winUser.OBJID_CLIENT,
+			idChild=0,
+			paProps=self.properties,
+			cProps=len(self.properties)
+		)


### PR DESCRIPTION
### Link to issue number:
Fixes #8916 

### Summary of the issue:
gui.nvdaControls.CustomCheckListBox uses a custom AccPropServer for accessibility. However, when destroying the control, the AccPropServer isn't properly unregistered. This leads to unexpected behavior, sometimes even to system freezes, though I've not been able to reproduce these myself.

### Description of how this pull request fixes the issue:
This has been fixed for gui.nvdaControls.AutoWidthColumnCheckListCtrl but not yet for the CustomListBox. Fixing this in a similar way would mean a whole lot of copied code. This pr actually fixes it for good, making the AccPropServer instance itself responsible for registration and unregistration.

### Testing performed:
Tested by several people in #8916. The current code is rebased on master.

### Known issues with pull request:
We could debate whether the server itself should be responsible for registration and unregistration. I think it makes sense, as every IAccPropServer_Impl will now automatically have the needed functionality to register, and more importantly, unregister itself.

### Change log entry:
* Bug fixes
    + Fixed a possible crash when restarting NVDA after the keyboard settings had been opened previously, (#8916) 