### PR TITLE
Fix OneCore rateboost always initialized at 50% rate and SSML converter issues

### DIFF
--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -140,7 +140,7 @@ class SynthDriver(SynthDriver):
 		self._dll.ocSpeech_getCurrentVoiceLanguage.restype = ctypes.c_wchar_p
 		# Set initial values for parameters that can't be queried when prosody is not supported.
 		# This initialises our cache for the value.
-		# When prosody is supported, the value are used for cachign reasons only.
+		# When prosody is supported, the values are used for cachign reasons.
 		self._rate = 50
 		self._pitch = 50
 		self._volume = 100
@@ -277,6 +277,8 @@ class SynthDriver(SynthDriver):
 	def _set_rateBoost(self, enable):
 		if enable == self._rateBoost:
 			return
+		# Use the cached rate to calculate the new rate with rate boost enabled.
+		# If we don't, getting the rate property will return the default rate when initializing the driver and applying settings.
 		rate = self._rate
 		self._rateBoost = enable
 		self.rate = rate

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -33,7 +33,9 @@ ocSpeech_Callback = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_int, ctypes
 
 class _OcSsmlConverter(speechXml.SsmlConverter):
 
-	def _convertProsody(self, command, attr, default, base):
+	def _convertProsody(self, command, attr, default, base=None):
+		if base is None:
+			base = default
 		if command.multiplier == 1 and base == default:
 			# Returning to synth default.
 			return speechXml.DelAttrCommand("prosody", attr)
@@ -44,11 +46,13 @@ class _OcSsmlConverter(speechXml.SsmlConverter):
 			return speechXml.SetAttrCommand("prosody", attr, "%d%%" % val)
 
 	def convertRateCommand(self, command):
-		return self._convertProsody(command, "rate", 50, self._rate)
+		return self._convertProsody(command, "rate", 50)
+
 	def convertPitchCommand(self, command):
-		return self._convertProsody(command, "pitch", 50, self._pitch)
+		return self._convertProsody(command, "pitch", 50)
+
 	def convertVolumeCommand(self, command):
-		return self._convertProsody(command, "volume", 100, self._volume)
+		return self._convertProsody(command, "volume", 100)
 
 	def convertCharacterModeCommand(self, command):
 		# OneCore's character speech sounds weird and doesn't support pitch alteration.
@@ -81,6 +85,15 @@ class _OcPreAPI5SsmlConverter(_OcSsmlConverter):
 		yield self.convertPitchCommand(speech.PitchCommand(multiplier=1))
 		for command in commands:
 			yield command
+
+	def convertRateCommand(self, command):
+		return self._convertProsody(command, "rate", 50, self._rate)
+
+	def convertPitchCommand(self, command):
+		return self._convertProsody(command, "pitch", 50, self._pitch)
+
+	def convertVolumeCommand(self, command):
+		return self._convertProsody(command, "volume", 100, self._volume)
 
 class SynthDriver(SynthDriver):
 


### PR DESCRIPTION
 ### Link to issue number:
fixes #9558, regression from #8934 
Fixes #9576 
 
### Summary of the issue:
In #8934, a new method was introduced to set pitch, volume and rate for OneCore voices. When setting these parameters, NVDA queues an entry to self._queuedSpeech, which is then processed in self._processQueue. This means that there is a delay between changing and applying the parameter.

Now the following happens when initializing the driver with rate boost on:

1. Volume, pitch, rate and rate boost are loaded from config
2. Volume, pitch and rate changes are queued. Rate boost fetches the current rate, enables rate boost and than sets the rate again, which again queues a change of the rate to the speech queue. However, when fetching the rate during that action, the rate change queued earlier has not yet been processed.
3. After that, when the actual queue is processed, the queue contains two rate changes, namely the initial rate change according to the config, and the second rate change that was initiated by enabling rate boost, effectively reseeting it to the default rate.

### Description of how this pull request fixes the issue:
When setting pitch, volume and rate, parameters are still queued to the speech queue. However, the set values are also cached in _pitch, _volume and _rate attributes, respectively. Rate boost now fetches the rate from self._rate, making sure that the proper rate is used when calculating the new rate after enabling rate boost.

This pr also fixes errors caused when processing speech.Pitch/Volume/RateCommands.

### Possible alternative
Forcefully process the speech queue before fetching the rate when setting rate boost. I decided not to do this, as this could have unexpected side effects whe enabling rate boost while speech is in the queue.

### Testing performed:
1. Tested the steps from #9558, I was no longer able to reproduce the issue.
2. Spelled a long line of text with mixed case. Ensured that pitch changes occur as they should.
3. Turned on speak typed characters and tested that typing upper case and lower case letters changes pitch as it should.
4. Adjusted rate in the Settings dialog. Ensured that the rate is changed appropriately as the new percentage is spoken. Tested with up arrow/down arrow/Page up/page down/home/end
5. Did the same with the settings ring.
6. Tested Pitch/Volume/RateCommands

### Known issues with pull request:
Volume and pitch are cached without actually using the cached attributes later on. However, it made more sense to cache them all than creating a unbalanced approach.

### Change log entry:
None