### PR TITLE
Windows 10 Mail: catch COM error thrown when Mail app dies and tree interceptor/alive method is attempted

### DIFF
--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -1,11 +1,12 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016 NV Access Limited
+#Copyright (C) 2016-2019 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 """An appModule for the Windows 10 Mail app"""
 
 import appModuleHandler
+from comtypes import COMError
 import UIAHandler
 from NVDAObjects.UIA.wordDocument import WordDocument
 
@@ -21,7 +22,11 @@ class MailWordDocument(WordDocument):
 		# Locate the Reading pane in the ancestors
 		condition=UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_ClassNamePropertyId,"ReadingPaneModern")
 		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)
-		parent=walker.NormalizeElement(self.UIAElement)
+		# #9341: when Mail app exits, tree interceptor isn't cleaned up properly ,raising COM error exception and causing NVDA to go silent.
+		try:
+			parent=walker.NormalizeElement(self.UIAElement)
+		except COMError:
+			parent=None
 		if not parent:
 			return False
 		# If we can find the message headers, then it is read-only and therefore needs browseMode

--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016 NV Access Limited, Joseph Lee
+#Copyright (C) 2016-2019 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016-2019 NV Access Limited, Joseph Lee
+#Copyright (C) 2016 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 


### PR DESCRIPTION
### Link to issue number:
Fixes #9341 

### Summary of the issue:
When Windows 10 Mail app dies, NVDA goes silent due to unhandled COM error.

### Description of how this pull request fixes the issue:
When walking up to parent in Mail app's Word document tree interceptor, catch COM error if the parent is gone (noticeable when Mail app dies).

### Testing performed:
Tested with an implementation in Windows 10 App Essentials add-on:

1. Exit Mail app without opening a message: success.
2. Exit Mail app while a message is open: success.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

NVDA will no longer become silent after exiting Windows 10 Mail app. (#9341)

Thanks.