### PR TITLE
Python 3: work around deprecation warning with a major rewrite of extensionPoints.callWithSUpportedKwargs, and add some tests for Py3 specific functionality

### DIFF
--- a/source/extensionPoints/util.py
+++ b/source/extensionPoints/util.py
@@ -82,10 +82,11 @@ class HandlerRegistrar(object):
 		However, the callable must be kept alive by your code otherwise it will be de-registered. This is due to the use
 		of weak references. This is especially relevant when using lambdas.
 		"""
-		# #9720 (Py3 review required): this method causes unittest to fail in Python 3.
-		if hasattr(handler, "__self__"):
-			if not handler.__self__:
+		if inspect.isfunction(handler):
+			sig = inspect.signature(handler)
+			if sig.parameters and list(sig.parameters)[0] == "self":
 				raise TypeError("Registering unbound instance methods not supported.")
+		if inspect.ismethod(handler):
 			weak = BoundMethodWeakref(handler, self.unregister)
 		else:
 			weak = AnnotatableWeakref(handler, self.unregister)

--- a/tests/unit/test_extensionPoints.py
+++ b/tests/unit/test_extensionPoints.py
@@ -9,6 +9,7 @@
 
 import unittest
 import extensionPoints
+from functools import partial
 
 class ExampleClass(object):
 	def method(self):
@@ -94,7 +95,7 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 	def test_instanceMethodHandlerTakesParamsAndKwargs_givenKwargs(self):
 		"""Test to ensure that a instance method handler gets the correct arguments, including implicit "self"
-		Handler takes a parameter and **kwargs.
+		Handler takes a positional parameter and **kwargs.
 		callWithSupportedKwargs given key word arguments.
 		Handler should get all values.
 		"""
@@ -111,7 +112,7 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 	def test_instanceMethodHandlerTakesParamsAndKwargs_givenPositional(self):
 		"""Test to ensure that a instanceMethod handler gets the correct arguments, including implicit "self"
-		Handler takes parameter and key word arguments.
+		Handler takes positional parameter and key word arguments.
 		callWithSupportedKwargs given a positional.
 		Handler should get positional.
 		"""
@@ -128,7 +129,7 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 	def test_instanceMethodHandlerTakesParams_givenPositional(self):
 		"""Test to ensure that a instance method handler gets the correct arguments, including implicit "self"
-		Handler takes a parameter.
+		Handler takes a positional parameter.
 		callWithSupportedKwargs given a positional.
 		Handler should get positional.
 		"""
@@ -140,6 +141,22 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 		h = handlerClass()
 		extensionPoints.callWithSupportedKwargs(h.handlerMethod, 'a value')
+		self.assertEqual(calledKwargs, {'a': 'a value'})
+
+	def test_instanceMethodHandlerTakesParams_givenRequiredKwarg(self):
+		"""Test to ensure that a instance method handler gets the correct arguments, including implicit "self"
+		Handler takes a required keyword argument.
+		callWithSupportedKwargs given a keyword arg with a matching name.
+		Handler should get required kwarg.
+		"""
+		calledKwargs = {}
+
+		class handlerClass():
+			def handlerMethod(self, *, a):
+				calledKwargs['a'] = a
+
+		h = handlerClass()
+		extensionPoints.callWithSupportedKwargs(h.handlerMethod, a='a value')
 		self.assertEqual(calledKwargs, {'a': 'a value'})
 
 	def test_instanceMethodHandlerTakesParams_givenMatchingNameKwarg(self):
@@ -241,7 +258,6 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 			gotParams['a'] = a
 		with self.assertRaises(TypeError):
 			extensionPoints.callWithSupportedKwargs(handler, b='b value')
-
 
 	def test_handlerTakesTwoParamsWithoutDefaults_NotEnoughPositionalsGiven_exceptionRaised(self):
 		""" Tests that handlers that when a handler expects params which are not provided, then the function is not called.
@@ -450,6 +466,22 @@ class TestAction(unittest.TestCase):
 		self.action.notify(a='a value')
 		self.assertEqual(calledKwargs, {'a': 'a value'})
 
+	def test_partialHandler(self):
+		""" Test that a L{functools.partial} can be used as a handler.
+		Note: the partial must be kept alive, since register uses a weak reference to it.
+		"""
+
+		calledKwargs = {}
+
+		def handler(a, b):
+			calledKwargs['a'] = a
+			calledKwargs['b'] = b
+
+		p = partial(handler, a=1)
+		self.action.register(p)
+		self.action.notify(b='a value')
+		self.assertEqual(calledKwargs, {'a': 1, 'b': 'a value'})
+
 	def test_handlerException(self):
 		"""Test that a handler which raises an exception doesn't affect later handlers.
 		"""
