### PR TITLE
Make Developer scratchpad setting global 

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -351,7 +351,12 @@ class ConfigManager(object):
 
 	#: Sections that only apply to the base configuration;
 	#: i.e. they cannot be overridden in profiles.
-	BASE_ONLY_SECTIONS = {"general", "update", "upgrade"}
+	BASE_ONLY_SECTIONS = {
+	"general", 
+	"update", 
+	"upgrade",
+	"development",
+}
 
 	def __init__(self):
 		self.spec = confspec


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9260 

### Summary of the issue:
The new Developer scratchpad setting is currently able to be configured for specific configuration profiles. This does not make sense for this setting and should be global like the settings in General and update etc.

### Description of how this pull request fixes the issue:
the development config section is now included in the base-only sections, thus it will not paticipate in config profiles at all.
 
### Testing performed:
Created a config profile and activated it.
Turned on developer scratchpad in the Advanced settings and saved configuration.
Restarted NVDA and ensured the config profile previously created was not in use.
Confirmed that the developer scratchpad setting was still switched on.

### Known issues with pull request:
There could be a little confusion with the Advanced settings panel as now one of the options is global and the rest are config profile specific. I don't believe this is a big problem as I think it makes logical sense why this is. However, if there is a bit concirn from others, perhaps we should move this particular option to its own Development settings panel. 

### Change log entry:
None needed.