### PR TITLE
Make readOnlyEditBox really work on older builds of Win 10

### DIFF
--- a/source/appModules/dllhost.py
+++ b/source/appModules/dllhost.py
@@ -10,6 +10,7 @@ This simply imports a proper class from the explorer app module, and maps it to 
 """
 
 import appModuleHandler
+import controlTypes
 from .explorer import ReadOnlyEditBox
 
 class AppModule(appModuleHandler.AppModule):


### PR DESCRIPTION
### Link to issue number:
None. Caused by #9779
### Summary of the issue:
On older builds of Windows 10 dllhost is responsible for displaying properties window. The appModule for it used to remove RTL and LTR marks requires additional import after merge of #9779 which I've missed initially.
### Description of how this pull request fixes the issue:
controlTypes are imported at the top of the module which makes it working again.
### Testing performed:
Tested that RTL and LTR marks are removed on Windows 10 builds 1511 and 1507.
### Known issues with pull request:
None
### Change log entry:
None needed.