### PR TITLE
work around application with multibyte file name and Python 2

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -171,7 +171,9 @@ def fetchAppModule(processID,appName):
 	# First, check whether the module exists.
 	# We need to do this separately because even though an ImportError is raised when a module can't be found, it might also be raised for other reasons.
 	# Python 2.x can't properly handle unicode module names, so convert them.
-	modName = appName.encode("mbcs")
+	modName = appName
+	if sys.version_info.major == 2 and not isinstance(modName, bytes):
+		modName = modName.encode("mbcs")
 
 	if doesAppModuleExist(modName):
 		try:

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -92,12 +92,8 @@ def getAppNameFromProcessID(processID,includeExt=False):
 
 	# This might be an executable which hosts multiple apps.
 	# Try querying the app module for the name of the app being hosted.
-	# Python 2.x can't properly handle unicode module names, so convert them.
-	# No longer the case in Python 3.
-	if sys.version_info.major == 2:
-		appName = appName.encode("mbcs")
 	try:
-		mod = importlib.import_module("appModules.%s" % appName, package="appModules")
+		mod = importlib.import_module(u"appModules.%s" % appName, package="appModules")
 		return mod.getAppNameFromHost(processID)
 	except (ImportError, AttributeError, LookupError):
 		pass
@@ -157,7 +153,7 @@ def cleanup():
 			log.exception("Error terminating app module %r" % deadMod)
 
 def doesAppModuleExist(name):
-	return any(importer.find_module("appModules.%s" % name) for importer in _importers)
+	return any(importer.find_module(u"appModules.%s" % name) for importer in _importers)
 
 def fetchAppModule(processID,appName):
 	"""Returns an appModule found in the appModules directory, for the given application name.
@@ -170,17 +166,11 @@ def fetchAppModule(processID,appName):
 	"""  
 	# First, check whether the module exists.
 	# We need to do this separately because even though an ImportError is raised when a module can't be found, it might also be raised for other reasons.
-	# Python 2.x can't properly handle unicode module names, so convert them.
-	modName = appName
-	if not isinstance(modName, bytes):
-		modName = modName.encode("mbcs")
-
-	if doesAppModuleExist(modName):
+	if doesAppModuleExist(appName):
 		try:
-			return importlib.import_module("appModules.%s" % modName, package="appModules").AppModule(processID, appName)
+			return importlib.import_module(u"appModules.%s" % appName, package="appModules").AppModule(processID, appName)
 		except:
-			log.error("error in appModule %r"%modName, exc_info=True)
-			# We can't present a message which isn't unicode, so use appName, not modName.
+			log.error("error in appModule %r"%appName, exc_info=True)
 			# Translators: This is presented when errors are found in an appModule (example output: error in appModule explorer).
 			ui.message(_("Error in appModule %s")%appName)
 

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -92,8 +92,12 @@ def getAppNameFromProcessID(processID,includeExt=False):
 
 	# This might be an executable which hosts multiple apps.
 	# Try querying the app module for the name of the app being hosted.
+	# Python 2.x can't properly handle unicode module names, so convert them.
+	# No longer the case in Python 3.
+	if sys.version_info.major == 2:
+		appName = appName.encode("mbcs")
 	try:
-		mod = importlib.import_module(u"appModules.%s" % appName, package="appModules")
+		mod = importlib.import_module("appModules.%s" % appName, package="appModules")
 		return mod.getAppNameFromHost(processID)
 	except (ImportError, AttributeError, LookupError):
 		pass
@@ -153,7 +157,7 @@ def cleanup():
 			log.exception("Error terminating app module %r" % deadMod)
 
 def doesAppModuleExist(name):
-	return any(importer.find_module(u"appModules.%s" % name) for importer in _importers)
+	return any(importer.find_module("appModules.%s" % name) for importer in _importers)
 
 def fetchAppModule(processID,appName):
 	"""Returns an appModule found in the appModules directory, for the given application name.
@@ -166,11 +170,17 @@ def fetchAppModule(processID,appName):
 	"""  
 	# First, check whether the module exists.
 	# We need to do this separately because even though an ImportError is raised when a module can't be found, it might also be raised for other reasons.
