### PR TITLE
Python 3: use threading instead of thread. 

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -26,7 +26,6 @@ import ctypes
 from logHandler import log
 import config
 import time
-import thread
 import appModuleHandler
 from baseObject import AutoPropertyObject
 import re

--- a/source/core.py
+++ b/source/core.py
@@ -19,7 +19,7 @@ import comtypesMonkeyPatches
 
 import sys
 import winVersion
-import thread
+import threading
 import nvwave
 import os
 import time
@@ -37,7 +37,7 @@ postNvdaStartup = extensionPoints.Action()
 PUMP_MAX_DELAY = 10
 
 #: The thread identifier of the main thread.
-mainThreadId = thread.get_ident()
+mainThreadId = threading.get_ident()
 
 #: Notifies when a window message has been received by NVDA.
 #: This allows components to perform an action when several system events occur,
@@ -585,7 +585,7 @@ def requestPump():
 	if not _pump or _isPumpPending:
 		return
 	_isPumpPending = True
-	if thread.get_ident() == mainThreadId:
+	if threading.get_ident() == mainThreadId:
 		_pump.Start(PUMP_MAX_DELAY, True)
 		return
 	# This isn't the main thread. wx timers cannot be run outside the main thread.
@@ -600,7 +600,7 @@ def callLater(delay, callable, *args, **kwargs):
 	This function can be safely called from any thread.
 	"""
 	import wx
-	if thread.get_ident() == mainThreadId:
+	if threading.get_ident() == mainThreadId:
 		return wx.CallLater(delay, _callLaterExec, callable, args, kwargs)
 	else:
 		return wx.CallAfter(wx.CallLater,delay, _callLaterExec, callable, args, kwargs)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
In Python3, the thread module is no longer available. The threading module should be used instead.

### Description of how this pull request fixes the issue:
Replace use of the thread module with threading. We only used thread.get_ident, which also exists in threading.

### Testing performed:
tbd.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

