### PR TITLE
textUtils module to deal with offset differences between Python 3 strings and Windows wide character strings with surrogate characters

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -19,6 +19,7 @@ import eventHandler
 import controlTypes
 import NVDAObjects.JAB
 import core
+import textutils
 
 #Some utility functions to help with function defines
 
@@ -390,9 +391,10 @@ class JABContext(object):
 		length=((end+1)-start)
 		if length<=0:
 			return u""
-		text=create_unicode_buffer(length+1)
-		bridgeDll.getAccessibleTextRange(self.vmID,self.accContext,start,end,text,length)
-		return text.value
+		# Use a string buffer, as from an unicode buffer, we can't get the raw data.
+		buf = create_string_buffer((length +1) * 2)
+		bridgeDll.getAccessibleTextRange(self.vmID, self.accContext, start, end, buf, length)
+		return textUtils.getTextFromStringBuffer(buf, numChars=length, encoding=textUtils.WCHAR_ENCODING)
 
 	def getAccessibleTextLineBounds(self,index):
 		index=max(index,0)

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -394,7 +394,7 @@ class JABContext(object):
 		# Use a string buffer, as from an unicode buffer, we can't get the raw data.
 		buf = create_string_buffer((length +1) * 2)
 		bridgeDll.getAccessibleTextRange(self.vmID, self.accContext, start, end, buf, length)
-		return textUtils.getTextFromStringBuffer(buf, numChars=length, encoding=textUtils.WCHAR_ENCODING)
+		return textUtils.getTextFromRawBytes(buf.raw, numChars=length, encoding=textUtils.WCHAR_ENCODING)
 
 	def getAccessibleTextLineBounds(self,index):
 		index=max(index,0)

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -19,7 +19,7 @@ import eventHandler
 import controlTypes
 import NVDAObjects.JAB
 import core
-import textutils
+import textUtils
 
 #Some utility functions to help with function defines
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -15,7 +15,7 @@ from comInterfaces.tom import ITextDocument
 import tones
 import languageHandler
 import textInfos.offsets
-from textInfos.offsets import HIGH_SURROGATE_FIRST, HIGH_SURROGATE_LAST, LOW_SURROGATE_FIRST, LOW_SURROGATE_LAST
+from textUtils import HIGH_SURROGATE_FIRST, HIGH_SURROGATE_LAST, LOW_SURROGATE_FIRST, LOW_SURROGATE_LAST
 import colors
 import time
 import displayModel
@@ -117,6 +117,9 @@ def normalizeIA2TextFormatField(formatField):
 class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	detectFormattingAfterCursorMaybeSlow=False
+
+	def _get_encoding(self):
+		return super().encoding
 
 	def _getOffsetFromPoint(self,x,y):
 		if self.obj.IAccessibleTextObject.nCharacters>0:

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -20,6 +20,7 @@ from compoundDocuments import CompoundTextInfo
 import locationHelper
 
 class FakeEmbeddingTextInfo(textInfos.offsets.OffsetsTextInfo):
+	encoding = None
 
 	def _getStoryLength(self):
 		return self.obj.childCount

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -36,6 +36,8 @@ class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
 	"""
 
 	locationText=None
+	# Do not use encoded text.
+	encoding = None
 
 	def _get_unit_mouseChunk(self):
 		return textInfos.UNIT_STORY

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -47,10 +47,6 @@ class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _getStoryLength(self):
 		return len(self._getStoryText())
 
-	def _getTextRange(self,start,end):
-		text=self._getStoryText()
-		return text[start:end]
-
 	def _get_boundingRects(self):
 		if self.obj.hasIrrelevantLocation:
 			raise LookupError("Object is off screen, invisible or has no location")

--- a/source/NVDAObjects/inputComposition.py
+++ b/source/NVDAObjects/inputComposition.py
@@ -27,6 +27,7 @@ def calculateInsertedChars(oldComp,newComp):
 	return newComp[diffStart:diffEnd]
 
 class InputCompositionTextInfo(OffsetsTextInfo):
+	encoding = None
 
 	def _getSelectionOffsets(self):
 		return self.obj.readingSelectionOffsets if self.obj.isReading else self.obj.compositionSelectionOffsets

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -351,7 +351,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 		else:
 			# ForWM_GETTEXTLENGTH documentation, see
 			# https://docs.microsoft.com/en-us/windows/desktop/winmsg/wm-gettextlength
-			# It tetermines the length, in characters, of the text associated with a window.
+			# It determines the length, in characters, of the text associated with a window.
 			# Py3 review: investigation with Python 2 NVDA revealed that
 			# adding 1 to this created an off by one error.
 			# Tested using Notepad

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -391,9 +391,9 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 			):
 				encoding = textUtils.WCHAR_ENCODING
 			else:
-				# De encoding will be determined by L{textUtils.getTextFromStringBuffer}
+				# De encoding will be determined by L{textUtils.getTextFromRawBytes}
 				encoding = None
-			text = textUtils.getTextFromStringBuffer(buf, numChars, encoding)
+			text = textUtils.getTextFromRawBytes(buf.raw, numChars, encoding)
 			# #4095: Some protected richEdit controls do not hide their password characters.
 			# We do this specifically.
 			# Note that protected standard edit controls get characters hidden in _getStoryText.

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -68,6 +68,13 @@ class TextRangeStruct(ctypes.Structure):
 
 class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 
+	def _get_encoding(self):
+		cp=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_GETCODEPAGE,0,0)
+		if cp==SC_CP_UTF8:
+			return "utf-8"
+		else:
+			return locale.getlocale()[1]
+
 	def _getOffsetFromPoint(self,x,y):
 		x, y = winUser.ScreenToClient(self.obj.windowHandle, x, y)
 		return watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONFROMPOINT,x,y)
@@ -174,12 +181,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 			winKernel.readProcessMemory(processHandle,internalBuf,buf,bufLen,None)
 		finally:
 			winKernel.virtualFreeEx(processHandle,internalBuf,0,winKernel.MEM_RELEASE)
-		cp=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_GETCODEPAGE,0,0)
-		if cp==SC_CP_UTF8:
-			encoding="utf-8"
-		else:
-			encoding=locale.getlocale()[1]
-		return buf.value.decode(encoding,errors="replace")
+		return buf.value.decode(self.encoding,errors="replace")
 
 	def _getWordOffsets(self,offset):
 		start=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_WORDSTARTPOSITION,offset,0)

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -14,6 +14,7 @@ import locale
 import watchdog
 import eventHandler
 import locationHelper
+import textUtils
 
 # Window messages
 SCI_POSITIONFROMPOINT=2022
@@ -181,12 +182,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 			winKernel.readProcessMemory(processHandle, internalBuf, buf, bufLen, None)
 		finally:
 			winKernel.virtualFreeEx(processHandle, internalBuf, 0, winKernel.MEM_RELEASE)
-		textBytes = buf.raw[:numBytes]
-		if not any(textBytes):
-			# textBytes is empty or only contains null characters.
-			# If this is a document with only null characters in it, there's not much we can do about this.
-			return ""
-		return textBytes.decode(self.encoding, errors="surrogateescape")
+		return textUtils.getTextFromStringBuffer(buf, numChars=numBytes, encoding=self.encoding, errorsFallback="surrogateescape")
 
 	def _getWordOffsets(self,offset):
 		start=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_WORDSTARTPOSITION,offset,0)

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -182,7 +182,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 			winKernel.readProcessMemory(processHandle, internalBuf, buf, bufLen, None)
 		finally:
 			winKernel.virtualFreeEx(processHandle, internalBuf, 0, winKernel.MEM_RELEASE)
-		return textUtils.getTextFromStringBuffer(buf, numChars=numBytes, encoding=self.encoding, errorsFallback="surrogateescape")
+		return textUtils.getTextFromRawBytes(buf.raw, numChars=numBytes, encoding=self.encoding, errorsFallback="surrogateescape")
 
 	def _getWordOffsets(self,offset):
 		start=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_WORDSTARTPOSITION,offset,0)

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -282,6 +282,8 @@ class SimpleResultTextInfo(textInfos.offsets.OffsetsTextInfo):
 	This should only be instantiated by L{SimpleTextResult}.
 	"""
 
