### PR TITLE
Python 3: 'ur' string prefixes no longer supported.

### DIFF
--- a/keyCommandsDoc.py
+++ b/keyCommandsDoc.py
@@ -213,7 +213,7 @@ class KeyCommandsMaker(object):
 		self._headings.append(m)
 		self._kcLastHeadingLevel = min(self._kcLastHeadingLevel, level - 1)
 
-	RE_SETTING_SINGLE_KEY = re.compile(ur"^[^|]+?[:：]\s*(.+?)\s*$")
+	RE_SETTING_SINGLE_KEY = re.compile(r"^[^|]+?[:：]\s*(.+?)\s*$")
 	def _handleSetting(self):
 		if not self._settingsHeaderRow:
 			raise KeyCommandsError("%d, setting command cannot be used before settingsSection command" % self._lineNum)

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -507,7 +507,7 @@ class SpeechSymbolProcessor(object):
 		# Simple symbols.
 		# These are all handled in one named group.
 		# Because the symbols are just text, we know which symbol matched just by looking at the matched text.
-		patterns.append(ur"(?P<simple>{multiChars}|{singleChars})".format(
+		patterns.append(r"(?P<simple>{multiChars}|{singleChars})".format(
 			multiChars="|".join(re.escape(identifier) for identifier in multiChars),
 			singleChars=characters
 		))

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -169,7 +169,7 @@ def initConfigPath(configPath=None):
 		if not os.path.isdir(subdir):
 			os.makedirs(subdir)
 
-RUN_REGKEY = ur"SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+RUN_REGKEY = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
 
 def getStartAfterLogon():
 	if (easeOfAccess.isSupported and easeOfAccess.canConfigTerminateOnDesktopSwitch
@@ -237,7 +237,7 @@ SLAVE_FILENAME = u"nvda_slave.exe"
 
 #: The name of the registry key stored under  HKEY_LOCAL_MACHINE where system wide NVDA settings are stored.
 #: Note that NVDA is a 32-bit application, so on X64 systems, this will evaluate to "SOFTWARE\WOW6432Node\nvda"
-NVDA_REGKEY = ur"SOFTWARE\NVDA"
+NVDA_REGKEY = r"SOFTWARE\NVDA"
 
 def getStartOnLogonScreen():
 	if easeOfAccess.isSupported and easeOfAccess.willAutoStart(winreg.HKEY_LOCAL_MACHINE):

--- a/source/mathPres/mathPlayer.py
+++ b/source/mathPres/mathPlayer.py
@@ -21,9 +21,9 @@ RE_MP_SPEECH = re.compile(
 	# Break.
 	r"<break time='(?P<break>\d+)ms'/> ?"
 	# Pronunciation of characters.
-	ur"|<say-as interpret-as='characters'>(?P<char>[^<])</say-as> ?"
+	r"|<say-as interpret-as='characters'>(?P<char>[^<])</say-as> ?"
 	# Specific pronunciation.
-	ur"|<phoneme alphabet='ipa' ph='(?P<ipa>[^']+)'> (?P<phonemeText>[^ <]+)</phoneme> ?"
+	r"|<phoneme alphabet='ipa' ph='(?P<ipa>[^']+)'> (?P<phonemeText>[^ <]+)</phoneme> ?"
 	# Prosody.
 	r"|<prosody(?: pitch='(?P<pitch>\d+)%')?(?: volume='(?P<volume>\d+)%')?(?: rate='(?P<rate>\d+)%')?> ?"
 	r"|(?P<prosodyReset></prosody>) ?"

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -50,8 +50,8 @@ VBufStorage_findMatch_notEmpty = object()
 
 FINDBYATTRIBS_ESCAPE_TABLE = {
 	# Symbols that are escaped in the attributes string.
-	ord(u":"): ur"\\:",
-	ord(u";"): ur"\\;",
+	ord(u":"): r"\\:",
+	ord(u";"): r"\\;",
 	ord(u"\\"): u"\\\\\\\\",
 }
 # Symbols that must be escaped for a regular expression.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#8660

### Summary of the issue:
Python 3 does not support 'ur' string literals

### Description of how this pull request fixes the issue:
Change 'ur' to 'r'

### Testing performed: 

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

