### PR TITLE
Python3: implement new way of converting COMError to CallCancelled

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -140,9 +140,12 @@ class AutoPropertyObject(object, metaclass=AutoPropertyType):
 	def _getPropertyViaCache(self,getterMethod=None):
 		if not getterMethod:
 			raise ValueError("getterMethod is None")
+		missing=False
 		try:
 			val=self._propertyCache[getterMethod]
 		except KeyError:
+			missing=True
+		if missing:
 			val=getterMethod(self)
 			self._propertyCache[getterMethod]=val
 		return val

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -3,6 +3,47 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+import ctypes
+import _ctypes
+
+# A version of ctypes.WINFUNCTYPE 
+# that produces a WinFunctionType class whos instance will convert COMError into a CallCancelled exception when called as a function.
+old_WINFUNCTYPE=ctypes.WINFUNCTYPE
+def new_WINFUNCTYPE(restype,*argtypes,**kwargs):
+	cls=old_WINFUNCTYPE(restype,*argtypes,**kwargs)
+	class WinFunctionType(cls):
+		# We must manually pull the manditory class variables from the super class,
+		# as the metaclass of _ctypes.CFuncPtr seems to expect these on the outermost subclass.
+		_argtypes_=cls._argtypes_
+		_restype_=cls._restype_
+		_flags_=cls._flags_
+		def __call__(self,*args,**kwargs):
+			try:
+				return super().__call__(*args,**kwargs)
+			except _ctypes.COMError as e:
+				from core import CallCancelled, RPC_E_CALL_CANCELED
+				if e.args[0]==RPC_E_CALL_CANCELED:
+					# As this is a cancelled COM call,
+					# raise CallCancelled instead of the original COMError.
+					# Also raising from None gives a cleaner traceback,
+					# Hiding the fact we were already in an except block.
+					raise CallCancelled("COM call cancelled") from None
+				# Otherwise, just continue the original COMError exception up the stack.
+				raise
+	return WinFunctionType
+
+# While importing comtypes,
+# Replace WINFUNCTYPE in ctypes with our own version,
+# So that comtypes will use this in all its COM method calls. 
+# As comtypes imports WINFUNCTYPE from ctypes by name,
+# We only need to replace it for the duration of importing comtypes, 
+# as it will then have it for ever.
+ctypes.WINFUNCTYPE=new_WINFUNCTYPE
+try:
+	import comtypes
+finally:
+	ctypes.WINFUNCTYPE=old_WINFUNCTYPE
+
 from logHandler import log
 
 from comtypes import COMError

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -7,12 +7,12 @@ import ctypes
 import _ctypes
 
 # A version of ctypes.WINFUNCTYPE 
-# that produces a WinFunctionType class whos instance will convert COMError into a CallCancelled exception when called as a function.
+# that produces a WinFunctionType class whose instance will convert COMError into a CallCancelled exception when called as a function.
 old_WINFUNCTYPE=ctypes.WINFUNCTYPE
 def new_WINFUNCTYPE(restype,*argtypes,**kwargs):
 	cls=old_WINFUNCTYPE(restype,*argtypes,**kwargs)
 	class WinFunctionType(cls):
-		# We must manually pull the manditory class variables from the super class,
+		# We must manually pull the mandatory class variables from the super class,
 		# as the metaclass of _ctypes.CFuncPtr seems to expect these on the outermost subclass.
 		_argtypes_=cls._argtypes_
 		_restype_=cls._restype_

--- a/source/core.py
+++ b/source/core.py
@@ -7,15 +7,22 @@
 
 """NVDA core"""
 
-# Do this first to initialise comtypes.client.gen_dir and the comtypes.gen search path.
+RPC_E_CALL_CANCELED = -2147418110
+
+class CallCancelled(Exception):
+	"""Raised when a call is cancelled.
+	"""
+
+# Apply several monky patches to comtypes
+import comtypesMonkeyPatches
+
+# Initialise comtypes.client.gen_dir and the comtypes.gen search path 
+# and Append our comInterfaces directory to the comtypes.gen search path.
+import comtypes
 import comtypes.client
-# Append our comInterfaces directory to the comtypes.gen search path.
 import comtypes.gen
 import comInterfaces
 comtypes.gen.__path__.append(comInterfaces.__path__[0])
