### PR TITLE
Windows Console Handler: use floor division assignment operator when calculating coordinates

### DIFF
--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -173,7 +173,8 @@ class WinConsoleTextInfo(textInfos.offsets.OffsetsTextInfo):
 		consoleScreenBufferInfo=self.consoleScreenBufferInfo
 		x=offset%consoleScreenBufferInfo.dwSize.x
 		y=offset-x
-		y/=consoleScreenBufferInfo.dwSize.x
+		# #9641: add another slash because this is an integer, otherwise int/float conflict is seen and backspacing fails.
+		y//=consoleScreenBufferInfo.dwSize.x
 		y+=consoleScreenBufferInfo.srWindow.Top
 		return x,y
 


### PR DESCRIPTION
### Link to issue number:
Another fix for #9641 

### Summary of the issue:
In Windows Console handler, coordinate calculation returns float instead of integer, and backspace doesn't work.

### Description of how this pull request fixes the issue:
Changed classic division assignment (/=) to floor division assignment (//=) to guarantee integers.

Steps:

1. Grep -r "/=" source
2. Change /= to //= based on context.

### Testing performed:
Tested with a binary build of this PR and ensured that console handling was working (tested with Command Prompt and WSL/Ubuntu).

### Known issues with pull request:
None

### Change log entry:
None
