### PR TITLE
Python Console: Preserve the result of the last executed command (#9782)

### DIFF
--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -771,7 +771,11 @@ You can navigate through the history of previously entered lines using the up an
 Output (responses from the interpreter) will be spoken when enter is pressed.
 The f6 key toggles between the input and output controls.
 
-Closing the console window simply hides it.
+The result of the last executed command is stored in the "_" global variable.
+This shadows the gettext function which is stored as a built-in with the same name.
+It can be unshadowed by executing "del _" and avoided altogether by executing "_ = _".
+
+Closing the console window (with escape or alt+F4) simply hides it.
 This allows the user to return to the session as it was left when it was closed, including history and variables.
 
 ++ Namespace ++[PythonConsoleNamespace]


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9782

### Summary of the issue:

The NVDA Python Console implementation prevents clobbering of the gettext "_" built-in but at the same time prevents the user from taking advantage of the standard sys.displayhook saving the last returned value under that same name.

### Description of how this pull request fixes the issue:

Save the last execution result in the global namespace rather than in `__builtins__`.
Gettext is thus not affected.

### Testing performed:

### Known issues with pull request:

Unlike on the standard Python Console where the "_" special variable is stored in __builtins__, a variable named "_" in the global namespace will be overridden every time a command is executed.
An exception is made for the gettext function. That is, if it is explicitly promoted to the global namespace by executing `_ = _` it won't get overridden on subsequent commands execution until explicitly deleted by `del _`.
If this is to be considered a problem, a little more intrusive implementation could extend the namespace dictionary to specially handle "_" and preserve any manually defined global with that name.

Furthermore, `None` is the only special value in the standard `sys.displayhook`, as it never overrides the "_" built-in. This PR treats the gettext function in the same way and thus does not override the last result if the executed command returns either `None` or the gettext function.
If this is to be considered a problem, I guess a custom display hook could do the trick, but I doubt it would be worth the effort.

### Change log entry:

Python Console: The global variable "_" now stores the result of the last executed command.

