### PR TITLE
UI Automation in Windows Console: remove the isTyping logic from UIA consoles

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -206,7 +206,7 @@ class winConsoleUIA(Terminal):
 
 	def _reportNewText(self, line):
 		# Additional typed character filtering beyond that in LiveText
-		if len(line.strip()) < 3:
+		if len(line.strip()) < max(len(speech.curWordChars) + 1, 3):
 			return
 		if self._hasNewLines:
 			# Clear the typed word buffer for new text lines.
@@ -261,18 +261,13 @@ class winConsoleUIA(Terminal):
 
 	def _calculateNewText(self, newLines, oldLines):
 		self._hasNewLines = (
-			self._findLastLineIndex(newLines)
-			!= self._findLastLineIndex(oldLines)
+			self._findNonBlankIndices(newLines)
+			!= self._findNonBlankIndices(oldLines)
 		)
 		return super(winConsoleUIA, self)._calculateNewText(newLines, oldLines)
 
-	def _findLastLineIndex(self, lines):
-		res = 0
-		for index, line in enumerate(lines):
-			if line:
-				res = index
-		return res
-
+	def _findNonBlankIndices(self, lines):
+		return [index for index, line in enumerate(lines) if line]
 
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -288,7 +288,7 @@ class LiveText(NVDAObject):
 				newLines = self._getTextLines()
 				if config.conf["presentation"]["reportDynamicContentChanges"]:
 					outLines = self._calculateNewText(newLines, oldLines)
-					if len(outLines) == 1 and len(outLines[0]) == 1:
+					if len(outLines) == 1 and len(outLines[0].strip()) == 1:
 						# This is only a single character,
 						# which probably means it is just a typed character,
 						# so ignore it.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614.

### Summary of the issue:
Currently, in UIA consoles:

* In console applications that update the screen while the user is typing (i.e. before `winConsoleUIA._isTyping` is cleared), reporting of new text and speak typed words may not function correctly.

### Description of how this pull request fixes the issue:
This PR removes the `_isTyping` check from consoles. Instead:

* `LiveText` objects strip spaces when filtering typed characters from new text.
* In UIA consoles, if a new text line (after stripping spaces) contains two characters or fewer, it is not reported.
* when a new line is written to the console, the typed word buffer and typed character queue are flushed.

### Testing performed:
On Windows 10 1903, with "speak typed words" and UIA in consoles enabled:

1. Opened a command console.
2. In a git repository, typed `git log`.
3. pressed q.
4. typed git and pressed space.

Before this change: NVDA says "qgit".
After this change: NVDA says "git".

### Known issues with pull request:
When typing quickly, a few typed characters may bypass the filter, resulting in doubled or incorrectly echoed characters. A more severe form of this issue also occurs in legacy consoles. We might want to filter more aggressively at the risk of missing some new text.

### Change log entry:
None.