### PR TITLE
No longer always log typeError for presentational table coordinates

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1107,12 +1107,12 @@ the NVDAObject for IAccessible
 		index=self.IA2Attributes.get('rowindex')
 		if index is None and isinstance(self.parent,IAccessible):
 			index=self.parent.IA2Attributes.get('rowindex')
+		if index is None:
+			raise NotImplementedError
 		try:
 			index=int(index)
 		except (ValueError,TypeError):
 			log.debugWarning("value %s is not an int"%index,exc_info=True)
-			index=None
-		if index is None:
 			raise NotImplementedError
 		return index
 
@@ -1156,12 +1156,12 @@ the NVDAObject for IAccessible
 
 	def _get_presentationalColumnNumber(self):
 		index=self.IA2Attributes.get('colindex')
+		if index is None:
+			raise NotImplementedError
 		try:
 			index=int(index)
 		except (ValueError,TypeError):
 			log.debugWarning("value %s is not an int"%index,exc_info=True)
-			index=None
-		if index is None:
 			raise NotImplementedError
 		return index
 
@@ -1185,12 +1185,12 @@ the NVDAObject for IAccessible
 
 	def _get_presentationalRowCount(self):
 		count=self.IA2Attributes.get('rowcount')
+		if count is None:
+			raise NotImplementedError
 		try:
 			count=int(count)
 		except (ValueError,TypeError):
 			log.debugWarning("value %s is not an int"%count,exc_info=True)
-			count=None
-		if count is None:
 			raise NotImplementedError
 		return count
 
@@ -1209,12 +1209,12 @@ the NVDAObject for IAccessible
 
 	def _get_presentationalColumnCount(self):
 		count=self.IA2Attributes.get('colcount')
+		if count is None:
+			raise NotImplementedError
 		try:
 			count=int(count)
 		except (ValueError,TypeError):
 			log.debugWarning("value %s is not an int"%count,exc_info=True)
-			count=None
-		if count is None:
 			raise NotImplementedError
 		return count
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9598 

### Summary of the issue:
Since the merging of PR #9562, IAccessible NVDAObject's presentational table coordinate properties continuously log a typeError when they can't look up the needed IAccessible2 attributes.

### Description of how this pull request fixes the issue:
This PR refactors these properties so that when the attribute is missing (it is None) is handled as being not implemented. Where as any other value that can't be converted to an int is still handled as an error.

### Testing performed:
* Confirmed that errors are no longer continuously logged.
* Ran through the original tests in #9562.
 
### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

