### PR TITLE
Python 3: Update py2exe to fix several issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,31 +57,32 @@ If you didn't pass the `--recursive` option to git clone, you will need to run `
 Whenever a required submodule commit changes (e.g. after git pull), you will need to run `git submodule update`.
 If you aren't sure, run `git submodule update` after every git pull, merge or checkout.
 
-For reference, the following dependencies are included in Git submodules:
+For reference, the following run time dependencies are included in Git submodules:
 
 * [comtypes](https://github.com/enthought/comtypes), version 1.1.7
 * [wxPython](http://www.wxpython.org/), version 4.0.3
-* [Six](https://pypi.python.org/pypi/six), version 1.10.0, required by wxPython
-* [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 218
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 86e67a
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
+* [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
 * [liblouis](http://www.liblouis.org/), version 3.10.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
-* System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * Adobe FlashAccessibility interface typelib
-* [txt2tags](http://txt2tags.sourceforge.net/), version 2.5
 * [MinHook](https://github.com/RaMMicHaeL/minhook), tagged version 1.2.2
-* [SCons](http://www.scons.org/), version 3.0.4
 * brlapi Python bindings, version 0.7.0 or later, distributed with [BRLTTY for Windows](http://brl.thefreecat.org/brltty/), version 4.2-2
-* ALVA BC6 generic dll, version 3.0.4.1
 * lilli.dll, version 2.1.0.0
 * [pySerial](http://pypi.python.org/pypi/pyserial), version 3.4
 * [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)
-* [Py2Exe](http://sourceforge.net/projects/py2exe/), version 0.6.9
+
+Additionally, the following build time dependencies are included in Git submodules:
+
+* [Py2Exe](http://github.com/albertosottile/py2exe/), version 0.9.3.2 commit b372a8e
+* [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 224, required by py2exe
+* [txt2tags](http://txt2tags.sourceforge.net/), version 2.5
+* [SCons](http://www.scons.org/), version 3.0.4
 * [Nulsoft Install System](http://nsis.sourceforge.net/), version 2.51
 * [NSIS UAC plug-in](http://nsis.sourceforge.net/UAC_plug-in), version 0.2.4, ansi
 * xgettext and msgfmt from [GNU gettext](http://sourceforge.net/projects/cppcms/files/boost_locale/gettext_for_windows/)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -94,11 +94,15 @@ def getCodePath(f):
 	return ".".join(x for x in (path,className,funcName) if x)
 
 # Function to strip the base path of our code from traceback text to improve readability.
-BASE_PATH = os.path.split(__file__)[0] + os.sep
-TB_BASE_PATH_PREFIX = '  File "'
-TB_BASE_PATH_MATCH = TB_BASE_PATH_PREFIX + BASE_PATH
-def stripBasePathFromTracebackText(text):
-	return text.replace(TB_BASE_PATH_MATCH, TB_BASE_PATH_PREFIX)
+if getattr(sys, "frozen", None):
+	# We're running a py2exe build.
+	stripBasePathFromTracebackText = lambda text: text
+else:
+	BASE_PATH = os.path.split(__file__)[0] + os.sep
+	TB_BASE_PATH_PREFIX = '  File "'
+	TB_BASE_PATH_MATCH = TB_BASE_PATH_PREFIX + BASE_PATH
+	def stripBasePathFromTracebackText(text):
+		return text.replace(TB_BASE_PATH_MATCH, TB_BASE_PATH_PREFIX)
 
 class Logger(logging.Logger):
 	# Import standard levels for convenience.

--- a/source/setup.py
+++ b/source/setup.py
@@ -198,11 +198,13 @@ setup(
 			"serial.socket_connection",
 			# netbios (from pywin32) is optionally used by Python3's uuid module.
 			# This is not needed.
+			# We also need to exclude win32wnet explicitly.
 			"netbios",
+			"win32wnet"
 			# winxptheme is optionally used by wx.lib.agw.aui.
 			# We don't need this.
 			"winxptheme",
-			],
+		],
 		"packages": ["NVDAObjects","virtualBuffers","appModules","comInterfaces","brailleDisplayDrivers","synthDrivers"],
 		"includes": [
 			"nvdaBuiltin",

--- a/source/setup.py
+++ b/source/setup.py
@@ -200,7 +200,7 @@ setup(
 			# This is not needed.
 			# We also need to exclude win32wnet explicitly.
 			"netbios",
-			"win32wnet"
+			"win32wnet",
 			# winxptheme is optionally used by wx.lib.agw.aui.
 			# We don't need this.
 			"winxptheme",


### PR DESCRIPTION
### Link to issue number:
Fixes #9813 
Closes #9841 
Fixes #9831

### Summary of the issue:
During development of the threshold_py3_staging branch, some issues have been identified in py2exe. They have either been merged into upstream or have been considered stable by us.

### Description of how this pull request fixes the issue:
1. importing _ssl will no longer raise a module not found error
2. Trace backs now contain proper paths
3. win32wnet and pywintypes are excluded at build time, as they are not necessary for a running copy of NVDA
4. Traceback paths are no longer stripped when NVDA is frozen, as before (in master)
5. Updated the readme, removing some outdated stuff as well and added a distinction between run time and build time dependencies.

### Testing performed:
Made sure that the steps to reproduce revealed the expected behaviour.
I will also test the try build again when it is finished.

### Known issues with pull request:
None

### Change log entry:
None