### PR TITLE
Python3: gettext is unicode, and pgettext is placed in builtins properly

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -133,7 +133,7 @@ def makePgettext(translations):
 				return message
 	else:
 		def pgettext(context, message):
-			return unicode(message)
+			return message
 	return pgettext
 
 def getWindowsLanguage():
@@ -190,9 +190,10 @@ def setLanguage(lang):
 	except IOError:
 		trans=gettext.translation("nvda",fallback=True)
 		curLang="en"
-	trans.install(unicode=True)
+	trans.install()
 	# Install our pgettext function.
-	__builtin__.__dict__["pgettext"] = makePgettext(trans)
+	import builtins
+	builtins.pgettext = makePgettext(trans)
 
 def getLanguage():
 	return curLang

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -120,20 +120,22 @@ def getAvailableLanguages(presentational=False):
 def makePgettext(translations):
 	"""Obtaina  pgettext function for use with a gettext translations instance.
 	pgettext is used to support message contexts,
-	but Python 2.7's gettext module doesn't support this,
+	but Python's gettext module doesn't support this,
 	so NVDA must provide its own implementation.
 	"""
 	if isinstance(translations, gettext.GNUTranslations):
 		def pgettext(context, message):
-			message = unicode(message)
 			try:
 				# Look up the message with its context.
 				return translations._catalog[u"%s\x04%s" % (context, message)]
 			except KeyError:
 				return message
-	else:
+	elif isinstance(translations, gettext.NullTranslations):
+		# A language with out a translation catalog, such as English.
 		def pgettext(context, message):
 			return message
+	else:
+		raise ValueError("%s is Not a GNUTranslations or NullTranslations object"%translations)
 	return pgettext
 
 def getWindowsLanguage():

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -26,7 +26,7 @@ import gettext
 try:
 	gettext.translation('nvda',localedir='locale',languages=[locale.getdefaultlocale()[0]]).install(True)
 except:
-	gettext.install('nvda',unicode=True)
+	gettext.install('nvda')
 
 import time
 import argparse

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -12,9 +12,9 @@ import gettext
 import locale
 #Localization settings
 try:
-	gettext.translation('nvda',localedir='locale',languages=[locale.getdefaultlocale()[0]]).install(True)
+	gettext.translation('nvda',localedir='locale',languages=[locale.getdefaultlocale()[0]]).install()
 except:
-	gettext.install('nvda',unicode=True)
+	gettext.install('nvda')
 
 import sys
 import os

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -21,7 +21,7 @@ import locale
 import gettext
 #Localization settings
 locale.setlocale(locale.LC_ALL,'')
-gettext.install('nvda',unicode=True)
+gettext.install('nvda')
 
 # The path to the unit tests.
 UNIT_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Python3's gettext installation functions no longer support the unicode argument as gettext is always unicode now.
Also the way we insert pgettext as a builtin no longer works as the builtins module name has changed in Python3.
 
### Description of how this pull request fixes the issue:
* No longer pass unicode=True to the gettext installation functions in nvda.pyw, languageHandler and nvda_slave.pyw.
* Make pgettext available via Python3's builtins module.
* Our fake version of pgettext now always assumes unicode.

### Testing performed:
Tbd.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

