### PR TITLE
Update espeak-ng to latest master

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ For reference, the following dependencies are included in Git submodules:
 * [wxPython](http://www.wxpython.org/), version 4.0.3
 * [Six](https://pypi.python.org/pypi/six), version 1.10.0, required by wxPython
 * [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 218
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 919f3240cbb
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 86e67a
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,10 @@ What's New in NVDA
 - Added an experimental option to the Advanced Settings panel that allows you to try out a new, work-in-progress rewrite of NVDA's Windows Console support using the Microsoft UI Automation API. (#9614)
 
 
+== changes ==
+- Updated eSpeak-NG to commit 86e67a.
+
+
 == Bug Fixes ==
 - In Mozilla Firefox, updates to a live region are no longer reported if the live region is in a background tab. (#1318)
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
eSpeak-ng in NVDA is  at least 6 months old now. We should upgrade to latest eSpeak-ng master.

### Description of how this pull request fixes the issue:
Updates espeak-ng to commit 86e67a.

### Testing performed:
Ran NVDA and used eSpeak for several minutes in English.

### Known issues with pull request:
None.

### Change log entry:
Changes:
Updated espeak to commit 86e67a.