### PR TITLE
Fixed NVDA not reporting text right after inline elements when navigating with the mouse in Firefox

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -168,7 +168,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			except ValueError:
 				pass
 			try:
-				self._endOffset=text.index(u'\ufffc',oldEnd-self._startOffset)
+				self._endOffset=text.index(u'\ufffc', oldStart)
 			except ValueError:
 				pass
 


### PR DESCRIPTION

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixed #9235.

### Summary of the issue:

When navigating accross paragraphs in Firefox using the mouse, NVDA was unable to report the text located right after an inline element (e.g. a link or a button) if they were not at the start of the paragraph.

### Description of how this pull request fixes the issue:

In IAccessible2 TextInfo, the way the end offset was computed inside the `expand` function could fail to find the end of the range, when expanding from a point (the U+FFFC character index that were found indicated the previous inline element's position rather than the end of the text info).

### Testing performed:

Tried getting NVDA to read text on web pages where text and links are mixed inside paragraphs such as Wikipedia articles. Also checked that this PR doesn't break anything in Chrome.

### Known issues with pull request:

None, but it might add a slight performance cost in really large chunks of text, I guess.

### Change log entry:

Section: Bug fixes

Reading text using the mouse in Firefox is now more consistent.