### PR TITLE
Install older version of pyAutoGui to  make system tests on AppVeyor working again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,10 +118,9 @@ build_script:
  - cd ..
 
 before_test:
- # Manually grab pyGetWindow 0.0.4 as latest release cannot be installed on Python 2.7.
- # See https://github.com/asweigart/PyGetWindow/issues/9
- - py -m pip install pygetwindow==0.0.4
- - py -m pip install robotframework robotremoteserver nose pyautogui
+ # install required packages
+ - py -m pip install -r tests/system/requirements.txt
+ - py -m pip install 
  - mkdir testOutput
  - mkdir testOutput\unit
  - mkdir testOutput\system

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,7 +120,6 @@ build_script:
 before_test:
  # install required packages
  - py -m pip install -r tests/system/requirements.txt
- - py -m pip install 
  - mkdir testOutput
  - mkdir testOutput\unit
  - mkdir testOutput\system

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -2,19 +2,9 @@
 
 ### Dependencies
 
-The system tests depend on the following:
+To install all required packages move to the root directory of this repo and execute:
 
-- Robot Framework
-- Robot Remote Server
-- PyAutoGui
-
-Which can be installed with `pip`:
-
-```
-pip install robotframework
-pip install robotremoteserver
-pip install pyautogui
-```
+`python -m pip install -r tests/system/requirements.txt`
 
 ### Running the tests
 

--- a/tests/system/requirements.txt
+++ b/tests/system/requirements.txt
@@ -1,0 +1,9 @@
+# Manually grab pyGetWindow 0.0.4 as latest release cannot be installed on Python 2.7.
+# See https://github.com/asweigart/PyGetWindow/issues/9
+pygetwindow==0.0.4
+# Latest version of PyAutoGui requires PyGetWindow=0.0.5 which cannot be installed - see above
+# Therefore install last working version
+pyautogui==0.9.43
+nose
+robotframework
+robotremoteserver


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Latest version of PyGetWindow cannot be installed under Python 2.7 see #9592 Unfortunately it is required when installing PyAutoGui 0.9.44. This currently causes system tests on AppVeyor to fail.
### Description of how this pull request fixes the issue:
The older version of PyAutoGui is installed. In addition I've moved all ddependencies to the separate requirements file to make it easier for developers to install required version of packages on their machines, but also to update required version of dependencies in one place.
### Testing performed:
Build and tests on AppVeyor succeeded. It is good to go.
### Known issues with pull request:
None
### Change log entry:
None needed