### PR TITLE
Allow add-on API version strings to exclude Minor, defaulting to 0. 

### DIFF
--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -669,13 +669,13 @@ Otherwise, the add-on will not install.
 - url: A URL where this add-on, further info and upgrades can be found.
 - docFileName: The name of the main documentation file for this add-on; e.g. readme.html. See the [Add-on Documentation #AddonDoc] section for more details.
 - minimumNVDAVersion: The minimum required version of NVDA for this add-on to be installed or enabled.
-  - e.g "2019.1.0"
-  - Must be a three part version string I.E. Year.Minor.Minor. Two part version strings ("2019.1") will not pass validation.
+  - e.g "2019.1.1"
+  - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
   - Must be less than or equal to `lastTestedNVDAVersion`
 - lastTestedNVDAVersion: The last version of NVDA this add-on has been tested with.
   - e.g "2019.1.0"
-  - Must be a three part version string I.E. Year.Minor.Minor. Two part version strings ("2019.1") will not pass validation.
+  - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
   - Must be greater than or equal to `minimumNVDAVersion`
 -

--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -23,7 +23,7 @@ EG: (x, y, z): Large changes to speech.py
 
 #: Compiled regular expression to match an addon API version string.
 #: Supports year.major.minor versions (e.g. 2018.1.1).
-# Although year and major are manditory, minor is optional.
+# Although year and major are mandatory, minor is optional.
 #: Resulting match objects expose three groups reflecting release year, release major, and release minor version,
 # respectively.
 # As minor is optional, the final group in the resulting match object may be None if minor is not provided in the original string. In this case it should be treated as being 0. 

--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -23,11 +23,12 @@ EG: (x, y, z): Large changes to speech.py
 
 #: Compiled regular expression to match an addon API version string.
 #: Supports year.major.minor versions (e.g. 2018.1.1).
+# Although year and major are manditory, minor is optional.
 #: Resulting match objects expose three groups reflecting release year, release major, and release minor version,
 # respectively.
+# As minor is optional, the final group in the resulting match object may be None if minor is not provided in the original string. In this case it should be treated as being 0. 
 #: @type: RegexObject
-ADDON_API_VERSION_REGEX = re.compile(r"^(0|\d{4})\.(\d)\.(\d)$")
-
+ADDON_API_VERSION_REGEX = re.compile(r"^(0|\d{4})\.(\d)(?:\.(\d))?$")
 
 def getAPIVersionTupleFromString(version):
 	"""Converts a string containing an NVDA version to a tuple of the form (versionYear, versionMajor, versionMinor)"""

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -657,7 +657,8 @@ docFileName = string(default=None)
 # Eg: 2019.1.0 or 0.0.0
 # Must have 3 integers separated by dots.
 # The first integer must be a Year (4 characters)
-# "0.0.0" is also valid
+# "0.0.0" is also valid.
+# The final integer can be left out, and in that case will default to 0. E.g. 2019.1
 
 """))
 

--- a/tests/unit/test_addonVersionCheck.py
+++ b/tests/unit/test_addonVersionCheck.py
@@ -88,11 +88,17 @@ class TestAddonVersionCheck(unittest.TestCase):
 
 class TestGetAPIVersionTupleFromString(unittest.TestCase):
 
-	def test_getAPIVersionTupleFromString_succeeds(self):
+	def test_getAPIVersionTupleFromString_3_succeeds(self):
 		"""Tests trying to get the API version tuple from an API version string with a standard version
 		layout will succeed.
 		"""
 		self.assertEqual((2019, 1, 0), addonAPIVersion.getAPIVersionTupleFromString("2019.1.0"))
+
+	def test_getAPIVersionTupleFromString_2_succeeds(self):
+		"""Tests trying to get the API version tuple from an API version where the Minor part is omitted and therefore defaults to 0.
+		This will succeed.
+		"""
+		self.assertEqual((2019, 1, 0), addonAPIVersion.getAPIVersionTupleFromString("2019.1"))
 
 	def test_getAPIVersionTupleFromString_allZeros_succeeds(self):
 		"""Tests trying to get the API version tuple from an API version string that is all zeros.
@@ -123,12 +129,6 @@ class TestGetAPIVersionTupleFromString(unittest.TestCase):
 		results in an error being raised
 		"""
 		self.assertRaises(ValueError, addonAPIVersion.getAPIVersionTupleFromString, "2019.")
-
-	def test_getAPIVersionTupleFromString_twoMatch_raises(self):
-		"""Tests trying to get the API version tuple from an API version string with two matching groups
-		results in an error being raised
-		"""
-		self.assertRaises(ValueError, addonAPIVersion.getAPIVersionTupleFromString, "2019.1")
 
 	def test_getAPIVersionTupleFromString_devAppended_raises(self):
 		"""Tests trying to get the API version tuple from an API version string with three matching groups

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,8 +23,9 @@ What's New in NVDA
 
 == Changes ==
 - Updated liblouis braille translator to version 3.8.0. (#9013)
-- Add-on authors now can enforce a minimum required NVDA version for their add-ons. Unsupported add-ons will not load or install. (#6275)
-- Add-on authors must now specify the last version of NVDA the add-on has been tested against. Users will be warned against installing or enabling untested add-ons. (#6275)
+- Add-on authors now can enforce a minimum required NVDA version for their add-ons. NVDA will refuse to install or load an add-on whos minimum required NVDA version is higher than the current NVDA version. (#6275)
+- Add-on authors can now specify the last version of NVDA the add-on has been tested against. If an add-on has been only tested against a  version of NVDA lower than the current version, then NVDA will refuse to install or load the add-on. (#6275)
+- This version of NVDA will allow installing and loading of add-ons  that do not yet contain Minimum and Last Tested NVDA version information, but upgrading to future versions of NvDA (E.g. 2019.2) will automatically cause these older add-ons to be disabled.
 - The move mouse to navigator object command is now available in Microsoft Word as well as for UIA controls, particularly Microsoft Edge. (#7916, #8371)
 - Reporting of text under the mouse has been improved within Microsoft Edge and other UIA applications. (#8370)
 - When NVDA is started with the `--portable-path` command line parameter, the provided path is automatically filled in when trying to create a portable copy of NVDA using the NVDA menu. (#8623)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -25,7 +25,7 @@ What's New in NVDA
 - Updated liblouis braille translator to version 3.8.0. (#9013)
 - Add-on authors now can enforce a minimum required NVDA version for their add-ons. NVDA will refuse to install or load an add-on whose minimum required NVDA version is higher than the current NVDA version. (#6275)
 - Add-on authors can now specify the last version of NVDA the add-on has been tested against. If an add-on has been only tested against a  version of NVDA lower than the current version, then NVDA will refuse to install or load the add-on. (#6275)
-- This version of NVDA will allow installing and loading of add-ons  that do not yet contain Minimum and Last Tested NVDA version information, but upgrading to future versions of NvDA (E.g. 2019.2) may automatically cause these older add-ons to be disabled.
+- This version of NVDA will allow installing and loading of add-ons  that do not yet contain Minimum and Last Tested NVDA version information, but upgrading to future versions of NVDA (E.g. 2019.2) may automatically cause these older add-ons to be disabled.
 - The move mouse to navigator object command is now available in Microsoft Word as well as for UIA controls, particularly Microsoft Edge. (#7916, #8371)
 - Reporting of text under the mouse has been improved within Microsoft Edge and other UIA applications. (#8370)
 - When NVDA is started with the `--portable-path` command line parameter, the provided path is automatically filled in when trying to create a portable copy of NVDA using the NVDA menu. (#8623)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,9 +23,9 @@ What's New in NVDA
 
 == Changes ==
 - Updated liblouis braille translator to version 3.8.0. (#9013)
-- Add-on authors now can enforce a minimum required NVDA version for their add-ons. NVDA will refuse to install or load an add-on whos minimum required NVDA version is higher than the current NVDA version. (#6275)
+- Add-on authors now can enforce a minimum required NVDA version for their add-ons. NVDA will refuse to install or load an add-on whose minimum required NVDA version is higher than the current NVDA version. (#6275)
 - Add-on authors can now specify the last version of NVDA the add-on has been tested against. If an add-on has been only tested against a  version of NVDA lower than the current version, then NVDA will refuse to install or load the add-on. (#6275)
-- This version of NVDA will allow installing and loading of add-ons  that do not yet contain Minimum and Last Tested NVDA version information, but upgrading to future versions of NvDA (E.g. 2019.2) will automatically cause these older add-ons to be disabled.
+- This version of NVDA will allow installing and loading of add-ons  that do not yet contain Minimum and Last Tested NVDA version information, but upgrading to future versions of NvDA (E.g. 2019.2) may automatically cause these older add-ons to be disabled.
 - The move mouse to navigator object command is now available in Microsoft Word as well as for UIA controls, particularly Microsoft Edge. (#7916, #8371)
 - Reporting of text under the mouse has been improved within Microsoft Edge and other UIA applications. (#8370)
 - When NVDA is started with the `--portable-path` command line parameter, the provided path is automatically filled in when trying to create a portable copy of NVDA using the NVDA menu. (#8623)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
NVDA Alpha currently refuses to install or load add-ons whos minimumRequiredNVDAVersion and lastTestedNVDAVersion strings are insufficient for the current version of NVDA. However, NvDA is very strict about these version strings, inforcing that they *must* be in the form of Year.Major.Minor. Although this allows for matching on minor releases such as 2019.1.1,  specifying the most common case of 2019.1 would require the author to write 2019.1.0, which although is logical, does not match other version strings displayed in NVDA. This even includes in the About Add-on dialog where currently the MinimumRequiredNVDAVersion and LastTestedNVDAVersion strings are displayed without the Minor part if it is 0.

### Description of how this pull request fixes the issue:
Discussing with @feerrunrut we have now agreed to allow the Minor part to be dropped from the strings in the add-on manifest, and in this case 0 will be assumed.
This PR changes the regular expression used by the manifest validator to handle this case by making the .Minor part optional. Code already existed to handle the case where a match grouping was None (like it would be here) and falls back to adding 0 to the generated version tuple.
Examples in code comments have also been updated to reflect this, the developer guide has been corrected, and changes.t2t also now contains a more true list of changes regarding the add-on versioning features.

### Testing performed:
Installed the UnicodeBrailleInput add-on from the add-on repository, where  its API version requirements were 2017.3 to 2019.1.
Before this change, NVDA would complain that the add-on was invalid and refuse to install it in the first place. Now it installs, and meets the requirements for being enabled.
Similarly, an edited version of the same add-on with 2017.3.0 and 2019.1.0 respectively, also successfully installs and is enabled.
Also tested the same add-on but with a mimumRequriedNVDAVersion of 2019.1.1. (above the current API version). this refused to install.

### Known issues with pull request:
None.

### Change log entry:
None.