### PR TITLE
Stop regex_error exception when quick navigating to article landmarks

### DIFF
--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -125,7 +125,7 @@ VBufStorage_fieldNode_t* VBufStorage_fieldNode_t::nextNodeInTree(int direction, 
 // @param out the stream to which the escaped attribute string should be written
 // @param text The attribute string to be escaped
 // @param maxLength the maximum length of the attribute string that should be copied. If maxLength is 0 or not specified, the entire string is copied.
-// @return the number of characters written to the output stream (before expantion / filtering). This number can be used to see if the string was truncated at all.
+// @return the number of characters written to the output stream (before expansion / filtering). This number can be used to see if the string was truncated at all.
 inline size_t outputEscapedAttribute(wostringstream& out, const wstring& text, size_t maxLength=0) {
 	size_t count=0;
 	for (wstring::const_iterator it = text.begin(); it != text.end(); ++it) {

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -122,7 +122,11 @@ VBufStorage_fieldNode_t* VBufStorage_fieldNode_t::nextNodeInTree(int direction, 
 	return tempNode;
 }
 
-inline void outputEscapedAttribute(wostringstream& out, const wstring& text) {
+// @param out the stream to which the escaped attribute string should be written
+// @param text The attribute string to be escaped
+// @param maxLength the maximum length of the attribute string that should be copied. If maxLength is 0 or not specified, the entire string is copied.
+inline void outputEscapedAttribute(wostringstream& out, const wstring& text, size_t maxLength=0) {
+	size_t count=0;
 	for (wstring::const_iterator it = text.begin(); it != text.end(); ++it) {
 		switch (*it) {
 			case L':':
@@ -132,10 +136,20 @@ inline void outputEscapedAttribute(wostringstream& out, const wstring& text) {
 			default:
 			out << *it;
 		}
+		if(maxLength>0) {
+			count++;
+			if(count==maxLength) {
+				break;
+			}
+		}
 	}
 }
 
 bool VBufStorage_fieldNode_t::matchAttributes(const std::vector<std::wstring>& attribs, const std::wregex& regexp) {
+	// The max length for a node attribute value when used in a regular expression for matching.
+	// regex_match throws regex_error (error_stack) In Firefox when a value is very large.
+	// Most values will be way under this limit, but for large ones such as name for example, as we only are checking whether it is not empty, then truncating is fine.
+	const size_t regexAttribValueLimit=100;
 	wostringstream regexpInput;
 	wstring parentPrefix=L"parent::";
 	for (vector<wstring>::const_iterator attribName = attribs.begin(); attribName != attribs.end(); ++attribName) {
@@ -148,18 +162,23 @@ bool VBufStorage_fieldNode_t::matchAttributes(const std::vector<std::wstring>& a
 		if(this->parent&&attribName->find(parentPrefix)==0) {
 			VBufStorage_attributeMap_t::const_iterator foundAttrib = this->parent->attributes.find(attribName->substr(parentPrefix.length()));
 			if (foundAttrib != this->parent->attributes.end()) {
-				outputEscapedAttribute(regexpInput, foundAttrib->second);
+				outputEscapedAttribute(regexpInput, foundAttrib->second,regexAttribValueLimit);
 			}
 			regexpInput << L";";
 		} else { // not a parent attribute
 			VBufStorage_attributeMap_t::const_iterator foundAttrib = attributes.find(*attribName);
 			if (foundAttrib != attributes.end()) {
-				outputEscapedAttribute(regexpInput, foundAttrib->second);
+				outputEscapedAttribute(regexpInput, foundAttrib->second,regexAttribValueLimit);
 			}
 			regexpInput << L";";
 		}
 	}
-	return regex_match(regexpInput.str(), regexp);
+	try {
+		return regex_match(regexpInput.str(), regexp);
+	} catch(const std::regex_error& e) {
+		LOG_DEBUGWARNING(L"regex_match threw "<<(e.what()));
+	}
+	return false;
 }
 
 int VBufStorage_fieldNode_t::calculateOffsetInTree() const {

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -166,7 +166,7 @@ bool VBufStorage_fieldNode_t::matchAttributes(const std::vector<std::wstring>& a
 			if (foundAttrib != this->parent->attributes.end()) {
 				auto outLen=outputEscapedAttribute(regexpInput, foundAttrib->second,regexAttribValueLimit);
 				if(outLen<foundAttrib->second.length()) {
-					LOG_DEBUGWARNING(L"Truncated "<<(*attribName));
+					LOG_DEBUGWARNING(L"Truncated attribute "<<(*attribName));
 				}
 			}
 			regexpInput << L";";
@@ -175,7 +175,7 @@ bool VBufStorage_fieldNode_t::matchAttributes(const std::vector<std::wstring>& a
 			if (foundAttrib != attributes.end()) {
 				auto outLen=outputEscapedAttribute(regexpInput, foundAttrib->second,regexAttribValueLimit);
 				if(outLen<foundAttrib->second.length()) {
-					LOG_DEBUGWARNING(L"Truncated "<<(*attribName));
+					LOG_DEBUGWARNING(L"Truncated attribute "<<(*attribName));
 				}
 			}
 			regexpInput << L";";

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -65,7 +65,8 @@ What's New in NVDA
 - In Mozilla Firefox and Google Chrome, empty alerts are no longer reported. (#5657)
 - Significant performance improvements when navigating cells in Microsoft Excel, particularly when the spreadsheet contains comments and or validation dropdown lists. (#7348)
 - It should be no longer necessary to turn off in-cell editing in Microsoft Excel's options to access the cell edit control with NVDA in Excel 2016/365. (#8146).
- 
+- Fixed a freeze in Firefox sometimes seen when quick navigating by landmarks, if the extendedAria add-on is in use. (#8980)
+
 
 == Changes for Developers ==
 - NVDA can now  be built with all editions of Microsoft Visual Studio 2017 (not just the Community edition). (#8939)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8980 

### Summary of the issue:
NvDA's browseMode quick navigation in virtualBuffers uses regular expressions to match on a node's attributes to locate the next valid item.
However, in certain scenarios, Firefox can seem to freeze when quick navigating by landmarks, if the extendedAria add-on in installed and reportArticles is enabled.
Technically:
In Firefox at least, it seems that the c++ regex_match function can throw a regex_error exception if the input string is too long. For instance, if searching for landmarks (including articles) and it comes upon an article node with an aria-label with a length greater than 294 characters.
 
### Description of how this pull request fixes the issue:
1. We now catch regex_error thrown by regex_match, log a debug warning, and return false (I.e. pretend the regex did not match). This in itself stops the freeze, but does mean that a possible article will be skipped.
2. We limit the  length of attribute value strings added to re regular expression input to 100 characters.  Currently this is for all attribute values, as matchAttributes is really supposed to be agnostic to what attributes it is dealing with. Though we could specifically hardcode a check for 'name'. I can't however really think of a situation where any attribute value needs to be more than 100 characters for matching purposes. We could instead also up the limit to say 256, or in deed 294, but I have a feeling this may not be universal across machines.


### Testing performed:
Tested the original testcases in #8980. The correct articles were found, and no freeze occured.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* Fixed a freeze in Firefox sometimes seen when qquick navigating by landmarks, if the extendedAria add-on is in use. (#8980)
