### PR TITLE
Log a warning instead of error when disabling Word screen updating fails

### DIFF
--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -71,7 +71,7 @@ class ScreenUpdatingDisabler {
 		}
 		HRESULT res=_com_dispatch_raw_propput(arg_pDispatchApplication,wdDISPID_APPLICATION_SCREENUPDATING,VT_BOOL,false);
 		if(res!=S_OK) {
-			LOG_ERROR(L"application.screenUpdating false failed with code "<<res);
+			LOG_WARNING(L"application.screenUpdating false failed with code "<<res);
 			return;
 		}
 		pDispatchApplication=arg_pDispatchApplication;
@@ -81,7 +81,7 @@ class ScreenUpdatingDisabler {
 		if(!pDispatchApplication) return;
 		HRESULT res=_com_dispatch_raw_propput(pDispatchApplication,wdDISPID_APPLICATION_SCREENUPDATING,VT_BOOL,true);
 		if(res!=S_OK) {
-			LOG_ERROR(L"application.screenUpdating true failed with code "<<res);
+			LOG_WARNING(L"application.screenUpdating true failed with code "<<res);
 		}
 	}
 


### PR DESCRIPTION
### Link to issue number:
Closes #9271

### Summary of the issue:
The recent word speed improvements logged an error when disabling Word screen updating failed. However, you can't disable screen updating when in protected view, which made reading documents in protected view a horrible experience for development build users.

### Description of how this pull request fixes the issue:
Logs a warning instead of an error.

### Considered alternative
Do a check of whether Word is in sandbox mode before trying to disable screen updating. However, this would result in an extra com call.

### Testing performed:
Tested in Word 2016 protected view

### Known issues with pull request:
None

### Change log entry:
NOne
