### PR TITLE
fixes regression regarding multibyte filename executables

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -171,7 +171,9 @@ def fetchAppModule(processID,appName):
 	# First, check whether the module exists.
 	# We need to do this separately because even though an ImportError is raised when a module can't be found, it might also be raised for other reasons.
 	# Python 2.x can't properly handle unicode module names, so convert them.
-	modName = appName.encode("mbcs")
+	modName = appName
+	if not isinstance(modName, bytes):
+		modName = modName.encode("mbcs")
 
 	if doesAppModuleExist(modName):
 		try:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1628,7 +1628,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Indicates the name of the current program (example output: explorer.exe is currently running).
 		# Note that it does not give friendly name such as Windows Explorer; it presents the file name of the current application.
 		# For example, the complete message for Windows explorer is: "explorer module is loaded. Explorer.exe is currenty running."
-		message +=_(" %s is currently running.") % appName
+		message +=_(" %s is currently running.") % (appName.decode("mbcs") if isinstance(appName, bytes) else appName)
 		ui.message(message)
 	# Translators: Input help mode message for report current program name and app module name command.
 	script_reportAppModuleInfo.__doc__ = _("Speaks the filename of the active application along with the name of the currently loaded appModule")


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

#9583 
previous PRs are #9590 #9610

### Summary of the issue:

If the executable file name of an app uses multibyte character, NVDA raises errors, and the app is not accessible.
Ctrl+NVDA+F1 should work with the apps as well.

This issue did not occur with NVDA 2019.1.1 or previous versions.
I understand that the issue is caused by PR #8727.

### Description of how this pull request fixes the issue:

The patch is against the beta branch.
The approach is once reviewed in PR #9590.

### Testing performed:

Not yet for this branch.

### Known issues with pull request:

### Change log entry:

Section: Bug fixes

