### PR TITLE
WinKernel: create a wrapper for MoveFileExW function and associated flag constants

### DIFF
--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -11,9 +11,7 @@ from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from logHandler import log
 from six import text_type
-
-#: Constant; flag for MoveFileEx(). If a file with the destination filename already exists, it is overwritten.
-MOVEFILE_REPLACE_EXISTING = 1
+import winKernel
 
 @contextmanager
 def FaultTolerantFile(name):
@@ -39,9 +37,7 @@ def FaultTolerantFile(name):
 		f.flush()
 		os.fsync(f)
 		f.close()
-		moveFileResult = ctypes.windll.kernel32.MoveFileExW(f.name, name, MOVEFILE_REPLACE_EXISTING)
-		if moveFileResult == 0:
-			raise ctypes.WinError()
+		winKernel.moveFileEx(f.name, name, winKernel.MOVEFILE_REPLACE_EXISTING)
 
 def getFileVersionInfo(name, *attributes):
 	"""Gets the specified file version info attributes from the provided file."""

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,8 +1,9 @@
 #fileUtils.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017 NV Access Limited, Bram Duvigneau
+#Copyright (C) 2017-2019 NV Access Limited, Bram Duvigneau
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+
 import os
 import ctypes
 import ctypes.wintypes

--- a/source/installer.py
+++ b/source/installer.py
@@ -364,7 +364,7 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 	if rebootOK:
 		log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		try:
-			# #9847: convert the path qualifier to Unicode so temp path can be appended correctly.
+			# #9847: convert the path qualifier to Unicode so temp path can be appended correctly due to issues seen when appending unicode to raw strings for certain strings.
 			winKernel.moveFileEx(u"\\\\?\\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
 		except WinError:
 			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)

--- a/source/installer.py
+++ b/source/installer.py
@@ -364,8 +364,11 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 	if rebootOK:
 		log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		try:
