### PR TITLE
Remove Python 2 specific workarounds from Python 3 code

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -1005,7 +1005,7 @@ class AggregatedSection(object):
 				keys.add(key)
 				yield key
 
-	def iteritems(self):
+	def items(self):
 		for key in self:
 			try:
 				yield (key, self[key])
@@ -1014,14 +1014,14 @@ class AggregatedSection(object):
 				pass
 
 	def copy(self):
-		return dict(self.iteritems())
+		return dict(self.items())
 
 	def dict(self):
 		"""Return a deepcopy of self as a dictionary.
 		Adapted from L{configobj.Section.dict}.
 		"""
 		newdict = {}
-		for key, value in self.iteritems():
+		for key, value in self.items():
 			if isinstance(value, AggregatedSection):
 				value = value.dict()
 			elif isinstance(value, list):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -36,10 +36,6 @@ import api
 from . import guiHelper
 import winVersion
 
-# Temporary: #8599: add cp65001 codec
-#            #7105: upgrading to python 3 should fix this issue. See https://bugs.python.org/issue13216
-codecs.register(lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
-
 try:
 	import updateCheck
 except RuntimeError:

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -7,6 +7,7 @@
 import time
 import weakref
 import inspect
+import types
 import config
 import speech
 import sayAllHandler
@@ -264,9 +265,8 @@ def script(
 	if gestures is None:
 		gestures = []
 	def script_decorator(decoratedScript):
-		# Scripts are unbound instance methods in python 2 and functions in python 3.
-		# Therefore, we use inspect.isroutine to check whether a script is either a function or instance method.
-		if not inspect.isroutine(decoratedScript):
+		# Decoratable scripts are functions, not bound instance methods.
+		if not isinstance(decoratedScript, types.FunctionType):
 			log.warning(
 				"Using the script decorator is unsupported for %r" % decoratedScript,
 				stack_info=True

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -193,10 +193,8 @@ class BgThread(threading.Thread):
 				log.error("Error running function from queue", exc_info=True)
 			bgQueue.task_done()
 
-def _execWhenDone(func, *args, **kwargs):
+def _execWhenDone(func, *args, mustBeAsync=False, **kwargs):
 	global bgQueue
-	# This can't be a kwarg in the function definition because it will consume the first non-keywor dargument which is meant for func.
-	mustBeAsync = kwargs.pop("mustBeAsync", False)
 	if mustBeAsync or bgQueue.unfinished_tasks != 0:
 		# Either this operation must be asynchronous or There is still an operation in progress.
 		# Therefore, run this asynchronously in the background thread.

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -252,7 +252,7 @@ class CancellableCallThread(threading.Thread):
 		self._executionDoneEvent = ctypes.windll.kernel32.CreateEventW(None, False, False, None)
 		self.isUsable = True
 
-	def execute(self, func, args, kwargs, pumpMessages=True):
+	def execute(self, func, *args, pumpMessages=True, **kwargs):
 		# Don't even bother making the call if the core is already dead.
 		if isAttemptingRecovery:
 			raise CallCancelled
@@ -298,7 +298,7 @@ class CancellableCallThread(threading.Thread):
 		ctypes.windll.kernel32.CloseHandle(self._executionDoneEvent)
 
 cancellableCallThread = None
-def cancellableExecute(func, *args, **kwargs):
+def cancellableExecute(func, *args, ccPumpMessages=True, **kwargs):
 	"""Execute a function in the main thread, making it cancellable.
 	@param func: The function to execute.
 	@type func: callable
@@ -309,7 +309,6 @@ def cancellableExecute(func, *args, **kwargs):
 	@raise CallCancelled: If the call was cancelled.
 	"""
 	global cancellableCallThread
-	pumpMessages = kwargs.pop("ccPumpMessages", True)
 	if not isRunning or _suspended or not isinstance(threading.currentThread(), threading._MainThread):
 		# Watchdog is not running or this is a background thread,
 		# so just execute the call.
@@ -319,7 +318,7 @@ def cancellableExecute(func, *args, **kwargs):
 		# Create a new one.
 		cancellableCallThread = CancellableCallThread()
 		cancellableCallThread.start()
-	return cancellableCallThread.execute(func, args, kwargs, pumpMessages=pumpMessages)
+	return cancellableCallThread.execute(func, *args, pumpMessages=ccPumpMessages, **kwargs)
 
 def cancellableSendMessage(hwnd, msg, wParam, lParam, flags=0, timeout=60000):
 	"""Send a window message, making the call cancellable.


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Our Python 2 code contained some workarounds  and code paths that are no longer necessary or confusing when on Python 3.

1. Most notably, this is related to functions with `*args` and `**kwargs` catch all handlers which also required a specific keyword argument. Once of these was part of the `hwIo` module and has already been removed in an earlier state.
2. Furthermore, there was a workaround in the `gui` code to register support for the `cp65001` codec in Python 2, which is a known codec in Python 3.
3. The `scriptHandler.script` decorator checked whether the decorated script was a routine. This also returned `True` for bound instance methods, and therefore no warning was raised when trying to decorate a bound instance method (which is unsupported). Now, such a warning will be raised. See also #9884 
4. `config.AggregatedSection` still had an `iteritems` method.

### Description of how this pull request fixes the issue:
1. Code where we pop a particular argument from `kwargs` now contains that argument as a keyword only argument in the signature of the function.
2. When decorating a script, we now use `isinstance(script, types.FunctionType)`
3. `config.AggregatedSection.iteritems` has been renamed to items.

### Testing performed:
1. Tested that NVDA from source still works as expected with espeak and code that uses `cancelable` messages.
2. Tested that throwing the script decorator over a bound instance method (such as a class method) now logs a warning.

### Known issues with pull request:
None

### Change log entry:
None