### PR TITLE
Support in-cell editing in Excel 2016/365

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -758,7 +758,11 @@ class UIA(Window):
 				cacheRequest.addProperty(ID)
 			except COMError:
 				log.debug("Couldn't add property ID %d to cache request, most likely unsupported on this version of Windows"%ID)
-		cacheElement=self.UIAElement.buildUpdatedCache(cacheRequest)
+		try:
+			cacheElement=self.UIAElement.buildUpdatedCache(cacheRequest)
+		except COMError:
+			log.debugWarning("IUIAutomationElement.buildUpdatedCache failed given IDs of %s"%IDs)
+			return
 		for ID in IDs:
 			elementCache[ID]=cacheElement
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -279,10 +279,15 @@ class UIAHandler(COMObject):
 			obj=focus
 		eventHandler.queueEvent(NVDAEventName,obj)
 
+	# The last UIAElement that received a UIA focus event
+	# This is updated no matter if this is a native element, the window is UIA blacklisted by NVDA, or  the element is proxied from MSAA 
+	lastFocusedUIAElement=None
+
 	def IUIAutomationFocusChangedEventHandler_HandleFocusChangedEvent(self,sender):
 		if not self.MTAThreadInitEvent.isSet():
 			# UIAHandler hasn't finished initialising yet, so just ignore this event.
 			return
+		self.lastFocusedUIAElement=sender
 		if not self.isNativeUIAElement(sender):
 			return
 		import NVDAObjects.UIA

--- a/source/appModules/excel.py
+++ b/source/appModules/excel.py
@@ -14,6 +14,7 @@ import appModuleHandler
 from NVDAObjects.window import DisplayModelEditableText
 from NVDAObjects.window.edit import UnidentifiedEdit
 from NVDAObjects.window import Window
+from NVDAObjects.window.excel import ExcelCell
 
 class Excel6(Window):
 	"""
@@ -24,7 +25,7 @@ class Excel6(Window):
 	def _get_focusRedirect(self):
 		if self.role==controlTypes.ROLE_UNKNOWN:
 			# The control is inaccessible, try several times to find the CellEdit UIA element with focus and use that instead.
-			for count in xrange(5):
+			for count in xrange(10):
 				if count>=1:
 					api.processPendingEvents(processEventQueue=False)
 					if eventHandler.isPendingEvents("gainFocus"):
@@ -33,7 +34,13 @@ class Excel6(Window):
 				e=UIAHandler.handler.lastFocusedUIAElement
 				if e and e.cachedAutomationID=="CellEdit":
 					obj=UIA(UIAElement=e)
-					obj.parent=api.getFocusObject()
+					oldFocus=api.getFocusObject()
+					if isinstance(oldFocus,ExcelCell):
+						# Set the edit control's parent as the cell that previously had focus. I.e. the cell being edited.
+						# otherwise a whole bunch of UIA focus ancestors for the edit control will be reported.
+						obj.parent=oldFocus
+					# Cache this for as long as this object exists.
+					self.focusRedirect=obj
 					return obj
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/excel.py
+++ b/source/appModules/excel.py
@@ -4,9 +4,37 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
+import time
+import eventHandler
+import api
+import UIAHandler
+from NVDAObjects.UIA import UIA
+import controlTypes
 import appModuleHandler
 from NVDAObjects.window import DisplayModelEditableText
 from NVDAObjects.window.edit import UnidentifiedEdit
+from NVDAObjects.window import Window
+
+class Excel6(Window):
+	"""
+	The Excel cell edit window.
+	If it is not accessible (no displayModel) then wait for the CellEdit UIA element to get focus and redirect to that.
+	"""
+
+	def _get_focusRedirect(self):
+		if self.role==controlTypes.ROLE_UNKNOWN:
+			# The control is inaccessible, try several times to find the CellEdit UIA element with focus and use that instead.
+			for count in xrange(5):
+				if count>=1:
+					api.processPendingEvents(processEventQueue=False)
+					if eventHandler.isPendingEvents("gainFocus"):
+						return
+					time.sleep(0.05)
+				e=UIAHandler.handler.lastFocusedUIAElement
+				if e and e.cachedAutomationID=="CellEdit":
+					obj=UIA(UIAElement=e)
+					obj.parent=api.getFocusObject()
+					return obj
 
 class AppModule(appModuleHandler.AppModule):
 
@@ -19,3 +47,5 @@ class AppModule(appModuleHandler.AppModule):
 			except ValueError:
 				pass
 			clsList.insert(0, DisplayModelEditableText)
+		if windowClass=="EXCEL6":
+			clsList.insert(0,Excel6)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -64,7 +64,8 @@ What's New in NVDA
 - Responsiveness in Microsoft Word when navigating by line, paragraph or table cell may be significantly improved in some documents. A reminder that for best performance, set Microsoft Word to Draft view with alt+w,e after opening a document. (#9217) 
 - In Mozilla Firefox and Google Chrome, empty alerts are no longer reported. (#5657)
 - Significant performance improvements when navigating cells in Microsoft Excel, particularly when the spreadsheet contains comments and or validation dropdown lists. (#7348)
-
+- It should be no longer necessary to turn off in-cell editing in Microsoft Excel's options to access the cell edit control with NVDA in Excel 2016/365. (#8146).
+ 
 
 == Changes for Developers ==
 - NVDA can now  be built with all editions of Microsoft Visual Studio 2017 (not just the Community edition). (#8939)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8146 

### Summary of the issue:
In Excel 2010 and below, NVDA would use its displayModel code to interact with the formula / cell edit control.
Excel 2013 introduced UI Automation support for the  edit control.
However, in Excel 2016/365 it seems that the UI Automation element for the in-cell edit control is a child of the active cell, and therefore uses the window handle for the sheet, rather than the specific EXCEL6 in-cell edit window.
But because we ignore UI Automation in the EXCEL7 (sheet) window, all we get now is a generic MSAA client object in the EXCEL6 window with focus. In short, NVDA just says "unknown" and the edit control is not usable.
Turning off in-cell editing in Excel's options allows NVDA to interact with the edit control properly as the window handle for the edit control will be "EXCEL<" not "EXCEL7". But this is just a work-around and many users do not know to do this.

### Description of how this pull request fixes the issue:
Provide an EXCEL6 NVDAObject overlay class in the Excel appModule, which if inaccessible redirects focus to the UIA element for the in-cell edit control if available.

### Testing performed:
In a sheet with in-cell editing turned on: pressed f2 and confirmed that NVDA announced the edit control and that the arrow keys allowed navigating the text.
Then with in-cell editing turned off, pressed f2 and confirmed that NVDA still announced the edit control and that the arrow keys could navigate the edit control.
Performed the above 2 tests but this time rather than pressing f2, simply started typing in the cell.
Testing on Excel 2010 is still required.
 
### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* When editing cells in Excel 2016/365, NvDA can correctly report and interact with the edit control. (#8146)