-			# #9847: convert the path qualifier to Unicode so temp path can be appended correctly due to issues seen when appending unicode to raw strings for certain strings.
-			winKernel.moveFileEx(u"\\\\?\\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
+			# Use escapes in a unicode string instead of raw.
+			# In a raw string the trailing slash escapes the closing quote leading to a python syntax error.
+			pathQualifier=u"\\\\?\\"
+			# #9847: Move file to None to delete it.
+			winKernel.moveFileEx(pathQualifier+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
 		except WinError:
 			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		return

--- a/source/installer.py
+++ b/source/installer.py
@@ -364,7 +364,8 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 	if rebootOK:
 		log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		try:
-			winKernel.moveFileEx(r"\\?\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
+			# #9847: convert the path qualifier to Unicode so temp path can be appended correctly.
+			winKernel.moveFileEx(u"\\\\?\\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
 		except WinError:
 			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		return

--- a/source/installer.py
+++ b/source/installer.py
@@ -363,7 +363,10 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 		time.sleep(retryInterval)
 	if rebootOK:
 		log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
-		winKernel.moveFileEx("\\\\?\\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
+		try:
+			winKernel.moveFileEx(r"\\?\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
+		except WinError:
+			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		return
 	try:
 		os.rename(tempPath,path)

--- a/source/installer.py
+++ b/source/installer.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2011-2017 NV Access Limited, Joseph Lee, Babbage B.V.
+#Copyright (C) 2011-2019 NV Access Limited, Joseph Lee, Babbage B.V.
 
 from ctypes import *
 from ctypes.wintypes import *

--- a/source/installer.py
+++ b/source/installer.py
@@ -22,6 +22,7 @@ from logHandler import log
 import addonHandler
 import easeOfAccess
 import COMRegistrationFixes
+import winKernel
 
 _wsh=None
 def _getWSH():
@@ -362,8 +363,7 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 		time.sleep(retryInterval)
 	if rebootOK:
 		log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
-		MoveFileEx=windll.kernel32.MoveFileExW
-		MoveFileEx("\\\\?\\"+tempPath,None,4)
+		winKernel.moveFileEx("\\\\?\\"+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
 		return
 	try:
 		os.rename(tempPath,path)
@@ -387,7 +387,7 @@ def tryCopyFile(sourceFilePath,destFilePath):
 		except (WindowsError,OSError):
 			log.error("Failed to rename %s after failed overwrite"%destFilePath,exc_info=True)
 			raise RetriableFailure("Failed to rename %s after failed overwrite"%destFilePath) 
-		windll.kernel32.MoveFileExW(tempPath,None,4)
+		winKernel.moveFileEx(tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
 		if windll.kernel32.CopyFileW(sourceFilePath,destFilePath,False)==0:
 			errorCode=GetLastError()
 			raise OSError("Unable to copy file %s to %s, error %d"%(sourceFilePath,destFilePath,errorCode))

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2018 NV Access Limited, Zahari Yurukov, Babbage B.V.
+#Copyright (C) 2012-2019 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
 
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -520,8 +520,9 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 	def onPostponeButton(self, evt):
 		finalDest=os.path.join(storeUpdatesDir, os.path.basename(self.destPath))
 		try:
-			# #9825: behavior of os.rename(s) has changed in Python 3 (needed for file renames, possibly across drives in case of portable cop0y).
-			# See https://bugs.python.org/issue28356.
+			# #9825: behavior of os.rename(s) has changed (see https://bugs.python.org/issue28356).
+			# In Python 2, os.renames did rename files across drives, no longer allowed in Python 3 (error 17 (cannot move files across drives) is raised).
+			# This is prominent when trying to postpone an update for portable copy of NVDA if this runs from a USB flash drive or another internal storage device.
 			# Therefore use kernel32::MoveFileEx with copy allowed (0x2) flag set.
 			winKernel.moveFileEx(self.destPath, finalDest, winKernel.MOVEFILE_COPY_ALLOWED)
 		except:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -42,6 +42,7 @@ from logHandler import log, isPathExternalToNVDA
 import config
 import shellapi
 import winUser
+import winKernel
 import fileUtils
 from gui.dpiScalingHelper import DpiScalingHelperMixin
 
@@ -519,7 +520,10 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 	def onPostponeButton(self, evt):
 		finalDest=os.path.join(storeUpdatesDir, os.path.basename(self.destPath))
 		try:
-			os.renames(self.destPath, finalDest)
+			# #9825: behavior of os.rename(s) has changed in Python 3.
+			# See https://bugs.python.org/issue28356.
+			# Therefore use kernel32::MoveFileEx with copy allowed (0x2) flag set.
+			winKernel.moveFileEx(self.destPath, finalDest, winKernel.MOVEFILE_COPY_ALLOWED)
 		except:
 			log.debugWarning("Unable to rename the file from {} to {}".format(self.destPath, finalDest), exc_info=True)
 			gui.messageBox(

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -520,7 +520,7 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 	def onPostponeButton(self, evt):
 		finalDest=os.path.join(storeUpdatesDir, os.path.basename(self.destPath))
 		try:
-			# #9825: behavior of os.rename(s) has changed in Python 3.
+			# #9825: behavior of os.rename(s) has changed in Python 3 (needed for file renames, possibly across drives in case of portable cop0y).
 			# See https://bugs.python.org/issue28356.
 			# Therefore use kernel32::MoveFileEx with copy allowed (0x2) flag set.
 			winKernel.moveFileEx(self.destPath, finalDest, winKernel.MOVEFILE_COPY_ALLOWED)

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -394,7 +394,5 @@ MOVEFILE_REPLACE_EXISTING = 0x1
 MOVEFILE_WRITE_THROUGH = 0x8
 
 def moveFileEx(lpExistingFileName, lpNewFileName, dwFlags):
-	moveFileResult=kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags)
-	if moveFileResult==0:
+	if not kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags):
 		raise ctypes.WinError()
-	return moveFileResult

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -385,3 +385,16 @@ class HGLOBAL(HANDLE):
 		Necessary if you pass this HGLOBAL to an API that takes ownership and therefore will handle freeing itself.
 		"""
 		self.value=None
+
+MOVEFILE_COPY_ALLOWED = 0x2
+MOVEFILE_CREATE_HARDLINK = 0x10
+MOVEFILE_DELAY_UNTIL_REBOOT = 0x4
+MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20
+MOVEFILE_REPLACE_EXISTING = 0x1
+MOVEFILE_WRITE_THROUGH = 0x8
+
+def moveFileEx(lpExistingFileName, lpNewFileName, dwFlags):
+	moveFileResult=kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags)
+	if moveFileResult==0:
+		raise ctypes.WinError()
+	return moveFileResult

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -1,8 +1,10 @@
 #winKernel.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2019 NV Access Limited, Rui Batista, Aleksey Sadovoy, Peter Vagner, Mozilla Corporation, Babbage B.V., Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+
+"""Functions that wrap Windows API functions from kernel32.dll and advapi32.dll"""
 
 import contextlib
 import ctypes

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -393,6 +393,6 @@ MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20
 MOVEFILE_REPLACE_EXISTING = 0x1
 MOVEFILE_WRITE_THROUGH = 0x8
 
-def moveFileEx(lpExistingFileName, lpNewFileName, dwFlags):
+def moveFileEx(lpExistingFileName: str, lpNewFileName: str, dwFlags: int):
 	if not kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags):
 		raise ctypes.WinError()

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -394,5 +394,6 @@ MOVEFILE_REPLACE_EXISTING = 0x1
 MOVEFILE_WRITE_THROUGH = 0x8
 
 def moveFileEx(lpExistingFileName: str, lpNewFileName: str, dwFlags: int):
+	# If MoveFileExW fails, Windows will raise appropriate errors.
 	if not kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags):
 		raise ctypes.WinError()


### PR DESCRIPTION
### Link to issue number:
Fixes #9847 
Fixes #9825 

### Summary of the issue:
Create a wrapper for kernel32.dll::MoveFileExW.

### Description of how this pull request fixes the issue:
A new wrapper function and flags for MoveFileExW has been created in winKernel module, with various file move operations transfered from different modules. The edited modules include file utils, instlaler, and update check. In case of update check, this resolves #9825.

### Testing performed:
Tested with update checking and fault-tolerant file.

### Known issues with pull request:
None at the moment

### Change log entry:
None (unless needed for developers
