### PR TITLE
readme.md: Fix broken link to Doxygen version 1.7.3 Windows installer…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ For reference, the following dependencies are included in Git submodules:
 ### Other Dependencies
 These dependencies are not included in Git submodules, but aren't needed by most people.
 
-* To generate developer documentation for nvdaHelper: [Doxygen Windows installer](http://www.stack.nl/~dimitri/doxygen/download.html), version 1.7.3:
+* To generate developer documentation for nvdaHelper: [Doxygen version 1.7.3 Windows installer](https://sourceforge.net/projects/doxygen/files/rel-1.7.3/doxygen-1.7.3-setup.exe)
 
 ## Preparing the Source Tree
 Before you can run the NVDA source code, you must prepare the source tree.


### PR DESCRIPTION
… (#9513)

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9513

### Summary of the issue:

In readme.md, the link to Doxygen is broken: http://www.stack.nl/~dimitri/doxygen/download.html
Returns 403 Forbidden

### Description of how this pull request fixes the issue:

Direct link to Doxygen 1.7.3 Windows installer at SourceForge: https://sourceforge.net/projects/doxygen/files/rel-1.7.3/doxygen-1.7.3-setup.exe

### Testing performed:

This new link is active.
Did not try to install, though.

### Known issues with pull request:

### Change log entry:

N/A