### PR TITLE
UI Automation in Windows Console: Remove "Text area", replace isAtLeastWin10, and code cleanup

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -193,12 +193,16 @@ class consoleUIAWindow(Window):
 			To work around this, we must redirect focus to the console text area.
 		"""
 		for child in self.children:
-			if isinstance(child, winConsoleUIA):
+			if isinstance(child, WinConsoleUIA):
 				return child
 		return None
 
 
-class winConsoleUIA(Terminal):
+class WinConsoleUIA(Terminal):
+	#: Disable the name as it won't be localized
+	name = ""
+	#: Only process text changes every 30 ms, in case the console is getting
+	#: a lot of text.
 	STABILIZE_DELAY = 0.03
 	_TextInfo = consoleUIATextInfo
 	_queuedChars = []
@@ -271,6 +275,6 @@ class winConsoleUIA(Terminal):
 
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":
-		clsList.append(winConsoleUIA)
+		clsList.append(WinConsoleUIA)
 	elif obj.UIAElement.cachedAutomationId == "Console Window":
 		clsList.append(consoleUIAWindow)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -13,7 +13,7 @@ import textInfos
 import UIAHandler
 
 from scriptHandler import script
-from winVersion import isAtLeastWin10
+from winVersion import isWin10
 from . import UIATextInfo
 from ..behaviors import Terminal
 from ..window import Window
@@ -24,7 +24,7 @@ class consoleUIATextInfo(UIATextInfo):
 
 	def __init__(self, obj, position, _rangeObj=None):
 		super(consoleUIATextInfo, self).__init__(obj, position, _rangeObj)
-		if position == textInfos.POSITION_CARET and isAtLeastWin10(1903):
+		if position == textInfos.POSITION_CARET and isWin10(1903, atLeast=False):
 			# The UIA implementation in 1903 causes the caret to be
 			# off-by-one, so move it one position to the right
 			# to compensate.

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -98,19 +98,15 @@ class consoleUIATextInfo(UIATextInfo):
 						endPoint=endPoint
 					)
 		else:  # moving by a unit other than word
-			res = super(consoleUIATextInfo, self).move(unit, direction, endPoint)
+			res = super(consoleUIATextInfo, self).move(unit, direction,
+														endPoint)
 		if oldRange and (
 			self._rangeObj.CompareEndPoints(
-				UIAHandler.TextPatternRangeEndpoint_Start,
-				firstVisiRange,
-				UIAHandler.TextPatternRangeEndpoint_Start
-			) < 0
+				UIAHandler.TextPatternRangeEndpoint_Start, firstVisiRange,
+				UIAHandler.TextPatternRangeEndpoint_Start) < 0
 			or self._rangeObj.CompareEndPoints(
-				UIAHandler.TextPatternRangeEndpoint_Start,
-				lastVisiRange,
-				UIAHandler.TextPatternRangeEndpoint_End
-			) >= 0
-		):
+				UIAHandler.TextPatternRangeEndpoint_Start, lastVisiRange,
+				UIAHandler.TextPatternRangeEndpoint_End) >= 0):
 			self._rangeObj = oldRange
 			return 0
 		return res
@@ -217,7 +213,7 @@ class WinConsoleUIA(Terminal):
 			# This will need to be changed once #8110 is merged.
 			speech.curWordChars = []
 			self._queuedChars = []
-		super(winConsoleUIA, self)._reportNewText(line)
+		super(WinConsoleUIA, self)._reportNewText(line)
 
 	def event_typedCharacter(self, ch):
 		if ch == '\t':
@@ -233,13 +229,13 @@ class WinConsoleUIA(Terminal):
 		):
 			self._queuedChars.append(ch)
 		else:
-			super(winConsoleUIA, self).event_typedCharacter(ch)
+			super(WinConsoleUIA, self).event_typedCharacter(ch)
 
 	def event_textChange(self):
 		while self._queuedChars:
 			ch = self._queuedChars.pop(0)
-			super(winConsoleUIA, self).event_typedCharacter(ch)
-		super(winConsoleUIA, self).event_textChange()
+			super(WinConsoleUIA, self).event_typedCharacter(ch)
+		super(WinConsoleUIA, self).event_textChange()
 
 	@script(gestures=[
 		"kb:enter",
@@ -251,11 +247,13 @@ class WinConsoleUIA(Terminal):
 	])
 	def script_flush_queuedChars(self, gesture):
 		"""
