### PR TITLE
Python 3: No longer encode or decode if it is not necessary

### DIFF
--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -57,7 +57,7 @@ class XMLTextParser(object):
 
 	def parse(self,XMLText):
 		try:
-			self.parser.Parse(XMLText.encode('utf-8'))
+			self.parser.Parse(XMLText)
 		except:
 			log.error("XML: %s"%XMLText,exc_info=True)
 		return self._commandList

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -422,7 +422,7 @@ class Addon(AddonBase):
 
 	def _getPathForInclusionInPackage(self, package):
 		extension_path = os.path.join(self.path, package.__name__)
-		return extension_path.encode("mbcs")
+		return extension_path
 
 	def loadModule(self, name):
 		""" loads a python module from the addon directory

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -456,7 +456,7 @@ class AppModule(baseObject.ScriptableObject):
 		This should only be called if instructed by a developer.
 		"""
 		path = os.path.join(tempfile.gettempdir(),
-			"nvda_crash_%s_%d.dmp" % (self.appName, self.processID)).decode("mbcs")
+			"nvda_crash_%s_%d.dmp" % (self.appName, self.processID))
 		NVDAHelper.localLib.nvdaInProcUtils_dumpOnCrash(
 			self.helperLocalBindingHandle, path)
 		print("Dump path: %s" % path)

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -268,7 +268,7 @@ def setSystemConfigToCurrentConfig():
 
 def _setSystemConfig(fromPath):
 	import installer
-	toPath=os.path.join(sys.prefix.decode('mbcs'),'systemConfig')
+	toPath=os.path.join(sys.prefix,'systemConfig')
 	log.debug("Copying config to systemconfig dir: %s", toPath)
 	if os.path.isdir(toPath):
 		installer.tryRemoveFile(toPath)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1139,18 +1139,7 @@ class GlobalCommands(ScriptableObject):
 			try:
 				c = ord(info.text)
 			except TypeError:
-				# This might be a character taking multiple code points.
-				# If it is a 32 bit character, encode it to UTF-32 and calculate the ord manually.
-				# In Python 3, this is no longer necessary.
-				try:
-					encoded = info.text.encode("utf_32_le")
-				except UnicodeEncodeError:
-					c = None
-				else:
-					if len(encoded)==4:
-						c = sum(ord(cp)<<i*8 for i, cp in enumerate(encoded))
-					else:
-						c = None
+				c = None
 			if c is not None:
 				speech.speakMessage("%d," % c)
 				speech.speakSpelling(hex(c))
@@ -2494,12 +2483,11 @@ class ConfigProfileActivationCommands(ScriptableObject):
 		name = name.encode("utf-8")
 		invalidChars = set()
 		for c in name:
-			if not c.isalnum() and c != "_":
+			if not c.isalnum() and c != b"_":
 				invalidChars.add(c)
 		for c in invalidChars:
 			name=name.replace(c, b16encode(c))
-		# Python 3: Revisit this to ensure that script names are decoded correctly
-		return "profile_%s" % name
+		return "profile_%s" % name.decode("utf-8")
 
 	@classmethod
 	def _profileScript(cls, name):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2480,14 +2480,13 @@ class ConfigProfileActivationCommands(ScriptableObject):
 
 	@classmethod
 	def _getScriptNameForProfile(cls, name):
-		name = name.encode("utf-8")
 		invalidChars = set()
 		for c in name:
-			if not c.isalnum() and c != b"_":
+			if not c.isalnum() and c != "_":
 				invalidChars.add(c)
 		for c in invalidChars:
-			name=name.replace(c, b16encode(c))
-		return "profile_%s" % name.decode("utf-8")
+			name=name.replace(c, b16encode(c.encode()).decode("ascii"))
+		return "profile_%s" % name
 
 	@classmethod
 	def _profileScript(cls, name):

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -72,10 +72,6 @@ if not winVersion.isSupportedOS():
 	winUser.MessageBox(0, ctypes.FormatError(winUser.ERROR_OLD_WIN_VERSION), None, winUser.MB_ICONERROR)
 	sys.exit(1)
 
-def decodeMbcs(string):
-	"""Decode a multi-byte character set string"""
-	return string.decode("mbcs")
-
 def stringToBool(string):
 	"""Wrapper for configobj.validate.is_boolean to raise the proper exception for wrong values."""
 	from configobj.validate import is_boolean, ValidateError
