### PR TITLE
Correct a few places where we are trying to do integer comparisons with None

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -480,7 +480,7 @@ the NVDAObject for IAccessible
 		if ((windowClassName in ("MozillaWindowClass", "GeckoPluginWindow") and not isinstance(self.IAccessibleObject, IAccessibleHandler.IAccessible2))
 				or windowClassName in ("MacromediaFlashPlayerActiveX", "ApolloRuntimeContentWindow", "ShockwaveFlash", "ShockwaveFlashLibrary", "ShockwaveFlashFullScreen", "GeckoFPSandboxChildWindow")):
 			maybeFlash = True
-		elif windowClassName == "Internet Explorer_Server" and self.event_objectID > 0:
+		elif windowClassName == "Internet Explorer_Server" and self.event_objectID is not None and self.event_objectID > 0:
 			# #2454: In Windows 8 IE, Flash is exposed in the same HWND as web content.
 			from .MSHTML import MSHTML
 			# This is only possibly Flash if it isn't MSHTML.

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1067,8 +1067,11 @@ def getSpeechTextForProperties(reason=controlTypes.REASON_QUERY,**propertyValues
 		# Don't update the oldTableID if no tableID was given.
 		if tableID and not sameTable:
 			oldTableID = tableID
-		rowSpan = propertyValues.get("rowSpan")
-		columnSpan = propertyValues.get("columnSpan")
+		# When fetching row and column span
+		# default the values to 1 to make further checks a lot simpler.
+		# After all, a table cell that has no rowspan implemented is assumed to span one row.
+		rowSpan = propertyValues.get("rowSpan") or 1
+		columnSpan = propertyValues.get("columnSpan") or 1
 		if rowNumber and (not sameTable or rowNumber != oldRowNumber or rowSpan != oldRowSpan):
 			rowHeaderText = propertyValues.get("rowHeaderText")
 			if rowHeaderText:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Related to  #9107 

### Summary of the issue:
In Python3, it is no longer valid to compair a number with None with operators such as less-than or greater-than.
Our codebase does this in quite a few places.
Most notably at the moment are places that affect:
* Internet Explorer support
* table support. 
 
### Description of how this pull request fixes the issue:
* Internet explorer support: ensure that event_objectID is not None before checking if greater than 0.
* speech: when fetching rowSpan and columnSpan, force these values to 1 if they are 0 or None, as a table cell that has no rowSpan can be assumed to have a rowSpan of 1.
 
### Testing performed:
* Tables can be spoken and navigated in Firefox in this 
[test case](https://github.com/nvaccess/nvda/files/3318671/table.html.txt)
 * Opening and reading any page in Internet Explorer now works again.

### Known issues with pull request:
I'm sure there are many more places we need to check, but these will really only be found either through prolonged use, or through static type checking.

### Change log entry:
None.