### PR TITLE
Only clear curWordChars on focus / caret movement

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1031,6 +1031,10 @@ This code is executed if a gain focus event is received by this object.
 		braille.handler.handleGainFocus(self)
 		brailleInput.handler.handleGainFocus(self)
 
+	def event_loseFocus(self):
+		# Forget the word currently being typed as focus is moving to a new control. 
+		speech.clearTypedWordBuffer()
+
 	def event_foreground(self):
 		"""Called when the foreground window changes.
 		This method should only perform tasks specific to the foreground window changing.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -131,6 +131,8 @@ class EditableText(TextContainerObject,ScriptableObject):
 		braille.handler.handleCaretMove(self)
 
 	def _caretMovementScriptHelper(self, gesture, unit):
+		# Forget the word currently being typed as the user is moving the caret somewhere else.
+		speech.clearTypedWordBuffer()
 		try:
 			info=self.makeTextInfo(textInfos.POSITION_CARET)
 		except:

--- a/source/speech.py
+++ b/source/speech.py
@@ -513,8 +513,7 @@ def speak(speechSequence, symbolLevel=None, priority=None):
 		for item in speechSequence:
 			if isinstance(item, basestring):
 				speechViewer.appendText(item)
-	global beenCanceled, curWordChars
-	curWordChars=[]
+	global beenCanceled
 	if speechMode==speechMode_off:
 		return
 	elif speechMode==speechMode_beeps:
@@ -2527,3 +2526,11 @@ class _SpeechManager(object):
 #: The singleton _SpeechManager instance used for speech functions.
 #: @type: L{_SpeechManager}
 _manager = _SpeechManager()
+
+def clearTypedWordBuffer():
+	"""
+	Forgets any word currently being built up with typed characters for speaking. 
+	This should be called when the user's context changes such that they could no longer complete the word (such as a focus change or choosing to move the caret).
+	"""
+	global curWordChars
+	curWordChars=[]

--- a/source/speech.py
+++ b/source/speech.py
@@ -2530,7 +2530,8 @@ _manager = _SpeechManager()
 def clearTypedWordBuffer():
 	"""
 	Forgets any word currently being built up with typed characters for speaking. 
-	This should be called when the user's context changes such that they could no longer complete the word (such as a focus change or choosing to move the caret).
+	This should be called when the user's context changes such that they could no longer 
+	complete the word (such as a focus change or choosing to move the caret).
 	"""
 	global curWordChars
 	curWordChars=[]


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9577 
May partly address #7000 812

### Summary of the issue:
Since speech refactor, typing a word and pressing space, with speak typed characters and speak typed words on, NVDA only announces the characters (including the space) and not the typed word. It is supposed to announce the typed word and then the space.
speech.speak currently clears curWordChars, forgetting the currently typed word every time it is called. This was originally done so that most speech would forget the current word as  it was most probable that the user was performing an unrelated action. Yet, because speech.speakSpelling did not call speech.speak (rather it called speak on the synth directly) typing further chracters did not cause curWordCars to be cleared.
However, speech refactor changed speech.speakSpelling to call speech.speak, which then means that curWordChars is always cleared every time a typed character is spoken, and the word is never built up. 

### Description of how this pull request fixes the issue:
speech.speak no longer clears curWordChars. Rather a new clearTypedWordBuffer function has been added to speak which does this, and is called from event_loseFocus on the base NvDAObject and EditableText's _caretMovementScriptHelper method, essentially forgetting the current word for every focus change and user-initiated caret move.
 
 ### Testing performed:
In Notepad with speak typed characters on and speak typed words on:
* typed "ding dong ". NVDA announced "d i n g ding space d o n g dong space"
In Notepad with speak typed characters off and speak typed words on:
* Typed "ding" and pressed leftArrow until moving before the "o" and then typed "dong ". NVDA announced "dong".
* Typed "ding" alt+tabbed to Thunderbird and back again, then typed "dong ". NVDA announced "dong".

### Known issues with pull request:
None.

### Change log entry:
None.