+	encoding = None
+
 	def __init__(self, obj, position, result):
 		self.result = result
 		super(SimpleResultTextInfo, self).__init__(obj, position)

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -220,6 +220,8 @@ class LwrTextInfo(textInfos.offsets.OffsetsTextInfo):
 	This should only be instantiated by L{LinesWordsResult}.
 	"""
 
+	encoding = None
+
 	def __init__(self, obj, position, result):
 		self.result = result
 		super(LwrTextInfo, self).__init__(obj, position)

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -124,7 +124,7 @@ def processFieldsAndRectsRangeReadingdirection(commandList,rects,startIndex,star
 						for i in range(runStartIndex,index,2):
 							command=commandList[i]
 							text=commandList[i+1]
-							rectsEnd=rectsStart + textUtils.WideStringOffsetConverter(text).wideStringLength
+							rectsEnd = rectsStart + textUtils.WideStringOffsetConverter(text).wideStringLength
 							commandList[i+1]=command
 							shouldReverseText=command.field.get('shouldReverseText',True)
 							commandList[i]=normalizeRtlString(text[::-1] if shouldReverseText else text)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -147,10 +147,8 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	detectFormattingAfterCursorMaybeSlow: bool = True
 	#: Use uniscribe to calculate word offsets etc.
 	useUniscribe: bool = True
-	#: The encoding used for wide characters
-	_WCHAR_ENCODING: str = "utf_16_le"
 	#: The encoding internal to the underlying text info implementation.
-	encoding: Optional[str] = _WCHAR_ENCODING
+	encoding: Optional[str] = textUtils.WCHAR_ENCODING
 
 	def __eq__(self,other):
 		if self is other or (isinstance(other,OffsetsTextInfo) and self._startOffset==other._startOffset and self._endOffset==other._endOffset):
@@ -281,7 +279,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		@rtype: str
 		"""
 		text=self._getStoryText()
-		if self.encoding == self._WCHAR_ENCODING:
+		if self.encoding == textUtils.WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(text)
 			start, end = offsetConverter.wideToStrOffsets(start, end)
 		elif self.encoding not in (None, "utf_32_le", locale.getlocale()[1]):
@@ -304,7 +302,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return formatField,(startOffset,endOffset)
 
 	def _getCharacterOffsets(self,offset):
-		if self.encoding == self._WCHAR_ENCODING:
+		if self.encoding == textUtils.WCHAR_ENCODING:
 			lineStart,lineEnd=self._getLineOffsets(offset)
 			lineText=self._getTextRange(lineStart,lineEnd)
 			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
@@ -317,7 +315,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return offset, offset + 1
 
 	def _getWordOffsets(self,offset):
