### PR TITLE
Python 3: file function -> open function

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -412,7 +412,8 @@ class RemoteLoader64(object):
 		pipeRead = self._duplicateAsInheritable(pipeReadOrig)
 		winKernel.closeHandle(pipeReadOrig)
 		# stdout/stderr of the loader process should go to nul.
-		with file("nul", "w") as nul:
+		# #9038 (Py3 review required): File() function is gone, replaced by open().
+		with open("nul", "w") as nul:
 			nulHandle = self._duplicateAsInheritable(msvcrt.get_osfhandle(nul.fileno()))
 		# Set the process to start with the appropriate std* handles.
 		si = winKernel.STARTUPINFO(dwFlags=winKernel.STARTF_USESTDHANDLES, hSTDInput=pipeRead, hSTDOutput=nulHandle, hSTDError=nulHandle)

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -47,7 +47,8 @@ def loadState():
 	global state
 	statePath=os.path.join(globalVars.appArgs.configPath,stateFilename)
 	try:
-		state = cPickle.load(file(statePath, "r"))
+		with open(statePath, "r") as f:
+			state = cPickle.load(f)
 		if "disabledAddons" not in state:
 			state["disabledAddons"] = set()
 		if "pendingDisableSet" not in state:
@@ -67,7 +68,8 @@ def loadState():
 def saveState():
 	statePath=os.path.join(globalVars.appArgs.configPath,stateFilename)
 	try:
-		cPickle.dump(state, file(statePath, "wb"))
+		with open(statePath, "wb") as f:
+			cPickle.dump(state, f)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -47,7 +47,8 @@ def loadState():
 	global state
 	statePath=os.path.join(globalVars.appArgs.configPath,stateFilename)
 	try:
-		with open(statePath, "r") as f:
+		# #9038: Python 3 requires binary format when working with pickles.
+		with open(statePath, "rb") as f:
 			state = cPickle.load(f)
 		if "disabledAddons" not in state:
 			state["disabledAddons"] = set()
@@ -68,6 +69,7 @@ def loadState():
 def saveState():
 	statePath=os.path.join(globalVars.appArgs.configPath,stateFilename)
 	try:
+		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "wb") as f:
 			cPickle.dump(state, f)
 	except:

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -18,14 +18,16 @@ def _updateVersionFromVCS():
 	# The root of the Git working tree will be the parent of this module's directory.
 	gitDir = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".git")
 	try:
-		head = file(os.path.join(gitDir, "HEAD"), "r").read().rstrip()
+		with open(os.path.join(gitDir, "HEAD"), "r") as f:
+			head = f.read().rstrip()
 		if not head.startswith("ref: "):
 			# Detached head.
 			version = "source-DETACHED-%s" % head[:7]
 			return
 		# Strip the "ref: " prefix to get the ref.
 		ref = head[5:]
-		commit = file(os.path.join(gitDir, ref), "r").read().rstrip()
+		with open(os.path.join(gitDir, ref), "r") as f:
+			commit = f.read().rstrip()
 		version = "source-%s-%s" % (
 			os.path.basename(ref),
 			commit[:7])

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -588,7 +588,8 @@ class ConfigManager(object):
 		if os.path.isfile(fn):
 			raise ValueError("A profile with the same name already exists: %s" % name)
 		# Just create an empty file to make sure we can.
-		file(fn, "w")
+		# #9038 (Py3 review required): open and then immediatley close the file.
+		open(fn, "w").close()
 		# Register a script for the new profile.
 		# Import late to avoid circular import.
 		from globalCommands import ConfigProfileActivationCommands

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -80,6 +80,7 @@ class LogViewer(wx.Frame):
 		try:
 			# codecs.open() forces binary mode, which is bad under Windows because line endings won't be converted to crlf automatically.
 			# Therefore, do the encoding manually.
