### PR TITLE
IntelliSense support for Visual Studio

### DIFF
--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -95,12 +95,6 @@ class AppModule(appModuleHandler.AppModule):
 
 	intellisenseItem = None
 
-	def _get_major(self):
-		return int(self.productVersion.split(".", 2)[0])
-
-	def _get_minor(self):
-		return int(self.productVersion.split(".", 2)[1])
-
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		vsMajor, vsMinor, rest = self.productVersion.split(".", 2)
 		vsMajor, vsMinor = int(vsMajor), int(vsMinor)

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -95,6 +95,12 @@ class AppModule(appModuleHandler.AppModule):
 
 	intellisenseItem = None
 
+	def _get_major(self):
+		return int(self.productVersion.split(".", 2)[0])
+
+	def _get_minor(self):
+		return int(self.productVersion.split(".", 2)[1])
+
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		vsMajor, vsMinor, rest = self.productVersion.split(".", 2)
 		vsMajor, vsMinor = int(vsMajor), int(vsMinor)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Issue #8336

### Summary of the issue:

When IntelliSense menu is open and you select an item with keyboard arrows, the entire line is read before the actual IntelliSense item.

### Description of how this pull request fixes the issue:

This PR stops speech and speak the current item when it is highlighted. Also adds an implementation for "event_liveRegionChange" that avoids duplicate speak of the item when it is fired.

Another feature is the implementation of suggestions model for the code editor, but this is not important, just a little addition.

### Testing performed:

Tested with a C++ project under Visual studio 2017 and with an Asp.Net Core ones in Visual Studio 2019.

### Known issues with pull request:

In Visual Studio 2019, when the popup is opened and an item is not yet selected, there is a default item marked as highlighted. As a consequence, when you press the arrow to select an item, speech is not stopped and the item is not read until the help message gets spoken. To stop speech, simply press the arrow twice to select another item.

Edit note: The inconsistencies mentioned before are between C# and C++ projects. I don't know if there are more cases of inconsistencies, I need to test more.

### Change log entry:

Section: Bug Fixes.
* In Visual Studio 2017 and 2019, in the code editor, the entire line is not read anymore when an IntelliSense item is selected with keyboard arrow keys. #8336
