### PR TITLE
Python 3: Fix several local overrides of range function

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -281,9 +281,9 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 				commentReference=field.field.get('comment')
 				if commentReference:
 					offset=int(commentReference)
-					range=self.WinwordDocumentObject.range(offset,offset+1)
+					textRange=self.WinwordDocumentObject.range(offset, offset + 1)
 					try:
-						text=range.comments[1].range.text
+						text = textRange.comments[1].range.text
 					except COMError:
 						break
 					if text:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -423,12 +423,12 @@ class UIATextInfo(textInfos.TextInfo):
 				pass
 		return field
 
-	def _getTextFromUIARange(self,range):
+	def _getTextFromUIARange(self, textRange):
 		"""
 		Fetches plain text from the given UI Automation text range.
 		Just calls getText(-1). This only exists to be overridden for filtering.
 		"""
-		return range.getText(-1)
+		return textRange.getText(-1)
 
 	def _getTextWithFields_text(self,textRange,formatConfig,UIAFormatUnits=None):
 		"""
@@ -652,7 +652,7 @@ class UIATextInfo(textInfos.TextInfo):
 	def _get_text(self):
 		return self._getTextFromUIARange(self._rangeObj)
 
-	def _getBoundingRectsFromUIARange(self,range):
+	def _getBoundingRectsFromUIARange(self, textRange):
 		"""
 		Fetches per line bounding rectangles from the given UI Automation text range.
 		Note that if the range object doesn't cover a whole line (e.g. a character),
