### PR TITLE
Update check/Python 3: use a new kernel32 wrapper for MoveFileEx instead of os.renames for renaming update installer when 'Postpone' button is clicked

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -42,6 +42,7 @@ from logHandler import log, isPathExternalToNVDA
 import config
 import shellapi
 import winUser
+import winKernel
 import fileUtils
 from gui.dpiScalingHelper import DpiScalingHelperMixin
 
@@ -519,7 +520,10 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 	def onPostponeButton(self, evt):
 		finalDest=os.path.join(storeUpdatesDir, os.path.basename(self.destPath))
 		try:
-			os.renames(self.destPath, finalDest)
+			# #9825: behavior of os.rename(s) has changed in Python 3.
+			# See https://bugs.python.org/issue28356.
+			# Therefore use kernel32::MoveFileEx with write-through (0x8) and copy allowed (0x2) flags set.
+			winKernel.kernel32.MoveFileExW(self.destPath, finalDest, 0xa)
 		except:
 			log.debugWarning("Unable to rename the file from {} to {}".format(self.destPath, finalDest), exc_info=True)
 			gui.messageBox(

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -523,7 +523,7 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 			# #9825: behavior of os.rename(s) has changed in Python 3.
 			# See https://bugs.python.org/issue28356.
 			# Therefore use kernel32::MoveFileEx with copy allowed (0x2) flag set.
-			winKernel.kernel32.MoveFileExW(self.destPath, finalDest, 0x2)
+			winKernel.moveFileEx(self.destPath, finalDest, winKernel.MOVEFILE_COPY_ALLOWED)
 		except:
 			log.debugWarning("Unable to rename the file from {} to {}".format(self.destPath, finalDest), exc_info=True)
 			gui.messageBox(

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -522,8 +522,8 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 		try:
 			# #9825: behavior of os.rename(s) has changed in Python 3.
 			# See https://bugs.python.org/issue28356.
-			# Therefore use kernel32::MoveFileEx with write-through (0x8) and copy allowed (0x2) flags set.
-			winKernel.kernel32.MoveFileExW(self.destPath, finalDest, 0xa)
+			# Therefore use kernel32::MoveFileEx with copy allowed (0x2) flag set.
+			winKernel.kernel32.MoveFileExW(self.destPath, finalDest, 0x2)
 		except:
 			log.debugWarning("Unable to rename the file from {} to {}".format(self.destPath, finalDest), exc_info=True)
 			gui.messageBox(

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -1,8 +1,10 @@
 #winKernel.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2019 NV Access Limited, Rui Batista, Aleksey Sadovoy, Peter Vagner, Mozilla Corporation, Babbage B.V., Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+
+"""Functions that wrap Windows API functions from kernel32.dll and advapi32.dll"""
 
 import contextlib
 import ctypes

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -385,3 +385,16 @@ class HGLOBAL(HANDLE):
 		Necessary if you pass this HGLOBAL to an API that takes ownership and therefore will handle freeing itself.
 		"""
 		self.value=None
+
+MOVEFILE_COPY_ALLOWED = 0x2
+MOVEFILE_CREATE_HARDLINK = 0x10
+MOVEFILE_DELAY_UNTIL_REBOOT = 0x4
+MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20
+MOVEFILE_REPLACE_EXISTING = 0x1
+MOVEFILE_WRITE_THROUGH = 0x8
+
+def moveFileEx(lpExistingFileName, lpNewFileName, dwFlags):
+	res=kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags)
+	if res==0:
+		raise ctypes.WinError()
+	return res


### PR DESCRIPTION
### Link to issue number:
Fixes #9825 

### Summary of the issue:
In Python 3, if os.renames is attempted when moving files from one drive to another, error 17 (canot move file to a different drive) is presented.

### Description of how this pull request fixes the issue:
Changed to use shutil.move to "rename" the update installer when "Postpone" button is clicked. Note that because shutil.move blocks, a dedicated thread will be used to rename the installer.

### Testing performed:
Tested with a modified Python 3 staging source, checking to make sure the installer was renamed and update check state dictionary was consistent.

### Known issues with pull request:
None

### Change log entry:
None
