### PR TITLE
Python3: Provide __hash__ methods where ever we have provided __eq__ methods

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -347,6 +347,11 @@ class JABContext(object):
 		else:
 			return False
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 	def __ne__(self,jabContext):
 		if self.vmID!=jabContext.vmID or not bridgeDll.isSameObject(self.vmID,self.accContext,jabContext.accContext):
 			return True

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -321,6 +321,11 @@ class UIATextInfo(textInfos.TextInfo):
 		if self.__class__ is not other.__class__: return False
 		return bool(self._rangeObj.compare(other._rangeObj))
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 	def _get_NVDAObjectAtStart(self):
 		e=self.UIAElementAtStart
 		if e:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -319,6 +319,11 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 			return False
 		return self._isEqual(other)
  
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 	def __ne__(self,other):
 		"""The opposite to L{NVDAObject.__eq__}
 		"""

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -173,6 +173,11 @@ class CompoundTextInfo(textInfos.TextInfo):
 			return False
 		return self._start == other._start and self._startObj == other._startObj and self._end == other._end and self._endObj == other._endObj
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 	def __ne__(self, other):
 		return not self == other
 

--- a/source/locationHelper.py
+++ b/source/locationHelper.py
@@ -152,6 +152,10 @@ class Point(namedtuple("Point",("x","y"))):
 			return NotImplemented
 		return self.x == other.x and self.y == other.y
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	def __hash__(self):
+		return hash((self.x,self.y))
+
 	def __ne__(self,other):
 		if not isinstance(other,POINT_CLASSES):
 			return NotImplemented
@@ -319,6 +323,10 @@ class _RectMixin:
 		if not isinstance(other,RECT_CLASSES):
 			return NotImplemented
 		return other.left == self.left and other.top == self.top and other.right == self.right and other.bottom == self.bottom
+
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	def __hash__(self):
+		return hash((self.left,self.top,self.right,self.bottom))
 
 	def __ne__(self,other):
 		if not isinstance(other,RECT_CLASSES):

--- a/source/locationHelper.py
+++ b/source/locationHelper.py
@@ -154,7 +154,7 @@ class Point(namedtuple("Point",("x","y"))):
 
 	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
 	def __hash__(self):
-		return hash((self.x,self.y))
+		return super().__hash__()
 
 	def __ne__(self,other):
 		if not isinstance(other,POINT_CLASSES):
@@ -326,7 +326,7 @@ class _RectMixin:
 
 	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
 	def __hash__(self):
-		return hash((self.left,self.top,self.right,self.bottom))
+		return super().__hash__()
 
 	def __ne__(self,other):
 		if not isinstance(other,RECT_CLASSES):

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -118,6 +118,11 @@ class espeak_VOICE(Structure):
 	def __eq__(self, other):
 		return isinstance(other, type(self)) and addressof(self) == addressof(other)
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 # constants that can be returned by espeak_callback
 CALLBACK_CONTINUE_SYNTHESIS=0
 CALLBACK_ABORT_SYNTHESIS=1

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -181,6 +181,11 @@ class Bookmark(baseObject.AutoPropertyObject):
 		if isinstance(other,Bookmark) and self.infoClass==other.infoClass and self.data==other.data:
 			return True
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 	def __ne__(self,other):
 		return not self==other
 

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -39,6 +39,11 @@ class Offsets(object):
 		else:
 			return False
 
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
+
 	def __ne__(self,other):
 		return not self==other
  
@@ -165,6 +170,11 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			return True
 		else:
 			return False
+
+	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
+	# The default hash implementation is fine for  our purposes.
+	def __hash__(self):
+		return super().__hash__()
 
 	def _get_locationText(self):
 		textList=[]


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Replacement for pr #9746 as it was reverted with pr #9756.
Not all cases were handled with that approach.

In baseObject.AutoPropertyObject: all instances are tracked on the class by storing them in a WeakKeyDictionary. Tracking of these instances is to allow clearing the proprty cache of all living objects in one go.
In eventHandler: there are several dictionaries that track currently queued events, keyed by eventName, object, or eventName and object.
In browseMode: _isNVDAObject in application keeps a cache of results, keyed by NvDAObject.

Storing NvDAObjects and or TextInfo objects in these dictionaries requires these objects to be hashable.
However, in Python3, if an object's equality check is customized (I.e. a custom __eq__ method is provided), the object becomes unhashable, as Python3 requires that any two objects that report being equal must also share the same hash value.
If __eq__ is implemented on an object and there is a need for the object to be hashable, one must also implement __hash__ on the object.

### Description of how this pull request fixes the issue:
Provides a ```__hash__``` methods on all classes we have provided a ```__eq__``` method.
In the majority of cases, the implementation just calls super, which falls back to the default hash implementation which uses the object's address for the hash. However, for the cases in locationHelper, the hash is generated from the member variables (I.e. point's hash is a hash of the tuple holding self.x and self.y). This makes for a more optimal hash for storing collections of numbers like this.
 
### Testing performed:
Again, no TypeError("unhashable type") is raised when starting NvDA dn or using broaseMode documents.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