-
-#Apply several monky patches to comtypes
-import comtypesMonkeyPatches
 
 import sys
 import winVersion

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -167,8 +167,7 @@ class Logger(logging.Logger):
 		However, certain exceptions which aren't considered errors (or aren't errors that we can fix) are expected and will therefore be logged at a lower level.
 		"""
 		import comtypes
-		import watchdog
-		from watchdog import RPC_E_CALL_CANCELED
+		from core import CallCancelled, RPC_E_CALL_CANCELED
 		if exc_info is True:
 			exc_info = sys.exc_info()
 
@@ -176,7 +175,7 @@ class Logger(logging.Logger):
 		if (
 			(isinstance(exc, WindowsError) and exc.winerror in (ERROR_INVALID_WINDOW_HANDLE, ERROR_TIMEOUT, RPC_S_SERVER_UNAVAILABLE, RPC_S_CALL_FAILED_DNE, EPT_S_NOT_REGISTERED, RPC_E_CALL_CANCELED))
 			or (isinstance(exc, comtypes.COMError) and (exc.hresult in (E_ACCESSDENIED, CO_E_OBJNOTCONNECTED, EVENT_E_ALL_SUBSCRIBERS_FAILED, RPC_E_CALL_REJECTED, RPC_E_CALL_CANCELED, RPC_E_DISCONNECTED) or exc.hresult & 0xFFFF == RPC_S_SERVER_UNAVAILABLE))
-			or isinstance(exc, watchdog.CallCancelled)
+			or isinstance(exc, CallCancelled)
 		):
 			level = self.DEBUGWARNING
 		else:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9763 

### Summary of the issue:
When running NVDA from the threshold_py3_staging branch, it fails to start as watchdog cannot replace _ctypes.COMError's constructor with its own custom version in order to raise CallCanceled.

### Description of how this pull request fixes the issue:
Rather than raising CallCancelled in COMError's constructor (which is no longer possible):
Wrap the low-level ctypes function call for all comtypes methods and properties, and catch COMError. If the COMError is due to a cancelled COM call, raise CallCancelled. otherwise keep raising the original COMError.

We do this in the following way:
For the duration of importing comtypes for the very first time, we replace ctypes.WINFUNCTTYPE with our own custom version.
As comtypes imports WINFUNCTYPE specifically by name, comtypes will keep our custom version, even after we replace the original after comtypes has been imported.
Comtypes uses our custom version of WINFUNCTYPE in order to generate its ctypes function caller objects, in comtypes._cominterface_meta._make_methods.
Our custom version of WINFUNCTYPE calls the original WINFUNCTYPE, but returns a custom subclass of the resulting function prototype CFuncPtr class.
This custom subclass overrides ```__call__``` and wraps the super call in a try block, catching COMError and raising CallCancelled if the COMError is for a cancelled COM call, otherwise continuing to raise the original COMError.

In order to do this, a couple things had to be moved around:
* CallCancelled had to be moved from watchdog to the top of core.
* comtypesMonkeyPatches (where we do the replacing of WINFUNCTYPE) had to be moved to the top of core, before -- before it was slightly lower down after the fixing of the comtyps.gen interface cache directory.

Finally, one extra change was made to baseObject.AutoPropertyObject's property cache getter code:
Previously, when fetching a property, we would try directly fetching it from the property cache, and if it raised KeyError, in the except block we would then actually fetch the property for real. 
Although this code still worked in Python3, it produced a rather strange traceback if an exception (E.g. CallCancelled) was raised from inside the property itself. In short Python3 would log the KeyError traceback, and then underneath state that while handling this exception, another exception occured, which was the actual exception in the property.
 To make this more readable, the code was slightly restructured to just set a 'missing' variable to True in the except block for KeyError, and then completely outside of the try except blocks, fetch the real property if missing is True. Therefore, if the real property raises an exception, it won't be seen as part of the KeyError exception, which was very missleading.

### Testing performed:
* Used NVDA for a while, ensuring that COMErrors were still being caught in general by all our NVDAObject properties etc. This was confirmed by looking at the log and not noticing any strange COMError tracebacks. Also the debugWarning about accRole failing (like it seems to do a lot in Windows) still showed up, which is logged when catching COMError.
* Using the following [test case](https://github.com/nvaccess/nvda/files/3318728/click.html.txt)
in Internet Explorer, ensured that NVDA was able to cancel COM calls, and that CallCancelled was being raised and correctly logged, by placing focus on the "message" button in the test case, opening the Python console, and calling:
```
nav.HTMLNode.click()
```
Which is known to freeze NVDA's main thread (as that button shows a javascript alert). Then alt+tabbin away from the Python console, which causes NVDA's watchdog to kick in and try cancelling the call.
Once NVDA recovered, looking in the Python Console output, confirmed that the correct CallCancelled traceback was printed.

 
### Known issues with pull request:
None.

### Change log entry:
None.
