### PR TITLE
App module handler/does app mod exists: return false when called before imports are initialized 

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -153,7 +153,11 @@ def cleanup():
 			log.exception("Error terminating app module %r" % deadMod)
 
 def doesAppModuleExist(name):
-	return any(importer.find_module("appModules.%s" % name) for importer in _importers)
+	# #9797: when invoked from system tests, importers list isn't initialized (attribute error on a None object), thus assume no app module exists.
+	try:
+		return any(importer.find_module("appModules.%s" % name) for importer in _importers)
+	except AttributeError:
+		return False
 
 def fetchAppModule(processID,appName):
 	"""Returns an appModule found in the appModules directory, for the given application name.

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -154,10 +154,9 @@ def cleanup():
 
 def doesAppModuleExist(name):
 	# #9797: when invoked from system tests, importers list isn't initialized (attribute error on a None object), thus assume no app module exists.
-	try:
-		return any(importer.find_module("appModules.%s" % name) for importer in _importers)
-	except AttributeError:
+	if _importers is None:
 		return False
+	return any(importer.find_module("appModules.%s" % name) for importer in _importers)
 
 def fetchAppModule(processID,appName):
 	"""Returns an appModule found in the appModules directory, for the given application name.


### PR DESCRIPTION
### Link to issue number:
Fixes #9797 

### Summary of the issue:
Attribute error is thrown if doesAppModuleExist function is invoked from system tests in Python 3.

### Description of how this pull request fixes the issue:
When invoked from system tests under Python 3, app module handler will not be initialized, leaving importers (a private list) as None. By the time does app module exists function is called, this will return an attribute error. Thus return False if this happens.

### Testing performed:
Tested with Python 2 and 3 source copies.

### Known issues with pull request:
None

### Change log entry:
None

### Additional context:
This PR is part of an overall PR series on system tests.

Thanks.