### PR TITLE
Python3: fix NVDA's logging infrastructure

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -24,7 +24,8 @@ from copy import deepcopy
 from collections import OrderedDict
 from configobj import ConfigObj, ConfigObjError
 from configobj.validate import Validator
-from logHandler import log, levelNames
+from logHandler import log
+import logging
 from logging import DEBUG
 import shlobj
 import baseObject
@@ -452,7 +453,7 @@ class ConfigManager(object):
 			logLevelName = profile["general"]["loggingLevel"]
 		except KeyError as e:
 			logLevelName = None
-		if log.isEnabledFor(log.DEBUG) or (logLevelName and DEBUG >= levelNames.get(logLevelName)):
+		if log.isEnabledFor(log.DEBUG) or (logLevelName and DEBUG >= logging.getLevelName(logLevelName)):
 			# Log at level info to ensure that the profile is logged.
 			log.info(u"Config loaded (after upgrade, and in the state it will be used by NVDA):\n{0}".format(profile))
 		return profile

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5,6 +5,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+import logging
 from abc import abstractmethod
 from six import with_metaclass
 import os
@@ -787,7 +788,7 @@ class GeneralSettingsPanel(SettingsPanel):
 		config.conf["general"]["askToExit"]=self.askToExitCheckBox.IsChecked()
 		config.conf["general"]["playStartAndExitSounds"]=self.playStartAndExitSoundsCheckBox.IsChecked()
 		logLevel=self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
-		config.conf["general"]["loggingLevel"]=logHandler.levelNames[logLevel]
+		config.conf["general"]["loggingLevel"]=logging.getLevelName(logLevel)
 		logHandler.setLogLevelFromConfig()
 		if self.startAfterLogonCheckBox.IsEnabled():
 			config.setStartAfterLogon(self.startAfterLogonCheckBox.GetValue())

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -12,7 +12,6 @@ import sys
 import warnings
 from encodings import utf_8
 import logging
-# #7105: Python 3 split the following into two dictionaries.
 import inspect
 import winsound
 import traceback
@@ -80,14 +79,14 @@ def getCodePath(f):
 				if memberType is FunctionType and member.__code__ is f.f_code:
 					# the function was found as a standard method
 					className=cls.__name__
-				elif memberType is classmethod and type(member.__func__) is FunctionType and member.__func__.func_code is f.f_code:
+				elif memberType is classmethod and type(member.__func__) is FunctionType and member.__func__.__code__ is f.f_code:
 					# function was found as a class method
 					className=cls.__name__
 				elif memberType is property:
-					if type(member.fget) is FunctionType and member.fget.func_code is f.f_code:
+					if type(member.fget) is FunctionType and member.fget.__code__ is f.f_code:
 						# The function was found as a property getter
 						className=cls.__name__
-					elif type(member.fset) is FunctionType and member.fset.func_code is f.f_code:
+					elif type(member.fset) is FunctionType and member.fset.__code__ is f.f_code:
 						# the function was found as a property setter
 						className=cls.__name__
 				if className:
@@ -221,7 +220,7 @@ class FileHandler(logging.FileHandler):
 				nvwave.playWaveFile("waves\\error.wav")
 			except:
 				pass
-		return logging.FileHandler.handle(self,record)
+		return super().handle(record)
 
 class Formatter(logging.Formatter):
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -13,7 +13,6 @@ import warnings
 from encodings import utf_8
 import logging
 # #7105: Python 3 split the following into two dictionaries.
-from logging import _levelNames as levelNames
 import inspect
 import winsound
 import traceback
@@ -218,7 +217,7 @@ class FileHandler(logging.StreamHandler):
 		# We need to open the file in text mode to get CRLF line endings.
 		# Therefore, we can't use codecs.open(), as it insists on binary mode. See PythonIssue:691291.
 		# We know that \r and \n are safe in UTF-8, so PythonIssue:691291 doesn't matter here.
-		logging.StreamHandler.__init__(self, utf_8.StreamWriter(file(filename, mode)))
+		logging.StreamHandler.__init__(self, utf_8.StreamWriter(open(filename, mode)))
 
 	def close(self):
 		self.flush()
@@ -360,11 +359,12 @@ def setLogLevelFromConfig():
 		return
 	import config
 	levelName=config.conf["general"]["loggingLevel"]
-	level = levelNames.get(levelName)
+	# logging.getLevelName can give you a level number if given a name.
+	level = logging.getLevelName(levelName)
 	# The lone exception to level higher than INFO is "OFF" (100).
 	# Setting a log level to something other than options found in the GUI is unsupported.
 	if level not in (log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):
 		log.warning("invalid setting for logging level: %s" % levelName)
 		level = log.INFO
-		config.conf["general"]["loggingLevel"] = levelNames[log.INFO]
+		config.conf["general"]["loggingLevel"] = logging.getLevelName(log.INFO)
 	log.setLevel(level)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
In Python3: several issues cause NVDA's logging to fail:
* NVDA makes use of logging._levelNames which no longer exists in Python3.
* When NvDA calculates a code path when logging, it accesses a function's code object via its func_code property. In Python3 this is now ```__code__```.
* As strings are now unicode, and files that are opened in text mode deal in unicode, NVDA's logHandler.FileHandler no longer works. 
 
### Description of how this pull request fixes the issue:
* No longer use logging._levelNames, rather use logging.getLevelName.
* Changed logHandler.getCodePath to use ```__code__``` instead of func_code.
* logHandler.FileHandler now inherits from logging.Filehandler rather than the lower-level StreamHandler, and no longer converts to utf8 before writing. Rather the File object itself handles the utf8 encoding.

### Testing performed:
Started NVDA under Python3. Info messages and tracebacks were successfully logged.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

