### PR TITLE
Python Console: Additions to the initial namespace (#9789)

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -76,25 +76,13 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 	def __init__(self, outputFunc, setPromptFunc, exitFunc, echoFunc=None, **kwargs):
 		self._output = outputFunc
 		self._echo = echoFunc
+		self._exit = exitFunc
 		self._setPrompt = setPromptFunc
 
 		#: The namespace available to the console. This can be updated externally.
 		#: @type: dict
-		# Populate with useful modules.
-		exitCmd = ExitConsoleCommand(exitFunc)
-		self.namespace = {
-			"help": HelpCommand(),
-			"exit": exitCmd,
-			"quit": exitCmd,
-			"sys": sys,
-			"os": os,
-			"wx": wx,
-			"log": log,
-			"api": api,
-			"queueHandler": queueHandler,
-			"speech": speech,
-			"braille": braille,
-		}
+		self.namespace = {}
+		self.initNamespace()
 		#: The variables last added to the namespace containing a snapshot of NVDA's state.
 		#: @type: dict
 		self._namespaceSnapshotVars = None
@@ -126,6 +114,35 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		__builtin__._ = saved_
 		self.prompt = "..." if more else ">>>"
 		return more
+
+	def initNamespace(self):
+		"""(Re-)Initialize the console namespace with useful globals.
+		"""
+		exitCmd = ExitConsoleCommand(self._exit)
+		import appModules
+		import config
+		import controlTypes
+		import globalPlugins
+		import textInfos
+		self.namespace.clear()
+		self.namespace.update({
+			"help": HelpCommand(),
+			"exit": exitCmd,
+			"quit": exitCmd,
+			"os": os,
+			"sys": sys,
+			"wx": wx,
+			"api": api,
+			"appModules": appModules,
+			"braille": braille,
+			"config": config,
+			"controlTypes": controlTypes,
+			"globalPlugins": globalPlugins,
+			"log": log,
+			"queueHandler": queueHandler,
+			"speech": speech,
+			"textInfos": textInfos,
+		})
 
 	def updateNamespaceSnapshotVars(self):
 		"""Update the console namespace with a snapshot of NVDA's current state.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9789

### Summary of the issue:

The initial namespace of the Python Console lacks a few common imports that would allow to take full advantage of the tab-completion capability:
 - appModules
 - config
 - controlTypes
 - globalPlugins
 - textInfos

Furthermore, one cannot customize it using a global plugin without first initializing the console.

### Description of how this pull request fixes the issue:

 - Add the above-mentioned imports to the initial namespace.
 - Initialize the namespace in a dedicated method.

### Testing performed:

### Known issues with pull request:

### Change log entry:


