### PR TITLE
Python 3: more native imports and modules

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -14,7 +14,7 @@ import itertools
 import collections
 import pkgutil
 import shutil
-from six.moves import cStringIO as StringIO
+from io import StringIO
 import pickle
 from six import string_types
 import globalVars

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -14,7 +14,8 @@ import itertools
 import collections
 import pkgutil
 import shutil
-from six.moves import cStringIO as StringIO, cPickle
+from six.moves import cStringIO as StringIO
+import pickle
 from six import string_types
 import globalVars
 import zipfile
@@ -49,7 +50,7 @@ def loadState():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "rb") as f:
-			state = cPickle.load(f)
+			state = pickle.load(f)
 		if "disabledAddons" not in state:
 			state["disabledAddons"] = set()
 		if "pendingDisableSet" not in state:
@@ -71,7 +72,7 @@ def saveState():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "wb") as f:
-			cPickle.dump(state, f)
+			pickle.dump(state, f)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -120,10 +120,10 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		stdout, stderr = sys.stdout, sys.stderr
 		sys.stdout = sys.stderr = self
 		# Prevent this from messing with the gettext "_" builtin.
-		saved_ = __builtin__._
+		saved_ = builtins._
 		more = code.InteractiveConsole.push(self, line)
 		sys.stdout, sys.stderr = stdout, stderr
-		__builtin__._ = saved_
+		builtins._ = saved_
 		self.prompt = "..." if more else ">>>"
 		return more
 

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -23,7 +23,7 @@ import os
 import inspect
 import threading
 import time
-import cPickle
+import pickle
 import urllib
 import tempfile
 import hashlib
@@ -737,7 +737,7 @@ def saveState():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(_stateFilename, "wb") as f:
-			cPickle.dump(state, f)
+			pickle.dump(state, f)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 
@@ -747,7 +747,7 @@ def initialize():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(_stateFilename, "rb") as f:
-			state = cPickle.load(f)
+			state = pickle.load(f)
 	except:
 		log.debugWarning("Couldn't retrieve update state", exc_info=True)
 		# Defaults.


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
There are more modules that could see Python 3 native import.

### Description of how this pull request fixes the issue:
Deferred from @MichaelDCurran's native imports work:

1. cPickle -> pickle
2. Python console: __builtin__ -> builtins, resolving things such as obtaining __debug__ flag via Python Console.

Steps:

1. Grep -r "\_\_builtin" source and grep -r "cPickle", as well as others.
2. Edit the source code as appropriate.

### Testing performed:
Tested with both Python 2 and 3 versions of NVDA, along with Python interpreters.

### Known issues with pull request:
None

### Change log entry:
None

### Additional context:
There might be more modules that are not seeing Python 3 native imports. Also, there might be modules that are imported but are not used at all e.g. io.StringIO is imported from config main module but isn't used.
