### PR TITLE
Allow pasting multiple lines in the Python Console (#9776)

### DIFF
--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -764,8 +764,8 @@ See [Snapshot Variables #PythonConsoleSnapshotVariables] for more details.
 -
 
 The console is similar to the standard interactive Python interpreter.
-Input is accepted one line at a time.
-The current line is processed when enter is pressed.
+Input is accepted one line at a time and processed when enter is pressed.
+Multiple lines can be pasted at once from the clipboard and will be processed one by one. 
 You can navigate through the history of previously entered lines using the up and down arrow keys.
 
 Output (responses from the interpreter) will be spoken when enter is pressed.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9776

### Summary of the issue:

It is currently impossible to paste more than one line in the python console. It would be handy if this could be possible, as it will make copying and testing code from the console easier.

### Description of how this pull request fixes the issue:

Like on the standard Python Console, the input field remains single-line.
However, when pasting multiple lines from the clipboard, these are executed sequentially like if typed one by one.
Care is taken to consider the text already present in the input field and the position of the cursor to obtain the same result as pasting in a multi-line field.
Unlike on the standard Python Console, if a compilation error occurs on one line, pasting of the remaining lines stops to avoid execution of the remaining lines and ease reading of output error. In such a case, the original input text after the cursor is restored in the input field.
Nevertheless, as one would expect, pasting of multiple lines does not stop if the execution itself raises an exception.

### Testing performed:

Ported from an add-on in use for a few months.
Probably better to further test live, though.

### Known issues with pull request:

### Change log entry:

In the Python Console, the input field now supports pasting multiple lines from the clipboard.

