### PR TITLE
Global commands: restore commands affected by division operator differences between Python 2 and 3

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -707,8 +707,8 @@ class GlobalCommands(ScriptableObject):
 				# Translators: Reported when the object has no location for the mouse to move to it.
 				ui.message(_("Object has no location"))
 				return
-			x=left+(width/2)
-			y=top+(height/2)
+			x=left+(width//2)
+			y=top+(height//2)
 		winUser.setCursorPos(x,y)
 		mouseHandler.executeMouseMoveEvent(x,y)
 	# Translators: Input help mode message for move mouse to navigator object command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1639,7 +1639,7 @@ class GlobalCommands(ScriptableObject):
 		if sps.ACLineStatus & AC_ONLINE: text += _("AC power on")
 		elif sps.BatteryLifeTime!=0xffffffff: 
 			# Translators: This is the estimated remaining runtime of the laptop battery.
-			text += _("{hours:d} hours and {minutes:d} minutes remaining") .format(hours=sps.BatteryLifeTime / 3600, minutes=(sps.BatteryLifeTime % 3600) / 60)
+			text += _("{hours:d} hours and {minutes:d} minutes remaining") .format(hours=sps.BatteryLifeTime // 3600, minutes=(sps.BatteryLifeTime % 3600) // 60)
 		ui.message(text)
 	# Translators: Input help mode message for report battery status command.
 	script_say_battery_status.__doc__ = _("Reports battery status and time remaining if AC is not plugged in")


### PR DESCRIPTION
### Link to issue number:
Another variant of #9641 

### Summary of the issue:
Global commands involving divisoin operators are broken in Python 3: move mouse to navigator object and battery status.

### Description of how this pull request fixes the issue:
Changed one slash to two slashes for affected commands.

### Testing performed:
Compiled a Python 3 version of NVDA and ran affected commands before and after division operator change.

### Known issues with pull request:
None

### Change log entry:
None

### Additional context:
There are division operator issues in other files that cannot be patched until UI Access privilege is restored, the most prominent one being touch tracking (may or may not be an integer when calculating touch gesture tracking).
