### PR TITLE
Installer GUI/Python 3: check if install comparison method returns None or not

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -260,7 +260,7 @@ class InstallingOverNewerVersionDialog(wx.Dialog, DpiScalingHelperMixin):
 def showInstallGui():
 	gui.mainFrame.prePopup()
 	previous = installer.comparePreviousInstall()
-	if previous > 0:
+	if previous is not None and previous > 0:
 		# The existing installation is newer, which means this will be a downgrade.
 		d = InstallingOverNewerVersionDialog()
 		with d:


### PR DESCRIPTION
### Link to issue number:
Fixes #9923 

### Summary of the issue:
Installer GUI does not catch type error when attempting to install NVDA from scratch.

### Description of how this pull request fixes the issue:
Make sure installer's install comparison function's return value is not None before checking if an upgrade or a warning dialog is shown when trying to update or install NVDA from scratch.

### Testing performed:
Tested inside Windows 10 Version 1903 sandbox.

### Known issues with pull request:
None

### Change log entry:
None
