### PR TITLE
Hopefully no longer freeze NVDA when Chinese input method is in use in Windows Explorer

### DIFF
--- a/source/appModules/dllhost.py
+++ b/source/appModules/dllhost.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2018-2019 NV Access Limited, Łukasz Golonka
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,5 +16,5 @@ class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		windowClass = obj.windowClassName
-		if windowClass == "Edit":
+		if windowClass == "Edit" and controlTypes.STATE_READONLY in obj.states:
 			clsList.insert(0, ReadOnlyEditBox)

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,6 +1,7 @@
+# -*- coding: UTF-8 -*-
 #appModules/explorer.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Joseph Lee
+#Copyright (C) 2006-2019 NV Access Limited, Joseph Lee, Łukasz Golonka
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -184,7 +185,7 @@ class ReadOnlyEditBox(IAccessible):
 
 	def _get_windowText(self):
 		windowText = super(ReadOnlyEditBox, self).windowText
-		if windowText is not None and controlTypes.STATE_READONLY in self.states:
+		if windowText is not None:
 			return windowText.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 		return windowText
 
@@ -219,7 +220,7 @@ class AppModule(appModuleHandler.AppModule):
 					clsList.insert(0, NotificationArea)
 			return 
 
-		if windowClass == "Edit":
+		if windowClass == "Edit" and controlTypes.STATE_READONLY in obj.states:
 			clsList.insert(0, ReadOnlyEditBox)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 


### PR DESCRIPTION
This is opened against Beta because it fixes a regression which is not in a release yet. It'd be good to have it in 2019.2.
### Link to issue number:
Fixes #9772
### Summary of the issue:
When Chinese and Japanese  input methods are in use and something is typed into edit boxes in Windows Explorer NVDA freezes. It is assumed that #8643 is the culprit. In this PR I've created new class readOnnlyEditBox and mapped it to all edit fields in Windows Explorer.
### Description of how this pull request fixes the issue:
Now the class is mapped only to read-only ones. This not regresses #8361 because RTL and LTR marks should be removed only from read-only ones. Initially I've written it this way to make check for class only in one file.
### Testing performed:
Build with this fix was tested by @dingpengyu and @man0528 and they both confirm that the freeze no longer occurs.
### Known issues with pull request:
None known.
### Change log entry:
I don't know what is a policy so late in the release cycle. It fixes a bug  in the functionality which isn't in a release yet, so maybe Change log entry isn't necscessarry.