### PR TITLE
Don't report IAccessible alert events if there's no content.

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1412,6 +1412,9 @@ the NVDAObject for IAccessible
 		if self.role != controlTypes.ROLE_ALERT:
 			# Ignore alert events on objects that aren't alerts.
 			return
+		if not self.name and not self.description and self.childCount == 0:
+			# Don't report if there's no content.
+			return
 		# If the focus is within the alert object, don't report anything for it.
 		if eventHandler.isPendingEvents("gainFocus"):
 			# The alert event might be fired before the focus.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -58,6 +58,7 @@ What's New in NVDA
 - In Windows 10 October 2018 Update and later, when searching for emojis in emoji panel, NVDA will announce top search result. (#9112)
 - NVDA no longer freezes in the mainwindow of Virtualbox 5.2 and above. (#9202)
 - Responsiveness in Microsoft Word when navigating by line, paragraph or table cell may be significantly improved in some documents. A reminder that for best performance, set Microsoft Word to Draft view with alt+w,e after opening a document. (#9217) 
+- In Mozilla Firefox and Google Chrome, empty alerts are no longer reported. (#5657)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #5657.

### Summary of the issue:
In Firefox and Chrome, NVDA reports "alert" when an empty element with role="alert" is shown.

### Description of how this pull request fixes the issue:
In IAccessible's event_alert, return early if there's no content.
As well as the childCount, we also check name and description, as these might be set using ARIA even on an alert with no children.

### Testing performed:
In both Firefox and Chrome, tested with the following test cases.

Empty alert. When button is pressed, nothing is reported:
`data:text/html,<div id="al" role="alert" hidden></div><button onClick="al.hidden = false;">Alert</button>`

Alert with text content. When button is pressed, "alert  text" is reported:
`data:text/html,<div id="al" role="alert" hidden>text</div><button onClick="al.hidden = false;">Alert</button>`

Alert with aria-label. When button is pressed, "label  alert" is reported:
`data:text/html,<div id="al" role="alert" aria-label="label" hidden></div><button onClick="al.hidden = false;">Alert</button>`

Alert with aria-describedby. When button is pressed, "alert  desc" is reported:
`data:text/html,<div id="desc">desc</div><div id="al" role="alert" aria-describedby="desc" hidden></div><button onClick="al.hidden = false;">Alert</button>`

Alert with button. When button outside the alert is pressed, "alert,  inner  button" is reported:
`data:text/html,<div id="al" role="alert" hidden><button>inner</button></div><button onClick="al.hidden = false;">Alert</button>`

### Known issues with pull request:
There are obscure cases this won't catch like an alert containing an empty paragraph, but fixing that is somewhat trickier and I doubt it happens in the real world. If it does, we can extend this later.

### Change log entry:

Bug Fixes:

`- In Mozilla Firefox and Google Chrome, empty alerts are no longer reported.`