### PR TITLE
Python 3/urllib: imports, timeout

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -24,7 +24,9 @@ import inspect
 import threading
 import time
 import pickle
-import urllib
+# #9818: one must import at least urllib.request in Python 3 in order to use full urllib functionality.
+import urllib.request
+import urllib.parse
 import tempfile
 import hashlib
 import ctypes.wintypes

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -809,7 +809,7 @@ def _updateWindowsRootCertificates():
 	crypt = ctypes.windll.crypt32
 	# Get the server certificate.
 	sslCont = ssl._create_unverified_context()
-	u = urllib.urlopen("https://www.nvaccess.org/nvdaUpdateCheck", context=sslCont)
+	u = urllib.request.urlopen("https://www.nvaccess.org/nvdaUpdateCheck", context=sslCont)
 	cert = u.fp._sock.getpeercert(True)
 	u.close()
 	# Convert to a form usable by Windows.

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -123,14 +123,14 @@ def checkForUpdate(auto=False):
 		params.update(extraParams)
 	url = "%s?%s" % (CHECK_URL, urllib.parse.urlencode(params))
 	try:
-		res = urllib.urlopen(url)
+		res = urllib.request.urlopen(url)
 	except IOError as e:
 		if isinstance(e.strerror, ssl.SSLError) and e.strerror.reason == "CERTIFICATE_VERIFY_FAILED":
 			# #4803: Windows fetches trusted root certificates on demand.
 			# Python doesn't trigger this fetch (PythonIssue:20916), so try it ourselves
 			_updateWindowsRootCertificates()
 			# and then retry the update check.
-			res = urllib.urlopen(url)
+			res = urllib.request.urlopen(url)
 		else:
 			raise
 	if res.code != 200:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -121,7 +121,7 @@ def checkForUpdate(auto=False):
 			"outputBrailleTable":config.conf['braille']['translationTable'] if brailleDisplayClass else None,
 		}
 		params.update(extraParams)
-	url = "%s?%s" % (CHECK_URL, urllib.urlencode(params))
+	url = "%s?%s" % (CHECK_URL, urllib.parse.urlencode(params))
 	try:
 		res = urllib.urlopen(url)
 	except IOError as e:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -612,13 +612,12 @@ class UpdateDownloader(object):
 		self._guiExec(self._downloadSuccess)
 
 	def _download(self, url):
-		remote = urllib.urlopen(url)
-		if remote.code != 200:
-			raise RuntimeError("Download failed with code %d" % remote.code)
 		# #2352: Some security scanners such as Eset NOD32 HTTP Scanner
 		# cause huge read delays while downloading.
 		# Therefore, set a higher timeout.
-		remote.fp._sock.settimeout(120)
+		remote = urllib.request.urlopen(url, timeout=120)
+		if remote.code != 200:
+			raise RuntimeError("Download failed with code %d" % remote.code)
 		size = int(remote.headers["content-length"])
 		with open(self.destPath, "wb") as local:
 			if self.fileHash:


### PR DESCRIPTION
### Link to issue number:
Fixes #9818 

### Summary of the issue:
Update check functionality does not work due to incomplete imports.

###  Description of how this pull request fixes the issue:
Edited update check module:

1. Import urllib.parse and urllib.request with an explanatory comment.
2. urllib.urlopen -> urllib.request.urlopen
3. urlib.urlencode -> urllib.parse.urlencode
4. For timeout, urlopen function is now used to specify timeout, thus moved the code and comments for #2352 around.
5. Removed fp.soc line for specifying timeout, as urlopen now takes care of it.

### Testing performed:
Tested with a custom build of Python 3 staging branch (with update version type specified) to simulate update check and via Python 3 interepreter.

### Known issues with pull request:
More to be uncovered as update check module is converted.

### Change log entry:
None
