### PR TITLE
Fix wrong brackets in DisplayModelTextInfo.boundingRects property

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -501,7 +501,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 		for lineEndOffset in lineEndOffsets:
 			startOffset=endOffset
 			endOffset=lineEndOffset
-			rects.append(RectLTWH.fromCollection(*self._storyFieldsAndRects[1][startOffset:endOffset].toPhysical(self.obj.windowHandle)))
+			rects.append(RectLTWH.fromCollection(*self._storyFieldsAndRects[1][startOffset:endOffset]).toPhysical(self.obj.windowHandle))
 		return rects
 
 	def _getFirstVisibleOffset(self):


### PR DESCRIPTION
### Link to issue number:
Fixes mistake introduced in #8572

### Description of this pull request
in displaymodel.DisplayModelTextInfo._get_boundingRects, there was a mistake in how the brackets were positioned when converting a rectangle from logical to physical coordinates. Because of this, the code tried to call the toPhysical method on a list instead of a locationHelper.RectLTWH instance.

### Testing performed:
Tested as part of the vision framework (#9064) when moving with the review cursor from a PuTTY terminal window.

### Known issues with pull request:
None

### Change log entry:
None needed