### PR TITLE
Support for ARIA 1.1 combo boxes in Firefox and Chrome.

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -369,6 +369,38 @@ CComPtr<IAccessible2> GeckoVBufBackend_t::getSelectedItem(
 	return nullptr;
 }
 
+/**
+ * Get the text box inside a combo box, if any.
+ */
+CComPtr<IAccessible2> getTextBoxInComboBox(
+	IAccessible2* comboBox
+) {
+	CComPtr<IDispatch> childDisp;
+	// We only check the first child.
+	if (FAILED(comboBox->get_accChild(CComVariant(1), &childDisp))) {
+		return nullptr;
+	}
+	CComQIPtr<IAccessible2> child = childDisp;
+	if (!child) {
+		return nullptr;
+	}
+	long role;
+	if (FAILED(child->role(&role))) {
+		return nullptr;
+	}
+	if (role != ROLE_SYSTEM_TEXT) {
+		return nullptr;
+	}
+	CComVariant state;
+	if (FAILED(child->get_accState(CComVariant(CHILDID_SELF), &state))) {
+		return nullptr;
+	}
+	if (state.vt != VT_I4 || !(state.lVal & STATE_SYSTEM_FOCUSABLE)) {
+		return nullptr;
+	}
+	return child;
+}
+
 const vector<wstring>ATTRLIST_ROLES(1, L"IAccessible2::attribute_xml-roles");
 const wregex REGEX_PRESENTATION_ROLE(L"IAccessible2\\\\:\\\\:attribute_xml-roles:.*\\bpresentation\\b.*;");
 
@@ -966,6 +998,25 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(IAccessible2* pacc,
 					static_cast<VBufStorage_controlFieldNode_t*>(tempNode)->requiresParentUpdate = true;
 				} else {
 					LOG_DEBUG(L"Error in calling fillVBuf");
+				}
+			}
+
+		} else if (role == ROLE_SYSTEM_COMBOBOX) {
+			CComPtr<IAccessible2> textBox = getTextBoxInComboBox(pacc);
+			if (textBox) {
+				// ARIA 1.1 combobox. Render the text box child.
+				if (tempNode = this->fillVBuf(textBox, buffer, parentNode, previousNode,
+					paccTable, paccTable2, tableID, presentationalRowNumber,
+					ignoreInteractiveUnlabelledGraphics)
+				) {
+					previousNode=tempNode;
+				} else {
+					LOG_DEBUG(L"Error in calling fillVBuf");
+				}
+			} else if (value) {
+				previousNode=buffer->addTextFieldNode(parentNode,previousNode,value);
+				if(previousNode && !locale.empty()) {
+					previousNode->addAttribute(L"language", locale);
 				}
 			}
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1582,8 +1582,12 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		if (
 			# roles such as application and dialog should be treated as being within a "application" and therefore outside of the browseMode document. 
 			obj.role in self.APPLICATION_ROLES 
-			# Anything inside a combo box should be treated as being outside a browseMode document.
-			or (obj.container and obj.container.role==controlTypes.ROLE_COMBOBOX)
+			# Anything other than an editable text box inside a combo box should be
+			# treated as being outside a browseMode document.
+			or (
+				obj.role != controlTypes.ROLE_EDITABLETEXT and obj.container
+				and obj.container.role == controlTypes.ROLE_COMBOBOX
+			)
 		):
 			return True
 		return None


### PR DESCRIPTION
### Link to issue number:
Fixes #9616 .

### Summary of the issue:
ARIA 1.1 combo boxes (where the combo box contains a text box and a pop-up such as a list box) often weren't rendered in browse mode at all, making them effectively non-existent. Even if they were, you couldn't read the value or press enter to interact with the text box.

### Description of how this pull request fixes the issue:
1. If the first child of a combo box is a text box, render that text box in browse mode.
2. Previously, we treated anything inside a combo box as being outside a browse mode document (#8687). Don't do this for text boxes. Otherwise, you can't switch back to browse mode when the text box has focus.

### Testing performed:
1. In Firefox, tested the [ARIA 1.1 Combobox with Listbox Popup Examples](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html). Ensured that the combo box and its text box were rendered in browse mode, that pressing enter focused the text box and switched to focus mode and that it's possible to switch back to browse mode with escape or NVDA+space.
2. In Firefox, tested a simple HTML select with size 1. Confirmed that the behaviour is unchanged; i.e. the combo box and its value are rendered in browse mode.

### Known issues with pull request:
This assumes that a text box will always be the first child of the combo box. All the examples (including the official spec examples) do this and this is what I've seen in the wild. We could change this to scan all children, but I'm reluctant to do this unless we have to.

### Change log entry:

Bug Fixes:
`- ARIA 1.1 combo boxes are now supported in Mozilla Firefox and Google Chrome. (#9616)`