### PR TITLE
Developer guide: change scriptHandler.script to script to resolve a namespace error

### DIFF
--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -269,7 +269,7 @@ import versionInfo
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
-	@scriptHandler.script(gesture="kb:NVDA+shift+v")
+	@script(gesture="kb:NVDA+shift+v")
 	def script_announceNVDAVersion(self, gesture):
 		ui.message(versionInfo.version)
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
N/A
### Summary of the issue:
In the developer guide, the `script` decorator was imported into the main namespace, but incorrectly referenced as `scriptHandler.script`, leading to namespace errors.
### Description of how this pull request fixes the issue:
Changed `scriptHandler.script` in the place where it appeared to `script`, in line with the rest of the examples.
### Testing performed:
N/A
### Known issues with pull request:
None known.
### Change log entry:
N/A