### PR TITLE
Avoid crash in Chrome by no longer fetching currently selected item in listboxes

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -339,15 +339,10 @@ CComPtr<IAccessible2> GeckoVBufBackend_t::getSelectedItem(
 	IAccessible2* container, const map<wstring, wstring>& attribs
 ) {
 	if (this->toolkitName.compare(L"Chrome") == 0) {
-		const auto attribsIt = attribs.find(L"tag");
-		if (attribsIt != attribs.end() &&
-				attribsIt->second.compare(L"select") == 0) {
-			// In a <select size>1>, Chrome reports that list items are focusable,
-			// but programmatically focusing them does nothing. Therefore, we don't
-			// want to render this in Chrome because a user wouldn't be able to focus
-			// these list boxes in browse mode if we did.
-			return nullptr;
-		}
+		// #9364: Google Chrome crashes when fetching the currently selected item from some listboxes.
+		// Specifically when calling IEnumVARIANT::next.
+		// Due to this, and other issues around incorrect focus state setting, it is best to disable fetching of currently selected item in listboxes in Chrome all together.
+		return nullptr;
 	}
 
 	CComVariant selection;

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,6 +6,7 @@ What's New in NVDA
 = 2019.1.1 =
 This point release fixes the following bugs:
 - NVDA no longer causes Excel 2007 to crash or refuses to report if a cell has a formular. (#9431)
+- Google Chrome no longer crashes when interacting with certain listboxes. (#9364)
 
 
 = 2019.1 =


### PR DESCRIPTION
### Link to issue number:
Fixes #9364 

### Summary of the issue:
When using Google Chrome with NVDA 2019.1, Chrome can crash when the user interacts with certain listboxes. The crash is in Chrome's IEnumVARIANT::next, when fetched from IAccessible::accSelection.
NVDA calls this to render the currently selected item in a listbox into its virtualBuffer.
This code was introduced in #9166.
It is unclear as to the exact situation that causes this crash, as not all listboxes seem to crash necessarily. An issue has been filed with Google, but until  the crash is addressed in Chrome stable, we should avoid it completely by not trying to fetch the selection at all in Chrome, which was what we did in NVDA 2018.4 and below.
This code has already been diabled for particular listboxes in Chrome due to other bugs, so we should just disable it for all of them for now.

### Description of how this pull request fixes the issue:
This PR stops NVDA from fetching and rendering the currently selected item in listboxes, specifically in Google Chrome. Causing NVDA to exhibit the same behaviour it did in 2018.4.

### Testing performed:
Tested with the steps in #9364 to ensure that Chrome no longer crashes.
Ensured that in Mozilla Gecko browsers we still render the currently ssleected item in listboxes, using tests in #9166.

### Known issues with pull request:
This approach may be a little boarder than it should be, but until we completely understand the cause from Google's side, this is the safest option.

### Change log entry:
Bug fixes:
* Google Chrome no longer crashes when interacting with certain listboxes. (#9364)
 * However, to avoid this, the currently selected item in listboxes is no longer presented in browse mdoe in Chrome, similar to NVDA 2018.4 and below.