### PR TITLE
Revert "Avoid crash in Chrome by no longer fetching selected item of listboxes"

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -339,10 +339,15 @@ CComPtr<IAccessible2> GeckoVBufBackend_t::getSelectedItem(
 	IAccessible2* container, const map<wstring, wstring>& attribs
 ) {
 	if (this->toolkitName.compare(L"Chrome") == 0) {
-		// #9364: Google Chrome crashes when fetching the currently selected item from some listboxes.
-		// Specifically when calling IEnumVARIANT::next.
-		// Due to this, and other issues around incorrect focus state setting, it is best to disable fetching of currently selected item in listboxes in Chrome all together.
-		return nullptr;
+		const auto attribsIt = attribs.find(L"tag");
+		if (attribsIt != attribs.end() &&
+				attribsIt->second.compare(L"select") == 0) {
+			// In a <select size>1>, Chrome reports that list items are focusable,
+			// but programmatically focusing them does nothing. Therefore, we don't
+			// want to render this in Chrome because a user wouldn't be able to focus
+			// these list boxes in browse mode if we did.
+			return nullptr;
+		}
 	}
 
 	CComVariant selection;

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,8 +20,6 @@ What's New in NVDA
 - NVDA no longer fails to start when the users regional settings are set to a locale unknown to NVDA, such as English (Netherlands). (#8726)
 - When browse mode is enabled in Microsoft Excel and you switch to a browser in focus mode or vise versa, browse mode state is now reported appropriately. (#8846)
 - NVDA now properly reports the line at the mouse cursor in Notepad++ and other Scintilla based editors. (#5450)
-- Google Chrome no longer crashes when interacting with certain listboxes. (#9364)
- - However, to avoid this, the currently selected item in listboxes is no longer presented in browse mode in Chrome, similar to NVDA 2018.4 and earlier.
 
 
 == Changes for Developers ==


### PR DESCRIPTION
Reverts nvaccess/nvda#9430
Reason: This is going to be uplifted to rc in a separate pr instead. 