### PR TITLE
Threshold: Revert "Restore VoiceSettingsSlider to ensure we don't break compatibility with Audio Themes add-on (#9826)"

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -48,7 +48,6 @@ import weakref
 import time
 import keyLabels
 from dpiScalingHelper import DpiScalingHelperMixin
-import warnings
 
 class SettingsDialog(with_metaclass(guiHelper.SIPABCMeta, wx.Dialog, DpiScalingHelperMixin)):
 	"""A settings dialog.
@@ -3362,11 +3361,3 @@ class InputGesturesDialog(SettingsDialog):
 					_("Error"), wx.OK | wx.ICON_ERROR)
 
 		super(InputGesturesDialog, self).onOk(evt)
-
-class VoiceSettingsSlider(nvdaControls.EnhancedInputSlider):
-	"""@Deprecated: use L{gui.NVDAControls.EnhancedInputSlider} instead."""
-
-	def __init__(self,*args, **kwargs):
-		warnings.warn("gui.settingsDialogs.VoiceSettingsSlider is deprecated. Use gui.NVDAControls.EnhancedInputSlider instead",
-			DeprecationWarning, stacklevel=2)
-		super(VoiceSettingsSlider,self).__init__(*args,**kwargs)


### PR DESCRIPTION
#8214 broke compatibility with the audio themes add-on. This has been fixed in #9826, however in threshold, it is undesirable to keep this compatibility layer.

This reverts commit 7f986ca252a80b569e99245b3407a47831810f92.
