### PR TITLE
Update setup script for Python 3.7

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -96,17 +96,11 @@ def getCodePath(f):
 	return ".".join([x for x in path,className,funcName if x])
 
 # Function to strip the base path of our code from traceback text to improve readability.
-if getattr(sys, "frozen", None):
-	# We're running a py2exe build.
-	# The base path already seems to be stripped in this case, so do nothing.
-	def stripBasePathFromTracebackText(text):
-		return text
-else:
-	BASE_PATH = os.path.split(__file__)[0] + os.sep
-	TB_BASE_PATH_PREFIX = '  File "'
-	TB_BASE_PATH_MATCH = TB_BASE_PATH_PREFIX + BASE_PATH
-	def stripBasePathFromTracebackText(text):
-		return text.replace(TB_BASE_PATH_MATCH, TB_BASE_PATH_PREFIX)
+BASE_PATH = os.path.split(__file__)[0] + os.sep
+TB_BASE_PATH_PREFIX = '  File "'
+TB_BASE_PATH_MATCH = TB_BASE_PATH_PREFIX + BASE_PATH
+def stripBasePathFromTracebackText(text):
+	return text.replace(TB_BASE_PATH_MATCH, TB_BASE_PATH_PREFIX)
 
 class Logger(logging.Logger):
 	# Import standard levels for convenience.

--- a/source/setup.py
+++ b/source/setup.py
@@ -8,95 +8,78 @@
 import os
 import copy
 import gettext
-gettext.install("nvda", unicode=True)
-from distutils.core import setup
+gettext.install("nvda")
+from setuptools import setup
 import py2exe as py2exeModule
 from glob import glob
 import fnmatch
 from versionInfo import *
-from py2exe import build_exe
+from py2exe import distutils_buildexe
+from py2exe.dllfinder import DllFinder
 import wx
-import imp
+import importlib.machinery
 
-MAIN_MANIFEST_EXTRA = r"""
-<file name="brailleDisplayDrivers\handyTech\HtBrailleDriverServer.dll">
-	<comClass
-		description="HtBrailleDriver Class"
-		clsid="{209445BA-92ED-4AB2-83EC-F24ACEE77EE0}"
-		threadingModel="Apartment"
-		progid="HtBrailleDriverServer.HtBrailleDriver"
-		tlbid="{33257EFB-336F-4680-B94E-F5013BA6B9B3}" />
-</file>
-<file name="brailleDisplayDrivers\handyTech\HtBrailleDriverServer.tlb">
-	<typelib tlbid="{33257EFB-336F-4680-B94E-F5013BA6B9B3}"
-		version="1.0"
-		helpdir="" />
-</file>
-<comInterfaceExternalProxyStub
-	name="IHtBrailleDriverSink"
-	iid="{EF551F82-1C7E-421F-963D-D9D03548785A}"
-	proxyStubClsid32="{00020420-0000-0000-C000-000000000046}"
-	baseInterface="{00000000-0000-0000-C000-000000000046}"
-	tlbid="{33257EFB-336F-4680-B94E-F5013BA6B9B3}" />
-<comInterfaceExternalProxyStub
-	name="IHtBrailleDriver"
-	iid="{43A71F9B-58EE-42D4-B58E-0F9FBA28D995}"
-	proxyStubClsid32="{00020424-0000-0000-C000-000000000046}"
-	baseInterface="{00000000-0000-0000-C000-000000000046}"
-	tlbid="{33257EFB-336F-4680-B94E-F5013BA6B9B3}" />
-<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-	<application>
-		<!-- Windows Vista -->
-		<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-		<!-- Windows 7 -->
-		<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-		<!-- Windows 8 -->
-		<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-		<!-- Windows 8.1 -->
-		<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-		<!-- Windows 10 -->
-		<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-	</application> 
-</compatibility>
+RT_MANIFEST = 24
+manifest_template = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel
+					level="asInvoker"
+					uiAccess="%(uiAccess)s"
+				/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!-- Windows 7 -->
+			<supportedOS
+				Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"
+			/>
+			<!-- Windows 8 -->
+			<supportedOS
+				Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"
+			/>
+			<!-- Windows 8.1 -->
+			<supportedOS
+				Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"
+			/>
+			<!-- Windows 10 -->
+			<supportedOS
+				Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
+			/>
+		</application> 
+	</compatibility>
+</assembly>
 """
 
-def getModuleExtention(thisModType):
-	for ext,mode,modType in imp.get_suffixes():
-		if modType==thisModType:
-			return ext
-	raise ValueError("unknown mod type %s"%thisModType)
-
 # py2exe's idea of whether a dll is a system dll appears to be wrong sometimes, so monkey patch it.