-		if self.encoding not in (self._WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
+		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
 			raise NotImplementedError
 		lineStart,lineEnd=self._getLineOffsets(offset)
 		lineText=self._getTextRange(lineStart,lineEnd)
@@ -332,13 +330,13 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			if NVDAHelper.localLib.calculateWordOffsets(lineText,len(lineText),offset-lineStart,ctypes.byref(start),ctypes.byref(end)):
 				start = start.value
 				end = end.value
-				if self.encoding != self._WCHAR_ENCODING:
+				if self.encoding != textUtils.WCHAR_ENCODING:
 					# We need to convert the uniscribe based offsets to str offsets.
 					offsetConverter = textUtils.WideStringOffsetConverter(lineText)
 					start, end = offsetConverter.wideToStrOffsets(start, end)
 				return (start, end)
 		#Fall back to the older word offsets detection that only breaks on non alphanumeric
-		if self.encoding == self._WCHAR_ENCODING:
+		if self.encoding == textUtils.WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
 			relOffset = offset - lineStart
 			relStrOffset = offsetConverter.wideToStrOffsets(relOffset, relOffset)[0]
@@ -355,7 +353,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 
 	def _getLineOffsets(self,offset):
 		text=self._getStoryText()
-		if self.encoding == self._WCHAR_ENCODING:
+		if self.encoding == textUtils.WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(text)
 			strOffset = offsetConverter.wideToStrOffsets(offset, offset)[0]
 			strStart=findStartOfLine(text, strOffset)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -146,7 +146,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	#: Honours documentFormatting config option if true - set to false if this is not at all slow.
 	detectFormattingAfterCursorMaybeSlow: bool = True
 	#: Use uniscribe to calculate word offsets etc.
-	useUniscribe: bool = True
+	useUniscribe: bool = False
 	#: The encoding used for wide characters
 	_WCHAR_ENCODING: str = "utf_16_le"
 	#: The encoding internal to the underlying text info implementation.
@@ -340,7 +340,8 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		#Fall back to the older word offsets detection that only breaks on non alphanumeric
 		if self.encoding == self._WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
-			relStrOffset = offsetConverter.wideToStrOffsets(offset, offset - lineStart)[0]
+			relOffset = offset - lineStart
+			relStrOffset = offsetConverter.wideToStrOffsets(relOffset, relOffset)[0]
 			relStrStart = findStartOfWord(lineText, relStrOffset)
 			relStrEnd = findEndOfWord(lineText, relStrOffset)
 			relWideStringStart, relWideStringEnd = offsetConverter.strToWideOffsets(relStrStart, relStrEnd)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -129,7 +129,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	"""An abstract TextInfo for text implementations which represent ranges using numeric offsets relative to the start of the text.
 	In such implementations, the start of the text is represented by 0 and the end is the length of the entire text.
 	
-	All subclasses must implement L{encoding} and L{_getStoryLength}.
+	All subclasses must implement L{_getStoryLength}.
 	Aside from this, there are two possible implementations:
 		* If the underlying text implementation does not support retrieval of line offsets, L{_getStoryText} should be implemented.
 		In this case, the base implementation of L{_getLineOffsets} will retrieve the entire text of the object and use text searching algorithms to find line offsets.
@@ -146,7 +146,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	#: Honours documentFormatting config option if true - set to false if this is not at all slow.
 	detectFormattingAfterCursorMaybeSlow: bool = True
 	#: Use uniscribe to calculate word offsets etc.
-	useUniscribe: bool = False
+	useUniscribe: bool = True
 	#: The encoding used for wide characters
 	_WCHAR_ENCODING: str = "utf_16_le"
 	#: The encoding internal to the underlying text info implementation.

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -129,7 +129,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	"""An abstract TextInfo for text implementations which represent ranges using numeric offsets relative to the start of the text.
 	In such implementations, the start of the text is represented by 0 and the end is the length of the entire text.
 	
-	All subclasses must implement L{_getStoryLength}.
+	All subclasses must implement L{encoding} and L{_getStoryLength}.
 	Aside from this, there are two possible implementations:
 		* If the underlying text implementation does not support retrieval of line offsets, L{_getStoryText} should be implemented.
 		In this case, the base implementation of L{_getLineOffsets} will retrieve the entire text of the object and use text searching algorithms to find line offsets.
@@ -147,10 +147,10 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	detectFormattingAfterCursorMaybeSlow: bool = True
 	#: Use uniscribe to calculate word offsets etc.
 	useUniscribe: bool = True
-	#: The encoding used for uniscribe
-	_UNISCRIBE_ENCODING: str = "utf_16_le"
-	#: The encoding internal to the underlying text info implementation
-	encoding: Optional[str] = _UNISCRIBE_ENCODING
+	#: The encoding used for wide characters
+	_WCHAR_ENCODING: str = "utf_16_le"
+	#: The encoding internal to the underlying text info implementation.
+	encoding: Optional[str] = _WCHAR_ENCODING
 
 	def __eq__(self,other):
 		if self is other or (isinstance(other,OffsetsTextInfo) and self._startOffset==other._startOffset and self._endOffset==other._endOffset):
@@ -281,7 +281,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		@rtype: str
 		"""
 		text=self._getStoryText()
-		if self.encoding == self._UNISCRIBE_ENCODING:
+		if self.encoding == self._WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(text)
 			start, end = offsetConverter.wideToStrOffsets(start, end)
 		elif self.encoding not in (None, "utf_32_le", locale.getlocale()[1]):
@@ -304,16 +304,20 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return formatField,(startOffset,endOffset)
 
 	def _getCharacterOffsets(self,offset):
-		if self.encoding == self._UNISCRIBE_ENCODING:
-			offsetConverter = textUtils.WideStringOffsetConverter(self._getStoryText())
-			strStart, strEnd = offsetConverter.wideToStrOffsets(offset, offset + 1)
-			return offsetConverter.strToWideOffsets(strStart, strEnd)
+		if self.encoding == self._WCHAR_ENCODING:
+			lineStart,lineEnd=self._getLineOffsets(offset)
+			lineText=self._getTextRange(lineStart,lineEnd)
+			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
+			relOffset = offset - lineStart
+			relStrStart, relStrEnd = offsetConverter.wideToStrOffsets(relOffset, relOffset + 1)
+			relWideStringStart, relWideStringEnd = offsetConverter.strToWideOffsets(relStrStart, relStrEnd)
+			return (relWideStringStart + lineStart, relWideStringEnd + lineStart)
 		elif self.encoding not in (None, "utf_32_le", locale.getlocale()[1]):
 			raise NotImplementedError
 		return offset, offset + 1
 
 	def _getWordOffsets(self,offset):
-		if self.encoding not in (self._UNISCRIBE_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
+		if self.encoding not in (self._WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
 			raise NotImplementedError
 		lineStart,lineEnd=self._getLineOffsets(offset)
 		lineText=self._getTextRange(lineStart,lineEnd)
@@ -328,13 +332,13 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			if NVDAHelper.localLib.calculateWordOffsets(lineText,len(lineText),offset-lineStart,ctypes.byref(start),ctypes.byref(end)):
 				start = start.value
 				end = end.value
-				if self.encoding != self._UNISCRIBE_ENCODING:
+				if self.encoding != self._WCHAR_ENCODING:
 					# We need to convert the uniscribe based offsets to str offsets.
 					offsetConverter = textUtils.WideStringOffsetConverter(lineText)
 					start, end = offsetConverter.wideToStrOffsets(start, end)
 				return (start, end)
 		#Fall back to the older word offsets detection that only breaks on non alphanumeric
-		if self.encoding == self._UNISCRIBE_ENCODING:
+		if self.encoding == self._WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
 			relStrOffset = offsetConverter.wideToStrOffsets(offset, offset - lineStart)[0]
 			relStrStart = findStartOfWord(lineText, relStrOffset)
@@ -350,7 +354,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 
 	def _getLineOffsets(self,offset):
 		text=self._getStoryText()
-		if self.encoding == self._UNISCRIBE_ENCODING:
+		if self.encoding == self._WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(text)
 			strOffset = offsetConverter.wideToStrOffsets(offset, offset)[0]
 			strStart=findStartOfLine(text, strOffset)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -328,7 +328,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			# uniscribe does some strange things when you give it a string  with not more than two alphanumeric chars in a row.
 			# Inject two alphanumeric characters at the end to fix this 
 			lineText += "xx"
-			# We can't rely on len(lineText) to calculate the length of the lin.
+			# We can't rely on len(lineText) to calculate the length of the line.
 			lineLength = (lineEnd - lineStart) + 2
 			if NVDAHelper.localLib.calculateWordOffsets(lineText, lineLength, relOffset, ctypes.byref(relStart), ctypes.byref(relEnd)):
 				relStart = relStart.value

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 #textUtils.py
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -82,7 +82,7 @@ class WideStringOffsetConverter:
 		if strStart == 0 and strEnd == 0:
 			return (0, 0)
 		if strEnd < strStart:
-			raise valueError(
+			raise ValueError(
 				"strEnd=%d must be greater than or equal to strStart=%d"
 				% (strEnd, strStart)
 			)
@@ -136,7 +136,7 @@ class WideStringOffsetConverter:
 		if wideStringStart == 0 and wideStringEnd == 0:
 			return (0, 0)
 		if wideStringEnd < wideStringStart:
-			raise valueError(
+			raise ValueError(
 				"wideStringEnd=%d must be greater than or equal to wideStringStart=%d"
 				% (wideStringEnd, wideStringStart)
 			)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -142,11 +142,11 @@ class WideStringOffsetConverter:
 			)
 		if wideStringStart < 0 or wideStringStart > self.wideStringLength:
 			if raiseOnError:
-				raise IndexError("Encoding aware start index out of range")
+				raise IndexError("Wide string start index out of range")
 			wideStringStart = max(0, min(wideStringStart, self.wideStringLength))
 		if wideStringEnd < 0 or wideStringEnd > self.wideStringLength:
 			if raiseOnError:
-				raise IndexError("Encoding aware end index out of range")
+				raise IndexError("Wide string end index out of range")
 			wideStringEnd = max(0, min(wideStringEnd, self.wideStringLength))
 		bytesStart: int = wideStringStart * self._bytesPerIndex
 		bytesEnd: int = wideStringEnd * self._bytesPerIndex

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,0 +1,120 @@
+#textUtils.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2018-2019 NV Access Limited, Babbage B.V.
+
+"""
+Classes and utilities to deal with offsets variable width encodings, particularly utf_16.
+"""
+
+import encodings
+import sys
+import ctypes
+from collections.abc import ByteString # Python 3 import
+from typing import Tuple
+
+HIGH_SURROGATE_FIRST = u"\uD800"
+HIGH_SURROGATE_LAST = u"\uDBFF"
+LOW_SURROGATE_FIRST = u"\uDC00"
+LOW_SURROGATE_LAST = u"\uDFFF"
+
+class WideStringOffsetConverter:
+	"""
+	Object that holds a string in both its decoded and its UTF-16 encoded form.
+	The object allows for easy convertion between offsets in str type strings,
+	and offsets that are aware of surrogate characters in UTF-16.
+	"""
+
+	_encoding: str = "utf_16_le"
+	_bytesPerIndex: int = ctypes.sizeof(ctypes.c_wchar)
+
+	def __init__(self, strVal: str):
+		super(WideStringOffsetConverter, self).__init__()
+		if not isinstance(strVal, str):
+			raise TypeError("Value must be of type str")
+		self.decoded: str = strVal
+		self.encoded: bytes = strVal.encode(self._encoding, errors="surrogatepass")
+
+	def __repr__(self):
+		return "{}({})".format(self.__class__.__name__, repr(self.decoded))
+
+	@property
+	def wideStringLength(self) -> int:
+		return len(self.encoded) // self._bytesPerIndex
+
+	@property
+	def strLength(self) -> int:
+		return len(self.decoded)
+
+	def strToWideOffsets(
+		self,
+		strStart: int,
+		strEnd: int,
+		strict: bool =False
+	) -> Tuple[int, int]:
+		if strStart > self.strLength:
+			if strict:
+				raise IndexError("str start index out of range")
+			strStart = min(strStart, self.strLength)
+		if strEnd > self.strLength:
+			if strict:
+				raise IndexError("str end index out of range")
+			strEnd = min(strEnd, self.strLength)
+		# If the original string contains surrogate characters, we want to preserve them
+		if strStart == 0:
+			wideStringStart: int = 0
+		else:
+			precedingBytes: bytes = self.decoded[:strStart].encode(self._encoding, errors="surrogatepass")
+			wideStringStart= len(precedingBytes) // self._bytesPerIndex
+		if strStart == strEnd:
+			return (wideStringStart, wideStringStart)
+		encodedRange: bytes = self.decoded[strStart:strEnd].encode(self._encoding, errors="surrogatepass")
+		wideStringEnd: int = wideStringStart + (len(encodedRange) // self._bytesPerIndex)
+		return (wideStringStart, wideStringEnd)
+
+	def wideToStrOffsets(
+		self,
+		wideStringStart: int,
+		wideStringEnd: int,
+		strict: bool = False
+	) -> Tuple[int, int]:
+		if wideStringStart > self.wideStringLength:
+			if strict:
+				raise IndexError("Encoding aware start index out of range")
+			wideStringStart = min(wideStringStart, self.wideStringLength)
+		if wideStringEnd > self.wideStringLength:
+			if strict:
+				raise IndexError("Encoding aware end index out of range")
+			wideStringEnd = min(wideStringEnd, self.wideStringLength)
+		bytesStart: int = wideStringStart * self._bytesPerIndex
+		bytesEnd: int = wideStringEnd * self._bytesPerIndex
+		if bytesStart == 0:
+			precedingStr: str = ""
+			strStart: int = 0
+		else:
+			precedingStr= self.encoded[:bytesStart].decode(self._encoding, errors="surrogatepass")
+			strStart= len(precedingStr)
+		if bytesStart == bytesEnd and bytesEnd <= (len(self.encoded) - self._bytesPerIndex):
+			# Though we are trying to fetch str offsets for a single offset,
+			# we need to make sure to avoid off by one errors caused by surrogates
+			correctedBytesEnd = bytesEnd + self._bytesPerIndex
+		else:
+			correctedBytesEnd = bytesEnd
+		decodedRange: str = self.encoded[bytesStart:correctedBytesEnd].decode(self._encoding, errors="surrogatepass")
+		strEnd: int = strStart + len(decodedRange)
+		# In the case where precedingStr ends with a high surrogate,
+		# and decodedRange ends with a low surrogate character
+		# They take one offset in the resulting string, so our offsets are off by one.
+		if (
+			precedingStr
+			and HIGH_SURROGATE_FIRST <= precedingStr[-1] <= HIGH_SURROGATE_LAST
+			and decodedRange
+			and LOW_SURROGATE_FIRST <= decodedRange[0] <= LOW_SURROGATE_LAST
+		):
+			strStart -= 1
+			strEnd -= 1
+		if correctedBytesEnd > bytesEnd:
+			# Compensate for the case where we stretched our offsets earlier
+			strEnd -= (correctedBytesEnd - bytesEnd) // self._bytesPerIndex
+		return (strStart, strEnd)

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -10,6 +10,7 @@ import contextlib
 from ctypes import *
 from ctypes.wintypes import *
 import winKernel
+from textUtils import WCHAR_ENCODING
 
 #dll handles
 user32=windll.user32
@@ -653,12 +654,12 @@ def setClipboardData(format,data):
 	if format!=CF_UNICODETEXT:
 		raise ValueError("Unsupported format")
 	text = data
+	bufLen = len(text.encode(WCHAR_ENCODING, errors="surrogatepass")) + 2
 	# Allocate global memory
-	h=winKernel.HGLOBAL.alloc(winKernel.GMEM_MOVEABLE,(len(text)+1)*2)
+	h=winKernel.HGLOBAL.alloc(winKernel.GMEM_MOVEABLE, bufLen)
 	# Acquire a lock to the global memory receiving a local memory address
 	with h.lock() as addr:
 		# Write the text into the allocated memory
-		bufLen=len(text)+1
 		buf=(c_wchar*bufLen).from_address(addr)
 		buf.value=text
 	# Set the clipboard data with the global memory

--- a/source/wincon.py
+++ b/source/wincon.py
@@ -1,5 +1,6 @@
 from ctypes import *
 from ctypes.wintypes import *
+import textUtils
 
 """
 Lower level utility functions and constants for NVDA's
@@ -55,11 +56,12 @@ def GetConsoleSelectionInfo():
 	return info
 
 def ReadConsoleOutputCharacter(handle,length,x,y):
-	buf=create_unicode_buffer(length)
+	# Use a string buffer, as from an unicode buffer, we can't get the raw data.
+	buf=create_string_buffer(length * 2)
 	numCharsRead=c_int()
 	if windll.kernel32.ReadConsoleOutputCharacterW(handle,buf,length,COORD(x,y),byref(numCharsRead))==0:
 		raise WinError()
-	return buf.value
+	return textUtils.getTextFromStringBuffer(buf, numChars=numCharsRead.value, encoding=textUtils.WCHAR_ENCODING)
 
 def ReadConsoleOutput(handle, length, rect):
 	BufType=CHAR_INFO*length

--- a/source/wincon.py
+++ b/source/wincon.py
@@ -61,7 +61,7 @@ def ReadConsoleOutputCharacter(handle,length,x,y):
 	numCharsRead=c_int()
 	if windll.kernel32.ReadConsoleOutputCharacterW(handle,buf,length,COORD(x,y),byref(numCharsRead))==0:
 		raise WinError()
-	return textUtils.getTextFromStringBuffer(buf, numChars=numCharsRead.value, encoding=textUtils.WCHAR_ENCODING)
+	return textUtils.getTextFromRawBytes(buf.raw, numChars=numCharsRead.value, encoding=textUtils.WCHAR_ENCODING)
 
 def ReadConsoleOutput(handle, length, rect):
 	BufType=CHAR_INFO*length

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -42,6 +42,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at a
 		self.assertEqual(ti.offsets, (0, 1)) # One offset
 
+	@unittest.expectedFailure
 	def test_surrogatePairsForward(self):
 		obj = BasicTextProvider(text=u"\ud83e\udd26\ud83d\ude0a\ud83d\udc4d") # 🤦😊👍
 		ti = obj.makeTextInfo(Offsets(0, 0))
@@ -54,6 +55,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at 👍
 		self.assertEqual(ti.offsets, (4, 6)) # Two offsets
 
+	@unittest.expectedFailure
 	def test_surrogatePairsBackward(self):
 		obj = BasicTextProvider(text=u"\ud83e\udd26\ud83d\ude0a\ud83d\udc4d") # 🤦😊👍
 		ti = obj.makeTextInfo(Offsets(5, 5))
@@ -66,6 +68,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at 🤦
 		self.assertEqual(ti.offsets, (0, 2)) # Two offsets
 
+	@unittest.expectedFailure
 	def test_mixedSurrogatePairsAndNonSurrogatesForward(self):
 		obj = BasicTextProvider(text=u"a\ud83e\udd26b") # a🤦b
 		ti = obj.makeTextInfo(Offsets(0, 0))
@@ -78,6 +81,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at c
 		self.assertEqual(ti.offsets, (3, 4)) # One offset
 
+	@unittest.expectedFailure
 	def test_mixedSurrogatePairsAndNonSurrogatesBackward(self):
 		obj = BasicTextProvider(text=u"a\ud83e\udd26b") # a🤦b
 		ti = obj.makeTextInfo(Offsets(3, 3))
@@ -90,6 +94,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at a
 		self.assertEqual(ti.offsets, (0, 1)) # One offset
 
+	@unittest.expectedFailure
 	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogatesForward(self):
 		"""
 		Tests surrogate pairs, non surrogates as well as
@@ -112,6 +117,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at c
 		self.assertEqual(ti.offsets, (5, 6)) # One offset
 
+	@unittest.expectedFailure
 	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogatesBackward(self):
 		obj = BasicTextProvider(text=u"a\ud83e\ud83e\udd26\udd26b")
 		ti = obj.makeTextInfo(Offsets(5, 5))

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -16,6 +16,8 @@ class TestCharacterOffsets(unittest.TestCase):
 	"""
 	Tests for textInfos.offsets.OffsetsTextInfo for its ability to deal with
 	UTF-16 surrogate characters (i.e. whether a surrogate pair is treated as one character).
+	These tests are also implicit tests for the textUtils module,
+	as its logic is used for character offset calculation in wide character strings.
 	"""
 
 	def test_nonSurrogateForward(self):
@@ -113,7 +115,7 @@ class TestCharacterOffsets(unittest.TestCase):
 		self.assertEqual(ti.offsets, (5, 6)) # One offset
 
 	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogatesBackward(self):
-		obj = BasicTextProvider(text=u"a\ud83e\ud83e\udd26\udd26b")
+		obj = BasicTextProvider(text=u"a\ud83e\U0001f926\udd26b")
 		ti = obj.makeTextInfo(Offsets(5, 5))
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at c
 		self.assertEqual(ti.offsets, (5, 6)) # One offset

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -42,9 +42,8 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at a
 		self.assertEqual(ti.offsets, (0, 1)) # One offset
 
-	@unittest.expectedFailure
 	def test_surrogatePairsForward(self):
-		obj = BasicTextProvider(text=u"\ud83e\udd26\ud83d\ude0a\ud83d\udc4d") # 🤦😊👍
+		obj = BasicTextProvider(text=u"\U0001f926\U0001f60a\U0001f44d") # 🤦😊👍
 		ti = obj.makeTextInfo(Offsets(0, 0))
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at 🤦
 		self.assertEqual(ti.offsets, (0, 2)) # Two offsets
@@ -55,9 +54,8 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at 👍
 		self.assertEqual(ti.offsets, (4, 6)) # Two offsets
 
-	@unittest.expectedFailure
 	def test_surrogatePairsBackward(self):
-		obj = BasicTextProvider(text=u"\ud83e\udd26\ud83d\ude0a\ud83d\udc4d") # 🤦😊👍
+		obj = BasicTextProvider(text=u"\U0001f926\U0001f60a\U0001f44d") # 🤦😊👍
 		ti = obj.makeTextInfo(Offsets(5, 5))
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at 👍
 		self.assertEqual(ti.offsets, (4, 6)) # Two offsets
@@ -68,9 +66,8 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at 🤦
 		self.assertEqual(ti.offsets, (0, 2)) # Two offsets
 
-	@unittest.expectedFailure
 	def test_mixedSurrogatePairsAndNonSurrogatesForward(self):
-		obj = BasicTextProvider(text=u"a\ud83e\udd26b") # a🤦b
+		obj = BasicTextProvider(text=u"a\U0001f926b") # a🤦b
 		ti = obj.makeTextInfo(Offsets(0, 0))
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at a
 		self.assertEqual(ti.offsets, (0, 1)) # One offset
@@ -81,9 +78,8 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at c
 		self.assertEqual(ti.offsets, (3, 4)) # One offset
 
-	@unittest.expectedFailure
 	def test_mixedSurrogatePairsAndNonSurrogatesBackward(self):
-		obj = BasicTextProvider(text=u"a\ud83e\udd26b") # a🤦b
+		obj = BasicTextProvider(text=u"a\U0001f926b") # a🤦b
 		ti = obj.makeTextInfo(Offsets(3, 3))
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at c
 		self.assertEqual(ti.offsets, (3, 4)) # One offset
@@ -94,13 +90,12 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at a
 		self.assertEqual(ti.offsets, (0, 1)) # One offset
 
-	@unittest.expectedFailure
 	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogatesForward(self):
 		"""
 		Tests surrogate pairs, non surrogates as well as
 		single surrogate characters (i.e. incomplete pairs)
 		"""
-		obj = BasicTextProvider(text=u"a\ud83e\ud83e\udd26\udd26b")
+		obj = BasicTextProvider(text=u"a\ud83e\U0001f926\udd26b")
 		ti = obj.makeTextInfo(Offsets(0, 0))
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at a
 		self.assertEqual(ti.offsets, (0, 1)) # One offset
@@ -117,7 +112,6 @@ class TestCharacterOffsets(unittest.TestCase):
 		ti.expand(textInfos.UNIT_CHARACTER) # Range at c
 		self.assertEqual(ti.offsets, (5, 6)) # One offset
 
-	@unittest.expectedFailure
 	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogatesBackward(self):
 		obj = BasicTextProvider(text=u"a\ud83e\ud83e\udd26\udd26b")
 		ti = obj.makeTextInfo(Offsets(5, 5))

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -1,0 +1,196 @@
+# -*- coding: UTF-8 -*-
+#tests/unit/test_textUtils.py
+#A part of NonVisual Desktop Access (NVDA)
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Copyright (C) 2019 NV Access Limited, Babbage B.V., Leonard de Ruijter
+
+"""Unit tests for the textUtils module."""
+
+import unittest
+from textUtils import WideStringOffsetConverter
+
+class TestStrToWideOffsets(unittest.TestCase):
+	"""
+	Tests that ensure that offsets in a string are properly converted to wide string offsets.
+	Every string offset for 32-bit unicode characters (e.g. emoji) take two offsets in a wide string representation.
+	"""
+
+	def test_nonSurrogate(self):
+		converter = WideStringOffsetConverter(text="abc")
+		self.assertEqual(converter.wideStringLength, 3)
+		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.strToWideOffsets(0, 2), (0, 2))
+		self.assertEqual(converter.strToWideOffsets(0, 3), (0, 3))
+		self.assertEqual(converter.strToWideOffsets(1, 1), (1, 1))
+		self.assertEqual(converter.strToWideOffsets(1, 2), (1, 2))
+		self.assertEqual(converter.strToWideOffsets(1, 3), (1, 3))
+		self.assertEqual(converter.strToWideOffsets(2, 2), (2, 2))
+		self.assertEqual(converter.strToWideOffsets(2, 3), (2, 3))
+		self.assertEqual(converter.strToWideOffsets(3, 3), (3, 3))
+
+	def test_surrogatePairs(self):
+		converter = WideStringOffsetConverter(text=u"\U0001f926\U0001f60a\U0001f44d") # 🤦😊👍
+		self.assertEqual(converter.wideStringLength, 6)
+		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 2))
+		self.assertEqual(converter.strToWideOffsets(0, 2), (0, 4))
+		self.assertEqual(converter.strToWideOffsets(0, 3), (0, 6))
+		self.assertEqual(converter.strToWideOffsets(1, 1), (2, 2))
+		self.assertEqual(converter.strToWideOffsets(1, 2), (2, 4))
+		self.assertEqual(converter.strToWideOffsets(1, 3), (2, 6))
+		self.assertEqual(converter.strToWideOffsets(2, 2), (4, 4))
+		self.assertEqual(converter.strToWideOffsets(2, 3), (4, 6))
+		self.assertEqual(converter.strToWideOffsets(3, 3), (6, 6))
+
+	def test_mixedSurrogatePairsAndNonSurrogates(self):
+		converter = WideStringOffsetConverter(text=u"a\U0001f926b") # a🤦b
+		self.assertEqual(converter.wideStringLength, 4)
+		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.strToWideOffsets(0, 2), (0, 3))
+		self.assertEqual(converter.strToWideOffsets(0, 3), (0, 4))
+		self.assertEqual(converter.strToWideOffsets(1, 1), (1, 1))
+		self.assertEqual(converter.strToWideOffsets(1, 2), (1, 3))
+		self.assertEqual(converter.strToWideOffsets(1, 3), (1, 4))
+		self.assertEqual(converter.strToWideOffsets(2, 2), (3, 3))
+		self.assertEqual(converter.strToWideOffsets(2, 3), (3, 4))
+		self.assertEqual(converter.strToWideOffsets(3, 3), (4, 4))
+
+	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogates(self):
+		"""
+		Tests surrogate pairs, non surrogates as well as
+		single surrogate characters (i.e. incomplete pairs)
+		"""
+		converter = WideStringOffsetConverter(text=u"a\ud83e\U0001f926\udd26b")
+		self.assertEqual(converter.wideStringLength, 6)
+		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.strToWideOffsets(0, 2), (0, 2))
+		self.assertEqual(converter.strToWideOffsets(0, 3), (0, 4))
+		self.assertEqual(converter.strToWideOffsets(0, 4), (0, 5))
+		self.assertEqual(converter.strToWideOffsets(0, 5), (0, 6))
+		self.assertEqual(converter.strToWideOffsets(1, 1), (1, 1))
+		self.assertEqual(converter.strToWideOffsets(1, 2), (1, 2))
+		self.assertEqual(converter.strToWideOffsets(1, 3), (1, 4))
+		self.assertEqual(converter.strToWideOffsets(1, 4), (1, 5))
+		self.assertEqual(converter.strToWideOffsets(1, 5), (1, 6))
+		self.assertEqual(converter.strToWideOffsets(2, 2), (2, 2))
+		self.assertEqual(converter.strToWideOffsets(2, 3), (2, 4))
+		self.assertEqual(converter.strToWideOffsets(2, 4), (2, 5))
+		self.assertEqual(converter.strToWideOffsets(2, 5), (2, 6))
+		self.assertEqual(converter.strToWideOffsets(3, 3), (4, 4))
+		self.assertEqual(converter.strToWideOffsets(3, 4), (4, 5))
+		self.assertEqual(converter.strToWideOffsets(3, 5), (4, 6))
+		self.assertEqual(converter.strToWideOffsets(4, 4), (5, 5))
+		self.assertEqual(converter.strToWideOffsets(4, 5), (5, 6))
+		self.assertEqual(converter.strToWideOffsets(5, 5), (6, 6))
+
+class TestWideToStrOffsets(unittest.TestCase):
+	"""
+	Tests that ensure that offsets in a wide string are properly converted to str offsets.
+	Every string offset for 32-bit unicode characters (e.g. emoji) take two offsets in a wide string representation.
+	"""
+
+	def test_nonSurrogate(self):
+		converter = WideStringOffsetConverter(text="abc")
+		self.assertEqual(converter.strLength, 3)
+		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.wideToStrOffsets(0, 2), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(0, 3), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(1, 1), (1, 1))
+		self.assertEqual(converter.wideToStrOffsets(1, 2), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(1, 3), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(2, 2), (2, 2))
+		self.assertEqual(converter.wideToStrOffsets(2, 3), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(3, 3), (3, 3))
+
+	def test_surrogatePairs(self):
+		converter = WideStringOffsetConverter(text=u"\U0001f926\U0001f60a\U0001f44d") # 🤦😊👍
+		self.assertEqual(converter.strLength, 3)
+		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.wideToStrOffsets(0, 2), (0, 1))
+		self.assertEqual(converter.wideToStrOffsets(0, 3), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(0, 4), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(0, 5), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(0, 6), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(1, 1), (0, 0))
+		self.assertEqual(converter.wideToStrOffsets(1, 2), (0, 1))
+		self.assertEqual(converter.wideToStrOffsets(1, 3), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(1, 4), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(1, 5), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(1, 6), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(2, 2), (1, 1))
+		self.assertEqual(converter.wideToStrOffsets(2, 3), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(2, 4), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(2, 5), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(2, 6), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(3, 3), (1, 1))
+		self.assertEqual(converter.wideToStrOffsets(3, 4), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(3, 5), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(3, 6), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(4, 4), (2, 2))
+		self.assertEqual(converter.wideToStrOffsets(4, 5), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(4, 6), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(5, 5), (2, 2))
+		self.assertEqual(converter.wideToStrOffsets(5, 6), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(6, 6), (3, 3))
+
+	def test_mixedSurrogatePairsAndNonSurrogates(self):
+		converter = WideStringOffsetConverter(text=u"a\U0001f926b") # a🤦b
+		self.assertEqual(converter.strLength, 3)
+		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.wideToStrOffsets(0, 2), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(0, 3), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(0, 4), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(1, 1), (1, 1))
+		self.assertEqual(converter.wideToStrOffsets(1, 2), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(1, 3), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(1, 4), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(2, 2), (1, 1))
+		self.assertEqual(converter.wideToStrOffsets(2, 3), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(2, 4), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(3, 3), (2, 2))
+		self.assertEqual(converter.wideToStrOffsets(3, 4), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(4, 4), (3, 3))
+
+	def test_mixedSurrogatePairsNonSurrogatesAndSingleSurrogates(self):
+		"""
+		Tests surrogate pairs, non surrogates as well as
+		single surrogate characters (i.e. incomplete pairs)
+		"""
+		converter = WideStringOffsetConverter(text=u"a\ud83e\U0001f926\udd26b")
+		self.assertEqual(converter.strLength, 5)
+		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
+		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))
+		self.assertEqual(converter.wideToStrOffsets(0, 2), (0, 2))
+		self.assertEqual(converter.wideToStrOffsets(0, 3), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(0, 4), (0, 3))
+		self.assertEqual(converter.wideToStrOffsets(0, 5), (0, 4))
+		self.assertEqual(converter.wideToStrOffsets(0, 6), (0, 5))
+		self.assertEqual(converter.wideToStrOffsets(1, 1), (1, 1))
+		self.assertEqual(converter.wideToStrOffsets(1, 2), (1, 2))
+		self.assertEqual(converter.wideToStrOffsets(1, 3), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(1, 4), (1, 3))
+		self.assertEqual(converter.wideToStrOffsets(1, 5), (1, 4))
+		self.assertEqual(converter.wideToStrOffsets(1, 6), (1, 5))
+		self.assertEqual(converter.wideToStrOffsets(2, 2), (2, 2))
+		self.assertEqual(converter.wideToStrOffsets(2, 3), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(2, 4), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(2, 5), (2, 4))
+		self.assertEqual(converter.wideToStrOffsets(2, 6), (2, 5))
+		self.assertEqual(converter.wideToStrOffsets(3, 3), (2, 2))
+		self.assertEqual(converter.wideToStrOffsets(3, 4), (2, 3))
+		self.assertEqual(converter.wideToStrOffsets(3, 5), (2, 4))
+		self.assertEqual(converter.wideToStrOffsets(3, 6), (2, 5))
+		self.assertEqual(converter.wideToStrOffsets(4, 4), (3, 3))
+		self.assertEqual(converter.wideToStrOffsets(4, 5), (3, 4))
+		self.assertEqual(converter.wideToStrOffsets(4, 6), (3, 5))
+		self.assertEqual(converter.wideToStrOffsets(5, 5), (4, 4))
+		self.assertEqual(converter.wideToStrOffsets(5, 6), (4, 5))
+		self.assertEqual(converter.wideToStrOffsets(6, 6), (5, 5))
+

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -194,3 +194,34 @@ class TestWideToStrOffsets(unittest.TestCase):
 		self.assertEqual(converter.wideToStrOffsets(5, 6), (4, 5))
 		self.assertEqual(converter.wideToStrOffsets(6, 6), (5, 5))
 
+class TestEdgeCases(unittest.TestCase):
+	"""
+	Tests for edge cases, such as offsets out of range of a string,
+	or end offsets less than start offsets.
+	"""
+
+	def test_wideToStrOffsets(self):
+		converter = WideStringOffsetConverter(text="abc")
+		self.assertEqual(converter.strLength, 3)
+		self.assertEqual(
+			converter.wideToStrOffsets(-1, 0, raiseOnError=False),
+			(0, 0))
+		self.assertEqual(
+			converter.wideToStrOffsets(0, 4, raiseOnError=False),
+			(0, 3))
+		self.assertRaises(IndexError, converter.wideToStrOffsets, -1, 0, raiseOnError=True)
+		self.assertRaises(IndexError, converter.wideToStrOffsets, 0, 4, raiseOnError=True)
+		self.assertRaises(ValueError, converter.wideToStrOffsets, 1, 0)
+
+	def test_strToWideOffsets(self):
+		converter = WideStringOffsetConverter(text="abc")
+		self.assertEqual(converter.wideStringLength, 3)
+		self.assertEqual(
+			converter.strToWideOffsets(-1, 0, raiseOnError=False),
+			(0, 0))
+		self.assertEqual(
+			converter.strToWideOffsets(0, 4, raiseOnError=False),
+			(0, 3))
+		self.assertRaises(IndexError, converter.strToWideOffsets, -1, 0, raiseOnError=True)
+		self.assertRaises(IndexError, converter.strToWideOffsets, 0, 4, raiseOnError=True)
+		self.assertRaises(ValueError, converter.strToWideOffsets, 1, 0)

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -10,6 +10,10 @@
 import unittest
 from textUtils import WideStringOffsetConverter
 
+FACE_PALM = u"\U0001f926" # 🤦
+SMILE = u"\U0001f60a" # 😊
+THUMBS_UP = u"\U0001f44d" # 👍
+
 class TestStrToWideOffsets(unittest.TestCase):
 	"""
 	Tests that ensure that offsets in a string are properly converted to wide string offsets.
@@ -31,7 +35,7 @@ class TestStrToWideOffsets(unittest.TestCase):
 		self.assertEqual(converter.strToWideOffsets(3, 3), (3, 3))
 
 	def test_surrogatePairs(self):
-		converter = WideStringOffsetConverter(text=u"\U0001f926\U0001f60a\U0001f44d") # 🤦😊👍
+		converter = WideStringOffsetConverter(text=FACE_PALM + SMILE + THUMBS_UP)
 		self.assertEqual(converter.wideStringLength, 6)
 		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
 		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 2))
