### PR TITLE
VirtualBuffer._isNVDAObjectInApplication_noWalk: Gracefully handle rare exception from getIdentifierFromNVDAObject

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -699,7 +699,12 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		if inApp is not None:
 			return inApp
 		# If the object is in the buffer, it's definitely not in an application.
-		docHandle, objId = self.getIdentifierFromNVDAObject(obj)
+		try:
+			docHandle, objId = self.getIdentifierFromNVDAObject(obj)
+		except:
+			log.debugWarning("getIdentifierFromNVDAObject failed. "
+				"Object probably died while walking ancestors.", exc_info=True)
+			return None
 		node = VBufRemote_nodeHandle_t()
 		if not self.VBufHandle:
 			return None


### PR DESCRIPTION
### Link to issue number:
Reported in https://github.com/nvaccess/nvda/pull/9114#issuecomment-467528740.

### Summary of the issue:
@ABuffEr wrote:

> maybe for optimization, or not... I often get this error, quite annoying in snapshot (even if I use traditional browse mode, so with latest alpha too):
> ```
> ERROR - eventHandler.executeEvent (18:10:47.924):
> error executing event: caret on <NVDAObjects.IAccessible.mozilla.Mozilla object at 0x057DB590> with extra args of {}
> Traceback (most recent call last):
> File "eventHandler.pyc", line 155, in executeEvent
> File "eventHandler.pyc", line 92, in **init**
> File "eventHandler.pyc", line 98, in next
> File "eventHandler.pyc", line 126, in gen
> File "NVDAObjects__init__.pyc", line 361, in _get_treeInterceptor
> File "treeInterceptorHandler.pyc", line 20, in getTreeInterceptor
> File "virtualBuffers\gecko_ia2.pyc", line 143, in **contains**
> File "browseMode.pyc", line 1571, in _isNVDAObjectInApplication File "virtualBuffers__init__.pyc", line 702, in _isNVDAObjectInApplication_noWalk
> File "virtualBuffers\gecko_ia2.pyc", line 177, in getIdentifierFromNVDAObject
> AttributeError: 'Desktop' object has no attribute 'IA2UniqueID'
> ```

### Description of how this pull request fixes the issue:
Rarely, _isNVDAObjectInApplication can walk to the desktop object. This probably happens if the object dies while we're walking ancestors, in which case accParent will fail and NVDA will fall back to the window parent, which is the desktop. When that happens, getIdentifierFromNVDAObject will fail. There's not much we can do about this, so just catch the exception and return early.

### Testing performed:
This is a simple but nevertheless speculative fix, as I can't reproduce this myself. I confirmed that the original functionality works as expected and I confirmed that the except block works as expected (by artificially causing an exception).

### Known issues with pull request:
Speculative fix; not confirmed in the wild. I think this is mitigated by the triviality of the fix.

### Change log entry:
Not applicable.