### PR TITLE
Don't produce an errorr after exiting math content.

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1954,7 +1954,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		if self._tether != self.TETHER_REVIEW:
 			return
 		region = self.mainBuffer.regions[-1] if self.mainBuffer.regions else None
-		if region and region.obj == reviewPos.obj:
+		if region == reviewPos.obj:
 			self._doCursorMove(region)
 		else:
 			# We're reviewing a different object.


### PR DESCRIPTION
### Link to issue number:
Fixes #9481 
### Summary of the issue:
When braille display is used NVDA produce an error after exiting math content. I've discovered that it happens only when braille is tethered to review.
### Description of how this pull request fixes the issue:
I've slightly changed a condition which was responsible for that error.
### Testing performed:
Tested with steps from issue, an error isn't produced.
### Known issues with pull request:
None, but I am not very familiar with this code, so it may require further testing and opinion from contributors of that modified file.
cc @leonardder 
### Change log entry:
Section: Bug fixes
When braille is tethered to review it is now possible to exit math content without errors (#9481).