### PR TITLE
Python 3: zip function -> list(zip), itertools.izip -> zip()

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -627,7 +627,8 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		otherAncs = self._getAncestors(otherTi, otherObj)
 		# Find the first common ancestor.
 		maxAncIndex = min(len(selfAncs), len(otherAncs)) - 1
-		for (selfAncTi, selfAncObj), (otherAncTi, otherAncObj) in zip(selfAncs[maxAncIndex::-1], otherAncs[maxAncIndex::-1]):
+		for (selfAncTi, selfAncObj), (otherAncTi, otherAncObj) in
+			zip(selfAncs[maxAncIndex::-1], otherAncs[maxAncIndex::-1]):
 			if selfAncObj == otherAncObj:
 				break
 		else:

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -8,7 +8,6 @@
 This is now used by other applications as well.
 """
 
-import itertools
 from comtypes import COMError
 import winUser
 import textInfos
@@ -628,7 +627,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		otherAncs = self._getAncestors(otherTi, otherObj)
 		# Find the first common ancestor.
 		maxAncIndex = min(len(selfAncs), len(otherAncs)) - 1
-		for (selfAncTi, selfAncObj), (otherAncTi, otherAncObj) in itertools.izip(selfAncs[maxAncIndex::-1], otherAncs[maxAncIndex::-1]):
+		for (selfAncTi, selfAncObj), (otherAncTi, otherAncObj) in zip(selfAncs[maxAncIndex::-1], otherAncs[maxAncIndex::-1]):
 			if selfAncObj == otherAncObj:
 				break
 		else:

--- a/source/braille.py
+++ b/source/braille.py
@@ -1434,7 +1434,7 @@ def getFocusContextRegions(obj, oldFocusRegions=None):
 		# We only want the ancestors of the buffer's root NVDAObject.
 		if obj != api.getFocusObject():
 			# Search backwards through the focus ancestors to find the index of obj.
-			for index, ancestor in itertools.izip(range(len(ancestors) - 1, 0, -1), reversed(ancestors)):
+			for index, ancestor in zip(range(len(ancestors) - 1, 0, -1), reversed(ancestors)):
 				if obj == ancestor:
 					ancestorsEnd = index
 					break
@@ -1446,7 +1446,7 @@ def getFocusContextRegions(obj, oldFocusRegions=None):
 		# Also, we don't ever want to fetch ancestor 0 (the desktop).
 		newAncestorsStart = max(min(_cachedFocusAncestorsEnd, ancestorsEnd), 1)
 		# Search backwards through the old regions to find the last common region.
-		for index, region in itertools.izip(range(len(oldFocusRegions) - 1, -1, -1), reversed(oldFocusRegions)):
+		for index, region in zip(range(len(oldFocusRegions) - 1, -1, -1), reversed(oldFocusRegions)):
 			ancestorIndex = getattr(region, "_focusAncestorIndex", None)
 			if ancestorIndex is None:
 				continue

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -108,8 +108,7 @@ def getAvailableLanguages(presentational=False):
 		displayNames.append("%s, %s"%(desc,entry) if desc else entry)
 	#Prepare a zipped view of language codes and descriptions.
 	# #7284: especially for sorting by description.
-	# #7105 (Py3 review required): Python 2 list 0> Python 3 iterator.
-	# Thus wrap this inside a list call.
+	# Python 3: zip function changed from returning a list to an iterator, thus wrap this inside a list call.
 	langs = list(zip(locales,displayNames))
 	if presentational:
 		langs.sort(key=lambda lang: lang[1])

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -108,8 +108,8 @@ def getAvailableLanguages(presentational=False):
 		displayNames.append("%s, %s"%(desc,entry) if desc else entry)
 	#Prepare a zipped view of language codes and descriptions.
 	# #7284: especially for sorting by description.
-	 # #7105 (Py3 review required): Python 2 list 0> Python 3 iterator.
-	 # Thus wrap this inside a list call.
+	# #7105 (Py3 review required): Python 2 list 0> Python 3 iterator.
+	# Thus wrap this inside a list call.
 	langs = list(zip(locales,displayNames))
 	if presentational:
 		langs.sort(key=lambda lang: lang[1])

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -108,7 +108,9 @@ def getAvailableLanguages(presentational=False):
 		displayNames.append("%s, %s"%(desc,entry) if desc else entry)
 	#Prepare a zipped view of language codes and descriptions.
 	# #7284: especially for sorting by description.
-	langs = zip(locales,displayNames)
+	 # #7105 (Py3 review required): Python 2 list 0> Python 3 iterator.
+	 # Thus wrap this inside a list call.
+	langs = list(zip(locales,displayNames))
 	if presentational:
 		langs.sort(key=lambda lang: lang[1])
 	#include a 'user default, windows' language, which just represents the default language for this user account


### PR DESCRIPTION
Hi,

Discovered through a series of failing unit tests:

### Link to issue number:
None

### Summary of the issue:
Python 2 and 3 zip functions have different behaviors: returns a list in Python 2 vs an iterator in Python 3.

### Description of how this pull request fixes the issue:
Changed instances of zip() function call to list(zip), as well as rename itertools.izip to zip().

Steps:

1. Grep "zip(" source.
2. First, wrap language handler zip function inside a list call.
3. Convert itertools.izip to zip and remove itertools import from IA1 mozilla text module.

### Testing performed:
Tested in Python 2 and 3 interpreters.

### Known issues with pull request:
None

### Change log entry:
None

