### PR TITLE
MozillaCompoundTextInfo: Don't skip ignored objects when determining whether the range covers the end of any ancestors of endObj.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -184,3 +184,4 @@ Thomas Stivers
 Eurobraille
 Bachir Benanou
 Arnold Loubriat
+Mozilla Corporation

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2015-2017 NV Access Limited
+#Copyright (C) 2015-2019 NV Access Limited, Mozilla Corporation
 
 """Support for the IAccessible2 rich text model first implemented by Mozilla.
 This is now used by other applications as well.
@@ -324,11 +324,12 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 				field = controlStack.pop()
 				if field:
 					fields.append(textInfos.FieldCommand("controlEnd", None))
-					if ti.compareEndPoints(self._makeRawTextInfo(obj, textInfos.POSITION_ALL), "endToEnd") == 0:
+				if ti.compareEndPoints(self._makeRawTextInfo(obj, textInfos.POSITION_ALL), "endToEnd") == 0:
+					if field:
 						field["_endOfNode"] = True
-					else:
-						# We're not at the end of this object, which also means we're not at the end of any ancestors.
-						break
+				else:
+					# We're not at the end of this object, which also means we're not at the end of any ancestors.
+					break
 				ti = self._getEmbedding(obj)
 				obj = ti.obj
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In Google Docs (and other web-based editors), braille incorrectly displays "lst end" before the cursor in a list in some cases, even if the cursor is in the middle of the list item.

### Description of how this pull request fixes the issue:
In order to display markers at the end of containers in braille (e.g. "lst end" at the end of lists), MozillaCompoundTextInfo needs to check the object at the end of the range (endObj) and its ancestors. If the range is at the end of any of these objects, we mark the associated control field as being at the end of its node. For example, if the range is at the end of a list, we mark the list's control field as being at end of node, which causes braille to display "lst end". However, if the range is *not* at the end of one of these objects, the range also can't be at the end of any of its ancestors. For example, if the range ends in the middle of a list item, it obviously doesn't cover the end of the list, even if the list item (as a whole) is the last item in the list. In this case, we don't check the remaining ancestors.

Previously, this was failing where there was a single paragraph inside the last list item in a list. The list would be marked as end of node, even if the range ended in the middle of the paragraph, resulting in a spurious "lst end" indicator before the cursor in braille.

This happened because we ignore paragraphs as irrelevant and thus don't generate control fields for them. However, the code which checks whether the range is at the end of endObj or its ancestors only ran if there was a control field. Because the paragraph had no control field, we'd skip it completely, not determining that the range ended in the middle of it and thus aborting the search. We'd then check the next ancestor, and since the paragraph was the last child of the list item which was in turn the last child of the list, we'd mark all of these as end of node, including the list.

To fix this, we now run this check regardless of whether we generated a control field for an object; i.e. regardless of whether we ignored a paragraph.

### Testing performed:
1. Opened this test case:
    `data:text/html,<div contenteditable role="textbox" aria-multiline="true"><ul><li><p>test</p></li></ul></div>`
2. Focused the text box.
3. Pressed home. Observed that braille displays "lst • test lst end".
4. Pressed right arrow.
    - Result after the patch (expected result): Braille displayed "lst • test lst end"
    - Result before the patch (incorrect result): Braille displayed "lst • t lst end est lst end"

Also tested the same scenario in Google Docs and confirmed that it works as expected.

### Known issues with pull request:
None known.

### Change log entry:

Bug Fixes:

`- In Google Docs (and other web-based editors), braille no longer sometimes incorrectly shows "lst end" before the cursor in the middle of a list item.`