### PR TITLE
Revert "appveyor: manually install pygetwindow 0.0.4 as 0.0.5 is broken"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,8 +120,6 @@ build_script:
 before_test:
  # Manually grab pyscreeze 0.1.13 as latest release is completely broken.
  - py -m pip install pyscreeze==0.1.13
- # Manually grab pygetwindow 0.0.4 as 0.0.5 is broken. 
- - py -m pip install pygetwindow==0.0.4
  # The latest release of PyAutoGUI requires PyScreeze 0.1.20 which unfortunately doesn't work with Python 2.7.
  # See https://github.com/asweigart/pyscreeze/issues/46
  # Therefore install version 0.9.41.


### PR DESCRIPTION
Reverting in favor of #9592.

Reverts nvaccess/nvda#9593