### PR TITLE
Python 3: use importlib for importing modules

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -10,6 +10,7 @@ import ctypes
 import os
 import re
 import itertools
+import importlib
 from comInterfaces.tom import ITextDocument
 import tones
 import languageHandler
@@ -438,7 +439,8 @@ the NVDAObject for IAccessible
 			if classString and classString.find('.')>0:
 				modString,classString=os.path.splitext(classString)
 				classString=classString[1:]
-				mod=__import__(modString,globals(),locals(),[])
+				# #8712: Python 3 wants a dot (.) when loading a module from the same folder via relative imports, and this is done via package argument.
+				mod=importlib.import_module("NVDAObjects.IAccessible.%s"%modString, package="NVDAObjects.IAccessible")
 				newCls=getattr(mod,classString)
 			elif classString:
 				newCls=globals()[classString]

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -17,6 +17,7 @@ import os
 import sys
 import winVersion
 import pkgutil
+import importlib
 import threading
 import tempfile
 import comtypes.client
@@ -93,8 +94,8 @@ def getAppNameFromProcessID(processID,includeExt=False):
 	# Try querying the app module for the name of the app being hosted.
 	try:
 		# Python 2.x can't properly handle unicode module names, so convert them.
-		mod = __import__("appModules.%s" % appName.encode("mbcs"),
-			globals(), locals(), ("appModules",))
+		# #8768 (Py3 review required): no longer the case in Python 3.
+		mod = importlib.import_module("appModules.%s" % appName, package="appModules")
 		return mod.getAppNameFromHost(processID)
 	except (ImportError, AttributeError, LookupError):
 		pass
@@ -172,7 +173,7 @@ def fetchAppModule(processID,appName):
 
 	if doesAppModuleExist(modName):
 		try:
-			return __import__("appModules.%s" % modName, globals(), locals(), ("appModules",)).AppModule(processID, appName)
+			return importlib.import_module("appModules.%s" % modName, package="appModules").AppModule(processID, appName)
 		except:
 			log.error("error in appModule %r"%modName, exc_info=True)
 			# We can't present a message which isn't unicode, so use appName, not modName.

--- a/source/braille.py
+++ b/source/braille.py
@@ -10,6 +10,7 @@ import itertools
 import os
 import driverHandler
 import pkgutil
+import importlib
 import ctypes.wintypes
 import threading
 import time
@@ -313,14 +314,14 @@ def NVDAObjectHasUsefulText(obj):
 
 def _getDisplayDriver(moduleName, caseSensitive=True):
 	try:
-		return __import__("brailleDisplayDrivers.%s" % moduleName, globals(), locals(), ("brailleDisplayDrivers",)).BrailleDisplayDriver
+		return importlib.import_module("brailleDisplayDrivers.%s" % moduleName, package="brailleDisplayDrivers").BrailleDisplayDriver
 	except ImportError as initialException:
 		if caseSensitive:
 			raise initialException
 		for loader, name, isPkg in pkgutil.iter_modules(brailleDisplayDrivers.__path__):
 			if name.startswith('_') or name.lower() != moduleName.lower():
 				continue
-			return __import__("brailleDisplayDrivers.%s" % name, globals(), locals(), ("brailleDisplayDrivers",)).BrailleDisplayDriver
+			return importlib.import_module("brailleDisplayDrivers.%s" % name, package="brailleDisplayDrivers").BrailleDisplayDriver
 		else:
 			raise initialException
 

--- a/source/globalPluginHandler.py
+++ b/source/globalPluginHandler.py
@@ -6,6 +6,7 @@
 
 import sys
 import pkgutil
+import importlib
 import config
 import baseObject
 from logHandler import log
@@ -19,7 +20,7 @@ def listPlugins():
 		if name.startswith("_"):
 			continue
 		try:
-			plugin = __import__("globalPlugins.%s" % name, globals(), locals(), ("globalPlugins",)).GlobalPlugin
+			plugin = importlib.import_module("globalPlugins.%s" % name, package="globalPlugins").GlobalPlugin
 		except:
 			log.error("Error importing global plugin %s" % name, exc_info=True)
 			continue

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -7,6 +7,7 @@
 
 import os
 import pkgutil
+import importlib
 import config
 import baseObject
 import winVersion
@@ -38,7 +39,7 @@ def changeVoice(synth, voice):
 	speechDictHandler.loadVoiceDict(synth)
 
 def _getSynthDriver(name):
-	return __import__("synthDrivers.%s" % name, globals(), locals(), ("synthDrivers",)).SynthDriver
+	return importlib.import_module("synthDrivers.%s" % name, package="synthDrivers").SynthDriver
 
 def getSynthList():
 	synthList=[]


### PR DESCRIPTION
Hi,

Reworked version of a previous PR:

### Link to issue number:
Fixes #8768 

### Summary of the issue:
Uses importlib for importing modules instead of using __import__ function.

### Description of how this pull request fixes the issue:
Same as a reverted PR but only concerns importlib. This affects IAccessible objects, app modules, braille display drivers, global plugin handler and synth drivers.

Also, unlike previous PR, this one is strictly Python 3 - no encoding/decoding done.

### Testing performed:
Tested with source code copy (Python 2 and 3).

### Known issues with pull request:
Possible Unicode-related issues may surface.

### Change log entry:
None

