### PR TITLE
Prevented add-ons from being enabled if NVDA has been started with --disable-addons flag

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -389,7 +389,7 @@ class Addon(AddonBase):
 			if self.name in state["pendingEnableSet"]:
 				# Undoing a pending enable.
 				state["pendingEnableSet"].discard(self.name)
-			# No need to disable an addon that is already disabled, except if all add-ons are disabled.
+			# No need to disable an addon that is already disabled.
 			# This also prevents the status in the add-ons dialog from saying "disabled, pending disable"
 			elif self.name not in state["disabledAddons"]:
 				state["pendingDisableSet"].add(self.name)

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #addonHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V.
+#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V., Arnold Loubriat
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -389,20 +389,20 @@ class Addon(AddonBase):
 			if self.name in state["pendingEnableSet"]:
 				# Undoing a pending enable.
 				state["pendingEnableSet"].discard(self.name)
-			# No need to disable an addon that is already disabled.
+			# No need to disable an addon that is already disabled, except if all add-ons are disabled.
 			# This also prevents the status in the add-ons dialog from saying "disabled, pending disable"
-			elif self.name not in state["disabledAddons"]:
+			elif self.name not in state["disabledAddons"] or globalVars.appArgs.disableAddons:
 				state["pendingDisableSet"].add(self.name)
 		# Record enable/disable flags as a way of preparing for disaster such as sudden NVDA crash.
 		saveState()
 
 	@property
 	def isRunning(self):
-		return not (self.isPendingInstall or self.isDisabled or self.isBlocked)
+		return not (globalVars.appArgs.disableAddons or self.isPendingInstall or self.isDisabled or self.isBlocked)
 
 	@property
 	def isDisabled(self):
-		return globalVars.appArgs.disableAddons or self.name in _disabledAddons
+		return self.name in _disabledAddons
 
 	@property
 	def isBlocked(self):

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #addonHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2012-2018 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V.
+#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -16,6 +16,7 @@ import pkgutil
 import shutil
 from six.moves import cStringIO as StringIO, cPickle
 from six import string_types
+import globalVars
 import zipfile
 from configobj import ConfigObj
 from configobj.validate import Validator
@@ -401,7 +402,7 @@ class Addon(AddonBase):
 
 	@property
 	def isDisabled(self):
-		return self.name in _disabledAddons
+		return globalVars.appArgs.disableAddons or self.name in _disabledAddons
 
 	@property
 	def isBlocked(self):

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -391,7 +391,7 @@ class Addon(AddonBase):
 				state["pendingEnableSet"].discard(self.name)
 			# No need to disable an addon that is already disabled, except if all add-ons are disabled.
 			# This also prevents the status in the add-ons dialog from saying "disabled, pending disable"
-			elif self.name not in state["disabledAddons"] or globalVars.appArgs.disableAddons:
+			elif self.name not in state["disabledAddons"]:
 				state["pendingDisableSet"].add(self.name)
 		# Record enable/disable flags as a way of preparing for disaster such as sudden NVDA crash.
 		saveState()

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -176,7 +176,9 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 				"You may modify the enabled / disabled state, and install or uninstall add-ons. "
 				"Changes will not take effect until after NVDA is restarted."
 			)
-			firstTextSizer.Add(wx.StaticText(self, label=label))
+			addonsDisabledText = wx.StaticText(self, label=label)
+			addonsDisabledText.Wrap(self.scaleSize(670))
+			firstTextSizer.Add(addonsDisabledText)
 		# Translators: the label for the installed addons list in the addons manager.
 		entriesLabel = _("Installed Add-ons")
 		firstTextSizer.Add(wx.StaticText(self, label=entriesLabel))

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -157,9 +157,13 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		AddonsDialog._instance = weakref.ref(self)
 		# Translators: The title of the Addons Dialog
 		title = _("Add-ons Manager")
-		# Translators: The title of the Addons Dialog when add-ons are globally disabled
-		titleWhenAddonsAreDisabled = _("Add-ons Manager (add-ons globally disabled)")
-		wx.Dialog.__init__(self, parent, title=title if not globalVars.appArgs.disableAddons else titleWhenAddonsAreDisabled)
+		# Translators: The title of the Addons Dialog when add-ons are disabled
+		titleWhenAddonsAreDisabled = _("Add-ons Manager (add-ons disabled)")
+		wx.Dialog.__init__(
+			self,
+			parent,
+			title=title if not globalVars.appArgs.disableAddons else titleWhenAddonsAreDisabled
+		)
 		DpiScalingHelperMixin.__init__(self, self.GetHandle())
 
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
@@ -167,7 +171,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		listAndButtonsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=wx.BoxSizer(wx.HORIZONTAL))
 		if globalVars.appArgs.disableAddons:
 			# Translators: A message in the add-ons manager shown when add-ons are globally disabled.
