### PR TITLE
Windows Store edition: disable developer scratch user interface

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #settingsDialogs.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee, Heiko Folkerts, Zahari Yurukov, Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee, Heiko Folkerts, Zahari Yurukov, Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1981,7 +1981,6 @@ class AdvancedPanelControls(wx.Panel):
 		super(AdvancedPanelControls, self).__init__(parent)
 		self._defaultsRestored = False
 
-		# #9438: Windows Store version does not allow add-ons to be loaded, so there is no point enabling this.
 		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		self.SetSizer(sHelper.sizer)
 		# Translators: This is the label for a group of advanced options in the
@@ -1991,8 +1990,7 @@ class AdvancedPanelControls(wx.Panel):
 			parent=self,
 			sizer=wx.StaticBoxSizer(parent=self, label=groupText, orient=wx.VERTICAL)
 		)
-		if not config.isAppX:
-			sHelper.addItem(devGroup)
+		sHelper.addItem(devGroup)
 
 		# Translators: This is the label for a checkbox in the
 		#  Advanced settings panel.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1981,6 +1981,7 @@ class AdvancedPanelControls(wx.Panel):
 		super(AdvancedPanelControls, self).__init__(parent)
 		self._defaultsRestored = False
 
+		# #9438: Windows Store version does not allow add-ons to be loaded, so there is no point enabling this.
 		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		self.SetSizer(sHelper.sizer)
 		# Translators: This is the label for a group of advanced options in the
@@ -1990,7 +1991,8 @@ class AdvancedPanelControls(wx.Panel):
 			parent=self,
 			sizer=wx.StaticBoxSizer(parent=self, label=groupText, orient=wx.VERTICAL)
 		)
-		sHelper.addItem(devGroup)
+		if not config.isAppX:
+			sHelper.addItem(devGroup)
 
 		# Translators: This is the label for a checkbox in the
 		#  Advanced settings panel.
@@ -2002,12 +2004,16 @@ class AdvancedPanelControls(wx.Panel):
 			wx.EVT_CHECKBOX,
 			lambda evt: self.openScratchpadButton.Enable(evt.IsChecked())
 		)
+		if config.isAppX:
+			self.scratchpadCheckBox.Disable()
 
 		# Translators: the label for a button in the Advanced settings category
 		label=_("Open developer scratchpad directory")
 		self.openScratchpadButton=devGroup.addItem(wx.Button(self, label=label))
 		self.openScratchpadButton.Enable(config.conf["development"]["enableScratchpadDir"])
 		self.openScratchpadButton.Bind(wx.EVT_BUTTON,self.onOpenScratchpadDir)
+		if config.isAppX:
+			self.openScratchpadButton.Disable()
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel


### PR DESCRIPTION
### Link to issue number:
Fixes #9438 

### Summary of the issue:
In Windows Store edition of nVDA, developer scratchpad user interface is shown when third-party modules are not supported yet.

### Description of how this pull request fixes the issue:
In Preferences/Advanced, disable developer scratchpad 9checkbox and theo pen button) if config.isAppX is in effect.

### Testing performed:
Tested with source code copy with config.isAppX set to true, along with a Windows Store side loadable version of NVDA with changes applied.

### Known issues with pull request:
None

### Change log entry:
None
