### PR TITLE
Add-on handler/translations: ugettext -> gettext

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -532,7 +532,7 @@ def initTranslation():
 	# FIXME: shall we retrieve the caller module object explicitly?
 	try:
 		callerFrame = inspect.currentframe().f_back
-		callerFrame.f_globals['_'] = translations.ugettext
+		callerFrame.f_globals['_'] = translations.gettext
 		# Install our pgettext function.
 		callerFrame.f_globals['pgettext'] = languageHandler.makePgettext(translations)
 	finally:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Translations.ugettext is gone in Python 3.

### Description of how this pull request fixes the issue:
Change ugettext to gettext.

### Testing performed:
Tested with various add-ons with translations applied.

### Known issues with pull request:
None

### Change log entry:
None
