### PR TITLE
Speed up _isNVDAObjectInApplication in virtual buffers by using the buffer.

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -694,6 +694,23 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 				return item.field
 		raise LookupError
 
+	def _isNVDAObjectInApplication_noWalk(self, obj):
+		inApp = super(VirtualBuffer, self)._isNVDAObjectInApplication_noWalk(obj)
+		if inApp is not None:
+			return inApp
+		# If the object is in the buffer, it's definitely not in an application.
+		docHandle, objId = self.getIdentifierFromNVDAObject(obj)
+		node = VBufRemote_nodeHandle_t()
+		if not self.VBufHandle:
+			return None
+		try:
+			NVDAHelper.localLib.VBuf_getControlFieldNodeWithIdentifier(self.VBufHandle, docHandle, objId,ctypes.byref(node))
+		except WindowsError:
+			return None
+		if node:
+			return False
+		return None
+
 	__gestures = {
 		"kb:NVDA+f5": "refreshBuffer",
 		"kb:NVDA+v": "toggleScreenLayout",

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -132,6 +132,9 @@ class Gecko_ia2(VirtualBuffer):
 			return False
 		if self.rootNVDAObject.windowHandle==obj.windowHandle:
 			ID=obj.IA2UniqueID
+			if not ID:
+				# Dead object.
+				return False
 			try:
 				self.rootNVDAObject.IAccessibleObject.accChild(ID)
 			except COMError:


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Performance improvement; see below for results.

`_isNVDAObjectInApplication` is called by various TreeInterceptor implementations whenever we need to determine whether an object is contained within the document. It needs to walk ancestors in order to make a determination and often ends up walking to the root object. We cache results for an object and its ancestors, but this only really helps focus, since that's the only place where we reuse cached ancestors. Thus, object navigation and events for anything other than the focus don't benefit and can be slow.

### Description of how this pull request fixes the issue:
Virtual buffers only know about objects that should be considered part of the document. Therefore, if an object is in the buffer (a relatively fast check), we can immediately conclude that it is not within an application. This avoids the need to walk the remaining ancestors.

To facilitate this, part of `_isNVDAObjectInApplication` has been split into a separate method, `_isNVDAObjectInApplication_noWalk`. This method can return a definite answer if possible  or it can return None, in which case we walk to the next ancestor.

The Gecko vbuf's `__contains__` method also had to be tweaked to return early for dead objects. Otherwise, `_isNVDAObjectInApplication` walks ancestors and ends up hitting the desktop object.

### Testing performed:
In Firefox:

#### Test Case 1

`data:text/html,<div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><div role="section"><button>a</button><button>b</button></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div>`

1. Turned on NVDA's IO and timeSinceInput debug logging.
2. Focused the "a" button.
3. Moved to next navigator object.
4. Observed that time since input for the announcement is 30-60ms with the change. Repeated several times to confirm.

In contrast, without the change, the time is 100ms or more.

#### Test Case 2

`data:text/html,<button>before</button><div role="application"><button>inside</button></div>`

1. Tabbed to the before button.
2. Using up and down arrows, confirmed before was the only button in browse mode.
3. Tabbed to the inside button.
4. Confirmed that up and down arrows do nothing (no browse mode).
5. Pressed NVDA+space to force browse mode.
6. Using up and down arrows, confirmed that only the inside button was present.
7. Shift+tabbed to the before button.
8. Using up and down arrows, confirmed before was the only button in browse mode.
9. Tabbed to the inside button.
10. Using up and down arrows, confirmed that only the inside button was present.

### Known issues with pull request:
None known.

### Change log entry:

Probably not significant enough to justify one. Certainly, I can't give a specific real world example where this is notable, though it should help things overall when there are a lot of events.