### PR TITLE
Fix alpha updates and lint error reporting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -196,8 +196,15 @@ test_script:
 
 on_finish:
  - ps: |
-    $root = Resolve-Path output\
-    [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)}
+    $uploadFromFolder = "output\"
+    if( Test-Path $uploadFromFolder ){
+      $root = Resolve-Path .\
+      $output = Resolve-Path $uploadFromFolder
+      $paths = [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories')
+      $paths | % {
+        Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)
+      }
+    }
 
 deploy_script:
  - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -196,8 +196,8 @@ test_script:
 
 on_finish:
  - ps: |
-      Get-ChildItem output\*   | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-      Get-ChildItem output\*\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+    $root = Resolve-Path output\
+    [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)}
 
 deploy_script:
  - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -200,7 +200,7 @@ on_finish:
     if( Test-Path $uploadFromFolder ){
       $root = Resolve-Path .\
       $output = Resolve-Path $uploadFromFolder
-      $paths = [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories')
+      $paths = [IO.Directory]::GetFiles($output.Path, '*.*', 'AllDirectories')
       $paths | % {
         Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)
       }

--- a/tests/lint/createJunitReport.py
+++ b/tests/lint/createJunitReport.py
@@ -30,7 +30,7 @@ WE_POST = r'''
 
 
 def makeJunitXML(inFileName, outFileName):
-	with open(inFileName, 'rt', encoding='UTF-8') as flake8In:
+	with open(inFileName, 'rt', encoding='ANSI', errors='replace') as flake8In:
 		errorText = flake8In.read()
 	if len(errorText) > 0:
 		# make "with error" xml content
@@ -39,7 +39,7 @@ def makeJunitXML(inFileName, outFileName):
 		# make "no error" xml content
 		outContents = NO_ERROR
 
-	with open(outFileName, 'wt', encoding='UTF-8') as out:
+	with open(outFileName, 'wt', encoding='UTF-8', errors='replace') as out:
 		out.write(outContents)
 
 

--- a/tests/lint/flake8.ini
+++ b/tests/lint/flake8.ini
@@ -2,6 +2,7 @@
 
 # Plugins
 use-flake8-tabs = True
+# Not all checks are replaced by flake8-tabs, we decide manually in the ignore section.
 use-pycodestyle-indent = True
 
 # Reporting
@@ -12,13 +13,20 @@ show-source = True
 # Options
 max-complexity = 15
 max-line-length = 110
-hang-closing = True
+# Final bracket should match indentation of the start of the line of the opening bracket
+hang-closing = False
 
 ignore =
-	W191, # indentation contains tabs
-	E126, # continuation line over-indented for hanging indent
-	E133, # closing bracket is missing indentation
-	W503, # line break before binary operator. As opposed to W504 (line break after binary operator) which we want to check for.
+	W191,  # indentation contains tabs
+	W503,  # line break before binary operator. We want W504(line break after binary operator)
+	### The following are replaced by flake8-tabs plugin, reported as ET codes rather than E codes.
+	E121, E122, E123, E126, E127, E128,
+	### The following are not replaced by flake8-tabs: ###
+	E124,  # Disable, requires mixing spaces and tabs: Closing bracket does not match visual indentation.
+	#E125, # Enable: Continuation line with same indent as next logical line
+	E129,  # Disable, requires mixing spaces and tabs: Visually indented line with same indent as next logical line
+	E131,  # Disable, requires mixing spaces and tabs: Continuation line unaligned for hanging indent
+	E133,  # Disable, our preference handled by ET126: Closing bracket is missing indentation
 
 builtins = # inform flake8 about functions we consider built-in.
 	_, # translation lookup


### PR DESCRIPTION
# Link to issue number:

### Summary of the issue:
- Alpha users are unable to update
  - The new method of uploading artifacts does so with out preserving the folder structure
  - The URL for updates expects the executable to live at <URL>output/nvda....exe
- Some lint test failures are not being reported
  - The build fails
  - Lint error comment is added to the PR
  - The tests section of build result shows all tests pass
  - The `PR-Flake8.txt` file is available from artifacts
  - Example: https://ci.appveyor.com/project/NVAccess/nvda/builds/26411941/tests
  - Build console log shows an encoding error when trying to create the `junit.xml` file

### Description of how this pull request fixes the issue:

- Use a structure preserving mechanism to upload artifacts
- Read `PR-Flake8.txt` as ANSI, ignore errors.

### Testing performed:
- Wait for build to complete, see if artifact URL is as required.
- Locally converted the `Flake8.txt` file from the example failed build using the  `createJunitReport.py ` script

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

