### PR TITLE
Address crash in Excel 2007

### DIFF
--- a/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
+++ b/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
@@ -83,6 +83,6 @@ interface NvdaInProcUtils {
  */
  	error_status_t outlook_getMAPIProp(const long threadID, [in] IUnknown* mapiObject, const unsigned long mapiPropTag, [out] VARIANT* val);
 
-	error_status_t excel_getCellInfos([in] const unsigned long windowHandle,[in] IDispatch* rangeObj, [in] long cellInfoFlags, [in] long cellCount, [out,size_is(cellCount)] EXCEL_CELLINFO* cellInfos, [out] long* numCellsFetched);
+	error_status_t excel_getCellInfos([in] const unsigned long windowHandle,[in] LRESULT rangeID, [in] long cellInfoFlags, [in] long cellCount, [out,size_is(cellCount)] EXCEL_CELLINFO* cellInfos, [out] long* numCellsFetched);
 
 }

--- a/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
+++ b/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
@@ -83,6 +83,6 @@ interface NvdaInProcUtils {
  */
  	error_status_t outlook_getMAPIProp(const long threadID, [in] IUnknown* mapiObject, const unsigned long mapiPropTag, [out] VARIANT* val);
 
-	error_status_t excel_getCellInfos([in] const unsigned long windowHandle,[in] LRESULT rangeID, [in] long cellInfoFlags, [in] long cellCount, [out,size_is(cellCount)] EXCEL_CELLINFO* cellInfos, [out] long* numCellsFetched);
+	error_status_t excel_getCellInfos([in] const unsigned long windowHandle,[in] BSTR rangeAddress, [in] long cellInfoFlags, [in] long cellCount, [out,size_is(cellCount)] EXCEL_CELLINFO* cellInfos, [out] long* numCellsFetched);
 
 }

--- a/nvdaHelper/remote/excel.cpp
+++ b/nvdaHelper/remote/excel.cpp
@@ -457,7 +457,7 @@ error_status_t nvdaInProcUtils_excel_getCellInfos(handle_t bindingHandle, const 
 	execInThread(threadID,[&](){
 		// Unmarshal the IDispatch pointer from the COM global interface table.
 		CComPtr<IDispatch> pDispatchRange=nullptr;
-		HRESULT res=ObjectFromLresult(arg_rangeID,IID_IDispatch,0,reinterpret_cast<void**>(&pDispatchRange));
+		HRESULT res=ObjectFromLresult(arg_rangeID,IID_IDispatch,nullptr,reinterpret_cast<void**>(&pDispatchRange));
 		if(res!=S_OK) {
 			LOG_ERROR(L"ObjectFromLResult failed with "<<res);
 			return;

--- a/nvdaHelper/remote/excel/Constants.h
+++ b/nvdaHelper/remote/excel/Constants.h
@@ -17,6 +17,8 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 const long xlValidateList=3;
 
 // Excel IDispatch IDs
+const long XLDISPID_WINDOW_APPLICATION=148;
+const long XLDISPID_APPLICATION_RANGE=197;
 const long XLDISPID_RANGE__NEWENUM=-4;
 const long XLDISPID_RANGE_FORMULA=261;
 const long XLDISPID_RANGE_ITEM=170;

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1119,7 +1119,7 @@ class ExcelCellInfoQuicknavIterator(with_metaclass(abc.ABCMeta,object)):
 		count=collectionObject.count
 		cellInfos=(ExcelCellInfo*count)()
 		numCellsFetched=ctypes.c_long()
-		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.document.appModule.helperLocalBindingHandle,self.document.windowHandle,oleacc.LresultFromObject(-0,collectionObject._comobj),self.cellInfoFlags,count,cellInfos,ctypes.byref(numCellsFetched))
+		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.document.appModule.helperLocalBindingHandle,self.document.windowHandle,oleacc.LresultFromObject(None,collectionObject._comobj),self.cellInfoFlags,count,cellInfos,ctypes.byref(numCellsFetched))
 		for index in xrange(numCellsFetched.value):
 			ci=cellInfos[index]
 			if not ci.address:
@@ -1148,7 +1148,7 @@ class ExcelCell(ExcelBase):
 			return None
 		ci=ExcelCellInfo()
 		numCellsFetched=ctypes.c_long()
-		res=NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.appModule.helperLocalBindingHandle,self.windowHandle,oleacc.LresultFromObject(0,self.excelCellObject._comobj),NVCELLINFOFLAG_ALL,1,ctypes.byref(ci),ctypes.byref(numCellsFetched))
+		res=NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.appModule.helperLocalBindingHandle,self.windowHandle,oleacc.LresultFromObject(None,self.excelCellObject._comobj),NVCELLINFOFLAG_ALL,1,ctypes.byref(ci),ctypes.byref(numCellsFetched))
 		if res!=0 or numCellsFetched.value==0:
 			return None
 		return ci

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -7,7 +7,7 @@
 import abc
 from six import with_metaclass
 import ctypes
-from comtypes import COMError
+from comtypes import COMError, BSTR
 import comtypes.automation
 import wx
 import time
@@ -15,7 +15,6 @@ import winsound
 import re
 import uuid
 import collections
-import oleacc
 import NVDAHelper
 import oleacc
 import ui
