### PR TITLE
restore prompt for restart after installing an addon from shell

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -685,7 +685,7 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		self.aboutButton.Disable()
 		self.aboutButton.Bind(wx.EVT_BUTTON, self.onAbout)
 		# Translators: The close button on an NVDA dialog. This button will dismiss the dialog.
-		button = buttonSizer.addButton(self, label=_("Close"), id=wx.ID_CLOSE)
+		button = buttonSizer.addButton(self, label=_("&Close"), id=wx.ID_CLOSE)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		sHelper.addDialogDismissButtons(buttonSizer)
 		mainSizer.Add(settingsSizer, border=20, flag=wx.ALL)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -549,7 +549,8 @@ def handleRemoteAddonInstall(addonPath):
 			wx.OK | wx.ICON_ERROR)
 		return
 	gui.mainFrame.prePopup()
-	installAddon(gui.mainFrame, addonPath)
+	if installAddon(gui.mainFrame, addonPath):
+		promptUserForRestart()
 	gui.mainFrame.postPopup()
 
 

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -707,7 +707,7 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		):
 			# Translators: The reason an add-on is not compatible. A more recent version of NVDA is
 			# required for the add-on to work. The placeholder will be replaced with Year.Major.Minor (EG 2019.1).
-			return _("An apdated version of NVDA is required. NVDA version {} or later."
+			return _("An updated version of NVDA is required. NVDA version {} or later."
 			).format(addonAPIVersion.formatForGUI(addon.minimumNVDAVersion))
 		elif not addonVersionCheck.isAddonTested(
 			addon,


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9226

### Summary of the issue:
When installing an addon using shell extensions (EG via windows explorer) NVDA is no longer prompting to be restarted.

### Description of how this pull request fixes the issue:
If the install is successful the user is prompted to restart.

### Testing performed:
- Installed an addon from the shell.
- Cancelled an installation of an addon after starting it from the shell
- Failed to install an incompatible addon (triggered from the shell)

### Known issues with pull request:
None.

### Change log entry:
None.
Section: New features, Changes, Bug fixes

