### PR TITLE
Launcher: Default to replacing an already running NVDA (#8320)

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -104,7 +104,7 @@ def doStartupDialogs():
 			gui.runScriptModalDialog(gui.AskAllowUsageStatsDialog(None),onResult)
 
 def restart(disableAddons=False, debugLogging=False):
-	"""Restarts NVDA by starting a new copy with -r."""
+	"""Restarts NVDA by starting a new copy."""
 	if globalVars.appArgs.launcher:
 		import wx
 		globalVars.exitCode=3
@@ -114,8 +114,6 @@ def restart(disableAddons=False, debugLogging=False):
 	import winUser
 	import shellapi
 	options=[]
-	if "-r" not in sys.argv:
-		options.append("-r")
 	try:
 		sys.argv.remove('--disable-addons')
 	except ValueError:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -71,10 +71,14 @@ def doInstall(createDesktopShortcut,startOnLogon,copyPortableConfig,isUpdate,sil
 			_("Success"))
 	if startAfterInstall:
 		# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL  
-		shellapi.ShellExecute(None, None,
+		shellapi.ShellExecute(
+			None,
+			None,
 			os.path.join(installer.defaultInstallPath,'nvda.exe'),
-			u"-r",
-			None, winUser.SW_SHOWNORMAL)
+			None,
+			None,
+			winUser.SW_SHOWNORMAL
+		)
 	else:
 		wx.GetApp().ExitMainLoop()
 
@@ -379,7 +383,11 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 			_("Success"))
 		if startAfterCreate:
 			# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL  
-			shellapi.ShellExecute(None, None,
+			shellapi.ShellExecute(
+				None,
+				None,
 				os.path.join(os.path.abspath(portableDirectory),'nvda.exe'),
-				u"-r",
-				None, winUser.SW_SHOWNORMAL)
+				None,
+				None,
+				winUser.SW_SHOWNORMAL
+			)

