### PR TITLE
Python 3: fix say all for DisplayModelEditableText

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -575,7 +575,7 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 		if offset>=len(rects):
 			raise RuntimeError("offset %d out of range")
 		rect = rects[offset]
-		x = rect.x
+		x = rect.left
 		y= rect.center.y
 		x,y=windowUtils.logicalToPhysicalPoint(self.obj.windowHandle,x,y)
 		oldX,oldY=winUser.getCursorPos()


### PR DESCRIPTION
### Link to issue number:
Fixes #9860 

### Summary of the issue:
The deprecate functionality pr introduced an issue that prevented say all from working in DisplayModelEditableText

### Description of how this pull request fixes the issue:
Rather than getting the x attribute on a rectangle (which didn't exist), get the left coordinate.

### Testing performed:
Tested by @lukaszgo1 

### Known issues with pull request:
* As an x coordinate, we're getting the left coordinate of the rectangle instead of the x of the center point. I don't know why this is, this has been so since #659 introduced setCaretOffset, so I'm tempted to leave it as is. It might have been so for a reason we don't know, and it is likely that @michaeldcurran doesn't know this any more given this code is over 9 years old.
* This bug was introduced in threshold, not threshold_py3_staging. @feerrenrut: do you want me to change the base for this?

### Change log entry:
None
