### PR TITLE
Python 3: Clean the current words buffer in more cases

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -244,17 +244,14 @@ class WinConsoleUIA(Terminal):
 		if len(line.strip()) < max(len(speech.curWordChars) + 1, 3):
 			return
 		if self._hasNewLines:
-			# Clear the typed word buffer for new text lines.
-			# This will need to be changed once #8110 is merged.
-			speech.curWordChars = []
+			# Clear the queued characters buffer for new text lines.
 			self._queuedChars = []
 		super(WinConsoleUIA, self)._reportNewText(line)
 
 	def event_typedCharacter(self, ch):
 		if ch == '\t':
 			# Clear the typed word buffer for tab completion.
-			# This will need to be changed once #8110 is merged.
-			speech.curWordChars = []
+			speech.clearTypedWordBuffer()
 		if (
 			(
 				config.conf['keyboard']['speakTypedCharacters']
@@ -288,7 +285,7 @@ class WinConsoleUIA(Terminal):
 		"""
 		gesture.send()
 		self._queuedChars = []
-		speech.curWordChars = []
+		speech.clearTypedWordBuffer()
 
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -363,6 +363,7 @@ class Terminal(LiveText, EditableText):
 		self.startMonitoring()
 
 	def event_loseFocus(self):
+		super(Terminal, self).event_loseFocus()
 		self.stopMonitoring()
 
 class CandidateItem(NVDAObject):

--- a/source/NVDAObjects/window/winConsole.py
+++ b/source/NVDAObjects/window/winConsole.py
@@ -9,6 +9,8 @@ from . import Window
 from ..behaviors import Terminal, EditableTextWithoutAutoSelectDetection
 import api
 import core
+from scriptHandler import script
+import speech
 
 class WinConsole(Terminal, EditableTextWithoutAutoSelectDetection, Window):
 	"""
@@ -70,6 +72,23 @@ class WinConsole(Terminal, EditableTextWithoutAutoSelectDetection, Window):
 				winConsoleHandler.connectConsole(self)
 				self.startMonitoring()
 		core.callLater(200,reconnect)
+
+	@script(gestures=[
+		"kb:enter",
+		"kb:numpadEnter",
+		"kb:tab",
+		"kb:control+c",
+		"kb:control+d",
+		"kb:control+pause"
+	])
+	def script_flush_queuedChars(self, gesture):
+		"""
+		Flushes the typed word buffer if present.
+		Since these gestures clear the current word/line, we should flush the
+		current words buffer to avoid erroneously reporting words that already have been processed.
+		"""
+		gesture.send()
+		speech.clearTypedWordBuffer()
 
 	__gestures={
 		"kb:alt+f4":"close",

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -127,6 +127,8 @@ class EditableText(TextContainerObject,ScriptableObject):
 				info = self.makeTextInfo(textInfos.POSITION_CARET)
 			except:
 				return
+		# Forget the word currently being typed as the user has moved the caret somewhere else.
+		speech.clearTypedWordBuffer()
 		review.handleCaretMove(info)
 		if speakUnit and not willSayAllResume(gesture):
 			info.expand(speakUnit)
@@ -134,8 +136,6 @@ class EditableText(TextContainerObject,ScriptableObject):
 		braille.handler.handleCaretMove(self)
 
 	def _caretMovementScriptHelper(self, gesture, unit):
-		# Forget the word currently being typed as the user is moving the caret somewhere else.
-		speech.clearTypedWordBuffer()
 		try:
 			info=self.makeTextInfo(textInfos.POSITION_CARET)
 		except:


### PR DESCRIPTION
### Link to issue number:
Fixes #9769 

### Summary of the issue:
Speech refactor introduced a new way to clear the current words buffer for speech. However, in some cases, this buffer wasn't cleared, particularly in the following cases:

1. in legacy windows consoles, when typing a word and pressing enter, pressing space still reported the previous word that was already sent to the console.
2. When moving by sentence in Word, the buffer wasn't cleared.

### Description of how this pull request fixes the issue:
1. in EditableText, the logic to clear the buffer was moved from _caretMovementScriptHelper to _caretScriptPostMovedHelper. This ensures that the buffer is also cleared when navigating by sentence, while not clearing it when the cart hasn't moved, such as when trying sentence nav in an application that doesn't implement it.
2. I copied the flush_queuedChars from winConsoleUIA to winConsole. Cc @codeofdusk

### Testing performed:
Tested the steps to reproduce from #9769, as well as whether the buffer was cleared with sentence nav.

### Known issues with pull request:
None

### Change log entry:
none