--- a/source/installer.py
+++ b/source/installer.py
@@ -247,6 +247,9 @@ def registerInstallation(installDir,startMenuFolder,shouldCreateDesktopShortcut,
 	NVDAExe=os.path.join(installDir,u"nvda.exe")
 	slaveExe=os.path.join(installDir,u"nvda_slave.exe")
 	if shouldCreateDesktopShortcut:
+		# #8320: -r|--replace is now the default. Nevertheless, keep creating
+		# the shortcut with the now superfluous argument in case a downgrade of
+		# NVDA is later performed.
 		# Translators: The shortcut key used to start NVDA.
 		# This should normally be left as is, but might be changed for some locales
 		# if the default key causes problems for the normal locale keyboard layout.

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -84,7 +84,6 @@ def stringToBool(string):
 parser=NoConsoleOptionParser()
 quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument('-q','--quit',action="store_true",dest='quit',default=False,help="Quit already running copy of NVDA")
-quitGroup.add_argument('-r','--replace',action="store_true",dest='replace',default=False,help="Quit already running copy of NVDA and start this one")
 parser.add_argument('-k','--check-running',action="store_true",dest='check_running',default=False,help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running")
 parser.add_argument('-f','--log-file',dest='logFileName',type=str,help="The file where log messages should be written to")
 parser.add_argument('-l','--log-level',dest='logLevel',type=int,default=0,choices=[10, 12, 15, 20, 30, 40, 50, 100],help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, warning 30, error 40, critical 50, off 100), default is info")
@@ -145,12 +144,15 @@ except:
 	oldAppWindowHandle=0
 if not winUser.isWindow(oldAppWindowHandle):
 	oldAppWindowHandle=0
-if oldAppWindowHandle and (globalVars.appArgs.quit or globalVars.appArgs.replace):
+if oldAppWindowHandle:
+	if globalVars.appArgs.check_running:
+		# NVDA is running.
+		sys.exit(0)
 	try:
 		terminateRunningNVDA(oldAppWindowHandle)
 	except:
 		sys.exit(1)
-if globalVars.appArgs.quit or (oldAppWindowHandle and not globalVars.appArgs.replace):
+if globalVars.appArgs.quit:
 	sys.exit(0)
 elif globalVars.appArgs.check_running:
 	# NVDA is not running.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -144,13 +144,15 @@ Press OK to dismiss this dialog.
 ++ Launching NVDA ++[LaunchingNVDA]
 If you have installed NVDA with the installer, then starting NVDA is as simple as either pressing control+alt+n, or choosing NVDA from the NVDA menu under Programs on the Start Menu.
 Additionally you can type NVDA into the Run dialog and press Enter.
-You can also pass some [command line options #CommandLineOptions] which allows you to restart NVDA (-r), quit (-q), disable add-ons (--disable-addons), etc.
+If NVDA is already running, it will be restarted.
+You can also pass some [command line options #CommandLineOptions] which allows you to quit (-q), disable add-ons (--disable-addons), etc.
 
 For installed copies, NVDA stores the configuration in the roaming application data folder of the current user by default (e.g. "C:\Users\<user>\AppData\Roaming").
 It is possible to change this in a way that NVDA loads its configuration from the local application data folder instead.
 Consult the section about [system wide parameters #SystemWideParameters] for more details.
 
 To start the portable version, go to the directory you unpacked NVDA to, and press enter or double click on nvda.exe.
+If NVDA was already running, it will automatically stop before starting the portable version.
 
 As NVDA starts, you will first hear an ascending set of tones (telling you that NVDA is loading).
 Depending on how fast your computer is, or if you are running NVDA off a USB key or other slow media, it may take a little while to start.
@@ -2898,8 +2900,7 @@ NVDA can accept one or more additional options when it starts which alter its be
 You can pass as many options as you need.
 These options can be passed when starting from a shortcut (in the shortcut properties), from the Run dialog (Start Menu -> Run or Windows+r) or from a Windows command console.
 Options should be separated from the name of NVDA's executable file and from other options by spaces.
-For example, the Desktop shortcut that NVDA creates during installation has the -r option, which tells NVDA to close the currently running copy before starting the new one.
-Another useful option is --disable-addons, which tells NVDA to suspend all running add-ons.
+For example, a useful option is --disable-addons, which tells NVDA to suspend all running add-ons.
 This allows you to determine whether a problem is caused by an add-on and to recover from serious problems caused by add-ons.
 
 As an example, you can exit the currently running copy of NVDA by entering the following in the Run dialog:
@@ -2908,8 +2909,8 @@ nvda -q
 
 Some of the command line options have a short and a long version, while some of them have only a long version.
 For those which have a short version, you can combine them like this:
-| nvda -rm | This will exit the currently running copy of NVDA and will start a new copy with startup sounds disabled, etc. |
-| nvda -rm --disable-addons | Same as above, but with add-ons disabled |
+| nvda -mc CONFIGPATH | This will start NVDA with startup sounds and message disabled, and the specified configuration |
+| nvda -mc CONFIGPATH --disable-addons | Same as above, but with add-ons disabled |
 
 Some of the command line options accept additional parameters; e.g. how detailed the logging should be or the path to the user configuration directory.
 Those parameters should be placed after the option, separated from the option by a space when using the short version or an equals sign (=) when using the long version; e.g.:
@@ -2921,7 +2922,6 @@ Following are the command line options for NVDA:
 || Short | Long | Description |
 | -h | --help | show command line help and exit |
 | -q | --quit | Quit already running copy of NVDA |
-| -r | --replace | Quit already running copy of NVDA and start this one |
 | -k | --check-running | Report whether NVDA is running via the exit code; 0 if running, 1 if not running |
 | -f LOGFILENAME | --log-file=LOGFILENAME | The file where log messages should be written to |
 | -l LOGLEVEL | --log-level=LOGLEVEL | The lowest level of message logged (debug 10, input/output 12, debug warning 15, info 20, warning 30, error 40, critical 50, disabled 100), default is warning |


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #8320

### Summary of the issue:

It can be difficult at times for a non-initiated user to pass the -r|--replace command line parameter, even though it is the most expected behavior when running the executable of a portable copy.

### Description of how this pull request fixes the issue:

 - Removed -r|--replace altogether. It is still accepted - yet ignored - as a command line parameter
 - An already running NVDA is always terminated, unless -k|--check-running
 - -q|--quit and -k|--check-running are now mutually exclusive
 - The desktop shortcut is still created with -r, in order to support downgrading an installed version

### Testing performed:

 - Behavior of -q and -k with and without a running NVDA.
 - Launching a newly created portable copy

### Known issues with pull request:

I have updated the user documentation in the command line arguments section.
I did not thoroughly read it through to check if a mention to the replace mechanism is present somewhere else.

### Change log entry:

Section: New features, Changes, Bug fixes

Changes: Running nvda.exe now defaults to replace an already running copy of NVDA. The -r|--replace command line parameter is still accepted, but ignored.