### PR TITLE
txt2tags for python3 #8734

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/RaMMicHaeL/minhook
 [submodule "miscDeps"]
 	path = miscDeps
-	url = https://github.com/nvaccess/nvda-misc-deps
+	url = https://github.com/nvdajp/nvda-misc-deps
 [submodule "include/espeak"]
 	path = include/espeak
 	url=https://github.com/espeak-ng/espeak-ng

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/RaMMicHaeL/minhook
 [submodule "miscDeps"]
 	path = miscDeps
-	url = https://github.com/nvdajp/nvda-misc-deps
+	url = https://github.com/nvaccess/nvda-misc-deps
 [submodule "include/espeak"]
 	path = include/espeak
 	url=https://github.com/espeak-ng/espeak-ng

--- a/keyCommandsDoc.py
+++ b/keyCommandsDoc.py
@@ -4,6 +4,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 #Copyright (C) 2010-2015 NV Access Limited, Mesar Hameed
+#Copyright (C) 2018-2019 Takuya Nishimoto
 
 """Utilities related to NVDA Key Commands documents.
 """
@@ -13,7 +14,7 @@ import codecs
 import re
 import txt2tags
 
-LINE_END = u"\r\n"
+LINE_END = "\r\n"
 
 class KeyCommandsError(Exception):
 	"""Raised due to an error encountered in the User Guide related to generation of the Key Commands document.
@@ -195,7 +196,7 @@ class KeyCommandsMaker(object):
 		for level, heading in enumerate(self._headings[level:], level):
 			# We don't want numbered headings in the output.
 			label=heading.group("label")
-			headingText = u"{id}{txt}{id}{label}".format(
+			headingText = "{id}{txt}{id}{label}".format(
 				id="=" * len(heading.group("id")),
 				txt=heading.group("txt"),
 				label="[%s]" % label if label else "")
@@ -213,7 +214,7 @@ class KeyCommandsMaker(object):
 		self._headings.append(m)
 		self._kcLastHeadingLevel = min(self._kcLastHeadingLevel, level - 1)
 
-	RE_SETTING_SINGLE_KEY = re.compile(ur"^[^|]+?[:：]\s*(.+?)\s*$")
+	RE_SETTING_SINGLE_KEY = re.compile(r"^[^|]+?[:：]\s*(.+?)\s*$")
 	def _handleSetting(self):
 		if not self._settingsHeaderRow:
 			raise KeyCommandsError("%d, setting command cannot be used before settingsSection command" % self._lineNum)
@@ -237,7 +238,7 @@ class KeyCommandsMaker(object):
 		# The next few lines should be table rows for each layout.
 		# Alternatively, if the key is common to all layouts, there will be a single line of text specifying the key after a colon.
 		keys = []
-		for layout in xrange(self._settingsNumLayouts):
+		for layout in range(self._settingsNumLayouts):
 			line = next(self._ug).strip()
 			self._lineNum += 1
 			m = self.RE_SETTING_SINGLE_KEY.match(line)
@@ -254,7 +255,7 @@ class KeyCommandsMaker(object):
 		if 1 == len(keys) < self._settingsNumLayouts:
 			# The key has only been specified once, so it is the same in all layouts.
 			key = keys[0]
-			keys[1:] = (key for layout in xrange(self._settingsNumLayouts - 1))
+			keys[1:] = (key for layout in range(self._settingsNumLayouts - 1))
 
 		# There should now be a blank line.
 		line = next(self._ug).strip()
@@ -266,9 +267,9 @@ class KeyCommandsMaker(object):
 		desc = next(self._ug).strip()
 		self._lineNum += 1
 
-		self._kc.write(u"| {name} | {keys} | {desc} |{lineEnd}".format(
+		self._kc.write("| {name} | {keys} | {desc} |{lineEnd}".format(
 			name=name,
-			keys=u" | ".join(keys),
+			keys=" | ".join(keys),
 			desc=desc, lineEnd=LINE_END))
 
 	def remove(self):

--- a/keyCommandsDoc.py
+++ b/keyCommandsDoc.py
@@ -4,7 +4,6 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 #Copyright (C) 2010-2019 NV Access Limited, Mesar Hameed, Takuya Nishimoto
-#Copyright (C) 2018-2019 Takuya Nishimoto
 
 """Utilities related to NVDA Key Commands documents.
 """

--- a/keyCommandsDoc.py
+++ b/keyCommandsDoc.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2010-2015 NV Access Limited, Mesar Hameed
+#Copyright (C) 2010-2019 NV Access Limited, Mesar Hameed, Takuya Nishimoto
 #Copyright (C) 2018-2019 Takuya Nishimoto
 
 """Utilities related to NVDA Key Commands documents.

--- a/keyCommandsDoc.py
+++ b/keyCommandsDoc.py
@@ -14,7 +14,7 @@ import codecs
 import re
 import txt2tags
 
-LINE_END = "\r\n"
+LINE_END = u"\r\n"
 
 class KeyCommandsError(Exception):
 	"""Raised due to an error encountered in the User Guide related to generation of the Key Commands document.
@@ -196,7 +196,7 @@ class KeyCommandsMaker(object):
 		for level, heading in enumerate(self._headings[level:], level):
 			# We don't want numbered headings in the output.
 			label=heading.group("label")
-			headingText = "{id}{txt}{id}{label}".format(
+			headingText = u"{id}{txt}{id}{label}".format(
 				id="=" * len(heading.group("id")),
 				txt=heading.group("txt"),
 				label="[%s]" % label if label else "")
@@ -267,9 +267,9 @@ class KeyCommandsMaker(object):
 		desc = next(self._ug).strip()
 		self._lineNum += 1
 
-		self._kc.write("| {name} | {keys} | {desc} |{lineEnd}".format(
+		self._kc.write(u"| {name} | {keys} | {desc} |{lineEnd}".format(
 			name=name,
-			keys=" | ".join(keys),
+			keys=u" | ".join(keys),
 			desc=desc, lineEnd=LINE_END))
 
 	def remove(self):


### PR DESCRIPTION
### Link to issue number:

#8734

### Summary of the issue:

This PR is against the threshold branch.
It replaces txt2tags.py and keyCommandDoc.py with my work of https://github.com/nvdajp/txt2tags.
Note that nvda-misc-deps is forked and https://github.com/nvdajp/nvda-misc-deps is used.

### Description of how this pull request fixes the issue:

Part of this repository is verified that it can make the same documents using Python 3.7.3.

### Testing performed:

This repository itself is not tested.

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

