### PR TITLE
appveyor: manually install pygetwindow 0.0.4 as 0.0.5 is broken

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,6 +120,8 @@ build_script:
 before_test:
  # Manually grab pyscreeze 0.1.13 as latest release is completely broken.
  - py -m pip install pyscreeze==0.1.13
+ # Manually grab pygetwindow 0.0.4 as 0.0.5 is broken. 
+ - py -m pip install pygetwindow==0.0.4
  # The latest release of PyAutoGUI requires PyScreeze 0.1.20 which unfortunately doesn't work with Python 2.7.
  # See https://github.com/asweigart/pyscreeze/issues/46
  # Therefore install version 0.9.41.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Appveyor builds are currently broken as pygetwindow 0.0.5 (required by pyautogui) will not build on Windows.
 
### Description of how this pull request fixes the issue:
Manually install pygetwindow 0.0.4 before installing pyautogui.

### Testing performed:
Build succeeds.

### Known issues with pull request:
None

### Change log entry:
None

Section: New features, Changes, Bug fixes

