### PR TITLE
Python 3: Fix use of subprocess

### DIFF
--- a/appveyor/mozillaSyms.py
+++ b/appveyor/mozillaSyms.py
@@ -6,7 +6,6 @@ It expects the crash-stats auth token to be placed in the mozillaSymsAuthToken e
 To update the list of symbols uploaded to Mozilla, see the DLL_NAMES constant below.
 """
 
-from __future__ import print_function
 import argparse
 import os
 import subprocess
@@ -43,7 +42,8 @@ class ProcError(Exception):
 def check_output(command):
 	proc = subprocess.Popen(command,
 		stdout=subprocess.PIPE,
-		stderr=subprocess.PIPE)
+		stderr=subprocess.PIPE,
+		text=True)
 	stdout, stderr = proc.communicate()
 	if proc.returncode != 0:
 		raise ProcError(proc.returncode, stderr)

--- a/appx/sconscript
+++ b/appx/sconscript
@@ -32,7 +32,7 @@ def getCertPublisher(env):
 	certPassword=env.get('certPassword','')
 	cmd=['certutil','-dump','-p',certPassword,File('#'+certFile).abspath.replace('/','\\')]
 	lines=subprocess.run(cmd,check=True,capture_output=True,text=True).stdout.splitlines()
-	linePrefix=b'Subject: '
+	linePrefix='Subject: '
 	for line in lines:
 		if line.startswith(linePrefix):
 			subject=line[len(linePrefix):].rstrip()

--- a/appx/sconscript
+++ b/appx/sconscript
@@ -31,8 +31,8 @@ def getCertPublisher(env):
 		return env['publisher']
 	certPassword=env.get('certPassword','')
 	cmd=['certutil','-dump','-p',certPassword,File('#'+certFile).abspath.replace('/','\\')]
-	lines=subprocess.check_output(cmd).splitlines()
-	linePrefix='Subject: '
+	lines=subprocess.run(cmd,check=True,capture_output=True,text=True).stdout.splitlines()
+	linePrefix=b'Subject: '
 	for line in lines:
 		if line.startswith(linePrefix):
 			subject=line[len(linePrefix):].rstrip()

--- a/source/core.py
+++ b/source/core.py
@@ -125,8 +125,8 @@ def restart(disableAddons=False, debugLogging=False):
 	except ValueError:
 		pass
 	shellapi.ShellExecute(None, None,
-		sys.executable.decode("mbcs"),
-		subprocess.list2cmdline(sys.argv + options).decode("mbcs"),
+		sys.executable,
+		subprocess.list2cmdline(sys.argv + options),
 		None,
 		# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
 		winUser.SW_SHOWNORMAL)

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -380,6 +380,6 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 		if startAfterCreate:
 			# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL  
 			shellapi.ShellExecute(None, None,
-				os.path.join(os.path.abspath(unicode(portableDirectory)),'nvda.exe'),
+				os.path.join(os.path.abspath(portableDirectory),'nvda.exe'),
 				u"-r",
 				None, winUser.SW_SHOWNORMAL)

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -48,8 +48,8 @@ def main():
 			import shellapi
 			import winUser
 			shellapi.ShellExecute(0,None,
-				ur"%s\nvda.exe"%sys.exec_prefix.decode("mbcs"),
-				subprocess.list2cmdline(args).decode("mbcs"),
+				r"%s\nvda.exe"%sys.exec_prefix,
+				subprocess.list2cmdline(args),
 				None,winUser.SW_SHOWNORMAL)
 		elif action=="setNvdaSystemConfig":
 			import config

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -206,7 +206,7 @@ def _executeUpdate(destPath):
 			executeParams = u"--launcher"
 	# #4475: ensure that the new process shows its first window, by providing SW_SHOWNORMAL
 	shellapi.ShellExecute(None, None,
-		destPath.decode("mbcs"),
+		destPath,
 		executeParams,
 		None, winUser.SW_SHOWNORMAL)
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
By default, the subprocess module outputs stdout in a bytes object. However, in several cases, we want to fetch strings from this output.

### Description of how this pull request fixes the issue:
Provide the new text keyword argument to subprocess function calls. In the case of appx/sconscript, switch to subprocess.run(check=True) instead of subprocess.check.
Also, several uses of subprocess.list2cmdline where related to the use of shellapi.ShellExecute. I also looked at shellapi.ShellExecute as part of this and removed all unnecessary and broken calls of decode on unicode strings.

### Testing performed:
T.b.d. I don't know of a good way to test the appx code locally.

### Known issues with pull request:
None known