+			# #9038 (Py3 review required): although eligible for "with open" function conversion, encoding issue must be settled first.
 			file(filename, "w").write(self.outputCtrl.GetValue().encode("UTF-8"))
 		except (IOError, OSError), e:
 			# Translators: Dialog text presented when NVDA cannot save a log file.

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -80,8 +80,9 @@ class LogViewer(wx.Frame):
 		try:
 			# codecs.open() forces binary mode, which is bad under Windows because line endings won't be converted to crlf automatically.
 			# Therefore, do the encoding manually.
-			# #9038 (Py3 review required): although eligible for "with open" function conversion, encoding issue must be settled first.
-			file(filename, "w").write(self.outputCtrl.GetValue().encode("UTF-8"))
+			# #9038: work with UTF-8 from the start.
+			with open(filename, "w", encoding="UTF-8") as f:
+				f.write(self.outputCtrl.GetValue())
 		except (IOError, OSError), e:
 			# Translators: Dialog text presented when NVDA cannot save a log file.
 			gui.messageBox(_("Error saving log: %s") % e.strerror, _("Error"), style=wx.OK | wx.ICON_ERROR, parent=self)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -735,6 +735,7 @@ class DonateRequestDialog(wx.Dialog):
 
 def saveState():
 	try:
+		# #9038: Python 3 requires binary format when working with pickles.
 		with open(_stateFilename, "wb") as f:
 			cPickle.dump(state, f)
 	except:
@@ -744,7 +745,8 @@ def initialize():
 	global state, _stateFilename, autoChecker
 	_stateFilename = os.path.join(globalVars.appArgs.configPath, "updateCheckState.pickle")
 	try:
-		with open(_stateFilename, "r") as f:
+		# #9038: Python 3 requires binary format when working with pickles.
+		with open(_stateFilename, "rb") as f:
 			state = cPickle.load(f)
 	except:
 		log.debugWarning("Couldn't retrieve update state", exc_info=True)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -735,7 +735,8 @@ class DonateRequestDialog(wx.Dialog):
 
 def saveState():
 	try:
-		cPickle.dump(state, file(_stateFilename, "wb"))
+		with open(_stateFilename, "wb") as f:
+			cPickle.dump(state, f)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 
@@ -743,7 +744,8 @@ def initialize():
 	global state, _stateFilename, autoChecker
 	_stateFilename = os.path.join(globalVars.appArgs.configPath, "updateCheckState.pickle")
 	try:
-		state = cPickle.load(file(_stateFilename, "r"))
+		with open(_stateFilename, "r") as f:
+			state = cPickle.load(f)
 	except:
 		log.debugWarning("Couldn't retrieve update state", exc_info=True)
 		# Defaults.

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -156,7 +156,8 @@ def _crashHandler(exceptionInfo):
 	# Write a minidump.
 	dumpPath = os.path.abspath(os.path.join(globalVars.appArgs.logFileName, "..", "nvda_crash.dmp"))
 	try:
-		with file(dumpPath, "w") as mdf:
+		# #9038 (Py3 review required): file() function is gone, replaced by open().
+		with open(dumpPath, "w") as mdf:
 			mdExc = MINIDUMP_EXCEPTION_INFORMATION(ThreadId=threadId,
 				ExceptionPointers=exceptionInfo, ClientPointers=False)
 			if not ctypes.windll.DbgHelp.MiniDumpWriteDump(


### PR DESCRIPTION
### Link to issue number:
Fixes #9038 

### Summary of the issue:
Python 3 retires file function in favor of using open function (with or without "with" statement).

### Description of how this pull request fixes the issue:
Edits to call "open" or "with open":

* NVDA helper and Watchdog: with file -> with open
* Add-on handler and update check: cPicle load/dump functions changed to use a "with open" block
* Config: use open/close for creating an empty config file
* Build version: use with open block
* Log viewer: a note about conversion eligibility and encoding issue notes.

### Testing performed:
Tested with source copy of NVDA (Python 3) along with source code version of latest master branch.

### Known issues with pull request:
As noted in log viewer comment, although log viewer/save log routine is eligible to be converted to "with open" block, there is a note about UTF-8 conversion, thus excluded for now.

### Change log entry:
None
