### PR TITLE
Update CLDR emoji annotations to version 35.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ For reference, the following dependencies are included in Git submodules:
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [liblouis](http://www.liblouis.org/), version 3.8.0, commit 90a808bf
-* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 34.0
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)


### PR DESCRIPTION
### Link to issue number:
Fixes #9445 

### Description of this pull request
This updates the CLDR emoji annotations from version 34.0 to 35.0. The new annotations include the new emoji 12 emoji, such as 🦮.

* [Release notes](http://cldr.unicode.org/index/downloads/cldr-35)

### Testing performed:
Made sure that emoji still read. Made sure that the 🦮 emoji is announced properly.

### Known issues with pull request:
None

### Change log entry:
* Changes
    + Updated Unicode Common Locale Data Repository emoji annotations to version 35.0. (#9445)