### PR TITLE
Python3: stop using unichr in brailleInput.py

### DIFF
--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -475,7 +475,6 @@ class BrailleInputGesture(inputCore.InputGesture):
 
 	@classmethod
 	def _makeDisplayText(cls, dots, space):
-		out = ""
 		if space and dots:
 			# Translators: Reported when braille space is pressed with dots in input help mode.
 			out = _("space with dot")
@@ -496,7 +495,6 @@ class BrailleInputGesture(inputCore.InputGesture):
 
 	@classmethod
 	def getDisplayTextForIdentifier(cls, identifier):
-		assert isinstance(identifier, str)
 		# Translators: Used when describing keys on a braille keyboard.
 		source = _("braille keyboard")
 		if identifier == cls.GENERIC_ID_SPACE_DOTS:

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -36,7 +36,7 @@ LOUIS_DOTS_IO_START = 0x8000
 #: @type: int
 UNICODE_BRAILLE_START = 0x2800
 #: The Unicode braille character to use when masking cells in protected fields.
-#: @type: unicode
+#: @type: str
 UNICODE_BRAILLE_PROTECTED = u"⣿" # All dots down
 
 #: The singleton BrailleInputHandler instance.
@@ -82,7 +82,7 @@ class BrailleInputHandler(AutoPropertyObject):
 		#: or were translated but did not produce any text.
 		#: This is used to show these cells to the user while they're entering braille.
 		#: This is a string of Unicode braille.
-		#: @type: unicode
+		#: @type: str
 		self.untranslatedBraille = ""
 		#: The position in L{brailleBuffer} where untranslated braille begins.
 		self.untranslatedStart = 0
@@ -126,7 +126,7 @@ class BrailleInputHandler(AutoPropertyObject):
 			self.bufferText = u""
 		oldTextLen = len(self.bufferText)
 		pos = self.untranslatedStart + self.untranslatedCursorPos
-		data = u"".join([unichr(cell | LOUIS_DOTS_IO_START) for cell in self.bufferBraille[:pos]])
+		data = u"".join([chr(cell | LOUIS_DOTS_IO_START) for cell in self.bufferBraille[:pos]])
 		mode = louis.dotsIO | louis.noUndefinedDots
 		if (not self.currentFocusIsTextObj or self.currentModifiers) and self._table.contracted:
 			mode |=  louis.partialTrans
@@ -175,10 +175,10 @@ class BrailleInputHandler(AutoPropertyObject):
 	def _translateForReportContractedCell(self, pos):
 		"""Translate text for current input as required by L{_reportContractedCell}.
 		@return: The previous translated text.
-		@rtype: unicode
+		@rtype: str
 		"""
 		cells = self.bufferBraille[:pos + 1]
-		data = u"".join([unichr(cell | LOUIS_DOTS_IO_START) for cell in cells])
+		data = u"".join([chr(cell | LOUIS_DOTS_IO_START) for cell in cells])
 		oldText = self.bufferText
 		text = louis.backTranslate(
 			[os.path.join(brailleTables.TABLES_DIR, self._table.fileName),
@@ -293,7 +293,7 @@ class BrailleInputHandler(AutoPropertyObject):
 		if api.isTypingProtected():
 			self.untranslatedBraille = UNICODE_BRAILLE_PROTECTED * (len(self.bufferBraille) - self.untranslatedStart)
 		else:
-			self.untranslatedBraille = "".join([unichr(UNICODE_BRAILLE_START + dots) for dots in self.bufferBraille[self.untranslatedStart:]])
+			self.untranslatedBraille = "".join([chr(UNICODE_BRAILLE_START + dots) for dots in self.bufferBraille[self.untranslatedStart:]])
 
 	def updateDisplay(self):
 		"""Update the braille display to reflect untranslated input.
@@ -385,7 +385,7 @@ class BrailleInputHandler(AutoPropertyObject):
 	def sendChars(self, chars):
 		"""Sends the provided unicode characters to the system.
 		@param chars: The characters to send to the system.
-		@type chars: unicode
+		@type chars: str
 		"""
 		inputs = []
 		for ch in chars:
@@ -475,6 +475,7 @@ class BrailleInputGesture(inputCore.InputGesture):
 
 	@classmethod
 	def _makeDisplayText(cls, dots, space):
+		out = ""
 		if space and dots:
 			# Translators: Reported when braille space is pressed with dots in input help mode.
 			out = _("space with dot")
@@ -495,6 +496,7 @@ class BrailleInputGesture(inputCore.InputGesture):
 
 	@classmethod
 	def getDisplayTextForIdentifier(cls, identifier):
+		assert isinstance(identifier, str)
 		# Translators: Used when describing keys on a braille keyboard.
 		source = _("braille keyboard")
 		if identifier == cls.GENERIC_ID_SPACE_DOTS:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Previously work was done to remove all usage of unichr from Python3, however brailleInput.py was not touched as it was thought that this would be handled when updating braille drivers in #9736.
However, pr #9736 does not do this.
Therefore, currently when trying to type on a braille display such as an Orbit Reader, the following traceback is seen:
```
Traceback (most recent call last):
  File "scriptHandler.py", line 189, in executeScript
    script(gesture)
  File "globalCommands.py", line 2059, in script_braille_dots
    brailleInput.handler.input(gesture.dots)
  File "brailleInput.py", line 247, in input
    if self._translate(endWord):
  File "brailleInput.py", line 129, in _translate
    data = u"".join([unichr(cell | LOUIS_DOTS_IO_START) for cell in self.bufferBraille[:pos]])
  File "brailleInput.py", line 129, in <listcomp>
    data = u"".join([unichr(cell | LOUIS_DOTS_IO_START) for cell in self.bufferBraille[:pos]])
NameError: name 'unichr' is not defined
```

### Description of how this pull request fixes the issue:
All references to unichr in brailleInput.py have been changed to chr. Also, any mention of the unicode type in docstrings has been changed to str.
 
### Testing performed:
Typed the following sentence on an Orbit Reader, using English 6 dot computer braille, UEB grade1 and UEB grade2, using contractions where possible:
"Hello, this is a test to see if this works."
Confirmed that the correct output was written and no traceback was produced.

### Known issues with pull request:
None.

### Change log entry:
None.
