### PR TITLE
Do not report UIA menu item description if equal to name

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2009-2018 NV Access Limited, Joseph Lee, Mohammad Suliman, Babbage B.V.
+#Copyright (C) 2009-2019 NV Access Limited, Joseph Lee, Mohammad Suliman, Babbage B.V., Leonard de Ruijter
 
 """Support for UI Automation (UIA) controls."""
 
@@ -817,6 +817,8 @@ class UIA(Window):
 			clsList.append(SensitiveSlider) 
 		if UIAControlType==UIAHandler.UIA_TreeItemControlTypeId:
 			clsList.append(TreeviewItem)
+		if UIAControlType==UIAHandler.UIA_MenuItemControlTypeId:
+			clsList.append(MenuItem)
 		# Some combo boxes and looping selectors do not expose value pattern.
 		elif (UIAControlType==UIAHandler.UIA_ComboBoxControlTypeId
 		# #5231: Announce values in time pickers by "transforming" them into combo box without value pattern objects.
@@ -1489,6 +1491,16 @@ class TreeviewItem(UIA):
 		info=super(TreeviewItem,self).positionInfo or {}
 		info['level']=self._level
 		return info
+
+class MenuItem(UIA):
+
+	def _get_description(self):
+		name=self.name
+		description=super(MenuItem,self)._get_description()
+		if description!=name:
+			return description
+		else:
+			return None
 
 class UIColumnHeader(UIA):
 


### PR DESCRIPTION
### Link to issue number:
Fixes #9252 

### Summary of the issue:
When we started using UIA for context menus in Office (#8919), some menu items started to be reported twice. This is because for IAccessible menu items, there is a default overlay class that sets the description to None when it is equal to the name of the menu item. For UIA, this was not yet the case.

### Description of how this pull request fixes the issue:
Added NVDAObjects.UIA.MenuItem which copies the description behavior of the IAccessible equivalent.

### Testing performed:
Tested in the Word 2016 context menu of the document area.

### Known issues with pull request:
None

### Change log entry:
None
