### PR TITLE
Reducing SynthSettingsRing volume step

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -183,3 +183,4 @@ Ethan Holliger
 Thomas Stivers
 Eurobraille
 Bachir Benanou
+Arnold Loubriat

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Joseph Lee
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Joseph Lee
 
 from copy import deepcopy
 import os

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -266,7 +266,7 @@ class SynthDriver(baseObject.AutoPropertyObject):
 	def VolumeSetting(cls,minStep=1):
 		"""Factory function for creating volume setting."""
 		# Translators: Label for a setting in voice settings dialog.
-		return NumericSynthSetting("volume",_("V&olume"),minStep=minStep,normalStep=10,
+		return NumericSynthSetting("volume",_("V&olume"),minStep=minStep,normalStep=5,
 		# Translators: Label for a setting in synth settings ring.
 		displayName=pgettext('synth setting','Volume'))
 	@classmethod

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Joseph Lee
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Joseph Lee, Arnold Loubriat
 
 from copy import deepcopy
 import os


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #6754.

### Summary of the issue:

When changing synth volume setting using the settings ring, the value is increased and decreased by 10, which is too much for some users.

### Description of how this pull request fixes the issue:

As suggested in #6754, the step has been decreased to 5, which is more acceptable.

### Testing performed:

Increased and decreased synth volume using the settings ring and made sure that the value was actually used by the current synth. Tested with the following synthesizers:

- eSpeak-ng,
- ETI-Eloquence,
- Microsoft Speech API version 5,
- Nuance Vocalizer expressive,
- Windows OneCore Voices.

### Known issues with pull request:

None

### Change log entry:

Section: Changes

- Synth's volume is now increased and decreased by 5 when using the settings ring.

