### PR TITLE
Python3: os.getcwdu -> os.getcwd

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -85,7 +85,9 @@ def isInstalledCopy():
 		return False
 	winreg.CloseKey(k)
 	try:
-		return os.stat(instDir)==os.stat(os.getcwdu()) 
+		return os.stat(instDir)==os.stat(os.getcwd()) 
+	except AttributeError:
+		return os.stat(instDir)==os.stat(os.getcwd()) 
 	except WindowsError:
 		return False
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -86,8 +86,6 @@ def isInstalledCopy():
 	winreg.CloseKey(k)
 	try:
 		return os.stat(instDir)==os.stat(os.getcwd()) 
-	except AttributeError:
-		return os.stat(instDir)==os.stat(os.getcwd()) 
 	except WindowsError:
 		return False
 

--- a/source/core.py
+++ b/source/core.py
@@ -385,7 +385,7 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 	if not wxLang and '_' in lang:
 		wxLang=locale.FindLanguageInfo(lang.split('_')[0])
 	if hasattr(sys,'frozen'):
-		locale.AddCatalogLookupPathPrefix(os.path.join(os.getcwdu(),"locale"))
+		locale.AddCatalogLookupPathPrefix(os.path.join(os.getcwd(),"locale"))
 	# #8064: Wx might know the language, but may not actually contain a translation database for that language.
 	# If we try to initialize this language, wx will show a warning dialog.
 	# #9089: some languages (such as Aragonese) do not have language info, causing language getter to fail.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -46,7 +46,7 @@ except RuntimeError:
 	updateCheck = None
 
 ### Constants
-NVDA_PATH = os.getcwdu()
+NVDA_PATH = os.getcwd()
 ICON_PATH=os.path.join(NVDA_PATH, "images", "nvda.ico")
 DONATE_URL = "http://www.nvaccess.org/donate/"
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -119,7 +119,7 @@ def getDocFilePath(fileName,installDir):
 				return tryPath
 
 def copyProgramFiles(destPath):
-	sourcePath=os.getcwdu()
+	sourcePath=os.getcwd()
 	detectUserConfig=True
 	detectNVDAExe=True
 	for curSourceDir,subDirs,files in os.walk(sourcePath):

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -196,7 +196,7 @@ def _executeUpdate(destPath):
 	if config.isInstalledCopy():
 		executeParams = u"--install -m"
 	else:
-		portablePath = os.getcwdu()
+		portablePath = os.getcwd()
 		if os.access(portablePath, os.W_OK):
 			executeParams = u'--create-portable --portable-path "{portablePath}" --config-path "{configPath}" -m'.format(
 				portablePath=portablePath,


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Python 3's os.getcwd is now unicode, and the old os.getcwdu no longer exists.
 
### Description of how this pull request fixes the issue:
Cherry-picked commit c42b9f from pr #9543, removing an unneeded except AttributeError, and changing one last getcwdu in updateCheck.
Reviewed by @michaelDCurran 
 Grepped for getcwdu, finding none left.

### Testing performed:
tbd.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

