### PR TITLE
Added contributors to the list

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -230,3 +230,4 @@ Oliver Edholm
 Abdel
 Luke Davis
 Larry Wang
+Doug Lee

--- a/contributors.txt
+++ b/contributors.txt
@@ -185,3 +185,6 @@ Eurobraille
 Bachir Benanou
 Arnold Loubriat
 Mozilla Corporation
+Adriani Botez
+Karl Eick
+Dang Manh Cuong

--- a/contributors.txt
+++ b/contributors.txt
@@ -207,3 +207,24 @@ Ralf Kefferpuetz
 Daniel Mayr
 Kostadin Kolev
 Francisco R. Del Roio
+Tony Malykh
+Laura Cornwell
+Austin Pinto
+Chris Leo
+Alberto Buffolino
+Hrvoje Katic
+Minaco Nonogaki
+Carter Temm
+Javi Dominguez
+Cyrille Bougot
+Adriano Barbieri
+Ricardo M. Leonarczyk
+Paul Bering
+Yannick Plassiard
+Oriol Gómez
+James Scholes
+Brian Gaff
+Damien Garwood
+Jose Manuel Delicado
+Oliver Edholm
+Abdel

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-﻿This is a list of people and organizations which contributed to the NVDA project in various ways since the project has started. For an overview of code contributors, see also
+﻿This is a list of people and organizations that contributed to the NVDA project in various ways since the beginning of the project. For an overview of code contributors, see also
 https://github.com/nvaccess/nvda/graphs/contributors
 
 NV Access Limited
@@ -228,3 +228,5 @@ Damien Garwood
 Jose Manuel Delicado
 Oliver Edholm
 Abdel
+Luke Davis
+Larry Wang

--- a/contributors.txt
+++ b/contributors.txt
@@ -213,7 +213,7 @@ Austin Pinto
 Chris Leo
 Alberto Buffolino
 Hrvoje Katic
-Minaco Nonogaki
+Minako Nonogaki
 Carter Temm
 Javi Dominguez
 Cyrille Bougot

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,6 +1,11 @@
-﻿NV Access Limited
+﻿This is a list of people and organizations which contributed to the NVDA project in either way since the project has started. For an overview of code contributors, see also
+https://github.com/nvaccess/nvda/graphs/contributors
+
+NV Access Limited
 Michael Curran
 James Teh
+Reef Turner
+Quentin Christensen
 Peter Vágner
 Aleksey Sadovoy
 Victor Tsaran
@@ -188,3 +193,12 @@ Mozilla Corporation
 Adriani Botez
 Karl Eick
 Dang Manh Cuong
+Christopher Toth
+Bill Dengler
+Aron Ocsvari
+Josiel Santos
+Karol Pecyna
+Blake Oliver
+Robert Haenggi
+Mikolaj Holysz
+André-Abush Clause

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-﻿This is a list of people and organizations which contributed to the NVDA project in either way since the project has started. For an overview of code contributors, see also
+﻿This is a list of people and organizations which contributed to the NVDA project in various ways since the project has started. For an overview of code contributors, see also
 https://github.com/nvaccess/nvda/graphs/contributors
 
 NV Access Limited
@@ -202,3 +202,8 @@ Blake Oliver
 Robert Haenggi
 Mikolaj Holysz
 André-Abush Clause
+Łukasz Golonka
+Ralf Kefferpuetz
+Daniel Mayr
+Kostadin Kolev
+Francisco R. Del Roio


### PR DESCRIPTION
### Link to issue number:
contributes to #9725. 

### Summary of the issue:
Some long term contributors are not yet in the contributors list and they asked for that on the translations maillist. Also many other contributors which are very active on users lists, addons maillist etc. are still not on the list.

### Description of how this pull request fixes the issue:
added the names to the contributors.txt 

### Testing performed:
Ran NVDA from local branch and checked that the list is updated

### Known issues with pull request:
none

### Change log entry:
== changes ==
- Updated the list of contributors.