### PR TITLE
Added support for Connect Braille and Basic Braille 84.

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -475,6 +475,7 @@ addUsbDevices("handyTech", KEY_SERIAL, {
 # Newer Handy Tech displays have a native HID processor
 addUsbDevices("handyTech", KEY_HID, {
 	"VID_1FE4&PID_0054", # Active Braille
+	"VID_1FE4&PID_0055", # Connect Braille
 	"VID_1FE4&PID_0081", # Basic Braille 16
 	"VID_1FE4&PID_0082", # Basic Braille 20
 	"VID_1FE4&PID_0083", # Basic Braille 32
@@ -483,6 +484,7 @@ addUsbDevices("handyTech", KEY_HID, {
 	"VID_1FE4&PID_0086", # Basic Braille 64
 	"VID_1FE4&PID_0087", # Basic Braille 80
 	"VID_1FE4&PID_008B", # Basic Braille 160
+	"VID_1FE4&PID_008C", # Basic Braille 84
 	"VID_1FE4&PID_0061", # Actilino
 	"VID_1FE4&PID_0064", # Active Star 40
 })

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -45,7 +45,7 @@ MODEL_MODULAR_EVOLUTION_88 = b"\x38"
 MODEL_MODULAR_CONNECT_88 = b"\x3A"
 MODEL_EASY_BRAILLE = b"\x44"
 MODEL_ACTIVE_BRAILLE = b"\x54"
-MODEL_CONNECT_BRAILLE_40 = b"\x55"
+MODEL_CONNECT_BRAILLE = b"\x55"
 MODEL_ACTILINO = b"\x61"
 MODEL_ACTIVE_STAR_40 = b"\x64"
 MODEL_BASIC_BRAILLE_16 = b"\x81"
@@ -56,6 +56,7 @@ MODEL_BASIC_BRAILLE_48 = b"\x8A"
 MODEL_BASIC_BRAILLE_64 = b"\x86"
 MODEL_BASIC_BRAILLE_80 = b"\x87"
 MODEL_BASIC_BRAILLE_160 = b"\x8B"
+MODEL_BASIC_BRAILLE_84 = b"\x8C"
 MODEL_BRAILLINO = b"\x72"
 MODEL_BRAILLE_STAR_40 = b"\x74"
 MODEL_BRAILLE_STAR_80 = b"\x78"
@@ -355,11 +356,11 @@ class ActiveBraille(TimeSyncMixin, AtcMixin, TripleActionKeysMixin, Model):
 	genericName = name = 'Active Braille'
 
 
-class ConnectBraille40(TimeSyncMixin, TripleActionKeysMixin, Model):
-	deviceId = MODEL_CONNECT_BRAILLE_40
+class ConnectBraille(TripleActionKeysMixin, Model):
+	deviceId = MODEL_CONNECT_BRAILLE
 	numCells = 40
 	genericName = "Connect Braille"
-	name = "Connect Braille 40"
+	name = "Connect Braille"
 
 
 class Actilino(TimeSyncMixin, AtcMixin, JoystickMixin, TripleActionKeysMixin, Model):
@@ -417,6 +418,7 @@ BasicBraille48 = basicBrailleFactory(48, MODEL_BASIC_BRAILLE_48)
 BasicBraille64 = basicBrailleFactory(64, MODEL_BASIC_BRAILLE_64)
 BasicBraille80 = basicBrailleFactory(80, MODEL_BASIC_BRAILLE_80)
 BasicBraille160 = basicBrailleFactory(160, MODEL_BASIC_BRAILLE_160)
+BasicBraille84 = basicBrailleFactory(84, MODEL_BASIC_BRAILLE_84)
 
 
 class BrailleStar(TripleActionKeysMixin, Model):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
 - Early support for apps such as Mozilla Firefox on computers with ARM64 (e.g. Qualcom Snapdragon) processors. (#9216)
 - A new Advanced Settings category has been added to NVDA's Settings dialog, including an option to try out NVDA's new support for Microsoft Word via the Microsoft UI Automation API. (#9200)
 - Added support for the graphical view in Windows Disk Management. (#1486)
+- Added support for Handy Tech Connect Braille and Basic Braille 84. (#9249)
 
 
 == Changes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None associated.
### Summary of the issue:
Connect Braille and Basic Braille 84 are not detected.
### Description of how this pull request fixes the issue:
VID/PID pairs have been added to bdDetect, and the Handy Tech driver has been updated to recognize Basic Braille 84.
### Testing performed:
Tested On Windows 7 64 bit.
### Known issues with pull request:
None.
### Change log entry:

Changes: Added support for Handy Tech Connect Braille and Basic Braille 84.

