### PR TITLE
UI Automation in Windows Console: disable some GetVisibleRanges dependent logic when consoles are maximized

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -993,6 +993,10 @@ class UIA(Window):
 		self.UIATextEditPattern=self._getUIAPattern(UIAHandler.UIA_TextEditPatternId,UIAHandler.IUIAutomationTextEditPattern,cache=False)
 		return self.UIATextEditPattern
 
+	def _get_UIAWindowPattern(self):
+		self.UIAWindowPattern=self._getUIAPattern(UIAHandler.UIA_WindowPatternId,UIAHandler.IUIAutomationWindowPattern)
+		return self.UIAWindowPattern
+
 	def _get_UIALegacyIAccessiblePattern(self):
 		self.UIALegacyIAccessiblePattern=self._getUIAPattern(UIAHandler.UIA_LegacyIAccessiblePatternId,UIAHandler.IUIAutomationLegacyIAccessiblePattern)
 		return self.UIALegacyIAccessiblePattern

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -294,7 +294,7 @@ class WinConsoleUIA(Terminal):
 		speech.curWordChars = []
 
 	def _get_maximized(self):
-		res = bool(self.parent.UIAWindowPattern.CurrentWindowVisualState)
+		res = self.parent.UIAWindowPattern.CurrentWindowVisualState == UIAHandler.WindowVisualState_Maximized
 		if res:
 			self._maximized = True
 		return self._maximized or res

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -6,6 +6,7 @@
 
 import config
 import ctypes
+import globalVars
 import NVDAHelper
 import speech
 import time
@@ -238,9 +239,6 @@ class WinConsoleUIA(Terminal):
 	_hasNewLines = False
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
-	#: Stores whether this console has ever been maximized
-	# (maximization breaks GetVisibleRanges).
-	_maximized = False
 
 	def _reportNewText(self, line):
 		# Additional typed character filtering beyond that in LiveText
@@ -294,10 +292,15 @@ class WinConsoleUIA(Terminal):
 		speech.curWordChars = []
 
 	def _get_maximized(self):
-		res = self.parent.UIAWindowPattern.CurrentWindowVisualState == UIAHandler.WindowVisualState_Maximized
-		if res:
-			self._maximized = True
-		return self._maximized or res
+		res = self.UIAElement.getRuntimeId() in globalVars.maximizedUIAConsoles
+		if (
+			self.parent.UIAWindowPattern.CurrentWindowVisualState
+			== UIAHandler.WindowVisualState_Maximized
+			and not res
+		):
+			globalVars.maximizedUIAConsoles.append(self.UIAElement.getRuntimeId())
+			return True
+		return res
 
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -18,6 +18,7 @@
 @type navigatorObject: L{NVDAObjects.NVDAObject}
 @var navigatorTracksFocus: if true, the navigator object will follow the focus as it changes
 @type navigatorTracksFocus: boolean
+@var maximizedUIAConsoles: stores state for maximized consoles, see #9899
 """
  
 startTime=0
@@ -38,3 +39,4 @@ appArgsExtra=None
 settingsRing = None
 speechDictionaryProcessing=True
 exitCode=0
+maximizedUIAConsoles = []


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614. Closes #9891.

### Summary of the issue:
When consoles are maximized, text review and automatic readout behave incorrectly.

### Description of how this pull request fixes the issue:
It appears that `UIATextPattern.GetVisibleRanges` is broken for at least Windows 10 1903 once a console window is maximized, even if later restored. Therefore, for these windows:

* `_getTextLines` now retrieves all text rather than all visible text. This is likely slower.
* Windows are essentially "top bounded" in #9687 terms (i.e. moving before the first visible line is not allowed, but movement beyond the last visible line is unconstrained).

### Testing performed:
On Windows 10 1903:

1. Opened Command Prompt.
2. Maximized the window.
3. Changed to the root of the NVDA repository.
4. Ran `git log`.
5. Attempted text review and verified functionality.
6. Pressed q and verified that automatic readout remained functional.

Testing on Windows 10 1803 suggests that the bug is less severe, but this PR does improve the situation. Since only UIA consoles are impacted by this issue, this PR should not affect legacy consoles.

### Known issues with pull request:
None.

### Change log entry:
None.