### PR TITLE
System tests/Python 3: syntax and imports

### DIFF
--- a/tests/system/libraries/nvdaRobotLib.py
+++ b/tests/system/libraries/nvdaRobotLib.py
@@ -63,8 +63,7 @@ def _findDepPath(depFileName, searchPaths):
 # relative to the python path
 requiredPythonImportsForSystemTestSpyPackage = [
 	r"robotremoteserver",
-	r"SimpleXMLRPCServer",
-	r"xmlrpclib",
+	r"xmlrpc",
 ]
 
 def _createNvdaSpyPackage():

--- a/tests/system/libraries/systemTestSpy.py
+++ b/tests/system/libraries/systemTestSpy.py
@@ -9,7 +9,7 @@ package. This allows us to share utility methods between the global plugin and t
 """
 import globalPluginHandler
 import threading
-from systemTestUtils import _blockUntilConditionMet
+from .systemTestUtils import _blockUntilConditionMet
 from logHandler import log
 from time import clock as _timer
 

--- a/tests/system/libraries/systemTestSpy.py
+++ b/tests/system/libraries/systemTestSpy.py
@@ -64,7 +64,7 @@ class SystemTestSpy(object):
 
 	def _getJoinedBaseStringsFromCommands(self, speechCommandArray):
 		wsChars = whitespaceMinusSlashN
-		baseStrings = [c.strip(wsChars) for c in speechCommandArray if isinstance(c, basestring)]
+		baseStrings = [c.strip(wsChars) for c in speechCommandArray if isinstance(c, str)]
 		return ''.join(baseStrings).strip()
 
 	# Public methods
@@ -95,7 +95,7 @@ class SystemTestSpy(object):
 		with threading.Lock():
 			for index, commands in enumerate(self._nvdaSpeech[startFromIndex:]):
 				index = index + startFromIndex
-				baseStrings = [c.strip() for c in commands if isinstance(c, basestring)]
+				baseStrings = [c.strip() for c in commands if isinstance(c, str)]
 				if any(speech in x for x in baseStrings):
 					return index
 			return -1


### PR DESCRIPTION
### Link to issue number:
Fixes #9798 

### Summary of the issue:
Converted system tests suite to Python 3.

### Description of how this pull request fixes the issue:
Changes made:

* Relative imports.
* xmlrpclib and SimpleXMLRPCServer -> xmlrpc.
* Basestring -> str.

### Testing performed:
Tested with Python 3 source code version of NVDA and made sure it ran to successful completion (consulting the test log, for instance).

### Known issues with pull request:
Due to app module handler/does app module exist function exception, tests will fail.

### Change log entry:
None
