### PR TITLE
V2 of disable caret events in the UIA console

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -287,6 +287,11 @@ class WinConsoleUIA(Terminal):
 		self._queuedChars = []
 		speech.clearTypedWordBuffer()
 
+	def _get_caretMovementDetectionUsesEvents(self):
+		"""Using caret events in consoles sometimes causes the last character of the
+		prompt to be read when quickly deleting text."""
+		return False
+
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA
 		ptr = self.UIATextPattern.GetVisibleRanges()

--- a/source/NVDAObjects/window/winConsole.py
+++ b/source/NVDAObjects/window/winConsole.py
@@ -73,6 +73,11 @@ class WinConsole(Terminal, EditableTextWithoutAutoSelectDetection, Window):
 				self.startMonitoring()
 		core.callLater(200,reconnect)
 
+	def _get_caretMovementDetectionUsesEvents(self):
+		"""Using caret events in consoles sometimes causes the last character of the
+		prompt to be read when quickly deleting text."""
+		return False
+
 	@script(gestures=[
 		"kb:enter",
 		"kb:numpadEnter",


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Builds on #9614. Identical to #9985.

### Summary of the issue:
Steps to reproduce:

1. Oepn a UIA console (`cmd.exe`).
2. Type echo
3. Quickly backspace the text.

Expected behavior: NVDA reads the characters being deleted, then nothing once none are left.
Observed behavior: NVDA sometimes reads the last character of the prompt when deleting fast enough.

### Description of how this pull request fixes the issue:
This PR disables the caret movement event detection from #9933 for UIA consoles (as with IA2 web).

### Testing performed:
Tested above steps and verified that the issue is no longer reproducible.

### Known issues with pull request:
Caret events may be useful in consoles, so we may want to look for a better workaround at some stage. This PR at least restores behavior from before py3.

### Change log entry:
None.