### PR TITLE
Python 3: fix several remaining division errors

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -156,7 +156,7 @@ def getZoomFactorsFromHTMLDocument(HTMLDocument):
 	except (COMError,NameError,AttributeError,TypeError):
 		log.debugWarning("unable to fetch DPI factors")
 		return (1,1)
-	return (devX/logX,devY/logY)
+	return (devX // logX, devY // logY)
 
 def IAccessibleFromHTMLNode(HTMLNode):
 	try:
@@ -483,7 +483,7 @@ class MSHTML(IAccessible):
 			# #3494: MSHTML's internal coordinates are always at a hardcoded DPI (usually 96) no matter the system DPI or zoom level.
 			xFactor,yFactor=getZoomFactorsFromHTMLDocument(HTMLNode.document)
 			try:
-				HTMLNode=HTMLNode.document.elementFromPoint(p.x/xFactor,p.y/yFactor)
+				HTMLNode=HTMLNode.document.elementFromPoint(p.x // xFactor, p.y // yFactor)
 			except:
 				HTMLNode=None
 			if not HTMLNode:

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -51,8 +51,8 @@ class ProgressBar(NVDAObject):
 			left,top,width,height=self.location
 		except:
 			left=top=width=height=0
-		x=left+(width/2)
-		y=top+(height/2)
+		x = left + (width // 2)
+		y = top+ (height // 2)
 		lastBeepProgressValue=self.progressValueCache.get("beep,%d,%d"%(x,y),None)
 		if pbConf["progressBarOutputMode"] in ("beep","both") and (lastBeepProgressValue is None or abs(percentage-lastBeepProgressValue)>=pbConf["beepPercentageInterval"]):
 			tones.beep(pbConf["beepMinHZ"]*2**(percentage/25.0),40)

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -257,7 +257,8 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 			formatField["font-name"]=charFormat.szFaceName
 		if formatConfig["reportFontSize"]:
 			if charFormat is None: charFormat=self._getCharFormat(offset)
-			formatField["font-size"]="%spt"%(charFormat.yHeight/20)
+			# Font size is supposed to be an integral value
+			formatField["font-size"]="%spt"%(charFormat.yHeight//20)
 		if formatConfig["reportFontAttributes"]:
 			if charFormat is None: charFormat=self._getCharFormat(offset)
 			formatField["bold"]=bool(charFormat.dwEffects&CFE_BOLD)

--- a/source/api.py
+++ b/source/api.py
@@ -257,11 +257,8 @@ def createStateList(states):
 def moveMouseToNVDAObject(obj):
 	"""Moves the mouse to the given NVDA object's position""" 
 	location=obj.location
-	if location and (len(location)==4):
-		(left,top,width,height)=location
-		x=(left+left+width)/2
-		y=(top+top+height)/2
-		winUser.setCursorPos(x,y)
+	if location:
+		winUser.setCursorPos(*location.center)
 
 def processPendingEvents(processEventQueue=True):
 	# Import late to avoid circular import.

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -179,13 +179,12 @@ class VsTextEditPaneTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _getOffsetFromPoint(self,x,y):
 		yMinUnit, yMaxUnit, yVisible, yFirstVisible = self._textView.GetScrollInfo(SB_VERT)
 		hMinUnit, hMaxUnit, hVisible, hFirstVisible = self._textView.GetScrollInfo(SB_HORZ)
-		
 		# These should probably be cached as they are fairly unlikely to change, but ...
 		lineHeight = self._textView.GetLineHeight()
-		charWidth = self._window.Width / hVisible
+		charWidth = self._window.Width // hVisible
 
-		offsetLine = (y - self._window.Top) / lineHeight + yFirstVisible
-		offsetChar = (x - self._window.Left) / charWidth + hFirstVisible
+		offsetLine = (y - self._window.Top) // lineHeight + yFirstVisible
+		offsetChar = (x - self._window.Left) // charWidth + hFirstVisible
 		return self._textView.GetNearestPosition(offsetLine, offsetChar)[0]
 
 	def __init__(self, obj, position):

--- a/source/appModules/nlnotes.py
+++ b/source/appModules/nlnotes.py
@@ -15,8 +15,7 @@ import virtualBuffers.lotusNotes
 class IrisTedit(IAccessible):
 
 	def _get_name(self):
-		left,top,width,height=self.location
-		label=api.getDesktopObject().objectFromPoint(left+(width/2),top+(height/2))
+		label=api.getDesktopObject().objectFromPoint(*self.location.center)
 		if label:
 			return label.name
 

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -414,10 +414,10 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 		#Enumerate the character rectangles
 		a=enumerate(self._storyFieldsAndRects[1])
 		#Convert calculate center points for all the rectangles
-		b=((charOffset,(charLeft+(charRight-charLeft)/2,charTop+(charBottom-charTop)/2)) for charOffset,(charLeft,charTop,charRight,charBottom) in a)
-		#Calculate distances from all center points to the given x and y
-		#But place the distance before the character offset, to make sorting by distance easier
-		c=((math.sqrt(abs(x-cx)**2+abs(y-cy)**2),charOffset) for charOffset,(cx,cy) in b)
+		b = ((charOffset, rect.center) for charOffset, rect in a)
+		# Calculate distances from all center points to the given x and y
+		# But place the distance before the character offset, to make sorting by distance easier
+		c = ((math.sqrt(abs(x - center.x) ** 2 + abs(y - center.y) ** 2), charOffset) for charOffset, center in b)
 		#produce a static list of distances and character offsets, sorted by distance 
 		d=sorted(c)
 		#Return the lowest offset with the shortest distance
@@ -446,9 +446,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 		if not l:
 			log.debugWarning("object has no location")
 			raise LookupError
-		x=l[0]+(l[2]/2)
-		y=l[1]+(l[3]/2)
-		offset=self._getClosestOffsetFromPoint(x,y)
+		offset=self._getClosestOffsetFromPoint(*l.center)
 		return offset,offset
 
 	def _getLineOffsets(self,offset):
@@ -569,9 +567,9 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 		rects=self._storyFieldsAndRects[1]
 		if offset>=len(rects):
 			raise RuntimeError("offset %d out of range")
-		left,top,right,bottom=rects[offset]
-		x=left #+(right-left)/2
-		y=top+(bottom-top)/2
+		rect = rects[offset]
+		x = rect.x
+		y= rect.center.y
 		x,y=windowUtils.logicalToPhysicalPoint(self.obj.windowHandle,x,y)
 		oldX,oldY=winUser.getCursorPos()
 		winUser.setCursorPos(x,y)

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -290,9 +290,8 @@ class TouchHandler(threading.Thread):
 		@param obj: The NVDAObject with which the user is interacting.
 		@type obj: L{NVDAObjects.NVDAObject}
 		"""
-		l, t, w, h = obj.location
 		oledll.oleacc.AccNotifyTouchInteraction(gui.mainFrame.Handle, obj.windowHandle,
-			POINT(l + (w / 2), t + (h / 2)))
+			obj.location.center.toPOINT())
 
 handler=None
 

--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -200,8 +200,8 @@ class TrackerManager(object):
 		numFingers=len(childTrackers)
 		if numFingers==0: return
 		if numFingers==1: return childTrackers[0]
-		avgX=sum(t.x for t in childTrackers)/numFingers
-		avgY=sum(t.y for t in childTrackers)/numFingers
+		avgX: int = sum(t.x for t in childTrackers) // numFingers
+		avgY: int = sum(t.y for t in childTrackers) // numFingers
 		tracker=MultiTouchTracker(action_hold,avgX,avgY,childTrackers[0].startTime,time.time(),numFingers)
 		tracker.childTrackers=childTrackers
 		return tracker
@@ -257,8 +257,8 @@ class TrackerManager(object):
 			childTrackers.extend(oldTracker.childTrackers) if oldTracker.numFingers>1 else childTrackers.append(oldTracker)
 			childTrackers.extend(newTracker.childTrackers) if newTracker.numFingers>1 else childTrackers.append(newTracker)
 			numFingers=oldTracker.numFingers+newTracker.numFingers
-			avgX=sum(t.x for t in childTrackers)/numFingers
-			avgY=sum(t.y for t in childTrackers)/numFingers
+			avgX: int =sum(t.x for t in childTrackers) // numFingers
+			avgY: int = sum(t.y for t in childTrackers) // numFingers
 			mergedTracker=MultiTouchTracker(newTracker.action,avgX,avgY,oldTracker.startTime,newTracker.endTime,numFingers,newTracker.actionCount,pluralTimeout=newTracker.pluralTimeout)
 			mergedTracker.childTrackers=childTrackers
 		elif self.numUnknownTrackers==0 and newTracker.pluralTimeout is not None and newTracker.startTime>=oldTracker.endTime and newTracker.startTime<oldTracker.pluralTimeout and newTracker.action==oldTracker.action and oldTracker.numFingers==newTracker.numFingers:

--- a/source/virtualBuffers/adobeFlash.py
+++ b/source/virtualBuffers/adobeFlash.py
@@ -125,10 +125,8 @@ class AdobeFlash(VirtualBuffer):
 		if not l:
 			log.debugWarning("no location for field")
 			return
-		x=(l[0]+l[2]/2)
-		y=l[1]+(l[3]/2) 
 		oldX,oldY=winUser.getCursorPos()
-		winUser.setCursorPos(x,y)
+		winUser.setCursorPos(*l.center)
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTDOWN,0,0)
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP,0,0)
 		winUser.setCursorPos(oldX,oldY)

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -207,23 +207,18 @@ class Gecko_ia2(VirtualBuffer):
 				break
 			except:
 				log.debugWarning("doAction failed")
-			if controlTypes.STATE_OFFSCREEN in obj.states or controlTypes.STATE_INVISIBLE in obj.states:
+			if obj.hasIrrelevantLocation:
+				# This check covers invisible, off screen and a None location
+				log.debugWarning("No relevant location for object")
 				obj = obj.parent
 				continue
-			try:
-				l, t, w, h = obj.location
-			except TypeError:
-				log.debugWarning("No location for object")
-				obj = obj.parent
-				continue
-			if not w or not h:
+			location = obj.location
+			if not location.width or not location.height:
 				obj = obj.parent
 				continue
 			log.debugWarning("Clicking with mouse")
-			x = l + w / 2
-			y = t + h / 2
 			oldX, oldY = winUser.getCursorPos()
-			winUser.setCursorPos(x, y)
+			winUser.setCursorPos(*location.center)
 			mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTDOWN, 0, 0)
 			mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP, 0, 0)
 			winUser.setCursorPos(oldX, oldY)

--- a/source/virtualBuffers/lotusNotes.py
+++ b/source/virtualBuffers/lotusNotes.py
@@ -88,10 +88,8 @@ class LotusNotesRichText(VirtualBuffer):
 		if not l:
 			log.debugWarning("no location for field")
 			return
-		x=(l[0]+l[2]/2)
-		y=l[1]+(l[3]/2) 
 		oldX,oldY=winUser.getCursorPos()
-		winUser.setCursorPos(x,y)
+		winUser.setCursorPos(*l.center)
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTDOWN,0,0)
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP,0,0)
 		winUser.setCursorPos(oldX,oldY)

--- a/source/virtualBuffers/webKit.py
+++ b/source/virtualBuffers/webKit.py
@@ -117,10 +117,8 @@ class WebKit(VirtualBuffer):
 		if not l:
 			log.debugWarning("no location for field")
 			return
-		x=(l[0]+l[2]/2)
-		y=l[1]+(l[3]/2) 
 		oldX,oldY=winUser.getCursorPos()
-		winUser.setCursorPos(x,y)
+		winUser.setCursorPos(*l.center)
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTDOWN,0,0)
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP,0,0)
 		winUser.setCursorPos(oldX,oldY)

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -179,30 +179,30 @@ class WinConsoleTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return x,y
 
 	def _getOffsetFromPoint(self,x,y):
-		consoleScreenBufferInfo=self.consoleScreenBufferInfo
-		screenLeft,screenTop,screenWidth,screenHeight=self.obj.location
-		relativeX=x-screenLeft
-		relativeY=y-screenTop
-		lineLength=(consoleScreenBufferInfo.srWindow.Right+1)-consoleScreenBufferInfo.srWindow.Left
-		numLines=(consoleScreenBufferInfo.srWindow.Bottom+1)-consoleScreenBufferInfo.srWindow.Top
-		characterWidth=screenWidth/lineLength
-		characterHeight=screenHeight/numLines
-		characterX=(relativeX/characterWidth)+consoleScreenBufferInfo.srWindow.Left
-		characterY=(relativeY/characterHeight)+consoleScreenBufferInfo.srWindow.Top
+		consoleScreenBufferInfo = self.consoleScreenBufferInfo
+		screenLeft, screenTop, screenWidth, screenHeight = self.obj.location
+		relativeX = x - screenLeft
+		relativeY = y - screenTop
+		lineLength = (consoleScreenBufferInfo.srWindow.Right + 1) - consoleScreenBufferInfo.srWindow.Left
+		numLines = (consoleScreenBufferInfo.srWindow.Bottom + 1) - consoleScreenBufferInfo.srWindow.Top
+		characterWidth = screenWidth // lineLength
+		characterHeight = screenHeight // numLines
+		characterX = (relativeX // characterWidth) + consoleScreenBufferInfo.srWindow.Left
+		characterY = (relativeY // characterHeight) + consoleScreenBufferInfo.srWindow.Top
 		return self._offsetFromConsoleCoord(characterX,characterY)
 
 	def _getPointFromOffset(self,offset):
-		consoleScreenBufferInfo=self.consoleScreenBufferInfo
-		characterX,characterY=self._consoleCoordFromOffset(offset)
-		screenLeft,screenTop,screenWidth,screenHeight=self.obj.location
-		lineLength=(consoleScreenBufferInfo.srWindow.Right+1)-consoleScreenBufferInfo.srWindow.Left
-		numLines=(consoleScreenBufferInfo.srWindow.Bottom+1)-consoleScreenBufferInfo.srWindow.Top
-		characterWidth=screenWidth/lineLength
-		characterHeight=screenHeight/numLines
-		relativeX=(characterX-consoleScreenBufferInfo.srWindow.Left)*characterWidth
-		relativeY=(characterY-consoleScreenBufferInfo.srWindow.Top)*characterHeight
-		x=relativeX+screenLeft
-		y=relativeY+screenTop
+		consoleScreenBufferInfo = self.consoleScreenBufferInfo
+		characterX, characterY = self._consoleCoordFromOffset(offset)
+		screenLeft, screenTop, screenWidth, screenHeight = self.obj.location
+		lineLength = (consoleScreenBufferInfo.srWindow.Right + 1)- consoleScreenBufferInfo.srWindow.Left
+		numLines = (consoleScreenBufferInfo.srWindow.Bottom + 1) - consoleScreenBufferInfo.srWindow.Top
+		characterWidth = screenWidth // lineLength
+		characterHeight = screenHeight // numLines
+		relativeX = (characterX - consoleScreenBufferInfo.srWindow.Left) * characterWidth
+		relativeY = (characterY - consoleScreenBufferInfo.srWindow.Top) * characterHeight
+		x = relativeX + screenLeft
+		y = relativeY + screenTop
 		return locationHelper.Point(x,y)
 
 	def _getCaretOffset(self):


### PR DESCRIPTION
### Link to issue number:
Hopefully fixes #9641 
Follow up to #9692, #9737 and #9748 

### Summary of the issue:
After the pull requests mentioned above, there were still some major issues with the behavioural changes to the Python 3 default division operator.

### Description of how this pull request fixes the issue:
On the source code, executed python modernize with the libmodernize.fixes.fix_classic_division operator. Recorded the diff and changed only the division operators for necessary cases. In the case where the mouse was positioned at the center of an object, switched to using locationHelper instead in order to be less error prone in the future.

### Testing performed:
t.b.d.

### Known issues with pull request:
I'm a human being. Therefore, I could have discarded some changes by modernize of which I thought they weren't necessary. Note that modernize is way too aggressive, though (i.e. it does not explore the context of division operators).

### Change log entry:
None