@@ -90,9 +86,9 @@ quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument('-q','--quit',action="store_true",dest='quit',default=False,help="Quit already running copy of NVDA")
 quitGroup.add_argument('-r','--replace',action="store_true",dest='replace',default=False,help="Quit already running copy of NVDA and start this one")
 parser.add_argument('-k','--check-running',action="store_true",dest='check_running',default=False,help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running")
-parser.add_argument('-f','--log-file',dest='logFileName',type=decodeMbcs,help="The file where log messages should be written to")
+parser.add_argument('-f','--log-file',dest='logFileName',type=str,help="The file where log messages should be written to")
 parser.add_argument('-l','--log-level',dest='logLevel',type=int,default=0,choices=[10, 12, 15, 20, 30, 40, 50, 100],help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, warning 30, error 40, critical 50, off 100), default is info")
-parser.add_argument('-c','--config-path',dest='configPath',default=None,type=decodeMbcs,help="The path where all settings for NVDA are stored")
+parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str,help="The path where all settings for NVDA are stored")
 parser.add_argument('-m','--minimal',action="store_true",dest='minimal',default=False,help="No sounds, no interface, no start message etc")
 parser.add_argument('-s','--secure',action="store_true",dest='secure',default=False,help="Secure mode (disable Python console)")
 parser.add_argument('--disable-addons',action="store_true",dest='disableAddons',default=False,help="Disable all add-ons")
@@ -104,7 +100,7 @@ installGroup.add_argument('--install',action="store_true",dest='install',default
 installGroup.add_argument('--install-silent',action="store_true",dest='installSilent',default=False,help="Installs NVDA silently (does not start the new copy after installation).")
 installGroup.add_argument('--create-portable',action="store_true",dest='createPortable',default=False,help="Creates a portable copy of NVDA (starting the new copy after installation)")
 installGroup.add_argument('--create-portable-silent',action="store_true",dest='createPortableSilent',default=False,help="Creates a portable copy of NVDA silently (does not start the new copy after installation).")
-parser.add_argument('--portable-path',dest='portablePath',default=None,type=decodeMbcs,help="The path where a portable copy will be created")
+parser.add_argument('--portable-path',dest='portablePath',default=None,type=str,help="The path where a portable copy will be created")
 parser.add_argument('--launcher',action="store_true",dest='launcher',default=False,help="Started from the launcher")
 parser.add_argument('--enable-start-on-logon',metavar="True|False",type=stringToBool,dest='enableStartOnLogon',default=None,
 	help="When installing, enable NVDA's start on the logon screen")

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -53,7 +53,7 @@ def main():
 				None,winUser.SW_SHOWNORMAL)
 		elif action=="setNvdaSystemConfig":
 			import config
-			config._setSystemConfig(args[0].decode('mbcs'))
+			config._setSystemConfig(args[0])
 		elif action == "config_setStartOnLogonScreen":
 			enable = bool(int(args[0]))
 			import config

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -525,10 +525,6 @@ IDRETRY=4
 IDCANCEL=3
 
 def MessageBox(hwnd, text, caption, type):
-	if isinstance(text, bytes):
-		text = text.decode('mbcs')
-	if isinstance(caption, bytes):
-		caption = caption.decode('mbcs')
 	res = user32.MessageBoxW(hwnd, text, caption, type)
 	if res == 0:
 		raise WinError()


### PR DESCRIPTION
### Link to issue number:
Fixes part of #8661 
Pr was based on #9724 and than rebased onto threshold_py3_staging. Therefore, this pr complements #9724 and doesn't conflict with it.

### Summary of the issue:
In python 3, paths are normal strings and dealt with internally, whereas in Python 2 we needed to encode/decode paths to/from the mbcs encoding. There are some additional cases where encoding/decoding is no longer necessary,

### Description of how this pull request fixes the issue:
Removed all unnecessary or erroneous encoding/decoding. Rather than providing review comments in the code, I will follow up this pr with inline review comments.

### Testing performed:
T.b.d.

### Known issues with pull request:
This does not cover the espeak module as well as braille display drivers. 

### Change log entry:
None