### PR TITLE
Check pot: file -> open

### DIFF
--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -113,7 +113,7 @@ def checkPot(fileName):
 	errors = 0
 	expectedErrors = 0
 	unexpectedSuccesses = 0
-	with file(fileName, "rt") as pot:
+	with open(fileName, "rt") as pot:
 		for line in pot:
 			line = line.rstrip()
 			if not line:

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2017 NV Access Limited
+#Copyright (C) 2017-2019 NV Access Limited
 
 """Check a translation template (pot) for strings without translator comments.
 """


### PR DESCRIPTION
Hi,

Based on Appveyor output:

### Link to issue number:
None

### Summary of the issue:
scons checkPot fails because file() function is in use.

### Description of how this pull request fixes the issue:
Changed file() to open(), also updated copyright years.

### Testing performed:
TBD (to be built via Appveyor)

### Known issues with pull request:
None

### Change log entry:
None
