### PR TITLE
Python3: sys.maxint to sys.maxsize

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1282,7 +1282,8 @@ the NVDAObject for IAccessible
 		# For our purposes, we can treat both S_OK and S_FALSE as success.
 		if res!=S_OK and res!=S_FALSE:
 			raise COMError(res,None,None)
-		return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxint
+		# Py3 review required: sys.maxint is gone in Python 2, replaced by sys.maxsize.
+		return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxsize
 
 	def getSelectedItemsCount(self,maxCount):
 		# To fetch the number of selected items, we first try MSAA's accSelection, but if that fails in any way, we fall back to using IAccessibleTable2's nSelectedCells, if we are on an IAccessible2 table.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

### Summary of the issue:
In Python3, sys.maxint has been replaced by sys.maxsize.

### Description of how this pull request fixes the issue:
Cherry picked commit 8898bab from pr #9543.
Reviewd by @michaelDCurran when cherry picked.
Grepped for maxint, finding none.

### Testing performed:
tbd.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

