### PR TITLE
Log never handled speech indexes, and don't make the speech queue lag behind

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -338,10 +338,7 @@ class SpeechManager(object):
 			lastCommand = seq[-1] if isinstance(seq, list) else None
 			if isinstance(lastCommand, IndexCommand):
 				if index > lastCommand.index:
-					log.debugWarning(
-						"Reached speech index {index :d}, but index {lastCommand.index :d} never handled"
-						.format(index=index, lastCommand=lastCommand)
-					)
+					log.debugWarning(f"Reached speech index {index :d}, but index {lastCommand.index :d} never handled")
 				elif index == lastCommand.index:
 					endOfUtterance = isinstance(self._curPriQueue.pendingSequences[seqIndex + 1][0], EndUtteranceCommand)
 					if endOfUtterance:

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -338,7 +338,10 @@ class SpeechManager(object):
 			lastCommand = seq[-1] if isinstance(seq, list) else None
 			if isinstance(lastCommand, IndexCommand):
 				if index > lastCommand.index:
-					log.debugWarning("Reached speech index %d, but index %d never handled" % (index, lastCommand.index))
+					log.debugWarning(
+						"Reached speech index {index :d}, but index {lastCommand.index :d} never handled"
+						.format(index=index, lastCommand=lastCommand)
+					)
 				elif index == lastCommand.index:
 					endOfUtterance = isinstance(self._curPriQueue.pendingSequences[seqIndex + 1][0], EndUtteranceCommand)
 					if endOfUtterance:

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -336,12 +336,15 @@ class SpeechManager(object):
 			return False, False
 		for seqIndex, seq in enumerate(self._curPriQueue.pendingSequences):
 			lastCommand = seq[-1] if isinstance(seq, list) else None
-			if isinstance(lastCommand, IndexCommand) and index >= lastCommand.index:
-				endOfUtterance = isinstance(self._curPriQueue.pendingSequences[seqIndex + 1][0], EndUtteranceCommand)
-				if endOfUtterance:
-					# Remove the EndUtteranceCommand as well.
-					seqIndex += 1
-				break # Found it!
+			if isinstance(lastCommand, IndexCommand):
+				if index > lastCommand.index:
+					log.debugWarning("Reached speech index %d, but index %d never handled" % (index, lastCommand.index))
+				elif index == lastCommand.index:
+					endOfUtterance = isinstance(self._curPriQueue.pendingSequences[seqIndex + 1][0], EndUtteranceCommand)
+					if endOfUtterance:
+						# Remove the EndUtteranceCommand as well.
+						seqIndex += 1
+					break # Found it!
 		else:
 			# Unknown index. Probably from a previous utterance which was cancelled.
 			return False, False


### PR DESCRIPTION
### Link to issue number:
Related to #9937 

### Summary of the issue:
From the speech manager docs:

> For every index reached, L{_handleIndex} is called.
> 		The completed sequence is removed from L{_pendingSequences}.
> 		If there is an associated callback, it is run.
> 		If the index marks the end of an utterance, L{_pushNextSpeech} is called to push more speech.

`_handleIndex` calls `_removeCompletedFromQueue` for the specified index. However, that code did check whether `currentIndex >= lastCommand.index`. In the case where the speech synthesizer sometimes doesn't send a notification for an index, this means the following:

1. Speech synth misses an index, calls the extension point for the index after the missing one
2. `_removeCompletedFromQueue` removes the sequence from the queue that is associated with the missed index, thereby ignoring the current index.
3. More importantly, `_removeCompletedFromQueue` checks the missed index to see whether it is the index for the end of an utterance.
4. If it is not, it expects the sequence to continue. However, if the current index was actually the end of the current utterance, the current index would be handled as soon as the next utterance starts as it is still in the queue, but as the end of the utterance is never handled, speech simply ceases.

### Description of how this pull request fixes the issue:
Log cases of indexes we missed, and clean up the sequences for the missed indexes.

### Testing performed:
Tested with #9937 that it did no longer stop speaking with espeak, which tends to miss indexes.

### Known issues with pull request:
It really looks like espeak's index handling is slightly buggy.

### Change log entry:
None
