### PR TITLE
UI Automation in Windows Console: fix "review start of line" script

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1092,9 +1092,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_startOfLine(self,gesture):
 		info=api.getReviewPosition().copy()
-		if info._expandCollapseBeforeReview:
-			info.expand(textInfos.UNIT_LINE)
-			info.collapse()
+		info.expand(textInfos.UNIT_LINE)
+		info.collapse()
 		api.setReviewPosition(info)
 		info.expand(textInfos.UNIT_CHARACTER)
 		ui.reviewMessage(_("Left"))


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
Currently, in UIA consoles, invoking the "review start of line" script (shift+numpad 1 by default) does not move the review cursor.

### Description of how this pull request fixes the issue:
Since expanding and collapsing the `textInfo` is essential for the functionality of this script (to move the `textInfo` to the start of the line), we should ignore the `_expandCollapseBeforeReview` flag.

### Testing performed:
Tested that the script works as expected in UIA consoles on Windows 10 1903. Legacy consoles are unaffected (as they remain functional).

### Known issues with pull request:
None.

### Change log entry:
None.
