### PR TITLE
always uses Unicode for appName

### DIFF
--- a/source/pythonMonkeyPatches.py
+++ b/source/pythonMonkeyPatches.py
@@ -24,3 +24,12 @@ def _dlopen(name, mode=ctypes.DEFAULT_MODE):
 		name = name.encode("mbcs")
 	return old_dlopen(name, mode)
 ctypes._dlopen = _dlopen
+
+# #9583: Python 2.x can't properly handle unicode module names, so convert them.
+import importlib
+old_import_module = importlib.import_module
+def import_module(name, package=None):
+	if not isinstance(name, bytes):
+		name = name.encode("mbcs")
+	return old_import_module(name, package=package)
+importlib.import_module = import_module


### PR DESCRIPTION
### Link to issue number:

#9583 #9590 

### Summary of the issue:

If the executable file of an application uses multibyte character, NVDA raises errors, and the app is not accessible.

### Description of how this pull request fixes the issue:

PR #9590 allows mixed use of Unicode and bytes for appName.

As @leonardder suggested, this PR always uses Unicode for appName, hopefully.

The work is once tried in #9590 and reverted, so I created new PR.

### Testing performed:

Not yet.

### Known issues with pull request:

For appModuleHandler.doesAppModuleExist(), I am not sure that is good. 
Without that, importer.find_module() raises the following error.

```
ERROR - core.CorePump.run (23:25:00.859):
errors in this core pump cycle
Traceback (most recent call last):
  File "core.pyc", line 489, in run
  File "IAccessibleHandler.pyc", line 897, in pumpAll
  File "IAccessibleHandler.pyc", line 614, in processGenericWinEvent
  File "appModuleHandler.pyc", line 133, in update
  File "appModuleHandler.pyc", line 119, in getAppModuleFromProcessID
  File "appModuleHandler.pyc", line 169, in fetchAppModule
  File "appModuleHandler.pyc", line 156, in doesAppModuleExist
  File "appModuleHandler.pyc", line 156, in <genexpr>
  File "pkgutil.pyc", line 183, in find_module
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-10: ordinal not in range(128)
```

### Change log entry:

Section: Bug fixes
