### PR TITLE
Fix failing system tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,13 +121,7 @@ before_test:
  # Manually grab pyGetWindow 0.0.4 as latest release cannot be installed on Python 2.7.
  # See https://github.com/asweigart/PyGetWindow/issues/9
  - py -m pip install pygetwindow==0.0.4
- # Manually grab pyscreeze 0.1.13 as latest release is completely broken.
- - py -m pip install pyscreeze==0.1.13
- # The latest release of PyAutoGUI requires PyScreeze 0.1.20 which unfortunately doesn't work with Python 2.7.
- # See https://github.com/asweigart/pyscreeze/issues/46
- # Therefore install version 0.9.41.
- - py -m pip install pyautogui==0.9.41
- - py -m pip install robotframework robotremoteserver nose
+ - py -m pip install robotframework robotremoteserver nose pyautogui
  - mkdir testOutput
  - mkdir testOutput\unit
  - mkdir testOutput\system

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,6 +118,9 @@ build_script:
  - cd ..
 
 before_test:
+ # Manually grab pyGetWindow 0.0.4 as latest release cannot be installed on Python 2.7.
+ # See https://github.com/asweigart/PyGetWindow/issues/9
+ - py -m pip install pygetwindow==0.0.4
  # Manually grab pyscreeze 0.1.13 as latest release is completely broken.
  - py -m pip install pyscreeze==0.1.13
  # The latest release of PyAutoGUI requires PyScreeze 0.1.20 which unfortunately doesn't work with Python 2.7.


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
PyGetWindow 0.0.4 cannot be installed under Python 2.7. This causes system tests on AppVeyor to fail. Additionally https://github.com/asweigart/pyscreeze/issues/46 is now fixed so there is no point in sticking to the old version of PyAutoGui.
### Description of how this pull request fixes the issue:
- Previous version of PyGetWindow is installed in appveyor.yml
- The workaround applied in #9358 is removed.
### Testing performed:
For some reason system test are failing on my machine, so AppVeyor is required to test these changes.
Build on AppVeyor Succeeded. It is got to go.
### Known issues with pull request:
None known.
### Change log entry:
None needed