### PR TITLE
Fix error when copying to system config

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -137,13 +137,15 @@ def getSystemConfigPath():
 			pass
 	return None
 
+SCRATCH_PAD_ONLY_DIRS = ('appModules','brailleDisplayDrivers','globalPlugins','synthDrivers')
+
 def getScratchpadDir(ensureExists=False):
 	""" Returns the path where custom appModules, globalPlugins and drivers can be placed while being developed."""
 	path=os.path.join(globalVars.appArgs.configPath,'scratchpad')
 	if ensureExists:
 		if not os.path.isdir(path):
 			os.makedirs(path)
-		for subdir in ('appModules','brailleDisplayDrivers','globalPlugins','synthDrivers'):
+		for subdir in SCRATCH_PAD_ONLY_DIRS:
 			subpath=os.path.join(path,subdir)
 			if not os.path.isdir(subpath):
 				os.makedirs(subpath)
@@ -269,13 +271,19 @@ def setSystemConfigToCurrentConfig():
 def _setSystemConfig(fromPath):
 	import installer
 	toPath=os.path.join(sys.prefix.decode('mbcs'),'systemConfig')
+	log.debug("Copying config to systemconfig dir: %s", toPath)
 	if os.path.isdir(toPath):
 		installer.tryRemoveFile(toPath)
-	for curSourceDir,subDirs,files in os.walk(fromPath):
-		if curSourceDir==fromPath:
-			curDestDir=toPath
+	for curSourceDir, subDirs, files in os.walk(fromPath):
+		relativePath = os.path.relpath(curSourceDir, fromPath)
+		# Don't copy files that we know will be ignored due to security risks.
+		if relativePath in SCRATCH_PAD_ONLY_DIRS:
+			log.debug("Ignored folder that may contain unpackaged addons: %s", curSourceDir)
+			continue
+		if curSourceDir == fromPath:
+			curDestDir = toPath
 		else:
-			curDestDir=os.path.join(toPath,os.path.relpath(curSourceDir,fromPath))
+			curDestDir = os.path.join(toPath, relativePath)
 		if not os.path.isdir(curDestDir):
 			os.makedirs(curDestDir)
 		for f in files:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -275,14 +275,15 @@ def _setSystemConfig(fromPath):
 	if os.path.isdir(toPath):
 		installer.tryRemoveFile(toPath)
 	for curSourceDir, subDirs, files in os.walk(fromPath):
-		relativePath = os.path.relpath(curSourceDir, fromPath)
-		# Don't copy files that we know will be ignored due to security risks.
-		if relativePath in SCRATCH_PAD_ONLY_DIRS:
-			log.debug("Ignored folder that may contain unpackaged addons: %s", curSourceDir)
-			continue
 		if curSourceDir == fromPath:
 			curDestDir = toPath
+			# Don't copy from top-level config dirs we know will be ignored due to security risks.
+			removeSubs = set(SCRATCH_PAD_ONLY_DIRS).intersection(subDirs)
+			for subPath in removeSubs:
+				log.debug("Ignored folder that may contain unpackaged addons: %s", subPath)
+				subDirs.remove(subPath)
 		else:
+			relativePath = os.path.relpath(curSourceDir, fromPath)
 			curDestDir = os.path.join(toPath, relativePath)
 		if not os.path.isdir(curDestDir):
 			os.makedirs(curDestDir)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -726,21 +726,29 @@ class GeneralSettingsPanel(SettingsPanel):
 			settingsSizerHelper.addItem(item)
 
 	def onCopySettings(self,evt):
