### PR TITLE
Include RemotePythonConsole in binary builds

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #setup.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Joseph Lee
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Joseph Lee, Łukasz Golonka
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -214,6 +214,8 @@ setup(
 			# Since configobj 5.1.0, validate is a part of the configobj package
 			# and should be imported as configobj.validate instead
 			"validate",
+			# RemotePythonConsole should be included in binary builds
+			"remotePythonConsole",
 		],
 	}},
 	data_files=[


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When binary builds of NVDA are used it is not possible to import remote Python console. As it isn't documented I believe that it wasn't intentional
### Description of how this pull request fixes the issue:
RemotePythonConsole was added to setup.py as it isn't used anywhere in the source code.
### Testing performed:
Crated binary build and imported remote Python console successfully.
### Known issues with pull request:
None known
### Change log entry:
As it will affect only developers and the remote Python console isn't even mentioned in the user guide I believe that is isn't needet. 