### PR TITLE
Python 3: Fix comparison error in start menu

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -235,8 +235,10 @@ class UIATextInfo(textInfos.TextInfo):
 					formatField['link']=True
 		if formatConfig["reportHeadings"]:
 			styleIDValue=fetcher.getValue(UIAHandler.UIA_StyleIdAttributeId,ignoreMixedValues=ignoreMixedValues)
-			if UIAHandler.StyleId_Heading1<=styleIDValue<=UIAHandler.StyleId_Heading9: 
-				formatField["heading-level"]=(styleIDValue-UIAHandler.StyleId_Heading1)+1
+			# #9842: styleIDValue can sometimes be a pointer to IUnknown.
+			# In Python 3, comparing an int with a pointer raises a TypeError.
+			if isinstance(styleIDValue, int) and UIAHandler.StyleId_Heading1 <= styleIDValue <= UIAHandler.StyleId_Heading9:
+				formatField["heading-level"] = (styleIDValue - UIAHandler.StyleId_Heading1) + 1
 		if fetchAnnotationTypes:
 			annotationTypes=fetcher.getValue(UIAHandler.UIA_AnnotationTypesAttributeId,ignoreMixedValues=ignoreMixedValues)
 			# Some UIA implementations return a single value rather than a tuple.

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -156,9 +156,11 @@ def UIAHeadingQuicknavIterator(itemType,document,position,direction="next"):
 		tempInfo=curPosition.copy()
 		tempInfo.expand(textInfos.UNIT_CHARACTER)
 		styleIDValue=getUIATextAttributeValueFromRange(tempInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId,ignoreMixedValues=True)
-		if (UIAHandler.StyleId_Heading1<=styleIDValue<=UIAHandler.StyleId_Heading9):
-			foundLevel=(styleIDValue-UIAHandler.StyleId_Heading1)+1
-			wantedLevel=int(itemType[7:]) if len(itemType)>7 else None
+		# #9842: styleIDValue can sometimes be a pointer to IUnknown.
+		# In Python 3, comparing an int with a pointer raises a TypeError.
+		if isinstance(styleIDValue, int) and UIAHandler.StyleId_Heading1 <= styleIDValue <= UIAHandler.StyleId_Heading9:
+			foundLevel = (styleIDValue - UIAHandler.StyleId_Heading1) + 1
+			wantedLevel = int(itemType[7:]) if len(itemType) > 7 else None
 			if not wantedLevel or wantedLevel==foundLevel: 
 				if not firstLoop or not position:
 					tempInfo.expand(textInfos.UNIT_PARAGRAPH)


### PR DESCRIPTION
### Link to issue number:
Fixes #9842 

### Summary of the issue:
Threshold_py3_staging can raise a TypeErrorin the Windows 10 start menu.

### Description of how this pull request fixes the issue:
Before detecting the UIA Heading level, make sure that we are comparing against an int, not against a pointer to IUnknown.

### Testing performed:
1. Made sure that the error in the start menu disappeared.
2. Made sure that heading detection still works in Edge.

### Known issues with pull request:
None

### Change log entry:
None
