### PR TITLE
Align braille input fall-back table to the default configuration (#9863)

### DIFF
--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -29,7 +29,7 @@ as there are built-in gesture bindings for braille input.
 """
 
 #: Table to use if the input table configuration is invalid.
-FALLBACK_TABLE = "en-us-comp8.ctb"
+FALLBACK_TABLE = "en-ueb-g1.ctb"
 DOT7 = 1 << 6
 DOT8 = 1 << 7
 #: This bit flag must be added to all braille cells when using liblouis with dotsIO.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9863

### Summary of the issue:

`brailleInput.FALLBACK_TABLE` is set to "en-us-comp8.ctb" as of 1c0d4905c2 (2017-07-07)
In `configSpec`, `["braille"]["inputTable"]` default has been updated to "en-ueb-g1.ctb" as of 7cec3350b0 (2017-08-01)

### Description of how this pull request fixes the issue:

Align the braille input fall-back table to the factory default for new configurations `en-ueb-g1.ctb`

### Testing performed:

### Known issues with pull request:

### Change log entry:

Probably not worth mentioning

