### PR TITLE
Enforced UIA implementation of Object Explorer window

### DIFF
--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -50,6 +50,7 @@ from NVDAObjects.window import Window
 from NVDAObjects.window import DisplayModelEditableText
 
 import appModuleHandler
+import UIAHandler
 
 
 #
@@ -145,6 +146,15 @@ class AppModule(appModuleHandler.AppModule):
 		self._textManager = serviceProvider.QueryService(SVsTextManager, IVsTextManager)
 		return self._textManager
 
+	def isGoodUIAWindow(self, hwnd):
+		vs_version = [int(x)
+			for x in self.productVersion.split(".")]
+
+		if vs_version[0] >= 15 and vs_version[1] >= 3:
+			#: #9311: Sometimes object explorer objects are recognized as IAccessible2 objects
+			return True
+
+		return UIAHandler.handler.isUIAWindow(hwnd)
 
 class VsTextEditPaneTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _InformUnsupportedWindowType(self,type):

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -156,7 +156,6 @@ class AppModule(appModuleHandler.AppModule):
 			if winUser.getClassName(hwnd) in ("LiteTreeView32", "RICHEDIT50W"):
 				return True
 
-		return UIAHandler.handler.isUIAWindow(hwnd)
 
 class VsTextEditPaneTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _InformUnsupportedWindowType(self,type):

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -98,7 +98,7 @@ class AppModule(appModuleHandler.AppModule):
 			except ValueError:
 				pass
 			clsList.insert(0, VsTextEditPane)
-			
+
 	def _getDTE(self):
 	# Return the already fetched instance if there is one.
 		try:
@@ -148,12 +148,14 @@ class AppModule(appModuleHandler.AppModule):
 		return self._textManager
 
 	def isGoodUIAWindow(self, hwnd):
-		vs_version = [int(x)
-			for x in self.productVersion.split(".")]
+		vs_major, vs_minor, rest = self.productVersion.split(".", 2)
+		vs_major, vs_minor = int(vs_major), int(vs_minor)
 
-		if vs_version[0] >= 15 and vs_version[1] >= 3:
-			#: #9311: Sometimes object explorer objects are recognized as IAccessible2 objects
-			if winUser.getClassName(hwnd) in ("LiteTreeView32", "RICHEDIT50W"):
+		if (vs_major == 15 and vs_minor >= 3)
+			or vs_major >= 16:
+
+			# #9311: Sometimes object explorer objects are recognized as IAccessible2 objects
+			if winUser.getClassName(hwnd) in ("LiteTreeView32",):
 				return True
 
 

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -51,6 +51,7 @@ from NVDAObjects.window import DisplayModelEditableText
 
 import appModuleHandler
 import UIAHandler
+import winUser
 
 
 #
@@ -152,7 +153,8 @@ class AppModule(appModuleHandler.AppModule):
 
 		if vs_version[0] >= 15 and vs_version[1] >= 3:
 			#: #9311: Sometimes object explorer objects are recognized as IAccessible2 objects
-			return True
+			if winUser.getClassName(hwnd) in ("LiteTreeView32", "RICHEDIT50W"):
+				return True
 
 		return UIAHandler.handler.isUIAWindow(hwnd)
 

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -151,8 +151,8 @@ class AppModule(appModuleHandler.AppModule):
 		vs_major, vs_minor, rest = self.productVersion.split(".", 2)
 		vs_major, vs_minor = int(vs_major), int(vs_minor)
 
-		if (vs_major == 15 and vs_minor >= 3)
-			or vs_major >= 16:
+		if ((vs_major == 15 and vs_minor >= 3)
+			or vs_major >= 16):
 
 			# #9311: Sometimes object explorer objects are recognized as IAccessible2 objects
 			if winUser.getClassName(hwnd) in ("LiteTreeView32",):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -66,7 +66,6 @@ What's New in NVDA
 - Significant performance improvements when navigating cells in Microsoft Excel, particularly when the spreadsheet contains comments and or validation dropdown lists. (#7348)
 - It should be no longer necessary to turn off in-cell editing in Microsoft Excel's options to access the cell edit control with NVDA in Excel 2016/365. (#8146).
 - Fixed a freeze in Firefox sometimes seen when quick navigating by landmarks, if the extendedAria add-on is in use. (#8980)
-- Visual Studio 2017: _Objects tree_ in _Objects Explorer_ was not working properly. (#9311)
 
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -64,7 +64,7 @@ What's New in NVDA
 - Responsiveness in Microsoft Word when navigating by line, paragraph or table cell may be significantly improved in some documents. A reminder that for best performance, set Microsoft Word to Draft view with alt+w,e after opening a document. (#9217) 
 - In Mozilla Firefox and Google Chrome, empty alerts are no longer reported. (#5657)
 - Significant performance improvements when navigating cells in Microsoft Excel, particularly when the spreadsheet contains comments and or validation dropdown lists. (#7348)
-
+- Visual Studio 2017: Object tree in object explorer now works as expected. (#9311)
 
 == Changes for Developers ==
 - NVDA can now  be built with all editions of Microsoft Visual Studio 2017 (not just the Community edition). (#8939)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -64,7 +64,7 @@ What's New in NVDA
 - Responsiveness in Microsoft Word when navigating by line, paragraph or table cell may be significantly improved in some documents. A reminder that for best performance, set Microsoft Word to Draft view with alt+w,e after opening a document. (#9217) 
 - In Mozilla Firefox and Google Chrome, empty alerts are no longer reported. (#5657)
 - Significant performance improvements when navigating cells in Microsoft Excel, particularly when the spreadsheet contains comments and or validation dropdown lists. (#7348)
-- Visual Studio 2017: Object tree in object explorer now works as expected. (#9311)
+- Visual Studio 2017: _Objects tree_ in _Objects Explorer_ was not working properly. (#9311)
 
 == Changes for Developers ==
 - NVDA can now  be built with all editions of Microsoft Visual Studio 2017 (not just the Community edition). (#8939)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Issue #9311

### Summary of the issue:

The objects tree of the object explorer was not working correct in Visual Studio 15.3 and up.

### Description of how this pull request fixes the issue:

I made some research and figured out that the three panes of the object explorer are being instantiated as IAccessible objects.

Basically, this enforces instantiation of all objects as UIA instances if it detects a version up from 15.3.

By doing this, NVDA is enforced to pick UIA versions of these objects, which work better.

### Testing performed:

Unfortunately, I can't test with more systems than my one because I didn't set up VMs for other configurations.

### Known issues with pull request:

The only problem is with level detection if the expanded is the last item on the tree, but this is an issue that occurs also with narrator.

I will keep doing research on this to see if it can be solved somehow.

### Change log entry:

Section: Bug fixes

* Visual Studio 2017: _Objects tree_ in _Objects Explorer_ was not working properly. (#9311)