### PR TITLE
UI Automation in Windows Console: add STABILIZE_DELAY and improve "speak typed words"

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -32,6 +32,7 @@ class consoleUIATextInfo(UIATextInfo):
 
 
 class winConsoleUIA(Terminal):
+	STABILIZE_DELAY = 0.03
 	_TextInfo = consoleUIATextInfo
 	_isTyping = False
 	_lastCharTime = 0

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -51,7 +51,7 @@ class winConsoleUIA(Terminal):
 	def event_typedCharacter(self, ch):
 		if not ch.isspace():
 			self._isTyping = True
-		if ch in ('\r', '\t'):
+		if ch in ('\n', '\r', '\t'):
 			# Clear the typed word buffer for tab and return.
 			# This will need to be changed once #8110 is merged.
 			speech.curWordChars = []

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -4,7 +4,6 @@
 # See the file COPYING for more details.
 # Copyright (C) 2019 Bill Dengler
 
-import config
 import speech
 import time
 import textInfos
@@ -42,7 +41,10 @@ class winConsoleUIA(Terminal):
 
 	def _reportNewText(self, line):
 		# Additional typed character filtering beyond that in LiveText
-		if self._isTyping and time.time() - self._lastCharTime <= self._TYPING_TIMEOUT:
+		if (
+			self._isTyping
+			and time.time() - self._lastCharTime <= self._TYPING_TIMEOUT
+		):
 			return
 		super(winConsoleUIA, self)._reportNewText(line)
 
@@ -56,7 +58,7 @@ class winConsoleUIA(Terminal):
 		self._lastCharTime = time.time()
 		super(winConsoleUIA, self).event_typedCharacter(ch)
 
-	@script(gestures = [
+	@script(gestures=[
 		"kb:enter",
 		"kb:numpadEnter",
 		"kb:tab",

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -4,6 +4,8 @@
 # See the file COPYING for more details.
 # Copyright (C) 2019 Bill Dengler
 
+import config
+import speech
 import time
 import textInfos
 import UIAHandler
@@ -47,10 +49,21 @@ class winConsoleUIA(Terminal):
 	def event_typedCharacter(self, ch):
 		if not ch.isspace():
 			self._isTyping = True
+		if ch in ('\r', '\t'):
+			# Clear the typed word buffer for tab and return.
+			# This will need to be changed once #8110 is merged.
+			speech.curWordChars = []
 		self._lastCharTime = time.time()
 		super(winConsoleUIA, self).event_typedCharacter(ch)
 
-	@script(gestures=["kb:enter", "kb:numpadEnter", "kb:tab"])
+	@script(gestures = [
+		"kb:enter",
+		"kb:numpadEnter",
+		"kb:tab",
+		"kb:control+c",
+		"kb:control+d",
+		"kb:control+pause"
+	])
 	def script_clear_isTyping(self, gesture):
 		gesture.send()
 		self._isTyping = False


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Split from #9646 (builds on #9614).

### Summary of the issue:
Currently, in consoles with UI Automation enabled:

* If "speak typed words" is enabled, the last typed word is announced when pressing enter.
* When pressing an interrupt character (such as control+c), the `_isTyping` flag is not cleared on the console, so new text is not announced immediately.

### Description of how this pull request fixes the issue:
The `speech.curWordChars` buffer is cleared when a `typedCharacter` of enter or tab is received. This prevents NVDA from speaking partially-typed words (during tab completion) or the last word of a command (when enter is pressed). This approach will need to be modified once #8110 is merged, as it significantly changes handling of typed words.

The interrupt characters control+c, control+d, and control+break have been bound to the `script_clear_isTyping` script on `NVDAObjects.UIA.winConsoleUIA`.

### Testing performed:
Tested "speak typed words" on Windows 10 1803 and 1903. Tested console performance with many `textChange` events on Windows 10 1903.
### Known issues with pull request:
See #9646 for all known console UIA issues to date.

### Change log entry:
None.