### PR TITLE
Fix Notepad++ 7.7x64 hanging for around 10 seconds when expanding the first character in a file

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -14,7 +14,7 @@ import locale
 import watchdog
 import eventHandler
 
-#Window messages
+# Window messages
 SCI_POSITIONFROMPOINT=2022
 SCI_POINTXFROMPOSITION=2164
 SCI_POINTYFROMPOSITION=2165
@@ -48,6 +48,8 @@ SCI_GETCODEPAGE=2137
 SCI_POSITIONAFTER=2418
 
 #constants
+#: Represents an invalid position within a document.
+INVALID_POSITION=-1
 STYLE_DEFAULT=32
 SC_CP_UTF8=65001
 
@@ -218,7 +220,8 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		end=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONAFTER,offset,0)
 		start=offset
 		tempOffset=offset-1
-		while tempOffset >= 0:
+		
+		while tempOffset > INVALID_POSITION:
 			start=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONAFTER,tempOffset,0)
 			if start<end:
 				break

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -218,7 +218,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		end=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONAFTER,offset,0)
 		start=offset
 		tempOffset=offset-1
-		while True:
+		while tempOffset >= 0:
 			start=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_POSITIONAFTER,tempOffset,0)
 			if start<end:
 				break

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -55,6 +55,7 @@ What's New in NVDA
 - The log can now be opened with NVDA+F1 when there is no developer info for the current navigator object. (#8613)
 - It is again possible to use NvDA's table navigation commands in Google Docs, in Firefox and Chrome. (#9494)
 - The bumper keys now work correctly on Freedom Scientific braille displays. (#8849)
+- When reading the first character of a document in Notepad++ 7.7 X64, NVDA no longer freezes for up to ten seconds. (#9609)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #9609

### Summary of the issue:
Notepad++ 7.7 X64 freezes when reading the first character of a file. This is because the logic to expand to textInfos.UNIT_CHARACTER gets stuck in a while loop due to NP++7.7 returning the wrong offset when getting the position after offset -1.

### Description of how this pull request fixes the issue:
Restricted the wile loop in such a way that it could never get the position after a negative offset.

### Testing performed:
Tested in Notepad++ 7.6 x64, 7.7 x64 and 7.7 x86 that the first character reads fine, whether it is a single or multi byte character.

### Known issues with pull request:
We may have to report this bug against scintilla or NP++ as well.

### Change log entry:
* Bug fixes
    + When reading the first character of a document in Notepad++ 7.7 X64, NVDA no longer freezes for up to ten seconds. (#9609)