### PR TITLE
UI Automation in Windows Console: make review bounds configurable

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -14,6 +14,7 @@ import textInfos
 import ui
 import UIAHandler
 
+from inputCore import SCRCAT_MISC
 from scriptHandler import script
 from winVersion import isAtLeastWin10
 from . import UIATextInfo
@@ -249,12 +250,20 @@ class winConsoleUIA(Terminal):
 		self._isTyping = False
 		self._queuedChars = []
 
-	@script(gesture="kb:NVDA+o")
+	@script(
+		gesture="kb:NVDA+o",
+		description=_("Selects the next review bounds setting"), # Translators: A gesture description.
+		category=SCRCAT_MISC,
+	)
 	def script_next_review_bound(self, gesture):
 		self._reviewBoundsSetting += 1
 		self._updateReviewBounds()
 
-	@script(gesture="kb:NVDA+shift+o")
+	@script(
+		gesture="kb:NVDA+shift+o",
+		description=_("Selects the previous review bounds setting"), # Translators: A gesture description.
+		category=SCRCAT_MISC,
+	)
 	def script_prev_review_bound(self, gesture):
 		self._reviewBoundsSetting -= 1
 		self._updateReviewBounds()

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -942,6 +942,24 @@ When in the table view of added books:
 | Context menu | applications | Opens the context menu for the selected book. |
 %kc:endInclude
 
+++ Windows Console ++[windoesConsole]
+
+By default, when UI Automation is enabled for the Windows Console, the review cursor is constrained to the text currently visible on the screen (i.e. once text scrolls off the top or below the bottom of the console, it cannot be reviewed). However, this can be changed on the fly to allow previously visible text to be reviewed. The following review modes are available:
+
+- Top bounded: Review before the beginning of the onscreen text is constrained, but review after it is not.
+- Doubly bounded (default): review is constrained to onscreen text.
+- Bottom bounded: review past the onscreen text is constrained, but review before it is permitted. This mode allows text that scrolled off the top of the screen to be reviewed.
+- Unbounded: No constraints are placed on review, so all text presented by the operating system can be read.
+
+
+%kc:beginInclude
+The following commands are available in the Windows Console when UI Automation is enabled:
+
+|| Name | Key | Description |
+| next review bounds setting | NVDA+o | Selects the next review bounds setting for this console window. |
+| previous review bounds setting | NVDA+shift+o | Selects the previous review bounds setting for this console window. |
+%kc:endInclude
+
 + Configuring NVDA +[ConfiguringNVDA]
 Most configuration can be performed using dialog boxes accessed through the Preferences sub-menu of the NVDA menu.
 Many of these settings can be found in the multi-page [NVDA Settings dialog #NVDASettings].


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614.

### Summary of the issue:
In the Windows Console, only onscreen text can be read using the review cursor; if text scrolls off the screen, it is impossible to review it.

### Description of how this pull request fixes the issue:
This PR allows the review bounds (i.e. which portion of the console buffer can be reviewed) to be changed on the fly using new gestures. Currently, nvda+o and nvda+shift+o cycle among the review bounds options.

### Testing performed:
Attempted to review text before and after running `git log` using the various modes on Windows 10 1903.

### Known issues with pull request:
* I don't really like NVDA+o for this. Can you think of an easier command to type?

### Change log entry:
None yet, but this should definitely get one once UIA becomes the default.