### PR TITLE
Add NVDA+F1 shortcut to the userguide

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1896,6 +1896,7 @@ To change NVDA's configuration on the logon/UAC screens, configure NVDA as you w
 
 ++ Log Viewer ++[LogViewer]
 The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred up until now from when you last started NVDA.
+Using NVDA+F1 will open the log viewer and display developer information about the current navigator object.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
 These actions are available under the viewer's Log menu.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:
The userguide does not mention the NVDA+F1 shortcut.

### Description of how this pull request fixes the issue:
Adds the shortcut, and a short description of developer info to the Log Viewer section.

### Testing performed:
None

### Known issues with pull request:
None

### Change log entry:
None