@@ -490,6 +522,17 @@ class TestAction(unittest.TestCase):
 		"""
 		calledKwargs = {}
 		def handler(a=0):
+			calledKwargs["a"] = a
+
+		self.action.register(handler)
+		self.action.notify(a=1)
+		self.assertEqual(calledKwargs, {"a": 1})
+
+	def test_handlerParamsWithRequiredKwarg(self):
+		""" Test that a handler that accepts required keyword arguments receives arguments
+		"""
+		calledKwargs = {}
+		def handler(*, a):
 			calledKwargs["a"] = a
 
 		self.action.register(handler)
@@ -595,6 +638,19 @@ class TestFilter(unittest.TestCase):
 		calledKwargs = {}
 
 		def handler(value, a=0):
+			calledKwargs['value'] = value
+			calledKwargs["a"] = a
+
+		self.filter.register(handler)
+		self.filter.apply("some value", a=1)
+		self.assertEqual(calledKwargs, {"value": "some value", "a": 1})
+
+	def test_handlerParamsWithRequiredKwarg(self):
+		""" Test that a handler that accepts required keyword arguments receives arguments
+		"""
+		calledKwargs = {}
+
+		def handler(value, *, a):
 			calledKwargs['value'] = value
 			calledKwargs["a"] = a
 
@@ -710,6 +766,18 @@ class TestDecider(unittest.TestCase):
 		calledKwargs = {}
 
 		def handler(a=0):
+			calledKwargs["a"] = a
+
+		self.decider.register(handler)
+		self.decider.decide(a=1)
+		self.assertEqual(calledKwargs, {"a": 1})
+
+	def test_handlerParamsWithRequiredKwarg(self):
+		""" Test that a handler that accepts required keyword arguments receives arguments
+		"""
+		calledKwargs = {}
+
+		def handler(*, a):
 			calledKwargs["a"] = a
 
 		self.decider.register(handler)

--- a/tests/unit/test_extensionPoints.py
+++ b/tests/unit/test_extensionPoints.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2017-2019 NV Access Limited
+#Copyright (C) 2017-2019 NV Access Limited, Leonard de Ruijter
 
 """Unit tests for the extensionPoints module.
 """

--- a/tests/unit/test_extensionPoints.py
+++ b/tests/unit/test_extensionPoints.py
@@ -351,8 +351,6 @@ class TestHandlerRegistrar(unittest.TestCase):
 		actual = list(self.reg.handlers)
 		self.assertEqual(actual, [inst.method])
 
-	# #9720 (Py3 review required): for some reason, this test keeps failing, so mark this as expected failure for now.
-	@unittest.expectedFailure
 	def test_registerUnboundInstanceMethod_raisesException(self):
 		unboundInstMethod = ExampleClass.method
 		with self.assertRaises(TypeError):

--- a/tests/unit/test_extensionPoints.py
+++ b/tests/unit/test_extensionPoints.py
@@ -95,7 +95,7 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 	def test_instanceMethodHandlerTakesParamsAndKwargs_givenKwargs(self):
 		"""Test to ensure that a instance method handler gets the correct arguments, including implicit "self"
-		Handler takes a positional parameter and **kwargs.
+		Handler takes a parameter and **kwargs.
 		callWithSupportedKwargs given key word arguments.
 		Handler should get all values.
 		"""
@@ -112,7 +112,7 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 	def test_instanceMethodHandlerTakesParamsAndKwargs_givenPositional(self):
 		"""Test to ensure that a instanceMethod handler gets the correct arguments, including implicit "self"
-		Handler takes positional parameter and key word arguments.
+		Handler takes parameter and key word arguments.
 		callWithSupportedKwargs given a positional.
 		Handler should get positional.
 		"""
@@ -129,7 +129,7 @@ class TestCallWithSupportedKwargs(unittest.TestCase):
 
 	def test_instanceMethodHandlerTakesParams_givenPositional(self):
 		"""Test to ensure that a instance method handler gets the correct arguments, including implicit "self"
-		Handler takes a positional parameter.
+		Handler takes a parameter.
 		callWithSupportedKwargs given a positional.
 		Handler should get positional.
 		"""


### PR DESCRIPTION
### Link to issue number:
Fixes #9770 

### Summary of the issue:
Using callWithSupportedKwargs to call a function results in a deprecation warning about inspect.getargspec

### Description of how this pull request fixes the issue:
This pr contains a major rewrite of callWithSUpportedKwargs. In python 2, we had to process positional arguments ourselves, mapping positional to keyword args and vice versa.
Python 3 contains inspect.Signature, a very handy class that for fills this need. This means that in callWithSUpportedKwargs, the only processing we have to do ourselves is not pass unsupported kwargs to the handler, but only if there is no **kwargs parameter in the handler. All other logic is handled by the inspect module.

### Testing performed:
Unit tests. I also added some new ones for:

1. Required kwargs: `def hello(*, requiredKwarg):`
2. partials

### Known issues with pull request:
None
### Change log entry:
* Changes for developers
    + extensionPoints classes and the callWithSupportedKwargs function now support functools.partial instances and functions with required keyword arguments.