### PR TITLE
Python 3: print statement -> print function

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -458,7 +458,7 @@ class AppModule(baseObject.ScriptableObject):
 			"nvda_crash_%s_%d.dmp" % (self.appName, self.processID)).decode("mbcs")
 		NVDAHelper.localLib.nvdaInProcUtils_dumpOnCrash(
 			self.helperLocalBindingHandle, path)
-		print "Dump path: %s" % path
+		print("Dump path: %s" % path)
 
 class AppProfileTrigger(config.ProfileTrigger):
 	"""A configuration profile trigger for when a particular application has focus.

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -37,9 +37,9 @@ class FunctionHooker(object):
 	def __init__(self,targetDll,importDll,funcName,newFunction):
 		hook=NVDAHelper.localLib.dllImportTableHooks_hookSingle(targetDll,importDll,funcName,newFunction)
 		if hook:
-			print("hooked %s"%funcName)
+			log.debug("hooked %s"%funcName)
 		else:
-			print("could not hook %s"%funcName)
+			log.debug("could not hook %s"%funcName)
 			raise RuntimeError("could not hook %s"%funcName)
 
 	def __del__(self):

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -37,9 +37,9 @@ class FunctionHooker(object):
 	def __init__(self,targetDll,importDll,funcName,newFunction):
 		hook=NVDAHelper.localLib.dllImportTableHooks_hookSingle(targetDll,importDll,funcName,newFunction)
 		if hook:
-			print "hooked %s"%funcName
+			print("hooked %s"%funcName)
 		else:
-			print "could not hook %s"%funcName
+			print("could not hook %s"%funcName)
 			raise RuntimeError("could not hook %s"%funcName)
 
 	def __del__(self):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In python 3, print keyword is now a function.

### Description of how this pull request fixes the issue:
Changes occurrence of "print" statement to a function. Note that this one is also applicable to Python 2, but it is based on Project Threshold/Python 3 assumptions.

### Testing performed:
Tested multiple times on source copy of Python 3 NVDA, Python 2 and 3 interpreter, and current NVDA alpha release.

### Known issues with pull request:
None

### Change log entry:
None
