### PR TITLE
MoveFileEx: catch WindowsError instead of WinError

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -370,7 +370,7 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 			# #9847: Move file to None to delete it.
 			winKernel.moveFileEx(pathQualifier+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
 		except WindowsError:
-			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
+			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath, exc_info=True)
 		return
 	try:
 		os.rename(tempPath,path)

--- a/source/installer.py
+++ b/source/installer.py
@@ -369,7 +369,7 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 			pathQualifier=u"\\\\?\\"
 			# #9847: Move file to None to delete it.
 			winKernel.moveFileEx(pathQualifier+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
-		except WinError:
+		except OSError:
 			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		return
 	try:

--- a/source/installer.py
+++ b/source/installer.py
@@ -369,7 +369,7 @@ def tryRemoveFile(path,numRetries=6,retryInterval=0.5,rebootOK=False):
 			pathQualifier=u"\\\\?\\"
 			# #9847: Move file to None to delete it.
 			winKernel.moveFileEx(pathQualifier+tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
-		except OSError:
+		except WindowsError:
 			log.debugWarning("Failed to delete file %s, marking for delete on reboot"%tempPath)
 		return
 	try:


### PR DESCRIPTION
### Link to issue number:
Follow-up to #9847 

### Summary of the issue:
In installer, MoveFileEx catches wrong exception.

### Description of how this pull request fixes the issue:
Instead of catching WinError, catch WindowsError (an alias of OSError in Python 3).

### Testing performed:
Tested in Python 3 interpreter and NvDA console.

### Known issues with pull request:
None

### Change log entry:
None
