### PR TITLE
Python 3: fix logging level not being updated correctly

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,6 +1,6 @@
 #logHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2018 NV Access Limited, Rui Batista, Joseph Lee
+#Copyright (C) 2007-2019 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -139,7 +139,7 @@ class Logger(logging.Logger):
 			msg += ("\nStack trace:\n"
 				+ stripBasePathFromTracebackText("".join(traceback.format_list(stack_info)).rstrip()))
 
-		res = logging.Logger._log(self,level, msg, args, exc_info, extra)
+		res = super()._log(level, msg, args, exc_info, extra)
 
 		if activateLogViewer:
 			# Make the log text we just wrote appear in the log viewer.
@@ -259,9 +259,11 @@ def redirectStdout(logger):
 	sys.stdout = StreamRedirector("stdout", logger, logging.WARNING)
 	sys.stderr = StreamRedirector("stderr", logger, logging.ERROR)
 
+# Register our logging class as the class for all loggers.
+logging.setLoggerClass(Logger)
 #: The singleton logger instance.
 #: @type: L{Logger}
-log = Logger("nvda")
+log = logging.getLogger("nvda")
 
 def _getDefaultLogFilePath():
 	if getattr(sys, "frozen", None):


### PR DESCRIPTION
### Link to issue number:
Fixes #9807 

### Summary of the issue:
Changing the log level on a running copy of NVDA with Python 3 doesn't have much effect.

We have been creating our logger instance in a way the Python docs discourage. They encourage a user to initialize a logger using logging.getLogger.
This wasn't a problem on Python 2. However, in python 3, isEnabledFor uses an internal cache for the enabled levels. This cache is cleared by the log manager, howver, as we didn't create our logger using the official route, the log manager didn't know about our logger and therefore didn't clear the logger cache.

### Description of how this pull request fixes the issue:
Before creating a logger, we make our logger class the default class using logging.setLoggerClass. Then, we create an instance using logging.getLogger.

### Testing performed:
Tested that log level changes as expected and debug logging works as expected.

### Known issues with pull request:
As our Logger class is now the default logger class, all other loggers, particularly comtypes, now also use our it. I don't think that should be a problem though, since our class extends on the default class.

### Change log entry:
None
