### PR TITLE
Don't report live regions in background tabs in Firefox

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,10 @@ What's New in NVDA
 - Added an experimental option to the Advanced Settings panel that allows you to try out a new, work-in-progress rewrite of NVDA's Windows Console support using the Microsoft UI Automation API. (#9614)
 
 
+== Bug Fixes ==
+- In Mozilla Firefox, updates to a live region are no longer reported if the live region is in a background tab. (#1318)
+
+
 = 2019.2 =
 Highlights of this release include auto detection of Freedom Scientific braille displays, an experimental setting in the Advanced panel to stop browse mode from automatically moving focus (which may provide performance improvements), a rate boost option for the Windows OneCore synthesizer to achieve very fast rates, and many other bug fixes.
 


### PR DESCRIPTION
### Link to issue number:
Fixes #1318.

### Summary of the issue:
In Firefox, live region updates are incorrectly reported even when the region is in a background tab.

### Description of how this pull request fixes the issue:
In Firefox, all tabs have the same HWND. Objects in background tabs do get the offscreen state, but offscreen live regions are used to report visually hidden information, so we can't filter based on that. Therefore, if the offscreen state is set, we do an additional background check. We get the tab document from the accessible, get the foreground tab document and compare them. If they differ, the event is for a background tab and we thus ignore the event.

### Testing performed:
All tests completed in both Firefox and Chrome.

Test case 1 (on-screen live region):
`data:text/html,<div id="live" aria-live="polite">Initial content</div><script>setTimeout(() => live.textContent = "Updated live content", 2000);</script>`

1. Opened the test case and waited 2 seconds. Confirmed that NVDA said "Updated content".
2. Opened the test case and immediately hit control+t to open a new tab. Confirmed that NVDA did not say "Updated content" within 2 seconds. (This test fails in Firefox without this patch.)

Test case 2 (off-screen live region):
`data:text/html,<div id="live" aria-live="polite" style="position: absolute; left: -1000px;">Initial content</div><script>setTimeout(() => live.textContent = "Updated live content", 2000);</script>`

Same tests as for test case 1. I wanted to verify that the presence of the offscreen state didn't cause unexpected problems, since the new code runs in this case.

### Known issues with pull request:
In theory, this could impact performance, as there are a few additional COM calls for off-screen live regions. However, I don't believe this is a concern in practical terms.

### Change log entry:

Bug fixes:

`- In Mozilla Firefox, updates to a live region are no longer reported if the live region is in a background tab. (#1318)`