### PR TITLE
Fix division error in papenmeier_serial

### DIFF
--- a/source/brailleDisplayDrivers/papenmeier_serial.py
+++ b/source/brailleDisplayDrivers/papenmeier_serial.py
@@ -182,8 +182,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		if(self._dev!=None):
 			data = brl_poll(self._dev)
 			if len(data) == 10 and data[1] == ord(b'K'):
-				pos = data[2] * 256 + data[3]
-				pos = (pos-768)/3
+				pos = (data[2] << 8) + data[3]
+				pos = (pos-768) // 3
 				pressed = data[6]
 				keys = data[8]
 				self._repeatcount = 0


### PR DESCRIPTION
### Link to issue number:
fixes #9981 

### Summary of the issue:
Routing cursor keys don't work on papenmeier serial due to division changes in python 3.

### Description of how this pull request fixes the issue:
use floor division with //. Also changed x * 256 into x << 8, which looked more appropriate.

### Testing performed:
T.b.d.

### Known issues with pull request:
Code is still a bit weird, especially the x - 768) // 3 part.

### Change log entry:
No change log entry necessary.