@@ -45,7 +49,7 @@ class TestStrToWideOffsets(unittest.TestCase):
 		self.assertEqual(converter.strToWideOffsets(3, 3), (6, 6))
 
 	def test_mixedSurrogatePairsAndNonSurrogates(self):
-		converter = WideStringOffsetConverter(text=u"a\U0001f926b") # a🤦b
+		converter = WideStringOffsetConverter(text=u"a" + FACE_PALM + u"b") # a🤦b
 		self.assertEqual(converter.wideStringLength, 4)
 		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
 		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 1))
@@ -63,7 +67,7 @@ class TestStrToWideOffsets(unittest.TestCase):
 		Tests surrogate pairs, non surrogates as well as
 		single surrogate characters (i.e. incomplete pairs)
 		"""
-		converter = WideStringOffsetConverter(text=u"a\ud83e\U0001f926\udd26b")
+		converter = WideStringOffsetConverter(text=u"a" + u"\ud83e" + FACE_PALM + u"\udd26" + u"b")
 		self.assertEqual(converter.wideStringLength, 6)
 		self.assertEqual(converter.strToWideOffsets(0, 0), (0, 0))
 		self.assertEqual(converter.strToWideOffsets(0, 1), (0, 1))
@@ -108,7 +112,7 @@ class TestWideToStrOffsets(unittest.TestCase):
 		self.assertEqual(converter.wideToStrOffsets(3, 3), (3, 3))
 
 	def test_surrogatePairs(self):
-		converter = WideStringOffsetConverter(text=u"\U0001f926\U0001f60a\U0001f44d") # 🤦😊👍
+		converter = WideStringOffsetConverter(text=FACE_PALM + SMILE + THUMBS_UP)
 		self.assertEqual(converter.strLength, 3)
 		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
 		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))
@@ -140,7 +144,7 @@ class TestWideToStrOffsets(unittest.TestCase):
 		self.assertEqual(converter.wideToStrOffsets(6, 6), (3, 3))
 
 	def test_mixedSurrogatePairsAndNonSurrogates(self):
-		converter = WideStringOffsetConverter(text=u"a\U0001f926b") # a🤦b
+		converter = WideStringOffsetConverter(text=u"a" + FACE_PALM + u"b") # a🤦b
 		self.assertEqual(converter.strLength, 3)
 		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
 		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))
@@ -163,7 +167,7 @@ class TestWideToStrOffsets(unittest.TestCase):
 		Tests surrogate pairs, non surrogates as well as
 		single surrogate characters (i.e. incomplete pairs)
 		"""
