### PR TITLE
Support for out-of-process iframes in Firefox

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -21,6 +21,8 @@ import aria
 import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
 
+IA2_RELATION_CONTAINING_DOCUMENT = "containingDocument"
+
 class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 
 	def _getBoundingRectFromOffset(self,offset):
@@ -127,18 +129,56 @@ class Gecko_ia2(VirtualBuffer):
 			return False
 		return True
 
+	def _getEmbedderOfContainingDocument(self, acc):
+		"""Get the embedder of the given object's containing document.
+		For example, if acc is a button inside an iframe, this will return the iframe (embedder).
+		"""
+		try:
+			# 1. Get the containing document.
+			if not isinstance(acc, IAccessibleHandler.IAccessible2_2):
+				# IAccessible NVDAObjects currently fetch IA2, but we need IA2_2 for relationTargetsOfType.
+				# (Out-of-process, for a single relation, this is cheaper than IA2::relations.)
+				acc = acc.QueryInterface(IAccessibleHandler.IAccessible2_2)
+			targets, count = acc.relationTargetsOfType(IA2_RELATION_CONTAINING_DOCUMENT, 1)
+			if count == 0:
+				return None
+			doc = targets[0].QueryInterface(IAccessibleHandler.IAccessible2_2)
+			# 2. Get its parent (the embedder); e.g. iframe.
+			embedder = doc.accParent
+			if not embedder:
+				return None
+			return embedder.QueryInterface(IAccessibleHandler.IAccessible2_2)
+		except COMError:
+			return None
+
 	def __contains__(self,obj):
 		if not (isinstance(obj,NVDAObjects.IAccessible.IAccessible) and isinstance(obj.IAccessibleObject,IAccessibleHandler.IAccessible2)) or not obj.windowClassName.startswith('Mozilla') or not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle,obj.windowHandle):
 			return False
-		if self.rootNVDAObject.windowHandle==obj.windowHandle:
-			ID=obj.IA2UniqueID
-			if not ID:
+		acc = obj.IAccessibleObject
+		accId = obj.IA2UniqueID
+		while True:
+			if not accId:
 				# Dead object.
 				return False
+			if accId == self.rootID:
+				return True
 			try:
-				self.rootNVDAObject.IAccessibleObject.accChild(ID)
+				self.rootNVDAObject.IAccessibleObject.accChild(accId)
+				# The object is definitely a descendant of the document.
+				break
 			except COMError:
-				return ID==self.rootNVDAObject.IA2UniqueID
+				pass
+			# accChild failed. This might be because the object is in an
+			# out-of-process iframe, in which case the embedder document won't know
+			# about it. Try the embedder iframe.
+			acc = self._getEmbedderOfContainingDocument(acc)
+			if not acc:
+				return False
+			try:
+				accId = acc.uniqueID
+			except COMError:
+				# Dead object.
+				return False
 
 		return not self._isNVDAObjectInApplication(obj)
 

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited, Babbage B.V., Mozilla Corporation
+#Copyright (C) 2008-2019 NV Access Limited, Babbage B.V., Mozilla Corporation
 
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
@@ -164,13 +164,8 @@ class Gecko_ia2(VirtualBuffer):
 			isDefunct=True
 		return not isDefunct
 
-
 	def getNVDAObjectFromIdentifier(self, docHandle, ID):
-		try:
-			pacc=self.rootNVDAObject.IAccessibleObject.accChild(ID)
-		except COMError:
-			return None
-		return NVDAObjects.IAccessible.IAccessible(windowHandle=docHandle,IAccessibleObject=IAccessibleHandler.normalizeIAccessible(pacc),IAccessibleChildID=0)
+		return NVDAObjects.IAccessible.getNVDAObjectFromEvent(docHandle, winUser.OBJID_CLIENT, ID)
 
 	def getIdentifierFromNVDAObject(self,obj):
 		docHandle=obj.windowHandle


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Firefox is adding support for out-of-process iframes; i.e. iframes rendered in a separate process to their embedder document. For an out-of-process iframe, the embedder has no knowledge of children in the embedded document and cannot communicate with the embedded document at all. This means that accChild for accessibles in the embedded document fails. This requires some changes to the gecko_ia2 virtual buffer.

### Description of how this pull request fixes the issue:
In the gecko_ia2 vbuf:

1. getNVDAObjectFromIdentifier: Use getNVDAObjectFromEvent instead of accChild on the document. This was changed last year to use accChild on the document in the theoretical hope that it might be slightly faster, since it doesn't need to go via the parent process. However, this was never proved to be a performance benefit in real terms. The root accessible is in the parent process and can fetch children in all content documents, so using AccessibleObjectFromEvent works as expected.
2. `__contains__`: If accChild fails, get the embedder iframe and try accChild with the iframe's id. There can be nested out-of-process iframes, so we keep trying this until there are no more embedders in the hierarchy (or until we hit the buffer's root id).

### Testing performed:

1. Loaded a document with two out-of-process iframes in one tab and a document with no iframes in another tab. In the Python console, saved the former document's TreeInterceptor as ti1 and the latter document's TreeInterceptor as ti2; e.g. `ti1 = nav.treeInterceptor`.
2. Moved the navigator object to a node in the innermost iframe and pressed NVDA+control+z to take a console snapshot.
3. Confirmed that `nav in ti1` is True and `nav in ti2` is False.
4. Moved the navigator object to a node in the document with no iframes and pressed NVDA+control+z.
5. Confirmed that `nav in ti1` is False and `nav in ti2` is True.

Also used a build with this change for a while doing some daily browsing with Gmail, GitHub, etc.

### Known issues with pull request:
There will be some additional COM calls for objects in out-of-process iframes. However, there don't tend to be many levels of nested iframes, so I don't anticipate this will be a significant issue in reality.

### Other avenues explored:
Originally, I tried having `__contains__` check the buffer itself to see if it contains the node in question. This also had to check ancestors (limited at an arbitrary number for performance) just in case the buffer hasn't caught up yet or in case we chose not to render descendants in the buffer.

1. I was uncomfortable with the arbitrary ancestor check limit, even though it's necessary for performance. With the new approach, we don't have to worry about performance as much because iframes generally aren't nested deeply (whereas nodes on a page often are).
2. This approach caused major problems when a buffer was being loaded. I didn't dig into this much, but I guess the buffer was reporting that nodes didn't exist (which makes total sense while it's loading). This would certainly confuse things because the focus would be reported as not being within the buffer.

### Change log entry:

Changes:

`- Support for out-of-process iframes in Mozilla Firefox.`