### PR TITLE
Python 3: Fix error when fetching JAVA text ranges

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -259,7 +259,7 @@ if bridgeDll:
 	_fixBridgeFunc(BOOL,'getAccessibleTextSelectionInfo',c_long,JOBJECT64,POINTER(AccessibleTextSelectionInfo),errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextAttributes',c_long,JOBJECT64,jint,POINTER(AccessibleTextAttributesInfo),errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextLineBounds',c_long,JOBJECT64,jint,POINTER(jint),POINTER(jint),errcheck=True)
-	_fixBridgeFunc(BOOL,'getAccessibleTextRange',c_long,JOBJECT64,jint,jint,POINTER(c_wchar),c_short,errcheck=True)
+	_fixBridgeFunc(BOOL,'getAccessibleTextRange',c_long,JOBJECT64,jint,jint,POINTER(c_char),c_short,errcheck=True)
 	_fixBridgeFunc(BOOL,'getCurrentAccessibleValueFromContext',c_long,JOBJECT64,POINTER(c_wchar),c_short,errcheck=True)
 	_fixBridgeFunc(BOOL,'selectTextRange',c_long,JOBJECT64,c_int,c_int,errcheck=True)
 	_fixBridgeFunc(BOOL,'getTextAttributesInRange',c_long,JOBJECT64,c_int,c_int,POINTER(AccessibleTextAttributesInfo),POINTER(c_short),errcheck=True)


### PR DESCRIPTION
### Link to issue number:
Fixes #9939

### Summary of the issue:
When fetching java text ranges, NVDA now throws a character buffer at getAccessibleTextRange (see commit 15d8374e46f0615ae5d892fbba2ae34d594f224e). This no longer matches the ctypes prototype applied to the function.

### Description of how this pull request fixes the issue:
Told ctypes that it should now expect a pointer to c_char instead of _wchar.

### Testing performed:
t.b.d.

### Known issues with pull request:
NOne

### Change log entry:
None
