### PR TITLE
Improve automatic reporting of incoming messages in Miranda NG

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Joseph Lee
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Joseph Lee, Bill Dengler
 
 """Mix-in classes which provide common behaviour for particular types of controls across different APIs.
 Behaviors described in this mix-in include providing table navigation commands for certain table rows, terminal input and output support, announcing notifications and suggestion items and so on.

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -380,7 +380,7 @@ for implementing history in chat programs."""
 			# Translators: This is presented to inform the user that
 			# no more items are available in the announcement history
 			# (such as for chat applications).
-			ui.message(_("No more"))
+			ui.message(_("No more items"))
 	# Translators: The description of an NVDA command to view items in the
 	# history (such as in chat applications).
 	script_readHistoryItem.__doc__=_("Displays items in the history")

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -399,18 +399,19 @@ class DisplayModelEditableText(EditableText, Window):
 		# Don't report value changes for editable text fields.
 		pass
 
-class DisplayModelLiveText(LiveText, Window):
-	TextInfo = displayModel.EditableTextDisplayModelTextInfo
-
+class DisplayModelLiveTextWithoutTextInfo(LiveText, Window):
 	def startMonitoring(self):
 		# Force the window to be redrawn, as our display model might be out of date.
 		self.redraw()
 		displayModel.requestTextChangeNotifications(self, True)
-		super(DisplayModelLiveText, self).startMonitoring()
+		super(DisplayModelLiveTextWithoutTextInfo, self).startMonitoring()
 
 	def stopMonitoring(self):
-		super(DisplayModelLiveText, self).stopMonitoring()
+		super(DisplayModelLiveTextWithoutTextInfo, self).stopMonitoring()
 		displayModel.requestTextChangeNotifications(self, False)
+
+class DisplayModelLiveText(DisplayModelLiveTextWithoutTextInfo):
+	TextInfo = displayModel.EditableTextDisplayModelTextInfo
 
 windowClassMap={
 	"EDIT":"Edit",

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -16,7 +16,7 @@ import config
 import displayModel
 import eventHandler
 from NVDAObjects import NVDAObject
-from NVDAObjects.behaviors import EditableText, LiveText
+from NVDAObjects.behaviors import EditableText, LiveText, DisplayModelTextMonitor
 import watchdog
 from locationHelper import RectLTWH
 
@@ -399,18 +399,8 @@ class DisplayModelEditableText(EditableText, Window):
 		# Don't report value changes for editable text fields.
 		pass
 
-class DisplayModelLiveTextWithoutTextInfo(LiveText, Window):
-	def startMonitoring(self):
-		# Force the window to be redrawn, as our display model might be out of date.
-		self.redraw()
-		displayModel.requestTextChangeNotifications(self, True)
-		super(DisplayModelLiveTextWithoutTextInfo, self).startMonitoring()
 
-	def stopMonitoring(self):
-		super(DisplayModelLiveTextWithoutTextInfo, self).stopMonitoring()
-		displayModel.requestTextChangeNotifications(self, False)
-
-class DisplayModelLiveText(DisplayModelLiveTextWithoutTextInfo):
+class DisplayModelLiveText(DisplayModelTextMonitor, LiveText):
 	TextInfo = displayModel.EditableTextDisplayModelTextInfo
 
 windowClassMap={

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -9,7 +9,7 @@ import ui
 import config
 from ctypes import *
 from ctypes.wintypes import *
-from NVDAObjects.window import DisplayModelLiveTextWithoutTextInfo
+from NVDAObjects.behaviors import DisplayModelTextMonitor, LiveText
 import winKernel
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
 from NVDAObjects.behaviors import Dialog, LiveTextHistoryMixin
@@ -252,5 +252,5 @@ class MirandaMessageWindow(IAccessible):
 			pass
 
 
-class MirandaMessageLog(LiveTextHistoryMixin, DisplayModelLiveTextWithoutTextInfo):
+class MirandaMessageLog(LiveTextHistoryMixin, DisplayModelTextMonitor, LiveText):
 	pass

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -31,6 +31,7 @@ class AppModule(appModuleHandler.AppModule):
 			ui.message(self.msgs[num-1])
 		except IndexError:
 			ui.message(_("No message yet"))
+	# Translators: A gesture description.
 	script_readMessage.__doc__=_("Displays one of the recent messages")
 
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #640, #1471.

### Summary of the issue:
In Miranda NG, NVDA often fails to automatically report incoming messages, particularly when there are less than ten messages in a conversation.

### Description of how this pull request fixes the issue:
An `NVDAObjects.behaviors.liveTextHistoryMixin` class, which adds an announcement history to `liveText` objects, has been added. A `displayModelLiveTextWithoutTextInfo` class has also been added, which uses the display model to receive text updates but doesn't override an object's `textInfo`. Instead of relying on `valueChange` events from the scrollbar in message windows, the Miranda NG app module now uses both of these new classes to implement automatic readout of incoming messages.

### Testing performed:
Tested automatic reporting in the #flood channel on Freenode after manually starting monitoring of the `liveText` object (with the Python console) and verified that it is functional starting from the very first message. Pressed control+nvda+1 through 0 while the conversation log had focus and verified that messages were being read.

### Known issues with pull request:
* This implementation of `MirandaMessageWindow._get_messageLog` does not correctly find the control, so `startMonitoring` and `stopMonitoring` are not called when a conversation gains or loses focus. Interestingly, while the `parent` property of the read-only edit field properly refers to the conversation window, the control does not appear as one of its descendants.
* The history gestures (control+NVDA+1 through 0) only execute the script when the read-only edit field has focus, but they should call the script when focused on any control in the window. I think we need to set the `canPropagate` property on the script to get this behavior, but even with that property set to `True` this is not functioning as expected.

### Change log entry:
== Bug Fixes ==
- In Miranda NG, incoming messages are now reported more consistently. (#9869)

== Changes for Developers ==
- Added a new `NVDAObjects.behaviors.liveTextHistoryMixin` class, which provides an announcement history class for `liveText` controls. This may be particularly useful for chat applications. (#9869)
- Added an `NVDAObjects.window.displayModelLiveTextWithoutTextInfo` class which uses the display model to report dynamic text changes without overriding an object's `textInfo`. (#9869)