### PR TITLE
Python 3 one core: Don't check for sys.frozen in the check method.

### DIFF
--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -117,12 +117,7 @@ class SynthDriver(SynthDriver):
 
 	@classmethod
 	def check(cls):
-		if not hasattr(sys, "frozen"):
-			# #3793: Source copies don't report the correct version on Windows 10 because Python isn't manifested for higher versions.
-			# We want this driver to work for source copies on Windows 10, so just return True here.
-			# If this isn't in fact Windows 10, it will fail when constructed, which is okay.
-			return True
-		# For binary copies, only present this as an available synth if this is Windows 10.
+		# Only present this as an available synth if this is Windows 10.
 		return winVersion.winVersion.major >= 10
 
 	def _get_supportsProsodyOptions(self):

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -118,7 +118,7 @@ class SynthDriver(SynthDriver):
 	@classmethod
 	def check(cls):
 		# Only present this as an available synth if this is Windows 10.
-		return winVersion.winVersion.major >= 10
+		return winVersion.isWin10()
 
 	def _get_supportsProsodyOptions(self):
 		self.supportsProsodyOptions = self._dll.ocSpeech_supportsProsodyOptions()

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -30,7 +30,6 @@ def isUwpOcrAvailable():
 def isWin10(version=1507, atLeast=True):
 	"""
 	Returns True if NVDA is running on the supplied release version of Windows 10. If no argument is supplied, returns True for all public Windows 10 releases.
-	@note: this function will always return False for source copies of NVDA due to a Python bug.
 	@param version: a release version of Windows 10 (such as 1903).
 	@param atLeast: return True if NVDA is running on at least this Windows 10 build (i.e. this version or higher).
 	"""


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When running a python 2 copy from source, NVDA is unable to detect if it is running under Windows 10. Therefore, the oneCore synthesizer contains a work around in its check method, always listing the synthesizer in the synthesizer list when running from source, even on Windows versions older than Windows 10.
On Python 3 however, the manifest of the main Python targets Windows 10 and therefore, this workaround is no longer necessary.

### Description of how this pull request fixes the issue:
Changed the check method to always evaluate the current windows version.

### Testing performed:
1. Tested that on Windows 10, the one core synth is listed and works when running from source.
2. Tested that when compatibility mode was enabled for Windows 8, the one core synthesizer doesn't show up when running from source.

### Known issues with pull request:
None

### Change log entry:
None. This only affects people running from source.