### PR TITLE
Scintilla: use UTF-8 decoding to convert font name to Unicode

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -119,14 +119,15 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		formatField=textInfos.FormatField()
 		if formatConfig["reportFontName"]:
 			#To get font name, We need to allocate memory with in Scintilla's process, and then copy it out
-			fontNameBuf=ctypes.create_string_buffer(32)
+			fontNameLength=32
+			fontNameBuf=ctypes.create_string_buffer(fontNameLength)
 			internalBuf=winKernel.virtualAllocEx(self.obj.processHandle,None,len(fontNameBuf),winKernel.MEM_COMMIT,winKernel.PAGE_READWRITE)
 			try:
 				watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_STYLEGETFONT,style, internalBuf)
 				winKernel.readProcessMemory(self.obj.processHandle,internalBuf,fontNameBuf,len(fontNameBuf),None)
 			finally:
 				winKernel.virtualFreeEx(self.obj.processHandle,internalBuf,0,winKernel.MEM_RELEASE)
-			formatField["font-name"]=fontNameBuf.value
+			formatField["font-name"]=textUtils.getTextFromRawBytes(fontNameBuf.raw,numChars=fontNameLength)
 		if formatConfig["reportFontSize"]:
 			formatField["font-size"]="%spt"%watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_STYLEGETSIZE,style,0)
 		if formatConfig["reportLineNumber"]:

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -119,15 +119,14 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		formatField=textInfos.FormatField()
 		if formatConfig["reportFontName"]:
 			#To get font name, We need to allocate memory with in Scintilla's process, and then copy it out
-			fontNameLength=32
-			fontNameBuf=ctypes.create_string_buffer(fontNameLength)
+			fontNameBuf=ctypes.create_string_buffer(32)
 			internalBuf=winKernel.virtualAllocEx(self.obj.processHandle,None,len(fontNameBuf),winKernel.MEM_COMMIT,winKernel.PAGE_READWRITE)
 			try:
 				watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_STYLEGETFONT,style, internalBuf)
 				winKernel.readProcessMemory(self.obj.processHandle,internalBuf,fontNameBuf,len(fontNameBuf),None)
 			finally:
 				winKernel.virtualFreeEx(self.obj.processHandle,internalBuf,0,winKernel.MEM_RELEASE)
-			formatField["font-name"]=textUtils.getTextFromRawBytes(fontNameBuf.raw,numChars=fontNameLength)
+			formatField["font-name"]=fontNameBuf.value.decode("utf-8")
 		if formatConfig["reportFontSize"]:
 			formatField["font-size"]="%spt"%watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_STYLEGETSIZE,style,0)
 		if formatConfig["reportLineNumber"]:

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -1,3 +1,8 @@
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2009-2019 NV Access Limited, Arnold Loubriat, Babbage B.V.
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
 import ctypes
 import IAccessibleHandler
 import speech


### PR DESCRIPTION
### Link to issue number:
Fixes #9892 

### Summary of the issue:
Format info command fails in Notepad++ and other Scintilla controls because font name is a bytes-like object.

### Description of how this pull request fixes the issue:
Font name is decoded using UTF-8.

### Testing performed:
Tested with Python 3 source code version of NVDA and notepad++, ensuring font name and other attributes are announced.

### Known issues with pull request:
None

### Change log entry:
None

### Additional context:
Originally, text utils was considered, but passing buffer.raw results in NULL characters being included in format info output. Thus directly decode buffer.value in UTF-8 mode.
