### PR TITLE
New command: Move review cursor to position marked as start for copy (#1969)

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1937,6 +1937,12 @@ class GlobalCommands(ScriptableObject):
 	script_review_markStartForCopy.__doc__ = _("Marks the current position of the review cursor as the start of text to be selected or copied")
 	script_review_markStartForCopy.category=SCRCAT_TEXTREVIEW
 
+	@script(
+		# Translators: Input help mode message for move review cursor to marked start position for a select or copy command
+		description=_("Move the review cursor to the position marked as the start of text to be selected or copied"),
+		category=SCRCAT_TEXTREVIEW,
+		gesture="kb:NVDA+shift+F9",
+	)
 	def script_review_moveToStartMarkedForCopy(self, gesture):
 		pos = api.getReviewPosition()
 		if not getattr(pos.obj, "_copyStartMarker", None):
@@ -1948,9 +1954,6 @@ class GlobalCommands(ScriptableObject):
 		startMarker.collapse()
 		startMarker.expand(textInfos.UNIT_CHARACTER)
 		speech.speakTextInfo(startMarker, unit=textInfos.UNIT_CHARACTER, reason=controlTypes.REASON_CARET)
-	# Translators: Input help mode message for move review cursor to marked start position for a select or copy command
-	script_review_moveToStartMarkedForCopy.__doc__ = _("Move the review cursor to the position marked as the start of text to be selected or copied")
-	script_review_moveToStartMarkedForCopy.category=SCRCAT_TEXTREVIEW
 
 	def script_review_copy(self, gesture):
 		pos = api.getReviewPosition().copy()
@@ -2395,7 +2398,6 @@ class GlobalCommands(ScriptableObject):
 		"kb(laptop):NVDA+shift+a": "review_sayAll",
 		"ts(text):3finger_flickDown":"review_sayAll",
 		"kb:NVDA+f9": "review_markStartForCopy",
-		"kb:NVDA+shift+f9": "review_moveToStartMarkedForCopy",
 		"kb:NVDA+f10": "review_copy",
 
 		# Flat review

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1938,8 +1938,11 @@ class GlobalCommands(ScriptableObject):
 	script_review_markStartForCopy.category=SCRCAT_TEXTREVIEW
 
 	@script(
-		# Translators: Input help mode message for move review cursor to marked start position for a select or copy command
-		description=_("Move the review cursor to the position marked as the start of text to be selected or copied"),
+		# Translators: Input help mode message for move review cursor to marked start position for a
+		# select or copy command
+		description=_(
+			"Move the review cursor to the position marked as the start of text to be selected or copied"
+		),
 		category=SCRCAT_TEXTREVIEW,
 		gesture="kb:NVDA+shift+F9",
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1937,6 +1937,21 @@ class GlobalCommands(ScriptableObject):
 	script_review_markStartForCopy.__doc__ = _("Marks the current position of the review cursor as the start of text to be selected or copied")
 	script_review_markStartForCopy.category=SCRCAT_TEXTREVIEW
 
+	def script_review_moveToStartMarkedForCopy(self, gesture):
+		pos = api.getReviewPosition()
+		if not getattr(pos.obj, "_copyStartMarker", None):
+			# Translators: Presented when attempting to move to the start marker for copy but none has been set.
+			ui.reviewMessage(_("No start marker set"))
+			return
+		startMarker = pos.obj._copyStartMarker.copy()
+		api.setReviewPosition(startMarker)
+		startMarker.collapse()
+		startMarker.expand(textInfos.UNIT_CHARACTER)
+		speech.speakTextInfo(startMarker, unit=textInfos.UNIT_CHARACTER, reason=controlTypes.REASON_CARET)
+	# Translators: Input help mode message for move review cursor to marked start position for a select or copy command
+	script_review_moveToStartMarkedForCopy.__doc__ = _("Move the review cursor to the position marked as the start of text to be selected or copied")
+	script_review_moveToStartMarkedForCopy.category=SCRCAT_TEXTREVIEW
+
 	def script_review_copy(self, gesture):
 		pos = api.getReviewPosition().copy()
 		if not getattr(pos.obj, "_copyStartMarker", None):
@@ -2380,6 +2395,7 @@ class GlobalCommands(ScriptableObject):
 		"kb(laptop):NVDA+shift+a": "review_sayAll",
 		"ts(text):3finger_flickDown":"review_sayAll",
 		"kb:NVDA+f9": "review_markStartForCopy",
+		"kb:NVDA+shift+f9": "review_moveToStartMarkedForCopy",
 		"kb:NVDA+f10": "review_copy",
 
 		# Flat review

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -400,6 +400,7 @@ The following commands are available for reviewing text:
 | Say all with review | numpadPlus | NVDA+shift+a | 3-finger flick down (text mode) | Reads from the current position of the review cursor, moving it as it goes |
 | Select then Copy from review cursor | NVDA+f9 | NVDA+f9 | none | Starts the select then copy process from the current position of the review cursor. The actual action is not performed until you tell NVDA where the end of the text range is |
 | Select then Copy to review cursor | NVDA+f10 | NVDA+f10 | none | On the first press, text is selected from the position previously set start marker up to and including the review cursor's current position. After pressing this key a second time, the text will be copied to the Windows clipboard |
+| Move to marked start for copy in review | NVDA+shift+f9 | NVDA+shift+f9 | none | Moves the review cursor to the position previously set start marker for copy |
 | Report text formatting | NVDA+f | NVDA+f | none | Reports the formatting of the text where the review cursor is currently situated. Pressing twice shows the information in browse mode |
 | Report current symbol replacement | None | None | none | Speaks the symbol where the review cursor is positioned. Pressed twice, shows the symbol and the text used to speak it in browse mode. |
 %kc:endInclude


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #1969

### Summary of the issue:

There is currently no way to tell which review position has been marked as the starting point for a select or copy operation.

### Description of how this pull request fixes the issue:

Add a new command to move the review cursor to the position previously marked as starting point.

### Testing performed:

Tested from source in a terminal, an editor and a web browser.

1. On the the licence agreement dialog for NVDA.
1. Use arrow keys to move the caret to the 'G' from GNU.
1. Press `NVDA+F9` to mark the start.
1. Press the down arrow key several times to move to a new line.
1. Press `NVDA+shift+F9` to move review cursor to start mark
1. Press `Numpad 6` and `Numpad 4` to review words either side of the start mark to get context.

### Known issues with pull request:

### Change log entry:

Section: New features

A command has been added to move the review cursor to the position previously set as start marker for selection or copy: NVDA+shift+F9