### PR TITLE
Python 3: sys.exec_prefix > sys.prefix for nvda_slave

### DIFF
--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -48,7 +48,7 @@ def main():
 			import shellapi
 			import winUser
 			shellapi.ShellExecute(0,None,
-				r"%s\nvda.exe"%sys.exec_prefix,
+				r"%s\nvda.exe"%sys.prefix,
 				subprocess.list2cmdline(args),
 				None,winUser.SW_SHOWNORMAL)
 		elif action=="setNvdaSystemConfig":


### PR DESCRIPTION
### Link to issue number:
Fixes #9870 

### Summary of the issue:
The desktop shortcut of installed copies does not work for threshold_py3_staging

### Description of how this pull request fixes the issue:
In nvda_slave, change sys.exec_prefix to sys.prefix, as everywhere else.

### Testing performed:
To be done with a try build. Note however that sys.prefix is properly filled in in a frozen build, whereas exec_prefix is not.

### Known issues with pull request:
None

### Change log entry:
None
