### PR TITLE
Remove usage of cmp function

### DIFF
--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -319,7 +319,13 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 			return selfTi.compareEndPoints(otherTi, which)
 
 		# Different objects, so we have to compare the hierarchical positions of the objects.
-		return cmp(self._getObjectPosition(selfObj), other._getObjectPosition(otherObj))
+		# cmp no longer exists in Python3.
+	# Per the Python3 What's New docs:
+	# cmp can be replaced with (a>b)-(a<b).
+	# In other words, False and True coerce to 0 and 1 respectively.
+		selfPosition=self._getObjectPosition(selfObj)
+		otherPosition=other._getObjectPosition(otherObj)
+		return (selfPosition>otherPosition)-(selfPosition<otherPosition)
 
 	def expand(self, unit):
 		if unit == textInfos.UNIT_READINGCHUNK:

--- a/source/installer.py
+++ b/source/installer.py
@@ -88,11 +88,15 @@ def comparePreviousInstall():
 	if not path or not os.path.isdir(path):
 		return None
 	try:
-		return cmp(
-			os.path.getmtime(os.path.join(path, "nvda_slave.exe")),
-			os.path.getmtime("nvda_slave.exe"))
+		oldTime=os.path.getmtime(os.path.join(path, "nvda_slave.exe"))
+		newTime=os.path.getmtime("nvda_slave.exe")
 	except OSError:
 		return None
+	# cmp no longer exists in Python3.
+	# Per the Python3 What's New docs:
+	# cmp can be replaced with (a>b)-(a<b).
+	# In other words, False and True coerce to 0 and 1 respectively.
+	return (oldTime>newTime)-(oldTime<newTime)
 
 def getDocFilePath(fileName,installDir):
 	rootPath=os.path.join(installDir,'documentation')


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
the cmp function no longer exists in Python3.

### Description of how this pull request fixes the issue:
Replace all usage of cmp with the recommended equivilant from the Python 3.0 what's new document: I.e.
```
(a>b)-(a<b)
```
This works as the bools returned from the comparison operators are coerced to ints (0 for False and 1 for True) when performing the subtraction.
 
### Testing performed:
NVDA no longer comaplsins about cmp being missing when using compoundDocuments (E.g. in Gecko editable documents).
NVDA no longer fails to show the installation dialog after pressing the Install button in the NVDA launcher.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

