### PR TITLE
Python 3: use floor division (//) to obtain integer results from division operations

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -154,8 +154,10 @@ class MainFrame(wx.Frame):
 		# The menu pops up at the location of the mouse, which means it pops up at an unpredictable location.
 		# Therefore, move the mouse to the centre of the screen so that the menu will always pop up there.
 		left, top, width, height = api.getDesktopObject().location
-		x = width / 2
-		y = height / 2
+		# #9641 (Py3 review required): pixel coordinates are integers, not floats.
+		# Thus perform a floor division.
+		x = width // 2
+		y = height // 2
 		winUser.setCursorPos(x, y)
 		self.evaluateUpdatePendingUpdateMenuItemCommand()
 		self.sysTrayIcon.onActivate(None)

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -170,7 +170,9 @@ class WavePlayer(object):
 			wfx.nChannels = self.channels
 			wfx.nSamplesPerSec = self.samplesPerSec
 			wfx.wBitsPerSample = self.bitsPerSample
-			wfx.nBlockAlign = self.bitsPerSample / 8 * self.channels
+			# #9641 (Py3 review required): wfx.nBlockAlign = ctypes.wintypes.WORD == ctypes.ushort == int.
+			# Thus use floor division so we can obtain an integer.
+			wfx.nBlockAlign = self.bitsPerSample // 8 * self.channels
 			wfx.nAvgBytesPerSec = self.samplesPerSec * wfx.nBlockAlign
 			waveout = HWAVEOUT(0)
 			with self._global_waveout_lock:

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -349,7 +349,9 @@ class SynthDriver(SynthDriver):
 			# pos is a time offset in 100-nanosecond units.
 			# Convert this to a byte offset.
 			# Order the equation so we don't have to do floating point.
-			pos = pos * self._bytesPerSec / HUNDRED_NS_PER_SEC
+			# #9641 (Py3 review required): one way to ensure no floating point is doing a floor division to obtain an integer.
+			# Because one slash operator will do true division in Python 3, which will return a float.
+			pos = pos * self._bytesPerSec // HUNDRED_NS_PER_SEC
 			# Push audio up to this marker.
 			self._player.feed(data[prevPos:pos],
 				onDone=lambda index=index: synthIndexReached.notify(synth=self, index=index))


### PR DESCRIPTION
### Link to issue number:
Fixes #9641 

### Summary of the issue:
Python 2 and 3 shows different behavior for traditional division (/) operator; classic versus true.

### Description of how this pull request fixes the issue:
Use floor division (//) operator to obtain integers because Python 3 will perform true division when only one slash (/) is written, which will result in returning floats instead of integers.

### Testing performed:
Tested with both Python 2 and 3 - Python Console, Python interpreters.

### Known issues with pull request:
There might be other cases not covered in this pull request, and in some cases, erroneous integer result may appear due to use of floor division (moving to the left side of the number line, especially for negative numbers).

### Change log entry:
None