-			Flushes the queue of typedCharacter events if present.
-			This is necessary to avoid speaking of passwords in the console if disabled.
+		Flushes the typed word buffer and queue of typedCharacter events if present.
+		Since these gestures clear the current word/line, we should flush the
+		queue to avoid erroneously reporting these chars.
 		"""
 		gesture.send()
 		self._queuedChars = []
+		speech.curWordChars = []
 
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA
@@ -268,7 +266,7 @@ class WinConsoleUIA(Terminal):
 			self._findNonBlankIndices(newLines)
 			!= self._findNonBlankIndices(oldLines)
 		)
-		return super(winConsoleUIA, self)._calculateNewText(newLines, oldLines)
+		return super(WinConsoleUIA, self)._calculateNewText(newLines, oldLines)
 
 	def _findNonBlankIndices(self, lines):
 		return [index for index, line in enumerate(lines) if line]

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -150,7 +150,7 @@ UIAEventIdsToNVDAEventNames={
 	UIA_SystemAlertEventId:"UIA_systemAlert",
 }
 
-if winVersion.isAtLeastWin10():
+if winVersion.isWin10():
 	UIAEventIdsToNVDAEventNames[UIA_Text_TextChangedEventId] = "textChange"
 
 ignoreWinEventsMap = {

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -200,7 +200,7 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 		from NVDAObjects.UIA.winConsoleUIA import winConsoleUIA
 		if (
 			# This is only possible in Windows 10 RS2 and above
-			winVersion.isAtLeastWin10(1703)
+			winVersion.isWin10(1703)
 			# And we only want to do this if the gesture did not result in an executed action 
 			and not gestureExecuted 
 			# and not if this gesture is a modifier key

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -197,7 +197,7 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 		# #6017: handle typed characters in Win10 RS2 and above where we can't detect typed characters in-process 
 		# This code must be in the 'finally' block as code above returns in several places yet we still want to execute this particular code.
 		focus=api.getFocusObject()
-		from NVDAObjects.UIA.winConsoleUIA import winConsoleUIA
+		from NVDAObjects.UIA.winConsoleUIA import WinConsoleUIA
 		if (
 			# This is only possible in Windows 10 RS2 and above
 			winVersion.isWin10(1703)
@@ -212,7 +212,7 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 				# or the focus is within a UWP app, where WM_CHAR never gets sent 
 				or focus.windowClassName.startswith('Windows.UI.Core')
 				#Or this is a UIA console window, where WM_CHAR messages are doubled
-				or isinstance(focus, winConsoleUIA)
+				or isinstance(focus, WinConsoleUIA)
 			)
 		):
 			keyStates=(ctypes.c_byte*256)()

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -27,11 +27,12 @@ UWP_OCR_DATA_PATH = os.path.expandvars(r"$windir\OCR")
 def isUwpOcrAvailable():
 	return os.path.isdir(UWP_OCR_DATA_PATH)
 
-def isAtLeastWin10(version=1507):
+def isWin10(version=1507, atLeast=True):
 	"""
-	Returns True if NVDA is running on at least the supplied release version of Windows 10. If no argument is supplied, returns True for all public Windows 10 releases.
-	Note: this function will always return False for source copies of NVDA due to a Python bug.
+	Returns True if NVDA is running on the supplied release version of Windows 10. If no argument is supplied, returns True for all public Windows 10 releases.
+	@note: this function will always return False for source copies of NVDA due to a Python bug.
 	@param version: a release version of Windows 10 (such as 1903).
+	@param atLeast: return True if NVDA is running on at least this Windows 10 build (i.e. this version or higher).
 	"""
 	from logHandler import log
 	win10VersionsToBuilds={
@@ -44,10 +45,15 @@ def isAtLeastWin10(version=1507):
 		1809: 17763,
 		1903: 18362
 	}
-	if winVersion.major < 10:
+	if atLeast and winVersion.major < 10:
+		return False
+	elif not atLeast and winVersion.major != 10:
 		return False
 	try:
-		return winVersion.build >= win10VersionsToBuilds[version]
+		if atLeast:
+			return winVersion.build >= win10VersionsToBuilds[version]
+		else:
+			return winVersion.build == win10VersionsToBuilds[version]
 	except KeyError:
 		log.error("Unknown Windows 10 version {}".format(version))
 		return False


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614.

### Summary of the issue:
Currently:

* If the system language is not English, the name of the UIA console is not localized.
* The windows 10 detection function always returns `True` if the currently-running version is at least the supplied one. For example, this makes it difficult to enable UIA consoles for Windows 10 1809 and later except 1903.
* Since  #9673, the last-typed word was sometimes still announced after pressing enter with "speak typed words" enabled, including deleted characters in some cases.

### Description of how this pull request fixes the issue:
* The name "Text area" is no longer reported for UIA consoles.
* The `isAtLeastWin10` function has been renamed to `isWin10`. It now takes an optional `atLeast` keyword argument, which defaults to `True`. The caret movement workarounds have been explicitly enabled for 1903 (not 1903 and later) in anticipation of a possible future Microsoft fix.
* `speech.curWordChars` is once again explicitly cleared when `script_flushQueuedChars` is called.
* `winConsoleUIA.winConsoleUIA` has been renamed to `winConsoleUIA.WinConsoleUIA` to remain consistent with other NVDA classes.
* Added clarifying comments and method docstrings.

### Testing performed:
Tested that the console is still functional and that `isWin10` returns expected results on Windows 10 1903.

### Known issues with pull request:
None.

### Change log entry:
== Changes for Developers ==
- Added a new isWin10 function to the winVersion module which returns whether or not this copy of NVDA is running on (at least) the supplied release version of Windows 10 (such as 1903). (#9761)