-origIsSystemDLL = build_exe.isSystemDLL
-def isSystemDLL(pathname):
-	dll = os.path.basename(pathname).lower()
-	if dll in ("msvcp71.dll", "msvcp90.dll", "gdiplus.dll","mfc71.dll", "mfc90.dll"):
-		# These dlls don't exist on many systems, so make sure they're included.
-		return 0
-	elif dll.startswith("api-ms-win-") or dll in ("powrprof.dll", "mpr.dll", "crypt32.dll"):
+orig_determine_dll_type = DllFinder.determine_dll_type
+def determine_dll_type(self, imagename):
+	dll = os.path.basename(imagename).lower()
+	if dll.startswith("api-ms-win-") or dll in ("powrprof.dll", "mpr.dll", "crypt32.dll"):
 		# These are definitely system dlls available on all systems and must be excluded.
 		# Including them can cause serious problems when a binary build is run on a different version of Windows.
-		return 1
-	return origIsSystemDLL(pathname)
-build_exe.isSystemDLL = isSystemDLL
+		return None
+	return orig_determine_dll_type(self, imagename)
+DllFinder.determine_dll_type = determine_dll_type
 
-class py2exe(build_exe.py2exe):
+class py2exe(distutils_buildexe.py2exe):
 	"""Overridden py2exe command to:
-		* Add a command line option --enable-uiAccess to enable uiAccess for the main executable
-		* Add extra info to the manifest
-		* Don't copy w9xpopen, as NVDA will never run on Win9x
+		* Add a command line option --enable-uiAccess to enable uiAccess for the main executable and EOA proxy
+		* Add a manifest to the executables
 	"""
 
