### PR TITLE
Add a script to start the wx inspection tool.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1462,6 +1462,15 @@ class GlobalCommands(ScriptableObject):
 		speech.speakMessage(text)
 		log.info(text)
 
+	def script_startWxInspectorTool(self, gesture):
+		import wx.lib.inspection
+		wx.lib.inspection.InspectionTool().Show()
+	script_startWxInspectorTool.__doc__ = _(
+		# Translators: GUI development tool, to get information about the components used the NVDA GUI
+		"Opens the WX GUI inspection tool."
+	)
+	script_startWxInspectorTool.category = SCRCAT_TOOLS
+
 	def script_navigatorObject_devInfo(self,gesture):
 		obj=api.getNavigatorObject()
 		log.info("Developer info for navigator object:\n%s" % "\n".join(obj.devInfo), activateLogViewer=True)
@@ -2373,6 +2382,7 @@ class GlobalCommands(ScriptableObject):
 		"kb:NVDA+f1": "navigatorObject_devInfo",
 		"kb:NVDA+control+f1": "reportAppModuleInfo",
 		"kb:NVDA+control+z": "activatePythonConsole",
+		"kb:NVDA+control+w": "startWxInspectorTool",
 		"kb:NVDA+control+f3": "reloadPlugins",
 		"kb(desktop):NVDA+control+f2": "test_navigatorDisplayModelText",
 		"kb:NVDA+alt+m": "interactWithMath",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2382,7 +2382,6 @@ class GlobalCommands(ScriptableObject):
 		"kb:NVDA+f1": "navigatorObject_devInfo",
 		"kb:NVDA+control+f1": "reportAppModuleInfo",
 		"kb:NVDA+control+z": "activatePythonConsole",
-		"kb:NVDA+control+w": "startWxInspectorTool",
 		"kb:NVDA+control+f3": "reloadPlugins",
 		"kb(desktop):NVDA+control+f2": "test_navigatorDisplayModelText",
 		"kb:NVDA+alt+m": "interactWithMath",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1462,14 +1462,14 @@ class GlobalCommands(ScriptableObject):
 		speech.speakMessage(text)
 		log.info(text)
 
-	def script_startWxInspectorTool(self, gesture):
+	def script_startWxInspectionTool(self, gesture):
 		import wx.lib.inspection
 		wx.lib.inspection.InspectionTool().Show()
-	script_startWxInspectorTool.__doc__ = _(
-		# Translators: GUI development tool, to get information about the components used the NVDA GUI
-		"Opens the WX GUI inspection tool."
+	script_startWxInspectionTool.__doc__ = _(
+		# Translators: GUI development tool, to get information about the components used in the NVDA GUI
+		"Opens the WX GUI inspection tool. Used to get more information about the state of GUI components."
 	)
-	script_startWxInspectorTool.category = SCRCAT_TOOLS
+	script_startWxInspectionTool.category = SCRCAT_TOOLS
 
 	def script_navigatorObject_devInfo(self,gesture):
 		obj=api.getNavigatorObject()


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:
When working on the NVDA GUI, it's helpful to be able to inspect the layout and properties of controls and sizers. WxPython includes an inspection tool, while this can be started from the python console, starting it interrupts ones workflow.

### Description of how this pull request fixes the issue:
Adds a global command and shortcut `NVDA+ctrl+w` to open the Wx Inspector tool.

### Testing performed:
Run NVDA, executed the command with the shortcut

### Known issues with pull request:
This command is not really applicable to general users. Ideally these tools would be hidden behind an option in an advanced settings panel, something like "Enable Dev tools".

### Change log entry:

Section: Developers:
```
A new command has been added to start the wx Inspection Tool. The default keyboard shortcut is NVDA+ctrl+w (#9246).
```

