### PR TITLE
Ensure scratchpad dirs exist before adding them to module paths

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -338,6 +338,9 @@ def addConfigDirsToPythonPackagePath(module, subdir=None):
 	if not subdir:
 		subdir = module.__name__
 	fullPath=os.path.join(getScratchpadDir(),subdir)
+	# Ensure this directory exists otherwise pkgutil.iter_importers may emit None for missing paths.
+	if not os.path.isdir(fullPath):
+		os.makedirs(fullPath)
 	# Insert this path at the beginning  of the module's search paths.
 	# The module's search paths may not be a mutable  list, so replace it with a new one 
 	pathList=[fullPath]


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9797 
Replaces pr #9800 

### Summary of the issue:
System tests fail due to NVDA failing to start because an exception is raised in appModuleHandler.doesAppModuleExist.
The system tests enable NVDA's scratchpad dir, in order to load a globalPlugin and synthDriver. However, it does not necessarily create other scratchpad directories (such as appModules).
It seems that pkgutil.iter_imports emits a None object in place of any path in a module's ```__path__``` that does not physically exist.
Although when creating the scratchpad dir from the GUI NVDA automatically creates the needed directories, it does not handle the situation where the scratchpad option has been enabled through some other way. NVDA should always ensure that the directories exist before adding them to a module's paths.

### Description of how this pull request fixes the issue:
config.addConfigDirsToPythonPackagePath now creates any subdirs before adding them to the module's ```__path__``` if they do not exist already.

### Testing performed:
NVDA no longer fails to start if launched with the scratchpad option enabled but missing one or more subdirs in the scratchpad directory.
 
### Known issues with pull request:
None.

### Change log entry:
None.