### PR TITLE
Ensure NVDA contains a signed and valid python37.dll

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -17,6 +17,7 @@ import os
 import time
 from glob import glob
 import sourceEnv
+from py2exe.dllfinder import pydll
 import importlib.util
 
 def recursiveCopy(env,targetDir,sourceDir):
@@ -261,6 +262,11 @@ def NVDADistGenerator(target, source, env, for_signature):
 		buildCmd.append("--enable-uiAccess")
 
 	action.append(buildCmd)
+
+	# Python3 has started signing its main python dll.
+	# However, Pytexe currently tries to add a string resource to it, invalidating the signature and possibly currupting the certificate.
+	# Therefore, copy a fresh version  of the dll one more time once py2exe has completed.
+	action.append(Copy(target[0],pydll))
 
 	if certFile:
 		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "nvda_eoaProxy.exe":

--- a/sconstruct
+++ b/sconstruct
@@ -264,7 +264,7 @@ def NVDADistGenerator(target, source, env, for_signature):
 	action.append(buildCmd)
 
 	# Python3 has started signing its main python dll.
-	# However, Pytexe currently tries to add a string resource to it, invalidating the signature and possibly currupting the certificate.
+	# However, Py2exe currently tries to add a string resource to it, invalidating the signature and possibly currupting the certificate.
 	# Therefore, copy a fresh version  of the dll one more time once py2exe has completed.
 	action.append(Copy(target[0],pydll))
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9762 

### Summary of the issue:
On threshold_py3_staging, NVDA fails to sign a side-loadable appx Windows store package of NVDA.
 The reason for this is that makeappx detects that python37.dll (included in the package) has a corrupt certificate.
It seems that when Py2exe copies python37.dll into NVDA's dist directory, it tries to add a string resource to the file. this not only invalidates the signature, but also seems to corrupt the certificate and truncate the file.
I think that in Python2.7 python27.dll was never signed, so this was not really an issue. But in Python3, python37.dll is now signed.

### Description of how this pull request fixes the issue:
After running py2exe, sconstruct copies a fresh version of python37.dll into dist that has not been tampered with by py2exe.
 
### Testing performed:
* Building this branch on appveyor successfully signs the side-loadable appx package.


### Known issues with pull request:
this p works around the issue. Obviously it would be good to know hy py2exe needs to add that string resource to the file.

### Change log entry:
None.
