### PR TITLE
Input core/input gestures dialog: script function object has no attribute named __func__

### DIFF
--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -677,7 +677,7 @@ class _AllGestureMappingsRetriever(object):
 				scripts[script] = scriptInfo
 		for gesture, script in obj._gestureMap.items():
 			try:
-				scriptInfo = scripts[script.__func__]
+				scriptInfo = scripts[script]
 			except KeyError:
 				continue
 			key = (scriptInfo.cls, gesture)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Input Gestures dialog does not work in Python 3, caused by attribute error.

### Description of how this pull request fixes the issue:
Removes a check for __func__ attribute in script info in input core. With this attribute, Input Gesture dialog won't work in Python 3 version. Now it is gone, Input Gestures dialog is back.

### Testing performed:
Tested with Python 2 and 3 NVDA versions as follows:

1. Open Input Gestures dialog (succeeded in Python 2, failed in Python 3 in the first pass).
2. Assign and remove some gestures.
3. Edit the source code in Python 3.
4. Reopen Input Gestures dialog, this time Python 3 version does open this dialog.
5. Assign and remove more gestures, and search for others.

### Known issues with pull request:
None

### Change log entry:
None
