### PR TITLE
Add extension points to eliminate NVDA Remote monkey patching

### DIFF
--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -124,7 +124,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		return self.model
 
 	def _updateSettings(self):
-		oldNumCells = self.numCells
 		if self.isHid:
 			displaySettings = self._dev.getFeature(ALVA_DISPLAY_SETTINGS_REPORT)
 			if displaySettings[ALVA_DISPLAY_SETTINGS_STATUS_CELL_SIDE_POS] > 1:
@@ -152,9 +151,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			self._ser6SendMessage(b"H", b"?")
 			# Get HID keyboard input state
 			self._ser6SendMessage(b"r", b"?")
-		if oldNumCells not in (0, self.numCells):
-			# In case of splitpoint changes, we need to update the braille handler as well
-			braille.handler.displaySize = self.numCells
 
 	def __init__(self, port="auto"):
 		super(BrailleDisplayDriver,self).__init__()

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1,6 +1,6 @@
 #nvwave.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
+#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -17,6 +17,7 @@ import winKernel
 import wave
 import config
 from logHandler import log
+import extensionPoints
 
 __all__ = (
 	"WavePlayer", "getOutputDeviceNames", "outputDeviceIDToName", "outputDeviceNameToID",
@@ -26,6 +27,14 @@ winmm = windll.winmm
 
 HWAVEOUT = HANDLE
 LPHWAVEOUT = POINTER(HWAVEOUT)
+
+#: Notifies when a wave file is about to be played,
+#: and allows components or add-ons to decide whether the wave file should be played.
+#: For example, when controlling a remote system,
+#: the remote system must be notified of sounds played on the local system.
+#: Also, registrars should be able to suppress playing sounds if desired.
+#: Handlers are called with the same arguments as L{playWaveFile} as keyword arguments.
+decide_playWaveFile = extensionPoints.Decider()
 
 class WAVEFORMATEX(Structure):
 	_fields_ = [
@@ -383,18 +392,28 @@ def outputDeviceNameToID(name, useDefaultIfInvalid=False):
 
 fileWavePlayer = None
 fileWavePlayerThread=None
-def playWaveFile(fileName, asynchronous=True):
+def playWaveFile(
+	fileName: str,
+	asynchronous: bool = True,
+	isSPeechWaveFileCommand: bool = False
+):
 	"""plays a specified wave file.
+	@param fileName: the path to the wave file, usually absolute.
 	@param asynchronous: whether the wave file should be played asynchronously
-	@type asynchronous: bool
+		If C{False}, the calling thread is blocked until the wave has finished playing.
+	@param isSPeechWaveFileCommand: whether this wave is played as part of a speech sequence.
 	"""
 	global fileWavePlayer, fileWavePlayerThread
 	f = wave.open(fileName,"r")
 	if f is None: raise RuntimeError("can not open file %s"%fileName)
 	if fileWavePlayer is not None:
 		fileWavePlayer.stop()
+	if not decide_playWaveFile.decide(fileName=fileName, asynchronous=asynchronous, isSPeechWaveFileCommand=isSPeechWaveFileCommand):
+		log.debug("Playing wave file canceled by handler registered to decide_playWaveFile extension point")
+		return
 	fileWavePlayer = WavePlayer(channels=f.getnchannels(), samplesPerSec=f.getframerate(),bitsPerSample=f.getsampwidth()*8, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
 	fileWavePlayer.feed(f.readframes(f.getnframes()))
+
 	if asynchronous:
 		if fileWavePlayerThread is not None:
 			fileWavePlayerThread.join()

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -271,7 +271,7 @@ class BeepCommand(BaseCallbackCommand):
 
 	def run(self):
 		import tones
-		tones.beep(self.hz, self.length, left=self.left, right=self.right)
+		tones.beep(self.hz, self.length, left=self.left, right=self.right, isSPeechBeepCommand=True)
 
 	def __repr__(self):
 		return "BeepCommand({hz}, {length}, left={left}, right={right})".format(
@@ -286,7 +286,7 @@ class WaveFileCommand(BaseCallbackCommand):
 
 	def run(self):
 		import nvwave
-		nvwave.playWaveFile(self.fileName, asynchronous=True)
+		nvwave.playWaveFile(self.fileName, asynchronous=True, isSPeechWaveFileCommand=True)
 
 	def __repr__(self):
 		return "WaveFileCommand(%r)" % self.fileName

--- a/source/tones.py
+++ b/source/tones.py
@@ -1,6 +1,6 @@
 #tones.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
+#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy, Babbage B.V.
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -12,13 +12,14 @@ import config
 import globalVars
 from logHandler import log
 from ctypes import create_string_buffer, byref
+import extensionPoints
 
 SAMPLE_RATE = 44100
 
 try:
 	player = nvwave.WavePlayer(channels=2, samplesPerSec=int(SAMPLE_RATE), bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
 except:
-	log.warning("Failed to initialize audio for tones")
+	log.warning("Failed to initialize audio for tones", exc_info=True)
 	player = None
 
 # When exiting, ensure player is deleted before modules get cleaned up.
@@ -28,18 +29,32 @@ def _cleanup():
 	global player
 	player = None
 
-def beep(hz,length,left=50,right=50):
+#: Notifies when a beep is about to be generated and played,
+#: and allows components or add-ons to decide whether the beep should actually be played.
+#: For example, when controlling a remote system,
+#: the remote system must be notified of beeps played on the local system.
+#: Also, registrars should be able to suppress playing beeps if desired.
+#: Handlers are called with the same arguments as L{beep} as keyword arguments.
+decide_beep = extensionPoints.Decider()
+
+def beep(
+	hz: float,
+	length: int,
+	left: int = 50,
+	right: int =50,
+	isSPeechBeepCommand: bool=False
+):
 	"""Plays a tone at the given hz, length, and stereo balance.
-	@param hz: pitch in hz of the tone
-	@type hz: float
-	@param length: length of the tone in ms
-	@type length: integer
-	@param left: volume of the left channel (0 to 100)
-	@type left: integer
-	@param right: volume of the right channel (0 to 100)
-	@type right: integer
+	@param hz: pitch in hz of the tone.
+	@param length: length of the tone in ms.
+	@param left: volume of the left channel (0 to 100).
+	@param right: volume of the right channel (0 to 100).
+	@param isSPeechBeepCommand: whether this beep is created as part of a speech sequence.
 	""" 
 	log.io("Beep at pitch %s, for %s ms, left volume %s, right volume %s"%(hz,length,left,right))
+	if not decide_beep.decide(hz=hz, length=length, left=left, right=right, isSPeechBeepCommand=isSPeechBeepCommand):
+		log.debug("Beep canceled by handler registered to decide_beep extension point")
+		return
 	if not player:
 		return
 	from NVDAHelper import generateBeep


### PR DESCRIPTION
### Link to issue number:
None. Some discussion around https://github.com/nvaccess/nvda/pull/7484#issuecomment-322806698 though
Follow up of #7594, now in draft form

### Summary of the issue:
NVDA Remote requires monkey patching to be notified of several actions on a controlled system (e.g. selecting a braille display or playing beeps).

### Description of how this pull request fixes the issue:
Implemented the following extension points:

* braille.handler.filter_writeCells: To filter raw cells before sending them to a braille display
* braille.handler.filter_displaySize: to filter the display size, e.g. when a remote system has a smaller display
* braille.handler.decide_enabled: to allow remote to forcefully disable the local braille handler
* braille.handler.pre_writeCells: To notify of cells about to be written to a display.
* inputCore.manager.decide_executeGesture: Decider to block some gestures from executing
* tones.decide_beep: to notify a remote system of beeps, allowing to disable local beeping
* nvwave.decide_playWaveFile: to notify a remote system of waves played, allowing to disable local playing
