### PR TITLE
Fix overlooked rename of ID to id in synthDriverHandler.LanguageInfo

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -480,5 +480,5 @@ class LanguageInfo(driverHandler.StringParameterInfo):
 	def __init__(self, id):
 		"""Given a language ID (locale name) the description is automatically calculated."""
 		displayName = languageHandler.getLanguageDescription(id)
-		super(LanguageInfo,self).__init__(ID, displayName)
+		super(LanguageInfo,self).__init__(id, displayName)
 


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/issues/7452#issuecomment-493666107

### Summary of the issue:
When renaming ID to id on driverHandler.StringParameterInfo, one case was missed for LanguageInfo.

### Description of how this pull request fixes the issue:
Fixed as suggested by @beqabeqa473

### Testing performed:
@beqabeqa473: With what driver did you encounter this? Would you be able to test this?

### Known issues with pull request:
None

### Change log entry:
None