### PR TITLE
appModule for VS Code to disable browse mode by default

### DIFF
--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -1,0 +1,10 @@
+#appModules/code.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2019 NV Access Limited, Babbage B.V.
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import appModuleHandler
+
+class AppModule(appModuleHandler.AppModule):
+	disableBrowseModeByDefault = True


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Visual Studio Code's primary goal is editing source code. However, as it is an electron app, browse mode is enabled by default.

### Description of how this pull request fixes the issue:
Browse mode is now disabled by default on the appModule level.

### Testing performed:
Tested that browse mode stays off by default in VS Code.

### Known issues with pull request:
None

### Change log entry:
* Changes
    + In Microsoft Visual Studio Code, browse mode is now off by default.

Cc @bramd