### PR TITLE
Fix waiting for outlook/powerpoint window to exist for ever

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -108,7 +108,10 @@ class AppModule(appModuleHandler.AppModule):
 		self._hasTriedoutlookAppSwitch=True
 		#Make sure NVDA detects and reports focus on the waiting dialog
 		api.processPendingEvents()
-		comtypes.client.PumpEvents(1)
+		try:
+			comtypes.client.PumpEvents(1)
+		except WindowsError:
+			log.debugWarning("Error while pumping com events", exc_info=True)
 		d.Destroy()
 		gui.mainFrame.postPopup()
 

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1257,7 +1257,10 @@ class AppModule(appModuleHandler.AppModule):
 		self.hasTriedPpAppSwitch=True
 		#Make sure NVDA detects and reports focus on the waiting dialog
 		api.processPendingEvents()
-		comtypes.client.PumpEvents(1)
+		try:
+			comtypes.client.PumpEvents(1)
+		except WindowsError:
+			log.debugWarning("Error while pumping com events", exc_info=True)
 		d.Destroy()
 		gui.mainFrame.postPopup()
 


### PR DESCRIPTION
### Link to issue number:
Fixes #9921 

### Summary of the issue:
In outlook and powerpoint, we create a waiting for xx window while pumping com events. However, comtypes.client.PumpEvents now always raises an error due to a bug in comtypes, see https://github.com/enthought/comtypes/pull/187

### Description of how this pull request fixes the issue:
As PumpEvents can also raise an error in other cases than a time out, I decided to wrap PumpEvents into a try except and log the exception. Until t the bug is fixed in comtypes, this will also log a debug warning for time outs, though that's not very problematic IMO.

### Testing performed:
T.b.d. not very easy to reproduce the bug.

### Known issues with pull request:
Still a bug in comtypes, with an open pr to fix it.

### Change log entry:
None