### PR TITLE
Python 3: Update UIAutomationCore.dll comtypes module

### DIFF
--- a/source/comInterfaces/_944DE083_8FB8_45CF_BCB7_C477ACB2F897_0_1_0.py
+++ b/source/comInterfaces/_944DE083_8FB8_45CF_BCB7_C477ACB2F897_0_1_0.py
@@ -5,114 +5,358 @@ from ctypes import *
 import comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0
 from comtypes import GUID
 from ctypes import HRESULT
-from comtypes.automation import _midlSAFEARRAY
 from comtypes import helpstring
 from comtypes import COMMETHOD
 from comtypes import dispid
-from comtypes.automation import VARIANT
-from ctypes.wintypes import tagPOINT
-from comtypes import IUnknown
-from comtypes import BSTR
-from ctypes.wintypes import tagRECT
-from comtypes.automation import VARIANT
-WSTRING = c_wchar_p
-from ctypes.wintypes import tagRECT
 from comtypes import CoClass
+from ctypes.wintypes import tagPOINT
+from comtypes.automation import _midlSAFEARRAY
+from comtypes import BSTR
+WSTRING = c_wchar_p
+from comtypes.automation import VARIANT
+from comtypes import IUnknown
+from ctypes.wintypes import tagRECT
+from comtypes.automation import VARIANT
+from ctypes.wintypes import tagRECT
 from comtypes.automation import IDispatch
 
 
-UIA_BulletStyleAttributeId = 40002 # Constant c_int
-UIA_AccessKeyPropertyId = 30007 # Constant c_int
-StyleId_NumberedList = 70016 # Constant c_int
-UIA_FormLandmarkTypeId = 80001 # Constant c_int
-UIA_PositionInSetPropertyId = 30152 # Constant c_int
-UIA_MainLandmarkTypeId = 80002 # Constant c_int
+class IUIAutomationSelectionPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{5ED5202E-B2AC-47A6-B638-4B0BF140D78E}')
+    _idlflags_ = []
+class IUIAutomationSelectionPattern2(IUIAutomationSelectionPattern):
+    _case_insensitive_ = True
+    _iid_ = GUID('{0532BFAE-C011-4E32-A343-6D642D798555}')
+    _idlflags_ = []
+class IUIAutomationElementArray(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{14314595-B4BC-4055-95F2-58F2E42C9855}')
+    _idlflags_ = []
+IUIAutomationSelectionPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetCurrentSelection',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentCanSelectMultiple',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsSelectionRequired',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedSelection',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedCanSelectMultiple',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsSelectionRequired',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationSelectionPattern implementation
+##class IUIAutomationSelectionPattern_Impl(object):
+##    def GetCurrentSelection(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentCanSelectMultiple(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsSelectionRequired(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedSelection(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedCanSelectMultiple(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsSelectionRequired(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationElement(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{D22108AA-8AC5-49A5-837B-37BBB3D7591E}')
+    _idlflags_ = []
+IUIAutomationSelectionPattern2._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentFirstSelectedItem',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLastSelectedItem',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentCurrentSelectedItem',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentItemCount',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFirstSelectedItem',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLastSelectedItem',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedCurrentSelectedItem',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedItemCount',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationSelectionPattern2 implementation
+##class IUIAutomationSelectionPattern2_Impl(object):
+##    @property
+##    def CurrentFirstSelectedItem(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLastSelectedItem(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentCurrentSelectedItem(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentItemCount(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFirstSelectedItem(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLastSelectedItem(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedCurrentSelectedItem(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedItemCount(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class CUIAutomation(CoClass):
+    'The Central Class for UIAutomation'
+    _reg_clsid_ = GUID('{FF48DBA4-60EF-4201-AA87-54103EEF594E}')
+    _idlflags_ = []
+    _typelib_path_ = typelib_path
+    _reg_typelib_ = ('{944DE083-8FB8-45CF-BCB7-C477ACB2F897}', 1, 0)
+class IUIAutomation(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{30CBE57D-D9D0-452A-AB13-7AC5AC4825EE}')
+    _idlflags_ = []
+CUIAutomation._com_interfaces_ = [IUIAutomation]
+
+class IUIAutomationTextPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{32EBA289-3583-42C9-9C59-3B6D9A1E9B6A}')
+    _idlflags_ = []
+class IUIAutomationTextPattern2(IUIAutomationTextPattern):
+    _case_insensitive_ = True
+    _iid_ = GUID('{506A921A-FCC9-409F-B23B-37EB74106872}')
+    _idlflags_ = []
+class IUIAutomationTextRange(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{A543CC6A-F4AE-494B-8239-C814481187A8}')
+    _idlflags_ = []
+class IUIAutomationTextRangeArray(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{CE4AE76A-E717-4C98-81EA-47371D028EB6}')
+    _idlflags_ = []
 
 # values for enumeration 'SupportedTextSelection'
 SupportedTextSelection_None = 0
 SupportedTextSelection_Single = 1
 SupportedTextSelection_Multiple = 2
 SupportedTextSelection = c_int # enum
-AnnotationType_ConflictingChange = 60018 # Constant c_int
-UIA_NavigationLandmarkTypeId = 80003 # Constant c_int
-class IUIAutomationProxyFactoryMapping(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{09E31E18-872D-4873-93D1-1E541EC133FD}')
-    _idlflags_ = []
-class IUIAutomationProxyFactoryEntry(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{D50E472E-B64B-490C-BCA1-D30696F9F289}')
-    _idlflags_ = []
-IUIAutomationProxyFactoryMapping._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'count',
-              ( ['retval', 'out'], POINTER(c_uint), 'count' )),
-    COMMETHOD([], HRESULT, 'GetTable',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(POINTER(IUIAutomationProxyFactoryEntry))), 'table' )),
-    COMMETHOD([], HRESULT, 'GetEntry',
-              ( ['in'], c_uint, 'index' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationProxyFactoryEntry)), 'entry' )),
-    COMMETHOD([], HRESULT, 'SetTable',
-              ( ['in'], _midlSAFEARRAY(POINTER(IUIAutomationProxyFactoryEntry)), 'factoryList' )),
-    COMMETHOD([], HRESULT, 'InsertEntries',
-              ( ['in'], c_uint, 'before' ),
-              ( ['in'], _midlSAFEARRAY(POINTER(IUIAutomationProxyFactoryEntry)), 'factoryList' )),
-    COMMETHOD([], HRESULT, 'InsertEntry',
-              ( ['in'], c_uint, 'before' ),
-              ( ['in'], POINTER(IUIAutomationProxyFactoryEntry), 'factory' )),
-    COMMETHOD([], HRESULT, 'RemoveEntry',
-              ( ['in'], c_uint, 'index' )),
-    COMMETHOD([], HRESULT, 'ClearTable'),
-    COMMETHOD([], HRESULT, 'RestoreDefaultTable'),
+IUIAutomationTextPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'RangeFromPoint',
+              ( ['in'], tagPOINT, 'pt' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+    COMMETHOD([], HRESULT, 'RangeFromChild',
+              ( ['in'], POINTER(IUIAutomationElement), 'child' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+    COMMETHOD([], HRESULT, 'GetSelection',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRangeArray)), 'ranges' )),
+    COMMETHOD([], HRESULT, 'GetVisibleRanges',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRangeArray)), 'ranges' )),
+    COMMETHOD(['propget'], HRESULT, 'DocumentRange',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+    COMMETHOD(['propget'], HRESULT, 'SupportedTextSelection',
+              ( ['out', 'retval'], POINTER(SupportedTextSelection), 'SupportedTextSelection' )),
 ]
 ################################################################
-## code template for IUIAutomationProxyFactoryMapping implementation
-##class IUIAutomationProxyFactoryMapping_Impl(object):
+## code template for IUIAutomationTextPattern implementation
+##class IUIAutomationTextPattern_Impl(object):
+##    def RangeFromPoint(self, pt):
+##        '-no docstring-'
+##        #return range
+##
+##    def RangeFromChild(self, child):
+##        '-no docstring-'
+##        #return range
+##
+##    def GetSelection(self):
+##        '-no docstring-'
+##        #return ranges
+##
+##    def GetVisibleRanges(self):
+##        '-no docstring-'
+##        #return ranges
+##
 ##    @property
-##    def count(self):
+##    def DocumentRange(self):
 ##        '-no docstring-'
-##        #return count
+##        #return range
 ##
-##    def ClearTable(self):
+##    @property
+##    def SupportedTextSelection(self):
 ##        '-no docstring-'
-##        #return 
-##
-##    def GetEntry(self, index):
-##        '-no docstring-'
-##        #return entry
-##
-##    def InsertEntries(self, before, factoryList):
-##        '-no docstring-'
-##        #return 
-##
-##    def RestoreDefaultTable(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def SetTable(self, factoryList):
-##        '-no docstring-'
-##        #return 
-##
-##    def GetTable(self):
-##        '-no docstring-'
-##        #return table
-##
-##    def InsertEntry(self, before, factory):
-##        '-no docstring-'
-##        #return 
-##
-##    def RemoveEntry(self, index):
-##        '-no docstring-'
-##        #return 
+##        #return SupportedTextSelection
 ##
 
-UIA_FontWeightAttributeId = 40007 # Constant c_int
+IUIAutomationTextPattern2._methods_ = [
+    COMMETHOD([], HRESULT, 'RangeFromAnnotation',
+              ( ['in'], POINTER(IUIAutomationElement), 'annotation' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+    COMMETHOD([], HRESULT, 'GetCaretRange',
+              ( ['out'], POINTER(c_int), 'isActive' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+]
+################################################################
+## code template for IUIAutomationTextPattern2 implementation
+##class IUIAutomationTextPattern2_Impl(object):
+##    def RangeFromAnnotation(self, annotation):
+##        '-no docstring-'
+##        #return range
+##
+##    def GetCaretRange(self):
+##        '-no docstring-'
+##        #return isActive, range
+##
+
+class IUIAutomationRangeValuePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{59213F4F-7346-49E5-B120-80555987A148}')
+    _idlflags_ = []
+IUIAutomationRangeValuePattern._methods_ = [
+    COMMETHOD([], HRESULT, 'SetValue',
+              ( ['in'], c_double, 'val' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentValue',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsReadOnly',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentMaximum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentMinimum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLargeChange',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentSmallChange',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedValue',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsReadOnly',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedMaximum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedMinimum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLargeChange',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedSmallChange',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationRangeValuePattern implementation
+##class IUIAutomationRangeValuePattern_Impl(object):
+##    def SetValue(self, val):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentValue(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsReadOnly(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentMaximum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentMinimum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLargeChange(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentSmallChange(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedValue(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsReadOnly(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedMaximum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedMinimum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLargeChange(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedSmallChange(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+
+# values for enumeration 'ConnectionRecoveryBehaviorOptions'
+ConnectionRecoveryBehaviorOptions_Disabled = 0
+ConnectionRecoveryBehaviorOptions_Enabled = 1
+ConnectionRecoveryBehaviorOptions = c_int # enum
 class IUIAutomationCondition(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{352FFBA8-0973-437C-A61F-F64CAFD81DF9}')
     _idlflags_ = []
-class IUIAutomationPropertyCondition(IUIAutomationCondition):
+class IUIAutomationAndCondition(IUIAutomationCondition):
     _case_insensitive_ = True
-    _iid_ = GUID('{99EBF2CB-5578-4267-9AD4-AFD6EA77E94B}')
+    _iid_ = GUID('{A7D0AF36-B912-45FE-9855-091DDC174AEC}')
     _idlflags_ = []
 IUIAutomationCondition._methods_ = [
 ]
@@ -120,887 +364,140 @@ IUIAutomationCondition._methods_ = [
 ## code template for IUIAutomationCondition implementation
 ##class IUIAutomationCondition_Impl(object):
 
-
-# values for enumeration 'PropertyConditionFlags'
-PropertyConditionFlags_None = 0
-PropertyConditionFlags_IgnoreCase = 1
-PropertyConditionFlags_MatchSubstring = 2
-PropertyConditionFlags = c_int # enum
-IUIAutomationPropertyCondition._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'propertyId',
-              ( ['retval', 'out'], POINTER(c_int), 'propertyId' )),
-    COMMETHOD(['propget'], HRESULT, 'PropertyValue',
-              ( ['retval', 'out'], POINTER(VARIANT), 'PropertyValue' )),
-    COMMETHOD(['propget'], HRESULT, 'PropertyConditionFlags',
-              ( ['retval', 'out'], POINTER(PropertyConditionFlags), 'flags' )),
-]
-################################################################
-## code template for IUIAutomationPropertyCondition implementation
-##class IUIAutomationPropertyCondition_Impl(object):
-##    @property
-##    def PropertyConditionFlags(self):
-##        '-no docstring-'
-##        #return flags
-##
-##    @property
-##    def propertyId(self):
-##        '-no docstring-'
-##        #return propertyId
-##
-##    @property
-##    def PropertyValue(self):
-##        '-no docstring-'
-##        #return PropertyValue
-##
-
-class IUIAutomationElement(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{D22108AA-8AC5-49A5-837B-37BBB3D7591E}')
-    _idlflags_ = []
-class IUIAutomationElement2(IUIAutomationElement):
-    _case_insensitive_ = True
-    _iid_ = GUID('{6749C683-F70D-4487-A698-5F79D55290D6}')
-    _idlflags_ = []
-class IUIAutomationElement3(IUIAutomationElement2):
-    _case_insensitive_ = True
-    _iid_ = GUID('{8471DF34-AEE0-4A01-A7DE-7DB9AF12C296}')
-    _idlflags_ = []
-
-# values for enumeration 'TreeScope'
-TreeScope_None = 0
-TreeScope_Element = 1
-TreeScope_Children = 2
-TreeScope_Descendants = 4
-TreeScope_Parent = 8
-TreeScope_Ancestors = 16
-TreeScope_Subtree = 7
-TreeScope = c_int # enum
-class IUIAutomationElementArray(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{14314595-B4BC-4055-95F2-58F2E42C9855}')
-    _idlflags_ = []
-class IUIAutomationCacheRequest(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{B32A92B5-BC25-4078-9C08-D7EE95C48E03}')
-    _idlflags_ = []
-
-# values for enumeration 'OrientationType'
-OrientationType_None = 0
-OrientationType_Horizontal = 1
-OrientationType_Vertical = 2
-OrientationType = c_int # enum
-IUIAutomationElement._methods_ = [
-    COMMETHOD([], HRESULT, 'SetFocus'),
-    COMMETHOD([], HRESULT, 'GetRuntimeId',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'runtimeId' )),
-    COMMETHOD([], HRESULT, 'FindFirst',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindAll',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindFirstBuildCache',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindAllBuildCache',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
-    COMMETHOD([], HRESULT, 'BuildUpdatedCache',
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'updatedElement' )),
-    COMMETHOD([], HRESULT, 'GetCurrentPropertyValue',
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentPropertyValueEx',
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['in'], c_int, 'ignoreDefaultValue' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedPropertyValue',
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedPropertyValueEx',
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['in'], c_int, 'ignoreDefaultValue' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentPatternAs',
-              ( ['in'], c_int, 'patternId' ),
-              ( ['in'], POINTER(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.GUID), 'riid' ),
-              ( ['retval', 'out'], POINTER(c_void_p), 'patternObject' )),
-    COMMETHOD([], HRESULT, 'GetCachedPatternAs',
-              ( ['in'], c_int, 'patternId' ),
-              ( ['in'], POINTER(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.GUID), 'riid' ),
-              ( ['retval', 'out'], POINTER(c_void_p), 'patternObject' )),
-    COMMETHOD([], HRESULT, 'GetCurrentPattern',
-              ( ['in'], c_int, 'patternId' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUnknown)), 'patternObject' )),
-    COMMETHOD([], HRESULT, 'GetCachedPattern',
-              ( ['in'], c_int, 'patternId' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUnknown)), 'patternObject' )),
-    COMMETHOD([], HRESULT, 'GetCachedParent',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'parent' )),
-    COMMETHOD([], HRESULT, 'GetCachedChildren',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'children' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentProcessId',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentControlType',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLocalizedControlType',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAcceleratorKey',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAccessKey',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentHasKeyboardFocus',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsKeyboardFocusable',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsEnabled',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAutomationId',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentClassName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentHelpText',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentCulture',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsControlElement',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsContentElement',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsPassword',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentNativeWindowHandle',
-              ( ['retval', 'out'], POINTER(c_void_p), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentItemType',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsOffscreen',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentOrientation',
-              ( ['retval', 'out'], POINTER(OrientationType), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentFrameworkId',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsRequiredForForm',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentItemStatus',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentBoundingRectangle',
-              ( ['retval', 'out'], POINTER(tagRECT), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLabeledBy',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAriaRole',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAriaProperties',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsDataValidForForm',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentControllerFor',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDescribedBy',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentFlowsTo',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentProviderDescription',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedProcessId',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedControlType',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLocalizedControlType',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAcceleratorKey',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAccessKey',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHasKeyboardFocus',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsKeyboardFocusable',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsEnabled',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAutomationId',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedClassName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHelpText',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedCulture',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsControlElement',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsContentElement',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsPassword',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedNativeWindowHandle',
-              ( ['retval', 'out'], POINTER(c_void_p), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedItemType',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsOffscreen',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedOrientation',
-              ( ['retval', 'out'], POINTER(OrientationType), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFrameworkId',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsRequiredForForm',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedItemStatus',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedBoundingRectangle',
-              ( ['retval', 'out'], POINTER(tagRECT), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLabeledBy',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAriaRole',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAriaProperties',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsDataValidForForm',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedControllerFor',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDescribedBy',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFlowsTo',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedProviderDescription',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetClickablePoint',
-              ( ['out'], POINTER(tagPOINT), 'clickable' ),
-              ( ['retval', 'out'], POINTER(c_int), 'gotClickable' )),
-]
-################################################################
-## code template for IUIAutomationElement implementation
-##class IUIAutomationElement_Impl(object):
-##    def SetFocus(self):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentItemStatus(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedHelpText(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsRequiredForForm(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAccessKey(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsKeyboardFocusable(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAriaRole(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentProviderDescription(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def FindFirst(self, scope, condition):
-##        '-no docstring-'
-##        #return found
-##
-##    @property
-##    def CurrentIsEnabled(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def FindAllBuildCache(self, scope, condition, cacheRequest):
-##        '-no docstring-'
-##        #return found
-##
-##    @property
-##    def CachedNativeWindowHandle(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAutomationId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAriaRole(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentHelpText(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsControlElement(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAcceleratorKey(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedControllerFor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedLabeledBy(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedProcessId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def FindAll(self, scope, condition):
-##        '-no docstring-'
-##        #return found
-##
-##    def GetCachedPropertyValueEx(self, propertyId, ignoreDefaultValue):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def BuildUpdatedCache(self, cacheRequest):
-##        '-no docstring-'
-##        #return updatedElement
-##
-##    @property
-##    def CachedIsControlElement(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def FindFirstBuildCache(self, scope, condition, cacheRequest):
-##        '-no docstring-'
-##        #return found
-##
-##    @property
-##    def CachedName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentPropertyValue(self, propertyId):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedPattern(self, patternId):
-##        '-no docstring-'
-##        #return patternObject
-##
-##    @property
-##    def CachedCulture(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedProviderDescription(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetRuntimeId(self):
-##        '-no docstring-'
-##        #return runtimeId
-##
-##    @property
-##    def CurrentAcceleratorKey(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentPattern(self, patternId):
-##        '-no docstring-'
-##        #return patternObject
-##
-##    @property
-##    def CurrentIsPassword(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentOrientation(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedChildren(self):
-##        '-no docstring-'
-##        #return children
-##
-##    @property
-##    def CurrentIsDataValidForForm(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentPatternAs(self, patternId, riid):
-##        '-no docstring-'
-##        #return patternObject
-##
-##    @property
-##    def CachedLocalizedControlType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAriaProperties(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsOffscreen(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentFrameworkId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedControlType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentClassName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAccessKey(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsKeyboardFocusable(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetClickablePoint(self):
-##        '-no docstring-'
-##        #return clickable, gotClickable
-##
-##    def GetCurrentPropertyValueEx(self, propertyId, ignoreDefaultValue):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentProcessId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentHasKeyboardFocus(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedHasKeyboardFocus(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsPassword(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedBoundingRectangle(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedClassName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentCulture(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLocalizedControlType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentControlType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsContentElement(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAriaProperties(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsRequiredForForm(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentFlowsTo(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedOrientation(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedPropertyValue(self, propertyId):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedItemStatus(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFrameworkId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentNativeWindowHandle(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLabeledBy(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentItemType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedItemType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentControllerFor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFlowsTo(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedDescribedBy(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAutomationId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsEnabled(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsContentElement(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentDescribedBy(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentBoundingRectangle(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsOffscreen(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedParent(self):
-##        '-no docstring-'
-##        #return parent
-##
-##    def GetCachedPatternAs(self, patternId, riid):
-##        '-no docstring-'
-##        #return patternObject
-##
-##    @property
-##    def CachedIsDataValidForForm(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-
-# values for enumeration 'LiveSetting'
-Off = 0
-Polite = 1
-Assertive = 2
-LiveSetting = c_int # enum
-IUIAutomationElement2._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentOptimizeForVisualContent',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedOptimizeForVisualContent',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLiveSetting',
-              ( ['retval', 'out'], POINTER(LiveSetting), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLiveSetting',
-              ( ['retval', 'out'], POINTER(LiveSetting), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentFlowsFrom',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFlowsFrom',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationElement2 implementation
-##class IUIAutomationElement2_Impl(object):
-##    @property
-##    def CurrentFlowsFrom(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLiveSetting(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedLiveSetting(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedOptimizeForVisualContent(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFlowsFrom(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentOptimizeForVisualContent(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-IUIAutomationElement3._methods_ = [
-    COMMETHOD([], HRESULT, 'ShowContextMenu'),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsPeripheral',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsPeripheral',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationElement3 implementation
-##class IUIAutomationElement3_Impl(object):
-##    @property
-##    def CurrentIsPeripheral(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsPeripheral(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def ShowContextMenu(self):
-##        '-no docstring-'
-##        #return 
-##
-
-HeadingLevel_None = 80050 # Constant c_int
-UIA_ClickablePointPropertyId = 30014 # Constant c_int
-UIA_SelectionPatternId = 10001 # Constant c_int
-UIA_IndentationFirstLineAttributeId = 40010 # Constant c_int
-AnnotationType_Author = 60019 # Constant c_int
-class IUIAutomationAndCondition(IUIAutomationCondition):
-    _case_insensitive_ = True
-    _iid_ = GUID('{A7D0AF36-B912-45FE-9855-091DDC174AEC}')
-    _idlflags_ = []
 IUIAutomationAndCondition._methods_ = [
     COMMETHOD(['propget'], HRESULT, 'ChildCount',
-              ( ['retval', 'out'], POINTER(c_int), 'ChildCount' )),
+              ( ['out', 'retval'], POINTER(c_int), 'ChildCount' )),
     COMMETHOD([], HRESULT, 'GetChildrenAsNativeArray',
               ( ['out'], POINTER(POINTER(POINTER(IUIAutomationCondition))), 'childArray' ),
               ( ['out'], POINTER(c_int), 'childArrayCount' )),
     COMMETHOD([], HRESULT, 'GetChildren',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(POINTER(IUIAutomationCondition))), 'childArray' )),
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(POINTER(IUIAutomationCondition))), 'childArray' )),
 ]
 ################################################################
 ## code template for IUIAutomationAndCondition implementation
 ##class IUIAutomationAndCondition_Impl(object):
-##    def GetChildren(self):
-##        '-no docstring-'
-##        #return childArray
-##
-##    def GetChildrenAsNativeArray(self):
-##        '-no docstring-'
-##        #return childArray, childArrayCount
-##
 ##    @property
 ##    def ChildCount(self):
 ##        '-no docstring-'
 ##        #return ChildCount
 ##
-
-class IUIAutomationElement4(IUIAutomationElement3):
-    _case_insensitive_ = True
-    _iid_ = GUID('{3B6E233C-52FB-4063-A4C9-77C075C2A06B}')
-    _idlflags_ = []
-IUIAutomationElement4._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentPositionInSet',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentSizeOfSet',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLevel',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationTypes',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationObjects',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedPositionInSet',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedSizeOfSet',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLevel',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationTypes',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationObjects',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationElement4 implementation
-##class IUIAutomationElement4_Impl(object):
-##    @property
-##    def CachedPositionInSet(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLevel(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedSizeOfSet(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentSizeOfSet(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAnnotationObjects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedLevel(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAnnotationObjects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentPositionInSet(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAnnotationTypes(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAnnotationTypes(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_IndentationTrailingAttributeId = 40012 # Constant c_int
-class IUIAutomationOrCondition(IUIAutomationCondition):
-    _case_insensitive_ = True
-    _iid_ = GUID('{8753F032-3DB1-47B5-A1FC-6E34A266C712}')
-    _idlflags_ = []
-IUIAutomationOrCondition._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'ChildCount',
-              ( ['retval', 'out'], POINTER(c_int), 'ChildCount' )),
-    COMMETHOD([], HRESULT, 'GetChildrenAsNativeArray',
-              ( ['out'], POINTER(POINTER(POINTER(IUIAutomationCondition))), 'childArray' ),
-              ( ['out'], POINTER(c_int), 'childArrayCount' )),
-    COMMETHOD([], HRESULT, 'GetChildren',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(POINTER(IUIAutomationCondition))), 'childArray' )),
-]
-################################################################
-## code template for IUIAutomationOrCondition implementation
-##class IUIAutomationOrCondition_Impl(object):
-##    def GetChildren(self):
-##        '-no docstring-'
-##        #return childArray
-##
 ##    def GetChildrenAsNativeArray(self):
 ##        '-no docstring-'
 ##        #return childArray, childArrayCount
 ##
-##    @property
-##    def ChildCount(self):
+##    def GetChildren(self):
 ##        '-no docstring-'
-##        #return ChildCount
+##        #return childArray
 ##
 
-HeadingLevel4 = 80054 # Constant c_int
-UIA_IsPasswordPropertyId = 30019 # Constant c_int
+class IUIAutomationTextEditPattern(IUIAutomationTextPattern):
+    _case_insensitive_ = True
+    _iid_ = GUID('{17E21576-996C-4870-99D9-BFF323380C06}')
+    _idlflags_ = []
+IUIAutomationTextEditPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetActiveComposition',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+    COMMETHOD([], HRESULT, 'GetConversionTarget',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+]
+################################################################
+## code template for IUIAutomationTextEditPattern implementation
+##class IUIAutomationTextEditPattern_Impl(object):
+##    def GetActiveComposition(self):
+##        '-no docstring-'
+##        #return range
+##
+##    def GetConversionTarget(self):
+##        '-no docstring-'
+##        #return range
+##
+
+class IUIAutomationSelectionItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{A8EFA66A-0FDA-421A-9194-38021F3578EA}')
+    _idlflags_ = []
+IUIAutomationSelectionItemPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'Select'),
+    COMMETHOD([], HRESULT, 'AddToSelection'),
+    COMMETHOD([], HRESULT, 'RemoveFromSelection'),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsSelected',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentSelectionContainer',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsSelected',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedSelectionContainer',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationSelectionItemPattern implementation
+##class IUIAutomationSelectionItemPattern_Impl(object):
+##    def Select(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddToSelection(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveFromSelection(self):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentIsSelected(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentSelectionContainer(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsSelected(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedSelectionContainer(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+
+# values for enumeration 'CoalesceEventsOptions'
+CoalesceEventsOptions_Disabled = 0
+CoalesceEventsOptions_Enabled = 1
+CoalesceEventsOptions = c_int # enum
+class CUIAutomation8(CoClass):
+    'The Central Class for UIAutomation8'
+    _reg_clsid_ = GUID('{E22AD333-B25F-460C-83D0-0581107395C9}')
+    _idlflags_ = []
+    _typelib_path_ = typelib_path
+    _reg_typelib_ = ('{944DE083-8FB8-45CF-BCB7-C477ACB2F897}', 1, 0)
+class IUIAutomation2(IUIAutomation):
+    _case_insensitive_ = True
+    _iid_ = GUID('{34723AFF-0C9D-49D0-9896-7AB52DF8CD8A}')
+    _idlflags_ = []
+class IUIAutomation3(IUIAutomation2):
+    _case_insensitive_ = True
+    _iid_ = GUID('{73D768DA-9B51-4B89-936E-C209290973E7}')
+    _idlflags_ = []
+class IUIAutomation4(IUIAutomation3):
+    _case_insensitive_ = True
+    _iid_ = GUID('{1189C02A-05F8-4319-8E21-E817E3DB2860}')
+    _idlflags_ = []
+class IUIAutomation5(IUIAutomation4):
+    _case_insensitive_ = True
+    _iid_ = GUID('{25F700C8-D816-4057-A9DC-3CBDEE77E256}')
+    _idlflags_ = []
+class IUIAutomation6(IUIAutomation5):
+    _case_insensitive_ = True
+    _iid_ = GUID('{AAE072DA-29E3-413D-87A7-192DBF81ED10}')
+    _idlflags_ = []
+CUIAutomation8._com_interfaces_ = [IUIAutomation2, IUIAutomation3, IUIAutomation4, IUIAutomation5, IUIAutomation6]
+
 class IUIAutomationCustomNavigationPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{01EA217A-1766-47ED-A6CC-ACF492854B1F}')
@@ -1016,7 +513,7 @@ NavigateDirection = c_int # enum
 IUIAutomationCustomNavigationPattern._methods_ = [
     COMMETHOD([], HRESULT, 'Navigate',
               ( ['in'], NavigateDirection, 'direction' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'pRetVal' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'pRetVal' )),
 ]
 ################################################################
 ## code template for IUIAutomationCustomNavigationPattern implementation
@@ -1026,891 +523,12 @@ IUIAutomationCustomNavigationPattern._methods_ = [
 ##        #return pRetVal
 ##
 
-UIA_StylesStyleIdPropertyId = 30120 # Constant c_int
-class IUIAutomationNotCondition(IUIAutomationCondition):
-    _case_insensitive_ = True
-    _iid_ = GUID('{F528B657-847B-498C-8896-D52B565407A1}')
-    _idlflags_ = []
-IUIAutomationNotCondition._methods_ = [
-    COMMETHOD([], HRESULT, 'GetChild',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
-]
-################################################################
-## code template for IUIAutomationNotCondition implementation
-##class IUIAutomationNotCondition_Impl(object):
-##    def GetChild(self):
-##        '-no docstring-'
-##        #return condition
-##
 
-UIA_ThumbControlTypeId = 50027 # Constant c_int
-HeadingLevel5 = 80055 # Constant c_int
-class IUIAutomationElement5(IUIAutomationElement4):
-    _case_insensitive_ = True
-    _iid_ = GUID('{98141C1D-0D0E-4175-BBE2-6BFF455842A7}')
-    _idlflags_ = []
-IUIAutomationElement5._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentLandmarkType',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLocalizedLandmarkType',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLandmarkType',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLocalizedLandmarkType',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationElement5 implementation
-##class IUIAutomationElement5_Impl(object):
-##    @property
-##    def CachedLandmarkType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedLocalizedLandmarkType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLandmarkType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLocalizedLandmarkType(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationTreeWalker(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{4042C624-389C-4AFC-A630-9DF854A541FC}')
-    _idlflags_ = []
-IUIAutomationTreeWalker._methods_ = [
-    COMMETHOD([], HRESULT, 'GetParentElement',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'parent' )),
-    COMMETHOD([], HRESULT, 'GetFirstChildElement',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'first' )),
-    COMMETHOD([], HRESULT, 'GetLastChildElement',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'last' )),
-    COMMETHOD([], HRESULT, 'GetNextSiblingElement',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'next' )),
-    COMMETHOD([], HRESULT, 'GetPreviousSiblingElement',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'previous' )),
-    COMMETHOD([], HRESULT, 'NormalizeElement',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'normalized' )),
-    COMMETHOD([], HRESULT, 'GetParentElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'parent' )),
-    COMMETHOD([], HRESULT, 'GetFirstChildElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'first' )),
-    COMMETHOD([], HRESULT, 'GetLastChildElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'last' )),
-    COMMETHOD([], HRESULT, 'GetNextSiblingElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'next' )),
-    COMMETHOD([], HRESULT, 'GetPreviousSiblingElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'previous' )),
-    COMMETHOD([], HRESULT, 'NormalizeElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'normalized' )),
-    COMMETHOD(['propget'], HRESULT, 'condition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
-]
-################################################################
-## code template for IUIAutomationTreeWalker implementation
-##class IUIAutomationTreeWalker_Impl(object):
-##    def GetFirstChildElementBuildCache(self, element, cacheRequest):
-##        '-no docstring-'
-##        #return first
-##
-##    def GetParentElement(self, element):
-##        '-no docstring-'
-##        #return parent
-##
-##    def GetLastChildElement(self, element):
-##        '-no docstring-'
-##        #return last
-##
-##    def GetPreviousSiblingElementBuildCache(self, element, cacheRequest):
-##        '-no docstring-'
-##        #return previous
-##
-##    def GetParentElementBuildCache(self, element, cacheRequest):
-##        '-no docstring-'
-##        #return parent
-##
-##    def GetNextSiblingElementBuildCache(self, element, cacheRequest):
-##        '-no docstring-'
-##        #return next
-##
-##    def GetNextSiblingElement(self, element):
-##        '-no docstring-'
-##        #return next
-##
-##    def GetPreviousSiblingElement(self, element):
-##        '-no docstring-'
-##        #return previous
-##
-##    def GetLastChildElementBuildCache(self, element, cacheRequest):
-##        '-no docstring-'
-##        #return last
-##
-##    def GetFirstChildElement(self, element):
-##        '-no docstring-'
-##        #return first
-##
-##    def NormalizeElementBuildCache(self, element, cacheRequest):
-##        '-no docstring-'
-##        #return normalized
-##
-##    @property
-##    def condition(self):
-##        '-no docstring-'
-##        #return condition
-##
-##    def NormalizeElement(self, element):
-##        '-no docstring-'
-##        #return normalized
-##
-
-UIA_IsOffscreenPropertyId = 30022 # Constant c_int
-UIA_MarginBottomAttributeId = 40018 # Constant c_int
-UIA_IsDialogPropertyId = 30174 # Constant c_int
-class IUIAutomationElement6(IUIAutomationElement5):
-    _case_insensitive_ = True
-    _iid_ = GUID('{4780D450-8BCA-4977-AFA5-A4A517F555E3}')
-    _idlflags_ = []
-IUIAutomationElement6._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentFullDescription',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFullDescription',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationElement6 implementation
-##class IUIAutomationElement6_Impl(object):
-##    @property
-##    def CachedFullDescription(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentFullDescription(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_MarginTopAttributeId = 40020 # Constant c_int
-class IUIAutomationElement7(IUIAutomationElement6):
-    _case_insensitive_ = True
-    _iid_ = GUID('{204E8572-CFC3-4C11-B0C8-7DA7420750B7}')
-    _idlflags_ = []
-
-# values for enumeration 'TreeTraversalOptions'
-TreeTraversalOptions_Default = 0
-TreeTraversalOptions_PostOrder = 1
-TreeTraversalOptions_LastToFirstOrder = 2
-TreeTraversalOptions = c_int # enum
-IUIAutomationElement7._methods_ = [
-    COMMETHOD([], HRESULT, 'FindFirstWithOptions',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
-              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindAllWithOptions',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
-              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindFirstWithOptionsBuildCache',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
-              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindAllWithOptionsBuildCache',
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
-              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
-    COMMETHOD([], HRESULT, 'GetCurrentMetadataValue',
-              ( ['in'], c_int, 'targetId' ),
-              ( ['in'], c_int, 'metadataId' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'returnVal' )),
-]
-################################################################
-## code template for IUIAutomationElement7 implementation
-##class IUIAutomationElement7_Impl(object):
-##    def FindAllWithOptionsBuildCache(self, scope, condition, cacheRequest, traversalOptions, root):
-##        '-no docstring-'
-##        #return found
-##
-##    def GetCurrentMetadataValue(self, targetId, metadataId):
-##        '-no docstring-'
-##        #return returnVal
-##
-##    def FindFirstWithOptions(self, scope, condition, traversalOptions, root):
-##        '-no docstring-'
-##        #return found
-##
-##    def FindAllWithOptions(self, scope, condition, traversalOptions, root):
-##        '-no docstring-'
-##        #return found
-##
-##    def FindFirstWithOptionsBuildCache(self, scope, condition, cacheRequest, traversalOptions, root):
-##        '-no docstring-'
-##        #return found
-##
-
-HeadingLevel8 = 80058 # Constant c_int
-UIA_OverlineStyleAttributeId = 40024 # Constant c_int
-AnnotationType_Highlighted = 60008 # Constant c_int
-UIA_StylesFillColorPropertyId = 30122 # Constant c_int
-UIA_DataItemControlTypeId = 50029 # Constant c_int
-UIA_StrikethroughStyleAttributeId = 40026 # Constant c_int
-UIA_Drag_DragStartEventId = 20026 # Constant c_int
-UIA_SummaryChangeId = 90000 # Constant c_int
-
-# values for enumeration 'ScrollAmount'
-ScrollAmount_LargeDecrement = 0
-ScrollAmount_SmallDecrement = 1
-ScrollAmount_NoAmount = 2
-ScrollAmount_LargeIncrement = 3
-ScrollAmount_SmallIncrement = 4
-ScrollAmount = c_int # enum
-UIA_SayAsInterpretAsMetadataId = 100000 # Constant c_int
-UIA_UnderlineStyleAttributeId = 40030 # Constant c_int
-class IUIAutomationPropertyChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{40CD37D4-C756-4B0C-8C6F-BDDFEEB13B50}')
-    _idlflags_ = ['oleautomation']
-IUIAutomationPropertyChangedEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandlePropertyChangedEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['in'], VARIANT, 'newValue' )),
-]
-################################################################
-## code template for IUIAutomationPropertyChangedEventHandler implementation
-##class IUIAutomationPropertyChangedEventHandler_Impl(object):
-##    def HandlePropertyChangedEvent(self, sender, propertyId, newValue):
-##        '-no docstring-'
-##        #return 
-##
-
-class IUIAutomationStructureChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{E81D1B4E-11C5-42F8-9754-E7036C79F054}')
-    _idlflags_ = ['oleautomation']
-
-# values for enumeration 'StructureChangeType'
-StructureChangeType_ChildAdded = 0
-StructureChangeType_ChildRemoved = 1
-StructureChangeType_ChildrenInvalidated = 2
-StructureChangeType_ChildrenBulkAdded = 3
-StructureChangeType_ChildrenBulkRemoved = 4
-StructureChangeType_ChildrenReordered = 5
-StructureChangeType = c_int # enum
-IUIAutomationStructureChangedEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleStructureChangedEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( ['in'], StructureChangeType, 'changeType' ),
-              ( ['in'], _midlSAFEARRAY(c_int), 'runtimeId' )),
-]
-################################################################
-## code template for IUIAutomationStructureChangedEventHandler implementation
-##class IUIAutomationStructureChangedEventHandler_Impl(object):
-##    def HandleStructureChangedEvent(self, sender, changeType, runtimeId):
-##        '-no docstring-'
-##        #return 
-##
-
-class IUIAutomationSpreadsheetPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{7517A7C8-FAAE-4DE9-9F08-29B91E8595C1}')
-    _idlflags_ = []
-IUIAutomationSpreadsheetPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetItemByName',
-              ( ['in'], BSTR, 'name' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
-]
-################################################################
-## code template for IUIAutomationSpreadsheetPattern implementation
-##class IUIAutomationSpreadsheetPattern_Impl(object):
-##    def GetItemByName(self, name):
-##        '-no docstring-'
-##        #return element
-##
-
-class IUIAutomationNotificationEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{C7CB2637-E6C2-4D0C-85DE-4948C02175C7}')
-    _idlflags_ = ['oleautomation']
-
-# values for enumeration 'NotificationKind'
-NotificationKind_ItemAdded = 0
-NotificationKind_ItemRemoved = 1
-NotificationKind_ActionCompleted = 2
-NotificationKind_ActionAborted = 3
-NotificationKind_Other = 4
-NotificationKind = c_int # enum
-
-# values for enumeration 'NotificationProcessing'
-NotificationProcessing_ImportantAll = 0
-NotificationProcessing_ImportantMostRecent = 1
-NotificationProcessing_All = 2
-NotificationProcessing_MostRecent = 3
-NotificationProcessing_CurrentThenMostRecent = 4
-NotificationProcessing = c_int # enum
-IUIAutomationNotificationEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleNotificationEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( [], NotificationKind, 'NotificationKind' ),
-              ( [], NotificationProcessing, 'NotificationProcessing' ),
-              ( ['in'], BSTR, 'displayString' ),
-              ( ['in'], BSTR, 'activityId' )),
-]
-################################################################
-## code template for IUIAutomationNotificationEventHandler implementation
-##class IUIAutomationNotificationEventHandler_Impl(object):
-##    def HandleNotificationEvent(self, sender, NotificationKind, NotificationProcessing, displayString, activityId):
-##        '-no docstring-'
-##        #return 
-##
-
-class IUIAutomationScrollItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{B488300F-D015-4F19-9C29-BB595E3645EF}')
-    _idlflags_ = []
-IUIAutomationScrollItemPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'ScrollIntoView'),
-]
-################################################################
-## code template for IUIAutomationScrollItemPattern implementation
-##class IUIAutomationScrollItemPattern_Impl(object):
-##    def ScrollIntoView(self):
-##        '-no docstring-'
-##        #return 
-##
-
-class IUIAutomationFocusChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{C270F6B5-5C69-4290-9745-7A7F97169468}')
-    _idlflags_ = ['oleautomation']
-IUIAutomationFocusChangedEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleFocusChangedEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' )),
-]
-################################################################
-## code template for IUIAutomationFocusChangedEventHandler implementation
-##class IUIAutomationFocusChangedEventHandler_Impl(object):
-##    def HandleFocusChangedEvent(self, sender):
-##        '-no docstring-'
-##        #return 
-##
-
-class IUIAutomationTablePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{620E691C-EA96-4710-A850-754B24CE2417}')
-    _idlflags_ = []
-
-# values for enumeration 'RowOrColumnMajor'
-RowOrColumnMajor_RowMajor = 0
-RowOrColumnMajor_ColumnMajor = 1
-RowOrColumnMajor_Indeterminate = 2
-RowOrColumnMajor = c_int # enum
-IUIAutomationTablePattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetCurrentRowHeaders',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentColumnHeaders',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentRowOrColumnMajor',
-              ( ['retval', 'out'], POINTER(RowOrColumnMajor), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedRowHeaders',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedColumnHeaders',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedRowOrColumnMajor',
-              ( ['retval', 'out'], POINTER(RowOrColumnMajor), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationTablePattern implementation
-##class IUIAutomationTablePattern_Impl(object):
-##    @property
-##    def CachedRowOrColumnMajor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedColumnHeaders(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedRowHeaders(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentColumnHeaders(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentRowOrColumnMajor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentRowHeaders(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationSelectionPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{5ED5202E-B2AC-47A6-B638-4B0BF140D78E}')
-    _idlflags_ = []
-IUIAutomationSelectionPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetCurrentSelection',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentCanSelectMultiple',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsSelectionRequired',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedSelection',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedCanSelectMultiple',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsSelectionRequired',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationSelectionPattern implementation
-##class IUIAutomationSelectionPattern_Impl(object):
-##    def GetCurrentSelection(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsSelectionRequired(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsSelectionRequired(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedSelection(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedCanSelectMultiple(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentCanSelectMultiple(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationTextEditTextChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{92FAA680-E704-4156-931A-E32D5BB38F3F}')
-    _idlflags_ = ['oleautomation']
-
-# values for enumeration 'TextEditChangeType'
-TextEditChangeType_None = 0
-TextEditChangeType_AutoCorrect = 1
-TextEditChangeType_Composition = 2
-TextEditChangeType_CompositionFinalized = 3
-TextEditChangeType_AutoComplete = 4
-TextEditChangeType = c_int # enum
-IUIAutomationTextEditTextChangedEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleTextEditTextChangedEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( ['in'], TextEditChangeType, 'TextEditChangeType' ),
-              ( ['in'], _midlSAFEARRAY(BSTR), 'eventStrings' )),
-]
-################################################################
-## code template for IUIAutomationTextEditTextChangedEventHandler implementation
-##class IUIAutomationTextEditTextChangedEventHandler_Impl(object):
-##    def HandleTextEditTextChangedEvent(self, sender, TextEditChangeType, eventStrings):
-##        '-no docstring-'
-##        #return 
-##
-
-UIA_IsTableItemPatternAvailablePropertyId = 30039 # Constant c_int
-UIA_GridPatternId = 10006 # Constant c_int
-StyleId_Custom = 70000 # Constant c_int
-UIA_IsActiveAttributeId = 40036 # Constant c_int
-class IUIAutomationChangesEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{58EDCA55-2C3E-4980-B1B9-56C17F27A2A0}')
-    _idlflags_ = ['oleautomation']
-class UiaChangeInfo(Structure):
-    pass
-IUIAutomationChangesEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleChangesEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( ['in'], POINTER(UiaChangeInfo), 'uiaChanges' ),
-              ( ['in'], c_int, 'changesCount' )),
-]
-################################################################
-## code template for IUIAutomationChangesEventHandler implementation
-##class IUIAutomationChangesEventHandler_Impl(object):
-##    def HandleChangesEvent(self, sender, uiaChanges, changesCount):
-##        '-no docstring-'
-##        #return 
-##
-
-class IUIAutomationSelectionPattern2(IUIAutomationSelectionPattern):
-    _case_insensitive_ = True
-    _iid_ = GUID('{0532BFAE-C011-4E32-A343-6D642D798555}')
-    _idlflags_ = []
-IUIAutomationSelectionPattern2._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentFirstSelectedItem',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLastSelectedItem',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentCurrentSelectedItem',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentItemCount',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFirstSelectedItem',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLastSelectedItem',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedCurrentSelectedItem',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedItemCount',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationSelectionPattern2 implementation
-##class IUIAutomationSelectionPattern2_Impl(object):
-##    @property
-##    def CachedFirstSelectedItem(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedCurrentSelectedItem(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentCurrentSelectedItem(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedLastSelectedItem(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentItemCount(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedItemCount(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentFirstSelectedItem(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLastSelectedItem(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationSelectionItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{A8EFA66A-0FDA-421A-9194-38021F3578EA}')
-    _idlflags_ = []
-IUIAutomationSelectionItemPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'Select'),
-    COMMETHOD([], HRESULT, 'AddToSelection'),
-    COMMETHOD([], HRESULT, 'RemoveFromSelection'),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsSelected',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentSelectionContainer',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsSelected',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedSelectionContainer',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationSelectionItemPattern implementation
-##class IUIAutomationSelectionItemPattern_Impl(object):
-##    def RemoveFromSelection(self):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CachedSelectionContainer(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsSelected(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsSelected(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentSelectionContainer(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def AddToSelection(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def Select(self):
-##        '-no docstring-'
-##        #return 
-##
-
-UIA_AutomationPropertyChangedEventId = 20004 # Constant c_int
-UiaChangeInfo._fields_ = [
-    ('uiaId', c_int),
-    ('payload', VARIANT),
-    ('extraInfo', VARIANT),
-]
-assert sizeof(UiaChangeInfo) == 40, sizeof(UiaChangeInfo)
-assert alignment(UiaChangeInfo) == 8, alignment(UiaChangeInfo)
-UIA_ValueValuePropertyId = 30045 # Constant c_int
-UIA_WindowControlTypeId = 50032 # Constant c_int
-class IUIAutomationTextRange(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{A543CC6A-F4AE-494B-8239-C814481187A8}')
-    _idlflags_ = []
-class IUIAutomationTextRange2(IUIAutomationTextRange):
-    _case_insensitive_ = True
-    _iid_ = GUID('{BB9B40E0-5E04-46BD-9BE0-4B601B9AFAD4}')
-    _idlflags_ = []
-class IUIAutomationTextRange3(IUIAutomationTextRange2):
-    _case_insensitive_ = True
-    _iid_ = GUID('{6A315D69-5512-4C2E-85F0-53FCE6DD4BC2}')
-    _idlflags_ = []
-
-# values for enumeration 'TextPatternRangeEndpoint'
-TextPatternRangeEndpoint_Start = 0
-TextPatternRangeEndpoint_End = 1
-TextPatternRangeEndpoint = c_int # enum
-
-# values for enumeration 'TextUnit'
-TextUnit_Character = 0
-TextUnit_Format = 1
-TextUnit_Word = 2
-TextUnit_Line = 3
-TextUnit_Paragraph = 4
-TextUnit_Page = 5
-TextUnit_Document = 6
-TextUnit = c_int # enum
-IUIAutomationTextRange._methods_ = [
-    COMMETHOD([], HRESULT, 'Clone',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'clonedRange' )),
-    COMMETHOD([], HRESULT, 'Compare',
-              ( ['in'], POINTER(IUIAutomationTextRange), 'range' ),
-              ( ['retval', 'out'], POINTER(c_int), 'areSame' )),
-    COMMETHOD([], HRESULT, 'CompareEndpoints',
-              ( ['in'], TextPatternRangeEndpoint, 'srcEndPoint' ),
-              ( ['in'], POINTER(IUIAutomationTextRange), 'range' ),
-              ( ['in'], TextPatternRangeEndpoint, 'targetEndPoint' ),
-              ( ['retval', 'out'], POINTER(c_int), 'compValue' )),
-    COMMETHOD([], HRESULT, 'ExpandToEnclosingUnit',
-              ( ['in'], TextUnit, 'TextUnit' )),
-    COMMETHOD([], HRESULT, 'FindAttribute',
-              ( ['in'], c_int, 'attr' ),
-              ( ['in'], VARIANT, 'val' ),
-              ( ['in'], c_int, 'backward' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'found' )),
-    COMMETHOD([], HRESULT, 'FindText',
-              ( ['in'], BSTR, 'text' ),
-              ( ['in'], c_int, 'backward' ),
-              ( ['in'], c_int, 'ignoreCase' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'found' )),
-    COMMETHOD([], HRESULT, 'GetAttributeValue',
-              ( ['in'], c_int, 'attr' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'value' )),
-    COMMETHOD([], HRESULT, 'GetBoundingRectangles',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_double)), 'boundingRects' )),
-    COMMETHOD([], HRESULT, 'GetEnclosingElement',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'enclosingElement' )),
-    COMMETHOD([], HRESULT, 'GetText',
-              ( ['in'], c_int, 'maxLength' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'text' )),
-    COMMETHOD([], HRESULT, 'Move',
-              ( ['in'], TextUnit, 'unit' ),
-              ( ['in'], c_int, 'count' ),
-              ( ['retval', 'out'], POINTER(c_int), 'moved' )),
-    COMMETHOD([], HRESULT, 'MoveEndpointByUnit',
-              ( ['in'], TextPatternRangeEndpoint, 'endpoint' ),
-              ( ['in'], TextUnit, 'unit' ),
-              ( ['in'], c_int, 'count' ),
-              ( ['retval', 'out'], POINTER(c_int), 'moved' )),
-    COMMETHOD([], HRESULT, 'MoveEndpointByRange',
-              ( ['in'], TextPatternRangeEndpoint, 'srcEndPoint' ),
-              ( ['in'], POINTER(IUIAutomationTextRange), 'range' ),
-              ( ['in'], TextPatternRangeEndpoint, 'targetEndPoint' )),
-    COMMETHOD([], HRESULT, 'Select'),
-    COMMETHOD([], HRESULT, 'AddToSelection'),
-    COMMETHOD([], HRESULT, 'RemoveFromSelection'),
-    COMMETHOD([], HRESULT, 'ScrollIntoView',
-              ( ['in'], c_int, 'alignToTop' )),
-    COMMETHOD([], HRESULT, 'GetChildren',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'children' )),
-]
-################################################################
-## code template for IUIAutomationTextRange implementation
-##class IUIAutomationTextRange_Impl(object):
-##    def CompareEndpoints(self, srcEndPoint, range, targetEndPoint):
-##        '-no docstring-'
-##        #return compValue
-##
-##    def Compare(self, range):
-##        '-no docstring-'
-##        #return areSame
-##
-##    def MoveEndpointByUnit(self, endpoint, unit, count):
-##        '-no docstring-'
-##        #return moved
-##
-##    def ScrollIntoView(self, alignToTop):
-##        '-no docstring-'
-##        #return 
-##
-##    def AddToSelection(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def FindAttribute(self, attr, val, backward):
-##        '-no docstring-'
-##        #return found
-##
-##    def GetEnclosingElement(self):
-##        '-no docstring-'
-##        #return enclosingElement
-##
-##    def ExpandToEnclosingUnit(self, TextUnit):
-##        '-no docstring-'
-##        #return 
-##
-##    def Clone(self):
-##        '-no docstring-'
-##        #return clonedRange
-##
-##    def Move(self, unit, count):
-##        '-no docstring-'
-##        #return moved
-##
-##    def FindText(self, text, backward, ignoreCase):
-##        '-no docstring-'
-##        #return found
-##
-##    def GetText(self, maxLength):
-##        '-no docstring-'
-##        #return text
-##
-##    def RemoveFromSelection(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def GetChildren(self):
-##        '-no docstring-'
-##        #return children
-##
-##    def GetAttributeValue(self, attr):
-##        '-no docstring-'
-##        #return value
-##
-##    def MoveEndpointByRange(self, srcEndPoint, range, targetEndPoint):
-##        '-no docstring-'
-##        #return 
-##
-##    def Select(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def GetBoundingRectangles(self):
-##        '-no docstring-'
-##        #return boundingRects
-##
-
-IUIAutomationTextRange2._methods_ = [
-    COMMETHOD([], HRESULT, 'ShowContextMenu'),
-]
-################################################################
-## code template for IUIAutomationTextRange2 implementation
-##class IUIAutomationTextRange2_Impl(object):
-##    def ShowContextMenu(self):
-##        '-no docstring-'
-##        #return 
-##
-
-IUIAutomationTextRange3._methods_ = [
-    COMMETHOD([], HRESULT, 'GetEnclosingElementBuildCache',
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'enclosingElement' )),
-    COMMETHOD([], HRESULT, 'GetChildrenBuildCache',
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'children' )),
-    COMMETHOD([], HRESULT, 'GetAttributeValues',
-              ( ['in'], POINTER(c_int), 'attributeIds' ),
-              ( ['in'], c_int, 'attributeIdCount' ),
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(VARIANT)), 'attributeValues' )),
-]
-################################################################
-## code template for IUIAutomationTextRange3 implementation
-##class IUIAutomationTextRange3_Impl(object):
-##    def GetEnclosingElementBuildCache(self, cacheRequest):
-##        '-no docstring-'
-##        #return enclosingElement
-##
-##    def GetAttributeValues(self, attributeIds, attributeIdCount):
-##        '-no docstring-'
-##        #return attributeValues
-##
-##    def GetChildrenBuildCache(self, cacheRequest):
-##        '-no docstring-'
-##        #return children
-##
-
-UIA_AsyncContentLoadedEventId = 20006 # Constant c_int
+# values for enumeration 'PropertyConditionFlags'
+PropertyConditionFlags_None = 0
+PropertyConditionFlags_IgnoreCase = 1
+PropertyConditionFlags_MatchSubstring = 2
+PropertyConditionFlags = c_int # enum
 class IUIAutomationSynchronizedInputPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{2233BE0B-AFB7-448B-9FDA-3B378AA5EAE1}')
@@ -1932,42 +550,449 @@ IUIAutomationSynchronizedInputPattern._methods_ = [
 ################################################################
 ## code template for IUIAutomationSynchronizedInputPattern implementation
 ##class IUIAutomationSynchronizedInputPattern_Impl(object):
-##    def Cancel(self):
-##        '-no docstring-'
-##        #return 
-##
 ##    def StartListening(self, inputType):
 ##        '-no docstring-'
 ##        #return 
 ##
-
-UIA_AfterParagraphSpacingAttributeId = 40042 # Constant c_int
-class Library(object):
-    name = u'UIAutomationClient'
-    _reg_typelib_ = ('{944DE083-8FB8-45CF-BCB7-C477ACB2F897}', 1, 0)
-
-class IUIAutomationInvokePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{FB377FBE-8EA6-46D5-9C73-6499642D3059}')
-    _idlflags_ = []
-IUIAutomationInvokePattern._methods_ = [
-    COMMETHOD([], HRESULT, 'Invoke'),
-]
-################################################################
-## code template for IUIAutomationInvokePattern implementation
-##class IUIAutomationInvokePattern_Impl(object):
-##    def Invoke(self):
+##    def Cancel(self):
 ##        '-no docstring-'
 ##        #return 
 ##
 
+class IUIAutomationActiveTextPositionChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{F97933B0-8DAE-4496-8997-5BA015FE0D82}')
+    _idlflags_ = ['oleautomation']
+IUIAutomationActiveTextPositionChangedEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleActiveTextPositionChangedEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( ['in'], POINTER(IUIAutomationTextRange), 'range' )),
+]
+################################################################
+## code template for IUIAutomationActiveTextPositionChangedEventHandler implementation
+##class IUIAutomationActiveTextPositionChangedEventHandler_Impl(object):
+##    def HandleActiveTextPositionChangedEvent(self, sender, range):
+##        '-no docstring-'
+##        #return 
+##
+
+class IUIAutomationLegacyIAccessiblePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{828055AD-355B-4435-86D5-3B51C14A9B1B}')
+    _idlflags_ = []
+class IAccessible(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IDispatch):
+    _case_insensitive_ = True
+    _iid_ = GUID('{618736E0-3C3D-11CF-810C-00AA00389B71}')
+    _idlflags_ = ['hidden', 'dual', 'oleautomation']
+IUIAutomationLegacyIAccessiblePattern._methods_ = [
+    COMMETHOD([], HRESULT, 'Select',
+              ( [], c_int, 'flagsSelect' )),
+    COMMETHOD([], HRESULT, 'DoDefaultAction'),
+    COMMETHOD([], HRESULT, 'SetValue',
+              ( [], WSTRING, 'szValue' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentChildId',
+              ( ['out', 'retval'], POINTER(c_int), 'pRetVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentName',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszName' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentValue',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszValue' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDescription',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszDescription' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentRole',
+              ( ['out', 'retval'], POINTER(c_ulong), 'pdwRole' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentState',
+              ( ['out', 'retval'], POINTER(c_ulong), 'pdwState' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentHelp',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszHelp' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentKeyboardShortcut',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszKeyboardShortcut' )),
+    COMMETHOD([], HRESULT, 'GetCurrentSelection',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'pvarSelectedChildren' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDefaultAction',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszDefaultAction' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedChildId',
+              ( ['out', 'retval'], POINTER(c_int), 'pRetVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedName',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszName' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedValue',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszValue' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDescription',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszDescription' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedRole',
+              ( ['out', 'retval'], POINTER(c_ulong), 'pdwRole' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedState',
+              ( ['out', 'retval'], POINTER(c_ulong), 'pdwState' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHelp',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszHelp' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedKeyboardShortcut',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszKeyboardShortcut' )),
+    COMMETHOD([], HRESULT, 'GetCachedSelection',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'pvarSelectedChildren' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDefaultAction',
+              ( ['out', 'retval'], POINTER(BSTR), 'pszDefaultAction' )),
+    COMMETHOD([], HRESULT, 'GetIAccessible',
+              ( ['out', 'retval'], POINTER(POINTER(IAccessible)), 'ppAccessible' )),
+]
+################################################################
+## code template for IUIAutomationLegacyIAccessiblePattern implementation
+##class IUIAutomationLegacyIAccessiblePattern_Impl(object):
+##    def Select(self, flagsSelect):
+##        '-no docstring-'
+##        #return 
+##
+##    def DoDefaultAction(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def SetValue(self, szValue):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentChildId(self):
+##        '-no docstring-'
+##        #return pRetVal
+##
+##    @property
+##    def CurrentName(self):
+##        '-no docstring-'
+##        #return pszName
+##
+##    @property
+##    def CurrentValue(self):
+##        '-no docstring-'
+##        #return pszValue
+##
+##    @property
+##    def CurrentDescription(self):
+##        '-no docstring-'
+##        #return pszDescription
+##
+##    @property
+##    def CurrentRole(self):
+##        '-no docstring-'
+##        #return pdwRole
+##
+##    @property
+##    def CurrentState(self):
+##        '-no docstring-'
+##        #return pdwState
+##
+##    @property
+##    def CurrentHelp(self):
+##        '-no docstring-'
+##        #return pszHelp
+##
+##    @property
+##    def CurrentKeyboardShortcut(self):
+##        '-no docstring-'
+##        #return pszKeyboardShortcut
+##
+##    def GetCurrentSelection(self):
+##        '-no docstring-'
+##        #return pvarSelectedChildren
+##
+##    @property
+##    def CurrentDefaultAction(self):
+##        '-no docstring-'
+##        #return pszDefaultAction
+##
+##    @property
+##    def CachedChildId(self):
+##        '-no docstring-'
+##        #return pRetVal
+##
+##    @property
+##    def CachedName(self):
+##        '-no docstring-'
+##        #return pszName
+##
+##    @property
+##    def CachedValue(self):
+##        '-no docstring-'
+##        #return pszValue
+##
+##    @property
+##    def CachedDescription(self):
+##        '-no docstring-'
+##        #return pszDescription
+##
+##    @property
+##    def CachedRole(self):
+##        '-no docstring-'
+##        #return pdwRole
+##
+##    @property
+##    def CachedState(self):
+##        '-no docstring-'
+##        #return pdwState
+##
+##    @property
+##    def CachedHelp(self):
+##        '-no docstring-'
+##        #return pszHelp
+##
+##    @property
+##    def CachedKeyboardShortcut(self):
+##        '-no docstring-'
+##        #return pszKeyboardShortcut
+##
+##    def GetCachedSelection(self):
+##        '-no docstring-'
+##        #return pvarSelectedChildren
+##
+##    @property
+##    def CachedDefaultAction(self):
+##        '-no docstring-'
+##        #return pszDefaultAction
+##
+##    def GetIAccessible(self):
+##        '-no docstring-'
+##        #return ppAccessible
+##
+
+class IUIAutomationScrollPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{88F4D42A-E881-459D-A77C-73BBBB7E02DC}')
+    _idlflags_ = []
+
+# values for enumeration 'ScrollAmount'
+ScrollAmount_LargeDecrement = 0
+ScrollAmount_SmallDecrement = 1
+ScrollAmount_NoAmount = 2
+ScrollAmount_LargeIncrement = 3
+ScrollAmount_SmallIncrement = 4
+ScrollAmount = c_int # enum
+IUIAutomationScrollPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'Scroll',
+              ( ['in'], ScrollAmount, 'horizontalAmount' ),
+              ( ['in'], ScrollAmount, 'verticalAmount' )),
+    COMMETHOD([], HRESULT, 'SetScrollPercent',
+              ( ['in'], c_double, 'horizontalPercent' ),
+              ( ['in'], c_double, 'verticalPercent' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentHorizontalScrollPercent',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentVerticalScrollPercent',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentHorizontalViewSize',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentVerticalViewSize',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentHorizontallyScrollable',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentVerticallyScrollable',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHorizontalScrollPercent',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedVerticalScrollPercent',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHorizontalViewSize',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedVerticalViewSize',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHorizontallyScrollable',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedVerticallyScrollable',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationScrollPattern implementation
+##class IUIAutomationScrollPattern_Impl(object):
+##    def Scroll(self, horizontalAmount, verticalAmount):
+##        '-no docstring-'
+##        #return 
+##
+##    def SetScrollPercent(self, horizontalPercent, verticalPercent):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentHorizontalScrollPercent(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentVerticalScrollPercent(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentHorizontalViewSize(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentVerticalViewSize(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentHorizontallyScrollable(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentVerticallyScrollable(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedHorizontalScrollPercent(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedVerticalScrollPercent(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedHorizontalViewSize(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedVerticalViewSize(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedHorizontallyScrollable(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedVerticallyScrollable(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationTablePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{620E691C-EA96-4710-A850-754B24CE2417}')
+    _idlflags_ = []
+
+# values for enumeration 'RowOrColumnMajor'
+RowOrColumnMajor_RowMajor = 0
+RowOrColumnMajor_ColumnMajor = 1
+RowOrColumnMajor_Indeterminate = 2
+RowOrColumnMajor = c_int # enum
+IUIAutomationTablePattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetCurrentRowHeaders',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentColumnHeaders',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentRowOrColumnMajor',
+              ( ['out', 'retval'], POINTER(RowOrColumnMajor), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedRowHeaders',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedColumnHeaders',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedRowOrColumnMajor',
+              ( ['out', 'retval'], POINTER(RowOrColumnMajor), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationTablePattern implementation
+##class IUIAutomationTablePattern_Impl(object):
+##    def GetCurrentRowHeaders(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentColumnHeaders(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentRowOrColumnMajor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedRowHeaders(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedColumnHeaders(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedRowOrColumnMajor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationOrCondition(IUIAutomationCondition):
+    _case_insensitive_ = True
+    _iid_ = GUID('{8753F032-3DB1-47B5-A1FC-6E34A266C712}')
+    _idlflags_ = []
+IUIAutomationOrCondition._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'ChildCount',
+              ( ['out', 'retval'], POINTER(c_int), 'ChildCount' )),
+    COMMETHOD([], HRESULT, 'GetChildrenAsNativeArray',
+              ( ['out'], POINTER(POINTER(POINTER(IUIAutomationCondition))), 'childArray' ),
+              ( ['out'], POINTER(c_int), 'childArrayCount' )),
+    COMMETHOD([], HRESULT, 'GetChildren',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(POINTER(IUIAutomationCondition))), 'childArray' )),
+]
+################################################################
+## code template for IUIAutomationOrCondition implementation
+##class IUIAutomationOrCondition_Impl(object):
+##    @property
+##    def ChildCount(self):
+##        '-no docstring-'
+##        #return ChildCount
+##
+##    def GetChildrenAsNativeArray(self):
+##        '-no docstring-'
+##        #return childArray, childArrayCount
+##
+##    def GetChildren(self):
+##        '-no docstring-'
+##        #return childArray
+##
+
+class IUIAutomationTableItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{0B964EB3-EF2E-4464-9C79-61D61737A27E}')
+    _idlflags_ = []
+IUIAutomationTableItemPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetCurrentRowHeaderItems',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentColumnHeaderItems',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedRowHeaderItems',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedColumnHeaderItems',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationTableItemPattern implementation
+##class IUIAutomationTableItemPattern_Impl(object):
+##    def GetCurrentRowHeaderItems(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentColumnHeaderItems(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedRowHeaderItems(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedColumnHeaderItems(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+UIA_FormLandmarkTypeId = 80001 # Constant c_int
 class IUIAutomationBoolCondition(IUIAutomationCondition):
     _case_insensitive_ = True
     _iid_ = GUID('{1B4E1F2E-75EB-4D0B-8952-5A69988E2307}')
     _idlflags_ = []
 IUIAutomationBoolCondition._methods_ = [
     COMMETHOD(['propget'], HRESULT, 'BooleanValue',
-              ( ['retval', 'out'], POINTER(c_int), 'boolVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'boolVal' )),
 ]
 ################################################################
 ## code template for IUIAutomationBoolCondition implementation
@@ -1978,288 +1003,1187 @@ IUIAutomationBoolCondition._methods_ = [
 ##        #return boolVal
 ##
 
-UIA_RangeValueMinimumPropertyId = 30049 # Constant c_int
-UIA_AutomationFocusChangedEventId = 20005 # Constant c_int
-UIA_PaneControlTypeId = 50033 # Constant c_int
-class IUIAutomationTogglePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{94CF8058-9B8D-4AB9-8BFD-4CD0A33C8C70}')
-    _idlflags_ = []
-
-# values for enumeration 'ToggleState'
-ToggleState_Off = 0
-ToggleState_On = 1
-ToggleState_Indeterminate = 2
-ToggleState = c_int # enum
-IUIAutomationTogglePattern._methods_ = [
-    COMMETHOD([], HRESULT, 'Toggle'),
-    COMMETHOD(['propget'], HRESULT, 'CurrentToggleState',
-              ( ['retval', 'out'], POINTER(ToggleState), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedToggleState',
-              ( ['retval', 'out'], POINTER(ToggleState), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationTogglePattern implementation
-##class IUIAutomationTogglePattern_Impl(object):
-##    @property
-##    def CurrentToggleState(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def Toggle(self):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CachedToggleState(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationGridPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{414C3CDC-856B-4F5B-8538-3131C6302550}')
-    _idlflags_ = []
-IUIAutomationGridPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetItem',
-              ( ['in'], c_int, 'row' ),
-              ( ['in'], c_int, 'column' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentRowCount',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentColumnCount',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedRowCount',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedColumnCount',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationGridPattern implementation
-##class IUIAutomationGridPattern_Impl(object):
-##    @property
-##    def CurrentColumnCount(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentRowCount(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedColumnCount(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetItem(self, row, column):
-##        '-no docstring-'
-##        #return element
-##
-##    @property
-##    def CachedRowCount(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationProxyFactory(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{85B94ECD-849D-42B6-B94D-D6DB23FDF5A4}')
-    _idlflags_ = []
-IUIAutomationProxyFactoryEntry._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'ProxyFactory',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationProxyFactory)), 'factory' )),
-    COMMETHOD(['propget'], HRESULT, 'ClassName',
-              ( ['retval', 'out'], POINTER(BSTR), 'ClassName' )),
-    COMMETHOD(['propget'], HRESULT, 'ImageName',
-              ( ['retval', 'out'], POINTER(BSTR), 'ImageName' )),
-    COMMETHOD(['propget'], HRESULT, 'AllowSubstringMatch',
-              ( ['retval', 'out'], POINTER(c_int), 'AllowSubstringMatch' )),
-    COMMETHOD(['propget'], HRESULT, 'CanCheckBaseClass',
-              ( ['retval', 'out'], POINTER(c_int), 'CanCheckBaseClass' )),
-    COMMETHOD(['propget'], HRESULT, 'NeedsAdviseEvents',
-              ( ['retval', 'out'], POINTER(c_int), 'adviseEvents' )),
-    COMMETHOD(['propput'], HRESULT, 'ClassName',
-              ( ['in'], WSTRING, 'ClassName' )),
-    COMMETHOD(['propput'], HRESULT, 'ImageName',
-              ( ['in'], WSTRING, 'ImageName' )),
-    COMMETHOD(['propput'], HRESULT, 'AllowSubstringMatch',
-              ( ['in'], c_int, 'AllowSubstringMatch' )),
-    COMMETHOD(['propput'], HRESULT, 'CanCheckBaseClass',
-              ( ['in'], c_int, 'CanCheckBaseClass' )),
-    COMMETHOD(['propput'], HRESULT, 'NeedsAdviseEvents',
-              ( ['in'], c_int, 'adviseEvents' )),
-    COMMETHOD([], HRESULT, 'SetWinEventsForAutomationEvent',
-              ( ['in'], c_int, 'eventId' ),
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['in'], _midlSAFEARRAY(c_uint), 'winEvents' )),
-    COMMETHOD([], HRESULT, 'GetWinEventsForAutomationEvent',
-              ( ['in'], c_int, 'eventId' ),
-              ( ['in'], c_int, 'propertyId' ),
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_uint)), 'winEvents' )),
-]
-################################################################
-## code template for IUIAutomationProxyFactoryEntry implementation
-##class IUIAutomationProxyFactoryEntry_Impl(object):
-##    def _get(self):
-##        '-no docstring-'
-##        #return CanCheckBaseClass
-##    def _set(self, CanCheckBaseClass):
-##        '-no docstring-'
-##    CanCheckBaseClass = property(_get, _set, doc = _set.__doc__)
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return ClassName
-##    def _set(self, ClassName):
-##        '-no docstring-'
-##    ClassName = property(_get, _set, doc = _set.__doc__)
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return ImageName
-##    def _set(self, ImageName):
-##        '-no docstring-'
-##    ImageName = property(_get, _set, doc = _set.__doc__)
-##
-##    @property
-##    def ProxyFactory(self):
-##        '-no docstring-'
-##        #return factory
-##
-##    def SetWinEventsForAutomationEvent(self, eventId, propertyId, winEvents):
-##        '-no docstring-'
-##        #return 
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return adviseEvents
-##    def _set(self, adviseEvents):
-##        '-no docstring-'
-##    NeedsAdviseEvents = property(_get, _set, doc = _set.__doc__)
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return AllowSubstringMatch
-##    def _set(self, AllowSubstringMatch):
-##        '-no docstring-'
-##    AllowSubstringMatch = property(_get, _set, doc = _set.__doc__)
-##
-##    def GetWinEventsForAutomationEvent(self, eventId, propertyId):
-##        '-no docstring-'
-##        #return winEvents
-##
-
+UIA_NavigationLandmarkTypeId = 80003 # Constant c_int
+UIA_MainLandmarkTypeId = 80002 # Constant c_int
+UIA_SearchLandmarkTypeId = 80004 # Constant c_int
+UIA_RangeValueMaximumPropertyId = 30050 # Constant c_int
+UIA_RangeValueIsReadOnlyPropertyId = 30048 # Constant c_int
+UIA_FontSizeAttributeId = 40006 # Constant c_int
+UIA_RangeValueLargeChangePropertyId = 30051 # Constant c_int
+UIA_FontWeightAttributeId = 40007 # Constant c_int
 UIA_ScrollHorizontalScrollPercentPropertyId = 30053 # Constant c_int
-AnnotationType_Endnote = 60009 # Constant c_int
-UIA_InvokePatternId = 10000 # Constant c_int
-UIA_IsStylesPatternAvailablePropertyId = 30127 # Constant c_int
-UIA_ScrollVerticalScrollPercentPropertyId = 30055 # Constant c_int
+UIA_ForegroundColorAttributeId = 40008 # Constant c_int
+UIA_RangeValueSmallChangePropertyId = 30052 # Constant c_int
+UIA_HorizontalTextAlignmentAttributeId = 40009 # Constant c_int
+UIA_RangeValueMinimumPropertyId = 30049 # Constant c_int
+UIA_IndentationFirstLineAttributeId = 40010 # Constant c_int
+UIA_ScrollPatternId = 10004 # Constant c_int
+UIA_IndentationLeadingAttributeId = 40011 # Constant c_int
+UIA_ExpandCollapsePatternId = 10005 # Constant c_int
+UIA_IndentationTrailingAttributeId = 40012 # Constant c_int
+UIA_GridPatternId = 10006 # Constant c_int
+UIA_IsHiddenAttributeId = 40013 # Constant c_int
+UIA_GridItemPatternId = 10007 # Constant c_int
+UIA_IsItalicAttributeId = 40014 # Constant c_int
+UIA_MultipleViewPatternId = 10008 # Constant c_int
+UIA_IsReadOnlyAttributeId = 40015 # Constant c_int
+UIA_WindowPatternId = 10009 # Constant c_int
+UIA_IsSubscriptAttributeId = 40016 # Constant c_int
+UIA_SelectionItemPatternId = 10010 # Constant c_int
+UIA_IsSuperscriptAttributeId = 40017 # Constant c_int
+UIA_DockPatternId = 10011 # Constant c_int
+UIA_MarginBottomAttributeId = 40018 # Constant c_int
+UIA_TablePatternId = 10012 # Constant c_int
+UIA_MarginLeadingAttributeId = 40019 # Constant c_int
+UIA_TableItemPatternId = 10013 # Constant c_int
+UIA_MarginTopAttributeId = 40020 # Constant c_int
+UIA_TextPatternId = 10014 # Constant c_int
+UIA_MarginTrailingAttributeId = 40021 # Constant c_int
+UIA_TogglePatternId = 10015 # Constant c_int
+UIA_OutlineStylesAttributeId = 40022 # Constant c_int
+UIA_TransformPatternId = 10016 # Constant c_int
+UIA_OverlineColorAttributeId = 40023 # Constant c_int
+UIA_ScrollItemPatternId = 10017 # Constant c_int
+UIA_OverlineStyleAttributeId = 40024 # Constant c_int
+UIA_LegacyIAccessiblePatternId = 10018 # Constant c_int
+UIA_StrikethroughColorAttributeId = 40025 # Constant c_int
+UIA_ItemContainerPatternId = 10019 # Constant c_int
+UIA_StrikethroughStyleAttributeId = 40026 # Constant c_int
+UIA_VirtualizedItemPatternId = 10020 # Constant c_int
+UIA_TabsAttributeId = 40027 # Constant c_int
+UIA_SynchronizedInputPatternId = 10021 # Constant c_int
+UIA_TextFlowDirectionsAttributeId = 40028 # Constant c_int
+UIA_ObjectModelPatternId = 10022 # Constant c_int
+UIA_UnderlineColorAttributeId = 40029 # Constant c_int
+UIA_AnnotationPatternId = 10023 # Constant c_int
+UIA_UnderlineStyleAttributeId = 40030 # Constant c_int
+UIA_TextPattern2Id = 10024 # Constant c_int
+UIA_AnnotationTypesAttributeId = 40031 # Constant c_int
+UIA_StylesPatternId = 10025 # Constant c_int
+UIA_AnnotationObjectsAttributeId = 40032 # Constant c_int
+UIA_SpreadsheetPatternId = 10026 # Constant c_int
+UIA_StyleNameAttributeId = 40033 # Constant c_int
+UIA_SpreadsheetItemPatternId = 10027 # Constant c_int
+UIA_StyleIdAttributeId = 40034 # Constant c_int
+UIA_TransformPattern2Id = 10028 # Constant c_int
+UIA_LinkAttributeId = 40035 # Constant c_int
+UIA_TextChildPatternId = 10029 # Constant c_int
+UIA_IsActiveAttributeId = 40036 # Constant c_int
+UIA_DragPatternId = 10030 # Constant c_int
+UIA_SelectionActiveEndAttributeId = 40037 # Constant c_int
+UIA_DropTargetPatternId = 10031 # Constant c_int
+UIA_CaretPositionAttributeId = 40038 # Constant c_int
+UIA_TextEditPatternId = 10032 # Constant c_int
+UIA_CaretBidiModeAttributeId = 40039 # Constant c_int
+UIA_CustomNavigationPatternId = 10033 # Constant c_int
+UIA_LineSpacingAttributeId = 40040 # Constant c_int
+UIA_SelectionPattern2Id = 10034 # Constant c_int
+UIA_BeforeParagraphSpacingAttributeId = 40041 # Constant c_int
+UIA_ToolTipOpenedEventId = 20000 # Constant c_int
+UIA_AfterParagraphSpacingAttributeId = 40042 # Constant c_int
+UIA_ToolTipClosedEventId = 20001 # Constant c_int
+UIA_SayAsInterpretAsAttributeId = 40043 # Constant c_int
+UIA_StructureChangedEventId = 20002 # Constant c_int
+UIA_ButtonControlTypeId = 50000 # Constant c_int
+UIA_MenuOpenedEventId = 20003 # Constant c_int
+UIA_CalendarControlTypeId = 50001 # Constant c_int
+UIA_AutomationPropertyChangedEventId = 20004 # Constant c_int
+UIA_CheckBoxControlTypeId = 50002 # Constant c_int
+UIA_AutomationFocusChangedEventId = 20005 # Constant c_int
+UIA_ComboBoxControlTypeId = 50003 # Constant c_int
+UIA_AsyncContentLoadedEventId = 20006 # Constant c_int
+UIA_EditControlTypeId = 50004 # Constant c_int
+UIA_MenuClosedEventId = 20007 # Constant c_int
+UIA_HyperlinkControlTypeId = 50005 # Constant c_int
+UIA_LayoutInvalidatedEventId = 20008 # Constant c_int
+UIA_ImageControlTypeId = 50006 # Constant c_int
+UIA_Invoke_InvokedEventId = 20009 # Constant c_int
+UIA_ListItemControlTypeId = 50007 # Constant c_int
+UIA_SelectionItem_ElementAddedToSelectionEventId = 20010 # Constant c_int
+UIA_ListControlTypeId = 50008 # Constant c_int
+UIA_SelectionItem_ElementRemovedFromSelectionEventId = 20011 # Constant c_int
+UIA_MenuControlTypeId = 50009 # Constant c_int
+UIA_SelectionItem_ElementSelectedEventId = 20012 # Constant c_int
+UIA_MenuBarControlTypeId = 50010 # Constant c_int
+UIA_Selection_InvalidatedEventId = 20013 # Constant c_int
+UIA_MenuItemControlTypeId = 50011 # Constant c_int
+UIA_Text_TextSelectionChangedEventId = 20014 # Constant c_int
+UIA_ProgressBarControlTypeId = 50012 # Constant c_int
+UIA_Text_TextChangedEventId = 20015 # Constant c_int
+UIA_RadioButtonControlTypeId = 50013 # Constant c_int
+UIA_Window_WindowOpenedEventId = 20016 # Constant c_int
+UIA_ScrollBarControlTypeId = 50014 # Constant c_int
+UIA_Window_WindowClosedEventId = 20017 # Constant c_int
+UIA_SliderControlTypeId = 50015 # Constant c_int
+UIA_MenuModeStartEventId = 20018 # Constant c_int
+UIA_SpinnerControlTypeId = 50016 # Constant c_int
+UIA_MenuModeEndEventId = 20019 # Constant c_int
+UIA_StatusBarControlTypeId = 50017 # Constant c_int
+UIA_InputReachedTargetEventId = 20020 # Constant c_int
+UIA_TabControlTypeId = 50018 # Constant c_int
+UIA_InputReachedOtherElementEventId = 20021 # Constant c_int
+UIA_TabItemControlTypeId = 50019 # Constant c_int
+UIA_InputDiscardedEventId = 20022 # Constant c_int
+UIA_TextControlTypeId = 50020 # Constant c_int
+UIA_SystemAlertEventId = 20023 # Constant c_int
+UIA_ToolBarControlTypeId = 50021 # Constant c_int
+UIA_LiveRegionChangedEventId = 20024 # Constant c_int
+UIA_ToolTipControlTypeId = 50022 # Constant c_int
+UIA_HostedFragmentRootsInvalidatedEventId = 20025 # Constant c_int
+UIA_TreeControlTypeId = 50023 # Constant c_int
+UIA_Drag_DragStartEventId = 20026 # Constant c_int
+UIA_TreeItemControlTypeId = 50024 # Constant c_int
+UIA_Drag_DragCancelEventId = 20027 # Constant c_int
+UIA_CustomControlTypeId = 50025 # Constant c_int
+UIA_Drag_DragCompleteEventId = 20028 # Constant c_int
+UIA_GroupControlTypeId = 50026 # Constant c_int
+UIA_DropTarget_DragEnterEventId = 20029 # Constant c_int
+UIA_ThumbControlTypeId = 50027 # Constant c_int
+UIA_DropTarget_DragLeaveEventId = 20030 # Constant c_int
+UIA_DataGridControlTypeId = 50028 # Constant c_int
+UIA_DropTarget_DroppedEventId = 20031 # Constant c_int
+UIA_DataItemControlTypeId = 50029 # Constant c_int
+UIA_TextEdit_TextChangedEventId = 20032 # Constant c_int
+UIA_DocumentControlTypeId = 50030 # Constant c_int
+UIA_TextEdit_ConversionTargetChangedEventId = 20033 # Constant c_int
+UIA_SplitButtonControlTypeId = 50031 # Constant c_int
+UIA_ChangesEventId = 20034 # Constant c_int
+UIA_WindowControlTypeId = 50032 # Constant c_int
+UIA_NotificationEventId = 20035 # Constant c_int
+UIA_PaneControlTypeId = 50033 # Constant c_int
+UIA_ActiveTextPositionChangedEventId = 20036 # Constant c_int
 UIA_HeaderControlTypeId = 50034 # Constant c_int
-class IUIAutomation(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+UIA_RuntimeIdPropertyId = 30000 # Constant c_int
+UIA_HeaderItemControlTypeId = 50035 # Constant c_int
+UIA_BoundingRectanglePropertyId = 30001 # Constant c_int
+UIA_TableControlTypeId = 50036 # Constant c_int
+UIA_ProcessIdPropertyId = 30002 # Constant c_int
+UIA_TitleBarControlTypeId = 50037 # Constant c_int
+UIA_ControlTypePropertyId = 30003 # Constant c_int
+UIA_SeparatorControlTypeId = 50038 # Constant c_int
+UIA_LocalizedControlTypePropertyId = 30004 # Constant c_int
+UIA_SemanticZoomControlTypeId = 50039 # Constant c_int
+UIA_NamePropertyId = 30005 # Constant c_int
+UIA_AppBarControlTypeId = 50040 # Constant c_int
+UIA_AcceleratorKeyPropertyId = 30006 # Constant c_int
+AnnotationType_Unknown = 60000 # Constant c_int
+UIA_AccessKeyPropertyId = 30007 # Constant c_int
+AnnotationType_SpellingError = 60001 # Constant c_int
+UIA_HasKeyboardFocusPropertyId = 30008 # Constant c_int
+AnnotationType_GrammarError = 60002 # Constant c_int
+UIA_IsKeyboardFocusablePropertyId = 30009 # Constant c_int
+AnnotationType_Comment = 60003 # Constant c_int
+UIA_IsEnabledPropertyId = 30010 # Constant c_int
+AnnotationType_FormulaError = 60004 # Constant c_int
+UIA_AutomationIdPropertyId = 30011 # Constant c_int
+AnnotationType_TrackChanges = 60005 # Constant c_int
+UIA_ClassNamePropertyId = 30012 # Constant c_int
+AnnotationType_Header = 60006 # Constant c_int
+UIA_HelpTextPropertyId = 30013 # Constant c_int
+AnnotationType_Footer = 60007 # Constant c_int
+UIA_ClickablePointPropertyId = 30014 # Constant c_int
+AnnotationType_Highlighted = 60008 # Constant c_int
+UIA_CulturePropertyId = 30015 # Constant c_int
+AnnotationType_Endnote = 60009 # Constant c_int
+UIA_IsControlElementPropertyId = 30016 # Constant c_int
+AnnotationType_Footnote = 60010 # Constant c_int
+UIA_IsContentElementPropertyId = 30017 # Constant c_int
+AnnotationType_InsertionChange = 60011 # Constant c_int
+UIA_LabeledByPropertyId = 30018 # Constant c_int
+AnnotationType_DeletionChange = 60012 # Constant c_int
+UIA_IsPasswordPropertyId = 30019 # Constant c_int
+AnnotationType_MoveChange = 60013 # Constant c_int
+UIA_NativeWindowHandlePropertyId = 30020 # Constant c_int
+AnnotationType_FormatChange = 60014 # Constant c_int
+UIA_ItemTypePropertyId = 30021 # Constant c_int
+AnnotationType_UnsyncedChange = 60015 # Constant c_int
+UIA_IsOffscreenPropertyId = 30022 # Constant c_int
+AnnotationType_EditingLockedChange = 60016 # Constant c_int
+UIA_OrientationPropertyId = 30023 # Constant c_int
+AnnotationType_ExternalChange = 60017 # Constant c_int
+UIA_FrameworkIdPropertyId = 30024 # Constant c_int
+AnnotationType_ConflictingChange = 60018 # Constant c_int
+UIA_IsRequiredForFormPropertyId = 30025 # Constant c_int
+AnnotationType_Author = 60019 # Constant c_int
+UIA_ItemStatusPropertyId = 30026 # Constant c_int
+AnnotationType_AdvancedProofingIssue = 60020 # Constant c_int
+UIA_IsDockPatternAvailablePropertyId = 30027 # Constant c_int
+AnnotationType_DataValidationError = 60021 # Constant c_int
+UIA_IsExpandCollapsePatternAvailablePropertyId = 30028 # Constant c_int
+AnnotationType_CircularReferenceError = 60022 # Constant c_int
+UIA_IsGridItemPatternAvailablePropertyId = 30029 # Constant c_int
+AnnotationType_Mathematics = 60023 # Constant c_int
+UIA_IsGridPatternAvailablePropertyId = 30030 # Constant c_int
+StyleId_Custom = 70000 # Constant c_int
+UIA_IsInvokePatternAvailablePropertyId = 30031 # Constant c_int
+StyleId_Heading1 = 70001 # Constant c_int
+UIA_IsMultipleViewPatternAvailablePropertyId = 30032 # Constant c_int
+StyleId_Heading2 = 70002 # Constant c_int
+UIA_IsRangeValuePatternAvailablePropertyId = 30033 # Constant c_int
+StyleId_Heading3 = 70003 # Constant c_int
+UIA_IsScrollPatternAvailablePropertyId = 30034 # Constant c_int
+StyleId_Heading4 = 70004 # Constant c_int
+UIA_IsScrollItemPatternAvailablePropertyId = 30035 # Constant c_int
+StyleId_Heading5 = 70005 # Constant c_int
+UIA_IsSelectionItemPatternAvailablePropertyId = 30036 # Constant c_int
+StyleId_Heading6 = 70006 # Constant c_int
+UIA_IsSelectionPatternAvailablePropertyId = 30037 # Constant c_int
+StyleId_Heading7 = 70007 # Constant c_int
+UIA_IsTablePatternAvailablePropertyId = 30038 # Constant c_int
+StyleId_Heading8 = 70008 # Constant c_int
+UIA_IsTableItemPatternAvailablePropertyId = 30039 # Constant c_int
+StyleId_Heading9 = 70009 # Constant c_int
+UIA_IsTextPatternAvailablePropertyId = 30040 # Constant c_int
+StyleId_Title = 70010 # Constant c_int
+UIA_IsTogglePatternAvailablePropertyId = 30041 # Constant c_int
+StyleId_Subtitle = 70011 # Constant c_int
+UIA_IsTransformPatternAvailablePropertyId = 30042 # Constant c_int
+StyleId_Normal = 70012 # Constant c_int
+UIA_IsValuePatternAvailablePropertyId = 30043 # Constant c_int
+StyleId_Emphasis = 70013 # Constant c_int
+UIA_IsWindowPatternAvailablePropertyId = 30044 # Constant c_int
+StyleId_Quote = 70014 # Constant c_int
+UIA_ValueValuePropertyId = 30045 # Constant c_int
+StyleId_BulletedList = 70015 # Constant c_int
+UIA_ValueIsReadOnlyPropertyId = 30046 # Constant c_int
+StyleId_NumberedList = 70016 # Constant c_int
+UIA_RangeValueValuePropertyId = 30047 # Constant c_int
+UIA_CustomLandmarkTypeId = 80000 # Constant c_int
+HeadingLevel1 = 80051 # Constant c_int
+class Library(object):
+    name = 'UIAutomationClient'
+    _reg_typelib_ = ('{944DE083-8FB8-45CF-BCB7-C477ACB2F897}', 1, 0)
+
+class IUIAutomationElement2(IUIAutomationElement):
     _case_insensitive_ = True
-    _iid_ = GUID('{30CBE57D-D9D0-452A-AB13-7AC5AC4825EE}')
+    _iid_ = GUID('{6749C683-F70D-4487-A698-5F79D55290D6}')
     _idlflags_ = []
-class IUIAutomation2(IUIAutomation):
+class IUIAutomationElement3(IUIAutomationElement2):
     _case_insensitive_ = True
-    _iid_ = GUID('{34723AFF-0C9D-49D0-9896-7AB52DF8CD8A}')
+    _iid_ = GUID('{8471DF34-AEE0-4A01-A7DE-7DB9AF12C296}')
+    _idlflags_ = []
+class IUIAutomationElement4(IUIAutomationElement3):
+    _case_insensitive_ = True
+    _iid_ = GUID('{3B6E233C-52FB-4063-A4C9-77C075C2A06B}')
+    _idlflags_ = []
+class IUIAutomationElement5(IUIAutomationElement4):
+    _case_insensitive_ = True
+    _iid_ = GUID('{98141C1D-0D0E-4175-BBE2-6BFF455842A7}')
+    _idlflags_ = []
+
+# values for enumeration 'TreeScope'
+TreeScope_None = 0
+TreeScope_Element = 1
+TreeScope_Children = 2
+TreeScope_Descendants = 4
+TreeScope_Parent = 8
+TreeScope_Ancestors = 16
+TreeScope_Subtree = 7
+TreeScope = c_int # enum
+class IUIAutomationCacheRequest(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{B32A92B5-BC25-4078-9C08-D7EE95C48E03}')
+    _idlflags_ = []
+
+# values for enumeration 'OrientationType'
+OrientationType_None = 0
+OrientationType_Horizontal = 1
+OrientationType_Vertical = 2
+OrientationType = c_int # enum
+IUIAutomationElement._methods_ = [
+    COMMETHOD([], HRESULT, 'SetFocus'),
+    COMMETHOD([], HRESULT, 'GetRuntimeId',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'runtimeId' )),
+    COMMETHOD([], HRESULT, 'FindFirst',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindAll',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindFirstBuildCache',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindAllBuildCache',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
+    COMMETHOD([], HRESULT, 'BuildUpdatedCache',
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'updatedElement' )),
+    COMMETHOD([], HRESULT, 'GetCurrentPropertyValue',
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentPropertyValueEx',
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['in'], c_int, 'ignoreDefaultValue' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedPropertyValue',
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedPropertyValueEx',
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['in'], c_int, 'ignoreDefaultValue' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentPatternAs',
+              ( ['in'], c_int, 'patternId' ),
+              ( ['in'], POINTER(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.GUID), 'riid' ),
+              ( ['out', 'retval'], POINTER(c_void_p), 'patternObject' )),
+    COMMETHOD([], HRESULT, 'GetCachedPatternAs',
+              ( ['in'], c_int, 'patternId' ),
+              ( ['in'], POINTER(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.GUID), 'riid' ),
+              ( ['out', 'retval'], POINTER(c_void_p), 'patternObject' )),
+    COMMETHOD([], HRESULT, 'GetCurrentPattern',
+              ( ['in'], c_int, 'patternId' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUnknown)), 'patternObject' )),
+    COMMETHOD([], HRESULT, 'GetCachedPattern',
+              ( ['in'], c_int, 'patternId' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUnknown)), 'patternObject' )),
+    COMMETHOD([], HRESULT, 'GetCachedParent',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'parent' )),
+    COMMETHOD([], HRESULT, 'GetCachedChildren',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'children' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentProcessId',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentControlType',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLocalizedControlType',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAcceleratorKey',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAccessKey',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentHasKeyboardFocus',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsKeyboardFocusable',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsEnabled',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAutomationId',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentClassName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentHelpText',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentCulture',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsControlElement',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsContentElement',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsPassword',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentNativeWindowHandle',
+              ( ['out', 'retval'], POINTER(c_void_p), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentItemType',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsOffscreen',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentOrientation',
+              ( ['out', 'retval'], POINTER(OrientationType), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentFrameworkId',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsRequiredForForm',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentItemStatus',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentBoundingRectangle',
+              ( ['out', 'retval'], POINTER(tagRECT), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLabeledBy',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAriaRole',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAriaProperties',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsDataValidForForm',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentControllerFor',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDescribedBy',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentFlowsTo',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentProviderDescription',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedProcessId',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedControlType',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLocalizedControlType',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAcceleratorKey',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAccessKey',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHasKeyboardFocus',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsKeyboardFocusable',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsEnabled',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAutomationId',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedClassName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHelpText',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedCulture',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsControlElement',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsContentElement',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsPassword',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedNativeWindowHandle',
+              ( ['out', 'retval'], POINTER(c_void_p), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedItemType',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsOffscreen',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedOrientation',
+              ( ['out', 'retval'], POINTER(OrientationType), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFrameworkId',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsRequiredForForm',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedItemStatus',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedBoundingRectangle',
+              ( ['out', 'retval'], POINTER(tagRECT), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLabeledBy',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAriaRole',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAriaProperties',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsDataValidForForm',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedControllerFor',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDescribedBy',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFlowsTo',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedProviderDescription',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetClickablePoint',
+              ( ['out'], POINTER(tagPOINT), 'clickable' ),
+              ( ['out', 'retval'], POINTER(c_int), 'gotClickable' )),
+]
+################################################################
+## code template for IUIAutomationElement implementation
+##class IUIAutomationElement_Impl(object):
+##    def SetFocus(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def GetRuntimeId(self):
+##        '-no docstring-'
+##        #return runtimeId
+##
+##    def FindFirst(self, scope, condition):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindAll(self, scope, condition):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindFirstBuildCache(self, scope, condition, cacheRequest):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindAllBuildCache(self, scope, condition, cacheRequest):
+##        '-no docstring-'
+##        #return found
+##
+##    def BuildUpdatedCache(self, cacheRequest):
+##        '-no docstring-'
+##        #return updatedElement
+##
+##    def GetCurrentPropertyValue(self, propertyId):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentPropertyValueEx(self, propertyId, ignoreDefaultValue):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedPropertyValue(self, propertyId):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedPropertyValueEx(self, propertyId, ignoreDefaultValue):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentPatternAs(self, patternId, riid):
+##        '-no docstring-'
+##        #return patternObject
+##
+##    def GetCachedPatternAs(self, patternId, riid):
+##        '-no docstring-'
+##        #return patternObject
+##
+##    def GetCurrentPattern(self, patternId):
+##        '-no docstring-'
+##        #return patternObject
+##
+##    def GetCachedPattern(self, patternId):
+##        '-no docstring-'
+##        #return patternObject
+##
+##    def GetCachedParent(self):
+##        '-no docstring-'
+##        #return parent
+##
+##    def GetCachedChildren(self):
+##        '-no docstring-'
+##        #return children
+##
+##    @property
+##    def CurrentProcessId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentControlType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLocalizedControlType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAcceleratorKey(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAccessKey(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentHasKeyboardFocus(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsKeyboardFocusable(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsEnabled(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAutomationId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentClassName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentHelpText(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentCulture(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsControlElement(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsContentElement(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsPassword(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentNativeWindowHandle(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentItemType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsOffscreen(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentOrientation(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentFrameworkId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsRequiredForForm(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentItemStatus(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentBoundingRectangle(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLabeledBy(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAriaRole(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAriaProperties(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentIsDataValidForForm(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentControllerFor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentDescribedBy(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentFlowsTo(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentProviderDescription(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedProcessId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedControlType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLocalizedControlType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAcceleratorKey(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAccessKey(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedHasKeyboardFocus(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsKeyboardFocusable(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsEnabled(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAutomationId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedClassName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedHelpText(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedCulture(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsControlElement(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsContentElement(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsPassword(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedNativeWindowHandle(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedItemType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsOffscreen(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedOrientation(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFrameworkId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsRequiredForForm(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedItemStatus(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedBoundingRectangle(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLabeledBy(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAriaRole(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAriaProperties(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsDataValidForForm(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedControllerFor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedDescribedBy(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFlowsTo(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedProviderDescription(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetClickablePoint(self):
+##        '-no docstring-'
+##        #return clickable, gotClickable
+##
+
+
+# values for enumeration 'LiveSetting'
+Off = 0
+Polite = 1
+Assertive = 2
+LiveSetting = c_int # enum
+IUIAutomationElement2._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentOptimizeForVisualContent',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedOptimizeForVisualContent',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLiveSetting',
+              ( ['out', 'retval'], POINTER(LiveSetting), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLiveSetting',
+              ( ['out', 'retval'], POINTER(LiveSetting), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentFlowsFrom',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFlowsFrom',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement2 implementation
+##class IUIAutomationElement2_Impl(object):
+##    @property
+##    def CurrentOptimizeForVisualContent(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedOptimizeForVisualContent(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLiveSetting(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLiveSetting(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentFlowsFrom(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFlowsFrom(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+IUIAutomationElement3._methods_ = [
+    COMMETHOD([], HRESULT, 'ShowContextMenu'),
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsPeripheral',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsPeripheral',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement3 implementation
+##class IUIAutomationElement3_Impl(object):
+##    def ShowContextMenu(self):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentIsPeripheral(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsPeripheral(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+IUIAutomationElement4._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentPositionInSet',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentSizeOfSet',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLevel',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationTypes',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationObjects',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedPositionInSet',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedSizeOfSet',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLevel',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationTypes',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationObjects',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement4 implementation
+##class IUIAutomationElement4_Impl(object):
+##    @property
+##    def CurrentPositionInSet(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentSizeOfSet(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLevel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAnnotationTypes(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAnnotationObjects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedPositionInSet(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedSizeOfSet(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLevel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAnnotationTypes(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAnnotationObjects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+IUIAutomationElement5._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentLandmarkType',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentLocalizedLandmarkType',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLandmarkType',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedLocalizedLandmarkType',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement5 implementation
+##class IUIAutomationElement5_Impl(object):
+##    @property
+##    def CurrentLandmarkType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentLocalizedLandmarkType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLandmarkType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedLocalizedLandmarkType(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationTreeWalker(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{4042C624-389C-4AFC-A630-9DF854A541FC}')
     _idlflags_ = []
 class IUIAutomationEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{146C3C17-F12E-4E22-8C27-F894B9B79C69}')
     _idlflags_ = ['oleautomation']
-class IAccessible(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IDispatch):
+class IUIAutomationPropertyChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
-    _iid_ = GUID('{618736E0-3C3D-11CF-810C-00AA00389B71}')
-    _idlflags_ = ['dual', 'oleautomation', 'hidden']
+    _iid_ = GUID('{40CD37D4-C756-4B0C-8C6F-BDDFEEB13B50}')
+    _idlflags_ = ['oleautomation']
+class IUIAutomationStructureChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{E81D1B4E-11C5-42F8-9754-E7036C79F054}')
+    _idlflags_ = ['oleautomation']
+class IUIAutomationFocusChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{C270F6B5-5C69-4290-9745-7A7F97169468}')
+    _idlflags_ = ['oleautomation']
+class IUIAutomationProxyFactory(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{85B94ECD-849D-42B6-B94D-D6DB23FDF5A4}')
+    _idlflags_ = []
+class IUIAutomationProxyFactoryEntry(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{D50E472E-B64B-490C-BCA1-D30696F9F289}')
+    _idlflags_ = []
+class IUIAutomationProxyFactoryMapping(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{09E31E18-872D-4873-93D1-1E541EC133FD}')
+    _idlflags_ = []
 IUIAutomation._methods_ = [
     COMMETHOD([], HRESULT, 'CompareElements',
               ( ['in'], POINTER(IUIAutomationElement), 'el1' ),
               ( ['in'], POINTER(IUIAutomationElement), 'el2' ),
-              ( ['retval', 'out'], POINTER(c_int), 'areSame' )),
+              ( ['out', 'retval'], POINTER(c_int), 'areSame' )),
     COMMETHOD([], HRESULT, 'CompareRuntimeIds',
               ( ['in'], _midlSAFEARRAY(c_int), 'runtimeId1' ),
               ( ['in'], _midlSAFEARRAY(c_int), 'runtimeId2' ),
-              ( ['retval', 'out'], POINTER(c_int), 'areSame' )),
+              ( ['out', 'retval'], POINTER(c_int), 'areSame' )),
     COMMETHOD([], HRESULT, 'GetRootElement',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'root' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'root' )),
     COMMETHOD([], HRESULT, 'ElementFromHandle',
               ( ['in'], c_void_p, 'hwnd' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'ElementFromPoint',
               ( ['in'], tagPOINT, 'pt' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'GetFocusedElement',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'GetRootElementBuildCache',
               ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'root' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'root' )),
     COMMETHOD([], HRESULT, 'ElementFromHandleBuildCache',
               ( ['in'], c_void_p, 'hwnd' ),
               ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'ElementFromPointBuildCache',
               ( ['in'], tagPOINT, 'pt' ),
               ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'GetFocusedElementBuildCache',
               ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'CreateTreeWalker',
               ( ['in'], POINTER(IUIAutomationCondition), 'pCondition' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
     COMMETHOD(['propget'], HRESULT, 'ControlViewWalker',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
     COMMETHOD(['propget'], HRESULT, 'ContentViewWalker',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
     COMMETHOD(['propget'], HRESULT, 'RawViewWalker',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTreeWalker)), 'walker' )),
     COMMETHOD(['propget'], HRESULT, 'RawViewCondition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
     COMMETHOD(['propget'], HRESULT, 'ControlViewCondition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
     COMMETHOD(['propget'], HRESULT, 'ContentViewCondition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
     COMMETHOD([], HRESULT, 'CreateCacheRequest',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCacheRequest)), 'cacheRequest' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCacheRequest)), 'cacheRequest' )),
     COMMETHOD([], HRESULT, 'CreateTrueCondition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateFalseCondition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreatePropertyCondition',
               ( ['in'], c_int, 'propertyId' ),
               ( ['in'], VARIANT, 'value' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreatePropertyConditionEx',
               ( ['in'], c_int, 'propertyId' ),
               ( ['in'], VARIANT, 'value' ),
               ( ['in'], PropertyConditionFlags, 'flags' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateAndCondition',
               ( ['in'], POINTER(IUIAutomationCondition), 'condition1' ),
               ( ['in'], POINTER(IUIAutomationCondition), 'condition2' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateAndConditionFromArray',
               ( ['in'], _midlSAFEARRAY(POINTER(IUIAutomationCondition)), 'conditions' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateAndConditionFromNativeArray',
               ( ['in'], POINTER(POINTER(IUIAutomationCondition)), 'conditions' ),
               ( ['in'], c_int, 'conditionCount' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateOrCondition',
               ( ['in'], POINTER(IUIAutomationCondition), 'condition1' ),
               ( ['in'], POINTER(IUIAutomationCondition), 'condition2' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateOrConditionFromArray',
               ( ['in'], _midlSAFEARRAY(POINTER(IUIAutomationCondition)), 'conditions' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateOrConditionFromNativeArray',
               ( ['in'], POINTER(POINTER(IUIAutomationCondition)), 'conditions' ),
               ( ['in'], c_int, 'conditionCount' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'CreateNotCondition',
               ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'newCondition' )),
     COMMETHOD([], HRESULT, 'AddAutomationEventHandler',
               ( ['in'], c_int, 'eventId' ),
               ( ['in'], POINTER(IUIAutomationElement), 'element' ),
@@ -2303,32 +2227,32 @@ IUIAutomation._methods_ = [
     COMMETHOD([], HRESULT, 'IntNativeArrayToSafeArray',
               ( ['in'], POINTER(c_int), 'array' ),
               ( ['in'], c_int, 'arrayCount' ),
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'safeArray' )),
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'safeArray' )),
     COMMETHOD([], HRESULT, 'IntSafeArrayToNativeArray',
               ( ['in'], _midlSAFEARRAY(c_int), 'intArray' ),
               ( ['out'], POINTER(POINTER(c_int)), 'array' ),
-              ( ['retval', 'out'], POINTER(c_int), 'arrayCount' )),
+              ( ['out', 'retval'], POINTER(c_int), 'arrayCount' )),
     COMMETHOD([], HRESULT, 'RectToVariant',
               ( ['in'], tagRECT, 'rc' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'var' )),
+              ( ['out', 'retval'], POINTER(VARIANT), 'var' )),
     COMMETHOD([], HRESULT, 'VariantToRect',
               ( ['in'], VARIANT, 'var' ),
-              ( ['retval', 'out'], POINTER(tagRECT), 'rc' )),
+              ( ['out', 'retval'], POINTER(tagRECT), 'rc' )),
     COMMETHOD([], HRESULT, 'SafeArrayToRectNativeArray',
               ( ['in'], _midlSAFEARRAY(c_double), 'rects' ),
               ( ['out'], POINTER(POINTER(tagRECT)), 'rectArray' ),
-              ( ['retval', 'out'], POINTER(c_int), 'rectArrayCount' )),
+              ( ['out', 'retval'], POINTER(c_int), 'rectArrayCount' )),
     COMMETHOD([], HRESULT, 'CreateProxyFactoryEntry',
               ( ['in'], POINTER(IUIAutomationProxyFactory), 'factory' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationProxyFactoryEntry)), 'factoryEntry' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationProxyFactoryEntry)), 'factoryEntry' )),
     COMMETHOD(['propget'], HRESULT, 'ProxyFactoryMapping',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationProxyFactoryMapping)), 'factoryMapping' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationProxyFactoryMapping)), 'factoryMapping' )),
     COMMETHOD([], HRESULT, 'GetPropertyProgrammaticName',
               ( ['in'], c_int, 'property' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'name' )),
+              ( ['out', 'retval'], POINTER(BSTR), 'name' )),
     COMMETHOD([], HRESULT, 'GetPatternProgrammaticName',
               ( ['in'], c_int, 'pattern' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'name' )),
+              ( ['out', 'retval'], POINTER(BSTR), 'name' )),
     COMMETHOD([], HRESULT, 'PollForPotentialSupportedPatterns',
               ( ['in'], POINTER(IUIAutomationElement), 'pElement' ),
               ( ['out'], POINTER(_midlSAFEARRAY(c_int)), 'patternIds' ),
@@ -2339,209 +2263,77 @@ IUIAutomation._methods_ = [
               ( ['out'], POINTER(_midlSAFEARRAY(BSTR)), 'propertyNames' )),
     COMMETHOD([], HRESULT, 'CheckNotSupported',
               ( ['in'], VARIANT, 'value' ),
-              ( ['retval', 'out'], POINTER(c_int), 'isNotSupported' )),
+              ( ['out', 'retval'], POINTER(c_int), 'isNotSupported' )),
     COMMETHOD(['propget'], HRESULT, 'ReservedNotSupportedValue',
-              ( ['retval', 'out'], POINTER(POINTER(IUnknown)), 'notSupportedValue' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUnknown)), 'notSupportedValue' )),
     COMMETHOD(['propget'], HRESULT, 'ReservedMixedAttributeValue',
-              ( ['retval', 'out'], POINTER(POINTER(IUnknown)), 'mixedAttributeValue' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUnknown)), 'mixedAttributeValue' )),
     COMMETHOD([], HRESULT, 'ElementFromIAccessible',
               ( ['in'], POINTER(IAccessible), 'accessible' ),
               ( ['in'], c_int, 'childId' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
     COMMETHOD([], HRESULT, 'ElementFromIAccessibleBuildCache',
               ( ['in'], POINTER(IAccessible), 'accessible' ),
               ( ['in'], c_int, 'childId' ),
               ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
 ]
 ################################################################
 ## code template for IUIAutomation implementation
 ##class IUIAutomation_Impl(object):
-##    def IntSafeArrayToNativeArray(self, intArray):
+##    def CompareElements(self, el1, el2):
 ##        '-no docstring-'
-##        #return array, arrayCount
+##        #return areSame
 ##
-##    def AddPropertyChangedEventHandlerNativeArray(self, element, scope, cacheRequest, handler, propertyArray, propertyCount):
+##    def CompareRuntimeIds(self, runtimeId1, runtimeId2):
 ##        '-no docstring-'
-##        #return 
+##        #return areSame
 ##
-##    def IntNativeArrayToSafeArray(self, array, arrayCount):
+##    def GetRootElement(self):
 ##        '-no docstring-'
-##        #return safeArray
-##
-##    def ElementFromHandleBuildCache(self, hwnd, cacheRequest):
-##        '-no docstring-'
-##        #return element
+##        #return root
 ##
 ##    def ElementFromHandle(self, hwnd):
 ##        '-no docstring-'
 ##        #return element
 ##
-##    def CreateOrCondition(self, condition1, condition2):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def PollForPotentialSupportedProperties(self, pElement):
-##        '-no docstring-'
-##        #return propertyIds, propertyNames
-##
-##    @property
-##    def ContentViewWalker(self):
-##        '-no docstring-'
-##        #return walker
-##
-##    def CreateTrueCondition(self):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def AddAutomationEventHandler(self, eventId, element, scope, cacheRequest, handler):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def ReservedNotSupportedValue(self):
-##        '-no docstring-'
-##        #return notSupportedValue
-##
-##    def CreatePropertyCondition(self, propertyId, value):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def AddFocusChangedEventHandler(self, cacheRequest, handler):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def RawViewCondition(self):
-##        '-no docstring-'
-##        #return condition
-##
-##    def CreateAndConditionFromNativeArray(self, conditions, conditionCount):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def CreateOrConditionFromNativeArray(self, conditions, conditionCount):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def ElementFromIAccessibleBuildCache(self, accessible, childId, cacheRequest):
+##    def ElementFromPoint(self, pt):
 ##        '-no docstring-'
 ##        #return element
 ##
-##    def CreateNotCondition(self, condition):
+##    def GetFocusedElement(self):
 ##        '-no docstring-'
-##        #return newCondition
+##        #return element
 ##
-##    def CreateOrConditionFromArray(self, conditions):
+##    def GetRootElementBuildCache(self, cacheRequest):
 ##        '-no docstring-'
-##        #return newCondition
+##        #return root
 ##
-##    def CreateAndConditionFromArray(self, conditions):
+##    def ElementFromHandleBuildCache(self, hwnd, cacheRequest):
 ##        '-no docstring-'
-##        #return newCondition
-##
-##    def CheckNotSupported(self, value):
-##        '-no docstring-'
-##        #return isNotSupported
-##
-##    def RemoveStructureChangedEventHandler(self, element, handler):
-##        '-no docstring-'
-##        #return 
-##
-##    def CreatePropertyConditionEx(self, propertyId, value, flags):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def RemovePropertyChangedEventHandler(self, element, handler):
-##        '-no docstring-'
-##        #return 
-##
-##    def CreateTreeWalker(self, pCondition):
-##        '-no docstring-'
-##        #return walker
-##
-##    def CreateCacheRequest(self):
-##        '-no docstring-'
-##        #return cacheRequest
+##        #return element
 ##
 ##    def ElementFromPointBuildCache(self, pt, cacheRequest):
 ##        '-no docstring-'
 ##        #return element
 ##
-##    def GetPatternProgrammaticName(self, pattern):
-##        '-no docstring-'
-##        #return name
-##
-##    def RemoveAllEventHandlers(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def ElementFromIAccessible(self, accessible, childId):
+##    def GetFocusedElementBuildCache(self, cacheRequest):
 ##        '-no docstring-'
 ##        #return element
 ##
-##    def AddStructureChangedEventHandler(self, element, scope, cacheRequest, handler):
+##    def CreateTreeWalker(self, pCondition):
 ##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def ProxyFactoryMapping(self):
-##        '-no docstring-'
-##        #return factoryMapping
-##
-##    def CreateProxyFactoryEntry(self, factory):
-##        '-no docstring-'
-##        #return factoryEntry
-##
-##    def CompareRuntimeIds(self, runtimeId1, runtimeId2):
-##        '-no docstring-'
-##        #return areSame
+##        #return walker
 ##
 ##    @property
 ##    def ControlViewWalker(self):
 ##        '-no docstring-'
 ##        #return walker
 ##
-##    def CreateAndCondition(self, condition1, condition2):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def GetRootElementBuildCache(self, cacheRequest):
-##        '-no docstring-'
-##        #return root
-##
-##    def RemoveFocusChangedEventHandler(self, handler):
-##        '-no docstring-'
-##        #return 
-##
-##    def ElementFromPoint(self, pt):
-##        '-no docstring-'
-##        #return element
-##
-##    def GetPropertyProgrammaticName(self, property):
-##        '-no docstring-'
-##        #return name
-##
-##    def VariantToRect(self, var):
-##        '-no docstring-'
-##        #return rc
-##
-##    def GetRootElement(self):
-##        '-no docstring-'
-##        #return root
-##
-##    def SafeArrayToRectNativeArray(self, rects):
-##        '-no docstring-'
-##        #return rectArray, rectArrayCount
-##
-##    def GetFocusedElementBuildCache(self, cacheRequest):
-##        '-no docstring-'
-##        #return element
-##
 ##    @property
-##    def ReservedMixedAttributeValue(self):
+##    def ContentViewWalker(self):
 ##        '-no docstring-'
-##        #return mixedAttributeValue
+##        #return walker
 ##
 ##    @property
 ##    def RawViewWalker(self):
@@ -2549,61 +2341,200 @@ IUIAutomation._methods_ = [
 ##        #return walker
 ##
 ##    @property
-##    def ControlViewCondition(self):
+##    def RawViewCondition(self):
 ##        '-no docstring-'
 ##        #return condition
 ##
-##    def GetFocusedElement(self):
+##    @property
+##    def ControlViewCondition(self):
 ##        '-no docstring-'
-##        #return element
-##
-##    def CompareElements(self, el1, el2):
-##        '-no docstring-'
-##        #return areSame
-##
-##    def RectToVariant(self, rc):
-##        '-no docstring-'
-##        #return var
-##
-##    def CreateFalseCondition(self):
-##        '-no docstring-'
-##        #return newCondition
-##
-##    def AddPropertyChangedEventHandler(self, element, scope, cacheRequest, handler, propertyArray):
-##        '-no docstring-'
-##        #return 
+##        #return condition
 ##
 ##    @property
 ##    def ContentViewCondition(self):
 ##        '-no docstring-'
 ##        #return condition
 ##
-##    def PollForPotentialSupportedPatterns(self, pElement):
+##    def CreateCacheRequest(self):
 ##        '-no docstring-'
-##        #return patternIds, patternNames
+##        #return cacheRequest
+##
+##    def CreateTrueCondition(self):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateFalseCondition(self):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreatePropertyCondition(self, propertyId, value):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreatePropertyConditionEx(self, propertyId, value, flags):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateAndCondition(self, condition1, condition2):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateAndConditionFromArray(self, conditions):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateAndConditionFromNativeArray(self, conditions, conditionCount):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateOrCondition(self, condition1, condition2):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateOrConditionFromArray(self, conditions):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateOrConditionFromNativeArray(self, conditions, conditionCount):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def CreateNotCondition(self, condition):
+##        '-no docstring-'
+##        #return newCondition
+##
+##    def AddAutomationEventHandler(self, eventId, element, scope, cacheRequest, handler):
+##        '-no docstring-'
+##        #return 
 ##
 ##    def RemoveAutomationEventHandler(self, eventId, element, handler):
 ##        '-no docstring-'
 ##        #return 
 ##
+##    def AddPropertyChangedEventHandlerNativeArray(self, element, scope, cacheRequest, handler, propertyArray, propertyCount):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddPropertyChangedEventHandler(self, element, scope, cacheRequest, handler, propertyArray):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemovePropertyChangedEventHandler(self, element, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddStructureChangedEventHandler(self, element, scope, cacheRequest, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveStructureChangedEventHandler(self, element, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddFocusChangedEventHandler(self, cacheRequest, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveFocusChangedEventHandler(self, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveAllEventHandlers(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def IntNativeArrayToSafeArray(self, array, arrayCount):
+##        '-no docstring-'
+##        #return safeArray
+##
+##    def IntSafeArrayToNativeArray(self, intArray):
+##        '-no docstring-'
+##        #return array, arrayCount
+##
+##    def RectToVariant(self, rc):
+##        '-no docstring-'
+##        #return var
+##
+##    def VariantToRect(self, var):
+##        '-no docstring-'
+##        #return rc
+##
+##    def SafeArrayToRectNativeArray(self, rects):
+##        '-no docstring-'
+##        #return rectArray, rectArrayCount
+##
+##    def CreateProxyFactoryEntry(self, factory):
+##        '-no docstring-'
+##        #return factoryEntry
+##
+##    @property
+##    def ProxyFactoryMapping(self):
+##        '-no docstring-'
+##        #return factoryMapping
+##
+##    def GetPropertyProgrammaticName(self, property):
+##        '-no docstring-'
+##        #return name
+##
+##    def GetPatternProgrammaticName(self, pattern):
+##        '-no docstring-'
+##        #return name
+##
+##    def PollForPotentialSupportedPatterns(self, pElement):
+##        '-no docstring-'
+##        #return patternIds, patternNames
+##
+##    def PollForPotentialSupportedProperties(self, pElement):
+##        '-no docstring-'
+##        #return propertyIds, propertyNames
+##
+##    def CheckNotSupported(self, value):
+##        '-no docstring-'
+##        #return isNotSupported
+##
+##    @property
+##    def ReservedNotSupportedValue(self):
+##        '-no docstring-'
+##        #return notSupportedValue
+##
+##    @property
+##    def ReservedMixedAttributeValue(self):
+##        '-no docstring-'
+##        #return mixedAttributeValue
+##
+##    def ElementFromIAccessible(self, accessible, childId):
+##        '-no docstring-'
+##        #return element
+##
+##    def ElementFromIAccessibleBuildCache(self, accessible, childId, cacheRequest):
+##        '-no docstring-'
+##        #return element
+##
 
 IUIAutomation2._methods_ = [
     COMMETHOD(['propget'], HRESULT, 'AutoSetFocus',
-              ( ['retval', 'out'], POINTER(c_int), 'AutoSetFocus' )),
+              ( ['out', 'retval'], POINTER(c_int), 'AutoSetFocus' )),
     COMMETHOD(['propput'], HRESULT, 'AutoSetFocus',
               ( ['in'], c_int, 'AutoSetFocus' )),
     COMMETHOD(['propget'], HRESULT, 'ConnectionTimeout',
-              ( ['retval', 'out'], POINTER(c_ulong), 'timeout' )),
+              ( ['out', 'retval'], POINTER(c_ulong), 'timeout' )),
     COMMETHOD(['propput'], HRESULT, 'ConnectionTimeout',
               ( ['in'], c_ulong, 'timeout' )),
     COMMETHOD(['propget'], HRESULT, 'TransactionTimeout',
-              ( ['retval', 'out'], POINTER(c_ulong), 'timeout' )),
+              ( ['out', 'retval'], POINTER(c_ulong), 'timeout' )),
     COMMETHOD(['propput'], HRESULT, 'TransactionTimeout',
               ( ['in'], c_ulong, 'timeout' )),
 ]
 ################################################################
 ## code template for IUIAutomation2 implementation
 ##class IUIAutomation2_Impl(object):
+##    def _get(self):
+##        '-no docstring-'
+##        #return AutoSetFocus
+##    def _set(self, AutoSetFocus):
+##        '-no docstring-'
+##    AutoSetFocus = property(_get, _set, doc = _set.__doc__)
+##
 ##    def _get(self):
 ##        '-no docstring-'
 ##        #return timeout
@@ -2618,18 +2549,109 @@ IUIAutomation2._methods_ = [
 ##        '-no docstring-'
 ##    TransactionTimeout = property(_get, _set, doc = _set.__doc__)
 ##
-##    def _get(self):
+
+class IUIAutomationElement6(IUIAutomationElement5):
+    _case_insensitive_ = True
+    _iid_ = GUID('{4780D450-8BCA-4977-AFA5-A4A517F555E3}')
+    _idlflags_ = []
+IUIAutomationElement6._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentFullDescription',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFullDescription',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement6 implementation
+##class IUIAutomationElement6_Impl(object):
+##    @property
+##    def CurrentFullDescription(self):
 ##        '-no docstring-'
-##        #return AutoSetFocus
-##    def _set(self, AutoSetFocus):
+##        #return retVal
+##
+##    @property
+##    def CachedFullDescription(self):
 ##        '-no docstring-'
-##    AutoSetFocus = property(_get, _set, doc = _set.__doc__)
+##        #return retVal
 ##
 
-class IUIAutomation3(IUIAutomation2):
+class IUIAutomationElement7(IUIAutomationElement6):
     _case_insensitive_ = True
-    _iid_ = GUID('{73D768DA-9B51-4B89-936E-C209290973E7}')
+    _iid_ = GUID('{204E8572-CFC3-4C11-B0C8-7DA7420750B7}')
     _idlflags_ = []
+
+# values for enumeration 'TreeTraversalOptions'
+TreeTraversalOptions_Default = 0
+TreeTraversalOptions_PostOrder = 1
+TreeTraversalOptions_LastToFirstOrder = 2
+TreeTraversalOptions = c_int # enum
+IUIAutomationElement7._methods_ = [
+    COMMETHOD([], HRESULT, 'FindFirstWithOptions',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
+              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindAllWithOptions',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
+              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindFirstWithOptionsBuildCache',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
+              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindAllWithOptionsBuildCache',
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCondition), 'condition' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['in'], TreeTraversalOptions, 'traversalOptions' ),
+              ( ['in'], POINTER(IUIAutomationElement), 'root' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'found' )),
+    COMMETHOD([], HRESULT, 'GetCurrentMetadataValue',
+              ( ['in'], c_int, 'targetId' ),
+              ( ['in'], c_int, 'metadataId' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'returnVal' )),
+]
+################################################################
+## code template for IUIAutomationElement7 implementation
+##class IUIAutomationElement7_Impl(object):
+##    def FindFirstWithOptions(self, scope, condition, traversalOptions, root):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindAllWithOptions(self, scope, condition, traversalOptions, root):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindFirstWithOptionsBuildCache(self, scope, condition, cacheRequest, traversalOptions, root):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindAllWithOptionsBuildCache(self, scope, condition, cacheRequest, traversalOptions, root):
+##        '-no docstring-'
+##        #return found
+##
+##    def GetCurrentMetadataValue(self, targetId, metadataId):
+##        '-no docstring-'
+##        #return returnVal
+##
+
+
+# values for enumeration 'TextEditChangeType'
+TextEditChangeType_None = 0
+TextEditChangeType_AutoCorrect = 1
+TextEditChangeType_Composition = 2
+TextEditChangeType_CompositionFinalized = 3
+TextEditChangeType_AutoComplete = 4
+TextEditChangeType = c_int # enum
+class IUIAutomationTextEditTextChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{92FAA680-E704-4156-931A-E32D5BB38F3F}')
+    _idlflags_ = ['oleautomation']
 IUIAutomation3._methods_ = [
     COMMETHOD([], HRESULT, 'AddTextEditTextChangedEventHandler',
               ( ['in'], POINTER(IUIAutomationElement), 'element' ),
@@ -2653,16 +2675,10 @@ IUIAutomation3._methods_ = [
 ##        #return 
 ##
 
-UIA_ScrollHorizontallyScrollablePropertyId = 30057 # Constant c_int
-UIA_ScrollVerticallyScrollablePropertyId = 30058 # Constant c_int
-class IUIAutomation4(IUIAutomation3):
+class IUIAutomationChangesEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
-    _iid_ = GUID('{1189C02A-05F8-4319-8E21-E817E3DB2860}')
-    _idlflags_ = []
-class IUIAutomation5(IUIAutomation4):
-    _case_insensitive_ = True
-    _iid_ = GUID('{25F700C8-D816-4057-A9DC-3CBDEE77E256}')
-    _idlflags_ = []
+    _iid_ = GUID('{58EDCA55-2C3E-4980-B1B9-56C17F27A2A0}')
+    _idlflags_ = ['oleautomation']
 IUIAutomation4._methods_ = [
     COMMETHOD([], HRESULT, 'AddChangesEventHandler',
               ( ['in'], POINTER(IUIAutomationElement), 'element' ),
@@ -2678,15 +2694,43 @@ IUIAutomation4._methods_ = [
 ################################################################
 ## code template for IUIAutomation4 implementation
 ##class IUIAutomation4_Impl(object):
-##    def RemoveChangesEventHandler(self, element, handler):
-##        '-no docstring-'
-##        #return 
-##
 ##    def AddChangesEventHandler(self, element, scope, changeTypes, changesCount, pCacheRequest, handler):
 ##        '-no docstring-'
 ##        #return 
 ##
+##    def RemoveChangesEventHandler(self, element, handler):
+##        '-no docstring-'
+##        #return 
+##
 
+class IUIAutomationElement8(IUIAutomationElement7):
+    _case_insensitive_ = True
+    _iid_ = GUID('{8C60217D-5411-4CDE-BCC0-1CEDA223830C}')
+    _idlflags_ = []
+IUIAutomationElement8._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentHeadingLevel',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedHeadingLevel',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement8 implementation
+##class IUIAutomationElement8_Impl(object):
+##    @property
+##    def CurrentHeadingLevel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedHeadingLevel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationNotificationEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{C7CB2637-E6C2-4D0C-85DE-4948C02175C7}')
+    _idlflags_ = ['oleautomation']
 IUIAutomation5._methods_ = [
     COMMETHOD([], HRESULT, 'AddNotificationEventHandler',
               ( ['in'], POINTER(IUIAutomationElement), 'element' ),
@@ -2709,8 +2753,331 @@ IUIAutomation5._methods_ = [
 ##        #return 
 ##
 
-UIA_SelectionSelectionPropertyId = 30059 # Constant c_int
-UIA_IsSpreadsheetPatternAvailablePropertyId = 30128 # Constant c_int
+class IUIAutomationObjectModelPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{71C284B3-C14D-4D14-981E-19751B0D756D}')
+    _idlflags_ = []
+IUIAutomationObjectModelPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetUnderlyingObjectModel',
+              ( ['out', 'retval'], POINTER(POINTER(IUnknown)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationObjectModelPattern implementation
+##class IUIAutomationObjectModelPattern_Impl(object):
+##    def GetUnderlyingObjectModel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationElement9(IUIAutomationElement8):
+    _case_insensitive_ = True
+    _iid_ = GUID('{39325FAC-039D-440E-A3A3-5EB81A5CECC3}')
+    _idlflags_ = []
+IUIAutomationElement9._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsDialog',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsDialog',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationElement9 implementation
+##class IUIAutomationElement9_Impl(object):
+##    @property
+##    def CurrentIsDialog(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsDialog(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class UiaChangeInfo(Structure):
+    pass
+IUIAutomationChangesEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleChangesEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( ['in'], POINTER(UiaChangeInfo), 'uiaChanges' ),
+              ( ['in'], c_int, 'changesCount' )),
+]
+################################################################
+## code template for IUIAutomationChangesEventHandler implementation
+##class IUIAutomationChangesEventHandler_Impl(object):
+##    def HandleChangesEvent(self, sender, uiaChanges, changesCount):
+##        '-no docstring-'
+##        #return 
+##
+
+
+# values for enumeration 'TextPatternRangeEndpoint'
+TextPatternRangeEndpoint_Start = 0
+TextPatternRangeEndpoint_End = 1
+TextPatternRangeEndpoint = c_int # enum
+
+# values for enumeration 'TextUnit'
+TextUnit_Character = 0
+TextUnit_Format = 1
+TextUnit_Word = 2
+TextUnit_Line = 3
+TextUnit_Paragraph = 4
+TextUnit_Page = 5
+TextUnit_Document = 6
+TextUnit = c_int # enum
+IUIAutomationTextRange._methods_ = [
+    COMMETHOD([], HRESULT, 'Clone',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'clonedRange' )),
+    COMMETHOD([], HRESULT, 'Compare',
+              ( ['in'], POINTER(IUIAutomationTextRange), 'range' ),
+              ( ['out', 'retval'], POINTER(c_int), 'areSame' )),
+    COMMETHOD([], HRESULT, 'CompareEndpoints',
+              ( ['in'], TextPatternRangeEndpoint, 'srcEndPoint' ),
+              ( ['in'], POINTER(IUIAutomationTextRange), 'range' ),
+              ( ['in'], TextPatternRangeEndpoint, 'targetEndPoint' ),
+              ( ['out', 'retval'], POINTER(c_int), 'compValue' )),
+    COMMETHOD([], HRESULT, 'ExpandToEnclosingUnit',
+              ( ['in'], TextUnit, 'TextUnit' )),
+    COMMETHOD([], HRESULT, 'FindAttribute',
+              ( ['in'], c_int, 'attr' ),
+              ( ['in'], VARIANT, 'val' ),
+              ( ['in'], c_int, 'backward' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'found' )),
+    COMMETHOD([], HRESULT, 'FindText',
+              ( ['in'], BSTR, 'text' ),
+              ( ['in'], c_int, 'backward' ),
+              ( ['in'], c_int, 'ignoreCase' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'found' )),
+    COMMETHOD([], HRESULT, 'GetAttributeValue',
+              ( ['in'], c_int, 'attr' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'value' )),
+    COMMETHOD([], HRESULT, 'GetBoundingRectangles',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_double)), 'boundingRects' )),
+    COMMETHOD([], HRESULT, 'GetEnclosingElement',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'enclosingElement' )),
+    COMMETHOD([], HRESULT, 'GetText',
+              ( ['in'], c_int, 'maxLength' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'text' )),
+    COMMETHOD([], HRESULT, 'Move',
+              ( ['in'], TextUnit, 'unit' ),
+              ( ['in'], c_int, 'count' ),
+              ( ['out', 'retval'], POINTER(c_int), 'moved' )),
+    COMMETHOD([], HRESULT, 'MoveEndpointByUnit',
+              ( ['in'], TextPatternRangeEndpoint, 'endpoint' ),
+              ( ['in'], TextUnit, 'unit' ),
+              ( ['in'], c_int, 'count' ),
+              ( ['out', 'retval'], POINTER(c_int), 'moved' )),
+    COMMETHOD([], HRESULT, 'MoveEndpointByRange',
+              ( ['in'], TextPatternRangeEndpoint, 'srcEndPoint' ),
+              ( ['in'], POINTER(IUIAutomationTextRange), 'range' ),
+              ( ['in'], TextPatternRangeEndpoint, 'targetEndPoint' )),
+    COMMETHOD([], HRESULT, 'Select'),
+    COMMETHOD([], HRESULT, 'AddToSelection'),
+    COMMETHOD([], HRESULT, 'RemoveFromSelection'),
+    COMMETHOD([], HRESULT, 'ScrollIntoView',
+              ( ['in'], c_int, 'alignToTop' )),
+    COMMETHOD([], HRESULT, 'GetChildren',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'children' )),
+]
+################################################################
+## code template for IUIAutomationTextRange implementation
+##class IUIAutomationTextRange_Impl(object):
+##    def Clone(self):
+##        '-no docstring-'
+##        #return clonedRange
+##
+##    def Compare(self, range):
+##        '-no docstring-'
+##        #return areSame
+##
+##    def CompareEndpoints(self, srcEndPoint, range, targetEndPoint):
+##        '-no docstring-'
+##        #return compValue
+##
+##    def ExpandToEnclosingUnit(self, TextUnit):
+##        '-no docstring-'
+##        #return 
+##
+##    def FindAttribute(self, attr, val, backward):
+##        '-no docstring-'
+##        #return found
+##
+##    def FindText(self, text, backward, ignoreCase):
+##        '-no docstring-'
+##        #return found
+##
+##    def GetAttributeValue(self, attr):
+##        '-no docstring-'
+##        #return value
+##
+##    def GetBoundingRectangles(self):
+##        '-no docstring-'
+##        #return boundingRects
+##
+##    def GetEnclosingElement(self):
+##        '-no docstring-'
+##        #return enclosingElement
+##
+##    def GetText(self, maxLength):
+##        '-no docstring-'
+##        #return text
+##
+##    def Move(self, unit, count):
+##        '-no docstring-'
+##        #return moved
+##
+##    def MoveEndpointByUnit(self, endpoint, unit, count):
+##        '-no docstring-'
+##        #return moved
+##
+##    def MoveEndpointByRange(self, srcEndPoint, range, targetEndPoint):
+##        '-no docstring-'
+##        #return 
+##
+##    def Select(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddToSelection(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveFromSelection(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def ScrollIntoView(self, alignToTop):
+##        '-no docstring-'
+##        #return 
+##
+##    def GetChildren(self):
+##        '-no docstring-'
+##        #return children
+##
+
+UIA_RangeValuePatternId = 10003 # Constant c_int
+class IUIAutomationScrollItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{B488300F-D015-4F19-9C29-BB595E3645EF}')
+    _idlflags_ = []
+IUIAutomationScrollItemPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'ScrollIntoView'),
+]
+################################################################
+## code template for IUIAutomationScrollItemPattern implementation
+##class IUIAutomationScrollItemPattern_Impl(object):
+##    def ScrollIntoView(self):
+##        '-no docstring-'
+##        #return 
+##
+
+class IUIAutomationTextRange2(IUIAutomationTextRange):
+    _case_insensitive_ = True
+    _iid_ = GUID('{BB9B40E0-5E04-46BD-9BE0-4B601B9AFAD4}')
+    _idlflags_ = []
+IUIAutomationTextRange2._methods_ = [
+    COMMETHOD([], HRESULT, 'ShowContextMenu'),
+]
+################################################################
+## code template for IUIAutomationTextRange2 implementation
+##class IUIAutomationTextRange2_Impl(object):
+##    def ShowContextMenu(self):
+##        '-no docstring-'
+##        #return 
+##
+
+class IUIAutomationTextRange3(IUIAutomationTextRange2):
+    _case_insensitive_ = True
+    _iid_ = GUID('{6A315D69-5512-4C2E-85F0-53FCE6DD4BC2}')
+    _idlflags_ = []
+IUIAutomationTextRange3._methods_ = [
+    COMMETHOD([], HRESULT, 'GetEnclosingElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'enclosingElement' )),
+    COMMETHOD([], HRESULT, 'GetChildrenBuildCache',
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'children' )),
+    COMMETHOD([], HRESULT, 'GetAttributeValues',
+              ( ['in'], POINTER(c_int), 'attributeIds' ),
+              ( ['in'], c_int, 'attributeIdCount' ),
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(VARIANT)), 'attributeValues' )),
+]
+################################################################
+## code template for IUIAutomationTextRange3 implementation
+##class IUIAutomationTextRange3_Impl(object):
+##    def GetEnclosingElementBuildCache(self, cacheRequest):
+##        '-no docstring-'
+##        #return enclosingElement
+##
+##    def GetChildrenBuildCache(self, cacheRequest):
+##        '-no docstring-'
+##        #return children
+##
+##    def GetAttributeValues(self, attributeIds, attributeIdCount):
+##        '-no docstring-'
+##        #return attributeValues
+##
+
+IUIAutomationTextRangeArray._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'Length',
+              ( ['out', 'retval'], POINTER(c_int), 'Length' )),
+    COMMETHOD([], HRESULT, 'GetElement',
+              ( ['in'], c_int, 'index' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'element' )),
+]
+################################################################
+## code template for IUIAutomationTextRangeArray implementation
+##class IUIAutomationTextRangeArray_Impl(object):
+##    @property
+##    def Length(self):
+##        '-no docstring-'
+##        #return Length
+##
+##    def GetElement(self, index):
+##        '-no docstring-'
+##        #return element
+##
+
+UIA_InvokePatternId = 10000 # Constant c_int
+UIA_SelectionPatternId = 10001 # Constant c_int
+class IUIAutomationTogglePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{94CF8058-9B8D-4AB9-8BFD-4CD0A33C8C70}')
+    _idlflags_ = []
+
+# values for enumeration 'ToggleState'
+ToggleState_Off = 0
+ToggleState_On = 1
+ToggleState_Indeterminate = 2
+ToggleState = c_int # enum
+IUIAutomationTogglePattern._methods_ = [
+    COMMETHOD([], HRESULT, 'Toggle'),
+    COMMETHOD(['propget'], HRESULT, 'CurrentToggleState',
+              ( ['out', 'retval'], POINTER(ToggleState), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedToggleState',
+              ( ['out', 'retval'], POINTER(ToggleState), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationTogglePattern implementation
+##class IUIAutomationTogglePattern_Impl(object):
+##    def Toggle(self):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentToggleState(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedToggleState(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+HeadingLevel_None = 80050 # Constant c_int
+HeadingLevel2 = 80052 # Constant c_int
+HeadingLevel4 = 80054 # Constant c_int
+HeadingLevel5 = 80055 # Constant c_int
 class IUIAutomationTransformPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{A9B55844-A55D-4EF0-926D-569C16FF89BB}')
@@ -2725,38 +3092,42 @@ IUIAutomationTransformPattern._methods_ = [
     COMMETHOD([], HRESULT, 'Rotate',
               ( ['in'], c_double, 'degrees' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentCanMove',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentCanResize',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentCanRotate',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedCanMove',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedCanResize',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedCanRotate',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
 ]
 ################################################################
 ## code template for IUIAutomationTransformPattern implementation
 ##class IUIAutomationTransformPattern_Impl(object):
-##    @property
-##    def CachedCanMove(self):
+##    def Move(self, x, y):
 ##        '-no docstring-'
-##        #return retVal
+##        #return 
+##
+##    def Resize(self, width, height):
+##        '-no docstring-'
+##        #return 
 ##
 ##    def Rotate(self, degrees):
 ##        '-no docstring-'
 ##        #return 
 ##
 ##    @property
-##    def CachedCanRotate(self):
+##    def CurrentCanMove(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
-##    def Move(self, x, y):
+##    @property
+##    def CurrentCanResize(self):
 ##        '-no docstring-'
-##        #return 
+##        #return retVal
 ##
 ##    @property
 ##    def CurrentCanRotate(self):
@@ -2764,7 +3135,7 @@ IUIAutomationTransformPattern._methods_ = [
 ##        #return retVal
 ##
 ##    @property
-##    def CurrentCanMove(self):
+##    def CachedCanMove(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
@@ -2774,118 +3145,195 @@ IUIAutomationTransformPattern._methods_ = [
 ##        #return retVal
 ##
 ##    @property
-##    def CurrentCanResize(self):
+##    def CachedCanRotate(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
-##    def Resize(self, width, height):
-##        '-no docstring-'
-##        #return 
-##
 
-UIA_SelectionCanSelectMultiplePropertyId = 30060 # Constant c_int
-UIA_HeaderItemControlTypeId = 50035 # Constant c_int
-class IUIAutomation6(IUIAutomation5):
+HeadingLevel6 = 80056 # Constant c_int
+class IUIAutomationExpandCollapsePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
-    _iid_ = GUID('{AAE072DA-29E3-413D-87A7-192DBF81ED10}')
-    _idlflags_ = []
-class IUIAutomationEventHandlerGroup(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{C9EE12F2-C13B-4408-997C-639914377F4E}')
+    _iid_ = GUID('{619BE086-1F4E-4EE4-BAFA-210128738730}')
     _idlflags_ = []
 
-# values for enumeration 'ConnectionRecoveryBehaviorOptions'
-ConnectionRecoveryBehaviorOptions_Disabled = 0
-ConnectionRecoveryBehaviorOptions_Enabled = 1
-ConnectionRecoveryBehaviorOptions = c_int # enum
-
-# values for enumeration 'CoalesceEventsOptions'
-CoalesceEventsOptions_Disabled = 0
-CoalesceEventsOptions_Enabled = 1
-CoalesceEventsOptions = c_int # enum
-class IUIAutomationActiveTextPositionChangedEventHandler(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{F97933B0-8DAE-4496-8997-5BA015FE0D82}')
-    _idlflags_ = ['oleautomation']
-IUIAutomation6._methods_ = [
-    COMMETHOD([], HRESULT, 'CreateEventHandlerGroup',
-              ( ['out'], POINTER(POINTER(IUIAutomationEventHandlerGroup)), 'handlerGroup' )),
-    COMMETHOD([], HRESULT, 'AddEventHandlerGroup',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationEventHandlerGroup), 'handlerGroup' )),
-    COMMETHOD([], HRESULT, 'RemoveEventHandlerGroup',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationEventHandlerGroup), 'handlerGroup' )),
-    COMMETHOD(['propget'], HRESULT, 'ConnectionRecoveryBehavior',
-              ( ['retval', 'out'], POINTER(ConnectionRecoveryBehaviorOptions), 'ConnectionRecoveryBehaviorOptions' )),
-    COMMETHOD(['propput'], HRESULT, 'ConnectionRecoveryBehavior',
-              ( ['in'], ConnectionRecoveryBehaviorOptions, 'ConnectionRecoveryBehaviorOptions' )),
-    COMMETHOD(['propget'], HRESULT, 'CoalesceEvents',
-              ( ['retval', 'out'], POINTER(CoalesceEventsOptions), 'CoalesceEventsOptions' )),
-    COMMETHOD(['propput'], HRESULT, 'CoalesceEvents',
-              ( ['in'], CoalesceEventsOptions, 'CoalesceEventsOptions' )),
-    COMMETHOD([], HRESULT, 'AddActiveTextPositionChangedEventHandler',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], TreeScope, 'scope' ),
-              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
-              ( ['in'], POINTER(IUIAutomationActiveTextPositionChangedEventHandler), 'handler' )),
-    COMMETHOD([], HRESULT, 'RemoveActiveTextPositionChangedEventHandler',
-              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
-              ( ['in'], POINTER(IUIAutomationActiveTextPositionChangedEventHandler), 'handler' )),
+# values for enumeration 'ExpandCollapseState'
+ExpandCollapseState_Collapsed = 0
+ExpandCollapseState_Expanded = 1
+ExpandCollapseState_PartiallyExpanded = 2
+ExpandCollapseState_LeafNode = 3
+ExpandCollapseState = c_int # enum
+IUIAutomationExpandCollapsePattern._methods_ = [
+    COMMETHOD([], HRESULT, 'Expand'),
+    COMMETHOD([], HRESULT, 'Collapse'),
+    COMMETHOD(['propget'], HRESULT, 'CurrentExpandCollapseState',
+              ( ['out', 'retval'], POINTER(ExpandCollapseState), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedExpandCollapseState',
+              ( ['out', 'retval'], POINTER(ExpandCollapseState), 'retVal' )),
 ]
 ################################################################
-## code template for IUIAutomation6 implementation
-##class IUIAutomation6_Impl(object):
-##    def _get(self):
-##        '-no docstring-'
-##        #return ConnectionRecoveryBehaviorOptions
-##    def _set(self, ConnectionRecoveryBehaviorOptions):
-##        '-no docstring-'
-##    ConnectionRecoveryBehavior = property(_get, _set, doc = _set.__doc__)
-##
-##    def AddActiveTextPositionChangedEventHandler(self, element, scope, cacheRequest, handler):
+## code template for IUIAutomationExpandCollapsePattern implementation
+##class IUIAutomationExpandCollapsePattern_Impl(object):
+##    def Expand(self):
 ##        '-no docstring-'
 ##        #return 
 ##
-##    def RemoveEventHandlerGroup(self, element, handlerGroup):
+##    def Collapse(self):
 ##        '-no docstring-'
 ##        #return 
 ##
-##    def _get(self):
+##    @property
+##    def CurrentExpandCollapseState(self):
 ##        '-no docstring-'
-##        #return CoalesceEventsOptions
-##    def _set(self, CoalesceEventsOptions):
-##        '-no docstring-'
-##    CoalesceEvents = property(_get, _set, doc = _set.__doc__)
+##        #return retVal
 ##
-##    def CreateEventHandlerGroup(self):
+##    @property
+##    def CachedExpandCollapseState(self):
 ##        '-no docstring-'
-##        #return handlerGroup
-##
-##    def RemoveActiveTextPositionChangedEventHandler(self, element, handler):
-##        '-no docstring-'
-##        #return 
-##
-##    def AddEventHandlerGroup(self, element, handlerGroup):
-##        '-no docstring-'
-##        #return 
+##        #return retVal
 ##
 
-UIA_GridRowCountPropertyId = 30062 # Constant c_int
+HeadingLevel7 = 80057 # Constant c_int
+HeadingLevel8 = 80058 # Constant c_int
+HeadingLevel9 = 80059 # Constant c_int
+UIA_SummaryChangeId = 90000 # Constant c_int
+UIA_SayAsInterpretAsMetadataId = 100000 # Constant c_int
 
-# values for enumeration 'ProviderOptions'
-ProviderOptions_ClientSideProvider = 1
-ProviderOptions_ServerSideProvider = 2
-ProviderOptions_NonClientAreaProvider = 4
-ProviderOptions_OverrideProvider = 8
-ProviderOptions_ProviderOwnsSetFocus = 16
-ProviderOptions_UseComThreading = 32
-ProviderOptions_RefuseNonClientSupport = 64
-ProviderOptions_HasNativeIAccessible = 128
-ProviderOptions_UseClientCoordinates = 256
-ProviderOptions = c_int # enum
-UIA_GridColumnCountPropertyId = 30063 # Constant c_int
-UIA_GridItemRowPropertyId = 30064 # Constant c_int
+# values for enumeration 'DockPosition'
+DockPosition_Top = 0
+DockPosition_Left = 1
+DockPosition_Bottom = 2
+DockPosition_Right = 3
+DockPosition_Fill = 4
+DockPosition_None = 5
+DockPosition = c_int # enum
+IUIAutomationElementArray._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'Length',
+              ( ['out', 'retval'], POINTER(c_int), 'Length' )),
+    COMMETHOD([], HRESULT, 'GetElement',
+              ( ['in'], c_int, 'index' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+]
+################################################################
+## code template for IUIAutomationElementArray implementation
+##class IUIAutomationElementArray_Impl(object):
+##    @property
+##    def Length(self):
+##        '-no docstring-'
+##        #return Length
+##
+##    def GetElement(self, index):
+##        '-no docstring-'
+##        #return element
+##
+
+
+# values for enumeration 'AutomationElementMode'
+AutomationElementMode_None = 0
+AutomationElementMode_Full = 1
+AutomationElementMode = c_int # enum
+IUIAutomationCacheRequest._methods_ = [
+    COMMETHOD([], HRESULT, 'AddProperty',
+              ( ['in'], c_int, 'propertyId' )),
+    COMMETHOD([], HRESULT, 'AddPattern',
+              ( ['in'], c_int, 'patternId' )),
+    COMMETHOD([], HRESULT, 'Clone',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCacheRequest)), 'clonedRequest' )),
+    COMMETHOD(['propget'], HRESULT, 'TreeScope',
+              ( ['out', 'retval'], POINTER(TreeScope), 'scope' )),
+    COMMETHOD(['propput'], HRESULT, 'TreeScope',
+              ( ['in'], TreeScope, 'scope' )),
+    COMMETHOD(['propget'], HRESULT, 'TreeFilter',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'filter' )),
+    COMMETHOD(['propput'], HRESULT, 'TreeFilter',
+              ( ['in'], POINTER(IUIAutomationCondition), 'filter' )),
+    COMMETHOD(['propget'], HRESULT, 'AutomationElementMode',
+              ( ['out', 'retval'], POINTER(AutomationElementMode), 'mode' )),
+    COMMETHOD(['propput'], HRESULT, 'AutomationElementMode',
+              ( ['in'], AutomationElementMode, 'mode' )),
+]
+################################################################
+## code template for IUIAutomationCacheRequest implementation
+##class IUIAutomationCacheRequest_Impl(object):
+##    def AddProperty(self, propertyId):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddPattern(self, patternId):
+##        '-no docstring-'
+##        #return 
+##
+##    def Clone(self):
+##        '-no docstring-'
+##        #return clonedRequest
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return scope
+##    def _set(self, scope):
+##        '-no docstring-'
+##    TreeScope = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return filter
+##    def _set(self, filter):
+##        '-no docstring-'
+##    TreeFilter = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return mode
+##    def _set(self, mode):
+##        '-no docstring-'
+##    AutomationElementMode = property(_get, _set, doc = _set.__doc__)
+##
+
+class IUIAutomationGridPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{414C3CDC-856B-4F5B-8538-3131C6302550}')
+    _idlflags_ = []
+IUIAutomationGridPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetItem',
+              ( ['in'], c_int, 'row' ),
+              ( ['in'], c_int, 'column' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentRowCount',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentColumnCount',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedRowCount',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedColumnCount',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationGridPattern implementation
+##class IUIAutomationGridPattern_Impl(object):
+##    def GetItem(self, row, column):
+##        '-no docstring-'
+##        #return element
+##
+##    @property
+##    def CurrentRowCount(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentColumnCount(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedRowCount(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedColumnCount(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
 class IUIAutomationValuePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{A94CD8B1-0844-4CD6-9D2D-640537AB39E9}')
@@ -2894,30 +3342,25 @@ IUIAutomationValuePattern._methods_ = [
     COMMETHOD([], HRESULT, 'SetValue',
               ( ['in'], BSTR, 'val' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentValue',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentIsReadOnly',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedValue',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedIsReadOnly',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
 ]
 ################################################################
 ## code template for IUIAutomationValuePattern implementation
 ##class IUIAutomationValuePattern_Impl(object):
-##    @property
-##    def CachedIsReadOnly(self):
+##    def SetValue(self, val):
 ##        '-no docstring-'
-##        #return retVal
+##        #return 
 ##
 ##    @property
 ##    def CurrentValue(self):
 ##        '-no docstring-'
 ##        #return retVal
-##
-##    def SetValue(self, val):
-##        '-no docstring-'
-##        #return 
 ##
 ##    @property
 ##    def CurrentIsReadOnly(self):
@@ -2929,10 +3372,94 @@ IUIAutomationValuePattern._methods_ = [
 ##        '-no docstring-'
 ##        #return retVal
 ##
+##    @property
+##    def CachedIsReadOnly(self):
+##        '-no docstring-'
+##        #return retVal
+##
 
-UIA_GridItemColumnPropertyId = 30065 # Constant c_int
-UIA_DockPatternId = 10011 # Constant c_int
-UIA_TablePatternId = 10012 # Constant c_int
+UIA_ValuePatternId = 10002 # Constant c_int
+class IUIAutomationGridItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{78F8EF57-66C3-4E09-BD7C-E79B2004894D}')
+    _idlflags_ = []
+IUIAutomationGridItemPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentContainingGrid',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentRow',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentColumn',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentRowSpan',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentColumnSpan',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedContainingGrid',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedRow',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedColumn',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedRowSpan',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedColumnSpan',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationGridItemPattern implementation
+##class IUIAutomationGridItemPattern_Impl(object):
+##    @property
+##    def CurrentContainingGrid(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentRow(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentColumn(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentRowSpan(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentColumnSpan(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedContainingGrid(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedRow(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedColumn(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedRowSpan(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedColumnSpan(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+HeadingLevel3 = 80053 # Constant c_int
 class IUIAutomationWindowPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{0FAEF453-9208-43EF-BBB2-3B485177864F}')
@@ -2955,63 +3482,51 @@ IUIAutomationWindowPattern._methods_ = [
     COMMETHOD([], HRESULT, 'Close'),
     COMMETHOD([], HRESULT, 'WaitForInputIdle',
               ( ['in'], c_int, 'milliseconds' ),
-              ( ['retval', 'out'], POINTER(c_int), 'success' )),
+              ( ['out', 'retval'], POINTER(c_int), 'success' )),
     COMMETHOD([], HRESULT, 'SetWindowVisualState',
               ( ['in'], WindowVisualState, 'state' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentCanMaximize',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentCanMinimize',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentIsModal',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentIsTopmost',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentWindowVisualState',
-              ( ['retval', 'out'], POINTER(WindowVisualState), 'retVal' )),
+              ( ['out', 'retval'], POINTER(WindowVisualState), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CurrentWindowInteractionState',
-              ( ['retval', 'out'], POINTER(WindowInteractionState), 'retVal' )),
+              ( ['out', 'retval'], POINTER(WindowInteractionState), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedCanMaximize',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedCanMinimize',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedIsModal',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedIsTopmost',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedWindowVisualState',
-              ( ['retval', 'out'], POINTER(WindowVisualState), 'retVal' )),
+              ( ['out', 'retval'], POINTER(WindowVisualState), 'retVal' )),
     COMMETHOD(['propget'], HRESULT, 'CachedWindowInteractionState',
-              ( ['retval', 'out'], POINTER(WindowInteractionState), 'retVal' )),
+              ( ['out', 'retval'], POINTER(WindowInteractionState), 'retVal' )),
 ]
 ################################################################
 ## code template for IUIAutomationWindowPattern implementation
 ##class IUIAutomationWindowPattern_Impl(object):
-##    @property
-##    def CurrentIsTopmost(self):
+##    def Close(self):
 ##        '-no docstring-'
-##        #return retVal
+##        #return 
+##
+##    def WaitForInputIdle(self, milliseconds):
+##        '-no docstring-'
+##        #return success
 ##
 ##    def SetWindowVisualState(self, state):
 ##        '-no docstring-'
 ##        #return 
 ##
 ##    @property
-##    def CurrentIsModal(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsTopmost(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentWindowInteractionState(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsModal(self):
+##    def CurrentCanMaximize(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
@@ -3020,9 +3535,25 @@ IUIAutomationWindowPattern._methods_ = [
 ##        '-no docstring-'
 ##        #return retVal
 ##
-##    def WaitForInputIdle(self, milliseconds):
+##    @property
+##    def CurrentIsModal(self):
 ##        '-no docstring-'
-##        #return success
+##        #return retVal
+##
+##    @property
+##    def CurrentIsTopmost(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentWindowVisualState(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentWindowInteractionState(self):
+##        '-no docstring-'
+##        #return retVal
 ##
 ##    @property
 ##    def CachedCanMaximize(self):
@@ -3035,23 +3566,19 @@ IUIAutomationWindowPattern._methods_ = [
 ##        #return retVal
 ##
 ##    @property
+##    def CachedIsModal(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsTopmost(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
 ##    def CachedWindowVisualState(self):
 ##        '-no docstring-'
 ##        #return retVal
-##
-##    @property
-##    def CurrentWindowVisualState(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentCanMaximize(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def Close(self):
-##        '-no docstring-'
-##        #return 
 ##
 ##    @property
 ##    def CachedWindowInteractionState(self):
@@ -3059,172 +3586,780 @@ IUIAutomationWindowPattern._methods_ = [
 ##        #return retVal
 ##
 
-UIA_DockDockPositionPropertyId = 30069 # Constant c_int
-UIA_ExpandCollapseExpandCollapseStatePropertyId = 30070 # Constant c_int
-class CUIAutomation8(CoClass):
-    u'The Central Class for UIAutomation8'
-    _reg_clsid_ = GUID('{E22AD333-B25F-460C-83D0-0581107395C9}')
-    _idlflags_ = []
-    _typelib_path_ = typelib_path
-    _reg_typelib_ = ('{944DE083-8FB8-45CF-BCB7-C477ACB2F897}', 1, 0)
-CUIAutomation8._com_interfaces_ = [IUIAutomation2, IUIAutomation3, IUIAutomation4, IUIAutomation5, IUIAutomation6]
-
-UIA_MultipleViewSupportedViewsPropertyId = 30072 # Constant c_int
-UIA_SpreadsheetPatternId = 10026 # Constant c_int
-UIA_LegacyIAccessiblePatternId = 10018 # Constant c_int
-UIA_WindowCanMinimizePropertyId = 30074 # Constant c_int
-UIA_TableItemPatternId = 10013 # Constant c_int
-StyleId_Heading5 = 70005 # Constant c_int
-UIA_VirtualizedItemPatternId = 10020 # Constant c_int
-UIA_DragGrabbedItemsPropertyId = 30144 # Constant c_int
-UIA_SynchronizedInputPatternId = 10021 # Constant c_int
-UIA_ObjectModelPatternId = 10022 # Constant c_int
-UIA_AnnotationPatternId = 10023 # Constant c_int
-UIA_SelectionItemIsSelectedPropertyId = 30079 # Constant c_int
-UIA_IsSpreadsheetItemPatternAvailablePropertyId = 30132 # Constant c_int
-StyleId_Heading6 = 70006 # Constant c_int
-UIA_GridItemColumnSpanPropertyId = 30067 # Constant c_int
-UIA_StylesPatternId = 10025 # Constant c_int
-UIA_SemanticZoomControlTypeId = 50039 # Constant c_int
-UIA_TableColumnHeadersPropertyId = 30082 # Constant c_int
-UIA_TableRowOrColumnMajorPropertyId = 30083 # Constant c_int
-AnnotationType_ExternalChange = 60017 # Constant c_int
-UIA_TextChildPatternId = 10029 # Constant c_int
-UIA_Transform2CanZoomPropertyId = 30133 # Constant c_int
-UIA_DragPatternId = 10030 # Constant c_int
-UIA_AppBarControlTypeId = 50040 # Constant c_int
-UIA_ToggleToggleStatePropertyId = 30086 # Constant c_int
-class IUIAutomationScrollPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+class IUIAutomationMultipleViewPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
-    _iid_ = GUID('{88F4D42A-E881-459D-A77C-73BBBB7E02DC}')
+    _iid_ = GUID('{8D253C91-1DC5-4BB5-B18F-ADE16FA495E8}')
     _idlflags_ = []
-IUIAutomationScrollPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'Scroll',
-              ( ['in'], ScrollAmount, 'horizontalAmount' ),
-              ( ['in'], ScrollAmount, 'verticalAmount' )),
-    COMMETHOD([], HRESULT, 'SetScrollPercent',
-              ( ['in'], c_double, 'horizontalPercent' ),
-              ( ['in'], c_double, 'verticalPercent' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentHorizontalScrollPercent',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentVerticalScrollPercent',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentHorizontalViewSize',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentVerticalViewSize',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentHorizontallyScrollable',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentVerticallyScrollable',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHorizontalScrollPercent',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedVerticalScrollPercent',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHorizontalViewSize',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedVerticalViewSize',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHorizontallyScrollable',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedVerticallyScrollable',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+IUIAutomationMultipleViewPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetViewName',
+              ( ['in'], c_int, 'view' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'name' )),
+    COMMETHOD([], HRESULT, 'SetCurrentView',
+              ( ['in'], c_int, 'view' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentCurrentView',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentSupportedViews',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedCurrentView',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedSupportedViews',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
 ]
 ################################################################
-## code template for IUIAutomationScrollPattern implementation
-##class IUIAutomationScrollPattern_Impl(object):
-##    @property
-##    def CachedVerticalScrollPercent(self):
+## code template for IUIAutomationMultipleViewPattern implementation
+##class IUIAutomationMultipleViewPattern_Impl(object):
+##    def GetViewName(self, view):
 ##        '-no docstring-'
-##        #return retVal
+##        #return name
 ##
-##    @property
-##    def CachedHorizontalViewSize(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedVerticalViewSize(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentHorizontalViewSize(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedHorizontalScrollPercent(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedHorizontallyScrollable(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentHorizontalScrollPercent(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def Scroll(self, horizontalAmount, verticalAmount):
+##    def SetCurrentView(self, view):
 ##        '-no docstring-'
 ##        #return 
 ##
 ##    @property
-##    def CurrentHorizontallyScrollable(self):
+##    def CurrentCurrentView(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentSupportedViews(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
 ##    @property
-##    def CurrentVerticalViewSize(self):
+##    def CachedCurrentView(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
-##    @property
-##    def CurrentVerticallyScrollable(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedVerticallyScrollable(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def SetScrollPercent(self, horizontalPercent, verticalPercent):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentVerticalScrollPercent(self):
+##    def GetCachedSupportedViews(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
 
+class IUIAutomationTextChildPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{6552B038-AE05-40C8-ABFD-AA08352AAB86}')
+    _idlflags_ = []
+IUIAutomationTextChildPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'TextContainer',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'container' )),
+    COMMETHOD(['propget'], HRESULT, 'TextRange',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
+]
+################################################################
+## code template for IUIAutomationTextChildPattern implementation
+##class IUIAutomationTextChildPattern_Impl(object):
+##    @property
+##    def TextContainer(self):
+##        '-no docstring-'
+##        #return container
+##
+##    @property
+##    def TextRange(self):
+##        '-no docstring-'
+##        #return range
+##
+
+class IUIAutomationDragPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{1DC7B570-1F54-4BAD-BCDA-D36A722FB7BD}')
+    _idlflags_ = []
+IUIAutomationDragPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentIsGrabbed',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedIsGrabbed',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDropEffect',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDropEffect',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDropEffects',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDropEffects',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentGrabbedItems',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedGrabbedItems',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationDragPattern implementation
+##class IUIAutomationDragPattern_Impl(object):
+##    @property
+##    def CurrentIsGrabbed(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedIsGrabbed(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentDropEffect(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedDropEffect(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentDropEffects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedDropEffects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentGrabbedItems(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedGrabbedItems(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationDropTargetPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{69A095F7-EEE4-430E-A46B-FB73B1AE39A5}')
+    _idlflags_ = []
+IUIAutomationDropTargetPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentDropTargetEffect',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDropTargetEffect',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDropTargetEffects',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDropTargetEffects',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationDropTargetPattern implementation
+##class IUIAutomationDropTargetPattern_Impl(object):
+##    @property
+##    def CurrentDropTargetEffect(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedDropTargetEffect(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentDropTargetEffects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedDropTargetEffects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+class IUIAutomationNotCondition(IUIAutomationCondition):
+    _case_insensitive_ = True
+    _iid_ = GUID('{F528B657-847B-498C-8896-D52B565407A1}')
+    _idlflags_ = []
+IUIAutomationNotCondition._methods_ = [
+    COMMETHOD([], HRESULT, 'GetChild',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
+]
+################################################################
+## code template for IUIAutomationNotCondition implementation
+##class IUIAutomationNotCondition_Impl(object):
+##    def GetChild(self):
+##        '-no docstring-'
+##        #return condition
+##
+
+UIA_AnimationStyleAttributeId = 40000 # Constant c_int
+UIA_CultureAttributeId = 40004 # Constant c_int
+UIA_BackgroundColorAttributeId = 40001 # Constant c_int
+IUIAutomationEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleAutomationEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( ['in'], c_int, 'eventId' )),
+]
+################################################################
+## code template for IUIAutomationEventHandler implementation
+##class IUIAutomationEventHandler_Impl(object):
+##    def HandleAutomationEvent(self, sender, eventId):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_CapStyleAttributeId = 40003 # Constant c_int
+UIA_BulletStyleAttributeId = 40002 # Constant c_int
+UIA_FontNameAttributeId = 40005 # Constant c_int
+UIA_ScrollHorizontalViewSizePropertyId = 30054 # Constant c_int
+UIA_ScrollVerticalScrollPercentPropertyId = 30055 # Constant c_int
+UIA_ScrollVerticalViewSizePropertyId = 30056 # Constant c_int
+class IUIAutomationStylesPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{85B5F0A2-BD79-484A-AD2B-388C9838D5FB}')
+    _idlflags_ = []
+class ExtendedProperty(Structure):
+    pass
+IUIAutomationStylesPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentStyleId',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentStyleName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentFillColor',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentFillPatternStyle',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentShape',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentFillPatternColor',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentExtendedProperties',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentExtendedPropertiesAsArray',
+              ( ['out'], POINTER(POINTER(ExtendedProperty)), 'propertyArray' ),
+              ( ['out'], POINTER(c_int), 'propertyCount' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedStyleId',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedStyleName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFillColor',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFillPatternStyle',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedShape',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFillPatternColor',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedExtendedProperties',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedExtendedPropertiesAsArray',
+              ( ['out'], POINTER(POINTER(ExtendedProperty)), 'propertyArray' ),
+              ( ['out'], POINTER(c_int), 'propertyCount' )),
+]
+################################################################
+## code template for IUIAutomationStylesPattern implementation
+##class IUIAutomationStylesPattern_Impl(object):
+##    @property
+##    def CurrentStyleId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentStyleName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentFillColor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentFillPatternStyle(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentShape(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentFillPatternColor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentExtendedProperties(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentExtendedPropertiesAsArray(self):
+##        '-no docstring-'
+##        #return propertyArray, propertyCount
+##
+##    @property
+##    def CachedStyleId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedStyleName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFillColor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFillPatternStyle(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedShape(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFillPatternColor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedExtendedProperties(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedExtendedPropertiesAsArray(self):
+##        '-no docstring-'
+##        #return propertyArray, propertyCount
+##
+
+UIA_ScrollHorizontallyScrollablePropertyId = 30057 # Constant c_int
+UIA_ScrollVerticallyScrollablePropertyId = 30058 # Constant c_int
+IAccessible._methods_ = [
+    COMMETHOD([dispid(-5000), 'hidden', 'propget'], HRESULT, 'accParent',
+              ( ['out', 'retval'], POINTER(POINTER(IDispatch)), 'ppdispParent' )),
+    COMMETHOD([dispid(-5001), 'hidden', 'propget'], HRESULT, 'accChildCount',
+              ( ['out', 'retval'], POINTER(c_int), 'pcountChildren' )),
+    COMMETHOD([dispid(-5002), 'hidden', 'propget'], HRESULT, 'accChild',
+              ( ['in'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(POINTER(IDispatch)), 'ppdispChild' )),
+    COMMETHOD([dispid(-5003), 'hidden', 'propget'], HRESULT, 'accName',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'pszName' )),
+    COMMETHOD([dispid(-5004), 'hidden', 'propget'], HRESULT, 'accValue',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'pszValue' )),
+    COMMETHOD([dispid(-5005), 'hidden', 'propget'], HRESULT, 'accDescription',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'pszDescription' )),
+    COMMETHOD([dispid(-5006), 'hidden', 'propget'], HRESULT, 'accRole',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'pvarRole' )),
+    COMMETHOD([dispid(-5007), 'hidden', 'propget'], HRESULT, 'accState',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'pvarState' )),
+    COMMETHOD([dispid(-5008), 'hidden', 'propget'], HRESULT, 'accHelp',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'pszHelp' )),
+    COMMETHOD([dispid(-5009), 'hidden', 'propget'], HRESULT, 'accHelpTopic',
+              ( ['out'], POINTER(BSTR), 'pszHelpFile' ),
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(c_int), 'pidTopic' )),
+    COMMETHOD([dispid(-5010), 'hidden', 'propget'], HRESULT, 'accKeyboardShortcut',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'pszKeyboardShortcut' )),
+    COMMETHOD([dispid(-5011), 'hidden', 'propget'], HRESULT, 'accFocus',
+              ( ['out', 'retval'], POINTER(VARIANT), 'pvarChild' )),
+    COMMETHOD([dispid(-5012), 'hidden', 'propget'], HRESULT, 'accSelection',
+              ( ['out', 'retval'], POINTER(VARIANT), 'pvarChildren' )),
+    COMMETHOD([dispid(-5013), 'hidden', 'propget'], HRESULT, 'accDefaultAction',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['out', 'retval'], POINTER(BSTR), 'pszDefaultAction' )),
+    COMMETHOD([dispid(-5014), 'hidden'], HRESULT, 'accSelect',
+              ( ['in'], c_int, 'flagsSelect' ),
+              ( ['in', 'optional'], VARIANT, 'varChild' )),
+    COMMETHOD([dispid(-5015), 'hidden'], HRESULT, 'accLocation',
+              ( ['out'], POINTER(c_int), 'pxLeft' ),
+              ( ['out'], POINTER(c_int), 'pyTop' ),
+              ( ['out'], POINTER(c_int), 'pcxWidth' ),
+              ( ['out'], POINTER(c_int), 'pcyHeight' ),
+              ( ['in', 'optional'], VARIANT, 'varChild' )),
+    COMMETHOD([dispid(-5016), 'hidden'], HRESULT, 'accNavigate',
+              ( ['in'], c_int, 'navDir' ),
+              ( ['in', 'optional'], VARIANT, 'varStart' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'pvarEndUpAt' )),
+    COMMETHOD([dispid(-5017), 'hidden'], HRESULT, 'accHitTest',
+              ( ['in'], c_int, 'xLeft' ),
+              ( ['in'], c_int, 'yTop' ),
+              ( ['out', 'retval'], POINTER(VARIANT), 'pvarChild' )),
+    COMMETHOD([dispid(-5018), 'hidden'], HRESULT, 'accDoDefaultAction',
+              ( ['in', 'optional'], VARIANT, 'varChild' )),
+    COMMETHOD([dispid(-5003), 'hidden', 'propput'], HRESULT, 'accName',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['in'], BSTR, 'pszName' )),
+    COMMETHOD([dispid(-5004), 'hidden', 'propput'], HRESULT, 'accValue',
+              ( ['in', 'optional'], VARIANT, 'varChild' ),
+              ( ['in'], BSTR, 'pszValue' )),
+]
+################################################################
+## code template for IAccessible implementation
+##class IAccessible_Impl(object):
+##    @property
+##    def accParent(self):
+##        '-no docstring-'
+##        #return ppdispParent
+##
+##    @property
+##    def accChildCount(self):
+##        '-no docstring-'
+##        #return pcountChildren
+##
+##    @property
+##    def accChild(self, varChild):
+##        '-no docstring-'
+##        #return ppdispChild
+##
+##    def _get(self, varChild):
+##        '-no docstring-'
+##        #return pszName
+##    def _set(self, varChild, pszName):
+##        '-no docstring-'
+##    accName = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self, varChild):
+##        '-no docstring-'
+##        #return pszValue
+##    def _set(self, varChild, pszValue):
+##        '-no docstring-'
+##    accValue = property(_get, _set, doc = _set.__doc__)
+##
+##    @property
+##    def accDescription(self, varChild):
+##        '-no docstring-'
+##        #return pszDescription
+##
+##    @property
+##    def accRole(self, varChild):
+##        '-no docstring-'
+##        #return pvarRole
+##
+##    @property
+##    def accState(self, varChild):
+##        '-no docstring-'
+##        #return pvarState
+##
+##    @property
+##    def accHelp(self, varChild):
+##        '-no docstring-'
+##        #return pszHelp
+##
+##    @property
+##    def accHelpTopic(self, varChild):
+##        '-no docstring-'
+##        #return pszHelpFile, pidTopic
+##
+##    @property
+##    def accKeyboardShortcut(self, varChild):
+##        '-no docstring-'
+##        #return pszKeyboardShortcut
+##
+##    @property
+##    def accFocus(self):
+##        '-no docstring-'
+##        #return pvarChild
+##
+##    @property
+##    def accSelection(self):
+##        '-no docstring-'
+##        #return pvarChildren
+##
+##    @property
+##    def accDefaultAction(self, varChild):
+##        '-no docstring-'
+##        #return pszDefaultAction
+##
+##    def accSelect(self, flagsSelect, varChild):
+##        '-no docstring-'
+##        #return 
+##
+##    def accLocation(self, varChild):
+##        '-no docstring-'
+##        #return pxLeft, pyTop, pcxWidth, pcyHeight
+##
+##    def accNavigate(self, navDir, varStart):
+##        '-no docstring-'
+##        #return pvarEndUpAt
+##
+##    def accHitTest(self, xLeft, yTop):
+##        '-no docstring-'
+##        #return pvarChild
+##
+##    def accDoDefaultAction(self, varChild):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_SelectionSelectionPropertyId = 30059 # Constant c_int
+UIA_SelectionCanSelectMultiplePropertyId = 30060 # Constant c_int
+UIA_SelectionIsSelectionRequiredPropertyId = 30061 # Constant c_int
+UIA_GridRowCountPropertyId = 30062 # Constant c_int
+UIA_GridColumnCountPropertyId = 30063 # Constant c_int
+UIA_GridItemRowPropertyId = 30064 # Constant c_int
+UIA_GridItemColumnPropertyId = 30065 # Constant c_int
+UIA_GridItemRowSpanPropertyId = 30066 # Constant c_int
+UIA_GridItemColumnSpanPropertyId = 30067 # Constant c_int
+UIA_GridItemContainingGridPropertyId = 30068 # Constant c_int
+UIA_DockDockPositionPropertyId = 30069 # Constant c_int
+UIA_ExpandCollapseExpandCollapseStatePropertyId = 30070 # Constant c_int
+IUIAutomationPropertyChangedEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandlePropertyChangedEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['in'], VARIANT, 'newValue' )),
+]
+################################################################
+## code template for IUIAutomationPropertyChangedEventHandler implementation
+##class IUIAutomationPropertyChangedEventHandler_Impl(object):
+##    def HandlePropertyChangedEvent(self, sender, propertyId, newValue):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_MultipleViewCurrentViewPropertyId = 30071 # Constant c_int
+UIA_MultipleViewSupportedViewsPropertyId = 30072 # Constant c_int
+UIA_WindowCanMaximizePropertyId = 30073 # Constant c_int
+UIA_WindowCanMinimizePropertyId = 30074 # Constant c_int
+UIA_WindowWindowVisualStatePropertyId = 30075 # Constant c_int
+UIA_WindowWindowInteractionStatePropertyId = 30076 # Constant c_int
+UIA_WindowIsModalPropertyId = 30077 # Constant c_int
+UIA_WindowIsTopmostPropertyId = 30078 # Constant c_int
+UIA_SelectionItemIsSelectedPropertyId = 30079 # Constant c_int
+
+# values for enumeration 'StructureChangeType'
+StructureChangeType_ChildAdded = 0
+StructureChangeType_ChildRemoved = 1
+StructureChangeType_ChildrenInvalidated = 2
+StructureChangeType_ChildrenBulkAdded = 3
+StructureChangeType_ChildrenBulkRemoved = 4
+StructureChangeType_ChildrenReordered = 5
+StructureChangeType = c_int # enum
+IUIAutomationStructureChangedEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleStructureChangedEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( ['in'], StructureChangeType, 'changeType' ),
+              ( ['in'], _midlSAFEARRAY(c_int), 'runtimeId' )),
+]
+################################################################
+## code template for IUIAutomationStructureChangedEventHandler implementation
+##class IUIAutomationStructureChangedEventHandler_Impl(object):
+##    def HandleStructureChangedEvent(self, sender, changeType, runtimeId):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_SelectionItemSelectionContainerPropertyId = 30080 # Constant c_int
+UIA_TableRowHeadersPropertyId = 30081 # Constant c_int
+UIA_TableColumnHeadersPropertyId = 30082 # Constant c_int
+UIA_TableRowOrColumnMajorPropertyId = 30083 # Constant c_int
+UIA_TableItemRowHeaderItemsPropertyId = 30084 # Constant c_int
+UIA_TableItemColumnHeaderItemsPropertyId = 30085 # Constant c_int
+UIA_ToggleToggleStatePropertyId = 30086 # Constant c_int
+UIA_TransformCanMovePropertyId = 30087 # Constant c_int
 UIA_TransformCanResizePropertyId = 30088 # Constant c_int
-UIA_SelectionPattern2Id = 10034 # Constant c_int
-UIA_IsSelectionPattern2AvailablePropertyId = 30168 # Constant c_int
-UIA_TransformPatternId = 10016 # Constant c_int
-UIA_IsTransformPattern2AvailablePropertyId = 30134 # Constant c_int
+UIA_TransformCanRotatePropertyId = 30089 # Constant c_int
 UIA_IsLegacyIAccessiblePatternAvailablePropertyId = 30090 # Constant c_int
 UIA_LegacyIAccessibleChildIdPropertyId = 30091 # Constant c_int
-UIA_CustomLandmarkTypeId = 80000 # Constant c_int
-UIA_ComboBoxControlTypeId = 50003 # Constant c_int
-UIA_HyperlinkControlTypeId = 50005 # Constant c_int
-StyleId_Normal = 70012 # Constant c_int
-StyleId_Title = 70010 # Constant c_int
-UIA_ListItemControlTypeId = 50007 # Constant c_int
-UIA_IsTextChildPatternAvailablePropertyId = 30136 # Constant c_int
+UIA_LegacyIAccessibleNamePropertyId = 30092 # Constant c_int
+UIA_LegacyIAccessibleValuePropertyId = 30093 # Constant c_int
+UIA_LegacyIAccessibleDescriptionPropertyId = 30094 # Constant c_int
+UIA_LegacyIAccessibleRolePropertyId = 30095 # Constant c_int
+UIA_LegacyIAccessibleStatePropertyId = 30096 # Constant c_int
+IUIAutomationFocusChangedEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleFocusChangedEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' )),
+]
+################################################################
+## code template for IUIAutomationFocusChangedEventHandler implementation
+##class IUIAutomationFocusChangedEventHandler_Impl(object):
+##    def HandleFocusChangedEvent(self, sender):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_LegacyIAccessibleHelpPropertyId = 30097 # Constant c_int
+UIA_LegacyIAccessibleKeyboardShortcutPropertyId = 30098 # Constant c_int
 UIA_LegacyIAccessibleSelectionPropertyId = 30099 # Constant c_int
-UIA_AriaPropertiesPropertyId = 30102 # Constant c_int
-UIA_Transform2ZoomLevelPropertyId = 30145 # Constant c_int
+ExtendedProperty._fields_ = [
+    ('PropertyName', BSTR),
+    ('PropertyValue', BSTR),
+]
+assert sizeof(ExtendedProperty) == 8, sizeof(ExtendedProperty)
+assert alignment(ExtendedProperty) == 4, alignment(ExtendedProperty)
 UIA_LegacyIAccessibleDefaultActionPropertyId = 30100 # Constant c_int
 UIA_AriaRolePropertyId = 30101 # Constant c_int
-UIA_MenuItemControlTypeId = 50011 # Constant c_int
+UIA_AriaPropertiesPropertyId = 30102 # Constant c_int
 UIA_IsDataValidForFormPropertyId = 30103 # Constant c_int
-UIA_RadioButtonControlTypeId = 50013 # Constant c_int
+UIA_ControllerForPropertyId = 30104 # Constant c_int
 UIA_DescribedByPropertyId = 30105 # Constant c_int
+UIA_FlowsToPropertyId = 30106 # Constant c_int
+IUIAutomationTextEditTextChangedEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleTextEditTextChangedEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( ['in'], TextEditChangeType, 'TextEditChangeType' ),
+              ( ['in'], _midlSAFEARRAY(BSTR), 'eventStrings' )),
+]
+################################################################
+## code template for IUIAutomationTextEditTextChangedEventHandler implementation
+##class IUIAutomationTextEditTextChangedEventHandler_Impl(object):
+##    def HandleTextEditTextChangedEvent(self, sender, TextEditChangeType, eventStrings):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_ProviderDescriptionPropertyId = 30107 # Constant c_int
+UIA_IsItemContainerPatternAvailablePropertyId = 30108 # Constant c_int
+UIA_IsVirtualizedItemPatternAvailablePropertyId = 30109 # Constant c_int
+UIA_IsSynchronizedInputPatternAvailablePropertyId = 30110 # Constant c_int
+UIA_OptimizeForVisualContentPropertyId = 30111 # Constant c_int
+UIA_IsObjectModelPatternAvailablePropertyId = 30112 # Constant c_int
+UIA_AnnotationAnnotationTypeIdPropertyId = 30113 # Constant c_int
+UIA_AnnotationAnnotationTypeNamePropertyId = 30114 # Constant c_int
+UIA_AnnotationAuthorPropertyId = 30115 # Constant c_int
+UIA_AnnotationDateTimePropertyId = 30116 # Constant c_int
+class IUIAutomationSpreadsheetPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{7517A7C8-FAAE-4DE9-9F08-29B91E8595C1}')
+    _idlflags_ = []
+IUIAutomationSpreadsheetPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'GetItemByName',
+              ( ['in'], BSTR, 'name' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
+]
+################################################################
+## code template for IUIAutomationSpreadsheetPattern implementation
+##class IUIAutomationSpreadsheetPattern_Impl(object):
+##    def GetItemByName(self, name):
+##        '-no docstring-'
+##        #return element
+##
+
+UIA_AnnotationTargetPropertyId = 30117 # Constant c_int
+UIA_IsAnnotationPatternAvailablePropertyId = 30118 # Constant c_int
+UIA_IsTextPattern2AvailablePropertyId = 30119 # Constant c_int
+UIA_StylesStyleIdPropertyId = 30120 # Constant c_int
+UIA_StylesStyleNamePropertyId = 30121 # Constant c_int
+UIA_StylesFillColorPropertyId = 30122 # Constant c_int
+UIA_StylesFillPatternStylePropertyId = 30123 # Constant c_int
+UIA_StylesShapePropertyId = 30124 # Constant c_int
+class IUIAutomationSpreadsheetItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{7D4FB86C-8D34-40E1-8E83-62C15204E335}')
+    _idlflags_ = []
+IUIAutomationSpreadsheetItemPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentFormula',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentAnnotationObjects',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCurrentAnnotationTypes',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedFormula',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedAnnotationObjects',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
+    COMMETHOD([], HRESULT, 'GetCachedAnnotationTypes',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationSpreadsheetItemPattern implementation
+##class IUIAutomationSpreadsheetItemPattern_Impl(object):
+##    @property
+##    def CurrentFormula(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentAnnotationObjects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCurrentAnnotationTypes(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedFormula(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedAnnotationObjects(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    def GetCachedAnnotationTypes(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+UIA_StylesFillPatternColorPropertyId = 30125 # Constant c_int
+UIA_StylesExtendedPropertiesPropertyId = 30126 # Constant c_int
+UIA_IsStylesPatternAvailablePropertyId = 30127 # Constant c_int
+UIA_IsSpreadsheetPatternAvailablePropertyId = 30128 # Constant c_int
+UIA_SpreadsheetItemFormulaPropertyId = 30129 # Constant c_int
+UIA_SpreadsheetItemAnnotationObjectsPropertyId = 30130 # Constant c_int
+class IUIAutomationItemContainerPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{C690FDB2-27A8-423C-812D-429773C9084E}')
+    _idlflags_ = []
+IUIAutomationItemContainerPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'FindItemByProperty',
+              ( ['in'], POINTER(IUIAutomationElement), 'pStartAfter' ),
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['in'], VARIANT, 'value' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'pFound' )),
+]
+################################################################
+## code template for IUIAutomationItemContainerPattern implementation
+##class IUIAutomationItemContainerPattern_Impl(object):
+##    def FindItemByProperty(self, pStartAfter, propertyId, value):
+##        '-no docstring-'
+##        #return pFound
+##
+
+UIA_SpreadsheetItemAnnotationTypesPropertyId = 30131 # Constant c_int
+UIA_IsSpreadsheetItemPatternAvailablePropertyId = 30132 # Constant c_int
+UIA_Transform2CanZoomPropertyId = 30133 # Constant c_int
+UIA_IsTransformPattern2AvailablePropertyId = 30134 # Constant c_int
+
+# values for enumeration 'NotificationKind'
+NotificationKind_ItemAdded = 0
+NotificationKind_ItemRemoved = 1
+NotificationKind_ActionCompleted = 2
+NotificationKind_ActionAborted = 3
+NotificationKind_Other = 4
+NotificationKind = c_int # enum
+
+# values for enumeration 'NotificationProcessing'
+NotificationProcessing_ImportantAll = 0
+NotificationProcessing_ImportantMostRecent = 1
+NotificationProcessing_All = 2
+NotificationProcessing_MostRecent = 3
+NotificationProcessing_CurrentThenMostRecent = 4
+NotificationProcessing = c_int # enum
+IUIAutomationNotificationEventHandler._methods_ = [
+    COMMETHOD([], HRESULT, 'HandleNotificationEvent',
+              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
+              ( [], NotificationKind, 'NotificationKind' ),
+              ( [], NotificationProcessing, 'NotificationProcessing' ),
+              ( ['in'], BSTR, 'displayString' ),
+              ( ['in'], BSTR, 'activityId' )),
+]
+################################################################
+## code template for IUIAutomationNotificationEventHandler implementation
+##class IUIAutomationNotificationEventHandler_Impl(object):
+##    def HandleNotificationEvent(self, sender, NotificationKind, NotificationProcessing, displayString, activityId):
+##        '-no docstring-'
+##        #return 
+##
+
+UIA_LiveSettingPropertyId = 30135 # Constant c_int
+UIA_IsTextChildPatternAvailablePropertyId = 30136 # Constant c_int
+UiaChangeInfo._fields_ = [
+    ('uiaId', c_int),
+    ('payload', VARIANT),
+    ('extraInfo', VARIANT),
+]
+assert sizeof(UiaChangeInfo) == 40, sizeof(UiaChangeInfo)
+assert alignment(UiaChangeInfo) == 8, alignment(UiaChangeInfo)
+UIA_IsDragPatternAvailablePropertyId = 30137 # Constant c_int
 class IUIAutomationVirtualizedItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{6BA3D7A6-04CF-4F11-8793-A8D1CDE9969F}')
@@ -3240,87 +4375,254 @@ IUIAutomationVirtualizedItemPattern._methods_ = [
 ##        #return 
 ##
 
-UIA_ProviderDescriptionPropertyId = 30107 # Constant c_int
-UIA_IsItemContainerPatternAvailablePropertyId = 30108 # Constant c_int
-UIA_WindowCanMaximizePropertyId = 30073 # Constant c_int
-UIA_IsVirtualizedItemPatternAvailablePropertyId = 30109 # Constant c_int
-UIA_TabItemControlTypeId = 50019 # Constant c_int
-UIA_LayoutInvalidatedEventId = 20008 # Constant c_int
-UIA_OptimizeForVisualContentPropertyId = 30111 # Constant c_int
-class IUIAutomationTextRangeArray(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+UIA_DragIsGrabbedPropertyId = 30138 # Constant c_int
+UIA_DragDropEffectPropertyId = 30139 # Constant c_int
+UIA_DragDropEffectsPropertyId = 30140 # Constant c_int
+UIA_IsDropTargetPatternAvailablePropertyId = 30141 # Constant c_int
+UIA_DropTargetDropTargetEffectPropertyId = 30142 # Constant c_int
+UIA_DropTargetDropTargetEffectsPropertyId = 30143 # Constant c_int
+UIA_DragGrabbedItemsPropertyId = 30144 # Constant c_int
+UIA_Transform2ZoomLevelPropertyId = 30145 # Constant c_int
+UIA_Transform2ZoomMinimumPropertyId = 30146 # Constant c_int
+class IUIAutomationInvokePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
-    _iid_ = GUID('{CE4AE76A-E717-4C98-81EA-47371D028EB6}')
+    _iid_ = GUID('{FB377FBE-8EA6-46D5-9C73-6499642D3059}')
     _idlflags_ = []
-IUIAutomationTextRangeArray._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'Length',
-              ( ['retval', 'out'], POINTER(c_int), 'Length' )),
-    COMMETHOD([], HRESULT, 'GetElement',
-              ( ['in'], c_int, 'index' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'element' )),
+IUIAutomationInvokePattern._methods_ = [
+    COMMETHOD([], HRESULT, 'Invoke'),
 ]
 ################################################################
-## code template for IUIAutomationTextRangeArray implementation
-##class IUIAutomationTextRangeArray_Impl(object):
-##    @property
-##    def Length(self):
+## code template for IUIAutomationInvokePattern implementation
+##class IUIAutomationInvokePattern_Impl(object):
+##    def Invoke(self):
 ##        '-no docstring-'
-##        #return Length
-##
-##    def GetElement(self, index):
-##        '-no docstring-'
-##        #return element
+##        #return 
 ##
 
-class IUIAutomationElement8(IUIAutomationElement7):
+UIA_Transform2ZoomMaximumPropertyId = 30147 # Constant c_int
+UIA_FlowsFromPropertyId = 30148 # Constant c_int
+UIA_IsTextEditPatternAvailablePropertyId = 30149 # Constant c_int
+UIA_IsPeripheralPropertyId = 30150 # Constant c_int
+class IUIAutomationDockPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
-    _iid_ = GUID('{8C60217D-5411-4CDE-BCC0-1CEDA223830C}')
+    _iid_ = GUID('{FDE5EF97-1464-48F6-90BF-43D0948E86EC}')
     _idlflags_ = []
-IUIAutomationElement8._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentHeadingLevel',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHeadingLevel',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
+IUIAutomationDockPattern._methods_ = [
+    COMMETHOD([], HRESULT, 'SetDockPosition',
+              ( ['in'], DockPosition, 'dockPos' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDockPosition',
+              ( ['out', 'retval'], POINTER(DockPosition), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDockPosition',
+              ( ['out', 'retval'], POINTER(DockPosition), 'retVal' )),
 ]
 ################################################################
-## code template for IUIAutomationElement8 implementation
-##class IUIAutomationElement8_Impl(object):
+## code template for IUIAutomationDockPattern implementation
+##class IUIAutomationDockPattern_Impl(object):
+##    def SetDockPosition(self, dockPos):
+##        '-no docstring-'
+##        #return 
+##
 ##    @property
-##    def CachedHeadingLevel(self):
+##    def CurrentDockPosition(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
 ##    @property
-##    def CurrentHeadingLevel(self):
+##    def CachedDockPosition(self):
 ##        '-no docstring-'
 ##        #return retVal
 ##
 
-UIA_LegacyIAccessibleHelpPropertyId = 30097 # Constant c_int
-UIA_LegacyIAccessibleNamePropertyId = 30092 # Constant c_int
-UIA_LegacyIAccessibleValuePropertyId = 30093 # Constant c_int
-UIA_LegacyIAccessibleDescriptionPropertyId = 30094 # Constant c_int
-UIA_LegacyIAccessibleRolePropertyId = 30095 # Constant c_int
-UIA_LegacyIAccessibleStatePropertyId = 30096 # Constant c_int
-UIA_AnnotationAnnotationTypeIdPropertyId = 30113 # Constant c_int
-UIA_Invoke_InvokedEventId = 20009 # Constant c_int
-UIA_SelectionItem_ElementAddedToSelectionEventId = 20010 # Constant c_int
-UIA_SelectionItem_ElementRemovedFromSelectionEventId = 20011 # Constant c_int
-UIA_SelectionItem_ElementSelectedEventId = 20012 # Constant c_int
-UIA_Selection_InvalidatedEventId = 20013 # Constant c_int
-UIA_AnnotationAnnotationTypeNamePropertyId = 30114 # Constant c_int
-UIA_Text_TextChangedEventId = 20015 # Constant c_int
-AnnotationType_TrackChanges = 60005 # Constant c_int
-UIA_Window_WindowOpenedEventId = 20016 # Constant c_int
-UIA_Window_WindowClosedEventId = 20017 # Constant c_int
-UIA_MenuModeStartEventId = 20018 # Constant c_int
-UIA_MenuModeEndEventId = 20019 # Constant c_int
-UIA_AnnotationAuthorPropertyId = 30115 # Constant c_int
-UIA_InputReachedOtherElementEventId = 20021 # Constant c_int
-UIA_InputDiscardedEventId = 20022 # Constant c_int
-UIA_SystemAlertEventId = 20023 # Constant c_int
-UIA_LiveRegionChangedEventId = 20024 # Constant c_int
-UIA_HostedFragmentRootsInvalidatedEventId = 20025 # Constant c_int
-UIA_CustomControlTypeId = 50025 # Constant c_int
+UIA_IsCustomNavigationPatternAvailablePropertyId = 30151 # Constant c_int
+UIA_PositionInSetPropertyId = 30152 # Constant c_int
+UIA_SizeOfSetPropertyId = 30153 # Constant c_int
+UIA_LevelPropertyId = 30154 # Constant c_int
+UIA_AnnotationTypesPropertyId = 30155 # Constant c_int
+class IUIAutomationTransformPattern2(IUIAutomationTransformPattern):
+    _case_insensitive_ = True
+    _iid_ = GUID('{6D74D017-6ECB-4381-B38B-3C17A48FF1C2}')
+    _idlflags_ = []
+
+# values for enumeration 'ZoomUnit'
+ZoomUnit_NoAmount = 0
+ZoomUnit_LargeDecrement = 1
+ZoomUnit_SmallDecrement = 2
+ZoomUnit_LargeIncrement = 3
+ZoomUnit_SmallIncrement = 4
+ZoomUnit = c_int # enum
+IUIAutomationTransformPattern2._methods_ = [
+    COMMETHOD([], HRESULT, 'Zoom',
+              ( ['in'], c_double, 'zoomValue' )),
+    COMMETHOD([], HRESULT, 'ZoomByUnit',
+              ( ['in'], ZoomUnit, 'ZoomUnit' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentCanZoom',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedCanZoom',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentZoomLevel',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedZoomLevel',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentZoomMinimum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedZoomMinimum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentZoomMaximum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedZoomMaximum',
+              ( ['out', 'retval'], POINTER(c_double), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationTransformPattern2 implementation
+##class IUIAutomationTransformPattern2_Impl(object):
+##    def Zoom(self, zoomValue):
+##        '-no docstring-'
+##        #return 
+##
+##    def ZoomByUnit(self, ZoomUnit):
+##        '-no docstring-'
+##        #return 
+##
+##    @property
+##    def CurrentCanZoom(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedCanZoom(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentZoomLevel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedZoomLevel(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentZoomMinimum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedZoomMinimum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentZoomMaximum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedZoomMaximum(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+UIA_AnnotationObjectsPropertyId = 30156 # Constant c_int
+UIA_LandmarkTypePropertyId = 30157 # Constant c_int
+UIA_LocalizedLandmarkTypePropertyId = 30158 # Constant c_int
+class IUIAutomationAnnotationPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{9A175B21-339E-41B1-8E8B-623F6B681098}')
+    _idlflags_ = []
+IUIAutomationAnnotationPattern._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationTypeId',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationTypeName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentAuthor',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentDateTime',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CurrentTarget',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationTypeId',
+              ( ['out', 'retval'], POINTER(c_int), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationTypeName',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedAuthor',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedDateTime',
+              ( ['out', 'retval'], POINTER(BSTR), 'retVal' )),
+    COMMETHOD(['propget'], HRESULT, 'CachedTarget',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
+]
+################################################################
+## code template for IUIAutomationAnnotationPattern implementation
+##class IUIAutomationAnnotationPattern_Impl(object):
+##    @property
+##    def CurrentAnnotationTypeId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAnnotationTypeName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentAuthor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentDateTime(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CurrentTarget(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAnnotationTypeId(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAnnotationTypeName(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedAuthor(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedDateTime(self):
+##        '-no docstring-'
+##        #return retVal
+##
+##    @property
+##    def CachedTarget(self):
+##        '-no docstring-'
+##        #return retVal
+##
+
+UIA_FullDescriptionPropertyId = 30159 # Constant c_int
+UIA_FillColorPropertyId = 30160 # Constant c_int
+UIA_OutlineColorPropertyId = 30161 # Constant c_int
+UIA_FillTypePropertyId = 30162 # Constant c_int
+UIA_VisualEffectsPropertyId = 30163 # Constant c_int
+UIA_OutlineThicknessPropertyId = 30164 # Constant c_int
+UIA_CenterPointPropertyId = 30165 # Constant c_int
+UIA_RotationPropertyId = 30166 # Constant c_int
+UIA_SizePropertyId = 30167 # Constant c_int
+UIA_IsSelectionPattern2AvailablePropertyId = 30168 # Constant c_int
+UIA_Selection2FirstSelectedItemPropertyId = 30169 # Constant c_int
+UIA_Selection2LastSelectedItemPropertyId = 30170 # Constant c_int
+UIA_Selection2CurrentSelectedItemPropertyId = 30171 # Constant c_int
+UIA_Selection2ItemCountPropertyId = 30172 # Constant c_int
+UIA_HeadingLevelPropertyId = 30173 # Constant c_int
+UIA_IsDialogPropertyId = 30174 # Constant c_int
 class IRawElementProviderSimple(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID('{D6DD68D1-86FD-4332-8666-9ABEDEA2D24C}')
@@ -3330,9 +4632,9 @@ IUIAutomationProxyFactory._methods_ = [
               ( ['in'], c_void_p, 'hwnd' ),
               ( ['in'], c_int, 'idObject' ),
               ( ['in'], c_int, 'idChild' ),
-              ( ['retval', 'out'], POINTER(POINTER(IRawElementProviderSimple)), 'provider' )),
+              ( ['out', 'retval'], POINTER(POINTER(IRawElementProviderSimple)), 'provider' )),
     COMMETHOD(['propget'], HRESULT, 'ProxyFactoryId',
-              ( ['retval', 'out'], POINTER(BSTR), 'factoryId' )),
+              ( ['out', 'retval'], POINTER(BSTR), 'factoryId' )),
 ]
 ################################################################
 ## code template for IUIAutomationProxyFactory implementation
@@ -3347,71 +4649,29 @@ IUIAutomationProxyFactory._methods_ = [
 ##        #return factoryId
 ##
 
-UIA_Drag_DragCompleteEventId = 20028 # Constant c_int
-UIA_DropTarget_DragEnterEventId = 20029 # Constant c_int
-UIA_DropTarget_DragLeaveEventId = 20030 # Constant c_int
-UIA_DropTarget_DroppedEventId = 20031 # Constant c_int
-UIA_TextEdit_TextChangedEventId = 20032 # Constant c_int
-class IUIAutomationElement9(IUIAutomationElement8):
-    _case_insensitive_ = True
-    _iid_ = GUID('{39325FAC-039D-440E-A3A3-5EB81A5CECC3}')
-    _idlflags_ = []
-IUIAutomationElement9._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsDialog',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsDialog',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationElement9 implementation
-##class IUIAutomationElement9_Impl(object):
-##    @property
-##    def CachedIsDialog(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsDialog(self):
-##        '-no docstring-'
-##        #return retVal
-##
 
-UIA_ChangesEventId = 20034 # Constant c_int
-UIA_NotificationEventId = 20035 # Constant c_int
-UIA_ActiveTextPositionChangedEventId = 20036 # Constant c_int
-UIA_RuntimeIdPropertyId = 30000 # Constant c_int
-UIA_ProcessIdPropertyId = 30002 # Constant c_int
-UIA_ControlTypePropertyId = 30003 # Constant c_int
-UIA_LocalizedControlTypePropertyId = 30004 # Constant c_int
-UIA_NamePropertyId = 30005 # Constant c_int
-UIA_AcceleratorKeyPropertyId = 30006 # Constant c_int
-UIA_IsTextPattern2AvailablePropertyId = 30119 # Constant c_int
-UIA_FlowsToPropertyId = 30106 # Constant c_int
-UIA_HasKeyboardFocusPropertyId = 30008 # Constant c_int
-UIA_IsKeyboardFocusablePropertyId = 30009 # Constant c_int
-UIA_IsEnabledPropertyId = 30010 # Constant c_int
-UIA_AutomationIdPropertyId = 30011 # Constant c_int
-UIA_ClassNamePropertyId = 30012 # Constant c_int
-UIA_HelpTextPropertyId = 30013 # Constant c_int
-AnnotationType_DeletionChange = 60012 # Constant c_int
-UIA_CulturePropertyId = 30015 # Constant c_int
-UIA_IsControlElementPropertyId = 30016 # Constant c_int
-UIA_IsContentElementPropertyId = 30017 # Constant c_int
-UIA_LabeledByPropertyId = 30018 # Constant c_int
-UIA_StylesStyleNamePropertyId = 30121 # Constant c_int
-UIA_NativeWindowHandlePropertyId = 30020 # Constant c_int
-UIA_ItemTypePropertyId = 30021 # Constant c_int
+# values for enumeration 'ProviderOptions'
+ProviderOptions_ClientSideProvider = 1
+ProviderOptions_ServerSideProvider = 2
+ProviderOptions_NonClientAreaProvider = 4
+ProviderOptions_OverrideProvider = 8
+ProviderOptions_ProviderOwnsSetFocus = 16
+ProviderOptions_UseComThreading = 32
+ProviderOptions_RefuseNonClientSupport = 64
+ProviderOptions_HasNativeIAccessible = 128
+ProviderOptions_UseClientCoordinates = 256
+ProviderOptions = c_int # enum
 IRawElementProviderSimple._methods_ = [
     COMMETHOD(['propget'], HRESULT, 'ProviderOptions',
-              ( ['retval', 'out'], POINTER(ProviderOptions), 'pRetVal' )),
+              ( ['out', 'retval'], POINTER(ProviderOptions), 'pRetVal' )),
     COMMETHOD([], HRESULT, 'GetPatternProvider',
               ( ['in'], c_int, 'patternId' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUnknown)), 'pRetVal' )),
+              ( ['out', 'retval'], POINTER(POINTER(IUnknown)), 'pRetVal' )),
     COMMETHOD([], HRESULT, 'GetPropertyValue',
               ( ['in'], c_int, 'propertyId' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'pRetVal' )),
+              ( ['out', 'retval'], POINTER(VARIANT), 'pRetVal' )),
     COMMETHOD(['propget'], HRESULT, 'HostRawElementProvider',
-              ( ['retval', 'out'], POINTER(POINTER(IRawElementProviderSimple)), 'pRetVal' )),
+              ( ['out', 'retval'], POINTER(POINTER(IRawElementProviderSimple)), 'pRetVal' )),
 ]
 ################################################################
 ## code template for IRawElementProviderSimple implementation
@@ -3425,513 +4685,364 @@ IRawElementProviderSimple._methods_ = [
 ##        '-no docstring-'
 ##        #return pRetVal
 ##
+##    def GetPropertyValue(self, propertyId):
+##        '-no docstring-'
+##        #return pRetVal
+##
 ##    @property
 ##    def HostRawElementProvider(self):
 ##        '-no docstring-'
 ##        #return pRetVal
 ##
-##    def GetPropertyValue(self, propertyId):
-##        '-no docstring-'
-##        #return pRetVal
-##
 
-UIA_OrientationPropertyId = 30023 # Constant c_int
-UIA_FrameworkIdPropertyId = 30024 # Constant c_int
-UIA_IsRequiredForFormPropertyId = 30025 # Constant c_int
-UIA_ItemStatusPropertyId = 30026 # Constant c_int
-UIA_IsDockPatternAvailablePropertyId = 30027 # Constant c_int
-UIA_IsExpandCollapsePatternAvailablePropertyId = 30028 # Constant c_int
-UIA_IsGridItemPatternAvailablePropertyId = 30029 # Constant c_int
-UIA_IsGridPatternAvailablePropertyId = 30030 # Constant c_int
-UIA_IsInvokePatternAvailablePropertyId = 30031 # Constant c_int
-UIA_IsMultipleViewPatternAvailablePropertyId = 30032 # Constant c_int
-UIA_IsRangeValuePatternAvailablePropertyId = 30033 # Constant c_int
-UIA_IsScrollPatternAvailablePropertyId = 30034 # Constant c_int
-UIA_IsScrollItemPatternAvailablePropertyId = 30035 # Constant c_int
-UIA_IsSelectionItemPatternAvailablePropertyId = 30036 # Constant c_int
-UIA_IsSelectionPatternAvailablePropertyId = 30037 # Constant c_int
-UIA_IsTablePatternAvailablePropertyId = 30038 # Constant c_int
-AnnotationType_Footer = 60007 # Constant c_int
-UIA_IsTransformPatternAvailablePropertyId = 30042 # Constant c_int
-UIA_IsTextPatternAvailablePropertyId = 30040 # Constant c_int
-UIA_IsTogglePatternAvailablePropertyId = 30041 # Constant c_int
-UIA_StructureChangedEventId = 20002 # Constant c_int
-UIA_IsValuePatternAvailablePropertyId = 30043 # Constant c_int
-UIA_IsWindowPatternAvailablePropertyId = 30044 # Constant c_int
-UIA_ValueIsReadOnlyPropertyId = 30046 # Constant c_int
-UIA_RangeValueValuePropertyId = 30047 # Constant c_int
-UIA_RangeValueIsReadOnlyPropertyId = 30048 # Constant c_int
-UIA_MenuOpenedEventId = 20003 # Constant c_int
-UIA_RangeValueMaximumPropertyId = 30050 # Constant c_int
-UIA_RangeValueLargeChangePropertyId = 30051 # Constant c_int
-UIA_RangeValueSmallChangePropertyId = 30052 # Constant c_int
-class IUIAutomationDockPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{FDE5EF97-1464-48F6-90BF-43D0948E86EC}')
-    _idlflags_ = []
-
-# values for enumeration 'DockPosition'
-DockPosition_Top = 0
-DockPosition_Left = 1
-DockPosition_Bottom = 2
-DockPosition_Right = 3
-DockPosition_Fill = 4
-DockPosition_None = 5
-DockPosition = c_int # enum
-IUIAutomationDockPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'SetDockPosition',
-              ( ['in'], DockPosition, 'dockPos' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDockPosition',
-              ( ['retval', 'out'], POINTER(DockPosition), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDockPosition',
-              ( ['retval', 'out'], POINTER(DockPosition), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationDockPattern implementation
-##class IUIAutomationDockPattern_Impl(object):
-##    @property
-##    def CachedDockPosition(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def SetDockPosition(self, dockPos):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentDockPosition(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_ScrollHorizontalViewSizePropertyId = 30054 # Constant c_int
-UIA_MenuClosedEventId = 20007 # Constant c_int
-UIA_ScrollVerticalViewSizePropertyId = 30056 # Constant c_int
-UIA_ValuePatternId = 10002 # Constant c_int
-UIA_RangeValuePatternId = 10003 # Constant c_int
-UIA_ScrollPatternId = 10004 # Constant c_int
-UIA_ExpandCollapsePatternId = 10005 # Constant c_int
-UIA_SelectionIsSelectionRequiredPropertyId = 30061 # Constant c_int
-UIA_GridItemPatternId = 10007 # Constant c_int
-UIA_MultipleViewPatternId = 10008 # Constant c_int
-UIA_WindowPatternId = 10009 # Constant c_int
-UIA_SelectionItemPatternId = 10010 # Constant c_int
-UIA_GridItemRowSpanPropertyId = 30066 # Constant c_int
-UIA_SpreadsheetItemFormulaPropertyId = 30129 # Constant c_int
-UIA_GridItemContainingGridPropertyId = 30068 # Constant c_int
-UIA_TextPatternId = 10014 # Constant c_int
-UIA_TogglePatternId = 10015 # Constant c_int
-UIA_MultipleViewCurrentViewPropertyId = 30071 # Constant c_int
-UIA_ScrollItemPatternId = 10017 # Constant c_int
-class IUIAutomationTextPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{32EBA289-3583-42C9-9C59-3B6D9A1E9B6A}')
-    _idlflags_ = []
-class IUIAutomationTextPattern2(IUIAutomationTextPattern):
-    _case_insensitive_ = True
-    _iid_ = GUID('{506A921A-FCC9-409F-B23B-37EB74106872}')
-    _idlflags_ = []
-IUIAutomationTextPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'RangeFromPoint',
-              ( ['in'], tagPOINT, 'pt' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-    COMMETHOD([], HRESULT, 'RangeFromChild',
-              ( ['in'], POINTER(IUIAutomationElement), 'child' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-    COMMETHOD([], HRESULT, 'GetSelection',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRangeArray)), 'ranges' )),
-    COMMETHOD([], HRESULT, 'GetVisibleRanges',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRangeArray)), 'ranges' )),
-    COMMETHOD(['propget'], HRESULT, 'DocumentRange',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-    COMMETHOD(['propget'], HRESULT, 'SupportedTextSelection',
-              ( ['retval', 'out'], POINTER(SupportedTextSelection), 'SupportedTextSelection' )),
-]
-################################################################
-## code template for IUIAutomationTextPattern implementation
-##class IUIAutomationTextPattern_Impl(object):
-##    def RangeFromChild(self, child):
-##        '-no docstring-'
-##        #return range
-##
-##    def GetVisibleRanges(self):
-##        '-no docstring-'
-##        #return ranges
-##
-##    def GetSelection(self):
-##        '-no docstring-'
-##        #return ranges
-##
-##    @property
-##    def DocumentRange(self):
-##        '-no docstring-'
-##        #return range
-##
-##    @property
-##    def SupportedTextSelection(self):
-##        '-no docstring-'
-##        #return SupportedTextSelection
-##
-##    def RangeFromPoint(self, pt):
-##        '-no docstring-'
-##        #return range
-##
-
-IUIAutomationTextPattern2._methods_ = [
-    COMMETHOD([], HRESULT, 'RangeFromAnnotation',
-              ( ['in'], POINTER(IUIAutomationElement), 'annotation' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-    COMMETHOD([], HRESULT, 'GetCaretRange',
-              ( ['out'], POINTER(c_int), 'isActive' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-]
-################################################################
-## code template for IUIAutomationTextPattern2 implementation
-##class IUIAutomationTextPattern2_Impl(object):
-##    def RangeFromAnnotation(self, annotation):
-##        '-no docstring-'
-##        #return range
-##
-##    def GetCaretRange(self):
-##        '-no docstring-'
-##        #return isActive, range
-##
-
-UIA_ItemContainerPatternId = 10019 # Constant c_int
-UIA_WindowWindowVisualStatePropertyId = 30075 # Constant c_int
-UIA_WindowWindowInteractionStatePropertyId = 30076 # Constant c_int
-UIA_WindowIsModalPropertyId = 30077 # Constant c_int
-UIA_WindowIsTopmostPropertyId = 30078 # Constant c_int
-UIA_TextPattern2Id = 10024 # Constant c_int
-UIA_SelectionItemSelectionContainerPropertyId = 30080 # Constant c_int
-UIA_TableRowHeadersPropertyId = 30081 # Constant c_int
-UIA_SpreadsheetItemPatternId = 10027 # Constant c_int
-UIA_TransformPattern2Id = 10028 # Constant c_int
-UIA_TableItemRowHeaderItemsPropertyId = 30084 # Constant c_int
-UIA_TableItemColumnHeaderItemsPropertyId = 30085 # Constant c_int
-UIA_DropTargetPatternId = 10031 # Constant c_int
-UIA_TransformCanMovePropertyId = 30087 # Constant c_int
-UIA_CustomNavigationPatternId = 10033 # Constant c_int
-UIA_TransformCanRotatePropertyId = 30089 # Constant c_int
-UIA_ToolTipOpenedEventId = 20000 # Constant c_int
-UIA_ToolTipClosedEventId = 20001 # Constant c_int
-UIA_CheckBoxControlTypeId = 50002 # Constant c_int
-StyleId_Quote = 70014 # Constant c_int
-HeadingLevel1 = 80051 # Constant c_int
-UIA_EditControlTypeId = 50004 # Constant c_int
-UIA_ImageControlTypeId = 50006 # Constant c_int
-UIA_AnimationStyleAttributeId = 40000 # Constant c_int
-UIA_LegacyIAccessibleKeyboardShortcutPropertyId = 30098 # Constant c_int
-UIA_ListControlTypeId = 50008 # Constant c_int
-UIA_MenuControlTypeId = 50009 # Constant c_int
-UIA_MenuBarControlTypeId = 50010 # Constant c_int
-UIA_LiveSettingPropertyId = 30135 # Constant c_int
-UIA_ProgressBarControlTypeId = 50012 # Constant c_int
-UIA_ControllerForPropertyId = 30104 # Constant c_int
-UIA_ScrollBarControlTypeId = 50014 # Constant c_int
-UIA_SliderControlTypeId = 50015 # Constant c_int
-UIA_SpinnerControlTypeId = 50016 # Constant c_int
-UIA_StatusBarControlTypeId = 50017 # Constant c_int
-UIA_TabControlTypeId = 50018 # Constant c_int
-UIA_IsSynchronizedInputPatternAvailablePropertyId = 30110 # Constant c_int
-UIA_TextControlTypeId = 50020 # Constant c_int
-UIA_IsObjectModelPatternAvailablePropertyId = 30112 # Constant c_int
-UIA_ToolTipControlTypeId = 50022 # Constant c_int
-IAccessible._methods_ = [
-    COMMETHOD([dispid(-5000), 'hidden', 'propget'], HRESULT, 'accParent',
-              ( ['retval', 'out'], POINTER(POINTER(IDispatch)), 'ppdispParent' )),
-    COMMETHOD([dispid(-5001), 'hidden', 'propget'], HRESULT, 'accChildCount',
-              ( ['retval', 'out'], POINTER(c_int), 'pcountChildren' )),
-    COMMETHOD([dispid(-5002), 'hidden', 'propget'], HRESULT, 'accChild',
-              ( ['in'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(POINTER(IDispatch)), 'ppdispChild' )),
-    COMMETHOD([dispid(-5003), 'hidden', 'propget'], HRESULT, 'accName',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'pszName' )),
-    COMMETHOD([dispid(-5004), 'hidden', 'propget'], HRESULT, 'accValue',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'pszValue' )),
-    COMMETHOD([dispid(-5005), 'hidden', 'propget'], HRESULT, 'accDescription',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'pszDescription' )),
-    COMMETHOD([dispid(-5006), 'hidden', 'propget'], HRESULT, 'accRole',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'pvarRole' )),
-    COMMETHOD([dispid(-5007), 'hidden', 'propget'], HRESULT, 'accState',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'pvarState' )),
-    COMMETHOD([dispid(-5008), 'hidden', 'propget'], HRESULT, 'accHelp',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'pszHelp' )),
-    COMMETHOD([dispid(-5009), 'hidden', 'propget'], HRESULT, 'accHelpTopic',
-              ( ['out'], POINTER(BSTR), 'pszHelpFile' ),
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(c_int), 'pidTopic' )),
-    COMMETHOD([dispid(-5010), 'hidden', 'propget'], HRESULT, 'accKeyboardShortcut',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'pszKeyboardShortcut' )),
-    COMMETHOD([dispid(-5011), 'hidden', 'propget'], HRESULT, 'accFocus',
-              ( ['retval', 'out'], POINTER(VARIANT), 'pvarChild' )),
-    COMMETHOD([dispid(-5012), 'hidden', 'propget'], HRESULT, 'accSelection',
-              ( ['retval', 'out'], POINTER(VARIANT), 'pvarChildren' )),
-    COMMETHOD([dispid(-5013), 'hidden', 'propget'], HRESULT, 'accDefaultAction',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'pszDefaultAction' )),
-    COMMETHOD([dispid(-5014), 'hidden'], HRESULT, 'accSelect',
-              ( ['in'], c_int, 'flagsSelect' ),
-              ( ['in', 'optional'], VARIANT, 'varChild' )),
-    COMMETHOD([dispid(-5015), 'hidden'], HRESULT, 'accLocation',
-              ( ['out'], POINTER(c_int), 'pxLeft' ),
-              ( ['out'], POINTER(c_int), 'pyTop' ),
-              ( ['out'], POINTER(c_int), 'pcxWidth' ),
-              ( ['out'], POINTER(c_int), 'pcyHeight' ),
-              ( ['in', 'optional'], VARIANT, 'varChild' )),
-    COMMETHOD([dispid(-5016), 'hidden'], HRESULT, 'accNavigate',
-              ( ['in'], c_int, 'navDir' ),
-              ( ['in', 'optional'], VARIANT, 'varStart' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'pvarEndUpAt' )),
-    COMMETHOD([dispid(-5017), 'hidden'], HRESULT, 'accHitTest',
-              ( ['in'], c_int, 'xLeft' ),
-              ( ['in'], c_int, 'yTop' ),
-              ( ['retval', 'out'], POINTER(VARIANT), 'pvarChild' )),
-    COMMETHOD([dispid(-5018), 'hidden'], HRESULT, 'accDoDefaultAction',
-              ( ['in', 'optional'], VARIANT, 'varChild' )),
-    COMMETHOD([dispid(-5003), 'hidden', 'propput'], HRESULT, 'accName',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['in'], BSTR, 'pszName' )),
-    COMMETHOD([dispid(-5004), 'hidden', 'propput'], HRESULT, 'accValue',
-              ( ['in', 'optional'], VARIANT, 'varChild' ),
-              ( ['in'], BSTR, 'pszValue' )),
-]
-################################################################
-## code template for IAccessible implementation
-##class IAccessible_Impl(object):
-##    @property
-##    def accRole(self, varChild):
-##        '-no docstring-'
-##        #return pvarRole
-##
-##    @property
-##    def accDescription(self, varChild):
-##        '-no docstring-'
-##        #return pszDescription
-##
-##    def accLocation(self, varChild):
-##        '-no docstring-'
-##        #return pxLeft, pyTop, pcxWidth, pcyHeight
-##
-##    @property
-##    def accState(self, varChild):
-##        '-no docstring-'
-##        #return pvarState
-##
-##    def accNavigate(self, navDir, varStart):
-##        '-no docstring-'
-##        #return pvarEndUpAt
-##
-##    def accDoDefaultAction(self, varChild):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def accChild(self, varChild):
-##        '-no docstring-'
-##        #return ppdispChild
-##
-##    @property
-##    def accChildCount(self):
-##        '-no docstring-'
-##        #return pcountChildren
-##
-##    @property
-##    def accHelp(self, varChild):
-##        '-no docstring-'
-##        #return pszHelp
-##
-##    def _get(self, varChild):
-##        '-no docstring-'
-##        #return pszName
-##    def _set(self, varChild, pszName):
-##        '-no docstring-'
-##    accName = property(_get, _set, doc = _set.__doc__)
-##
-##    def accSelect(self, flagsSelect, varChild):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def accKeyboardShortcut(self, varChild):
-##        '-no docstring-'
-##        #return pszKeyboardShortcut
-##
-##    def accHitTest(self, xLeft, yTop):
-##        '-no docstring-'
-##        #return pvarChild
-##
-##    @property
-##    def accSelection(self):
-##        '-no docstring-'
-##        #return pvarChildren
-##
-##    @property
-##    def accDefaultAction(self, varChild):
-##        '-no docstring-'
-##        #return pszDefaultAction
-##
-##    @property
-##    def accParent(self):
-##        '-no docstring-'
-##        #return ppdispParent
-##
-##    @property
-##    def accHelpTopic(self, varChild):
-##        '-no docstring-'
-##        #return pszHelpFile, pidTopic
-##
-##    def _get(self, varChild):
-##        '-no docstring-'
-##        #return pszValue
-##    def _set(self, varChild, pszValue):
-##        '-no docstring-'
-##    accValue = property(_get, _set, doc = _set.__doc__)
-##
-##    @property
-##    def accFocus(self):
-##        '-no docstring-'
-##        #return pvarChild
-##
-
-UIA_TreeItemControlTypeId = 50024 # Constant c_int
-UIA_AnnotationDateTimePropertyId = 30116 # Constant c_int
-UIA_GroupControlTypeId = 50026 # Constant c_int
-UIA_IsAnnotationPatternAvailablePropertyId = 30118 # Constant c_int
-UIA_DataGridControlTypeId = 50028 # Constant c_int
-AnnotationType_Header = 60006 # Constant c_int
-UIA_DocumentControlTypeId = 50030 # Constant c_int
-UIA_SplitButtonControlTypeId = 50031 # Constant c_int
-UIA_StylesFillPatternStylePropertyId = 30123 # Constant c_int
-UIA_StylesShapePropertyId = 30124 # Constant c_int
-UIA_StylesFillPatternColorPropertyId = 30125 # Constant c_int
-UIA_StylesExtendedPropertiesPropertyId = 30126 # Constant c_int
-UIA_TableControlTypeId = 50036 # Constant c_int
-UIA_TitleBarControlTypeId = 50037 # Constant c_int
-UIA_SeparatorControlTypeId = 50038 # Constant c_int
-UIA_SpreadsheetItemAnnotationObjectsPropertyId = 30130 # Constant c_int
-UIA_SpreadsheetItemAnnotationTypesPropertyId = 30131 # Constant c_int
-AnnotationType_Unknown = 60000 # Constant c_int
-AnnotationType_SpellingError = 60001 # Constant c_int
-AnnotationType_GrammarError = 60002 # Constant c_int
-AnnotationType_Comment = 60003 # Constant c_int
-AnnotationType_FormulaError = 60004 # Constant c_int
-UIA_IsDragPatternAvailablePropertyId = 30137 # Constant c_int
-UIA_DragIsGrabbedPropertyId = 30138 # Constant c_int
-UIA_DragDropEffectPropertyId = 30139 # Constant c_int
-UIA_DragDropEffectsPropertyId = 30140 # Constant c_int
-UIA_IsDropTargetPatternAvailablePropertyId = 30141 # Constant c_int
-UIA_DropTargetDropTargetEffectPropertyId = 30142 # Constant c_int
-UIA_DropTargetDropTargetEffectsPropertyId = 30143 # Constant c_int
-AnnotationType_Footnote = 60010 # Constant c_int
-AnnotationType_MoveChange = 60013 # Constant c_int
-UIA_Transform2ZoomMinimumPropertyId = 30146 # Constant c_int
-AnnotationType_UnsyncedChange = 60015 # Constant c_int
-AnnotationType_EditingLockedChange = 60016 # Constant c_int
-UIA_IsTextEditPatternAvailablePropertyId = 30149 # Constant c_int
-AnnotationType_InsertionChange = 60011 # Constant c_int
-UIA_IsCustomNavigationPatternAvailablePropertyId = 30151 # Constant c_int
-AnnotationType_AdvancedProofingIssue = 60020 # Constant c_int
-UIA_SizeOfSetPropertyId = 30153 # Constant c_int
-AnnotationType_CircularReferenceError = 60022 # Constant c_int
-UIA_AnnotationTypesPropertyId = 30155 # Constant c_int
-UIA_AnnotationObjectsPropertyId = 30156 # Constant c_int
-UIA_LandmarkTypePropertyId = 30157 # Constant c_int
-UIA_LocalizedLandmarkTypePropertyId = 30158 # Constant c_int
-StyleId_Heading1 = 70001 # Constant c_int
-class IUIAutomationTableItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{0B964EB3-EF2E-4464-9C79-61D61737A27E}')
-    _idlflags_ = []
-IUIAutomationTableItemPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetCurrentRowHeaderItems',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentColumnHeaderItems',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedRowHeaderItems',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedColumnHeaderItems',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationTableItemPattern implementation
-##class IUIAutomationTableItemPattern_Impl(object):
-##    def GetCachedRowHeaderItems(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentColumnHeaderItems(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedColumnHeaderItems(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentRowHeaderItems(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_FillColorPropertyId = 30160 # Constant c_int
-StyleId_Heading3 = 70003 # Constant c_int
-UIA_FillTypePropertyId = 30162 # Constant c_int
-UIA_VisualEffectsPropertyId = 30163 # Constant c_int
-UIA_OutlineThicknessPropertyId = 30164 # Constant c_int
-UIA_CenterPointPropertyId = 30165 # Constant c_int
-UIA_RotationPropertyId = 30166 # Constant c_int
-UIA_SizePropertyId = 30167 # Constant c_int
-AnnotationType_FormatChange = 60014 # Constant c_int
-IUIAutomationActiveTextPositionChangedEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleActiveTextPositionChangedEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( ['in'], POINTER(IUIAutomationTextRange), 'range' )),
-]
-################################################################
-## code template for IUIAutomationActiveTextPositionChangedEventHandler implementation
-##class IUIAutomationActiveTextPositionChangedEventHandler_Impl(object):
-##    def HandleActiveTextPositionChangedEvent(self, sender, range):
-##        '-no docstring-'
-##        #return 
-##
-
-UIA_Selection2LastSelectedItemPropertyId = 30170 # Constant c_int
-UIA_Selection2CurrentSelectedItemPropertyId = 30171 # Constant c_int
-UIA_Text_TextSelectionChangedEventId = 20014 # Constant c_int
-UIA_HeadingLevelPropertyId = 30173 # Constant c_int
-UIA_Transform2ZoomMaximumPropertyId = 30147 # Constant c_int
-class IUIAutomationItemContainerPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{C690FDB2-27A8-423C-812D-429773C9084E}')
-    _idlflags_ = []
-IUIAutomationItemContainerPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'FindItemByProperty',
-              ( ['in'], POINTER(IUIAutomationElement), 'pStartAfter' ),
+IUIAutomationProxyFactoryEntry._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'ProxyFactory',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationProxyFactory)), 'factory' )),
+    COMMETHOD(['propget'], HRESULT, 'ClassName',
+              ( ['out', 'retval'], POINTER(BSTR), 'ClassName' )),
+    COMMETHOD(['propget'], HRESULT, 'ImageName',
+              ( ['out', 'retval'], POINTER(BSTR), 'ImageName' )),
+    COMMETHOD(['propget'], HRESULT, 'AllowSubstringMatch',
+              ( ['out', 'retval'], POINTER(c_int), 'AllowSubstringMatch' )),
+    COMMETHOD(['propget'], HRESULT, 'CanCheckBaseClass',
+              ( ['out', 'retval'], POINTER(c_int), 'CanCheckBaseClass' )),
+    COMMETHOD(['propget'], HRESULT, 'NeedsAdviseEvents',
+              ( ['out', 'retval'], POINTER(c_int), 'adviseEvents' )),
+    COMMETHOD(['propput'], HRESULT, 'ClassName',
+              ( ['in'], WSTRING, 'ClassName' )),
+    COMMETHOD(['propput'], HRESULT, 'ImageName',
+              ( ['in'], WSTRING, 'ImageName' )),
+    COMMETHOD(['propput'], HRESULT, 'AllowSubstringMatch',
+              ( ['in'], c_int, 'AllowSubstringMatch' )),
+    COMMETHOD(['propput'], HRESULT, 'CanCheckBaseClass',
+              ( ['in'], c_int, 'CanCheckBaseClass' )),
+    COMMETHOD(['propput'], HRESULT, 'NeedsAdviseEvents',
+              ( ['in'], c_int, 'adviseEvents' )),
+    COMMETHOD([], HRESULT, 'SetWinEventsForAutomationEvent',
+              ( ['in'], c_int, 'eventId' ),
               ( ['in'], c_int, 'propertyId' ),
-              ( ['in'], VARIANT, 'value' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'pFound' )),
+              ( ['in'], _midlSAFEARRAY(c_uint), 'winEvents' )),
+    COMMETHOD([], HRESULT, 'GetWinEventsForAutomationEvent',
+              ( ['in'], c_int, 'eventId' ),
+              ( ['in'], c_int, 'propertyId' ),
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(c_uint)), 'winEvents' )),
 ]
 ################################################################
-## code template for IUIAutomationItemContainerPattern implementation
-##class IUIAutomationItemContainerPattern_Impl(object):
-##    def FindItemByProperty(self, pStartAfter, propertyId, value):
+## code template for IUIAutomationProxyFactoryEntry implementation
+##class IUIAutomationProxyFactoryEntry_Impl(object):
+##    @property
+##    def ProxyFactory(self):
 ##        '-no docstring-'
-##        #return pFound
+##        #return factory
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return ClassName
+##    def _set(self, ClassName):
+##        '-no docstring-'
+##    ClassName = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return ImageName
+##    def _set(self, ImageName):
+##        '-no docstring-'
+##    ImageName = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return AllowSubstringMatch
+##    def _set(self, AllowSubstringMatch):
+##        '-no docstring-'
+##    AllowSubstringMatch = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return CanCheckBaseClass
+##    def _set(self, CanCheckBaseClass):
+##        '-no docstring-'
+##    CanCheckBaseClass = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return adviseEvents
+##    def _set(self, adviseEvents):
+##        '-no docstring-'
+##    NeedsAdviseEvents = property(_get, _set, doc = _set.__doc__)
+##
+##    def SetWinEventsForAutomationEvent(self, eventId, propertyId, winEvents):
+##        '-no docstring-'
+##        #return 
+##
+##    def GetWinEventsForAutomationEvent(self, eventId, propertyId):
+##        '-no docstring-'
+##        #return winEvents
 ##
 
-StyleId_BulletedList = 70015 # Constant c_int
-UIA_CapStyleAttributeId = 40003 # Constant c_int
-UIA_CultureAttributeId = 40004 # Constant c_int
-UIA_FontNameAttributeId = 40005 # Constant c_int
-UIA_FontSizeAttributeId = 40006 # Constant c_int
-UIA_SearchLandmarkTypeId = 80004 # Constant c_int
+IUIAutomationTreeWalker._methods_ = [
+    COMMETHOD([], HRESULT, 'GetParentElement',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'parent' )),
+    COMMETHOD([], HRESULT, 'GetFirstChildElement',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'first' )),
+    COMMETHOD([], HRESULT, 'GetLastChildElement',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'last' )),
+    COMMETHOD([], HRESULT, 'GetNextSiblingElement',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'next' )),
+    COMMETHOD([], HRESULT, 'GetPreviousSiblingElement',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'previous' )),
+    COMMETHOD([], HRESULT, 'NormalizeElement',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'normalized' )),
+    COMMETHOD([], HRESULT, 'GetParentElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'parent' )),
+    COMMETHOD([], HRESULT, 'GetFirstChildElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'first' )),
+    COMMETHOD([], HRESULT, 'GetLastChildElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'last' )),
+    COMMETHOD([], HRESULT, 'GetNextSiblingElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'next' )),
+    COMMETHOD([], HRESULT, 'GetPreviousSiblingElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'previous' )),
+    COMMETHOD([], HRESULT, 'NormalizeElementBuildCache',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationElement)), 'normalized' )),
+    COMMETHOD(['propget'], HRESULT, 'condition',
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationCondition)), 'condition' )),
+]
+################################################################
+## code template for IUIAutomationTreeWalker implementation
+##class IUIAutomationTreeWalker_Impl(object):
+##    def GetParentElement(self, element):
+##        '-no docstring-'
+##        #return parent
+##
+##    def GetFirstChildElement(self, element):
+##        '-no docstring-'
+##        #return first
+##
+##    def GetLastChildElement(self, element):
+##        '-no docstring-'
+##        #return last
+##
+##    def GetNextSiblingElement(self, element):
+##        '-no docstring-'
+##        #return next
+##
+##    def GetPreviousSiblingElement(self, element):
+##        '-no docstring-'
+##        #return previous
+##
+##    def NormalizeElement(self, element):
+##        '-no docstring-'
+##        #return normalized
+##
+##    def GetParentElementBuildCache(self, element, cacheRequest):
+##        '-no docstring-'
+##        #return parent
+##
+##    def GetFirstChildElementBuildCache(self, element, cacheRequest):
+##        '-no docstring-'
+##        #return first
+##
+##    def GetLastChildElementBuildCache(self, element, cacheRequest):
+##        '-no docstring-'
+##        #return last
+##
+##    def GetNextSiblingElementBuildCache(self, element, cacheRequest):
+##        '-no docstring-'
+##        #return next
+##
+##    def GetPreviousSiblingElementBuildCache(self, element, cacheRequest):
+##        '-no docstring-'
+##        #return previous
+##
+##    def NormalizeElementBuildCache(self, element, cacheRequest):
+##        '-no docstring-'
+##        #return normalized
+##
+##    @property
+##    def condition(self):
+##        '-no docstring-'
+##        #return condition
+##
+
+IUIAutomationProxyFactoryMapping._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'count',
+              ( ['out', 'retval'], POINTER(c_uint), 'count' )),
+    COMMETHOD([], HRESULT, 'GetTable',
+              ( ['out', 'retval'], POINTER(_midlSAFEARRAY(POINTER(IUIAutomationProxyFactoryEntry))), 'table' )),
+    COMMETHOD([], HRESULT, 'GetEntry',
+              ( ['in'], c_uint, 'index' ),
+              ( ['out', 'retval'], POINTER(POINTER(IUIAutomationProxyFactoryEntry)), 'entry' )),
+    COMMETHOD([], HRESULT, 'SetTable',
+              ( ['in'], _midlSAFEARRAY(POINTER(IUIAutomationProxyFactoryEntry)), 'factoryList' )),
+    COMMETHOD([], HRESULT, 'InsertEntries',
+              ( ['in'], c_uint, 'before' ),
+              ( ['in'], _midlSAFEARRAY(POINTER(IUIAutomationProxyFactoryEntry)), 'factoryList' )),
+    COMMETHOD([], HRESULT, 'InsertEntry',
+              ( ['in'], c_uint, 'before' ),
+              ( ['in'], POINTER(IUIAutomationProxyFactoryEntry), 'factory' )),
+    COMMETHOD([], HRESULT, 'RemoveEntry',
+              ( ['in'], c_uint, 'index' )),
+    COMMETHOD([], HRESULT, 'ClearTable'),
+    COMMETHOD([], HRESULT, 'RestoreDefaultTable'),
+]
+################################################################
+## code template for IUIAutomationProxyFactoryMapping implementation
+##class IUIAutomationProxyFactoryMapping_Impl(object):
+##    @property
+##    def count(self):
+##        '-no docstring-'
+##        #return count
+##
+##    def GetTable(self):
+##        '-no docstring-'
+##        #return table
+##
+##    def GetEntry(self, index):
+##        '-no docstring-'
+##        #return entry
+##
+##    def SetTable(self, factoryList):
+##        '-no docstring-'
+##        #return 
+##
+##    def InsertEntries(self, before, factoryList):
+##        '-no docstring-'
+##        #return 
+##
+##    def InsertEntry(self, before, factory):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveEntry(self, index):
+##        '-no docstring-'
+##        #return 
+##
+##    def ClearTable(self):
+##        '-no docstring-'
+##        #return 
+##
+##    def RestoreDefaultTable(self):
+##        '-no docstring-'
+##        #return 
+##
+
+class IUIAutomationPropertyCondition(IUIAutomationCondition):
+    _case_insensitive_ = True
+    _iid_ = GUID('{99EBF2CB-5578-4267-9AD4-AFD6EA77E94B}')
+    _idlflags_ = []
+IUIAutomationPropertyCondition._methods_ = [
+    COMMETHOD(['propget'], HRESULT, 'propertyId',
+              ( ['out', 'retval'], POINTER(c_int), 'propertyId' )),
+    COMMETHOD(['propget'], HRESULT, 'PropertyValue',
+              ( ['out', 'retval'], POINTER(VARIANT), 'PropertyValue' )),
+    COMMETHOD(['propget'], HRESULT, 'PropertyConditionFlags',
+              ( ['out', 'retval'], POINTER(PropertyConditionFlags), 'flags' )),
+]
+################################################################
+## code template for IUIAutomationPropertyCondition implementation
+##class IUIAutomationPropertyCondition_Impl(object):
+##    @property
+##    def propertyId(self):
+##        '-no docstring-'
+##        #return propertyId
+##
+##    @property
+##    def PropertyValue(self):
+##        '-no docstring-'
+##        #return PropertyValue
+##
+##    @property
+##    def PropertyConditionFlags(self):
+##        '-no docstring-'
+##        #return flags
+##
+
+class IUIAutomationEventHandlerGroup(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID('{C9EE12F2-C13B-4408-997C-639914377F4E}')
+    _idlflags_ = []
+IUIAutomation6._methods_ = [
+    COMMETHOD([], HRESULT, 'CreateEventHandlerGroup',
+              ( ['out'], POINTER(POINTER(IUIAutomationEventHandlerGroup)), 'handlerGroup' )),
+    COMMETHOD([], HRESULT, 'AddEventHandlerGroup',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationEventHandlerGroup), 'handlerGroup' )),
+    COMMETHOD([], HRESULT, 'RemoveEventHandlerGroup',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationEventHandlerGroup), 'handlerGroup' )),
+    COMMETHOD(['propget'], HRESULT, 'ConnectionRecoveryBehavior',
+              ( ['out', 'retval'], POINTER(ConnectionRecoveryBehaviorOptions), 'ConnectionRecoveryBehaviorOptions' )),
+    COMMETHOD(['propput'], HRESULT, 'ConnectionRecoveryBehavior',
+              ( ['in'], ConnectionRecoveryBehaviorOptions, 'ConnectionRecoveryBehaviorOptions' )),
+    COMMETHOD(['propget'], HRESULT, 'CoalesceEvents',
+              ( ['out', 'retval'], POINTER(CoalesceEventsOptions), 'CoalesceEventsOptions' )),
+    COMMETHOD(['propput'], HRESULT, 'CoalesceEvents',
+              ( ['in'], CoalesceEventsOptions, 'CoalesceEventsOptions' )),
+    COMMETHOD([], HRESULT, 'AddActiveTextPositionChangedEventHandler',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], TreeScope, 'scope' ),
+              ( ['in'], POINTER(IUIAutomationCacheRequest), 'cacheRequest' ),
+              ( ['in'], POINTER(IUIAutomationActiveTextPositionChangedEventHandler), 'handler' )),
+    COMMETHOD([], HRESULT, 'RemoveActiveTextPositionChangedEventHandler',
+              ( ['in'], POINTER(IUIAutomationElement), 'element' ),
+              ( ['in'], POINTER(IUIAutomationActiveTextPositionChangedEventHandler), 'handler' )),
+]
+################################################################
+## code template for IUIAutomation6 implementation
+##class IUIAutomation6_Impl(object):
+##    def CreateEventHandlerGroup(self):
+##        '-no docstring-'
+##        #return handlerGroup
+##
+##    def AddEventHandlerGroup(self, element, handlerGroup):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveEventHandlerGroup(self, element, handlerGroup):
+##        '-no docstring-'
+##        #return 
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return ConnectionRecoveryBehaviorOptions
+##    def _set(self, ConnectionRecoveryBehaviorOptions):
+##        '-no docstring-'
+##    ConnectionRecoveryBehavior = property(_get, _set, doc = _set.__doc__)
+##
+##    def _get(self):
+##        '-no docstring-'
+##        #return CoalesceEventsOptions
+##    def _set(self, CoalesceEventsOptions):
+##        '-no docstring-'
+##    CoalesceEvents = property(_get, _set, doc = _set.__doc__)
+##
+##    def AddActiveTextPositionChangedEventHandler(self, element, scope, cacheRequest, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def RemoveActiveTextPositionChangedEventHandler(self, element, handler):
+##        '-no docstring-'
+##        #return 
+##
+
 IUIAutomationEventHandlerGroup._methods_ = [
     COMMETHOD([], HRESULT, 'AddActiveTextPositionChangedEventHandler',
               ( ['in'], TreeScope, 'scope' ),
@@ -3971,11 +5082,15 @@ IUIAutomationEventHandlerGroup._methods_ = [
 ################################################################
 ## code template for IUIAutomationEventHandlerGroup implementation
 ##class IUIAutomationEventHandlerGroup_Impl(object):
-##    def AddStructureChangedEventHandler(self, scope, cacheRequest, handler):
+##    def AddActiveTextPositionChangedEventHandler(self, scope, cacheRequest, handler):
 ##        '-no docstring-'
 ##        #return 
 ##
-##    def AddActiveTextPositionChangedEventHandler(self, scope, cacheRequest, handler):
+##    def AddAutomationEventHandler(self, eventId, scope, cacheRequest, handler):
+##        '-no docstring-'
+##        #return 
+##
+##    def AddChangesEventHandler(self, scope, changeTypes, changesCount, cacheRequest, handler):
 ##        '-no docstring-'
 ##        #return 
 ##
@@ -3987,7 +5102,7 @@ IUIAutomationEventHandlerGroup._methods_ = [
 ##        '-no docstring-'
 ##        #return 
 ##
-##    def AddAutomationEventHandler(self, eventId, scope, cacheRequest, handler):
+##    def AddStructureChangedEventHandler(self, scope, cacheRequest, handler):
 ##        '-no docstring-'
 ##        #return 
 ##
@@ -3995,1580 +5110,461 @@ IUIAutomationEventHandlerGroup._methods_ = [
 ##        '-no docstring-'
 ##        #return 
 ##
-##    def AddChangesEventHandler(self, scope, changeTypes, changesCount, cacheRequest, handler):
-##        '-no docstring-'
-##        #return 
-##
 
-UIA_HorizontalTextAlignmentAttributeId = 40009 # Constant c_int
-HeadingLevel2 = 80052 # Constant c_int
-UIA_IndentationLeadingAttributeId = 40011 # Constant c_int
-HeadingLevel3 = 80053 # Constant c_int
-UIA_IsHiddenAttributeId = 40013 # Constant c_int
-UIA_IsItalicAttributeId = 40014 # Constant c_int
-UIA_IsReadOnlyAttributeId = 40015 # Constant c_int
-UIA_IsSubscriptAttributeId = 40016 # Constant c_int
-UIA_IsSuperscriptAttributeId = 40017 # Constant c_int
-HeadingLevel6 = 80056 # Constant c_int
-UIA_MarginLeadingAttributeId = 40019 # Constant c_int
-HeadingLevel7 = 80057 # Constant c_int
-UIA_MarginTrailingAttributeId = 40021 # Constant c_int
-UIA_OutlineStylesAttributeId = 40022 # Constant c_int
-UIA_OverlineColorAttributeId = 40023 # Constant c_int
-HeadingLevel9 = 80059 # Constant c_int
-UIA_StrikethroughColorAttributeId = 40025 # Constant c_int
-IUIAutomationEventHandler._methods_ = [
-    COMMETHOD([], HRESULT, 'HandleAutomationEvent',
-              ( ['in'], POINTER(IUIAutomationElement), 'sender' ),
-              ( ['in'], c_int, 'eventId' )),
-]
-################################################################
-## code template for IUIAutomationEventHandler implementation
-##class IUIAutomationEventHandler_Impl(object):
-##    def HandleAutomationEvent(self, sender, eventId):
-##        '-no docstring-'
-##        #return 
-##
-
-UIA_TabsAttributeId = 40027 # Constant c_int
-UIA_TextFlowDirectionsAttributeId = 40028 # Constant c_int
-UIA_UnderlineColorAttributeId = 40029 # Constant c_int
-UIA_AnnotationTypesAttributeId = 40031 # Constant c_int
-UIA_AnnotationObjectsAttributeId = 40032 # Constant c_int
-UIA_StyleNameAttributeId = 40033 # Constant c_int
-UIA_StyleIdAttributeId = 40034 # Constant c_int
-UIA_LinkAttributeId = 40035 # Constant c_int
-AnnotationType_DataValidationError = 60021 # Constant c_int
-UIA_SelectionActiveEndAttributeId = 40037 # Constant c_int
-UIA_CaretPositionAttributeId = 40038 # Constant c_int
-UIA_CaretBidiModeAttributeId = 40039 # Constant c_int
-UIA_LineSpacingAttributeId = 40040 # Constant c_int
-UIA_BeforeParagraphSpacingAttributeId = 40041 # Constant c_int
-UIA_LevelPropertyId = 30154 # Constant c_int
-UIA_SayAsInterpretAsAttributeId = 40043 # Constant c_int
-UIA_ButtonControlTypeId = 50000 # Constant c_int
-AnnotationType_Mathematics = 60023 # Constant c_int
-class IUIAutomationExpandCollapsePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{619BE086-1F4E-4EE4-BAFA-210128738730}')
-    _idlflags_ = []
-
-# values for enumeration 'ExpandCollapseState'
-ExpandCollapseState_Collapsed = 0
-ExpandCollapseState_Expanded = 1
-ExpandCollapseState_PartiallyExpanded = 2
-ExpandCollapseState_LeafNode = 3
-ExpandCollapseState = c_int # enum
-IUIAutomationExpandCollapsePattern._methods_ = [
-    COMMETHOD([], HRESULT, 'Expand'),
-    COMMETHOD([], HRESULT, 'Collapse'),
-    COMMETHOD(['propget'], HRESULT, 'CurrentExpandCollapseState',
-              ( ['retval', 'out'], POINTER(ExpandCollapseState), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedExpandCollapseState',
-              ( ['retval', 'out'], POINTER(ExpandCollapseState), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationExpandCollapsePattern implementation
-##class IUIAutomationExpandCollapsePattern_Impl(object):
-##    @property
-##    def CachedExpandCollapseState(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def Collapse(self):
-##        '-no docstring-'
-##        #return 
-##
-##    def Expand(self):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentExpandCollapseState(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationAnnotationPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{9A175B21-339E-41B1-8E8B-623F6B681098}')
-    _idlflags_ = []
-IUIAutomationAnnotationPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationTypeId',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAnnotationTypeName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentAuthor',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDateTime',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentTarget',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationTypeId',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAnnotationTypeName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedAuthor',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDateTime',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedTarget',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationAnnotationPattern implementation
-##class IUIAutomationAnnotationPattern_Impl(object):
-##    @property
-##    def CachedTarget(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAuthor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAnnotationTypeId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAnnotationTypeName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAuthor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedAnnotationTypeName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedDateTime(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentTarget(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentAnnotationTypeId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentDateTime(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_ForegroundColorAttributeId = 40008 # Constant c_int
-UIA_FlowsFromPropertyId = 30148 # Constant c_int
-UIA_FullDescriptionPropertyId = 30159 # Constant c_int
-class ExtendedProperty(Structure):
-    pass
-ExtendedProperty._fields_ = [
-    ('PropertyName', BSTR),
-    ('PropertyValue', BSTR),
-]
-assert sizeof(ExtendedProperty) == 8, sizeof(ExtendedProperty)
-assert alignment(ExtendedProperty) == 4, alignment(ExtendedProperty)
-IUIAutomationElementArray._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'Length',
-              ( ['retval', 'out'], POINTER(c_int), 'Length' )),
-    COMMETHOD([], HRESULT, 'GetElement',
-              ( ['in'], c_int, 'index' ),
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'element' )),
-]
-################################################################
-## code template for IUIAutomationElementArray implementation
-##class IUIAutomationElementArray_Impl(object):
-##    @property
-##    def Length(self):
-##        '-no docstring-'
-##        #return Length
-##
-##    def GetElement(self, index):
-##        '-no docstring-'
-##        #return element
-##
-
-UIA_Drag_DragCancelEventId = 20027 # Constant c_int
-UIA_ToolBarControlTypeId = 50021 # Constant c_int
-StyleId_Heading2 = 70002 # Constant c_int
-class IUIAutomationStylesPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{85B5F0A2-BD79-484A-AD2B-388C9838D5FB}')
-    _idlflags_ = []
-IUIAutomationStylesPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentStyleId',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentStyleName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentFillColor',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentFillPatternStyle',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentShape',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentFillPatternColor',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentExtendedProperties',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentExtendedPropertiesAsArray',
-              ( ['out'], POINTER(POINTER(ExtendedProperty)), 'propertyArray' ),
-              ( ['out'], POINTER(c_int), 'propertyCount' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedStyleId',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedStyleName',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFillColor',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFillPatternStyle',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedShape',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFillPatternColor',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedExtendedProperties',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedExtendedPropertiesAsArray',
-              ( ['out'], POINTER(POINTER(ExtendedProperty)), 'propertyArray' ),
-              ( ['out'], POINTER(c_int), 'propertyCount' )),
-]
-################################################################
-## code template for IUIAutomationStylesPattern implementation
-##class IUIAutomationStylesPattern_Impl(object):
-##    @property
-##    def CurrentFillPatternColor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedStyleName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFillPatternColor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentFillColor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentFillPatternStyle(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentStyleId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentShape(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedExtendedPropertiesAsArray(self):
-##        '-no docstring-'
-##        #return propertyArray, propertyCount
-##
-##    @property
-##    def CachedExtendedProperties(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFillPatternStyle(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedShape(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentStyleName(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedStyleId(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFillColor(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentExtendedProperties(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentExtendedPropertiesAsArray(self):
-##        '-no docstring-'
-##        #return propertyArray, propertyCount
-##
-
-UIA_OutlineColorPropertyId = 30161 # Constant c_int
-StyleId_Heading4 = 70004 # Constant c_int
-class IUIAutomationLegacyIAccessiblePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{828055AD-355B-4435-86D5-3B51C14A9B1B}')
-    _idlflags_ = []
-IUIAutomationLegacyIAccessiblePattern._methods_ = [
-    COMMETHOD([], HRESULT, 'Select',
-              ( [], c_int, 'flagsSelect' )),
-    COMMETHOD([], HRESULT, 'DoDefaultAction'),
-    COMMETHOD([], HRESULT, 'SetValue',
-              ( [], WSTRING, 'szValue' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentChildId',
-              ( ['retval', 'out'], POINTER(c_int), 'pRetVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentName',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszName' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentValue',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszValue' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDescription',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszDescription' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentRole',
-              ( ['retval', 'out'], POINTER(c_ulong), 'pdwRole' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentState',
-              ( ['retval', 'out'], POINTER(c_ulong), 'pdwState' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentHelp',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszHelp' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentKeyboardShortcut',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszKeyboardShortcut' )),
-    COMMETHOD([], HRESULT, 'GetCurrentSelection',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'pvarSelectedChildren' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDefaultAction',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszDefaultAction' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedChildId',
-              ( ['retval', 'out'], POINTER(c_int), 'pRetVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedName',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszName' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedValue',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszValue' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDescription',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszDescription' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedRole',
-              ( ['retval', 'out'], POINTER(c_ulong), 'pdwRole' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedState',
-              ( ['retval', 'out'], POINTER(c_ulong), 'pdwState' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedHelp',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszHelp' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedKeyboardShortcut',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszKeyboardShortcut' )),
-    COMMETHOD([], HRESULT, 'GetCachedSelection',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'pvarSelectedChildren' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDefaultAction',
-              ( ['retval', 'out'], POINTER(BSTR), 'pszDefaultAction' )),
-    COMMETHOD([], HRESULT, 'GetIAccessible',
-              ( ['retval', 'out'], POINTER(POINTER(IAccessible)), 'ppAccessible' )),
-]
-################################################################
-## code template for IUIAutomationLegacyIAccessiblePattern implementation
-##class IUIAutomationLegacyIAccessiblePattern_Impl(object):
-##    @property
-##    def CurrentDescription(self):
-##        '-no docstring-'
-##        #return pszDescription
-##
-##    @property
-##    def CurrentHelp(self):
-##        '-no docstring-'
-##        #return pszHelp
-##
-##    @property
-##    def CachedValue(self):
-##        '-no docstring-'
-##        #return pszValue
-##
-##    def GetCachedSelection(self):
-##        '-no docstring-'
-##        #return pvarSelectedChildren
-##
-##    @property
-##    def CurrentState(self):
-##        '-no docstring-'
-##        #return pdwState
-##
-##    @property
-##    def CurrentValue(self):
-##        '-no docstring-'
-##        #return pszValue
-##
-##    @property
-##    def CachedName(self):
-##        '-no docstring-'
-##        #return pszName
-##
-##    @property
-##    def CurrentName(self):
-##        '-no docstring-'
-##        #return pszName
-##
-##    @property
-##    def CachedDescription(self):
-##        '-no docstring-'
-##        #return pszDescription
-##
-##    def GetIAccessible(self):
-##        '-no docstring-'
-##        #return ppAccessible
-##
-##    @property
-##    def CachedRole(self):
-##        '-no docstring-'
-##        #return pdwRole
-##
-##    @property
-##    def CurrentChildId(self):
-##        '-no docstring-'
-##        #return pRetVal
-##
-##    def DoDefaultAction(self):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CachedChildId(self):
-##        '-no docstring-'
-##        #return pRetVal
-##
-##    @property
-##    def CachedHelp(self):
-##        '-no docstring-'
-##        #return pszHelp
-##
-##    @property
-##    def CurrentRole(self):
-##        '-no docstring-'
-##        #return pdwRole
-##
-##    def SetValue(self, szValue):
-##        '-no docstring-'
-##        #return 
-##
-##    def GetCurrentSelection(self):
-##        '-no docstring-'
-##        #return pvarSelectedChildren
-##
-##    @property
-##    def CachedDefaultAction(self):
-##        '-no docstring-'
-##        #return pszDefaultAction
-##
-##    @property
-##    def CachedState(self):
-##        '-no docstring-'
-##        #return pdwState
-##
-##    @property
-##    def CurrentDefaultAction(self):
-##        '-no docstring-'
-##        #return pszDefaultAction
-##
-##    @property
-##    def CachedKeyboardShortcut(self):
-##        '-no docstring-'
-##        #return pszKeyboardShortcut
-##
-##    def Select(self, flagsSelect):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentKeyboardShortcut(self):
-##        '-no docstring-'
-##        #return pszKeyboardShortcut
-##
-
-
-# values for enumeration 'AutomationElementMode'
-AutomationElementMode_None = 0
-AutomationElementMode_Full = 1
-AutomationElementMode = c_int # enum
-IUIAutomationCacheRequest._methods_ = [
-    COMMETHOD([], HRESULT, 'AddProperty',
-              ( ['in'], c_int, 'propertyId' )),
-    COMMETHOD([], HRESULT, 'AddPattern',
-              ( ['in'], c_int, 'patternId' )),
-    COMMETHOD([], HRESULT, 'Clone',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCacheRequest)), 'clonedRequest' )),
-    COMMETHOD(['propget'], HRESULT, 'TreeScope',
-              ( ['retval', 'out'], POINTER(TreeScope), 'scope' )),
-    COMMETHOD(['propput'], HRESULT, 'TreeScope',
-              ( ['in'], TreeScope, 'scope' )),
-    COMMETHOD(['propget'], HRESULT, 'TreeFilter',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationCondition)), 'filter' )),
-    COMMETHOD(['propput'], HRESULT, 'TreeFilter',
-              ( ['in'], POINTER(IUIAutomationCondition), 'filter' )),
-    COMMETHOD(['propget'], HRESULT, 'AutomationElementMode',
-              ( ['retval', 'out'], POINTER(AutomationElementMode), 'mode' )),
-    COMMETHOD(['propput'], HRESULT, 'AutomationElementMode',
-              ( ['in'], AutomationElementMode, 'mode' )),
-]
-################################################################
-## code template for IUIAutomationCacheRequest implementation
-##class IUIAutomationCacheRequest_Impl(object):
-##    def AddPattern(self, patternId):
-##        '-no docstring-'
-##        #return 
-##
-##    def AddProperty(self, propertyId):
-##        '-no docstring-'
-##        #return 
-##
-##    def Clone(self):
-##        '-no docstring-'
-##        #return clonedRequest
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return scope
-##    def _set(self, scope):
-##        '-no docstring-'
-##    TreeScope = property(_get, _set, doc = _set.__doc__)
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return mode
-##    def _set(self, mode):
-##        '-no docstring-'
-##    AutomationElementMode = property(_get, _set, doc = _set.__doc__)
-##
-##    def _get(self):
-##        '-no docstring-'
-##        #return filter
-##    def _set(self, filter):
-##        '-no docstring-'
-##    TreeFilter = property(_get, _set, doc = _set.__doc__)
-##
-
-class IUIAutomationSpreadsheetItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{7D4FB86C-8D34-40E1-8E83-62C15204E335}')
-    _idlflags_ = []
-IUIAutomationSpreadsheetItemPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentFormula',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentAnnotationObjects',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentAnnotationTypes',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedFormula',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedAnnotationObjects',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedAnnotationTypes',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationSpreadsheetItemPattern implementation
-##class IUIAutomationSpreadsheetItemPattern_Impl(object):
-##    @property
-##    def CurrentFormula(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedFormula(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedAnnotationTypes(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentAnnotationTypes(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentAnnotationObjects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedAnnotationObjects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_BackgroundColorAttributeId = 40001 # Constant c_int
-class CUIAutomation(CoClass):
-    u'The Central Class for UIAutomation'
-    _reg_clsid_ = GUID('{FF48DBA4-60EF-4201-AA87-54103EEF594E}')
-    _idlflags_ = []
-    _typelib_path_ = typelib_path
-    _reg_typelib_ = ('{944DE083-8FB8-45CF-BCB7-C477ACB2F897}', 1, 0)
-CUIAutomation._com_interfaces_ = [IUIAutomation]
-
-class IUIAutomationGridItemPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{78F8EF57-66C3-4E09-BD7C-E79B2004894D}')
-    _idlflags_ = []
-IUIAutomationGridItemPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentContainingGrid',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentRow',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentColumn',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentRowSpan',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentColumnSpan',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedContainingGrid',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedRow',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedColumn',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedRowSpan',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedColumnSpan',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationGridItemPattern implementation
-##class IUIAutomationGridItemPattern_Impl(object):
-##    @property
-##    def CurrentColumn(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentRow(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedColumn(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentContainingGrid(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedRowSpan(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedColumnSpan(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedContainingGrid(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentRowSpan(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentColumnSpan(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedRow(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationTextEditPattern(IUIAutomationTextPattern):
-    _case_insensitive_ = True
-    _iid_ = GUID('{17E21576-996C-4870-99D9-BFF323380C06}')
-    _idlflags_ = []
-IUIAutomationTextEditPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetActiveComposition',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-    COMMETHOD([], HRESULT, 'GetConversionTarget',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-]
-################################################################
-## code template for IUIAutomationTextEditPattern implementation
-##class IUIAutomationTextEditPattern_Impl(object):
-##    def GetActiveComposition(self):
-##        '-no docstring-'
-##        #return range
-##
-##    def GetConversionTarget(self):
-##        '-no docstring-'
-##        #return range
-##
-
-StyleId_Heading7 = 70007 # Constant c_int
-UIA_TextEdit_ConversionTargetChangedEventId = 20033 # Constant c_int
-StyleId_Heading8 = 70008 # Constant c_int
-StyleId_Heading9 = 70009 # Constant c_int
-class IUIAutomationMultipleViewPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{8D253C91-1DC5-4BB5-B18F-ADE16FA495E8}')
-    _idlflags_ = []
-IUIAutomationMultipleViewPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetViewName',
-              ( ['in'], c_int, 'view' ),
-              ( ['retval', 'out'], POINTER(BSTR), 'name' )),
-    COMMETHOD([], HRESULT, 'SetCurrentView',
-              ( ['in'], c_int, 'view' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentCurrentView',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentSupportedViews',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedCurrentView',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedSupportedViews',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(c_int)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationMultipleViewPattern implementation
-##class IUIAutomationMultipleViewPattern_Impl(object):
-##    def SetCurrentView(self, view):
-##        '-no docstring-'
-##        #return 
-##
-##    def GetCurrentSupportedViews(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedSupportedViews(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentCurrentView(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetViewName(self, view):
-##        '-no docstring-'
-##        #return name
-##
-##    @property
-##    def CachedCurrentView(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationTransformPattern2(IUIAutomationTransformPattern):
-    _case_insensitive_ = True
-    _iid_ = GUID('{6D74D017-6ECB-4381-B38B-3C17A48FF1C2}')
-    _idlflags_ = []
-
-# values for enumeration 'ZoomUnit'
-ZoomUnit_NoAmount = 0
-ZoomUnit_LargeDecrement = 1
-ZoomUnit_SmallDecrement = 2
-ZoomUnit_LargeIncrement = 3
-ZoomUnit_SmallIncrement = 4
-ZoomUnit = c_int # enum
-IUIAutomationTransformPattern2._methods_ = [
-    COMMETHOD([], HRESULT, 'Zoom',
-              ( ['in'], c_double, 'zoomValue' )),
-    COMMETHOD([], HRESULT, 'ZoomByUnit',
-              ( ['in'], ZoomUnit, 'ZoomUnit' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentCanZoom',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedCanZoom',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentZoomLevel',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedZoomLevel',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentZoomMinimum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedZoomMinimum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentZoomMaximum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedZoomMaximum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationTransformPattern2 implementation
-##class IUIAutomationTransformPattern2_Impl(object):
-##    @property
-##    def CachedZoomMinimum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentZoomMinimum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedCanZoom(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedZoomMaximum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentCanZoom(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def ZoomByUnit(self, ZoomUnit):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CachedZoomLevel(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def Zoom(self, zoomValue):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentZoomLevel(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentZoomMaximum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_TextEditPatternId = 10032 # Constant c_int
-UIA_IsPeripheralPropertyId = 30150 # Constant c_int
-UIA_Selection2FirstSelectedItemPropertyId = 30169 # Constant c_int
-class IUIAutomationObjectModelPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{71C284B3-C14D-4D14-981E-19751B0D756D}')
-    _idlflags_ = []
-IUIAutomationObjectModelPattern._methods_ = [
-    COMMETHOD([], HRESULT, 'GetUnderlyingObjectModel',
-              ( ['retval', 'out'], POINTER(POINTER(IUnknown)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationObjectModelPattern implementation
-##class IUIAutomationObjectModelPattern_Impl(object):
-##    def GetUnderlyingObjectModel(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_TreeControlTypeId = 50023 # Constant c_int
-StyleId_Subtitle = 70011 # Constant c_int
-UIA_InputReachedTargetEventId = 20020 # Constant c_int
-UIA_BoundingRectanglePropertyId = 30001 # Constant c_int
-StyleId_Emphasis = 70013 # Constant c_int
-UIA_Selection2ItemCountPropertyId = 30172 # Constant c_int
-class IUIAutomationRangeValuePattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{59213F4F-7346-49E5-B120-80555987A148}')
-    _idlflags_ = []
-IUIAutomationRangeValuePattern._methods_ = [
-    COMMETHOD([], HRESULT, 'SetValue',
-              ( ['in'], c_double, 'val' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentValue',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsReadOnly',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentMaximum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentMinimum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentLargeChange',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentSmallChange',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedValue',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsReadOnly',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedMaximum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedMinimum',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedLargeChange',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedSmallChange',
-              ( ['retval', 'out'], POINTER(c_double), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationRangeValuePattern implementation
-##class IUIAutomationRangeValuePattern_Impl(object):
-##    @property
-##    def CachedIsReadOnly(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentValue(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def SetValue(self, val):
-##        '-no docstring-'
-##        #return 
-##
-##    @property
-##    def CurrentMaximum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentSmallChange(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedValue(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentIsReadOnly(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentLargeChange(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedSmallChange(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentMinimum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedMinimum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedMaximum(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedLargeChange(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationTextChildPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{6552B038-AE05-40C8-ABFD-AA08352AAB86}')
-    _idlflags_ = []
-IUIAutomationTextChildPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'TextContainer',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElement)), 'container' )),
-    COMMETHOD(['propget'], HRESULT, 'TextRange',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationTextRange)), 'range' )),
-]
-################################################################
-## code template for IUIAutomationTextChildPattern implementation
-##class IUIAutomationTextChildPattern_Impl(object):
-##    @property
-##    def TextContainer(self):
-##        '-no docstring-'
-##        #return container
-##
-##    @property
-##    def TextRange(self):
-##        '-no docstring-'
-##        #return range
-##
-
-UIA_AnnotationTargetPropertyId = 30117 # Constant c_int
-class IUIAutomationDropTargetPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{69A095F7-EEE4-430E-A46B-FB73B1AE39A5}')
-    _idlflags_ = []
-IUIAutomationDropTargetPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentDropTargetEffect',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDropTargetEffect',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDropTargetEffects',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDropTargetEffects',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationDropTargetPattern implementation
-##class IUIAutomationDropTargetPattern_Impl(object):
-##    @property
-##    def CachedDropTargetEffects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentDropTargetEffect(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedDropTargetEffect(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentDropTargetEffects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-class IUIAutomationDragPattern(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IUnknown):
-    _case_insensitive_ = True
-    _iid_ = GUID('{1DC7B570-1F54-4BAD-BCDA-D36A722FB7BD}')
-    _idlflags_ = []
-IUIAutomationDragPattern._methods_ = [
-    COMMETHOD(['propget'], HRESULT, 'CurrentIsGrabbed',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedIsGrabbed',
-              ( ['retval', 'out'], POINTER(c_int), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDropEffect',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDropEffect',
-              ( ['retval', 'out'], POINTER(BSTR), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CurrentDropEffects',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
-    COMMETHOD(['propget'], HRESULT, 'CachedDropEffects',
-              ( ['retval', 'out'], POINTER(_midlSAFEARRAY(BSTR)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCurrentGrabbedItems',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-    COMMETHOD([], HRESULT, 'GetCachedGrabbedItems',
-              ( ['retval', 'out'], POINTER(POINTER(IUIAutomationElementArray)), 'retVal' )),
-]
-################################################################
-## code template for IUIAutomationDragPattern implementation
-##class IUIAutomationDragPattern_Impl(object):
-##    @property
-##    def CurrentIsGrabbed(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentDropEffects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CurrentDropEffect(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCachedGrabbedItems(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedDropEffect(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedIsGrabbed(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    @property
-##    def CachedDropEffects(self):
-##        '-no docstring-'
-##        #return retVal
-##
-##    def GetCurrentGrabbedItems(self):
-##        '-no docstring-'
-##        #return retVal
-##
-
-UIA_CalendarControlTypeId = 50001 # Constant c_int
-__all__ = [ 'UIA_IsGridItemPatternAvailablePropertyId',
-           'IUIAutomationAndCondition',
-           'UIA_StrikethroughColorAttributeId',
-           'UIA_IndentationLeadingAttributeId',
-           'UIA_LegacyIAccessiblePatternId',
-           'UIA_Drag_DragCancelEventId',
-           'UIA_IsSpreadsheetItemPatternAvailablePropertyId',
-           'IUIAutomationElement', 'UIA_ClickablePointPropertyId',
-           'UiaChangeInfo', 'UIA_LandmarkTypePropertyId',
-           'WindowInteractionState_Running', 'UIA_StyleIdAttributeId',
-           'UIA_SliderControlTypeId',
-           'UIA_ForegroundColorAttributeId',
-           'UIA_HeaderControlTypeId', 'UIA_ScrollItemPatternId',
-           'UIA_StylesExtendedPropertiesPropertyId',
-           'UIA_Invoke_InvokedEventId', 'UIA_HyperlinkControlTypeId',
-           'UIA_Window_WindowOpenedEventId',
-           'IUIAutomationActiveTextPositionChangedEventHandler',
-           'OrientationType_None', 'UIA_DropTarget_DragLeaveEventId',
-           'UIA_ValueIsReadOnlyPropertyId',
-           'PropertyConditionFlags_None', 'UIA_ToolTipControlTypeId',
-           'UIA_MultipleViewCurrentViewPropertyId',
-           'TextEditChangeType_Composition',
-           'UIA_MarginLeadingAttributeId',
-           'UIA_IsScrollItemPatternAvailablePropertyId',
-           'UIA_GridColumnCountPropertyId', 'UIA_WindowControlTypeId',
-           'UIA_CaretBidiModeAttributeId',
-           'UIA_AnnotationObjectsAttributeId',
-           'UIA_LocalizedControlTypePropertyId',
-           'UIA_AnnotationObjectsPropertyId',
-           'UIA_SelectionItem_ElementAddedToSelectionEventId',
-           'AnnotationType_Highlighted', 'UIA_ButtonControlTypeId',
-           'AnnotationType_Header',
-           'UIA_LegacyIAccessibleRolePropertyId',
-           'UIA_InputReachedOtherElementEventId',
-           'UIA_SelectionItem_ElementRemovedFromSelectionEventId',
-           'UIA_CaretPositionAttributeId',
-           'IUIAutomationExpandCollapsePattern', 'DockPosition_None',
-           'UIA_MainLandmarkTypeId',
-           'SynchronizedInputType_LeftMouseUp',
-           'UIA_RotationPropertyId',
-           'UIA_LegacyIAccessibleDefaultActionPropertyId',
-           'TreeTraversalOptions',
-           'UIA_IsMultipleViewPatternAvailablePropertyId',
-           'UIA_RangeValueMinimumPropertyId',
-           'IUIAutomationTransformPattern2', 'HeadingLevel2',
-           'UIA_MenuBarControlTypeId', 'UIA_FontWeightAttributeId',
-           'UIA_DocumentControlTypeId', 'UIA_CustomControlTypeId',
-           'UIA_ExpandCollapsePatternId', 'ExtendedProperty',
-           'AnnotationType_Comment', 'HeadingLevel8',
-           'AnnotationType_DataValidationError',
-           'UIA_ScrollHorizontalViewSizePropertyId',
-           'WindowInteractionState_BlockedByModalWindow',
-           'UIA_IsPeripheralPropertyId',
-           'IUIAutomationTextRangeArray',
-           'UIA_IsTextPattern2AvailablePropertyId',
-           'StructureChangeType_ChildrenReordered',
-           'TextEditChangeType_None',
-           'UIA_SynchronizedInputPatternId',
-           'UIA_FullDescriptionPropertyId',
-           'UIA_TreeItemControlTypeId',
-           'IUIAutomationSpreadsheetPattern', 'UIA_InvokePatternId',
-           'UIA_SelectionItem_ElementSelectedEventId',
-           'IUIAutomationWindowPattern',
-           'UIA_IsDropTargetPatternAvailablePropertyId',
-           'AutomationElementMode_None',
-           'UIA_IsSelectionItemPatternAvailablePropertyId',
-           'UIA_LiveRegionChangedEventId',
-           'AnnotationType_FormatChange',
-           'UIA_BackgroundColorAttributeId',
-           'UIA_SizeOfSetPropertyId', 'UIA_AnimationStyleAttributeId',
-           'HeadingLevel_None', 'IUIAutomationNotCondition',
-           'UIA_OutlineColorPropertyId',
-           'IUIAutomationTransformPattern',
-           'UIA_InputDiscardedEventId',
-           'ExpandCollapseState_Expanded', 'UIA_IsItalicAttributeId',
-           'UIA_AnnotationDateTimePropertyId', 'StyleId_BulletedList',
-           'RowOrColumnMajor_Indeterminate',
-           'UIA_DataGridControlTypeId',
-           'UIA_DockDockPositionPropertyId',
-           'IUIAutomationTextPattern',
-           'UIA_IsExpandCollapsePatternAvailablePropertyId',
-           'IUIAutomationTreeWalker', 'UIA_LayoutInvalidatedEventId',
-           'UIA_LegacyIAccessibleStatePropertyId',
-           'UIA_TextPatternId', 'UIA_RangeValueSmallChangePropertyId',
-           'UIA_ValueValuePropertyId',
-           'IUIAutomationSelectionPattern2',
-           'UIA_IsSpreadsheetPatternAvailablePropertyId',
-           'UIA_SpinnerControlTypeId', 'AnnotationType_MoveChange',
-           'AnnotationType_CircularReferenceError',
-           'UIA_NativeWindowHandlePropertyId',
-           'UIA_RuntimeIdPropertyId', 'TextUnit_Document',
-           'HeadingLevel3', 'TextUnit_Word', 'HeadingLevel5',
-           'HeadingLevel4', 'HeadingLevel7',
-           'IUIAutomationSynchronizedInputPattern', 'HeadingLevel9',
-           'UIA_GridItemColumnPropertyId', 'UIA_SelectionPatternId',
-           'IUIAutomationOrCondition',
-           'WindowInteractionState_Closing',
-           'UIA_Selection2CurrentSelectedItemPropertyId',
-           'UIA_IsScrollPatternAvailablePropertyId',
-           'UIA_LevelPropertyId', 'UIA_TogglePatternId',
-           'UIA_SelectionActiveEndAttributeId',
-           'UIA_IsActiveAttributeId', 'IUIAutomationElement4',
-           'SynchronizedInputType_RightMouseDown',
-           'UIA_RangeValueMaximumPropertyId',
-           'IUIAutomationValuePattern',
-           'UIA_BoundingRectanglePropertyId',
-           'IUIAutomationEventHandler',
-           'UIA_TextFlowDirectionsAttributeId',
-           'UIA_MultipleViewPatternId', 'StyleId_NumberedList',
-           'UIA_Selection2ItemCountPropertyId',
-           'NavigateDirection_FirstChild',
-           'UIA_IsTextEditPatternAvailablePropertyId',
-           'UIA_SearchLandmarkTypeId', 'TreeScope_None',
-           'UIA_ScrollVerticallyScrollablePropertyId',
-           'UIA_TableControlTypeId',
-           'IUIAutomationChangesEventHandler',
+__all__ = [ 'UIA_TableItemPatternId', 'ToggleState',
            'UIA_TableColumnHeadersPropertyId',
+           'UIA_FillColorPropertyId', 'UIA_ToolTipClosedEventId',
+           'HeadingLevel3',
+           'UIA_MultipleViewSupportedViewsPropertyId',
+           'SynchronizedInputType_KeyDown',
+           'SynchronizedInputType_RightMouseUp',
+           'UIA_StylesFillPatternStylePropertyId',
+           'UIA_IsDialogPropertyId',
+           'SynchronizedInputType_LeftMouseUp',
+           'UIA_MenuModeEndEventId', 'DockPosition_Fill',
+           'NotificationKind_ItemAdded',
+           'UIA_DragDropEffectPropertyId',
+           'UIA_LiveSettingPropertyId',
+           'IUIAutomationRangeValuePattern',
+           'UIA_StylesStyleIdPropertyId',
+           'UIA_LegacyIAccessibleSelectionPropertyId',
+           'UIA_SelectionItemPatternId',
+           'UIA_LegacyIAccessibleStatePropertyId',
+           'UIA_IsDataValidForFormPropertyId',
+           'AnnotationType_Header',
+           'UIA_DropTargetDropTargetEffectsPropertyId',
+           'PropertyConditionFlags_None',
+           'SynchronizedInputType_RightMouseDown',
+           'UIA_ScrollVerticalViewSizePropertyId',
+           'IUIAutomationTablePattern', 'HeadingLevel7',
+           'NotificationProcessing_ImportantMostRecent',
+           'StyleId_Heading4', 'ZoomUnit_SmallDecrement',
+           'UIA_IsKeyboardFocusablePropertyId',
+           'IUIAutomationNotificationEventHandler',
+           'UIA_IsValuePatternAvailablePropertyId',
+           'UIA_TreeItemControlTypeId', 'UIA_AriaRolePropertyId',
+           'CoalesceEventsOptions_Enabled',
+           'OrientationType_Vertical', 'StyleId_Heading2',
+           'UIA_ProgressBarControlTypeId', 'UiaChangeInfo',
+           'UIA_WindowIsTopmostPropertyId',
+           'UIA_InputDiscardedEventId', 'UIA_MainLandmarkTypeId',
+           'WindowInteractionState', 'UIA_Drag_DragCompleteEventId',
+           'UIA_BeforeParagraphSpacingAttributeId',
+           'TextPatternRangeEndpoint_End', 'UIA_SizeOfSetPropertyId',
+           'UIA_TransformPattern2Id',
+           'UIA_StylesFillPatternColorPropertyId',
+           'UIA_SpreadsheetItemPatternId', 'ZoomUnit_LargeDecrement',
+           'UIA_RangeValueIsReadOnlyPropertyId',
+           'UIA_SelectionItem_ElementSelectedEventId',
+           'UIA_DockDockPositionPropertyId',
+           'UIA_AnnotationTargetPropertyId',
+           'UIA_IsSpreadsheetItemPatternAvailablePropertyId',
+           'UIA_InvokePatternId', 'UIA_IsPeripheralPropertyId',
+           'UIA_SpreadsheetPatternId',
+           'UIA_RangeValueValuePropertyId', 'ToggleState_On',
+           'UIA_Window_WindowClosedEventId', 'UIA_LevelPropertyId',
+           'TextEditChangeType',
+           'UIA_AnnotationAnnotationTypeIdPropertyId',
+           'TreeScope_Descendants', 'UIA_TextEdit_TextChangedEventId',
+           'IUIAutomationTextChildPattern', 'StyleId_Quote',
+           'UIA_TransformCanMovePropertyId',
+           'UIA_LandmarkTypePropertyId',
+           'UIA_LegacyIAccessibleNamePropertyId',
+           'UIA_WindowCanMaximizePropertyId',
+           'UIA_OutlineStylesAttributeId',
+           'IUIAutomationNotCondition',
+           'UIA_StrikethroughColorAttributeId',
+           'IUIAutomationElementArray', 'UIA_SliderControlTypeId',
+           'UIA_SpinnerControlTypeId', 'HeadingLevel2',
+           'UIA_IsScrollPatternAvailablePropertyId',
+           'UIA_SplitButtonControlTypeId',
+           'UIA_IsCustomNavigationPatternAvailablePropertyId',
+           'IUIAutomationElement5', 'UIA_IsReadOnlyAttributeId',
+           'UIA_ControllerForPropertyId',
+           'UIA_GridRowCountPropertyId', 'UIA_ToolTipControlTypeId',
+           'TreeScope_Element', 'UIA_ToolBarControlTypeId',
+           'UIA_StylesStyleNamePropertyId', 'ExtendedProperty',
+           'UIA_AnnotationPatternId', 'AnnotationType_Highlighted',
+           'UIA_Selection2ItemCountPropertyId',
+           'UIA_StatusBarControlTypeId', 'StyleId_Heading6',
+           'UIA_AccessKeyPropertyId', 'AutomationElementMode_None',
+           'ProviderOptions_UseComThreading',
+           'UIA_AnnotationObjectsAttributeId',
+           'UIA_IsRequiredForFormPropertyId', 'DockPosition',
+           'UIA_LegacyIAccessibleChildIdPropertyId',
+           'IUIAutomationStylesPattern',
+           'UIA_DropTarget_DragEnterEventId', 'TextUnit_Character',
+           'RowOrColumnMajor_ColumnMajor',
+           'TreeTraversalOptions_Default',
+           'UIA_ScrollVerticalScrollPercentPropertyId',
+           'UIA_SynchronizedInputPatternId',
+           'UIA_ProviderDescriptionPropertyId', 'StyleId_Heading7',
+           'UIA_GridItemColumnSpanPropertyId',
+           'ScrollAmount_NoAmount',
+           'UIA_IsTransformPatternAvailablePropertyId',
+           'UIA_AnimationStyleAttributeId',
+           'AnnotationType_FormatChange',
+           'UIA_IsTransformPattern2AvailablePropertyId',
+           'NavigateDirection', 'Assertive', 'UIA_MenuClosedEventId',
+           'UIA_ToggleToggleStatePropertyId',
+           'UIA_ImageControlTypeId', 'DockPosition_Bottom',
+           'AnnotationType_ExternalChange',
+           'UIA_IsControlElementPropertyId',
+           'IUIAutomationPropertyCondition',
+           'UIA_LocalizedControlTypePropertyId',
+           'UIA_AutomationIdPropertyId', 'DockPosition_Left',
            'UIA_Selection2LastSelectedItemPropertyId',
-           'UIA_SizePropertyId', 'UIA_AnnotationTypesPropertyId',
+           'UIA_NotificationEventId', 'UIA_CulturePropertyId',
+           'StyleId_Heading9', 'UIA_WindowPatternId',
+           'UIA_AsyncContentLoadedEventId', 'UIA_SelectionPatternId',
+           'IUIAutomation5', 'UIA_IsActiveAttributeId',
+           'UIA_AutomationFocusChangedEventId',
+           'ScrollAmount_SmallIncrement', 'StyleId_Title',
+           'UIA_TextEdit_ConversionTargetChangedEventId',
+           'OrientationType_None', 'TextUnit',
+           'UIA_ScrollHorizontallyScrollablePropertyId',
+           'StyleId_Emphasis',
+           'TreeTraversalOptions_LastToFirstOrder',
+           'StructureChangeType_ChildrenReordered',
+           'ExpandCollapseState_LeafNode',
+           'IUIAutomationSpreadsheetItemPattern',
+           'UIA_DescribedByPropertyId',
+           'UIA_ForegroundColorAttributeId',
+           'UIA_IsSelectionPattern2AvailablePropertyId',
+           'UIA_IsWindowPatternAvailablePropertyId',
+           'UIA_MultipleViewPatternId',
+           'UIA_ValueIsReadOnlyPropertyId',
+           'IUIAutomationScrollItemPattern',
+           'ProviderOptions_ProviderOwnsSetFocus',
+           'NotificationProcessing', 'UIA_CalendarControlTypeId',
+           'ProviderOptions_RefuseNonClientSupport',
+           'IUIAutomationAndCondition', 'TreeScope_None',
+           'UIA_SpreadsheetItemAnnotationObjectsPropertyId',
+           'UIA_Transform2ZoomMinimumPropertyId',
+           'AnnotationType_SpellingError', 'UIA_ItemTypePropertyId',
+           'UIA_IsTextEditPatternAvailablePropertyId',
+           'UIA_LegacyIAccessibleValuePropertyId',
+           'ConnectionRecoveryBehaviorOptions',
+           'IUIAutomationGridPattern',
+           'IUIAutomationSynchronizedInputPattern',
+           'IUIAutomationTextEditTextChangedEventHandler',
+           'IUIAutomationEventHandlerGroup',
+           'UIA_InputReachedTargetEventId',
+           'UIA_SemanticZoomControlTypeId', 'TreeTraversalOptions',
+           'UIA_SelectionItem_ElementRemovedFromSelectionEventId',
+           'WindowVisualState', 'ZoomUnit_NoAmount',
+           'UIA_CheckBoxControlTypeId', 'ZoomUnit_SmallIncrement',
+           'NotificationProcessing_All', 'UIA_DragPatternId',
+           'UIA_IsRangeValuePatternAvailablePropertyId',
+           'SynchronizedInputType_KeyUp',
+           'IUIAutomationItemContainerPattern',
+           'UIA_DragGrabbedItemsPropertyId',
+           'NavigateDirection_NextSibling', 'SupportedTextSelection',
+           'UIA_LegacyIAccessibleRolePropertyId',
+           'IUIAutomationProxyFactory', 'UIA_TitleBarControlTypeId',
+           'UIA_TableRowOrColumnMajorPropertyId',
+           'IUIAutomationBoolCondition', 'UIA_EditControlTypeId',
+           'UIA_IsItemContainerPatternAvailablePropertyId',
+           'UIA_FlowsFromPropertyId',
+           'UIA_IndentationTrailingAttributeId',
+           'UIA_GridItemRowSpanPropertyId', 'OrientationType',
+           'HeadingLevel8', 'UIA_WindowIsModalPropertyId', 'Off',
+           'HeadingLevel4',
+           'IUIAutomationPropertyChangedEventHandler',
+           'UIA_TransformCanResizePropertyId',
+           'ProviderOptions_NonClientAreaProvider',
+           'UIA_HorizontalTextAlignmentAttributeId',
+           'UIA_IsObjectModelPatternAvailablePropertyId',
            'TextPatternRangeEndpoint_Start',
            'UIA_TableItemColumnHeaderItemsPropertyId',
-           'SupportedTextSelection_Single',
-           'IUIAutomationTextPattern2', 'SynchronizedInputType',
-           'UIA_ClassNamePropertyId', 'UIA_UnderlineStyleAttributeId',
-           'NotificationKind_ItemRemoved',
-           'UIA_RangeValueValuePropertyId',
-           'UIA_HorizontalTextAlignmentAttributeId',
-           'UIA_SelectionItemSelectionContainerPropertyId',
-           'UIA_LegacyIAccessibleKeyboardShortcutPropertyId',
-           'TextUnit_Page', 'UIA_SelectionPattern2Id',
-           'UIA_Transform2ZoomMaximumPropertyId',
-           'UIA_PaneControlTypeId', 'UIA_CheckBoxControlTypeId',
-           'UIA_CenterPointPropertyId', 'UIA_GridItemPatternId',
-           'UIA_AnnotationAnnotationTypeIdPropertyId',
-           'IUIAutomationProxyFactoryMapping',
-           'WindowVisualState_Normal',
-           'UIA_WindowWindowVisualStatePropertyId',
-           'ConnectionRecoveryBehaviorOptions',
-           'IUIAutomationItemContainerPattern',
-           'UIA_DragDropEffectsPropertyId',
-           'ExpandCollapseState_Collapsed',
-           'UIA_MenuModeStartEventId', 'UIA_MenuClosedEventId',
-           'UIA_CustomLandmarkTypeId', 'UIA_WindowPatternId',
-           'UIA_ChangesEventId', 'IUIAutomationDockPattern',
-           'LiveSetting', 'IUIAutomationFocusChangedEventHandler',
-           'UIA_CalendarControlTypeId',
-           'UIA_OverlineColorAttributeId',
-           'IUIAutomationDropTargetPattern',
-           'UIA_StyleNameAttributeId', 'AnnotationType_Footer',
-           'TextUnit_Format',
-           'UIA_WindowWindowInteractionStatePropertyId',
-           'UIA_ScrollVerticalScrollPercentPropertyId',
-           'StyleId_Quote', 'UIA_FormLandmarkTypeId',
-           'UIA_SpreadsheetItemPatternId', 'AutomationElementMode',
-           'UIA_AnnotationTypesAttributeId', 'StyleId_Heading9',
-           'UIA_ItemContainerPatternId', 'StyleId_Heading5',
-           'StyleId_Heading4', 'StyleId_Heading7', 'StyleId_Heading6',
-           'StyleId_Heading1', 'StyleId_Heading3',
-           'UIA_SelectionIsSelectionRequiredPropertyId',
-           'UIA_ListItemControlTypeId', 'UIA_ObjectModelPatternId',
-           'UIA_LegacyIAccessibleSelectionPropertyId',
-           'UIA_TransformPatternId', 'TextPatternRangeEndpoint',
-           'UIA_AnnotationTargetPropertyId',
-           'UIA_Transform2ZoomLevelPropertyId',
-           'UIA_IsAnnotationPatternAvailablePropertyId',
-           'IUIAutomationTogglePattern',
-           'UIA_IsValuePatternAvailablePropertyId',
-           'IUIAutomationRangeValuePattern',
-           'ZoomUnit_LargeDecrement', 'UIA_ComboBoxControlTypeId',
-           'UIA_MarginBottomAttributeId',
-           'IUIAutomationObjectModelPattern', 'IUIAutomationElement9',
-           'IUIAutomationElement8', 'IUIAutomationTextChildPattern',
-           'IUIAutomationElement3', 'IUIAutomationElement2',
-           'IUIAutomationElement7', 'IUIAutomationElement6',
-           'IUIAutomationElement5', 'ToggleState_On',
-           'UIA_DockPatternId', 'UIA_IsRequiredForFormPropertyId',
-           'TextUnit_Line', 'AnnotationType_AdvancedProofingIssue',
-           'UIA_IsGridPatternAvailablePropertyId', 'CUIAutomation8',
-           'UIA_IsHiddenAttributeId',
-           'UIA_TableRowOrColumnMajorPropertyId',
-           'NotificationKind_ActionCompleted', 'TreeScope_Children',
-           'UIA_SpreadsheetItemAnnotationTypesPropertyId',
-           'WindowInteractionState_ReadyForUserInteraction',
-           'UIA_TableItemRowHeaderItemsPropertyId',
-           'UIA_SelectionCanSelectMultiplePropertyId',
-           'WindowInteractionState_NotResponding',
-           'UIA_Text_TextSelectionChangedEventId',
-           'ExpandCollapseState_LeafNode', 'UIA_ToolBarControlTypeId',
-           'IUIAutomation', 'TreeScope_Parent',
-           'IUIAutomationProxyFactory', 'IUIAutomationTextRange3',
-           'IUIAutomationTextRange2',
-           'ProviderOptions_ClientSideProvider',
-           'NavigateDirection_NextSibling',
-           'ScrollAmount_SmallIncrement',
-           'ProviderOptions_ProviderOwnsSetFocus', 'NotificationKind',
-           'UIA_FontNameAttributeId', 'IUIAutomationSelectionPattern',
-           'TreeScope_Element', 'WindowInteractionState',
-           'UIA_SummaryChangeId',
-           'UIA_IsInvokePatternAvailablePropertyId',
-           'ExpandCollapseState',
-           'IUIAutomationSpreadsheetItemPattern',
-           'UIA_OptimizeForVisualContentPropertyId',
-           'SynchronizedInputType_RightMouseUp',
-           'UIA_StrikethroughStyleAttributeId',
-           'UIA_IsWindowPatternAvailablePropertyId',
-           'UIA_IsDragPatternAvailablePropertyId',
-           'UIA_DragDropEffectPropertyId',
-           'UIA_AutomationPropertyChangedEventId',
-           'UIA_SpreadsheetItemAnnotationObjectsPropertyId',
-           'UIA_ExpandCollapseExpandCollapseStatePropertyId',
-           'UIA_StylesFillPatternStylePropertyId',
-           'DockPosition_Right', 'UIA_ProgressBarControlTypeId',
-           'Assertive', 'ProviderOptions_UseClientCoordinates',
-           'UIA_MenuOpenedEventId', 'UIA_MenuModeEndEventId',
-           'IUIAutomationPropertyCondition', 'UIA_AriaRolePropertyId',
-           'UIA_TransformCanResizePropertyId',
-           'PropertyConditionFlags_MatchSubstring',
-           'AutomationElementMode_Full',
-           'StructureChangeType_ChildrenBulkRemoved',
-           'IUIAutomationTextEditPattern', 'Off',
-           'AnnotationType_SpellingError',
-           'NotificationProcessing_ImportantMostRecent',
-           'UIA_MenuControlTypeId', 'UIA_OutlineThicknessPropertyId',
-           'CoalesceEventsOptions_Enabled',
-           'UIA_ScrollBarControlTypeId',
-           'UIA_SelectionItemIsSelectedPropertyId',
-           'UIA_LineSpacingAttributeId', 'UIA_CapStyleAttributeId',
-           'HeadingLevel1', 'UIA_AppBarControlTypeId',
-           'UIA_Drag_DragStartEventId', 'StyleId_Custom',
-           'UIA_ScrollHorizontalScrollPercentPropertyId',
-           'UIA_DragPatternId', 'AnnotationType_EditingLockedChange',
-           'WindowVisualState_Maximized', 'WindowVisualState',
-           'UIA_LiveSettingPropertyId', 'UIA_FlowsToPropertyId',
-           'AnnotationType_Author', 'UIA_HeaderItemControlTypeId',
-           'UIA_ListControlTypeId',
-           'UIA_ProviderDescriptionPropertyId',
-           'UIA_ScrollVerticalViewSizePropertyId', 'StyleId_Normal',
-           'StructureChangeType', 'UIA_NotificationEventId',
-           'UIA_SeparatorControlTypeId',
-           'UIA_IsContentElementPropertyId',
-           'ScrollAmount_LargeDecrement',
-           'UIA_MarginTrailingAttributeId',
-           'UIA_InputReachedTargetEventId',
-           'UIA_DragIsGrabbedPropertyId', 'AnnotationType_Endnote',
-           'DockPosition_Top', 'UIA_OrientationPropertyId',
-           'UIA_Selection2FirstSelectedItemPropertyId',
-           'UIA_SayAsInterpretAsMetadataId', 'IUIAutomationCondition',
-           'UIA_StructureChangedEventId',
-           'NotificationProcessing_All',
-           'UIA_IsSuperscriptAttributeId',
-           'UIA_MenuItemControlTypeId',
-           'UIA_Window_WindowClosedEventId', 'UIA_ImageControlTypeId',
-           'DockPosition_Left', 'PropertyConditionFlags_IgnoreCase',
-           'UIA_FlowsFromPropertyId',
-           'UIA_Transform2CanZoomPropertyId',
-           'UIA_SelectionSelectionPropertyId',
-           'SynchronizedInputType_KeyUp',
-           'UIA_LocalizedLandmarkTypePropertyId',
-           'UIA_StatusBarControlTypeId',
-           'UIA_TransformCanRotatePropertyId',
-           'UIA_NavigationLandmarkTypeId',
-           'UIA_AutomationIdPropertyId',
-           'SynchronizedInputType_LeftMouseDown',
-           'UIA_StylesStyleIdPropertyId',
-           'UIA_LegacyIAccessibleChildIdPropertyId',
-           'IUIAutomationTableItemPattern',
-           'TextPatternRangeEndpoint_End',
-           'UIA_IsObjectModelPatternAvailablePropertyId',
-           'ProviderOptions_ServerSideProvider',
-           'IUIAutomationTextRange', 'ToggleState_Off',
-           'ScrollAmount', 'TextEditChangeType_AutoCorrect',
-           'UIA_RangeValueIsReadOnlyPropertyId',
-           'IUIAutomationTextEditTextChangedEventHandler',
-           'IAccessible', 'NavigateDirection_Parent',
-           'ZoomUnit_LargeIncrement',
-           'UIA_ActiveTextPositionChangedEventId', 'ToggleState',
-           'ProviderOptions_UseComThreading',
-           'OrientationType_Vertical', 'AnnotationType_GrammarError',
-           'UIA_TreeControlTypeId', 'ZoomUnit_SmallIncrement',
-           'UIA_WindowCanMinimizePropertyId', 'HeadingLevel6',
-           'DockPosition_Bottom', 'UIA_ControllerForPropertyId',
-           'TreeScope_Subtree', 'UIA_GridRowCountPropertyId',
-           'ConnectionRecoveryBehaviorOptions_Enabled',
-           'NavigateDirection', 'UIA_IsOffscreenPropertyId',
-           'UIA_IsDialogPropertyId',
-           'UIA_LegacyIAccessibleDescriptionPropertyId',
-           'NotificationKind_ItemAdded',
-           'SupportedTextSelection_None', 'UIA_ValuePatternId',
-           'UIA_CulturePropertyId', 'IUIAutomationBoolCondition',
-           'AnnotationType_Unknown',
-           'UIA_IsLegacyIAccessiblePatternAvailablePropertyId',
-           'UIA_IsEnabledPropertyId', 'UIA_NamePropertyId',
-           'ZoomUnit_SmallDecrement', 'UIA_FontSizeAttributeId',
-           'IUIAutomationScrollPattern', 'ToggleState_Indeterminate',
-           'UIA_IsControlElementPropertyId',
-           'UIA_AcceleratorKeyPropertyId',
-           'UIA_HostedFragmentRootsInvalidatedEventId',
-           'UIA_IsStylesPatternAvailablePropertyId',
-           'UIA_DropTarget_DroppedEventId',
-           'AnnotationType_Mathematics',
-           'IUIAutomationMultipleViewPattern',
-           'TreeTraversalOptions_PostOrder',
-           'UIA_TextEdit_TextChangedEventId', 'UIA_TextControlTypeId',
-           'UIA_TextPattern2Id', 'UIA_LinkAttributeId',
-           'UIA_StylesPatternId',
-           'UIA_IsTransformPatternAvailablePropertyId',
-           'TextEditChangeType_AutoComplete',
-           'UIA_TextEdit_ConversionTargetChangedEventId',
-           'WindowVisualState_Minimized',
-           'AnnotationType_ExternalChange',
-           'IUIAutomationCacheRequest',
-           'UIA_Drag_DragCompleteEventId',
-           'UIA_AfterParagraphSpacingAttributeId',
-           'UIA_VirtualizedItemPatternId',
-           'AnnotationType_DeletionChange',
-           'TreeTraversalOptions_LastToFirstOrder',
-           'UIA_OutlineStylesAttributeId', 'UIA_IsPasswordPropertyId',
-           'SynchronizedInputType_KeyDown',
-           'UIA_SelectionItemPatternId', 'PropertyConditionFlags',
-           'UIA_UnderlineColorAttributeId',
-           'UIA_DataItemControlTypeId',
-           'RowOrColumnMajor_ColumnMajor',
-           'UIA_MultipleViewSupportedViewsPropertyId',
-           'IUIAutomationStructureChangedEventHandler',
-           'UIA_IndentationTrailingAttributeId',
-           'CoalesceEventsOptions',
-           'NotificationProcessing_MostRecent',
-           'UIA_ToolTipOpenedEventId',
-           'UIA_StylesFillPatternColorPropertyId', 'TreeScope',
-           'UIA_DropTargetPatternId',
-           'UIA_IsSelectionPattern2AvailablePropertyId',
-           'ScrollAmount_LargeIncrement', 'UIA_ThumbControlTypeId',
-           'UIA_GridItemContainingGridPropertyId',
-           'UIA_AnnotationPatternId',
-           'UIA_SpreadsheetItemFormulaPropertyId',
-           'UIA_ScrollPatternId',
-           'UIA_IsTablePatternAvailablePropertyId',
-           'UIA_GridItemColumnSpanPropertyId',
-           'UIA_BeforeParagraphSpacingAttributeId',
-           'SupportedTextSelection_Multiple',
-           'RowOrColumnMajor_RowMajor',
-           'UIA_WindowIsTopmostPropertyId',
-           'UIA_IsKeyboardFocusablePropertyId',
-           'UIA_EditControlTypeId', 'UIA_SemanticZoomControlTypeId',
-           'IUIAutomation2', 'IUIAutomation3', 'IUIAutomation4',
-           'IUIAutomation5', 'IUIAutomation6',
-           'AnnotationType_InsertionChange',
-           'UIA_WindowCanMaximizePropertyId', 'TextUnit_Paragraph',
-           'ProviderOptions_OverrideProvider', 'DockPosition',
-           'ExpandCollapseState_PartiallyExpanded',
-           'IRawElementProviderSimple', 'UIA_TablePatternId',
-           'UIA_AutomationFocusChangedEventId',
-           'UIA_TextChildPatternId',
-           'UIA_DropTargetDropTargetEffectsPropertyId',
-           'UIA_Selection_InvalidatedEventId', 'ProviderOptions',
-           'StructureChangeType_ChildRemoved',
-           'UIA_IsTransformPattern2AvailablePropertyId',
-           'UIA_DragGrabbedItemsPropertyId',
-           'UIA_GridItemRowSpanPropertyId',
-           'AnnotationType_ConflictingChange',
-           'UIA_AnnotationAuthorPropertyId',
-           'UIA_IsSelectionPatternAvailablePropertyId',
-           'OrientationType', 'UIA_StylesShapePropertyId',
-           'UIA_LabeledByPropertyId', 'IUIAutomationElementArray',
-           'IUIAutomationDragPattern',
-           'UIA_StylesStyleNamePropertyId',
-           'OrientationType_Horizontal',
-           'UIA_AnnotationAnnotationTypeNamePropertyId',
-           'AnnotationType_UnsyncedChange',
-           'UIA_PositionInSetPropertyId',
-           'IUIAutomationPropertyChangedEventHandler',
-           'ProviderOptions_RefuseNonClientSupport',
-           'IUIAutomationSelectionItemPattern',
-           'UIA_DescribedByPropertyId', 'IUIAutomationStylesPattern',
-           'UIA_IsReadOnlyAttributeId', 'UIA_Text_TextChangedEventId',
-           'TextUnit', 'IUIAutomationProxyFactoryEntry',
-           'SupportedTextSelection',
-           'UIA_RangeValueLargeChangePropertyId',
-           'UIA_TransformPattern2Id', 'UIA_VisualEffectsPropertyId',
+           'UIA_IsSelectionItemPatternAvailablePropertyId',
            'TreeScope_Ancestors',
-           'IUIAutomationCustomNavigationPattern',
-           'ScrollAmount_SmallDecrement',
-           'UIA_IsDataValidForFormPropertyId',
-           'NotificationProcessing',
-           'UIA_SayAsInterpretAsAttributeId',
-           'UIA_TitleBarControlTypeId', 'IUIAutomationInvokePattern',
-           'NavigateDirection_PreviousSibling',
-           'ConnectionRecoveryBehaviorOptions_Disabled',
-           'UIA_RangeValuePatternId', 'ZoomUnit',
-           'UIA_IsVirtualizedItemPatternAvailablePropertyId',
-           'UIA_BulletStyleAttributeId', 'UIA_MarginTopAttributeId',
-           'IUIAutomationGridPattern', 'DockPosition_Fill',
-           'CUIAutomation', 'NotificationProcessing_ImportantAll',
-           'UIA_HasKeyboardFocusPropertyId', 'StyleId_Subtitle',
-           'UIA_IsTextPatternAvailablePropertyId',
-           'UIA_ToggleToggleStatePropertyId',
-           'ProviderOptions_HasNativeIAccessible',
-           'UIA_TransformCanMovePropertyId',
-           'UIA_ItemStatusPropertyId',
-           'IUIAutomationScrollItemPattern',
-           'IUIAutomationAnnotationPattern',
-           'UIA_IsSubscriptAttributeId', 'UIA_SystemAlertEventId',
-           'TextEditChangeType_CompositionFinalized',
-           'UIA_FillColorPropertyId', 'UIA_TextEditPatternId',
-           'UIA_LegacyIAccessibleNamePropertyId',
-           'UIA_RadioButtonControlTypeId',
-           'AnnotationType_FormulaError',
-           'UIA_SplitButtonControlTypeId',
-           'UIA_LegacyIAccessibleValuePropertyId',
-           'UIA_IsCustomNavigationPatternAvailablePropertyId',
-           'UIA_SpreadsheetPatternId', 'UIA_HeadingLevelPropertyId',
-           'TextEditChangeType', 'AnnotationType_Footnote',
-           'NotificationProcessing_CurrentThenMostRecent',
+           'UIA_SelectionItem_ElementAddedToSelectionEventId',
+           'NotificationProcessing_MostRecent', 'TextUnit_Line',
+           'UIA_ListItemControlTypeId', 'UIA_Drag_DragStartEventId',
+           'UIA_ListControlTypeId', 'UIA_NamePropertyId',
+           'UIA_TabControlTypeId',
+           'WindowInteractionState_ReadyForUserInteraction',
+           'UIA_BoundingRectanglePropertyId',
+           'UIA_IsHiddenAttributeId',
+           'TextEditChangeType_AutoCorrect', 'TextUnit_Format',
+           'AnnotationType_Unknown',
+           'TextEditChangeType_AutoComplete',
+           'UIA_OverlineColorAttributeId',
+           'IUIAutomationTransformPattern', 'ToggleState_Off',
+           'IUIAutomation3', 'UIA_MarginTrailingAttributeId',
+           'IUIAutomationStructureChangedEventHandler',
+           'UIA_Transform2CanZoomPropertyId',
+           'UIA_FillTypePropertyId', 'UIA_HasKeyboardFocusPropertyId',
+           'HeadingLevel6', 'UIA_AutomationPropertyChangedEventId',
+           'UIA_IsLegacyIAccessiblePatternAvailablePropertyId',
+           'UIA_DropTarget_DroppedEventId',
+           'UIA_IsGridPatternAvailablePropertyId', 'HeadingLevel5',
+           'UIA_GridItemColumnPropertyId', 'ZoomUnit',
+           'UIA_GroupControlTypeId', 'UIA_DataGridControlTypeId',
+           'UIA_ScrollItemPatternId',
+           'UIA_IsAnnotationPatternAvailablePropertyId',
+           'UIA_DropTargetPatternId',
+           'UIA_SelectionSelectionPropertyId',
+           'UIA_AnnotationAnnotationTypeNamePropertyId',
+           'UIA_SayAsInterpretAsMetadataId',
            'StructureChangeType_ChildrenBulkAdded',
-           'UIA_IsDockPatternAvailablePropertyId',
-           'CoalesceEventsOptions_Disabled',
-           'IUIAutomationVirtualizedItemPattern',
-           'UIA_AsyncContentLoadedEventId', 'StyleId_Title',
-           'UIA_DropTargetDropTargetEffectPropertyId', 'Polite',
-           'TextUnit_Character', 'UIA_FrameworkIdPropertyId',
-           'UIA_DropTarget_DragEnterEventId',
-           'TreeTraversalOptions_Default',
-           'NotificationKind_ActionAborted', 'UIA_TableItemPatternId',
-           'TreeScope_Descendants', 'UIA_TabItemControlTypeId',
-           'IUIAutomationGridItemPattern',
-           'NavigateDirection_LastChild',
-           'UIA_IsSynchronizedInputPatternAvailablePropertyId',
-           'UIA_TabsAttributeId',
-           'StructureChangeType_ChildrenInvalidated',
-           'IUIAutomationTablePattern', 'AnnotationType_TrackChanges',
-           'ZoomUnit_NoAmount',
-           'UIA_IsTogglePatternAvailablePropertyId',
-           'UIA_ToolTipClosedEventId',
-           'UIA_IsRangeValuePatternAvailablePropertyId',
-           'UIA_GridItemRowPropertyId',
-           'UIA_IsTableItemPatternAvailablePropertyId',
-           'StyleId_Heading8', 'UIA_AriaPropertiesPropertyId',
-           'UIA_CustomNavigationPatternId',
-           'UIA_WindowIsModalPropertyId', 'UIA_ControlTypePropertyId',
-           'ScrollAmount_NoAmount', 'RowOrColumnMajor',
-           'ProviderOptions_NonClientAreaProvider',
-           'UIA_ItemTypePropertyId',
-           'UIA_IsTextChildPatternAvailablePropertyId',
-           'UIA_HelpTextPropertyId', 'UIA_CultureAttributeId',
-           'IUIAutomationEventHandlerGroup', 'NotificationKind_Other',
-           'UIA_LegacyIAccessibleHelpPropertyId',
-           'UIA_AccessKeyPropertyId', 'StyleId_Heading2',
-           'StructureChangeType_ChildAdded',
+           'NotificationKind_ActionCompleted',
+           'IUIAutomationActiveTextPositionChangedEventHandler',
+           'AnnotationType_DeletionChange', 'UIA_ButtonControlTypeId',
+           'UIA_Text_TextChangedEventId',
+           'UIA_HyperlinkControlTypeId', 'UIA_CultureAttributeId',
+           'IAccessible', 'UIA_StylesShapePropertyId',
+           'UIA_TextPatternId', 'UIA_Transform2ZoomMaximumPropertyId',
+           'IUIAutomationCustomNavigationPattern', 'StyleId_Custom',
+           'UIA_Invoke_InvokedEventId',
+           'UIA_Window_WindowOpenedEventId',
            'UIA_TableRowHeadersPropertyId',
-           'IUIAutomationLegacyIAccessiblePattern',
-           'UIA_FillTypePropertyId',
-           'UIA_IsItemContainerPatternAvailablePropertyId',
-           'UIA_IndentationFirstLineAttributeId', 'StyleId_Emphasis',
-           'UIA_GroupControlTypeId', 'UIA_ProcessIdPropertyId',
+           'IUIAutomationVirtualizedItemPattern',
+           'ToggleState_Indeterminate',
+           'ExpandCollapseState_PartiallyExpanded',
+           'UIA_SelectionItemSelectionContainerPropertyId',
+           'UIA_IsTextPatternAvailablePropertyId',
+           'UIA_IsSubscriptAttributeId', 'AnnotationType_Mathematics',
+           'IUIAutomationObjectModelPattern',
+           'UIA_Text_TextSelectionChangedEventId',
+           'AnnotationType_ConflictingChange', 'HeadingLevel9',
+           'IUIAutomationOrCondition', 'UIA_GridItemRowPropertyId',
+           'SupportedTextSelection_Multiple',
+           'ConnectionRecoveryBehaviorOptions_Enabled',
+           'UIA_AnnotationDateTimePropertyId', 'LiveSetting',
+           'UIA_UnderlineStyleAttributeId', 'UIA_TextPattern2Id',
+           'UIA_ExpandCollapseExpandCollapseStatePropertyId',
+           'UIA_HeaderControlTypeId',
+           'UIA_IsExpandCollapsePatternAvailablePropertyId',
+           'UIA_CenterPointPropertyId',
+           'IUIAutomationFocusChangedEventHandler',
+           'UIA_TableControlTypeId', 'TextPatternRangeEndpoint',
+           'IUIAutomationElement8',
+           'UIA_SelectionItemIsSelectedPropertyId',
+           'UIA_StylesExtendedPropertiesPropertyId',
+           'IUIAutomationCacheRequest', 'TextUnit_Document',
+           'TextUnit_Word', 'IUIAutomationElement6',
+           'UIA_ItemContainerPatternId',
+           'UIA_RangeValueSmallChangePropertyId',
+           'UIA_RangeValuePatternId', 'CUIAutomation8',
+           'UIA_ActiveTextPositionChangedEventId',
+           'UIA_AcceleratorKeyPropertyId',
+           'IUIAutomationSpreadsheetPattern',
+           'IUIAutomationDropTargetPattern',
+           'UIA_IsInvokePatternAvailablePropertyId',
+           'UIA_MenuBarControlTypeId', 'UIA_RadioButtonControlTypeId',
+           'NotificationKind_ItemRemoved', 'UIA_TabsAttributeId',
+           'AnnotationType_Author', 'StyleId_BulletedList',
+           'AnnotationType_CircularReferenceError',
+           'UIA_DocumentControlTypeId',
+           'UIA_TextFlowDirectionsAttributeId',
+           'AnnotationType_AdvancedProofingIssue',
+           'UIA_RangeValueMaximumPropertyId',
+           'UIA_DropTargetDropTargetEffectPropertyId',
+           'UIA_StrikethroughStyleAttributeId',
+           'UIA_StyleIdAttributeId',
+           'IUIAutomationMultipleViewPattern',
+           'WindowVisualState_Maximized',
+           'UIA_SpreadsheetItemAnnotationTypesPropertyId',
+           'ProviderOptions_ClientSideProvider',
+           'UIA_ControlTypePropertyId',
+           'IUIAutomationTextEditPattern',
+           'IUIAutomationTableItemPattern',
+           'ConnectionRecoveryBehaviorOptions_Disabled',
+           'RowOrColumnMajor', 'UIA_OrientationPropertyId',
+           'UIA_ScrollPatternId',
+           'TextEditChangeType_CompositionFinalized',
+           'UIA_ObjectModelPatternId', 'IUIAutomation6',
+           'StructureChangeType_ChildRemoved',
+           'IUIAutomationTextRangeArray',
+           'UIA_Drag_DragCancelEventId', 'PropertyConditionFlags',
+           'UIA_Selection_InvalidatedEventId',
+           'UIA_DragDropEffectsPropertyId',
+           'UIA_AnnotationTypesAttributeId', 'IUIAutomationElement7',
+           'UIA_NativeWindowHandlePropertyId',
+           'IUIAutomationExpandCollapsePattern',
+           'UIA_TransformCanRotatePropertyId',
+           'IUIAutomationTextPattern', 'UIA_TreeControlTypeId',
+           'IUIAutomationInvokePattern', 'StyleId_Heading3',
+           'RowOrColumnMajor_Indeterminate',
+           'UIA_UnderlineColorAttributeId', 'IUIAutomationTextRange',
+           'UIA_MenuOpenedEventId', 'IUIAutomationDragPattern',
+           'UIA_AfterParagraphSpacingAttributeId',
+           'UIA_IsScrollItemPatternAvailablePropertyId',
+           'StyleId_Subtitle', 'UIA_ToolTipOpenedEventId',
+           'UIA_BulletStyleAttributeId',
+           'UIA_IsTogglePatternAvailablePropertyId',
+           'UIA_LegacyIAccessibleDefaultActionPropertyId',
+           'UIA_SpreadsheetItemFormulaPropertyId',
+           'UIA_SystemAlertEventId',
+           'UIA_IsDragPatternAvailablePropertyId',
+           'ProviderOptions_UseClientCoordinates',
+           'DockPosition_Right', 'IUIAutomationProxyFactoryEntry',
+           'UIA_GridItemContainingGridPropertyId',
+           'UIA_TextChildPatternId',
+           'UIA_LocalizedLandmarkTypePropertyId',
+           'AnnotationType_Footnote',
+           'UIA_IsVirtualizedItemPatternAvailablePropertyId',
+           'IUIAutomationSelectionPattern2',
+           'IUIAutomationTogglePattern',
            'UIA_OverlineStyleAttributeId',
-           'UIA_ScrollHorizontallyScrollablePropertyId',
+           'UIA_IsTextChildPatternAvailablePropertyId',
+           'StyleId_Heading8', 'UIA_StylesPatternId',
+           'UIA_WindowCanMinimizePropertyId',
+           'ZoomUnit_LargeIncrement', 'UIA_FormLandmarkTypeId',
+           'UIA_HelpTextPropertyId', 'NotificationKind_Other',
+           'IUIAutomationValuePattern',
+           'UIA_DropTarget_DragLeaveEventId',
+           'UIA_InputReachedOtherElementEventId',
+           'UIA_IsMultipleViewPatternAvailablePropertyId',
+           'AutomationElementMode',
+           'UIA_OptimizeForVisualContentPropertyId',
+           'NotificationProcessing_ImportantAll',
+           'UIA_LineSpacingAttributeId',
+           'UIA_CaretPositionAttributeId',
+           'UIA_StructureChangedEventId',
+           'UIA_ScrollBarControlTypeId',
+           'UIA_IsSuperscriptAttributeId',
+           'AnnotationType_FormulaError', 'UIA_MenuControlTypeId',
+           'IUIAutomationLegacyIAccessiblePattern',
+           'WindowVisualState_Minimized',
+           'NavigateDirection_FirstChild',
+           'AnnotationType_TrackChanges',
+           'UIA_IsDockPatternAvailablePropertyId',
+           'UIA_MarginTopAttributeId', 'UIA_SizePropertyId',
+           'UIA_RotationPropertyId',
+           'AnnotationType_DataValidationError',
+           'UIA_IsOffscreenPropertyId', 'UIA_ProcessIdPropertyId',
+           'UIA_PositionInSetPropertyId', 'UIA_FrameworkIdPropertyId',
+           'UIA_SelectionIsSelectionRequiredPropertyId',
+           'UIA_BackgroundColorAttributeId',
+           'ScrollAmount_LargeDecrement', 'UIA_DockPatternId',
+           'UIA_SummaryChangeId', 'HeadingLevel1',
+           'UIA_IsStylesPatternAvailablePropertyId',
+           'AnnotationType_Footer', 'ExpandCollapseState_Expanded',
+           'AnnotationType_GrammarError', 'DockPosition_None',
+           'ExpandCollapseState', 'UIA_CustomLandmarkTypeId',
+           'UIA_CaretBidiModeAttributeId',
+           'IUIAutomationProxyFactoryMapping',
+           'UIA_MarginLeadingAttributeId', 'UIA_PaneControlTypeId',
+           'TextUnit_Page', 'UIA_RangeValueMinimumPropertyId',
+           'IUIAutomationElement9', 'WindowVisualState_Normal',
+           'WindowInteractionState_BlockedByModalWindow',
+           'CoalesceEventsOptions_Disabled', 'TreeScope',
+           'UIA_ComboBoxControlTypeId',
+           'UIA_SelectionCanSelectMultiplePropertyId',
+           'UIA_HostedFragmentRootsInvalidatedEventId',
+           'StructureChangeType_ChildAdded',
+           'UIA_AppBarControlTypeId',
+           'UIA_IsSelectionPatternAvailablePropertyId',
+           'CUIAutomation', 'UIA_ExpandCollapsePatternId',
+           'ProviderOptions_OverrideProvider',
+           'CoalesceEventsOptions', 'IUIAutomationTransformPattern2',
+           'UIA_ClassNamePropertyId', 'UIA_MenuItemControlTypeId',
+           'UIA_DragIsGrabbedPropertyId',
+           'WindowInteractionState_NotResponding',
+           'UIA_IsDropTargetPatternAvailablePropertyId',
+           'UIA_MultipleViewCurrentViewPropertyId',
+           'UIA_IndentationFirstLineAttributeId',
+           'UIA_IsContentElementPropertyId',
+           'IUIAutomationDockPattern',
+           'UIA_Transform2ZoomLevelPropertyId', 'IUIAutomation4',
+           'UIA_AnnotationAuthorPropertyId',
+           'UIA_TabItemControlTypeId', 'IUIAutomationElement4',
+           'NotificationKind', 'UIA_FontSizeAttributeId', 'Polite',
+           'TreeScope_Subtree', 'UIA_CapStyleAttributeId',
+           'ScrollAmount', 'IUIAutomationAnnotationPattern',
+           'IUIAutomationElement2', 'TextEditChangeType_None',
+           'StructureChangeType_ChildrenInvalidated',
+           'UIA_IndentationLeadingAttributeId',
+           'UIA_DataItemControlTypeId',
+           'UIA_Selection2CurrentSelectedItemPropertyId',
+           'UIA_SeparatorControlTypeId', 'IUIAutomation2',
+           'UIA_ScrollHorizontalScrollPercentPropertyId',
+           'UIA_IsTableItemPatternAvailablePropertyId',
+           'TreeScope_Children', 'AutomationElementMode_Full',
+           'StyleId_NumberedList', 'UIA_OutlineColorPropertyId',
+           'UIA_Selection2FirstSelectedItemPropertyId',
+           'SynchronizedInputType_LeftMouseDown', 'IUIAutomation',
+           'UIA_IsTextPattern2AvailablePropertyId',
+           'UIA_HeaderItemControlTypeId',
+           'UIA_LegacyIAccessibleDescriptionPropertyId',
+           'StyleId_Heading1', 'UIA_CustomNavigationPatternId',
+           'UIA_TextControlTypeId', 'IRawElementProviderSimple',
+           'UIA_TogglePatternId', 'UIA_FontWeightAttributeId',
+           'UIA_ValueValuePropertyId', 'UIA_IsEnabledPropertyId',
+           'IUIAutomationCondition', 'NavigateDirection_LastChild',
+           'SynchronizedInputType', 'UIA_ItemStatusPropertyId',
+           'UIA_IsTablePatternAvailablePropertyId',
+           'UIA_RuntimeIdPropertyId',
+           'UIA_TableItemRowHeaderItemsPropertyId',
+           'AnnotationType_EditingLockedChange',
+           'IUIAutomationEventHandler',
+           'IUIAutomationSelectionPattern', 'UIA_CustomControlTypeId',
+           'RowOrColumnMajor_RowMajor',
+           'UIA_LiveRegionChangedEventId',
+           'UIA_WindowWindowVisualStatePropertyId',
+           'ProviderOptions_ServerSideProvider',
+           'IUIAutomationTextRange3', 'UIA_FullDescriptionPropertyId',
+           'UIA_TextEditPatternId', 'UIA_FlowsToPropertyId',
+           'UIA_LegacyIAccessibleKeyboardShortcutPropertyId',
+           'IUIAutomationGridItemPattern',
+           'UIA_LegacyIAccessibleHelpPropertyId',
+           'AnnotationType_Comment', 'UIA_OutlineThicknessPropertyId',
+           'UIA_TablePatternId', 'UIA_GridPatternId',
+           'ProviderOptions_HasNativeIAccessible',
+           'UIA_SelectionActiveEndAttributeId',
+           'UIA_GridColumnCountPropertyId',
+           'NavigateDirection_PreviousSibling',
            'UIA_StylesFillColorPropertyId',
-           'UIA_Transform2ZoomMinimumPropertyId',
-           'IUIAutomationNotificationEventHandler',
-           'UIA_TabControlTypeId', 'UIA_GridPatternId']
+           'UIA_IsSpreadsheetPatternAvailablePropertyId',
+           'ProviderOptions', 'IUIAutomationTextPattern2',
+           'UIA_FontNameAttributeId',
+           'UIA_IsGridItemPatternAvailablePropertyId',
+           'TreeScope_Parent', 'IUIAutomationScrollPattern',
+           'AnnotationType_Endnote', 'NotificationKind_ActionAborted',
+           'SupportedTextSelection_None', 'UIA_ValuePatternId',
+           'UIA_IsItalicAttributeId', 'UIA_WindowControlTypeId',
+           'UIA_RangeValueLargeChangePropertyId',
+           'TreeTraversalOptions_PostOrder',
+           'IUIAutomationSelectionItemPattern',
+           'TextEditChangeType_Composition',
+           'NotificationProcessing_CurrentThenMostRecent',
+           'UIA_ScrollVerticallyScrollablePropertyId',
+           'HeadingLevel_None', 'UIA_HeadingLevelPropertyId',
+           'AnnotationType_MoveChange',
+           'WindowInteractionState_Closing',
+           'IUIAutomationTextRange2', 'UIA_MarginBottomAttributeId',
+           'PropertyConditionFlags_MatchSubstring',
+           'UIA_IsSynchronizedInputPatternAvailablePropertyId',
+           'UIA_MenuModeStartEventId', 'UIA_NavigationLandmarkTypeId',
+           'StyleId_Heading5', 'AnnotationType_UnsyncedChange',
+           'UIA_SearchLandmarkTypeId', 'UIA_GridItemPatternId',
+           'IUIAutomationTreeWalker', 'ScrollAmount_LargeIncrement',
+           'IUIAutomationElement', 'ExpandCollapseState_Collapsed',
+           'AnnotationType_InsertionChange', 'StructureChangeType',
+           'UIA_LabeledByPropertyId', 'UIA_TransformPatternId',
+           'PropertyConditionFlags_IgnoreCase',
+           'ScrollAmount_SmallDecrement',
+           'UIA_VirtualizedItemPatternId', 'IUIAutomationElement3',
+           'SupportedTextSelection_Single',
+           'IUIAutomationWindowPattern',
+           'UIA_VisualEffectsPropertyId',
+           'UIA_AnnotationObjectsPropertyId',
+           'UIA_ClickablePointPropertyId',
+           'IUIAutomationChangesEventHandler', 'DockPosition_Top',
+           'UIA_SelectionPattern2Id',
+           'UIA_SayAsInterpretAsAttributeId', 'UIA_LinkAttributeId',
+           'UIA_StyleNameAttributeId', 'UIA_LayoutInvalidatedEventId',
+           'UIA_ThumbControlTypeId', 'UIA_ChangesEventId',
+           'StructureChangeType_ChildrenBulkRemoved',
+           'NavigateDirection_Parent',
+           'UIA_WindowWindowInteractionStatePropertyId',
+           'UIA_AriaPropertiesPropertyId', 'UIA_IsPasswordPropertyId',
+           'UIA_ScrollHorizontalViewSizePropertyId',
+           'UIA_LegacyIAccessiblePatternId',
+           'OrientationType_Horizontal',
+           'UIA_AnnotationTypesPropertyId', 'TextUnit_Paragraph',
+           'WindowInteractionState_Running', 'StyleId_Normal']
 from comtypes import _check_version; _check_version('')


### PR DESCRIPTION
### Link to issue number:
None

### Description of this pull request
We bundle a comtypes wrapper for the UIAutomation dll as we want to make sure that everyone has the same wrapper that supports the most recent version of Windows. The current wrapper was build with an older version of comtypes on Python 2.

I ran comtypes.client.GetModule("UIAutomationCore.dll") from  a Python 3.7.3 interpretter with comtypes 1.1.7. As always, the order of definitions in the file has changed drastically.

### Testing performed:
Tested that NVDA still starts and has access to UIA

### Known issues with pull request:
NOne

### Change log entry:
None
