### PR TITLE
Python 3: Fix error with accPropServer

### DIFF
--- a/source/gui/accPropServer.py
+++ b/source/gui/accPropServer.py
@@ -6,16 +6,19 @@
 
 """Implementation of IAccProcServer, so that customization of a wx control can be done very fast."""
 from ctypes.wintypes import BOOL
-from typing import Optional, Tuple, Any, Union
+from typing import Optional, Tuple, Any, Union, Callable
 
 from logHandler import log
-from comtypes.automation import VT_EMPTY, S_OK, VARIANT, POINTER, c_int, c_double
-from  comtypes import COMObject, GUID
+from comtypes.automation import S_OK, VARIANT, POINTER, c_int, c_double, _oleaut32
+from comtypes import COMObject, GUID
 from comInterfaces.Accessibility import IAccPropServer, ANNO_CONTAINER, ANNO_THIS
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 import weakref
 import winUser
 import wx
+
+_VariantInit: Callable[[POINTER(VARIANT),], None] = _oleaut32.VariantInit
+_VariantInit.argtypes = (POINTER(VARIANT),)
 
 AcceptedGetPropTypes = Union[
 		bool,
@@ -136,7 +139,7 @@ class IAccPropServer_Impl(COMObject, metaclass=ABCMeta):
 		try:
 			# Preset values for "no prop value", in case we return early.
 			pfGotProp.contents.value = self.DOES_NOT_HAVE_PROP
-			pvarValue.contents.vt = VT_EMPTY
+			_VariantInit(pvarValue)
 
 			ret = self._getPropValue(pIDString, dwIDStringLen, idProp)
 			if ret is None:

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -3,8 +3,11 @@
 #Copyright (C) 2016-2018 NV Access Limited, Derek Riemer
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+from ctypes.wintypes import BOOL
+from typing import Any, Tuple, Optional
 
 import wx
+from comtypes import GUID
 from wx.lib.mixins import listctrl as listmix
 from gui import accPropServer
 from gui.dpiScalingHelper import DpiScalingHelperMixin
@@ -99,17 +102,17 @@ class AccPropertyOverride(accPropServer.IAccPropServer_Impl):
 	def _getPropValue(self, pIDString, dwIDStringLen, idProp):
 		control = self.control()  # self.control held as a weak ref, ensure it stays alive for the duration of this method
 		if control is None or not self.propertyAnnotations:
-			return self.NO_RETURN_VALUE
+			return None
 
 		try:
 			val = self.propertyAnnotations[idProp]
 			if callable(val):
 				val = val()
-			return val, self.HAS_PROP
+			return self._hasProp(val)
 		except KeyError:
 			pass
 
-		return self.NO_RETURN_VALUE
+		return None
 
 	def _cleanup(self):
 		# could contain references (via lambda) of our owner, set it to None to avoid a circular reference which
@@ -130,19 +133,19 @@ class ListCtrlAccPropServer(accPropServer.IAccPropServer_Impl):
 			annotateChildren=True
 		)
 
-	def _getPropValue(self, pIDString, dwIDStringLen, idProp):
+	def _getPropValue(self, pIDString: str, dwIDStringLen: int, idProp: GUID) -> Optional[Tuple[BOOL, Any]]:
 		control = self.control()  # self.control held as a weak ref, ensure it stays alive for the duration of this method
 		if control is None:
-			return self.NO_RETURN_VALUE
+			return None
 
 		# Import late to prevent circular import.
 		from IAccessibleHandler import accPropServices
 		handle, objid, childid = accPropServices.DecomposeHwndIdentityString(pIDString, dwIDStringLen)
 		if childid == winUser.CHILDID_SELF:
-			return self.NO_RETURN_VALUE
+			return None
 
 		if idProp == oleacc.PROPID_ACC_ROLE:
-			return oleacc.ROLE_SYSTEM_CHECKBUTTON, self.HAS_PROP
+			return self._hasProp(oleacc.ROLE_SYSTEM_CHECKBUTTON)
 
 		if idProp == oleacc.PROPID_ACC_STATE:
 			states = oleacc.STATE_SYSTEM_SELECTABLE|oleacc.STATE_SYSTEM_FOCUSABLE
@@ -152,7 +155,7 @@ class ListCtrlAccPropServer(accPropServer.IAccPropServer_Impl):
 				# wx doesn't seem to  have a method to check whether a list item is focused.
 				# Therefore, assume that a selected item is focused,which is the case in single select list boxes.
 				states |= oleacc.STATE_SYSTEM_SELECTED | oleacc.STATE_SYSTEM_FOCUSED
-			return states, self.HAS_PROP
+			return self._hasProp(states)
 
 class CustomCheckListBox(wx.CheckListBox):
 	"""Custom checkable list to fix a11y bugs in the standard wx checkable list box."""


### PR DESCRIPTION
### Link to issue number:
#9768

### Summary of the issue:
The `VARIANT` out-param had not been initialised correct.
Comtypes was not initialising `VARIANT.vt` to `VT_EMPTY`, and attempting to call `VariantClear` (oleauto.h) before assigning it the value returned from `getProp`.

### Description of how this pull request fixes the issue:
Instead, we implement a low-level (require a `this` param) `getProp` method, which is then provided pointers to the out-params, and can initialise them correctly.

### Testing performed:
Run locally from source.

### Known issues with pull request:
None

### Change log entry:
None
