### PR TITLE
Remove .pyc and .pyo files when updating

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -205,6 +205,21 @@ def removeOldProgramFiles(destPath):
 	if os.path.isfile(fn):
 		tryRemoveFile(fn)
 
+	# #9960: If compiled python files from older versions aren't removed correctly,
+	# this could cause strange errors when Python tries to create tracebacks
+	# in a newer version of NVDA.
+	for curDestDir,subDirs,files in os.walk(destPath):
+		for f in files:
+			if f.endswith((".pyc", ".pyo")):
+				# This also removes compiled files from system config,
+				# but that is fine.
+				path=os.path.join(curDestDir, f)
+				log.debug(f"Removing old byte compiled python file: {path!r}")
+				try:
+					tryRemoveFile(path)
+				except RetriableFailure:
+					log.warning(f"Couldn't remove file: {path!r}")
+
 uninstallerRegInfo={
 	"DisplayName":versionInfo.name,
 	"DisplayVersion":versionInfo.version,


### PR DESCRIPTION
### Link to issue number:
Fixes #9960

### Summary of the issue:
When updating NVDA, old *.pyc and *.pyo files can stay around. This could be problematic for Python 2 pyc files that Python 3 tries to open. Furthermore, it could cause issues such as reported in #9960, where the logHandler gets really mad if it tries to log a traceback for a file in library.zip which is also available in the installation directory.

### Description of how this pull request fixes the issue:
When removing old program files, check for *.pyc and *.pyo files and get rid of them/

### Testing performed:
Placed a handyTech.pyc file in `C:\Program Files (x86)\NVDA\brailleDisplayDrivers`. Made sure it disappeared after installing the try build for this pr.

### Known issues with pull request:
1. This removes *,pyc and *.pyo files from systemConfig as well, but I think that's fine.
2. This does not yet fix the issue where old braille display driver dll's stick around on the system, particularly handy tech, hims and alva.

### Change log entry:
None needed
