### PR TITLE
Windows Store edition: do not include ARM64 libraries

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -23,7 +23,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.15063.0" 
-			MaxVersionTested="10.0.17134.0" 
+			MaxVersionTested="10.0.18362.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/appx/sconscript
+++ b/appx/sconscript
@@ -66,6 +66,7 @@ excludedDistFiles=[
 	'lib/minHook.dll',
 	'lib/NVDAHelperRemote.dll',
 	'lib64/',
+	'libArm64/',
 	'uninstall.exe',
 ]
 

--- a/appx/sconscript
+++ b/appx/sconscript
@@ -1,3 +1,17 @@
+###
+#This file is a part of the NVDA project.
+#URL: https://www.nvaccess.org/
+#Copyright 2018-2019 NV Access Limited
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License version 2.0, as published by
+#the Free Software Foundation.
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#This license can be found at:
+#http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+###
+
 import subprocess
 import versionInfo
 


### PR DESCRIPTION
### Link to issue number:
Fixes #9436 

### Summary of the issue:
When building AppX package, ARM64 libs are included.

### Description of how this pull request fixes the issue:
Adds libArm64 to folders and files excluded from AppX package.

### Testing performed:
Tested the PR via Appveyor and compiling a local copy to make sure libArm64 directory wasn't present.

### Known issues with pull request:
None

### Change log entry:
None

### Additional work:
In addition to this work, appx/sconscript now has a proper copyright header, and updated manifest XML file to state that last tested build is 18362 (April 2019 Update).

Thanks.