### PR TITLE
Python 3: Write syntax errors and tracebacks to python console

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited
+#Copyright (C) 2008-2019 NV Access Limited, Leonard de Ruijter
 
 import watchdog
 
@@ -99,8 +99,7 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		#: @type: dict
 		self._namespaceSnapshotVars = None
 
-		# Can't use super here because stupid code.InteractiveConsole doesn't sub-class object. Grrr!
-		code.InteractiveConsole.__init__(self, locals=self.namespace, **kwargs)
+		super().__init__(locals=self.namespace, **kwargs)
 		self.prompt = ">>>"
 
 	def _set_prompt(self, prompt):
@@ -121,11 +120,23 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		sys.stdout = sys.stderr = self
 		# Prevent this from messing with the gettext "_" builtin.
 		saved_ = builtins._
-		more = code.InteractiveConsole.push(self, line)
+		more = super().push(line)
 		sys.stdout, sys.stderr = stdout, stderr
 		builtins._ = saved_
 		self.prompt = "..." if more else ">>>"
 		return more
+
+	def showsyntaxerror(self, filename=None):
+		excepthook = sys.excepthook
+		sys.excepthook = sys.__excepthook__
+		super().showsyntaxerror(filename=filename)
+		sys.excepthook = excepthook
+
+	def showtraceback(self):
+		excepthook = sys.excepthook
+		sys.excepthook = sys.__excepthook__
+		super().showtraceback()
+		sys.excepthook = excepthook
 
 	def updateNamespaceSnapshotVars(self):
 		"""Update the console namespace with a snapshot of NVDA's current state.


### PR DESCRIPTION
### Link to issue number:
Fixes #9073

### Summary of the issue:
In python 3, code.InteractiveConsole.showtraceback/showsyntaxerror will print output to sys.excepthook instead of directly to the console. This results in tracebacks being printed to the NVDA log instead of to our python console.

### Description of how this pull request fixes the issue:
Inspired by how we implement the push method, showtraceback and showsyntaxerror now save sys.excepthook, restore it to sys.__excepthook__ call super and then set it back to the initial value before calling the show method.

### Testing performed:
Tested that syntax errors and tracebacks generated on the python console are shown as in NVDA on Python 2.

### Known issues with pull request:
None