-		converter = WideStringOffsetConverter(text=u"a\ud83e\U0001f926\udd26b")
+		converter = WideStringOffsetConverter(text=u"a" + u"\ud83e" + FACE_PALM + u"\udd26" + u"b")
 		self.assertEqual(converter.strLength, 5)
 		self.assertEqual(converter.wideToStrOffsets(0, 0), (0, 0))
 		self.assertEqual(converter.wideToStrOffsets(0, 1), (0, 1))

--- a/tests/unit/textProvider.py
+++ b/tests/unit/textProvider.py
@@ -11,10 +11,19 @@ See the L{BasicTextProvider} class.
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 import textInfos
 from textInfos.offsets import Offsets
+import textUtils
 
 class BasicTextInfo(NVDAObjectTextInfo):
 	# NVDAHelper is not initialized, so we can't use Uniscribe.
 	useUniscribe = False
+	# Most of our code use UTF-16 as internal encoding.
+	# Mimic this behavior, so we can also implicitly test textUtils module code
+	encoding = NVDAObjectTextInfo._WCHAR_ENCODING
+
+	def _getStoryLength(self):
+		# NVDAObjectTextInfo will just return the str length of the story text,.
+		# As we are using UTF-16 as the internal encoding for this TextInfo, this is incorrect.
+		return textUtils.WideStringOffsetConverter(self._getStoryText()).wideStringLength
 
 	def _get_offsets(self):
 		return (self._startOffset, self._endOffset)

