### PR TITLE
Remove need for hashing NVDAObject and TextInfo objects

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -123,7 +123,7 @@ class AutoPropertyObject(with_metaclass(AutoPropertyType, object)):
 
 	#: Tracks the instances of this class; used by L{invalidateCaches}.
 	#: @type: weakref.WeakValueDictionary
-	# Theoretically we could use weakref.WeakSet, 
+	# We really just want to store the instances as a set of weak references, 
 	# but as there is no easy way to have NVDAObjects and TextInfos remain hashable in Python3, as they override equality,
 	# We store them on a WeakValueDictionary, keyed by their id (address).
 	__instances=weakref.WeakValueDictionary()

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -122,8 +122,11 @@ class AutoPropertyObject(with_metaclass(AutoPropertyType, object)):
 	"""
 
 	#: Tracks the instances of this class; used by L{invalidateCaches}.
-	#: @type: weakref.WeakKeyDictionary
-	__instances=weakref.WeakKeyDictionary()
+	#: @type: weakref.WeakValueDictionary
+	# Theoretically we could use weakref.WeakSet, 
+	# but as there is no easy way to have NVDAObjects and TextInfos remain hashable in Python3, as they override equality,
+	# We store them on a WeakValueDictionary, keyed by their id (address).
+	__instances=weakref.WeakValueDictionary()
 	#: Specifies whether properties are cached by default;
 	#: can be overridden for individual properties by setting _cache_propertyName.
 	#: @type: bool
@@ -135,7 +138,7 @@ class AutoPropertyObject(with_metaclass(AutoPropertyType, object)):
 		#: Maps properties to cached values.
 		#: @type: dict
 		self._propertyCache={}
-		self.__instances[self]=None
+		self.__instances[id(self)]=self
 		return self
 
 	def _getPropertyViaCache(self,getterMethod=None):
@@ -158,7 +161,7 @@ class AutoPropertyObject(with_metaclass(AutoPropertyType, object)):
 		# We use keys() here instead of iterkeys(), as invalidating the cache on an object may cause instances to disappear,
 		# which would in turn cause an exception due to the dictionary changing size during iteration.
 		# #9067 (Py3 review required): because of this, wrap this in a list, as dict.keys() in Python 3 returns iterators.
-		for instance in list(cls.__instances.keys()):
+		for instance in list(cls.__instances.values()):
 			instance.invalidateCache()
 
 class ScriptableType(AutoPropertyType):

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -22,8 +22,8 @@ import extensionPoints
 _pendingEventCountsByName={}
 # Note that due to the fact it is hard to keep NVDAObjects remaining hashable in Python3 due to their equality method being overridden,
 # the id (address) of the NVDAObject will be used as the key in the dict, not the NVDAObject itself.
-_pendingEventCountsByObj={}
-_pendingEventCountsByNameAndObj={}
+_pendingEventCountsByObjID={}
+_pendingEventCountsByNameAndObjID={}
 # Needed to ensure updates are atomic, as these might be updated from multiple threads simultaneously.
 _pendingEventCountsLock=threading.RLock()
 
@@ -40,8 +40,8 @@ def queueEvent(eventName,obj,**kwargs):
 		lastQueuedFocusObject=obj
 	with _pendingEventCountsLock:
 		_pendingEventCountsByName[eventName]=_pendingEventCountsByName.get(eventName,0)+1
-		_pendingEventCountsByObj[id(obj)]=_pendingEventCountsByObj.get(id(obj),0)+1
-		_pendingEventCountsByNameAndObj[(eventName,id(obj))]=_pendingEventCountsByNameAndObj.get((eventName,id(obj)),0)+1
+		_pendingEventCountsByObjID[id(obj)]=_pendingEventCountsByObjID.get(id(obj),0)+1
+		_pendingEventCountsByNameAndObjID[(eventName,id(obj))]=_pendingEventCountsByNameAndObjID.get((eventName,id(obj)),0)+1
 	queueHandler.queueFunction(queueHandler.eventQueue,_queueEventCallback,eventName,obj,kwargs)
 
 def _queueEventCallback(eventName,obj,kwargs):
@@ -51,16 +51,16 @@ def _queueEventCallback(eventName,obj,kwargs):
 			_pendingEventCountsByName[eventName]=(curCount-1)
 		elif curCount==1:
 			del _pendingEventCountsByName[eventName]
-		curCount=_pendingEventCountsByObj.get(id(obj),0)
+		curCount=_pendingEventCountsByObjID.get(id(obj),0)
 		if curCount>1:
-			_pendingEventCountsByObj[id(obj)]=(curCount-1)
+			_pendingEventCountsByObjID[id(obj)]=(curCount-1)
 		elif curCount==1:
-			del _pendingEventCountsByObj[id(obj)]
-		curCount=_pendingEventCountsByNameAndObj.get((eventName,id(obj)),0)
+			del _pendingEventCountsByObjID[id(obj)]
+		curCount=_pendingEventCountsByNameAndObjID.get((eventName,id(obj)),0)
 		if curCount>1:
-			_pendingEventCountsByNameAndObj[(eventName,id(obj))]=(curCount-1)
+			_pendingEventCountsByNameAndObjID[(eventName,id(obj))]=(curCount-1)
 		elif curCount==1:
-			del _pendingEventCountsByNameAndObj[(eventName,id(obj))]
+			del _pendingEventCountsByNameAndObjID[(eventName,id(obj))]
 	executeEvent(eventName,obj,**kwargs)
 
 def isPendingEvents(eventName=None,obj=None):
@@ -75,11 +75,11 @@ def isPendingEvents(eventName=None,obj=None):
 	if not eventName and not obj:
 		return bool(len(_pendingEventCountsByName))
 	elif not eventName and obj:
-		return id(obj) in _pendingEventCountsByObj
+		return id(obj) in _pendingEventCountsByObjID
 	elif eventName and not obj:
 		return eventName in _pendingEventCountsByName
 	elif eventName and obj:
-		return (eventName,id(obj)) in _pendingEventCountsByNameAndObj
+		return (eventName,id(obj)) in _pendingEventCountsByNameAndObjID
 
 class _EventExecuter(object):
 	"""Facilitates execution of a chain of event functions.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -20,6 +20,8 @@ import extensionPoints
 
 #Some dicts to store event counts by name and or obj
 _pendingEventCountsByName={}