@@ -1119,7 +1118,8 @@ class ExcelCellInfoQuicknavIterator(with_metaclass(abc.ABCMeta,object)):
 		count=collectionObject.count
 		cellInfos=(ExcelCellInfo*count)()
 		numCellsFetched=ctypes.c_long()
-		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.document.appModule.helperLocalBindingHandle,self.document.windowHandle,oleacc.LresultFromObject(None,collectionObject._comobj),self.cellInfoFlags,count,cellInfos,ctypes.byref(numCellsFetched))
+		address=collectionObject.address(True,True,xlA1,True)
+		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.document.appModule.helperLocalBindingHandle,self.document.windowHandle,BSTR(address),self.cellInfoFlags,count,cellInfos,ctypes.byref(numCellsFetched))
 		for index in xrange(numCellsFetched.value):
 			ci=cellInfos[index]
 			if not ci.address:
@@ -1148,7 +1148,8 @@ class ExcelCell(ExcelBase):
 			return None
 		ci=ExcelCellInfo()
 		numCellsFetched=ctypes.c_long()
-		res=NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.appModule.helperLocalBindingHandle,self.windowHandle,oleacc.LresultFromObject(None,self.excelCellObject._comobj),NVCELLINFOFLAG_ALL,1,ctypes.byref(ci),ctypes.byref(numCellsFetched))
+		address=self.excelCellObject.address(True,True,xlA1,True)
+		res=NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.appModule.helperLocalBindingHandle,self.windowHandle,BSTR(address),NVCELLINFOFLAG_ALL,1,ctypes.byref(ci),ctypes.byref(numCellsFetched))
 		if res!=0 or numCellsFetched.value==0:
 			return None
 		return ci

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -15,6 +15,7 @@ import winsound
 import re
 import uuid
 import collections
+import oleacc
 import NVDAHelper
 import oleacc
 import ui
@@ -1118,7 +1119,7 @@ class ExcelCellInfoQuicknavIterator(with_metaclass(abc.ABCMeta,object)):
 		count=collectionObject.count
 		cellInfos=(ExcelCellInfo*count)()
 		numCellsFetched=ctypes.c_long()
-		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.document.appModule.helperLocalBindingHandle,self.document.windowHandle,collectionObject._comobj,self.cellInfoFlags,count,cellInfos,ctypes.byref(numCellsFetched))
+		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.document.appModule.helperLocalBindingHandle,self.document.windowHandle,oleacc.LresultFromObject(-0,collectionObject._comobj),self.cellInfoFlags,count,cellInfos,ctypes.byref(numCellsFetched))
 		for index in xrange(numCellsFetched.value):
 			ci=cellInfos[index]
 			if not ci.address:
@@ -1147,7 +1148,7 @@ class ExcelCell(ExcelBase):
 			return None
 		ci=ExcelCellInfo()
 		numCellsFetched=ctypes.c_long()
-		res=NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.appModule.helperLocalBindingHandle,self.windowHandle,self.excelCellObject._comobj,NVCELLINFOFLAG_ALL,1,ctypes.byref(ci),ctypes.byref(numCellsFetched))
+		res=NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(self.appModule.helperLocalBindingHandle,self.windowHandle,oleacc.LresultFromObject(0,self.excelCellObject._comobj),NVCELLINFOFLAG_ALL,1,ctypes.byref(ci),ctypes.byref(numCellsFetched))
 		if res!=0 or numCellsFetched.value==0:
 			return None
 		return ci

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,11 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2019.1.1 =
+This point release fixes the following bugs:
+- NVDA no longer causes Excel 2007 to crash or refuses to report if a cell has a formular. (#9431)
+
+
 = 2019.1 =
 Highlights of this release include performance improvements when accessing both Microsoft word and Excel, stability and security improvements such as support for add-ons with version compatibility information, and many other bug fixes.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9431 

### Summary of the issue:
With the merging of PR #9257  which greatly increased performance in Excel, Excel 2007 began to crash on start-up for some users. And for others, NVDA would simply fail to report whether a cell had a formular or other related features.
In order to increase performance, NVDA began collecting all required cell information on one corss-process call, rather than via individusl cross-process calls. In order to communicate the correct cell range to fetch info for, the IDispatch pointer for that range was marshalled via RPC into Excel's process. Although this works for Excel 2010 and up, it seems that in Excel 2007, this is causing exceptions in the RPC infrastructure, specifically the error stating that CoInitialize had not been called on the RPC worker thread executing the in-process implementation of our excel_getCellInfos rpc function.

### Description of how this pull request fixes the issue:
This PR stops relying on Windows to try and marshal the Excel range object, and instead  the range's address is passed to the rpc function as a string. Then in Excel's main thread, a reference to Excel's object model is retreaved and a range object is created using the passed in address.
This solution works for Excel 2007 up to Excel 365 and does not seem to lose any performance gain.

### Testing performed:
Opened Excel 2007 and focused on a cell. Excel no longer crashes on the machine it used to crash on.
Ensured that NVDA reported "has formular" for cells that contain a fomrular, and "has comment" when a comment is inserted in the cell using NVDA.
These same tests were performed on Excel 365 with the same results.
 The original tests from pr #9257 were also performed on Excel 2007 / 365 with no loss in performance or functionality.
Excel 2013 has also been tested with similar results.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* NVDA no longer causes Excel 2007 to crash or refuses to report if a cell has a formular. (#9431)