### PR TITLE
Fix adobe reader int/str to NoneType comparisons as well as other identified cases

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -1139,7 +1139,7 @@ def findExtraIAccessibleOverlayClasses(obj, clsList):
 		clsList.append(MSAATextLeaf)
 		return
 
-	if iaRole == oleacc.ROLE_SYSTEM_WINDOW and obj.event_objectID > 0:
+	if iaRole == oleacc.ROLE_SYSTEM_WINDOW and obj.event_objectID is not None and obj.event_objectID > 0:
 		clsList.append(PluginWindow)
 	elif iaRole == oleacc.ROLE_SYSTEM_CLIENT and obj.event_objectID == winUser.OBJID_CLIENT:
 		clsList.append(RootClient)

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -58,9 +58,9 @@ class AcrobatNode(IAccessible):
 			log.debugWarning("Could not get IServiceProvider")
 			return
 
-		if self.event_objectID > 0:
+		if self.event_objectID is not None and self.event_objectID > 0:
 			self.accID = self.event_objectID
-		elif self.event_childID > 0:
+		elif self.event_childID is not None and self.event_childID > 0:
 			self.accID = self.event_childID
 		else:
 			try:

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -82,12 +82,10 @@ class AcrobatNode(IAccessible):
 				pass
 
 	def _get_role(self):
-		stdName = self.pdDomNode.GetStdName()
-		if stdName is not None:
-			try:
-				return normalizeStdName(stdName)[0]
-			except (AttributeError, LookupError, COMError):
-				pass
+		try:
+			return normalizeStdName(self.pdDomNode.GetStdName())[0]
+		except (AttributeError, LookupError, COMError, TypeError):
+			pass
 
 		role = super(AcrobatNode, self).role
 		if role == controlTypes.ROLE_PANE:

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -85,7 +85,7 @@ class AcrobatNode(IAccessible):
 		try:
 			return normalizeStdName(self.pdDomNode.GetStdName())[0]
 		except (AttributeError, LookupError, COMError, TypeError):
-			pass
+			log.debugWarning("Could not get role for AcrobatNode using normalizeStdName", exc_info=True)
 
 		role = super(AcrobatNode, self).role
 		if role == controlTypes.ROLE_PANE:

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -39,7 +39,7 @@ stdNamesToRoles = {
 }
 
 def normalizeStdName(stdName):
-	if "H1" <= stdName <= "H6":
+	if stdName and "H1" <= stdName <= "H6":
 		return controlTypes.ROLE_HEADING, stdName[1]
 
 	try:
@@ -84,8 +84,8 @@ class AcrobatNode(IAccessible):
 	def _get_role(self):
 		try:
 			return normalizeStdName(self.pdDomNode.GetStdName())[0]
-		except (AttributeError, LookupError, COMError, TypeError):
-			log.debugWarning("Could not get role for AcrobatNode using normalizeStdName", exc_info=True)
+		except (AttributeError, LookupError, COMError):
+			pass
 
 		role = super(AcrobatNode, self).role
 		if role == controlTypes.ROLE_PANE:

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -82,10 +82,12 @@ class AcrobatNode(IAccessible):
 				pass
 
 	def _get_role(self):
-		try:
-			return normalizeStdName(self.pdDomNode.GetStdName())[0]
-		except (AttributeError, LookupError, COMError):
-			pass
+		stdName = self.pdDomNode.GetStdName()
+		if stdName is not None:
+			try:
+				return normalizeStdName(stdName)[0]
+			except (AttributeError, LookupError, COMError):
+				pass
 
 		role = super(AcrobatNode, self).role
 		if role == controlTypes.ROLE_PANE:

--- a/source/braille.py
+++ b/source/braille.py
@@ -480,8 +480,11 @@ def getBrailleTextForProperties(**propertyValues):
 	cellCoordsText=propertyValues.get('cellCoordsText')
 	rowNumber = propertyValues.get("rowNumber")
 	columnNumber = propertyValues.get("columnNumber")
-	rowSpan = propertyValues.get("rowSpan")
-	columnSpan = propertyValues.get("columnSpan")
+	# When fetching row and column span
+	# default the values to 1 to make further checks a lot simpler.
+	# After all, a table cell that has no rowspan implemented is assumed to span one row.
+	rowSpan = propertyValues.get("rowSpan") or 1
+	columnSpan = propertyValues.get("columnSpan") or 1
 	includeTableCellCoords = propertyValues.get("includeTableCellCoords", True)
 	if role is not None and not roleText:
 		if role == controlTypes.ROLE_HEADING and level:

--- a/source/virtualBuffers/adobeFlash.py
+++ b/source/virtualBuffers/adobeFlash.py
@@ -36,7 +36,7 @@ class AdobeFlash(VirtualBuffer):
 
 	def __init__(self,rootNVDAObject):
 		super(AdobeFlash,self).__init__(rootNVDAObject,backendName="adobeFlash")
-		self.isWindowless = rootNVDAObject.event_objectID > 0
+		self.isWindowless = rootNVDAObject.event_objectID is not None and rootNVDAObject.event_objectID > 0
 
 	def __contains__(self,obj):
 		if self.isWindowless:


### PR DESCRIPTION
### Link to issue number:
Fixes #9859

### Summary of the issue:
Reading documents in Adobe Reader raises a TypeError

### Description of how this pull request fixes the issue:
Fixed this int to NoneType comparison, identified some others while at it. The following commands where used:

* git grep "ID > 0"
* git grep "ID < 0"
* git grep "ID>0"
* git grep "ID<0"

I did not touch comparisons for IAccessibleChildID, as I'm 99% sure that this will never be None.

### Testing performed:
T.b.d. @lukaszgo1 would you be able to test your case with Acrobat?

### Known issues with pull request:
one

### Change log entry:
None
