### PR TITLE
Python3: import HRESULT from comtypes instead of ctypes.wintypes 

### DIFF
--- a/source/objidl.py
+++ b/source/objidl.py
@@ -4,8 +4,8 @@
 #See the file COPYING for more details.
 
 from ctypes import *
-from ctypes.wintypes import HWND, HRESULT, BOOL
-from comtypes import GUID, COMMETHOD, IUnknown, tagBIND_OPTS2
+from ctypes.wintypes import HWND, BOOL
+from comtypes import HRESULT, GUID, COMMETHOD, IUnknown, tagBIND_OPTS2
 from comtypes.persist import IPersist
 WSTRING = c_wchar_p
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
In Python3, HRESULT is no longer available in ctypes.wintypes.
There is just one file in our code base that gets it from there. This should be changed to import from comtypes.

### Description of how this pull request fixes the issue:
objidl.py: import HRESULT from comtypes rather than ctypes.wintypes.

### Testing performed:
objidl successfully imports when starting NVDA.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

