### PR TITLE
Differentiate preselected from just selected text

### DIFF
--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -137,7 +137,7 @@ class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,Brow
 		# so retrieve and report the selection from Kindle.
 		# we can't just use self.makeTextInfo, as that will use our fake selection.
 		realSel = self.rootNVDAObject.makeTextInfo(textInfos.POSITION_SELECTION)
-		speech.speakSelectedText(realSel.text)
+		speech.speakTextSelected(realSel.text)
 		# Remove our virtual selection and move the caret to the active end.
 		fakeSel.innerTextInfo = realSel
 		fakeSel.collapse(end=not self._lastSelectionMovedStart)

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1081,7 +1081,7 @@ class SlideShowTreeInterceptor(DocumentTreeInterceptor):
 		else:
 			info = self.selection
 			if not info.isCollapsed:
-				speech.speakSelectedText(info.text)
+				speech.speakPreselectedText(info.text)
 			else:
 				info.expand(textInfos.UNIT_LINE)
 				speech.speakTextInfo(info, reason=controlTypes.REASON_CARET, unit=textInfos.UNIT_LINE)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1221,7 +1221,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 						speech.speakObject(self.rootNVDAObject, reason=controlTypes.REASON_FOCUS)
 				info = self.selection
 				if not info.isCollapsed:
-					speech.speakSelectedText(info.text)
+					speech.speakPreselectedText(info.text)
 				else:
 					info.expand(textInfos.UNIT_LINE)
 					speech.speakTextInfo(info, reason=controlTypes.REASON_CARET, unit=textInfos.UNIT_LINE)

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -446,7 +446,7 @@ class CompoundDocument(EditableText, DocumentTreeInterceptor):
 				info.expand(textInfos.UNIT_LINE)
 				speech.speakTextInfo(info, unit=textInfos.UNIT_LINE, reason=controlTypes.REASON_CARET)
 			else:
-				speech.speakSelectedText(info.text)
+				speech.speakPreselectedText(info.text)
 			braille.handler.handleGainFocus(self)
 			self.initAutoSelectDetection()
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -210,7 +210,7 @@ class GlobalCommands(ScriptableObject):
 		if not info or info.isCollapsed:
 			speech.speakMessage(_("No selection"))
 		else:
-			speech.speakSelectedText(info.text)
+			speech.speakTextSelected(info.text)
 	# Translators: Input help mode message for report current selection command.
 	script_reportCurrentSelection.__doc__=_("Announces the current selection in edit controls and documents. If there is no selection it says so.")
 	script_reportCurrentSelection.category=SCRCAT_SYSTEMCARET

--- a/source/speech.py
+++ b/source/speech.py
@@ -421,7 +421,7 @@ def speakObject(obj,reason=controlTypes.REASON_QUERY,index=None):
 			info=obj.makeTextInfo(textInfos.POSITION_SELECTION)
 			if not info.isCollapsed:
 				# if there is selected text, then there is a value and we do not report placeholder
-				speakSelectedText(info.text)
+				speakPreselectedText(info.text)
 			else:
 				info.expand(textInfos.UNIT_LINE)
 				_speakPlaceholderIfEmpty(info, obj, reason)
@@ -586,12 +586,34 @@ def speak(speechSequence,symbolLevel=None):
 				speechSequence[index]+=CHUNK_SEPARATOR
 	getSynth().speak(speechSequence)
 
-def speakSelectedText(text):
-	""" Helper method to speak the provided text with the word "selected" appended.
-	Implemented using L{speakSelectionMessage}, which allows for speaking text with an arbitrary attached message.
+def speakPreselectedText(text):
+	""" Helper method to announce that a newly focused control already has
+	text selected. This method is in contrast with L{speakTextSelected}.
+	The method will speak the word "selected" with the provided text appended.
+	The announcement order is different from L{speakTextSelected} in order to
+	inform a user that the newly focused control has content that is selected,
+	which they may unintentionally overwrite.
+
+	@remarks: Implemented using L{speakSelectionMessage}, which allows for
+		speaking text with an arbitrary attached message.
 	"""
-	# Translators: This is spoken to indicate what has been selected. for example 'hello world selected'
-	speakSelectionMessage(_("%s selected"),text)
+	# Translators: This is spoken to indicate that some text is already selected.
+	# 'selected' preceding text is intentional.
+	# For example 'selected hello world'
+	speakSelectionMessage(_("selected %s"), text)
+
+def speakTextSelected(text):
+	""" Helper method to announce that the user has caused text to be selected.
+	This method is in contrast with L{speakPreselectedText}.
+	The method will speak the provided text with the word "selected" appended.
+
+	@remarks: Implemented using L{speakSelectionMessage}, which allows for
+		speaking text with an arbitrary attached message.
+	"""
+	# Translators: This is spoken to indicate what has just been selected.
+	# The text preceding 'selected' is intentional.
+	# For example 'hello world selected'
+	speakSelectionMessage(_("%s selected"), text)
 
 def speakSelectionMessage(message,text):
 	if len(text) < 512:
@@ -650,12 +672,12 @@ def speakSelectionChange(oldInfo,newInfo,speakSelected=True,speakUnselected=True
 			for text in selectedTextList:
 				if  len(text)==1:
 					text=characterProcessing.processSpeechSymbol(locale,text)
-				speakSelectedText(text)
+				speakTextSelected(text)
 		elif len(selectedTextList)>0:
 			text=newInfo.text
 			if len(text)==1:
 				text=characterProcessing.processSpeechSymbol(locale,text)
-			speakSelectedText(text)
+			speakTextSelected(text)
 	if speakUnselected:
 		if not generalize:
 			for text in unselectedTextList:


### PR DESCRIPTION
Follow on from #9028

### Link to issue number:
None

### Summary of the issue:
The order of selection messages for preselected and just selected text needs to be different. When a control with preselected text gains focus, we must inform them it is selected first so they do not unintentionally modify the text. When a user intentionally selects text, the 'selected' part of the message is still important (for users who may not be familiar with a command), but the text selected is more important.

### Description of how this pull request fixes the issue:
This commit differentiates and documents the differences here with helper methods to make these announcements.

### Testing performed:
Selected text, confirmed that the message was "text selected"
Used run dialog to land on preselected text, confirmed the message was "selected text"

### Known issues with pull request:
None

### Change log entry:
None

