### PR TITLE
Python3: base virtualBuffer: coerce attribute values to a string before escaping for regular expression 

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -57,7 +57,8 @@ FINDBYATTRIBS_ESCAPE_TABLE = {
 # Symbols that must be escaped for a regular expression.
 FINDBYATTRIBS_ESCAPE_TABLE.update({(ord(s), u"\\" + s) for s in u"^$.*+?()[]{}|"})
 def _prepareForFindByAttributes(attribs):
-	escape = lambda text: text.translate(FINDBYATTRIBS_ESCAPE_TABLE)
+	# A lambda that coerces a value to a string and escapes xml characters.
+	escape = lambda val: val.translate(FINDBYATTRIBS_ESCAPE_TABLE)
 	reqAttrs = []
 	regexp = []
 	if isinstance(attribs, dict):

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -57,7 +57,7 @@ FINDBYATTRIBS_ESCAPE_TABLE = {
 # Symbols that must be escaped for a regular expression.
 FINDBYATTRIBS_ESCAPE_TABLE.update({(ord(s), u"\\" + s) for s in u"^$.*+?()[]{}|"})
 def _prepareForFindByAttributes(attribs):
-	# A lambda that coerces a value to a string and escapes xml characters.
+	# A lambda that coerces a value to a string and escapes characters suitable for a regular expression. 
 	escape = lambda val: str(val).translate(FINDBYATTRIBS_ESCAPE_TABLE)
 	reqAttrs = []
 	regexp = []

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -58,7 +58,7 @@ FINDBYATTRIBS_ESCAPE_TABLE = {
 FINDBYATTRIBS_ESCAPE_TABLE.update({(ord(s), u"\\" + s) for s in u"^$.*+?()[]{}|"})
 def _prepareForFindByAttributes(attribs):
 	# A lambda that coerces a value to a string and escapes xml characters.
-	escape = lambda val: val.translate(FINDBYATTRIBS_ESCAPE_TABLE)
+	escape = lambda val: str(val).translate(FINDBYATTRIBS_ESCAPE_TABLE)
 	reqAttrs = []
 	regexp = []
 	if isinstance(attribs, dict):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
When trying to read content in virtualBuffers with Python3, an AttributeError is raised as int does not have an attribute: translate.

### Description of how this pull request fixes the issue:
When preparing attribute values for a regular expression for finding attributes, make sure to coerce each value to a string before escaping symbols.

### Testing performed:
Ran NVDA and read a virtualBuffer document and AttributeError was no longer raised.

### Known issues with pull request:
None.

### Change log entry:
None.

Section: New features, Changes, Bug fixes

