### PR TITLE
Python 3: except exception, e -> except as e

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -608,7 +608,7 @@ the NVDAObject for IAccessible
 			try:
 				left,top,width,height = IAccessibleObject.accLocation(0)
 				windowHandle=winUser.user32.WindowFromPoint(winUser.POINT(left,top))
-			except COMError, e:
+			except COMError as e:
 				log.debugWarning("accLocation failed: %s" % e)
 		if not windowHandle:
 			raise InvalidNVDAObject("Can't get a window handle from IAccessible")

--- a/source/NVDAObjects/IAccessible/adobeFlash.py
+++ b/source/NVDAObjects/IAccessible/adobeFlash.py
@@ -21,7 +21,7 @@ class InputTextFieldTextInfo(NVDAObjectTextInfo):
 	def _getRawSelectionOffsets(self):
 		try:
 			return self.obj.ISimpleTextSelectionObject.GetSelection()
-		except COMError, e:
+		except COMError as e:
 			if e.hresult == hresult.E_FAIL:
 				# The documentation says that an empty field should return 0 for both values, but instead, we seem to get E_FAIL.
 				# An empty field still has a valid caret.

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -83,7 +83,7 @@ class LogViewer(wx.Frame):
 			# #9038: work with UTF-8 from the start.
 			with open(filename, "w", encoding="UTF-8") as f:
 				f.write(self.outputCtrl.GetValue())
-		except (IOError, OSError), e:
+		except (IOError, OSError) as e:
 			# Translators: Dialog text presented when NVDA cannot save a log file.
 			gui.messageBox(_("Error saving log: %s") % e.strerror, _("Error"), style=wx.OK | wx.ICON_ERROR, parent=self)
 

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -243,7 +243,7 @@ class GlobalGestureMap(object):
 		self.fileName = filename
 		try:
 			conf = configobj.ConfigObj(filename, file_error=True, encoding="UTF-8")
-		except (configobj.ConfigObjError,UnicodeDecodeError), e:
+		except (configobj.ConfigObjError,UnicodeDecodeError) as e:
 			log.warning("Error in gesture map '%s': %s"%(filename, e))
 			self.lastUpdateContainedError = True
 			return

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -100,7 +100,7 @@ def main():
 	except installer.RetriableFailure:
 		logHandler.log.error("Task failed, try again",exc_info=True)
 		sys.exit(2)
-	except Exception, e:
+	except Exception as e:
 		logHandler.log.error("slave error",exc_info=True)
 		sys.exit(1)
 

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -214,7 +214,7 @@ class WavePlayer(object):
 				try:
 					with self._global_waveout_lock:
 						winmm.waveOutWrite(self._waveout, LPWAVEHDR(whdr), sizeof(WAVEHDR))
-				except WindowsError, e:
+				except WindowsError as e:
 					self.close()
 					raise e
 			self.sync()


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Python 3 does not allow excewption assignment of the form "except, e" but rather prefers "except as e".

### Description of how this pull request fixes the issue:
Edit all instances of the former syntax to the new one.

Steps:

1. Use grep to look for ", e:".
2. Edit the instances found, looking carefully at context around them.

### Testing performed:
Tested with Python 2 and 3 interpreters, along with source code copies.

### Known issues with pull request:
None, although there is one instance where UnicodeDecodeError is raised, which may indicate Python 2 assumptions.

### Change log entry:
None
