### PR TITLE
Update Developer Guide re. tab completion (#9918)

### DIFF
--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -796,6 +796,15 @@ These variables are:
 - brlRegions: The braille regions from the active braille buffer
 -
 
+++ Tab completion ++
+The input control supports tab-completion of variables and member attributes names.
+Hit the tab key once to complete the current input if there is one single candidate.
+If there are more than one, hit the tab key a second time to open a menu listing all matching possibilities.
+By default, only "public" member attributes are listed.
+That is, if the input is "nav.", attributes names with no leading underscore are proposed.
+If the input is "nav._", attributes names with a single leading underscore are proposed.
+Similarily, if the input is "nav.__", attributes names with two leading underscores are proposed.
+
 + Remote Python Console +
 A remote Python console is available for situations where remote debugging of NVDA is useful.
 It is similar to the [local Python console #PythonConsole] discussed above, but is accessed via TCP.

--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -799,7 +799,7 @@ These variables are:
 ++ Tab completion ++
 The input control supports tab-completion of variables and member attributes names.
 Hit the tab key once to complete the current input if there is one single candidate.
-If there are more than one, hit the tab key a second time to open a menu listing all matching possibilities.
+If there is more than one, hit the tab key a second time to open a menu listing all matching possibilities.
 By default, only "public" member attributes are listed.
 That is, if the input is "nav.", attribute names with no leading underscore are proposed.
 If the input is "nav._", attribute names with a single leading underscore are proposed.

--- a/developerGuide.t2t
+++ b/developerGuide.t2t
@@ -801,9 +801,9 @@ The input control supports tab-completion of variables and member attributes nam
 Hit the tab key once to complete the current input if there is one single candidate.
 If there are more than one, hit the tab key a second time to open a menu listing all matching possibilities.
 By default, only "public" member attributes are listed.
-That is, if the input is "nav.", attributes names with no leading underscore are proposed.
-If the input is "nav._", attributes names with a single leading underscore are proposed.
-Similarily, if the input is "nav.__", attributes names with two leading underscores are proposed.
+That is, if the input is "nav.", attribute names with no leading underscore are proposed.
+If the input is "nav._", attribute names with a single leading underscore are proposed.
+Similarly, if the input is "nav.__", attribute names with two leading underscores are proposed.
 
 + Remote Python Console +
 A remote Python console is available for situations where remote debugging of NVDA is useful.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9918

### Summary of the issue:

In the Python console, the tab-completion is smarter with Python 3.

### Description of how this pull request fixes the issue:

Document the new behavior in the Developer Guide.

### Testing performed:

None.

### Known issues with pull request:

### Change log entry:

Section: Changes for developpers

The tab-completion in the Python console is now smarter. Refer to the Developer Guide for more details.