### PR TITLE
Update miscDeps to contain new brlApi module

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ For reference, the following dependencies are included in Git submodules:
 * [txt2tags](http://txt2tags.sourceforge.net/), version 2.5
 * [MinHook](https://github.com/RaMMicHaeL/minhook), tagged version 1.2.2
 * [SCons](http://www.scons.org/), version 3.0.4
-* brlapi Python bindings, version 0.5.7 or later, distributed with [BRLTTY for Windows](http://brl.thefreecat.org/brltty/), version 4.2-2
+* brlapi Python bindings, version 0.7.0 or later, distributed with [BRLTTY for Windows](http://brl.thefreecat.org/brltty/), version 4.2-2
 * ALVA BC6 generic dll, version 3.0.4.1
 * lilli.dll, version 2.1.0.0
 * [pySerial](http://pypi.python.org/pypi/pyserial), version 3.4


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
The brlApi module in miscDeps is for Python 2.7. Not only is it the wrong Python major version, but the worse issue is that it depends upon msvcrt90 rather than msvcrt140 (like Python 3.7). Mixing different crts in the same process is not recommended and is dangerous.
 
### Description of how this pull request fixes the issue:
Update miscDeps to latest master which contains the updated brlApi for Python 3.7. See pr nvaccess/nvda-misc-deps#14.

### Testing performed:
* Reported by @leonardder that brlApi loads and connects.
* Unit tests on appveyor no longer freeze.


### Known issues with pull request:
The brlTty braille Display driver has not at all been tested. There may be secondary issues with the changes to brlApi. However, other braille dirvers in the conversion to Python3 have not really been tested either, and most importantly this stops us loading an old crt into our process causing a freeze/crash.

### Change log entry:
None.