### PR TITLE
Fixed Say all in Scintilla controls when word wrapping is on

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -199,7 +199,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 			end=self._getOffsetFromPoint(location.right, y)
 			# If this line wraps to the next line,
 			# end is the first offset of the next line.
-			if watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POINTYFROMPOSITION,None,end)==y:
+			if location.top+watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POINTYFROMPOSITION,None,end)==y:
 				# This is the end of the document line.
 				# Include the EOL characters in the returned offsets.
 				end=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONAFTER,end,None)

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -199,7 +199,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 			end=self._getOffsetFromPoint(location.right, y)
 			# If this line wraps to the next line,
 			# end is the first offset of the next line.
-			if location.top+watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POINTYFROMPOSITION,None,end)==y:
+			if self._getPointFromOffset(end).y==y:
 				# This is the end of the document line.
 				# Include the EOL characters in the returned offsets.
 				end=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONAFTER,end,None)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9521.

### Summary of the issue:

When word wrapping is enabled on a Scintilla based application, the Say all command will only read the current line.

### Description of how this pull request fixes the issue:

We are forced to use screen coordinates to retrieve offsets in Scintilla controls when word wrapping is enabled. The problem with this approach however, is that Scintilla does not include the EoF characters in its output. Since when we are on a wrapped line, the end offset will be the start of the next line, we must add EoF only if the Y coordinate of the current line is equal to the one of the end offset. Although this test were already in place, I had to add the top offset of the control to the retrieved Y coordinate to match the other one.

### Testing performed:

Wrote several lines in Notepad++, made sure mouse tracking, keyboard navigation and Say all were working as expected with both word wrapping turned on and off, at 100%, 125% and 150% DPI factor.

### Known issues with pull request:

None.

### Change log entry:

None