### PR TITLE
New handy tech display models

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -524,8 +524,8 @@ addUsbDevices("handyTech", KEY_SERIAL, {
 addUsbDevices("handyTech", KEY_HID, {
 	"VID_1FE4&PID_0054", # Active Braille
 	"VID_1FE4&PID_0055", # Connect Braille
-	"VID_1FE4&PID_0061", # Actilino
-	"VID_1FE4&PID_0064", # Active Star 40
+	"VID_1FE4&PID_0061",  # Actilino
+	"VID_1FE4&PID_0064",  # Active Star 40
 	"VID_1FE4&PID_0081", # Basic Braille 16
 	"VID_1FE4&PID_0082", # Basic Braille 20
 	"VID_1FE4&PID_0083", # Basic Braille 32

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -524,6 +524,8 @@ addUsbDevices("handyTech", KEY_SERIAL, {
 addUsbDevices("handyTech", KEY_HID, {
 	"VID_1FE4&PID_0054", # Active Braille
 	"VID_1FE4&PID_0055", # Connect Braille
+	"VID_1FE4&PID_0061", # Actilino
+	"VID_1FE4&PID_0064", # Active Star 40
 	"VID_1FE4&PID_0081", # Basic Braille 16
 	"VID_1FE4&PID_0082", # Basic Braille 20
 	"VID_1FE4&PID_0083", # Basic Braille 32
@@ -535,8 +537,6 @@ addUsbDevices("handyTech", KEY_HID, {
 	"VID_1FE4&PID_008C", # Basic Braille 84
 	"VID_1FE4&PID_0093", # Basic Braille Plus 32
 	"VID_1FE4&PID_0094", # Basic Braille Plus 40
-	"VID_1FE4&PID_0061", # Actilino
-	"VID_1FE4&PID_0064", # Active Star 40
 })
 
 # Some older HT displays use a HID converter and an internal serial interface

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -91,6 +91,8 @@ MODEL_BASIC_BRAILLE_64 = b"\x86"
 MODEL_BASIC_BRAILLE_80 = b"\x87"
 MODEL_BASIC_BRAILLE_160 = b"\x8B"
 MODEL_BASIC_BRAILLE_84 = b"\x8C"
+MODEL_BASIC_BRAILLE_PLUS_32 = b"\x93"
+MODEL_BASIC_BRAILLE_PLUS_40 = b"\x94"
 MODEL_BRAILLINO = b"\x72"
 MODEL_BRAILLE_STAR_40 = b"\x74"
 MODEL_BRAILLE_STAR_80 = b"\x78"
@@ -446,7 +448,14 @@ class BasicBraille(Model):
 		return '{name} {cells}'.format(name=self.genericName, cells=self.numCells)
 
 
-def basicBrailleFactory(numCells: int, deviceId: bytes):
+class BasicBraillePlus(TripleActionKeysMixin, Model):
+	genericName = "Basic Braille Plus"
+
+	def _get_name(self):
+		return '{name} {cells}'.format(name=self.genericName, cells=self.numCells)
+
+
+def basicBrailleFactory(numCells, deviceId):
 	return type("BasicBraille{cells}".format(cells=numCells), (BasicBraille,), {
 		"deviceId": deviceId,
 		"numCells": numCells,
@@ -461,6 +470,16 @@ BasicBraille64 = basicBrailleFactory(64, MODEL_BASIC_BRAILLE_64)
 BasicBraille80 = basicBrailleFactory(80, MODEL_BASIC_BRAILLE_80)
 BasicBraille160 = basicBrailleFactory(160, MODEL_BASIC_BRAILLE_160)
 BasicBraille84 = basicBrailleFactory(84, MODEL_BASIC_BRAILLE_84)
+
+
+def basicBraillePlusFactory(numCells, deviceId):
+	return type("BasicBraillePlus{cells}".format(cells=numCells), (BasicBraillePlus,), {
+		"deviceId": deviceId,
+		"numCells": numCells,
+	})
+
+BasicBraillePlus32 = basicBraillePlusFactory(32, MODEL_BASIC_BRAILLE_PLUS_32)
+BasicBraillePlus40 = basicBraillePlusFactory(40, MODEL_BASIC_BRAILLE_PLUS_40)
 
 
 class BrailleStar(TripleActionKeysMixin, Model):

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -478,6 +478,7 @@ def basicBraillePlusFactory(numCells, deviceId):
 		"numCells": numCells,
 	})
 
+
 BasicBraillePlus32 = basicBraillePlusFactory(32, MODEL_BASIC_BRAILLE_PLUS_32)
 BasicBraillePlus40 = basicBraillePlusFactory(40, MODEL_BASIC_BRAILLE_PLUS_40)
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Does not apply.
### Summary of the issue:
New Handy Tech display models are not recognized by NVDA as they use new ID bytes and/or Bluetooth names.
### Description of how this pull request fixes the issue:
This branch is kept up to date with new Braille displays from Handy Tech.
### Testing performed:
Tested with current models.
### Known issues with pull request:
None.
### Change log entry:

Added support for the following Handy Tech Braille displays:
- Basic Braille Plus 40
- Basic Braille Plus 32
- Connect Braille