### PR TITLE
import Python 3 native modules

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,14 +1,11 @@
 # -*- coding: UTF-8 -*-
 #javaAccessBridgeHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
+#Copyright (C) 2007-2018 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-try:
-	import Queue as queue # Python 2.7 import
-except ImportError:
-	import queue # Python 3 import
+import queue
 from ctypes import *
 from ctypes.wintypes import *
 import time

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -6,10 +6,7 @@
 
 import os
 import sys
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import msvcrt
 import versionInfo
 import winKernel

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -7,7 +7,7 @@
 
 import time
 from collections import OrderedDict
-from cStringIO import StringIO
+from io import StringIO
 import braille
 import inputCore
 from logHandler import log

--- a/source/brailleDisplayDrivers/eurobraille.py
+++ b/source/brailleDisplayDrivers/eurobraille.py
@@ -6,7 +6,7 @@
 #Copyright (C) 2017-2019 NV Access Limited, Babbage B.V., Eurobraille
 
 from collections import OrderedDict, defaultdict
-from cStringIO import StringIO
+from io import StringIO
 import serial
 import bdDetect
 import braille

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -10,7 +10,7 @@ Braille display driver for Handy Tech braille displays.
 """
 
 from collections import OrderedDict
-from cStringIO import StringIO
+from io import StringIO
 import serial # pylint: disable=E0401
 import weakref
 import hwIo

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -6,7 +6,7 @@
 #Copyright (C) 2010-2018 Gianluca Casalino, NV Access Limited, Babbage B.V., Leonard de Ruijter, Bram Duvigneau
 
 import serial
-from cStringIO import StringIO
+from io import StringIO
 import os
 import hwIo
 import braille

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -27,10 +27,7 @@ import serial
 
 #for brxcom
 import ctypes as c
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import winUser
 
 #for scripting

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -12,15 +12,12 @@ For the latter two actions, one can perform actions prior to and/or after they t
 """ 
 
 import globalVars
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import ctypes
 import ctypes.wintypes
 import os
 import sys
-from cStringIO import StringIO
+from io import StringIO
 import itertools
 import contextlib
 from copy import deepcopy

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -4,7 +4,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-from cStringIO import StringIO
+from io import StringIO
 from configobj import ConfigObj
 
 #: The version of the schema outlined in this file. Increment this when modifying the schema and 

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -7,10 +7,7 @@
 """Utilities for working with the Windows Ease of Access Center.
 """
 
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import ctypes
 import winUser
 from winVersion import winVersion

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -11,12 +11,7 @@ from gui.dpiScalingHelper import DpiScalingHelperMixin
 import oleacc
 import winUser
 import winsound
-try:
-	# Python 3 import
-	from collections.abc import Callable
-except ImportError:
-	# Python 2 import
-	from collections import Callable
+from collections.abc import Callable
 
 class AutoWidthColumnListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
 	"""

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -9,10 +9,7 @@
 import itertools
 import ctypes
 from ctypes.wintypes import BOOL, WCHAR, HWND, DWORD, ULONG, WORD, USHORT
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import winKernel
 from winKernel import SYSTEMTIME
 import config

--- a/source/installer.py
+++ b/source/installer.py
@@ -6,10 +6,7 @@
 
 from ctypes import *
 from ctypes.wintypes import *
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import threading
 import time
 import os

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -8,7 +8,7 @@
 This module assists in NVDA going global through language services such as converting Windows locale ID's to friendly names and presenting available languages.
 """
 
-import __builtin__
+import builtins
 import os
 import sys
 import ctypes

--- a/source/mathType.py
+++ b/source/mathType.py
@@ -7,10 +7,7 @@
 """Utilities for working with MathType.
 """
 
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import ctypes
 import mathPres
 

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -177,10 +177,7 @@ if not mutex or ctypes.windll.kernel32.GetLastError()==ERROR_ALREADY_EXISTS:
 
 isSecureDesktop = desktopName == "Winlogon"
 if isSecureDesktop:
-	try:
-		import _winreg as winreg # Python 2.7 import
-	except ImportError:
-		import winreg # Python 3 import
+	import winreg
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, ur"SOFTWARE\NVDA")
 		if not winreg.QueryValueEx(k, u"serviceDebug")[0]:

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -10,7 +10,7 @@ import watchdog
 To use, call L{initialize} to create a singleton instance of the console GUI. This can then be accessed externally as L{consoleUI}.
 """
 
-import __builtin__
+import builtins
 import os
 import code
 import sys

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -5,10 +5,7 @@
 #See the file COPYING for more details.
 
 import types
-try:
-	from Queue import Queue # Python 2.7 import
-except ImportError:
-	from queue import Queue # Python 3 import
+from queue import Queue
 import globalVars
 from logHandler import log
 import watchdog

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -8,10 +8,7 @@
 import time
 import nvwave
 import threading
-try:
-	import Queue as queue # Python 2.7 import
-except ImportError:
-	import queue # Python 3 import
+import queue
 from ctypes import *
 import config
 import globalVars

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -8,7 +8,6 @@
 import os
 from collections import OrderedDict
 from . import _espeak
-import Queue
 import threading
 import languageHandler
 from synthDriverHandler import SynthDriver, VoiceInfo, synthIndexReached, synthDoneSpeaking

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -11,13 +11,10 @@ import os
 import sys
 from collections import OrderedDict
 import ctypes
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import wave
-import cStringIO
 from synthDriverHandler import SynthDriver, VoiceInfo, synthIndexReached, synthDoneSpeaking
+import io
 from logHandler import log
 import config
 import nvwave
@@ -329,7 +326,7 @@ class SynthDriver(SynthDriver):
 			self._processQueue()
 			return
 		# This gets called in a background thread.
-		stream = cStringIO.StringIO(ctypes.string_at(bytes, len))
+		stream = io.BytesIO(ctypes.string_at(bytes, len))
 		wav = wave.open(stream, "r")
 		self._maybeInitPlayer(wav)
 		data = wav.readframes(wav.getnframes())

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -6,10 +6,7 @@
 
 import locale
 from collections import OrderedDict
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 from comtypes import COMObject, COMError
 from ctypes import *
 from synthDriverHandler import SynthDriver,VoiceInfo, synthIndexReached, synthDoneSpeaking

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -13,10 +13,7 @@ import os
 from ctypes import *
 import comtypes.client
 from comtypes import COMError
-try:
-	import _winreg as winreg # Python 2.7 import
-except ImportError:
-	import winreg # Python 3 import
+import winreg
 import audioDucking
 import NVDAHelper
 import globalVars


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Several modules from the standard library have been renamed in Python 3. In particular:
* Queue is now queue
* _winreg is now winreg
* cStringIO is now io.StringIO

### Description of how this pull request fixes the issue:
Cherry picked commit e047a68 from pr #9543, fixed some conflicts, and added one missing change from nvda.pyw.
Reviewed by @michaelDCurran when cherry picked.
grepped for existance of all old modules.
 
### Testing performed:
tbd.

### Known issues with pull request:
None

### Change log entry:
None

Section: New features, Changes, Bug fixes

