### PR TITLE
Restore VoiceSettingsSlider to ensure we don't break compatibility with Audio Themes add-on

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -48,6 +48,7 @@ import weakref
 import time
 import keyLabels
 from dpiScalingHelper import DpiScalingHelperMixin
+import warnings
 
 class SettingsDialog(with_metaclass(guiHelper.SIPABCMeta, wx.Dialog, DpiScalingHelperMixin)):
 	"""A settings dialog.
@@ -3337,3 +3338,11 @@ class InputGesturesDialog(SettingsDialog):
 					_("Error"), wx.OK | wx.ICON_ERROR)
 
 		super(InputGesturesDialog, self).onOk(evt)
+
+class VoiceSettingsSlider(nvdaControls.EnhancedInputSlider):
+	"""@Deprecated: use L{gui.NVDAControls.EnhancedInputSlider} instead."""
+
+	def __init__(self,*args, **kwargs):
+		warnings.warn("gui.settingsDialogs.VoiceSettingsSlider is deprecated. Use gui.NVDAControls.EnhancedInputSlider instead",
+			DeprecationWarning, stacklevel=2)
+		super(VoiceSettingsSlider,self).__init__(*args,**kwargs)


### PR DESCRIPTION
### Link to issue number:
Fixes #9824 

### Summary of the issue:
#8214 moved settingsDialogs.VoiceSettingsSlider and didn't handle backwards compatibility correctly.

### Description of how this pull request fixes the issue:
Restore VoiceSettingsSlider, log a deprecation warning when it is initialized.

### Testing performed:
* Tested that audio themes add-on works again.
* Made sure that the warning about VoiceSettingSlider uses the proper stack level.

### Known issues with pull request:
The NVDA log is full of warnings when Audio Themes is used. I think that Audio Themes should no longer be listed at the NVDA add-ons website as a stable add-on until proper maintenance has taken place. Cc @Josephsl

### Change log entry:
None