### PR TITLE
Added shift+enter and shift+numpadEnter keys to announce the previous cell in the same column in Excel

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -877,6 +877,8 @@ class ExcelWorksheet(ExcelBase):
 		"kb:shift+tab",
 		"kb:enter",
 		"kb:numpadEnter",
+		"kb:shift+enter",
+		"kb:shift+numpadEnter",
 		"kb:upArrow",
 		"kb:downArrow",
 		"kb:leftArrow",


### PR DESCRIPTION

In principle, as the enter and numpadEnter keys announce the next cell in the same column, the shift+enter and shift+numpadEnter keys should announce the previous cell;

In fact, moving to previous or next cell is integrated by default in Excel, NVDA should just announce the current cell with each move.
