### PR TITLE
Fix sapi5 and MSSP on installed copies of threshold

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -40,12 +40,16 @@ class FunctionHooker(object):
 		newFunction # result of ctypes.WINFUNCTYPE
 	):
 		# dllImportTableHooks_hookSingle expects byte strings.
-		self._hook=NVDAHelper.localLib.dllImportTableHooks_hookSingle(
-			targetDll.encode(),
-			importDll.encode(),
-			funcName.encode(),
-			newFunction
-		)
+		try:
+			self._hook=NVDAHelper.localLib.dllImportTableHooks_hookSingle(
+				targetDll.encode("mbcs"),
+				importDll.encode("mbcs"),
+				funcName.encode("mbcs"),
+				newFunction
+			)
+		except UnicodeEncodeError:
+			log.error("Error encoding FunctionHooker input parameters", exc_info=True)
+			self._hook = None
 		if self._hook:
 			log.debug(f"Hooked {funcName}")
 		else:

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -31,16 +31,29 @@ SPAS_RUN=3
 
 class FunctionHooker(object):
 
-	def __init__(self,targetDll,importDll,funcName,newFunction):
-		hook=NVDAHelper.localLib.dllImportTableHooks_hookSingle(targetDll,importDll,funcName,newFunction)
-		if hook:
-			log.debug("hooked %s"%funcName)
+	def __init__(
+		self,
+		targetDll: str,
+		importDll: str,
+		funcName: str,
+		newFunction # result of ctypes.WINFUNCTYPE
+	):
+		# dllImportTableHooks_hookSingle expects byte strings.
+		self._hook=NVDAHelper.localLib.dllImportTableHooks_hookSingle(
+			targetDll.encode(),
+			importDll.encode(),
+			funcName.encode(),
+			newFunction
+		)
+		if self._hook:
+			log.debug(f"Hooked {funcName}")
 		else:
-			log.debug("could not hook %s"%funcName)
-			raise RuntimeError("could not hook %s"%funcName)
+			log.error(f"Could not hook {funcName}")
+			raise RuntimeError(f"Could not hook {funcName}")
 
 	def __del__(self):
-		NVDAHelper.localLib.dllImportTableHooks_unhookSingle(self._hook)
+		if self._hook:
+			NVDAHelper.localLib.dllImportTableHooks_unhookSingle(self._hook)
 
 _duckersByHandle={}
 

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -109,10 +109,18 @@ class SapiSink(object):
 		self.synthRef = weakref.ref(synth)
 
 	def Bookmark(self, streamNum, pos, bookmark, bookmarkId):
-		synthIndexReached.notify(synth=self.synthRef(), index=bookmarkId)
+		synth = self.synthRef()
+		if synth is None:
+			log.debugWarning("Called Bookmark method on SapiSink while driver is dead")
+			return
+		synthIndexReached.notify(synth=synth, index=bookmarkId)
 
 	def EndStream(self, streamNum, pos):
-		synthDoneSpeaking.notify(synth=self.synthRef())
+		synth = self.synthRef()
+		if synth is None:
+			log.debugWarning("Called Bookmark method on EndStream while driver is dead")
+			return
+		synthDoneSpeaking.notify(synth=synth)
 
 class SynthDriver(SynthDriver):
 	supportedSettings=(SynthDriver.VoiceSetting(),SynthDriver.RateSetting(),SynthDriver.PitchSetting(),SynthDriver.VolumeSetting())

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -22,6 +22,7 @@ from synthDriverHandler import SynthDriver, VoiceInfo, synthIndexReached, synthD
 import config
 import nvwave
 from logHandler import log
+import weakref
 
 # SPAudioState enumeration
 SPAS_CLOSED=0
@@ -101,13 +102,13 @@ class SapiSink(object):
 	"""
 
 	def __init__(self, synth):
-		self.synth = synth
+		self.synthRef = weakref.ref(synth)
 
 	def Bookmark(self, streamNum, pos, bookmark, bookmarkId):
-		synthIndexReached.notify(synth=self.synth, index=bookmarkId)
+		synthIndexReached.notify(synth=self.synthRef(), index=bookmarkId)
 
 	def EndStream(self, streamNum, pos):
-		synthDoneSpeaking.notify(synth=self.synth)
+		synthDoneSpeaking.notify(synth=self.synthRef())
 
 class SynthDriver(SynthDriver):
 	supportedSettings=(SynthDriver.VoiceSetting(),SynthDriver.RateSetting(),SynthDriver.PitchSetting(),SynthDriver.VolumeSetting())


### PR DESCRIPTION
### Link to issue number:
Fixes #9963 

### Summary of the issue:
1. SAPI5 doesn't work on installed copies of threshold, because `dllImportTableHooks_hookSingle` was getting wide strings, not byte strings.
2. Changing from sapi5 to another synthesizer still showed the sapi5 voices in the list of voices.

### Description of how this pull request fixes the issue:
1. Convert the parameters to UTF_8, which is a sane default (I think all these cases are ascii anyway.

    I also discovered that the `__del__` method tried to unhook `self._hook`, which was never saved as such. ` __del__` should now be a bit more graceful.

2. As part of speech refactor, SAPI5 got an event sync, which was keeping a reference to the synthesizer object. The gui wants the reference to die, though.

### Testing performed:
With a signed try build, made sure that sapi5 loads and audio ducking works with it. Also made sure that when switching from sapi5 to another synth, the voices list reflects the new synth.

### Known issues with pull request:
The wave out hooks are still global. I thought about moving them to the SynthDriver class, but then I realised that this would break if switching from SAPI5 to MSSP, for example.

### Change log entry:
None
