### PR TITLE
Python 3: use native metaclass definition syntax

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -147,7 +147,7 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 		"""
 		cls._dynamicClassCache.clear()
 
-class NVDAObject(with_metaclass(DynamicNVDAObjectType, documentBase.TextContainerObject,baseObject.ScriptableObject)):
+class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, metaclass=DynamicNVDAObjectType):
 	"""NVDA's representation of a single control/widget.
 	Every widget, regardless of how it is exposed by an application or the operating system, is represented by a single NVDAObject instance.
 	This allows NVDA to work with all widgets in a uniform way.

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -7,7 +7,6 @@
 
 """Module that contains the base NVDA object type"""
 
-from six import with_metaclass
 import time
 import re
 import weakref

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -5,7 +5,6 @@
 #See the file COPYING for more details.
 
 import abc
-from six import with_metaclass
 import ctypes
 from comtypes import COMError, BSTR
 import comtypes.automation

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1085,7 +1085,7 @@ class FormulaExcelCellInfoQuickNavItem(ExcelCellInfoQuickNavItem):
 	def label(self):
 		return "%s: %s"%(self.excelCellInfo.address.split('!')[-1],self.excelCellInfo.formula)
 
-class ExcelCellInfoQuicknavIterator(with_metaclass(abc.ABCMeta,object)):
+class ExcelCellInfoQuicknavIterator(object, metaclass=abc.ABCMeta):
 	cellInfoFlags=NVCELLINFOFLAG_ADDRESS|NVCELLINFOFLAG_COORDS
 
 	@abc.abstractproperty

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -104,7 +104,7 @@ class AutoPropertyType(ABCMeta):
 			# The __abstractmethods__ set is frozen, therefore we ought to override it.
 			self.__abstractmethods__=(self.__abstractmethods__|newAbstractProps)-oldAbstractProps
 
-class AutoPropertyObject(with_metaclass(AutoPropertyType, object)):
+class AutoPropertyObject(object, metaclass=AutoPropertyType):
 	"""A class that dynamically supports properties, by looking up _get_*, _set_*, and _del_* methods at runtime.
 	_get_x will make property x with a getter (you can get its value).
 	_set_x will make a property x with a setter (you can set its value).
@@ -188,7 +188,7 @@ class ScriptableType(AutoPropertyType):
 			setattr(cls, gesturesDictName, gestures)
 		return cls
 
-class ScriptableObject(with_metaclass(ScriptableType, AutoPropertyObject)):
+class ScriptableObject(AutoPropertyObject, metaclass=ScriptableType):
 	"""A class that implements NVDA's scripting interface.
 	Input gestures are bound to scripts such that the script will be executed when the appropriate input gesture is received.
 	Scripts are methods named with a prefix of C{script_}; e.g. C{script_foo}.

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -10,7 +10,6 @@
 import weakref
 from logHandler import log
 from abc import ABCMeta, abstractproperty
-from six import with_metaclass
 
 class Getter(object):
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -93,7 +93,7 @@ def mergeQuickNavItemIterators(iterators,direction="next"):
 			continue
 		curValues.append((it,newVal))
 
-class QuickNavItem(with_metaclass(ABCMeta, object)):
+class QuickNavItem(object, metaclass=ABCMeta):
 	""" Emitted by L{BrowseModeTreeInterceptor._iterNodesByType}, this represents one of many positions in a browse mode document, based on the type of item being searched for (e.g. link, heading, table etc)."""  
 
 	itemType=None #: The type of items searched for (e.g. link, heading, table etc) 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -35,7 +35,6 @@ import api
 import gui.guiHelper
 from NVDAObjects import NVDAObject
 from abc import ABCMeta, abstractmethod
-from six import with_metaclass
 
 REASON_QUICKNAV = "quickNav"
 

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -16,7 +16,6 @@ They are implemented using the L{ContentRecognizer} class.
 from collections import namedtuple
 import textInfos.offsets
 from abc import ABCMeta, abstractmethod
-from six import with_metaclass
 from locationHelper import RectLTWH
 
 class ContentRecognizer(object, metaclass=ABCMeta):

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -19,7 +19,7 @@ from abc import ABCMeta, abstractmethod
 from six import with_metaclass
 from locationHelper import RectLTWH
 
-class ContentRecognizer(with_metaclass(ABCMeta, object)):
+class ContentRecognizer(object, metaclass=ABCMeta):
 	"""Implementation of a content recognizer.
 	"""
 
