### PR TITLE
Don't use pycodestyle-indent checks

### DIFF
--- a/tests/lint/flake8.ini
+++ b/tests/lint/flake8.ini
@@ -2,8 +2,17 @@
 
 # Plugins
 use-flake8-tabs = True
-# Not all checks are replaced by flake8-tabs, we decide manually in the ignore section.
-use-pycodestyle-indent = True
+# Not all checks are replaced by flake8-tabs, however, pycodestyle is still not compatible with tabs.
+use-pycodestyle-indent = False
+## The following are replaced by flake8-tabs plugin, reported as ET codes rather than E codes.
+# E121, E122, E123, E126, E127, E128,
+## The following (all disabled) are not replaced by flake8-tabs,
+# E124 - Requires mixing spaces and tabs: Closing bracket does not match visual indentation.
+# E125 - Does not take tabs into consideration: Continuation line with same indent as next logical line.
+# E129 - Requires mixing spaces and tabs: Visually indented line with same indent as next logical line
+# E131 - Requires mixing spaces and tabs: Continuation line unaligned for hanging indent
+# E133 - Our preference handled by ET126: Closing bracket is missing indentation
+
 
 # Reporting
 statistics = True
@@ -19,14 +28,7 @@ hang-closing = False
 ignore =
 	W191,  # indentation contains tabs
 	W503,  # line break before binary operator. We want W504(line break after binary operator)
-	### The following are replaced by flake8-tabs plugin, reported as ET codes rather than E codes.
-	E121, E122, E123, E126, E127, E128,
-	### The following are not replaced by flake8-tabs: ###
-	E124,  # Disable, requires mixing spaces and tabs: Closing bracket does not match visual indentation.
-	#E125, # Enable: Continuation line with same indent as next logical line
-	E129,  # Disable, requires mixing spaces and tabs: Visually indented line with same indent as next logical line
-	E131,  # Disable, requires mixing spaces and tabs: Continuation line unaligned for hanging indent
-	E133,  # Disable, our preference handled by ET126: Closing bracket is missing indentation
+
 
 builtins = # inform flake8 about functions we consider built-in.
 	_, # translation lookup


### PR DESCRIPTION
# Link to issue number:
None

### Summary of the issue:
The indentation checks from pycodestyle are not compatible with tabs. The documentation of flake8-tabs seemed to suggest we may want to consider enabling them, however they just seem to be causing problems. 


### Description of how this pull request fixes the issue:
Disable the pycodestyle checks, however leave in comments about the interactions on error numbers between flake8-tabs and pycodestyle.

### Testing performed:
Local testing with exmaple code.

### Known issues with pull request:
none

### Change log entry:
None necessary 

