### PR TITLE
Excel cell range text should be translated.

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1283,7 +1283,8 @@ class ExcelCell(ExcelBase):
 			rawAddress=self.excelCellObject.address(False,False,1,False)
 		coords=rawAddress.split('!')[-1].split(':')
 		if len(coords)==2:
-			return "%s through %s"%(coords[0],coords[1])
+			# Translators: Used to express an address range in excel.
+			return _("{start} through {end}").format(start=coords[0], end=coords[1])
 		else:
 			return coords[0]
 


### PR DESCRIPTION
### Link to issue number:

none

### Summary of the issue:

NVDA does not use the localized message when reporting the position of merged cells in Microsoft Excel.

### Description of how this pull request fixes the issue:

This is against the beta branch, however, 
it reuses existing message which already has the translation,
so the additional translation is not necessary.

### Testing performed:

Office 365 Excel version 1903
NVDA 2019.1.1rc1
Windows 10 version 1809 Japanese

### Known issues with pull request:

### Change log entry:

In Microsoft Excel, NVDA uses the localized message when reporting the location of merged cells again.

Section: Bug fixes
