### PR TITLE
Respect UIA Notification processing flag

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1458,7 +1458,7 @@ class UIA(Window):
 		# Ideally, we wouldn't use getBrailleTextForProperties directly.
 		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
 
-	def event_UIA_notification(self, notificationKind=None, notificationProcessing=None, displayString=None, activityId=None):
+	def event_UIA_notification(self, notificationKind=None, notificationProcessing=UIAHandler.NotificationProcessing_CurrentThenMostRecent, displayString=None, activityId=None):
 		"""
 		Introduced in Windows 10 Fall Creators Update (build 16299).
 		This base implementation announces all notifications from the UIA element.
@@ -1469,6 +1469,10 @@ class UIA(Window):
 		if self.appModule != api.getFocusObject().appModule:
 			return
 		if displayString:
+			if notificationProcessing in (UIAHandler.NotificationProcessing_ImportantMostRecent, UIAHandler.NotificationProcessing_MostRecent):
+				# These notifications superseed earlier notifications.
+				# Note that no distinction is made between important and non-important.
+				speech.cancelSpeech()
 			ui.message(displayString)
 
 class TreeviewItem(UIA):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
IN the Windows 10 may 2019 update, Microsoft decided to announce volume changes using UIA notifications. This means that these volume notifications are announced when the keyboard focus is in Explorer. However, due to the way NVDA handled UIA notifications before this pr, these volume change notifications were queued one after another, resulting into lots of notifications being announced, including duplicates.

### Description of how this pull request fixes the issue:
UIA notifications have a notificationProcessing parameter. When this parameter is set to one of the [most recent NotificationProcessing constants](https://docs.microsoft.com/en-us/windows/desktop/api/uiautomationcore/ne-uiautomationcore-notificationprocessing), speech is cancelled before announcing the new notification.

### Testing performed:
Tested witth volume changes in Windows 10 1903. Only the last notification is now spoken.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + IN the Windows 10 May 2019 update, NVDA no longer speaks many volume notifications if changing the volume with hardware buttons when Windows Explorer has focus.