### PR TITLE
Fix missing string include in displayModel.h causing compilation to fail with Visual Studio 2019

### DIFF
--- a/nvdaHelper/remote/displayModel.h
+++ b/nvdaHelper/remote/displayModel.h
@@ -17,6 +17,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 #include <map>
 #include <deque>
+#include <string>
 #include <windows.h>
 #include <common/lock.h>
 


### PR DESCRIPTION
### Link to issue number:
None. Originally reported in [this NVDA-devel thread](https://groups.io/g/nvda-devel/message/43748) by @ dingpengyu
### Summary of the issue:
When compiling NVDAHelper with Visual Studio 2019, the following error is returned by SCons:
> build\x86\remote\displayModel.h(36): error C2039: "wstring": Not a member of "std"

### Description of how this pull request fixes the issue:
Added missing include of string to displayModel.h

### Testing performed:
Tested compilation again, with success.

### Known issues with pull request:
Visual Studio 2019 support for SCons still doesn't seem to be noptimal. See #9446 

### Change log entry:
None
