### PR TITLE
Shorten messages presented when profile is manually activated/deactivated

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2467,12 +2467,12 @@ class ConfigProfileActivationCommands(ScriptableObject):
 			config.conf.manualActivateProfile(None)
 			# Translators: a message when a configuration profile is manually deactivated.
 			# {profile} is replaced with the profile's name.
-			state = _("Configuration profile {profile} manually deactivated").format(profile=name)
+			state = _("{profile} profile deactivated").format(profile=name)
 		else:
 			config.conf.manualActivateProfile(name)
 			# Translators: a message when a configuration profile is manually activated.
 			# {profile} is replaced with the profile's name.
-			state = _("Configuration profile {profile} manually activated").format(profile=name)
+			state = _("{profile} profile activated").format(profile=name)
 		ui.message(state)
 
 	@classmethod

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2462,7 +2462,7 @@ class ConfigProfileActivationCommands(ScriptableObject):
 		if gui.shouldConfigProfileTriggersBeSuspended():
 			# Translators: a message indicating that configuration profiles can't be activated using gestures,
 			# due to profile activation being suspended.
-			state = _("Can't change the active configuration profile while an NVDA dialog is open")
+			state = _("Can't change the active profile while an NVDA dialog is open")
 		elif config.conf.profiles[-1].name == name:
 			config.conf.manualActivateProfile(None)
 			# Translators: a message when a configuration profile is manually deactivated.


### PR DESCRIPTION
### Link to issue number:
Fixes #9582 
### Summary of the issue:
Messages presented to the user when he / she activates or deactivates a profile with a keyboard shortcut are to long.
### Description of how this pull request fixes the issue:
The messages are shortened as per @feerrenrut  suggestion to '{profile} profile activated' and '{name} profile deactivated' respectively.
### Testing performed:
Created a profile activated and deactivated it with a keyboard shortcut. Ensured that the new messages are presented.
### Known issues with pull request:
None known
### Change log entry:
None needed if it would be included in 2019.2 as it is a new feature in this version.