### PR TITLE
Revert "App module handler/does app mod exists: return false when called before imports are initialized "

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -153,9 +153,6 @@ def cleanup():
 			log.exception("Error terminating app module %r" % deadMod)
 
 def doesAppModuleExist(name):
-	# #9797: when invoked from system tests, importers list isn't initialized (attribute error on a None object), thus assume no app module exists.
-	if _importers is None:
-		return False
 	return any(importer.find_module("appModules.%s" % name) for importer in _importers)
 
 def fetchAppModule(processID,appName):


### PR DESCRIPTION
Reverts nvaccess/nvda#9800
Will be replaced by pr #9814 which fixes the root cause of issue #9797