-		for packageType in ('addons','appModules','globalPlugins','brailleDisplayDrivers','synthDrivers'):
-			if len(os.listdir(os.path.join(globalVars.appArgs.configPath,packageType)))>0:
-				if gui.messageBox(
-					# Translators: A message to warn the user when attempting to copy current settings to system settings.
-					_("Add-ons were detected in your user settings directory. Copying these to the system profile could be a security risk. Do you still wish to copy your settings?"),
-					# Translators: The title of the warning dialog displayed when trying to copy settings for use in secure screens.
-					_("Warning"),wx.YES|wx.NO|wx.ICON_WARNING,self
-				)==wx.NO:
-					return
-				break
-		progressDialog = gui.IndeterminateProgressDialog(gui.mainFrame,
-		# Translators: The title of the dialog presented while settings are being copied
-		_("Copying Settings"),
-		# Translators: The message displayed while settings are being copied to the system configuration (for use on Windows logon etc)
-		_("Please wait while settings are copied to the system configuration."))
+		addonsDirPath = os.path.join(globalVars.appArgs.configPath, 'addons')
+		if os.path.isdir(addonsDirPath) and 0 < len(os.listdir(addonsDirPath)):
+			# Translators: A message to warn the user when attempting to copy current
+			# settings to system settings.
+			message = _(
+				"Add-ons were detected in your user settings directory. "
+				"Copying these to the system profile could be a security risk. "
+				"Do you still wish to copy your settings?"
+			)
+			# Translators: The title of the warning dialog displayed when trying to
+			# copy settings for use in secure screens.
+			title = _("Warning")
+			style = wx.YES | wx.NO | wx.ICON_WARNING
+			if wx.NO == gui.messageBox(message, title, style, self):
+				return
+		progressDialog = gui.IndeterminateProgressDialog(
+			gui.mainFrame,
+			# Translators: The title of the dialog presented while settings are being copied
+			_("Copying Settings"),
+			# Translators: The message displayed while settings are being copied
+			# to the system configuration (for use on Windows logon etc)
+			_("Please wait while settings are copied to the system configuration.")
+		)
 		while True:
 			try:
 				gui.ExecAndPump(config.setSystemConfigToCurrentConfig)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,6 +7,7 @@ What's New in NVDA
 This point release fixes the following bugs:
 - NVDA no longer causes Excel 2007 to crash or refuses to report if a cell has a formular. (#9431)
 - Google Chrome no longer crashes when interacting with certain listboxes. (#9364)
+- An issue has been fixed which prevented copying a users configuration to the system configuration profile. (#9448)
 
 
 = 2019.1 =


### PR DESCRIPTION

Dont copy folders that previously allowed unpackaged addons to be run.
These folders ('appModules','brailleDisplayDrivers','globalPlugins',
'synthDrivers') are now only used if they are within the scratchpad
directory and the advanced option is turned on.
See commit: d1a8a710d37f5a376ebf9f32600d7cb857554b38

Since we are not copying these folders, and the contents would not be run
even if they were copied, we no longer warn about them.

A log message is added if they are present and we skip over them.

### Link to issue number:
Fixes #9448 

### Summary of the issue:
For a fresh install, when a user tries to copy settings to the system config, an error sound is heard and nothing happens.

Before copying settings to the system profile, NVDA was checking for any files inside the following directories:
- 'addons'
- 'appModules'
- 'brailleDisplayDrivers'
- 'globalPlugins'
- 'synthDrivers'

However, when these folders do not exist an error is raised and the method does not complete.

### Description of how this pull request fixes the issue:
Now only warn the user about the presence of files inside the addons directory. Do not copy any of the other folder contents, these files will not be considered during NVDA runtime any more (see commit: d1a8a710d37f5a376ebf9f32600d7cb857554b38). 

### Testing performed:
1. Delete the contents of my system config directory
1. Deleted the above listed folders from my user config directory
1. Installed NVDA
1. From the general panel (`NVDA+control+g`), press the button to copy to system config.
1. Ensure there is no error, and the config has been copied.

Repeat, after adding a "appModules" folder in my user configuration. Ensure that the system config does not contain an "appModules" folder, and there is a debug level log entry explaining it has been ignored.

### Known issues with pull request:

### Change log entry:
Section: Bug fixes

` - An issue has been fixed which prevented copying a users configuration to the system configuration profile. (#9448)`