-			label = _("NVDA was started with all add-ons disabled, no add-ons will run until NVDA is restarted. You may modify the enabled / disabled state, install or uninstall add-ons, which will take effect after NVDA is restarted.")
+			label = _("NVDA was started with all add-ons disabled. You may modify the enabled / disabled state, and install or uninstall add-ons. Changes will not take effect after NVDA is restarted.")
 			firstTextSizer.Add(wx.StaticText(self, label=label))
 		# Translators: the label for the installed addons list in the addons manager.
 		entriesLabel = _("Installed Add-ons")
@@ -384,7 +388,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			if (addon.isPendingInstall or addon.isPendingRemove
 				or addon.isDisabled and addon.isPendingEnable
 				or addon.isRunning and addon.isPendingDisable
-				or (not addon.isRunning and addon.isPendingDisable and globalVars.appArgs.disableAddons)):
+				or not addon.isDisabled and addon.isPendingDisable):
 				needsRestart = True
 				break
 		if needsRestart:

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -171,7 +171,11 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		listAndButtonsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=wx.BoxSizer(wx.HORIZONTAL))
 		if globalVars.appArgs.disableAddons:
 			# Translators: A message in the add-ons manager shown when add-ons are globally disabled.
-			label = _("NVDA was started with all add-ons disabled. You may modify the enabled / disabled state, and install or uninstall add-ons. Changes will not take effect after NVDA is restarted.")
+			label = _(
+				"NVDA was started with all add-ons disabled. "
+				"You may modify the enabled / disabled state, and install or uninstall add-ons. "
+				"Changes will not take effect until after NVDA is restarted."
+			)
 			firstTextSizer.Add(wx.StaticText(self, label=label))
 		# Translators: the label for the installed addons list in the addons manager.
 		entriesLabel = _("Installed Add-ons")
@@ -316,12 +320,22 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		if addon.isPendingRemove:
 			# Translators: The status shown for an addon that has been marked as removed, before NVDA has been restarted.
 			statusList.append(_("Removed after restart"))
-		elif addon.isPendingDisable or (addon.isDisabled and not addon.isPendingEnable
-			and (addon.isPendingInstall or globalVars.appArgs.disableAddons)):
+		elif addon.isPendingDisable or (
+				# yet to be installed, disabled after install
+				not addon.isPendingEnable and addon.isPendingInstall and addon.isDisabled
+			) or (
+				# addons globally disabled, disabled after restart
+				globalVars.appArgs.disableAddons and addon.isDisabled and not addon.isPendingEnable
+			):
 			# Translators: The status shown for an addon when it requires a restart to become disabled
 			statusList.append(_("Disabled after restart"))
-		elif addon.isPendingEnable or (not addon.isDisabled
-			and (addon.isPendingInstall or globalVars.appArgs.disableAddons)):
+		elif addon.isPendingEnable or (
+				# yet to be installed, enabled after install
+				addon.isPendingInstall and not addon.isDisabled
+			) or (
+				# addons globally disabled, enabled after restart
+				globalVars.appArgs.disableAddons and not addon.isDisabled
+			):
 			# Translators: The status shown for an addon when it requires a restart to become enabled
 			statusList.append(_("Enabled after restart"))
 		return ", ".join(statusList)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -296,16 +296,16 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			return incompatibleStatus
 
 		statusList = []
-		if addon.isRunning:
-			# Translators: The status shown for an addon when its currently running in NVDA.
-			statusList.append(_("Enabled"))
-		elif addon.isPendingInstall:
+		if addon.isPendingInstall:
 			# Translators: The status shown for a newly installed addon before NVDA is restarted.
 			statusList.append(_("Install"))
 		# in some cases an addon can be expected to be disabled after install, so we want "install" to take precedence here
-		elif globalVars.appArgs.disableAddons or addon.isDisabled:
+		elif addon.isDisabled:
 			# Translators: The status shown for an addon when its currently suspended do to addons being disabled.
 			statusList.append(_("Disabled"))
+		elif addon.isRunning:
+			# Translators: The status shown for an addon when its currently running in NVDA.
+			statusList.append(_("Enabled"))
 		if addon.isPendingRemove:
 			# Translators: The status shown for an addon that has been marked as removed, before NVDA has been restarted.
 			statusList.append(_("Removed after restart"))