-	user_options = build_exe.py2exe.user_options + [
+	user_options = distutils_buildexe.py2exe.user_options + [
 		("enable-uiAccess", "u", "enable uiAccess for the main executable"),
 	]
 
 	def initialize_options(self):
-		build_exe.py2exe.initialize_options(self)
+		super(py2exe, self).initialize_options()
 		self.enable_uiAccess = False
-
-	def copy_w9xpopen(self, modules, dlls):
-		pass
 
 	def run(self):
 		dist = self.distribution
@@ -104,21 +87,21 @@ class py2exe(build_exe.py2exe):
 			# Add a target for nvda_uiAccess, using nvda_noUIAccess as a base.
 			target = copy.deepcopy(dist.windows[0])
 			target["dest_base"] = "nvda_uiAccess"
-			target["uac_info"] = (target["uac_info"][0], True)
+			target['uiAccess'] = True
 			dist.windows.insert(1, target)
 			# nvda_eoaProxy should have uiAccess.
 			target = dist.windows[3]
-			target["uac_info"] = (target["uac_info"][0], True)
-
-		build_exe.py2exe.run(self)
-
-	def build_manifest(self, target, template):
-		mfest, rid = build_exe.py2exe.build_manifest(self, target, template)
-		if getattr(target, "script", "").endswith(".pyw"):
-			# This is one of the main application executables.
-			mfest = mfest[:mfest.rindex("</assembly>")]
-			mfest += MAIN_MANIFEST_EXTRA + "</assembly>"
-		return mfest, rid
+			target['uiAccess'] = True
+		# Add a manifest resource to every target at runtime.
+		for target in dist.windows:
+			target["other_resources"] = [
+				(
+					RT_MANIFEST,
+					1,
+					(manifest_template % dict(uiAccess=target['uiAccess'])).encode("utf-8")
+				),
+			]
+		super(py2exe, self).run()
 
 def getLocaleDataFiles():
 	wxDir=wx.__path__[0]
@@ -146,8 +129,6 @@ def getRecursiveDataFiles(dest,source,excludes=()):
 	[rulesList.extend(getRecursiveDataFiles(os.path.join(dest,dirName),os.path.join(source,dirName),excludes=excludes)) for dirName in os.listdir(source) if os.path.isdir(os.path.join(source,dirName)) and not dirName.startswith('.')]
 	return rulesList
 
-compiledModExtention = getModuleExtention(imp.PY_COMPILED)
-sourceModExtention = getModuleExtention(imp.PY_SOURCE)
 setup(
 	name = name,
 	version=version,
@@ -169,10 +150,12 @@ setup(
 		{
 			"script":"nvda.pyw",
 			"dest_base":"nvda_noUIAccess",
-			"uac_info": ("asInvoker", False),
+			"uiAccess": False,
 			"icon_resources":[(1,"images/nvda.ico")],
+			"other_resources": [], # Populated at run time
 			"version":formatBuildVersionString(),
 			"description":"NVDA application",
+			"product_name":name,
 			"product_version":version,
 			"copyright":copyright,
 			"company_name":publisher,
@@ -180,9 +163,12 @@ setup(
 		# The nvda_uiAccess target will be added at runtime if required.
 		{
 			"script": "nvda_slave.pyw",
+			"uiAccess": False,
 			"icon_resources": [(1,"images/nvda.ico")],
+			"other_resources": [], # Populated at run time
 			"version":formatBuildVersionString(),
 			"description": name,
+			"product_name":name,
 			"product_version": version,
 			"copyright": copyright,
 			"company_name": publisher,
@@ -190,10 +176,12 @@ setup(
 		{
 			"script": "nvda_eoaProxy.pyw",
 			# uiAccess will be enabled at runtime if appropriate.
-			"uac_info": ("asInvoker", False),
+			"uiAccess": False,
 			"icon_resources": [(1,"images/nvda.ico")],
+			"other_resources": [], # Populated at run time
 			"version":formatBuildVersionString(),
 			"description": "NVDA Ease of Access proxy",
+			"product_name":name,
 			"product_version": version,
 			"copyright": copyright,
 			"company_name": publisher,
@@ -223,9 +211,23 @@ setup(
 		(".", ['message.html' ])
 	] + (
 		getLocaleDataFiles()
-		+ getRecursiveDataFiles("synthDrivers", "synthDrivers",
-			excludes=("*%s" % sourceModExtention, "*%s" % compiledModExtention, "*.exp", "*.lib", "*.pdb"))
-		+ getRecursiveDataFiles("brailleDisplayDrivers", "brailleDisplayDrivers", excludes=("*%s"%sourceModExtention,"*%s"%compiledModExtention))
+		+ getRecursveDataFiles("synthDrivers", "synthDrivers",
+			excludes=tuple(
+				"*%s" % ext
+				for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
+			) + (
+				"*.exp",
+				"*.lib",
+				"*.pdb",
+				"__pycache__"
+		))
+		+ getRecursiveDataFiles("brailleDisplayDrivers", "brailleDisplayDrivers",
+			excludes=tuple(
+				"*%s" % ext
+				for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
+			) + (
+				"__pycache__"
+		))
 		+ getRecursiveDataFiles('documentation', '../user_docs', excludes=('*.t2t', '*.t2tconf', '*/developerGuide.*'))
 	),
 )

--- a/source/setup.py
+++ b/source/setup.py
@@ -211,7 +211,7 @@ setup(
 		(".", ['message.html' ])
 	] + (
 		getLocaleDataFiles()
-		+ getRecursveDataFiles("synthDrivers", "synthDrivers",
+		+ getRecursiveDataFiles("synthDrivers", "synthDrivers",
 			excludes=tuple(
 				"*%s" % ext
 				for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
@@ -226,7 +226,7 @@ setup(
 				"*%s" % ext
 				for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
 			) + (
-				"__pycache__"
+				"__pycache__",
 		))
 		+ getRecursiveDataFiles('documentation', '../user_docs', excludes=('*.t2t', '*.t2tconf', '*/developerGuide.*'))
 	),

--- a/source/setup.py
+++ b/source/setup.py
@@ -189,7 +189,7 @@ setup(
 	],
 	options = {"py2exe": {
 		"bundle_files": 3,
-		"excludes": ["Tkinter",
+		"excludes": ["tkinter",
 			"serial.loopback_connection", "serial.rfc2217", "serial.serialcli", "serial.serialjava", "serial.serialposix", "serial.socket_connection"],
 		"packages": ["NVDAObjects","virtualBuffers","appModules","comInterfaces","brailleDisplayDrivers","synthDrivers"],
 		"includes": [


### PR DESCRIPTION
### Link to issue number:
Fixes #8375
Closes #9604 

### Summary of the issue:
For the Python 2 distribution of NVDA< we're using py2exe 0.6, which is compatible with NVDA. For the Python 3 migration/transition, we decided to go with the [py2exe fork](https://github.com/albertosottile/py2exe) by @albertosottile.

### Description of how this pull request fixes the issue:
This pr converts the setup script to be compatible with py2exe>0.9.3.1. In short, the following had to be changed:

* Several imports and super calls in our py2exe command subclass
* The monkeypatch that excludes certain system dlls is still there, though modified for the new situation
* The manifest implementation has been rebuild. I consider the new implementation to be more elegant, as it offers us full flexibility over the manifest. The uiAccess flag is added to the manifest at runtime of the builder.
* As py2exe no longer seems to strip the base path from tracebacks, the logHandler now does this in all cases.
* the product name is explicitly added to every target
* I decided to remove the handy tech com server from the manifest, see #9604. If it is decided to revert this change, it will require us to do more work in order for it only to be integrated in the executables that need it (i.e. I assume not in the slave and eoa proxy).

### Testing performed:
The command to run py2exe on my system looked as follows:
`c:\python37\python.exe setup.py build --build-base ..\build py2exe --dist-dir ..\dist`

* Tested locally using @josephsl's py3000 branch, which some small fixes to nvda_slave and appModules.soffice, which are not included into this pr. I also had to import sourceEnv in the setup script. This is a draft for a reason, see below
* Made sure that the manifests were added correctly, and that uiAccess is set to True in the manifest of nvda_uiAccess

### Known issues with pull request:
This relies on several things to be done first:

* Code syntax compatibility with Python 3
* Inclusion of pySerial 3.4: #8815 
* Update of scons to use python 3.7
* Update of several external dependencies, such as the wxPython binary distribution and miscdeps

### Change log entry:
t.b.d.