@@ -129,7 +129,7 @@ class RecogImageInfo(object):
 		"""
 		return int(height / self.resizeFactor)
 
-class RecognitionResult(with_metaclass(ABCMeta, object)):
+class RecognitionResult(object, metaclass=ABCMeta):
 	"""Provides access to the result of recognition by a recognizer.
 	The result is textual, but to facilitate navigation by word, line, etc.
 	and to allow for retrieval of screen coordinates within the text,

--- a/source/gui/accPropServer.py
+++ b/source/gui/accPropServer.py
@@ -11,7 +11,6 @@ from  comtypes.automation import VT_EMPTY
 from  comtypes import COMObject, GUID
 from comInterfaces.Accessibility import IAccPropServer, ANNO_CONTAINER, ANNO_THIS
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six import with_metaclass
 import weakref
 import winUser
 import wx

--- a/source/gui/accPropServer.py
+++ b/source/gui/accPropServer.py
@@ -16,7 +16,7 @@ import weakref
 import winUser
 import wx
 
-class IAccPropServer_Impl(with_metaclass(ABCMeta, COMObject)):
+class IAccPropServer_Impl(COMObject, metaclass=ABCMeta):
 	"""Base class for implementing a COM interface for a hwnd based AccPropServer\
 	to annotate a WX control.
 	The AccPropServer registers itself using the window handle of the WX control.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -7,7 +7,6 @@
 
 import logging
 from abc import abstractmethod
-from six import with_metaclass
 import os
 import copy
 import re

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -50,7 +50,7 @@ import time
 import keyLabels
 from .dpiScalingHelper import DpiScalingHelperMixin
 
-class SettingsDialog(with_metaclass(guiHelper.SIPABCMeta, wx.Dialog, DpiScalingHelperMixin)):
+class SettingsDialog(wx.Dialog, DpiScalingHelperMixin, metaclass=guiHelper.SIPABCMeta):
 	"""A settings dialog.
 	A settings dialog consists of one or more settings controls and OK and Cancel buttons and an optional Apply button.
 	Action may be taken in response to the OK, Cancel or Apply buttons.
@@ -243,7 +243,7 @@ class SettingsDialog(with_metaclass(guiHelper.SIPABCMeta, wx.Dialog, DpiScalingH
 # redo the layout in whatever way makes sense for their particular content.
 _RWLayoutNeededEvent, EVT_RW_LAYOUT_NEEDED = wx.lib.newevent.NewCommandEvent()
 
-class SettingsPanel(with_metaclass(guiHelper.SIPABCMeta, wx.Panel, DpiScalingHelperMixin)):
+class SettingsPanel(wx.Panel, DpiScalingHelperMixin, metaclass=guiHelper.SIPABCMeta):
 	"""A settings panel, to be used in a multi category settings dialog.
 	A settings panel consists of one or more settings controls.
 	Action may be taken in response to the parent dialog's OK or Cancel buttons.

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -229,7 +229,7 @@ class PhonemeCommand(SynthCommand):
 			out += ", text=%r" % self.text
 		return out + ")"
 
-class BaseCallbackCommand(with_metaclass(ABCMeta, SpeechCommand)):
+class BaseCallbackCommand(SpeechCommand, metaclass=ABCMeta):
 	"""Base class for commands which cause a function to be called when speech reaches them.
 	This class should not be instantiated directly.
 	It is designed to be subclassed to provide specific functionality;

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -7,7 +7,6 @@
 """Commands that can be embedded in a speech sequence for changing synth parameters, playing sounds or running other callbacks."""
  
 from abc import ABCMeta, abstractmethod
-from six import with_metaclass
 import config
 import languageHandler
 from synthDriverHandler import getSynth


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Changes metaclass definition syntax to follow Python 3 format.

### Description of how this pull request fixes the issue:
Change the metaclass definition of the form "__metaclass__ = metaclass" to "class class(bases, metaclass=metaclass)".

Steps:

1. Grep -lr "with\_metaclass" source.
2. Locate where metaclasses are defined.
3. Change the syntax and test.

Also, as part of this, six.with_metaclass import has been removed from modules that uses it.

### Testing performed:
Tested with Python 2 and 3 versions of NVDA, testing each time a module has been modified to make sure no regressions are introduced.

### Known issues with pull request:
None

### Change log entry:
None
