### PR TITLE
SAPI 5: percent to rate/pitch must return an integer

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -184,7 +184,8 @@ class SynthDriver(SynthDriver):
 			return None
 
 	def _percentToRate(self, percent):
-		return (percent - 50) / 5
+		# #9641 (Py3 review required): rate is an integer.
+		return (percent - 50) // 5
 
 	def _set_rate(self,rate):
 		self.tts.Rate = self._percentToRate(rate)
@@ -230,7 +231,8 @@ class SynthDriver(SynthDriver):
 		self._initTts(voice=voice)
 
 	def _percentToPitch(self, percent):
-		return percent / 2 - 25
+		# #9641 (Py3 review required): pitch is an integer.
+		return percent // 2 - 25
 
 	IPA_TO_SAPI = {
 		u"θ": u"th",


### PR DESCRIPTION
### Link to issue number:
None, although a follow-up to a previous division operator pull request

### Summary of the issue:
SAPI 5 synth cannot be used in Python 3 mode because pitch/rate is seen as a float.

### Description of how this pull request fixes the issue:
Changed one slash to two slashes in percent to pitch/rate methods to make sure these values are returned as integers.

### Testing performed:
Tested with source code copy (Python 2 and 3) and comparing results of these method calls.

### Known issues with pull request:
None

### Change log entry:
None