+# Note that due to the fact it is hard to keep NVDAObjects remaining hashable in Python3 due to their equality method being overridden,
+# the id (address) of the NVDAObject will be used as the key in the dict, not the NVDAObject itself.
 _pendingEventCountsByObj={}
 _pendingEventCountsByNameAndObj={}
 # Needed to ensure updates are atomic, as these might be updated from multiple threads simultaneously.
@@ -38,8 +40,8 @@ def queueEvent(eventName,obj,**kwargs):
 		lastQueuedFocusObject=obj
 	with _pendingEventCountsLock:
 		_pendingEventCountsByName[eventName]=_pendingEventCountsByName.get(eventName,0)+1
-		_pendingEventCountsByObj[obj]=_pendingEventCountsByObj.get(obj,0)+1
-		_pendingEventCountsByNameAndObj[(eventName,obj)]=_pendingEventCountsByNameAndObj.get((eventName,obj),0)+1
+		_pendingEventCountsByObj[id(obj)]=_pendingEventCountsByObj.get(id(obj),0)+1
+		_pendingEventCountsByNameAndObj[(eventName,id(obj))]=_pendingEventCountsByNameAndObj.get((eventName,id(obj)),0)+1
 	queueHandler.queueFunction(queueHandler.eventQueue,_queueEventCallback,eventName,obj,kwargs)
 
 def _queueEventCallback(eventName,obj,kwargs):
@@ -49,16 +51,16 @@ def _queueEventCallback(eventName,obj,kwargs):
 			_pendingEventCountsByName[eventName]=(curCount-1)
 		elif curCount==1:
 			del _pendingEventCountsByName[eventName]
-		curCount=_pendingEventCountsByObj.get(obj,0)
+		curCount=_pendingEventCountsByObj.get(id(obj),0)
 		if curCount>1:
-			_pendingEventCountsByObj[obj]=(curCount-1)
+			_pendingEventCountsByObj[id(obj)]=(curCount-1)
 		elif curCount==1:
-			del _pendingEventCountsByObj[obj]
-		curCount=_pendingEventCountsByNameAndObj.get((eventName,obj),0)
+			del _pendingEventCountsByObj[id(obj)]
+		curCount=_pendingEventCountsByNameAndObj.get((eventName,id(obj)),0)
 		if curCount>1:
-			_pendingEventCountsByNameAndObj[(eventName,obj)]=(curCount-1)
+			_pendingEventCountsByNameAndObj[(eventName,id(obj))]=(curCount-1)
 		elif curCount==1:
-			del _pendingEventCountsByNameAndObj[(eventName,obj)]
+			del _pendingEventCountsByNameAndObj[(eventName,id(obj))]
 	executeEvent(eventName,obj,**kwargs)
 
 def isPendingEvents(eventName=None,obj=None):
@@ -73,11 +75,11 @@ def isPendingEvents(eventName=None,obj=None):
 	if not eventName and not obj:
 		return bool(len(_pendingEventCountsByName))
 	elif not eventName and obj:
-		return obj in _pendingEventCountsByObj
+		return id(obj) in _pendingEventCountsByObj
 	elif eventName and not obj:
 		return eventName in _pendingEventCountsByName
 	elif eventName and obj:
-		return (eventName,obj) in _pendingEventCountsByNameAndObj
+		return (eventName,id(obj)) in _pendingEventCountsByNameAndObj
 
 class _EventExecuter(object):
 	"""Facilitates execution of a chain of event functions.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:
In baseObject.AutoPropertyObject: all instances are tracked on the class by storing them in a WeakKeyDictionary. Tracking of these instances is to allow clearing the proprty cache of all living objects in one go.
In eventHandler: there are several dictionaries that track currently queued events, keyed by eventName, object, or eventName and object. 
Storing NvDAObjects and or TextInfo objects in these dictionaries requires these objects to be hashable.
However, in Python3, if an object's equality check is customized (I.e. a custom ```__eq__``` method is provided), the object becomes unhashable, as Python3 requires that any two objects that report being equal must also share the same hash value.
If ```__eq__``` is implemented on an object and there is a need for the object to be hashable, one must also implement ```__hash__``` on the object (and all it subclasses it seems) as well.
As our equality checks are rather complex, and many of them short-circuit for performance reasons, it is next to impossible to provide an optimal ```__hash__``` that will honor the requirement that the hash values of two objects be equal if the objects report equal.
Therefore, we should try to remove the need to hash NVDAObjects and TextInfo instances, by no longer using these as keys for dictionaries.

### Description of how this pull request fixes the issue:
In baseObject.AutoPropertyObject:
The instance WeakKeyDictionary has been changed to a WeakValueDictionary which holds the instances as its values, keyed by the instance's id (address). 
The eventHandler._pendingEventCounts dictionaries no longer use the object as the key directly, rather the id (address) of the object.
In both cases of baseObject and eventHandler, we are only tracking the objects over their lifetime, and we expect to only look up the same physical object (not one that just "looks" like that object), thus using the object's id (address) is perfectly fine.

### Testing performed:
TypeError("Unhashable type") is no longer raised when trying to start / use NVDA.
 
### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

