### PR TITLE
Added shift+enter and shift+numpadEnter keys to announce the reverse located cell in the same column in Excel

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -877,6 +877,8 @@ class ExcelWorksheet(ExcelBase):
 		"kb:shift+tab",
 		"kb:enter",
 		"kb:numpadEnter",
+		"kb:shift+enter",
+		"kb:shift+numpadEnter",
 		"kb:upArrow",
 		"kb:downArrow",
 		"kb:leftArrow",


### PR DESCRIPTION
### Link to issue number:

Fixes #9499 

### Summary of the issue:

In the module 'NVDAObjects.window.excel.py', in the ExcelWorksheet class and more particularly, in the gestures parameter of the scriptHandler.script decorator, some gestures are missing.

When the user moves to the reverse located cell with shift + enter or shift + numpadEnter, no information is announced by NVDA, while the focus has moved to the reverse located cell (left, up, right or down, according to user's configuration in Excel).

### Description of how this pull request fixes the issue:

This PR adds 2 gestures in the excel.py module mentioned above for NVDA to announce the reverse located cell:

* shift+enter;
* shift+numpadEnter.

### Testing performed:

* Open Excel;
* In a sheet, move to cell B2 for example, with the arrow keys;
* Realize the gesture Shift+Enter or Shift+numpadEnter, the reverse located cell to which you have moved is announced.

Test performed on Office 2016, with Windows-10 version 1803.

### Known issues with pull request:

None, but it may require further testing and opinion from developers and users.

### Change log entry:

Section: Bug fixes


In Microsoft Excel, the user obtains the announcement of the reverse located cell when using the shift + enter and shift + numpadEnter gestures.
