### PR TITLE
Python 3: Update BRLTTY driver

### DIFF
--- a/source/brailleDisplayDrivers/brltty.py
+++ b/source/brailleDisplayDrivers/brltty.py
@@ -2,19 +2,22 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2010 James Teh <jamie@jantrid.net>
+#Copyright (C) 2008-2019 NV Access Limited, Babbage B.V>
 
 import time
 import wx
 import braille
 from logHandler import log
 import inputCore
+from typing import List
 try:
 	import brlapi
-	BRLAPI_CMD_KEYS = dict((code, name[8:].lower())
-		for name, code in brlapi.__dict__.items() if name.startswith("KEY_CMD_"))
+	BRLAPI_CMD_KEYS = {
+		code: name[8:].lower()
+		for name, code in vars(brlapi).items() if name.startswith("KEY_CMD_")
+	}
 except ImportError:
-	pass
+	brlapi = None
 
 KEY_CHECK_INTERVAL = 50
 
@@ -26,12 +29,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def check(cls):
-		try:
-			brlapi
-			return True
-		except NameError:
-			pass
-		return False
+		return bool(brlapi)
 
 	def __init__(self):
 		super(BrailleDisplayDriver, self).__init__()
@@ -41,7 +39,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self._keyCheckTimer.Start(KEY_CHECK_INTERVAL)
 		# BRLTTY simulates key presses for braille typing keys, so let BRLTTY handle them.
 		# NVDA may eventually implement this itself, but there's no reason to deny BRLTTY users this functionality in the meantime.
-		self._con.ignoreKeys(brlapi.rangeType_type, (long(brlapi.KEY_TYPE_SYM),))
+		self._con.ignoreKeys(brlapi.rangeType_type, (brlapi.KEY_TYPE_SYM,))
 
 	def terminate(self):
 		super(BrailleDisplayDriver, self).terminate()
@@ -61,12 +59,15 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	def _get_numCells(self):
 		return self._con.displaySize[0]
 
-	def display(self, cells):
-		cells = "".join(chr(cell) for cell in cells)
+	def display(self, cells: List[int]):
+		cells = bytes(cells)
 		# HACK: Temporarily work around a bug which causes brltty to freeze if data is written while there are key presses waiting.
 		# Simply consume and act upon any waiting key presses.
 		self._handleKeyPresses()
 		self._con.writeDots(cells)
+
+	def _get_driverName(self):
+		return self._con.driverName.decode()
 
 	def _handleKeyPresses(self):
 		while True:
@@ -86,7 +87,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		argument = key["argument"]
 		if keyType == brlapi.KEY_TYPE_CMD:
 			try:
-				inputCore.manager.executeGesture(InputGesture(command, argument))
+				inputCore.manager.executeGesture(
+					InputGesture(self.driverName, command, argument)
+				)
 			except inputCore.NoInputGestureAction:
 				pass
 
@@ -104,8 +107,9 @@ class InputGesture(braille.BrailleDisplayGesture):
 
 	source = BrailleDisplayDriver.name
 
-	def __init__(self, command, argument):
+	def __init__(self, model, command, argument):
 		super(InputGesture, self).__init__()
+		self.model = model
 		self.id = BRLAPI_CMD_KEYS[command]
 		if command == brlapi.KEY_CMD_ROUTE:
 			self.routingIndex = argument


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The BRLTTY driver is currently not compatible with Python 3.

### Description of how this pull request fixes the issue:
This pr adds Python 3 compatibility. I also added model support to input gestures, so it should be possible to add specific gestures for specific BRLTTY drivers.

### Testing performed:
Tested with BRLTTY 6.0 with a Handy Tech display. Unfortunately, I got very mixed results. SOmetimes, the driver just initialized correctly, sometimes the brltty process just crashes. I've also seen this with older versions of BRLTTY and NVDA though. I'm under the impression that the Python wrapper has some issues, but up until now, I haven't got official replies from the BRLTTY developers on my request to provide an official build of the bindings for python 3.7

### Known issues with pull request:
The current driver is far from stable, but it wasn't stable before aanyway. This pr at leasts makes it somehow work on Python 3.

### Change log entry:
None