### PR TITLE
Update liblouis to version 3.10

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -40,7 +40,7 @@ if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
 # Ignore all warnings as the code is not ours
-env.Append(CCFLAGS='/W0')
+env.Replace(CCFLAGS='/W0')
 
 env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir,espeakSrcDir.Dir('ucd-tools/src/include')])
 

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -41,6 +41,9 @@ env = env.Clone()
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
+# Ignore some warnings as the code is not ours
+env.Replace(CCFLAGS='/W2')
+
 env.Append(CPPDEFINES=[
 	# The Visual C++ C Runtime deprecates several standard library functions in
 	# preference for _s variants that are specific to Visual C++. This removes

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ For reference, the following dependencies are included in Git submodules:
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
-* [liblouis](http://www.liblouis.org/), version 3.9.0
+* [liblouis](http://www.liblouis.org/), version 3.10.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
[Liblouis 3.10.0 has been released](https://github.com/liblouis/liblouis/tree/v3.10.0).

### Description of how this pull request fixes the issue:
Updated the liblouis submodule and changed the readme. While there are added/renamed/removed tables, they are not used by NVDA.
Version 3.10 is no longer free of warnings. As the liblouis team doesn't seem to care much about being warning free for VC++, I've lowered the warning level to level 2, in which case everything builds again. For this, I was inspired by the espeak sonscript. However, the espeak sconscript used env.Append instead of env.Replace. I changed the espeak sconscript as well to avoid a command line warning due to both /W3 and /W0 provided on the command line.

### Testing performed:
Tested from source, everything worked as expected. Also, unit tests.

### Known issues with pull request:
None

### Change log entry:
* Changes
    + Updated liblouis braille translator to version 3.10.0.