### PR TITLE
Fix UnicodeEncodeError for advanced panel warning translation

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2115,7 +2115,7 @@ class AdvancedPanel(SettingsPanel):
 		"have been specifically instructed by NVDA developers."
 	)
 
-	panelDescription = "{}\n{}".format(warningHeader, warningExplanation)
+	panelDescription = u"{}\n{}".format(warningHeader, warningExplanation)
 
 	def makeSettings(self, settingsSizer):
 		"""

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -258,7 +258,7 @@ class SettingsPanel(with_metaclass(guiHelper.SIPABCMeta, wx.Panel, DpiScalingHel
 	"""
 
 	title=""
-	panelDescription=""
+	panelDescription=u""
 
 	def __init__(self, parent):
 		"""


### PR DESCRIPTION
### Link to issue number:
Fixes #9342

### Summary of the issue:
See https://github.com/nvaccess/nvda/issues/9342#issue-416623306

### Description of how this pull request fixes the issue:
AdvancedPanel.panelDescription is now an unicode string.