@@ -660,7 +660,7 @@ class UIATextInfo(textInfos.TextInfo):
 		@rtype: [locationHelper.RectLTWH]
 		"""
 		rects = []
-		rectArray = range.GetBoundingRectangles()
+		rectArray = textRange.GetBoundingRectangles()
 		if not rectArray:
 			return rects
 		rectIndexes = range(0, len(rectArray), 4)

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -80,10 +80,10 @@ class EdgeTextInfo(UIATextInfo):
 				if ('label=' in ariaProperties)  or ('labelledby=' in ariaProperties):
 					return element
 				try:
-					range=self.obj.UIATextPattern.rangeFromChild(element)
+					textRange=self.obj.UIATextPattern.rangeFromChild(element)
 				except COMError:
 					return
-				text=range.getText(-1)
+				text = textRange.getText(-1)
 				if not text or text.isspace():
 					return element
 			element=walker.getParentElementBuildCache(element,cacheRequest)
@@ -94,15 +94,15 @@ class EdgeTextInfo(UIATextInfo):
 		if not element:
 			return
 		try:
-			range=self.obj.UIATextPattern.rangeFromChild(element)
+			textRange=self.obj.UIATextPattern.rangeFromChild(element)
 		except COMError:
 			return
 		if not back:
-			range.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start,range,UIAHandler.TextPatternRangeEndpoint_End)
-			range.move(UIAHandler.TextUnit_Character,-1)
+			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start, textRange, UIAHandler.TextPatternRangeEndpoint_End)
+			textRange.move(UIAHandler.TextUnit_Character, -1)
 		else:
-			range.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,range,UIAHandler.TextPatternRangeEndpoint_Start)
-		self._rangeObj=range
+			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End, textRange, UIAHandler.TextPatternRangeEndpoint_Start)
+		self._rangeObj=textRange
 
 	def _collapsedMove(self,unit,direction,skipReplacedContent):
 		"""A simple collapsed move (i.e. both ends move together), but whether it classes replaced content as one character stop can be configured via the skipReplacedContent argument."""
@@ -413,13 +413,13 @@ class EdgeNode(UIA):
 	_TextInfo=EdgeTextInfo_preGapRemoval if _edgeIsPreGapRemoval else EdgeTextInfo
 
 	def getNormalizedUIATextRangeFromElement(self,UIAElement):
-		range=super(EdgeNode,self).getNormalizedUIATextRangeFromElement(UIAElement)
-		if not range or not self._edgeIsPreGapRemoval:
-			return range
+		textRange = super().getNormalizedUIATextRangeFromElement(UIAElement)
+		if not textRange or not self._edgeIsPreGapRemoval:
+			return textRange
 		#Move the start of a UIA text range past any element start character stops
-		lastCharInfo=EdgeTextInfo_preGapRemoval(self,None,_rangeObj=range)
-		lastCharInfo._rangeObj=range
-		charInfo=lastCharInfo.copy()
+		lastCharInfo = EdgeTextInfo_preGapRemoval(self,None, _rangeObj=textRange)
+		lastCharInfo._rangeObj = textRange
+		charInfo = lastCharInfo.copy()
 		charInfo.collapse()
 		while super(EdgeTextInfo,charInfo).move(textInfos.UNIT_CHARACTER,1)!=0:
 			charInfo.setEndPoint(lastCharInfo,"startToStart")
@@ -427,7 +427,7 @@ class EdgeNode(UIA):
 				break
 			lastCharInfo.setEndPoint(charInfo,"startToEnd")
 			charInfo.collapse(True)
-		return range
+		return textRange
 
 	def _get_role(self):
 		role=super(EdgeNode,self).role

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -140,8 +140,8 @@ class WordDocumentTextInfo(UIATextInfo):
 			field['value']=field.pop('description',None) or obj.description or field.pop('name',None) or obj.name
 		return field
 
-	def _getTextFromUIARange(self,range):
-		t=super(WordDocumentTextInfo,self)._getTextFromUIARange(range)
+	def _getTextFromUIARange(self, textRange):
+		t=super(WordDocumentTextInfo,self)._getTextFromUIARange(textRange)
 		if t:
 			# HTML emails expose a lot of vertical tab chars in their text
 			# Really better as carage returns

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -472,12 +472,13 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError
 
-	def _getFormatFieldAtRange(self,range,formatConfig):
+	def _getFormatFieldAtRange(self, textRange, formatConfig):
 		formatField=textInfos.FormatField()
 		fontObj=None
 		paraFormatObj=None
 		if formatConfig["reportAlignment"]:
-			if not paraFormatObj: paraFormatObj=range.para
+			if not paraFormatObj:
+				paraFormatObj = textRange.para
 			alignment=paraFormatObj.alignment
 			if alignment==comInterfaces.tom.tomAlignLeft:
 				formatField["text-align"]="left"
@@ -488,15 +489,18 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			elif alignment==comInterfaces.tom.tomAlignJustify:
 				formatField["text-align"]="justify"
 		if formatConfig["reportLineNumber"]:
-			formatField["line-number"]=range.getIndex(comInterfaces.tom.tomLine)
+			formatField["line-number"] = textRange.getIndex(comInterfaces.tom.tomLine)
 		if formatConfig["reportFontName"]:
-			if not fontObj: fontObj=range.font
+			if not fontObj:
+				fontObj = textRange.font
 			formatField["font-name"]=fontObj.name
 		if formatConfig["reportFontSize"]:
-			if not fontObj: fontObj=range.font
+			if not fontObj:
+				fontObj = textRange.font
 			formatField["font-size"]="%spt"%fontObj.size
 		if formatConfig["reportFontAttributes"]:
-			if not fontObj: fontObj=range.font
+			if not fontObj:
+				fontObj = textRange.font
 			formatField["bold"]=bool(fontObj.bold)
 			formatField["italic"]=bool(fontObj.italic)
 			formatField["underline"]=bool(fontObj.underline)
@@ -506,11 +510,12 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			elif fontObj.subscript:
 				formatField["text-position"]="sub"
 		if formatConfig["reportLinks"]:
-			linkRange=range.Duplicate
+			linkRange = textRange.Duplicate
 			linkRange.Collapse(comInterfaces.tom.tomStart)
 			formatField["link"]=linkRange.Expand(comInterfaces.tom.tomLink)>0
 		if formatConfig["reportColor"]:
-			if not fontObj: fontObj=range.font
+			if not fontObj:
+				fontObj = textRange.font
 			fgColor=fontObj.foreColor
 			if fgColor==comInterfaces.tom.tomAutoColor:
 				# Translators: The default color of text when a color has not been set by the author. 
@@ -531,7 +536,8 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 				formatField['background-color']=_("Unknown color")
 			else:
 				formatField["background-color"]=colors.RGB.fromCOLORREF(bkColor)
-		if not fontObj: fontObj=range.font
+		if not fontObj:
+			fontObj = textRange.font
 		try:
 			langId = fontObj.languageID
 			if langId:
@@ -541,10 +547,10 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			pass
 		return formatField
 
-	def _expandFormatRange(self,range,formatConfig):
+	def _expandFormatRange(self, textRange, formatConfig):
 		startLimit=self._rangeObj.start
 		endLimit=self._rangeObj.end
-		chunkRange=range.duplicate
+		chunkRange = textRange.duplicate
 		if formatConfig["reportLineNumber"]:
 			chunkRange.expand(comInterfaces.tom.tomLine)
 		else:
@@ -555,12 +561,12 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			startLimit=chunkStart
 		if endLimit>chunkEnd:
 			endLimit=chunkEnd
-		#range.moveEnd(comInterfaces.tom.tomCharFormat,1)
-		range.expand(comInterfaces.tom.tomCharFormat)
-		if range.end>endLimit:
-			range.end=endLimit
-		if range.start<startLimit:
-			range.start=startLimit
+		#textRange.moveEnd(comInterfaces.tom.tomCharFormat,1)
+		textRange.expand(comInterfaces.tom.tomCharFormat)
+		if textRange.end > endLimit:
+			textRange.end = endLimit
+		if textRange.start < startLimit:
+			textRange.start = startLimit
 
 	def _getEmbeddedObjectLabel(self,embedRangeObj):
 		label=None
@@ -661,22 +667,22 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 	def getTextWithFields(self,formatConfig=None):
 		if not formatConfig:
 			formatConfig=config.conf["documentFormatting"]
-		range=self._rangeObj.duplicate
-		range.collapse(True)
+		textRange=self._rangeObj.duplicate
+		textRange.collapse(True)
 		if not formatConfig["detectFormatAfterCursor"]:
-			range.expand(comInterfaces.tom.tomCharacter)
-			return [textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(range,formatConfig)),
+			textRange.expand(comInterfaces.tom.tomCharacter)
+			return [textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(textRange, formatConfig)),
 				self._getTextAtRange(self._rangeObj)]
 		commandList=[]
 		endLimit=self._rangeObj.end
-		while range.end<endLimit:
-			self._expandFormatRange(range,formatConfig)
-			commandList.append(textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(range,formatConfig)))
-			commandList.append(self._getTextAtRange(range))
-			end=range.end
-			range.start=end
+		while textRange.end<endLimit:
+			self._expandFormatRange(textRange, formatConfig)
+			commandList.append(textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(textRange, formatConfig)))
+			commandList.append(self._getTextAtRange(textRange))
+			end = textRange.end
+			textRange.start = end
 			#Trying to set the start past the end of the document forces both start and end back to the previous offset, so catch this
-			if range.end<end:
+			if textRange.end < end:
 				break
 		return commandList
 

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1034,9 +1034,9 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 			import mathType
 		except:
 			raise LookupError("MathType not installed")
-		range = self._rangeObj.Duplicate
-		range.Start = int(field["shapeoffset"])
-		obj = range.InlineShapes[0].OLEFormat
+		rangeObj = self._rangeObj.Duplicate
+		rangeObj.Start = int(field["shapeoffset"])
+		obj = rangeObj.InlineShapes[0].OLEFormat
 		try:
 			return mathType.getMathMl(obj)
 		except:

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -84,12 +84,12 @@ class UIAMixedAttributeError(ValueError):
 	"""Raised when a function would return a UIAutomation text attribute value that is mixed."""
 	pass
 
-def getUIATextAttributeValueFromRange(range,attrib,ignoreMixedValues=False):
+def getUIATextAttributeValueFromRange(rangeObj,attrib,ignoreMixedValues=False):
 	"""
 	Wraps IUIAutomationTextRange::getAttributeValue, returning UIAutomation's reservedNotSupportedValue on COMError, and raising UIAMixedAttributeError if a mixed value would be returned and ignoreMixedValues is False.
 	"""
 	try:
-		val=range.GetAttributeValue(attrib)
+		val = rangeObj.GetAttributeValue(attrib)
 	except COMError:
 		return UIAHandler.handler.reservedNotSupportedValue
 	if val==UIAHandler.handler.ReservedMixedAttributeValue:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1668,14 +1668,14 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 				pass
 		return None
 
-	def getEnclosingContainerRange(self,range):
-		range=range.copy()
-		range.collapse()
+	def getEnclosingContainerRange(self, textRange):
+		textRange = textRange.copy()
+		textRange.collapse()
 		try:
-			item = next(self._iterNodesByType("container", "up", range))
+			item = next(self._iterNodesByType("container", "up", textRange))
 		except (NotImplementedError,StopIteration):
 			try:
-				item = next(self._iterNodesByType("landmark", "up", range))
+				item = next(self._iterNodesByType("landmark", "up", textRange))
 			except (NotImplementedError,StopIteration):
 				return
 		return item.textInfo
@@ -1724,8 +1724,8 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 	script_movePastEndOfContainer.__doc__=_("Moves past the end  of the container element, such as a list or table")
 
 	NOT_LINK_BLOCK_MIN_LEN = 30
-	def _isSuitableNotLinkBlock(self,range):
-		return len(range.text)>=self.NOT_LINK_BLOCK_MIN_LEN
+	def _isSuitableNotLinkBlock(self, textRange):
+		return len(textRange.text) >= self.NOT_LINK_BLOCK_MIN_LEN
 
 	def _iterNotLinkBlock(self, direction="next", pos=None):
 		links = self._iterNodesByType("link", direction=direction, pos=pos)
@@ -1735,15 +1735,15 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			item2 = next(links)
 			# If the distance between the links is small, this is probably just a piece of non-link text within a block of links; e.g. an inactive link of a nav bar.
 			if direction=="previous":
-				range=item1.textInfo.copy()
-				range.collapse()
-				range.setEndPoint(item2.textInfo,"startToEnd")
+				textRange=item1.textInfo.copy()
+				textRange.collapse()
+				textRange.setEndPoint(item2.textInfo,"startToEnd")
 			else:
-				range=item2.textInfo.copy()
-				range.collapse()
-				range.setEndPoint(item1.textInfo,"startToEnd")
-			if self._isSuitableNotLinkBlock(range):
-				yield TextInfoQuickNavItem("notLinkBlock",self,range)
+				textRange=item2.textInfo.copy()
+				textRange.collapse()
+				textRange.setEndPoint(item1.textInfo,"startToEnd")
+			if self._isSuitableNotLinkBlock(textRange):
+				yield TextInfoQuickNavItem("notLinkBlock", self, textRange)
 			item1=item2
 
 	__gestures={

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -647,14 +647,14 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 			else:
 				raise LookupError
 
-	def _isSuitableNotLinkBlock(self,range):
-		return (range._endOffset-range._startOffset)>=self.NOT_LINK_BLOCK_MIN_LEN
+	def _isSuitableNotLinkBlock(self, textRange):
+		return (textRange._endOffset - textRange._startOffset) >= self.NOT_LINK_BLOCK_MIN_LEN
 
-	def getEnclosingContainerRange(self,range):
+	def getEnclosingContainerRange(self, textRange):
 		formatConfig=config.conf['documentFormatting'].copy()
 		formatConfig.update({"reportBlockQuotes":True,"reportTables":True,"reportLists":True,"reportFrames":True})
 		controlFields=[]
-		for cmd in range.getTextWithFields():
+		for cmd in textRange.getTextWithFields():
 			if not isinstance(cmd,textInfos.FieldCommand) or cmd.command!="controlStart":
 				break
 			controlFields.append(cmd.field)
@@ -667,7 +667,7 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		if not containerField: return None
 		docHandle=int(containerField['controlIdentifier_docHandle'])
 		ID=int(containerField['controlIdentifier_ID'])
-		offsets=range._getOffsetsFromFieldIdentifier(docHandle,ID)
+		offsets = textRange._getOffsetsFromFieldIdentifier(docHandle,ID)
 		return self.makeTextInfo(textInfos.offsets.Offsets(*offsets))
 
 	@classmethod


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In several cases in our code base, we are using `range` as a name of a local attribute or function parameter. In at least one case (uia `_getBoundingRectsFromUIARange`, this fails, as we are also calling the range function in that method.

### Description of how this pull request fixes the issue:
Look for every instance of `range` as a local attribute. In most cases, rename it to textRange.

I started with the following regex computed by @feerrenrut: `(,\W?|\W)range\W?[,)=]`
I also used `\Wrange[.]\w` to dig up some missed cases that weren't pick up by the first regex.

### Testing performed:
Tested that NVDA still starts and works as epxected. It is undoable to test every change, therefore careful review should be performed, possibly with the assistance of a linter.

### Known issues with pull request:
None

### Change log entry:
None
