### PR TITLE
UI Automation in Windows Console: add focus redirection for the UIA console main window

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -861,11 +861,14 @@ class UIA(Window):
 		# Support Windows Console's UIA interface
 		if (
 			self.windowClassName == "ConsoleWindowClass"
-			and self.UIAElement.cachedAutomationId == "Text Area"
 			and config.conf['UIA']['winConsoleImplementation'] == "UIA"
 		):
-			from .winConsoleUIA import winConsoleUIA
-			clsList.append(winConsoleUIA)
+			if self.UIAElement.cachedAutomationId == "Text Area":
+				from .winConsoleUIA import winConsoleUIA
+				clsList.append(winConsoleUIA)
+			if self.UIAElement.cachedAutomationId == "Console Window":
+				from .winConsoleUIA import consoleUIAWindow
+				clsList.append(consoleUIAWindow)
 		# Add editableText support if UIA supports a text pattern
 		if self.TextInfo==UIATextInfo:
 			clsList.append(EditableTextWithoutAutoSelectDetection)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -863,12 +863,8 @@ class UIA(Window):
 			self.windowClassName == "ConsoleWindowClass"
 			and config.conf['UIA']['winConsoleImplementation'] == "UIA"
 		):
-			if self.UIAElement.cachedAutomationId == "Text Area":
-				from .winConsoleUIA import winConsoleUIA
-				clsList.append(winConsoleUIA)
-			if self.UIAElement.cachedAutomationId == "Console Window":
-				from .winConsoleUIA import consoleUIAWindow
-				clsList.append(consoleUIAWindow)
+			from . import winConsoleUIA
+			winConsoleUIA.findExtraOverlayClasses(self, clsList)
 		# Add editableText support if UIA supports a text pattern
 		if self.TextInfo==UIATextInfo:
 			clsList.append(EditableTextWithoutAutoSelectDetection)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -262,5 +262,5 @@ class winConsoleUIA(Terminal):
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":
 		clsList.append(winConsoleUIA)
-	if obj.UIAElement.cachedAutomationId == "Console Window":
+	elif obj.UIAElement.cachedAutomationId == "Console Window":
 		clsList.append(consoleUIAWindow)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -258,3 +258,9 @@ class winConsoleUIA(Terminal):
 		ptr = self.UIATextPattern.GetVisibleRanges()
 		res = [ptr.GetElement(i).GetText(-1) for i in range(ptr.length)]
 		return res
+
+def findExtraOverlayClasses(obj, clsList):
+	if obj.UIAElement.cachedAutomationId == "Text Area":
+		clsList.append(winConsoleUIA)
+	if obj.UIAElement.cachedAutomationId == "Console Window":
+		clsList.append(consoleUIAWindow)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -16,6 +16,7 @@ from scriptHandler import script
 from winVersion import isAtLeastWin10
 from . import UIATextInfo
 from ..behaviors import Terminal
+from ..window import Window
 
 
 class consoleUIATextInfo(UIATextInfo):
@@ -181,6 +182,20 @@ class consoleUIATextInfo(UIATextInfo):
 			start.value,
 			min(end.value, max(1, len(lineText) - 2))
 		)
+
+
+class consoleUIAWindow(Window):
+	def _get_focusRedirect(self):
+		"""
+			Sometimes, attempting to interact with the console too quickly after
+			focusing the window can make NVDA unable to get any caret or review
+			information or receive new text events.
+			To work around this, we must redirect focus to the console text area.
+		"""
+		for child in self.children:
+			if isinstance(child, winConsoleUIA):
+				return child
+		return None
 
 
 class winConsoleUIA(Terminal):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614.

### Summary of the issue:
Currently, in UIA consoles:

* Sometimes, attempting to interact with the console too quickly after focusing the window can make NVDA unable to get any caret or review information or receive new text events.

### Description of how this pull request fixes the issue:
This PR adds focus redirection from the console application's window to its text area.

### Testing performed:
On Windows 10 1903 with UIA console support enabled:

1. Open a command console.
2. Press alt+space.
3. Press e to open the edit menu.
4. Press p to paste.

Before this change: NVDA became unable to interact with the console.
After this change: NVDA's console interaction was unaffected.

### Known issues with pull request:
None known.

### Change log entry:
None.