### PR TITLE
Properly check if the object is an instance of IAccessible2.

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -863,7 +863,7 @@ the NVDAObject for IAccessible
 			log.debugWarning("could not get IAccessible states",exc_info=True)
 		else:
 			states.update(IAccessibleHandler.IAccessibleStatesToNVDAStates[x] for x in (y for y in (1<<z for z in range(32)) if y&IAccessibleStates) if x in IAccessibleHandler.IAccessibleStatesToNVDAStates)
-		if not hasattr(self.IAccessibleObject,'states'):
+		if not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
 			# Not an IA2 object.
 			return states
 		IAccessible2States=self.IA2States


### PR DESCRIPTION
Fixes #9980.
Fixes #9988

Instead of using hasattr, use instanceof to check that the IAccessible object is an IA2 object before checking for the IA2 specific states.

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

#9980, #9988

### Summary of the issue:

In Firefox, under many circumstances, an error is generated when web site contents changes and states are being queried.

### Description of how this pull request fixes the issue:

After @leonardder's instruction in the issue comments, hasattr should never have been used for this kind of check. After changing to an instanceof check, the error went away.

### Testing performed:

Tested in Firefox when opening and closing Gmail conversations and going to different Twitter pages.

### Known issues with pull request:

None.

### Change log entry:

None. This is a side effect of the Python3 migration.