-	if doesAppModuleExist(appName):
+	# Python 2.x can't properly handle unicode module names, so convert them.
+	modName = appName
+	if not isinstance(modName, bytes):
+		modName = modName.encode("mbcs")
+
+	if doesAppModuleExist(modName):
 		try:
-			return importlib.import_module(u"appModules.%s" % appName, package="appModules").AppModule(processID, appName)
+			return importlib.import_module("appModules.%s" % modName, package="appModules").AppModule(processID, appName)
 		except:
-			log.error("error in appModule %r"%appName, exc_info=True)
+			log.error("error in appModule %r"%modName, exc_info=True)
+			# We can't present a message which isn't unicode, so use appName, not modName.
 			# Translators: This is presented when errors are found in an appModule (example output: error in appModule explorer).
 			ui.message(_("Error in appModule %s")%appName)
 

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -172,7 +172,7 @@ def fetchAppModule(processID,appName):
 	# We need to do this separately because even though an ImportError is raised when a module can't be found, it might also be raised for other reasons.
 	# Python 2.x can't properly handle unicode module names, so convert them.
 	modName = appName
-	if sys.version_info.major == 2 and not isinstance(modName, bytes):
+	if not isinstance(modName, bytes):
 		modName = modName.encode("mbcs")
 
 	if doesAppModuleExist(modName):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1628,7 +1628,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Indicates the name of the current program (example output: explorer.exe is currently running).
 		# Note that it does not give friendly name such as Windows Explorer; it presents the file name of the current application.
 		# For example, the complete message for Windows explorer is: "explorer module is loaded. Explorer.exe is currenty running."
-		message +=_(" %s is currently running.") % appName
+		message +=_(" %s is currently running.") % (appName.decode("mbcs") if isinstance(appName, bytes) else appName)
 		ui.message(message)
 	# Translators: Input help mode message for report current program name and app module name command.
 	script_reportAppModuleInfo.__doc__ = _("Speaks the filename of the active application along with the name of the currently loaded appModule")

--- a/source/pythonMonkeyPatches.py
+++ b/source/pythonMonkeyPatches.py
@@ -24,3 +24,12 @@ def _dlopen(name, mode=ctypes.DEFAULT_MODE):
 		name = name.encode("mbcs")
 	return old_dlopen(name, mode)
 ctypes._dlopen = _dlopen
+
+# #9583: Python 2.x can't properly handle unicode module names, so convert them.
+import importlib
+old_import_module = importlib.import_module
+def import_module(name, package=None):
+	if not isinstance(name, bytes):
+		name = name.encode("mbcs")
+	return old_import_module(name, package=package)
+importlib.import_module = import_module

--- a/source/pythonMonkeyPatches.py
+++ b/source/pythonMonkeyPatches.py
@@ -24,12 +24,3 @@ def _dlopen(name, mode=ctypes.DEFAULT_MODE):
 		name = name.encode("mbcs")
 	return old_dlopen(name, mode)
 ctypes._dlopen = _dlopen
-
-# #9583: Python 2.x can't properly handle unicode module names, so convert them.
-import importlib
-old_import_module = importlib.import_module
-def import_module(name, package=None):
-	if not isinstance(name, bytes):
-		name = name.encode("mbcs")
-	return old_import_module(name, package=package)
-importlib.import_module = import_module


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

#9583

### Summary of the issue:

Application with multibyte file name, such as "テストアプリケーション.exe" raises error.

### Description of how this pull request fixes the issue:

If Python 2 is used, make sure importlib.import_module uses bytes rather than unicode.

### Testing performed:

not yet.

### Known issues with pull request:

Haven't identified why this regression has happened. 

### Change log entry:

Section: Bug fixes