@@ -365,6 +365,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		self.aboutButton.Enable(addon is not None and not addon.isPendingRemove)
 		self.helpButton.Enable(bool(addon is not None and not addon.isPendingRemove and addon.getDocFilePath()))
 		self.enableDisableButton.Enable(
+			not globalVars.appArgs.disableAddons and
 			addon is not None and
 			not addon.isPendingRemove and
 			addonVersionCheck.isAddonCompatible(addon)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -164,8 +164,8 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		firstTextSizer = wx.BoxSizer(wx.VERTICAL)
 		listAndButtonsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=wx.BoxSizer(wx.HORIZONTAL))
 		if globalVars.appArgs.disableAddons:
-			# Translators: A message in the add-ons manager shown when all add-ons are disabled.
-			label = _("All add-ons are currently disabled. To enable add-ons you must restart NVDA.")
+			# Translators: A message in the add-ons manager shown when add-ons are globally disabled.
+			label = _("NVDA was started with all add-ons disabled, no add-ons will run until NVDA is restarted. You may modify the enabled / disabled state, install or uninstall add-ons, which will take effect after NVDA is restarted.")
 			firstTextSizer.Add(wx.StaticText(self, label=label))
 		# Translators: the label for the installed addons list in the addons manager.
 		entriesLabel = _("Installed Add-ons")
@@ -303,8 +303,8 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			# Translators: The status shown for a newly installed addon before NVDA is restarted.
 			statusList.append(_("Install"))
 		# in some cases an addon can be expected to be disabled after install, so we want "install" to take precedence here
-		# If add-ons are globally disabled, they should appear as such regardless of their real status.
-		elif addon.isDisabled or globalVars.appArgs.disableAddons:
+		# If add-ons are globally disabled, don't show this status.
+		elif addon.isDisabled and not globalVars.appArgs.disableAddons:
 			# Translators: The status shown for an addon when its currently suspended do to addons being disabled.
 			statusList.append(_("Disabled"))
 		if addon.isPendingRemove:

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -303,6 +303,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			# Translators: The status shown for a newly installed addon before NVDA is restarted.
 			statusList.append(_("Install"))
 		# in some cases an addon can be expected to be disabled after install, so we want "install" to take precedence here
+		# If add-ons are globally disabled, they should appear as such regardless of their real status.
 		elif addon.isDisabled or globalVars.appArgs.disableAddons:
 			# Translators: The status shown for an addon when its currently suspended do to addons being disabled.
 			statusList.append(_("Disabled"))

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -156,8 +156,10 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		# when add-ons manager reopens or another add-on is installed remotely.
 		AddonsDialog._instance = weakref.ref(self)
 		# Translators: The title of the Addons Dialog
-		title = _("Add-ons Manager") if not globalVars.appArgs.disableAddons else _("Add-ons Manager (add-ons globally disabled)")
-		wx.Dialog.__init__(self, parent, title=title)
+		title = _("Add-ons Manager")
+		# Translators: The title of the Addons Dialog when add-ons are globally disabled
+		titleWhenAddonsAreDisabled = _("Add-ons Manager (add-ons globally disabled)")
+		wx.Dialog.__init__(self, parent, title=title if not globalVars.appArgs.disableAddons else titleWhenAddonsAreDisabled)
 		DpiScalingHelperMixin.__init__(self, self.GetHandle())
 
 		mainSizer = wx.BoxSizer(wx.VERTICAL)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -156,7 +156,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		# when add-ons manager reopens or another add-on is installed remotely.
 		AddonsDialog._instance = weakref.ref(self)
 		# Translators: The title of the Addons Dialog
-		title = _("Add-ons Manager")
+		title = _("Add-ons Manager") if not globalVars.appArgs.disableAddons else _("Add-ons Manager (add-ons globally disabled)")
 		wx.Dialog.__init__(self, parent, title=title)
 		DpiScalingHelperMixin.__init__(self, self.GetHandle())
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9473.

### Summary of the issue:

When NVDA is launched with the `--disable-addons` flag, add-ons that were previously enabled will still appear as such in the add-ons dialog. Furthermore, it is possible to disable and enable them.

### Description of how this pull request fixes the issue:

- An add-on is now considered disabled if the `disableAddons` global flag is on, or the add-on is in the disabled add-ons list.
- The enable/disable button in the add-ons dialog has been disabled if the `disableAddons` global flag is on.

### Testing performed:

- Installed several add-ons, made sure that the actual behavior was untouched.
- Restarted NVDA with `--disable-addons` and ensured that all add-ons appeared disabled and that it was not possible anymore to trigger the enable button.

### Known issues with pull request:

None

### Change log entry:

Section: Bug fixes

- When NVDA is launched with the `--disable-addons` flag, all add-ons now appears disabled.