### PR TITLE
Perform lower case comparison of add-on names when updating, and make sure not to remove the previous add-on when the current add-on fails installation

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -496,7 +496,6 @@ def installAddon(parentWindow, addonPath):
 			wx.YES|wx.NO|wx.ICON_WARNING
 		) != wx.YES:
 				return False
-		prevAddon.requestRemove()
 
 	from contextlib import contextmanager
 
@@ -525,6 +524,8 @@ def installAddon(parentWindow, addonPath):
 		# Use context manager to ensure that `done` and `Destroy` are called on the progress dialog afterwards
 		with doneAndDestroy(progressDialog):
 			gui.ExecAndPump(addonHandler.installAddonBundle, bundle)
+			if prevAddon:
+				prevAddon.requestRemove()
 			return True
 	except:
 		log.error("Error installing  addon bundle from %s" % addonPath, exc_info=True)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -465,7 +465,7 @@ def installAddon(parentWindow, addonPath):
 
 	prevAddon = None
 	for addon in addonHandler.getAvailableAddons():
-		if not addon.isPendingRemove and bundle.name==addon.manifest['name']:
+		if not addon.isPendingRemove and bundle.name.lower()==addon.manifest['name'].lower():
 			prevAddon=addon
 			break
 	if prevAddon:


### PR DESCRIPTION
### Link to issue number:
None

### Steps to reproduce lowercase comparison issue
1. Install an add-on called `TEST`
2. Install an add-on called `test`

#### Expected
`TEST` and `test` are considered the same add-on

#### Actual
`test` is not the same as `TEST`, so `test` installs without removing `TEST`

#### Description of how this pull request fixes the issue:
When trying to find an existing add-on with the same name, use lower case string matching.

### Steps to reproduce failing add-on update issue
1. Install an add-on called test
2. Update the add-on with a new version which onInstall function raises an exception

#### Expected
The old version of test remains on the system

#### Actual
Neither the old nor the new version of test will be available after restarting NVDA, since the old version was marked for removal.

#### Description of how this pull request fixes the issue:
Mark the previous add-on for removal when the new version has been installed successfully.

### Testing performed:
Tested the steps to reproduce above

### Known issues with pull request:
None
### Change log entry:
* Bug fixes
    + Add-ons with names that only differ in capitalization are no longer treated as separate add-ons.