### PR TITLE
Update check/Python 3: convert update check resource from bytes to Unicode

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -137,7 +137,8 @@ def checkForUpdate(auto=False):
 		raise RuntimeError("Checking for update failed with code %d" % res.code)
 	info = {}
 	for line in res:
-		line = line.rstrip()
+		# #9819: update description resource returns bytes, so make it Unicode.
+		line = line.decode("utf-8").rstrip()
 		try:
 			key, val = line.split(": ", 1)
 		except ValueError:


### PR DESCRIPTION
### Link to issue number:
Fixes #9819 

### Summary of the issue:
Update check resource is presented as bytes-like object.

### Description of how this pull request fixes the issue:
Convert resource to Unicode before splitting into key:val pairs.

### Testing performed:
Tested to make sure update check facility returns update check resource as before and presents appropriate message.

### Known issues with pull request:
None

### Change log entry:
None
