### PR TITLE
Fix errors when profile name contains unicode characters

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2432,13 +2432,15 @@ class ConfigProfileActivationCommands(ScriptableObject):
 
 	@classmethod
 	def _getScriptNameForProfile(cls, name):
+		name = name.encode("mbcs")
 		invalidChars = set()
 		for c in name:
 			if not c.isalnum() and c != "_":
 				invalidChars.add(c)
 		for c in invalidChars:
 			name=name.replace(c, b16encode(c))
-		return str("profile_%s" % name)
+		# Python 3: Revisit this to ensure that script names are decoded correctly
+		return "profile_%s" % name
 
 	@classmethod
 	def _profileScript(cls, name):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2432,7 +2432,7 @@ class ConfigProfileActivationCommands(ScriptableObject):
 
 	@classmethod
 	def _getScriptNameForProfile(cls, name):
-		name = name.encode("mbcs")
+		name = name.encode("utf-8")
 		invalidChars = set()
 		for c in name:
 			if not c.isalnum() and c != "_":


### PR DESCRIPTION
### Link to issue number:
Fixes #9561
Fixes https://github.com/nvaccess/nvda/pull/8844#discussion_r283079112

### Summary of the issue:
When creating configuration profiles with characters that aren't in the ascii range, errors occur.

### Description of how this pull request fixes the issue:
When creating a configuration profile script name, first convert it to mbcs.

### Testing performed:
Tested with a configuration profile containing an emoji in its name. I was able to create it, assign a gesture to it and activate/deactivate it.

### Known issues with pull request:
1. The chance of creating duplicate scripts has slightly increased this way.
2. This needs to be revisited during the python 3 transition, as we probably have to decode the profile name before returning the desired script name.
3. The function to create a profile script name now assumes that a python variable name may only contain alphanumric characters and an underscore. However, with setattr and getattr, these limitations do not apply, you can even create script names with spaces in it. I'm still temped to keep the current conventions though.

### Change log entry:
None