### PR TITLE
Fix regression causing browse mode to be unavailable in Word

### DIFF
--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -27,7 +27,7 @@ def update(obj, force=False):
 	#If this object already has a treeInterceptor, just return that and don't bother trying to create one
 	ti=obj.treeInterceptor
 	if not ti:
-		if not obj.shouldCreateTreeInterceptor:
+		if not obj.shouldCreateTreeInterceptor and not force:
 			return None
 		try:
 			newClass=obj.treeInterceptorClass


### PR DESCRIPTION
### Link to issue number:
Fixes #9422

### Summary of the issue:
Pr #8846 introduced a bug where browse mode in Word didn't work any more. This was caused by treeInterceptorHandler.update returning early in the case that shouldCreateTreeInterceptor on an object was False, such as in Word, without checking for the new force parameter being True. When force is True, an object thrown at treeInterceptorHandler.update that has a treeInterceptorClass should always create a treeInterCeptor, regardless of shouldCreateTreeInterceptor on the object.

### Description of how this pull request fixes the issue:
The state of the force boolean is now checked, and if True, we do no longer return early when shouldCreateTreeInterceptor is False.

### Testing performed:
Tested locally with Word.

### Known issues with pull request:
None

### Change log entry:
None
