### PR TITLE
Add missing import of controlTypes in apModules.dllhost

### DIFF
--- a/source/appModules/dllhost.py
+++ b/source/appModules/dllhost.py
@@ -11,6 +11,7 @@ This simply imports a proper class from the explorer app module, and maps it to 
 
 import appModuleHandler
 from .explorer import ReadOnlyEditBox
+import controlTypes
 
 class AppModule(appModuleHandler.AppModule):
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None
### Summary of the issue:
Missing import of controlTypes in appModules.dllhost prevents the module from working.

### Description of how this pull request fixes the issue:
Add imporrt.
### Testing performed:
Tested in the network adapter properties where navigating the list of protocols and dialog gave errors.

### Known issues with pull request:
None
### Change log entry:
None


