### PR TITLE
NvDA slave: raw_input -> input

### DIFF
--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -91,7 +91,7 @@ def main():
 				comHelper._lresultFromGetActiveObject(args[0], bool(int(args[1]))))
 			sys.__stdout__.flush()
 			try:
-				raw_input()
+				input()
 			except EOFError:
 				pass
 		else:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
NVDA slave module uses raw_input function to scrape stdin, which throws name error in Python 3.

### Description of how this pull request fixes the issue:
Call to "raw_input" has been changed to "input".

Procedure:

1. Grep "raw_input" source (note one must escape underscores).
2. See which files are affected, edit, and test.

### Testing performed:
TBD (likely with installed copy)

### Known issues with pull request:
None

### Change log entry:
None
