### PR TITLE
Fix table navigation commands in Google Docs

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -114,8 +114,6 @@ template<typename TableType> inline void fillTableCounts(VBufStorage_controlFiel
 	wostringstream s;
 	long count = 0;
 	// Fetch row and column counts and add them as attributes on this vbuf node.
-	// The first set: table-physicalrowcount and table-physicalcolumncount represent the physical topology of the table and can be used programmatically to understand table limits.
-	// The second set: table-rowcount and table-columncount are duplicates of the physical ones, however may be overridden later on in fillVBuf with ARIA attributes. They are what is reported to the user.
 	if (paccTable->get_nRows(&count) == S_OK) {
 		s << count;
 		node->addAttribute(L"table-rowcount", s.str());
@@ -804,7 +802,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 
 	// Add some presentational table attributes
 	// Note these are only for reporting, the physical table attributes (table-rownumber etc) for aiding in navigation etc are added  later on.
-	// propagate table-rownumber down to the cell as Gecko only includes it on the row itself
+	// propagate table-rownumber-presentational down to the cell as Gecko only includes it on the row itself
 	if(parentPresentationalRowNumber) 
 		parentNode->addAttribute(L"table-rownumber-presentational",parentPresentationalRowNumber);
 	const wchar_t* presentationalRowNumber=NULL;

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -803,19 +803,27 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 	// Add some presentational table attributes
 	// Note these are only for reporting, the physical table attributes (table-rownumber etc) for aiding in navigation etc are added  later on.
 	// propagate table-rownumber-presentational down to the cell as Gecko only includes it on the row itself
-	if(parentPresentationalRowNumber) 
+	if(parentPresentationalRowNumber) {
 		parentNode->addAttribute(L"table-rownumber-presentational",parentPresentationalRowNumber);
+	}
 	const wchar_t* presentationalRowNumber=NULL;
-	if((IA2AttribsMapIt = IA2AttribsMap.find(L"rowindex")) != IA2AttribsMap.end()) {
+	IA2AttribsMapIt = IA2AttribsMap.find(L"rowindex");
+	if(IA2AttribsMapIt != IA2AttribsMap.end()) {
 		parentNode->addAttribute(L"table-rownumber-presentational",IA2AttribsMapIt->second);
 		presentationalRowNumber=IA2AttribsMapIt->second.c_str();
 	}
-	if((IA2AttribsMapIt = IA2AttribsMap.find(L"colindex")) != IA2AttribsMap.end())
+	IA2AttribsMapIt = IA2AttribsMap.find(L"colindex");
+	if(IA2AttribsMapIt != IA2AttribsMap.end()) {
 		parentNode->addAttribute(L"table-columnnumber-presentational",IA2AttribsMapIt->second);
-	if((IA2AttribsMapIt = IA2AttribsMap.find(L"rowcount")) != IA2AttribsMap.end())
+	}
+	IA2AttribsMapIt = IA2AttribsMap.find(L"rowcount");
+	if(IA2AttribsMapIt != IA2AttribsMap.end()) {
 		parentNode->addAttribute(L"table-rowcount-presentational",IA2AttribsMapIt->second);
-	if((IA2AttribsMapIt = IA2AttribsMap.find(L"colcount")) != IA2AttribsMap.end())
+	}
+	IA2AttribsMapIt = IA2AttribsMap.find(L"colcount");
+	if(IA2AttribsMapIt != IA2AttribsMap.end()) {
 		parentNode->addAttribute(L"table-columncount-presentational",IA2AttribsMapIt->second);
+	}
 
 	BSTR value=NULL;
 	if(pacc->get_accValue(varChild,&value)==S_OK) {

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -113,18 +113,16 @@ static IAccessible2* IAccessible2FromIdentifier(int docHandle, int ID) {
 template<typename TableType> inline void fillTableCounts(VBufStorage_controlFieldNode_t* node, IAccessible2* pacc, TableType* paccTable) {
 	wostringstream s;
 	long count = 0;
-	// Fetch row and column counts and add them as two sets of attributes on this vbuf node.
+	// Fetch row and column counts and add them as attributes on this vbuf node.
 	// The first set: table-physicalrowcount and table-physicalcolumncount represent the physical topology of the table and can be used programmatically to understand table limits.
 	// The second set: table-rowcount and table-columncount are duplicates of the physical ones, however may be overridden later on in fillVBuf with ARIA attributes. They are what is reported to the user.
 	if (paccTable->get_nRows(&count) == S_OK) {
 		s << count;
-		node->addAttribute(L"table-physicalrowcount", s.str());
 		node->addAttribute(L"table-rowcount", s.str());
 		s.str(L"");
 	}
 	if (paccTable->get_nColumns(&count) == S_OK) {
 		s << count;
-		node->addAttribute(L"table-physicalcolumncount", s.str());
 		node->addAttribute(L"table-columncount", s.str());
 	}
 }
@@ -151,16 +149,11 @@ inline void fillTableCellInfo_IATable(VBufStorage_controlFieldNode_t* node, IAcc
 	long row, column, rowExtents, columnExtents;
 	boolean isSelected;
 	// Fetch row and column extents and add them as attributes on this node.
-	// for rowNumber and columnNumber, store these as two sets of attributes.
-	// The first set: table-physicalrownumber and table-physicalcolumnnumber represent the physical topology of the table and can be used programmatically to fetch other table cells with IAccessibleTable etc.
-	// The second set: table-rownumber and table-columnnumber are duplicates of the physical ones, however may be overridden later on in fillVBuf with ARIA attributes. They are what is reported to the user.
 	if (paccTable->get_rowColumnExtentsAtIndex(cellIndex, &row, &column, &rowExtents, &columnExtents, &isSelected) == S_OK) {
 		s << row + 1;
-		node->addAttribute(L"table-physicalrownumber", s.str());
 		node->addAttribute(L"table-rownumber", s.str());
 		s.str(L"");
 		s << column + 1;
-		node->addAttribute(L"table-physicalcolumnnumber", s.str());
 		node->addAttribute(L"table-columnnumber", s.str());
 		if (columnExtents > 1) {
 			s.str(L"");
@@ -215,16 +208,11 @@ inline void GeckoVBufBackend_t::fillTableCellInfo_IATable2(VBufStorage_controlFi
 	long row, column, rowExtents, columnExtents;
 	boolean isSelected;
 	// Fetch row and column extents and add them as attributes on this node.
-	// for rowNumber and columnNumber, store these as two sets of attributes.
-	// The first set: table-physicalrownumber and table-physicalcolumnnumber represent the physical topology of the table and can be used programmatically to fetch other table cells with IAccessibleTable etc.
-	// The second set: table-rownumber and table-columnnumber are duplicates of the physical ones, however may be overridden later on in fillVBuf with ARIA attributes. They are what is reported to the user.
 	if (paccTableCell->get_rowColumnExtents(&row, &column, &rowExtents, &columnExtents, &isSelected) == S_OK) {
 		s << row + 1;
-		node->addAttribute(L"table-physicalrownumber", s.str());
 		node->addAttribute(L"table-rownumber", s.str());
 		s.str(L"");
 		s << column + 1;
-		node->addAttribute(L"table-physicalcolumnnumber", s.str());
 		node->addAttribute(L"table-columnnumber", s.str());
 		if (columnExtents > 1) {
 			s.str(L"");
@@ -815,21 +803,21 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 	}
 
 	// Add some presentational table attributes
-	// Note these are only for reporting, the physical table attributes (table-physicalrownumber etc) for aiding in navigation etc are added  later on.
+	// Note these are only for reporting, the physical table attributes (table-rownumber etc) for aiding in navigation etc are added  later on.
 	// propagate table-rownumber down to the cell as Gecko only includes it on the row itself
 	if(parentPresentationalRowNumber) 
-		parentNode->addAttribute(L"table-rownumber",parentPresentationalRowNumber);
+		parentNode->addAttribute(L"table-rownumber-presentational",parentPresentationalRowNumber);
 	const wchar_t* presentationalRowNumber=NULL;
 	if((IA2AttribsMapIt = IA2AttribsMap.find(L"rowindex")) != IA2AttribsMap.end()) {
-		parentNode->addAttribute(L"table-rownumber",IA2AttribsMapIt->second);
+		parentNode->addAttribute(L"table-rownumber-presentational",IA2AttribsMapIt->second);
 		presentationalRowNumber=IA2AttribsMapIt->second.c_str();
 	}
 	if((IA2AttribsMapIt = IA2AttribsMap.find(L"colindex")) != IA2AttribsMap.end())
-		parentNode->addAttribute(L"table-columnnumber",IA2AttribsMapIt->second);
+		parentNode->addAttribute(L"table-columnnumber-presentational",IA2AttribsMapIt->second);
 	if((IA2AttribsMapIt = IA2AttribsMap.find(L"rowcount")) != IA2AttribsMap.end())
-		parentNode->addAttribute(L"table-rowcount",IA2AttribsMapIt->second);
+		parentNode->addAttribute(L"table-rowcount-presentational",IA2AttribsMapIt->second);
 	if((IA2AttribsMapIt = IA2AttribsMap.find(L"colcount")) != IA2AttribsMap.end())
-		parentNode->addAttribute(L"table-columncount",IA2AttribsMapIt->second);
+		parentNode->addAttribute(L"table-columncount-presentational",IA2AttribsMapIt->second);
 
 	BSTR value=NULL;
 	if(pacc->get_accValue(varChild,&value)==S_OK) {

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -558,8 +558,32 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		"""
 		raise NotImplementedError
 
+	def _get_presentationalRowNumber(self):
+		"""
+		An optional version of the rowNumber property used purely for speech and braille presentation if implemented.
+		This is never used for navigational logic.
+		This property should be implemented if the table has virtual content which may not all be loaded at one time.
+		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  rowNumber might be row 2 of 10, the user needs to  be told it is perhaps row 500 (taking all virtual rows into account).
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
+		@rtype: int
+		"""
+		raise NotImplementedError
+
 	def _get_columnNumber(self):
 		"""Retreaves the column number of this object if it is in a table.
+		@rtype: int
+		"""
+		raise NotImplementedError
+
+	def _get_presentationalColumnNumber(self):
+		"""
+		An optional version of the columnNumber property used purely for speech and braille presentation if implemented.
+		This is never used for navigational logic.
+		This property should be implemented if the table has virtual content which may not all be loaded at one time.
+		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  columnNumber might be column 2 of 10, the user needs to  be told it is perhaps column 500 (taking all virtual columns into account).
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
 		@rtype: int
 		"""
 		raise NotImplementedError
@@ -578,8 +602,32 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		"""
 		raise NotImplementedError
 
+	def _get_presentationalRowCount(self):
+		"""
+		An optional version of the rowCount property used purely for speech and braille presentation if implemented.
+		This is never used for navigational logic.
+		This property should be implemented if the table has virtual content which may not all be loaded at one time.
+		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  rowCount might be 10, the user needs to  be told the table really has 1000 rows. 
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
+		@rtype: int
+		"""
+		raise NotImplementedError
+
 	def _get_columnCount(self):
 		"""Retreaves the number of columns this object contains if its a table.
+		@rtype: int
+		"""
+		raise NotImplementedError
+
+	def _get_presentationalColumnCount(self):
+		"""
+		An optional version of the columnCount property used purely for speech and braille presentation if implemented.
+		This is never used for navigational logic.
+		This property should be implemented if the table has virtual content which may not all be loaded at one time.
+		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  columnCount might be 10, the user needs to  be told the table really has 1000 columns. 
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
 		@rtype: int
 		"""
 		raise NotImplementedError

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -255,7 +255,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 
 	@staticmethod
 	def objectFromPoint(x,y):
-		"""Retreaves an NVDAObject instance representing a control in the Operating System at the given x and y coordinates.
+		"""Retrieves an NVDAObject instance representing a control in the Operating System at the given x and y coordinates.
 		@param x: the x coordinate.
 		@type x: int
 		@param y: the y coordinate.
@@ -269,7 +269,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 
 	@staticmethod
 	def objectWithFocus():
-		"""Retreaves the object representing the control currently with focus in the Operating System. This differens from NVDA's focus object as this focus object is the real focus object according to the Operating System, not according to NVDA.
+		"""Retrieves the object representing the control currently with focus in the Operating System. This differens from NVDA's focus object as this focus object is the real focus object according to the Operating System, not according to NVDA.
 		@return: the object with focus.
 		@rtype: L{NVDAObject}
 		"""
@@ -287,7 +287,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 
 	@staticmethod
 	def objectInForeground():
-		"""Retreaves the object representing the current foreground control according to the Operating System. This differes from NVDA's foreground object as this object is the real foreground object according to the Operating System, not according to NVDA.
+		"""Retrieves the object representing the current foreground control according to the Operating System. This differes from NVDA's foreground object as this object is the real foreground object according to the Operating System, not according to NVDA.
 		@return: the foreground object
 		@rtype: L{NVDAObject}
 		"""
@@ -372,7 +372,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 			self._treeInterceptor=None
 
 	def _get_appModule(self):
-		"""Retreaves the appModule representing the application this object is a part of by asking L{appModuleHandler}.
+		"""Retrieves the appModule representing the application this object is a part of by asking L{appModuleHandler}.
 		@return: the appModule
 		@rtype: L{appModuleHandler.AppModule}
 		"""
@@ -418,15 +418,15 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		return ""
 
 	def _get_controllerFor(self):
-		"""Retreaves the object/s that this object controls."""
+		"""Retrieves the object/s that this object controls."""
 		return []
 
 	def _get_actionCount(self):
-		"""Retreaves the number of actions supported by this object."""
+		"""Retrieves the number of actions supported by this object."""
 		return 0
 
 	def getActionName(self,index=None):
-		"""Retreaves the name of an action supported by this object.
+		"""Retrieves the name of an action supported by this object.
 		If index is not given then the default action will be used if it exists.
 		@param index: the optional 0-based index of the wanted action.
 		@type index: int
@@ -442,7 +442,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		raise NotImplementedError
 
 	def _get_defaultActionIndex(self):
-		"""Retreaves the index of the action that is the default."""
+		"""Retrieves the index of the action that is the default."""
 		return 0
 
 	def _get_keyboardShortcut(self):
@@ -458,7 +458,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		raise NotImplementedError
 
 	def _get_states(self):
-		"""Retreaves the current states of this object (example: selected, focused).
+		"""Retrieves the current states of this object (example: selected, focused).
 		@return: a set of  STATE_* constants from L{controlTypes}.
 		@rtype: set of int
 		"""
@@ -487,7 +487,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		return _("Object edges positioned {left:.1f} per cent from left edge of screen, {top:.1f} per cent from top edge of screen, width is {width:.1f} per cent of screen, height is {height:.1f} per cent of screen").format(left=percentFromLeft,top=percentFromTop,width=percentWidth,height=percentHeight)
 
 	def _get_parent(self):
-		"""Retreaves this object's parent (the object that contains this object).
+		"""Retrieves this object's parent (the object that contains this object).
 		@return: the parent object if it exists else None.
 		@rtype: L{NVDAObject} or None
 		"""
@@ -503,35 +503,35 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		return parent
 
 	def _get_next(self):
-		"""Retreaves the object directly after this object with the same parent.
+		"""Retrieves the object directly after this object with the same parent.
 		@return: the next object if it exists else None.
 		@rtype: L{NVDAObject} or None
 		"""
 		return None
 
 	def _get_previous(self):
-		"""Retreaves the object directly before this object with the same parent.
+		"""Retrieves the object directly before this object with the same parent.
 		@return: the previous object if it exists else None.
 		@rtype: L{NVDAObject} or None
 		"""
 		return None
 
 	def _get_firstChild(self):
-		"""Retreaves the first object that this object contains.
+		"""Retrieves the first object that this object contains.
 		@return: the first child object if it exists else None.
 		@rtype: L{NVDAObject} or None
 		"""
 		return None
 
 	def _get_lastChild(self):
-		"""Retreaves the last object that this object contains.
+		"""Retrieves the last object that this object contains.
 		@return: the last child object if it exists else None.
 		@rtype: L{NVDAObject} or None
 		"""
 		return None
 
 	def _get_children(self):
-		"""Retreaves a list of all the objects directly contained by this object (who's parent is this object).
+		"""Retrieves a list of all the objects directly contained by this object (who's parent is this object).
 		@rtype: list of L{NVDAObject}
 		"""
 		children=[]
@@ -553,37 +553,45 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		return self.children[index]
 
 	def _get_rowNumber(self):
-		"""Retreaves the row number of this object if it is in a table.
+		"""Retrieves the row number of this object if it is in a table.
 		@rtype: int
 		"""
 		raise NotImplementedError
 
 	def _get_presentationalRowNumber(self):
 		"""
-		An optional version of the rowNumber property used purely for speech and braille presentation if implemented.
+		An optional version of the rowNumber property 
+		used purely for speech and braille presentation if implemented.
 		This is never used for navigational logic.
 		This property should be implemented if the table has virtual content which may not all be loaded at one time.
-		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
-		Although the  rowNumber might be row 2 of 10, the user needs to  be told it is perhaps row 500 (taking all virtual rows into account).
-		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
+		For example, a table with 1000 rows and 1000 columns, 
+		yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  rowNumber might be row 2 of 10, 
+		the user needs to  be told it is perhaps row 500 (taking all virtual rows into account).
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, 
+		then this property should not be implemented.
 		@rtype: int
 		"""
 		raise NotImplementedError
 
 	def _get_columnNumber(self):
-		"""Retreaves the column number of this object if it is in a table.
+		"""Retrieves the column number of this object if it is in a table.
 		@rtype: int
 		"""
 		raise NotImplementedError
 
 	def _get_presentationalColumnNumber(self):
 		"""
-		An optional version of the columnNumber property used purely for speech and braille presentation if implemented.
+		An optional version of the columnNumber property 
+		used purely for speech and braille presentation if implemented.
 		This is never used for navigational logic.
 		This property should be implemented if the table has virtual content which may not all be loaded at one time.
-		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
-		Although the  columnNumber might be column 2 of 10, the user needs to  be told it is perhaps column 500 (taking all virtual columns into account).
-		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
+		For example, a table with 1000 rows and 1000 columns, 
+		yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  columnNumber might be column 2 of 10, 
+		the user needs to  be told it is perhaps column 500 (taking all virtual columns into account).
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, 
+		then this property should not be implemented.
 		@rtype: int
 		"""
 		raise NotImplementedError
@@ -597,37 +605,45 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		
 
 	def _get_rowCount(self):
-		"""Retreaves the number of rows this object contains if its a table.
+		"""Retrieves the number of rows this object contains if its a table.
 		@rtype: int
 		"""
 		raise NotImplementedError
 
 	def _get_presentationalRowCount(self):
 		"""
-		An optional version of the rowCount property used purely for speech and braille presentation if implemented.
+		An optional version of the rowCount property 
+		used purely for speech and braille presentation if implemented.
 		This is never used for navigational logic.
 		This property should be implemented if the table has virtual content which may not all be loaded at one time.
-		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
-		Although the  rowCount might be 10, the user needs to  be told the table really has 1000 rows. 
-		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
+		For example, a table with 1000 rows and 1000 columns, 
+		yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  rowCount might be 10, 
+		the user needs to  be told the table really has 1000 rows. 
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, 
+		then this property should not be implemented.
 		@rtype: int
 		"""
 		raise NotImplementedError
 
 	def _get_columnCount(self):
-		"""Retreaves the number of columns this object contains if its a table.
+		"""Retrieves the number of columns this object contains if its a table.
 		@rtype: int
 		"""
 		raise NotImplementedError
 
 	def _get_presentationalColumnCount(self):
 		"""
-		An optional version of the columnCount property used purely for speech and braille presentation if implemented.
+		An optional version of the columnCount property 
+		used purely for speech and braille presentation if implemented.
 		This is never used for navigational logic.
 		This property should be implemented if the table has virtual content which may not all be loaded at one time.
-		For example, a table with 1000 rows and 1000 columns, yet the table only shows perhaps 10 rows by 10 columns at a time.
-		Although the  columnCount might be 10, the user needs to  be told the table really has 1000 columns. 
-		If the underlying APIs do not distinguish between virtual and physical cell coordinates, then this property should not be implemented.
+		For example, a table with 1000 rows and 1000 columns, 
+		yet the table only shows perhaps 10 rows by 10 columns at a time.
+		Although the  columnCount might be 10, 
+		the user needs to  be told the table really has 1000 columns. 
+		If the underlying APIs do not distinguish between virtual and physical cell coordinates, 
+		then this property should not be implemented.
 		@rtype: int
 		"""
 		raise NotImplementedError
@@ -657,7 +673,7 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		raise NotImplementedError
 
 	def _get_table(self):
-		"""Retreaves the object that represents the table that this object is contained in, if this object is a table cell.
+		"""Retrieves the object that represents the table that this object is contained in, if this object is a table cell.
 		@rtype: L{NVDAObject}
 		"""
 		raise NotImplementedError
@@ -771,13 +787,13 @@ class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContaine
 		return child
 
 	def _get_childCount(self):
-		"""Retreaves the number of children this object contains.
+		"""Retrieves the number of children this object contains.
 		@rtype: int
 		"""
 		return len(self.children)
 
 	def _get_activeChild(self):
-		"""Retreaves the child of this object that currently has, or contains, the focus.
+		"""Retrieves the child of this object that currently has, or contains, the focus.
 		@return: the active child if it has one else None
 		@rtype: L{NVDAObject} or None
 		"""
@@ -807,21 +823,21 @@ Tries to force this object to take the focus.
 		raise NotImplementedError
 
 	def _get_labeledBy(self):
-		"""Retreaves the object that this object is labeled by (example: the static text label beside an edit field).
+		"""Retrieves the object that this object is labeled by (example: the static text label beside an edit field).
 		@return: the label object if it has one else None.
 		@rtype: L{NVDAObject} or None 
 		"""
 		return None
 
 	def _get_positionInfo(self):
-		"""Retreaves position information for this object such as its level, its index with in a group, and the number of items in that group.
+		"""Retrieves position information for this object such as its level, its index with in a group, and the number of items in that group.
 		@return: a dictionary containing any of level, groupIndex and similarItemsInGroup.
 		@rtype: dict
 		"""
 		return {}
 
 	def _get_processID(self):
-		"""Retreaves an identifyer of the process this object is a part of.
+		"""Retrieves an identifyer of the process this object is a part of.
 		@rtype: int
 		"""
 		raise NotImplementedError

--- a/source/braille.py
+++ b/source/braille.py
@@ -653,8 +653,8 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 		reportTableCellCoords = formatConfig["reportTableCellCoords"]
 		props = {
 			"states": states,
-			"rowNumber": field.get("table-rownumber"),
-			"columnNumber": field.get("table-columnnumber"),
+			"rowNumber": (field.get("table-rownumber-presentational") or field.get("table-rownumber")),
+			"columnNumber": (field.get("table-columnnumber-presentational") or field.get("table-columnnumber")),
 			"rowSpan": field.get("table-rowsspanned"),
 			"columnSpan": field.get("table-columnsspanned"),
 			"includeTableCellCoords": reportTableCellCoords,

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -34,10 +34,6 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 	A document that supports standard table navigiation comments (E.g. control+alt+arrows to move between table cells).
 	The document could be an NVDAObject, or a BrowseModeDocument treeIntercepter for example.
 	"""
-	#: The controlField attribute name that should be used as the row number when navigating in a table. By default this is the same as the presentational attribute name
-	navigationalTableRowNumberAttributeName="table-rownumber"
-	#: The controlField attribute name that should be used as the column number when navigating in a table. By default this is the same as the presentational attribute name
-	navigationalTableColumnNumberAttributeName="table-columnnumber"
 
 	def _getTableCellCoords(self, info):
 		"""
@@ -68,12 +64,12 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			tableID=attrs.get('table-id')
 			if tableID is None or tableID in layoutIDs:
 				continue
-			if self.navigationalTableColumnNumberAttributeName in attrs and not attrs.get('table-layout'):
+			if "table-columnnumber" in attrs and not attrs.get('table-layout'):
 				break
 		else:
 			raise LookupError("Not in a table cell")
 		return (attrs["table-id"],
-			attrs[self.navigationalTableRowNumberAttributeName], attrs[self.navigationalTableColumnNumberAttributeName],
+			attrs["table-rownumber"], attrs["table-columnnumber"],
 			attrs.get("table-rowsspanned", 1), attrs.get("table-columnsspanned", 1))
 
 	def _getTableCellAt(self,tableID,startPos,row,column):
@@ -169,6 +165,7 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		speech.speakTextInfo(info,formatConfig=formatConfig,reason=controlTypes.REASON_CARET)
 		info.collapse()
 		self.selection = info
+		#info.updateCaret()
 
 	def script_nextRow(self, gesture):
 		self._tableMovementScriptHelper(axis="row", movement="next")

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -165,7 +165,6 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		speech.speakTextInfo(info,formatConfig=formatConfig,reason=controlTypes.REASON_CARET)
 		info.collapse()
 		self.selection = info
-		#info.updateCaret()
 
 	def script_nextRow(self, gesture):
 		self._tableMovementScriptHelper(axis="row", movement="next")

--- a/source/speech.py
+++ b/source/speech.py
@@ -1252,7 +1252,17 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 		# Table.
 		rowCount=(attrs.get("table-rowcount-presentational") or attrs.get("table-rowcount"))
 		columnCount=(attrs.get("table-columncount-presentational") or attrs.get("table-columncount"))
-		return " ".join((nameText,roleText,stateText, getSpeechTextForProperties(_tableID=tableID, rowCount=rowCount, columnCount=columnCount),levelText))
+		return " ".join((
+			nameText,
+			roleText,
+			stateText, 
+			getSpeechTextForProperties(
+				_tableID=tableID, 
+				rowCount=rowCount, 
+				columnCount=columnCount
+			),
+			levelText
+		))
 	elif nameText and reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role in (controlTypes.ROLE_GROUPING, controlTypes.ROLE_PROPERTYPAGE):
 		# #3321, #709: Report the name of groupings (such as fieldsets) and tab pages for quicknav and focus jumps
 		return " ".join((nameText,roleText))

--- a/source/speech.py
+++ b/source/speech.py
@@ -273,10 +273,23 @@ def speakObjectProperties(obj,reason=controlTypes.REASON_QUERY,index=None,**allo
 			if positionInfo is None:
 				positionInfo=obj.positionInfo
 		elif value:
-			try:
-				newPropertyValues[name]=getattr(obj,name)
-			except NotImplementedError:
-				pass
+			# Certain properties such as row and column numbers have presentational versions, which should be used for speech if they are available.
+			# Therefore redirect to those values first if they are available, falling back to the normal properties if not.
+			names=[name]
+			if name=='rowNumber':
+				names.insert(0,'presentationalRowNumber')
+			elif name=='columnNumber':
+				names.insert(0,'presentationalColumnNumber')
+			elif name=='rowCount':
+				names.insert(0,'presentationalRowCount')
+			elif name=='columnCount':
+				names.insert(0,'presentationalColumnCount')
+			for tryName in names:
+				try:
+					newPropertyValues[name]=getattr(obj,tryName)
+				except NotImplementedError:
+					continue
+				break
 	if positionInfo:
 		if allowedProperties.get('positionInfo_level',False) and 'level' in positionInfo:
 			newPropertyValues['positionInfo_level']=positionInfo['level']
@@ -1237,7 +1250,9 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 		containerContainsText=_("with %s items")%childControlCount
 	elif fieldType=="start_addedToControlFieldStack" and role==controlTypes.ROLE_TABLE and tableID:
 		# Table.
-		return " ".join((nameText,roleText,stateText, getSpeechTextForProperties(_tableID=tableID, rowCount=attrs.get("table-rowcount"), columnCount=attrs.get("table-columncount")),levelText))
+		rowCount=(attrs.get("table-rowcount-presentational") or attrs.get("table-rowcount"))
+		columnCount=(attrs.get("table-columncount-presentational") or attrs.get("table-columncount"))
+		return " ".join((nameText,roleText,stateText, getSpeechTextForProperties(_tableID=tableID, rowCount=rowCount, columnCount=columnCount),levelText))
 	elif nameText and reason==controlTypes.REASON_FOCUS and fieldType == "start_addedToControlFieldStack" and role in (controlTypes.ROLE_GROUPING, controlTypes.ROLE_PROPERTYPAGE):
 		# #3321, #709: Report the name of groupings (such as fieldsets) and tab pages for quicknav and focus jumps
 		return " ".join((nameText,roleText))
@@ -1246,8 +1261,8 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 		reportTableHeaders = formatConfig["reportTableHeaders"]
 		reportTableCellCoords = formatConfig["reportTableCellCoords"]
 		getProps = {
-			'rowNumber': attrs.get("table-rownumber"),
-			'columnNumber': attrs.get("table-columnnumber"),
+			'rowNumber': (attrs.get("table-rownumber-presentational") or attrs.get("table-rownumber")),
+			'columnNumber': (attrs.get("table-columnnumber-presentational") or attrs.get("table-columnnumber")),
 			'rowSpan': attrs.get("table-rowsspanned"),
 			'columnSpan': attrs.get("table-columnsspanned"),
 			'includeTableCellCoords': reportTableCellCoords

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -44,7 +44,7 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 		return super(Gecko_ia2_TextInfo, self)._getBoundingRectFromOffset(offset)
 
 	def _normalizeControlField(self,attrs):
-		for attr in ("table-physicalrownumber","table-physicalcolumnnumber","table-physicalrowcount","table-physicalcolumncount"):
+		for attr in ("table-rownumber-presentational","table-columnnumber-presentational","table-rowcount-presentational","table-columncount-presentational"):
 			attrVal=attrs.get(attr)
 			if attrVal is not None:
 				attrs[attr]=int(attrVal)
@@ -314,12 +314,6 @@ class Gecko_ia2(VirtualBuffer):
 		if not self._handleScrollTo(obj):
 			return nextHandler()
 	event_scrollingStart.ignoreIsReady = True
-
-	# NVDA exposes IAccessible2 table interface row and column numbers as table-physicalrownumber and table-physicalcolumnnumber respectively.
-	# These should be used when navigating the physical table (I.e. these values should be provided to the table interfaces).
-	# The presentational table-columnnumber and table-rownumber attributes are normally duplicates of the physical ones, but are overridden  by the values of aria-rowindex and aria-colindex if present.
-	navigationalTableRowNumberAttributeName="table-physicalrownumber"
-	navigationalTableColumnNumberAttributeName="table-physicalcolumnnumber"
 
 	def _getTableCellAt(self,tableID,startPos,destRow,destCol):
 		docHandle = self.rootDocHandle

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ What's New in NVDA
 - Add-ons with names that only differ in capitalization are no longer treated as separate add-ons. (#9334)
 - For Windows OneCore voices, the rate set in NVDA is no longer affected by the rate set in Windows 10 Speech Settings. (#7498)
 - The log can now be opened with control+F1 when there is no Dev info for the current navigator object. (#8613)
+- It is again possible to use NvDA's table navigation commands in Google Docs, in Firefox and Chrome. (#9494)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9494

### Summary of the issue:
Currently trying to move around a table in Google Docs with Firefox or Chrome, using NVDA's table navigation commands fails with  an exception.
Specifically, NVDAObject's rowNumber, columnNumber etc expose web author specified rowindex and colindex ARIA values which don't work with the other IAccessible2 table methods for looking up cells.
For browseMode at least, this was already partly addressed by exposing special table-physical* attributes on controlFields which were used for table navigation, where as presentation (speech, braille) used the standard table-* attributes.

### Description of how this pull request fixes the issue:
Rewrite how presentational verses physical table properties are exposed entirely. Instead exposing default / physical table properties as their standard rowNumber, columnNumber etc. If the underlying API does have presentational coordinates, then expose these as the presentational* values, using them only for presentation, and not physical table navigation.
Specific changes:
* Expose the real IAccessible2 table coordinates for navigation via rowNumber, columnNumber, rowCount and columnCount NvDAObject properties, and controlField attributes, rather than IA2-specific table properties.
* Add new optional properties to NVDAObjects: presentationalRowNumber, presentationalColumnNumber, presentationalRowCount and presentationalColumnCount.
* Make use of these presentational* properties in speech if they are implemented, otherwise fall back to the standard properties.
* Provide implementations of the presentational* properties for tables on NVDAObjects for IAccessible2 that uses rowindex and colindex IA2 aria attributes, allowing web authors to override how table coordinates are presented without confusing actual table navigation logic.
* Similarly for controlFields, expose table-* and table-*-presentational attributes allowing for overriding of table coordinate presentation when the web author has specified it.
* IA2TextInfo's updateSelection method: If the requested start and end offsets are the same (I.e. the caller wants a collapsed selection) call setCaretOffset instead. This gets around strange bugs in Google Chrome / Google Docs where making collapsed selections in table cells selects the entire cell.

### Testing performed:
Using this testcase: 
[table.html.txt](https://github.com/nvaccess/nvda/files/3171353/table.html.txt)
Opened it in both Mozilla Firefox and Google Chrome.
Ensured that:
* Arrowing into the first table, and then switching to focus mode, that NVDA's table navigation commands (control/alt+up/down/left/right) successfully moved around the table.
*  Ensured that when arrowing through the second table in browseMode, that table coordinates reported correctly. (The table is a standard table with no ARIA properties). Also ensured that table navigation commands still worked.
* When arrowing into the 3rd table, ensured that table coordinates reported as expected. Although this table is only 3 rows by 2 columns, it should report as 20 rows by 20 columns, columns should be 10 and 11, and rows should be numbered: 1, 10 and 11. These coordinates have been specified using aria-rowindex etc.
* Created a table in Google Docs with Braille mode on, and ensured that  NVDA's table navigation commands successfully move around the table.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* It is again possible to use NvDA's table navigation commands in Google Docs, in Firefox and Chrome.