### PR TITLE
UI Automation in Windows Console: fix ConsoleUIATextInfo.collapse(end=True)

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -34,7 +34,7 @@ class consoleUIATextInfo(UIATextInfo):
 		# textRange back one character.
 		# Correct this by bringing the start back up to where the end is.
 		oldInfo=self.copy()
-		super(consoleUIATextInfo,self).collapse()
+		super(consoleUIATextInfo,self).collapse(end=end)
 		if not end:
 			self._rangeObj.MoveEndpointByRange(
 				UIAHandler.TextPatternRangeEndpoint_Start,


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614. Fixes #9875.

### Summary of the issue:
When collapsing a `ConsoleUIATextInfo`, the `end` keyword argument was not properly handled.

### Description of how this pull request fixes the issue:
This PR now passes the `end` argument through the `super` call in `collapse`.

### Testing performed:
Tested say all in review (numpad plus) and verified that it is functioning correctly.

### Known issues with pull request:
None.

### Change log entry:
None.