--- a/tests/unit/textProvider.py
+++ b/tests/unit/textProvider.py
@@ -18,7 +18,7 @@ class BasicTextInfo(NVDAObjectTextInfo):
 	useUniscribe = False
 	# Most of our code use UTF-16 as internal encoding.
 	# Mimic this behavior, so we can also implicitly test textUtils module code
-	encoding = NVDAObjectTextInfo._WCHAR_ENCODING
+	encoding = textUtils.WCHAR_ENCODING
 
 	def _getStoryLength(self):
 		# NVDAObjectTextInfo will just return the str length of the story text,.


### PR DESCRIPTION
### Link to issue number:
Closes #8981
Related to #8981
Follow up of #9044 

### Summary of the issue:
On Windows, wide characters are two bytes in size. This is also the case in python 2. This is best explained with an example:

```
>>> len(u"😉")
2
```

In Python 3 however, strings are saved using a variable byte size, based on the number of bytes that is needed to store the highest code point in the string. One index always corresponds with one code point.

A much more detailed description of the problem can be found in #8981.

### Description of how this pull request fixes the issue:
This pr currently only introduces a new textUtils module that intends to mitigate issues introduced with the Python 3 transition. Most offset based TextInfos are based on a two bytes wide character string representation. For example, uniscribe uses 2 byte wide characters, and therefore 😉 is treated as two characters by uniscribe whereas Python 3 treats it as one.

 This is where textUtils.WideStringOffsetConverter comes into view. This new class keeps the decoded and encoded form of a string in one object. This object can be used to convert string offsets between two implementations, namely the Python 3 one offset per code poitn implementation, and the Windows wide character implementation with surrogate offsets.

The initial version of this pr implemented a broader approach with a class that inherrited from str. After discussion with @feerrenrut and @michaelDCurran, it has been decided not to do this.
The initial pr also contained support for other encodings, particularly UTF-8. However, investigation revealed that this is far from ideal to store in one class. Furthermore, the only offsets implementation that uses UTF-8 for its internal encoding is Scintilla/Notepad++, and that implementation offers everything we need for text range ffetching.

### Testing performed:
Tested using the python 3 interpreter, running this branch from source with the fixes from the try-py3_ignoreSomeIssues branch applied. Also, most importantly, we have working unitTests. note that both the test_textUtils and test_textInfos modules apply here.

### Known issues with pull request:
None

### Change log entry:
May be we need to file some information in the changes for developers section, particularly about the new encoding property on OffsetsTextInfo