### PR TITLE
Version info: major version -> 3

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited
+#Copyright (C) 2006-2019 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -65,7 +65,7 @@ def formatVersionForGUI(year, major, minor):
 
 name="NVDA"
 version_year=2019
-version_major=2
+version_major=3
 version_minor=0
 version_build=0
 version=_formatDevVersionString()


### PR DESCRIPTION
Hi,

Perhaps an oversight (I think):

### Link to issue number:
None

### Summary of the issue:
Major version is set to 2 when Threshold was merged into master.

### Description of how this pull request fixes the issue:
Major version is set to 3.

### Testing performed:
TBD

### Known issues with pull request:
None (although it'll affect add-ons).

### Change log entry:
None