### PR TITLE
Python 3: dict.haskey -> key in dict

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -284,7 +284,7 @@ class JAB(Window):
 		stateString=self.JABStates
 		stateStrings=stateString.split(',')
 		for state in stateStrings:
-			if JABStatesToNVDAStates.has_key(state):
+			if state in JABStatesToNVDAStates:
 				stateSet.add(JABStatesToNVDAStates[state])
 		if "visible" not in stateStrings:
 			stateSet.add(controlTypes.STATE_INVISIBLE)

--- a/source/appModules/msimn.py
+++ b/source/appModules/msimn.py
@@ -65,7 +65,7 @@ class AppModule(appModuleHandler.AppModule):
 		parentClassName=winUser.getClassName(parentWindow)
 		#If this object is an email header field, and we have a custom label for it,
 		#Then set the object's name to the label 
-		if parentClassName=="OE_Envelope" and isinstance(obj,IAccessible) and obj.IAccessibleChildID==0 and envelopeNames.has_key(controlID):
+		if parentClassName=="OE_Envelope" and isinstance(obj,IAccessible) and obj.IAccessibleChildID==0 and controlID in envelopeNames:
 			obj.name=envelopeNames[controlID]
 			obj.useITextDocumentSupport=True
 			obj.editValueUnit=textInfos.UNIT_STORY


### PR DESCRIPTION
### Link to issue number:
Fixes #9640 

### Summary of the issue:
Python 3 retires dict.has_key in favor of key in dict.

### Description of how this pull request fixes the issue:
Edited instances of dict.has_key to use key in dict.

Steps:

1. Use grep to look for "\.has\_key".
2. Edit instances of has_key to key in dict.

Note that there were two other instances of has_key but they were taken care of via xrange to range conversion.

### Testing performed:
Tested with both Python 2 and 3 interpreters and source code copies.

### Known issues with pull request:
None

### Change log entry:
None
