### PR TITLE
UI Automation in Windows Console: Always use ConsoleUIATextInfo in UIA consoles

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -238,7 +238,11 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Use our custom textInfo for UIA consoles.
 	#: This fixes expand/collapse, implements word movement,
 	# and bounds review to the visible text.
-	TextInfo = consoleUIATextInfo
+	# Overriding _get_TextInfo and thus the TextInfo property on NVDAObjects.UIA.UIA
+	# consoleUIATextInfo fixes expand/collapse, implements word movement, and 
+	# bounds review to the visible text.
+	def _get_TextInfo(self):
+		return consoleUIATextInfo
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
 

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -235,7 +235,7 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
-	_TextInfo = consoleUIATextInfo
+	TextInfo = consoleUIATextInfo
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
 

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -235,16 +235,15 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
-	#: Use our custom textInfo for UIA consoles.
-	#: This fixes expand/collapse, implements word movement,
-	# and bounds review to the visible text.
-	# Overriding _get_TextInfo and thus the TextInfo property on NVDAObjects.UIA.UIA
-	# consoleUIATextInfo fixes expand/collapse, implements word movement, and 
-	# bounds review to the visible text.
-	def _get_TextInfo(self):
-		return consoleUIATextInfo
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
+
+	def _get_TextInfo(self):
+		"""Overriding _get_TextInfo and thus the TextInfo property
+		on NVDAObjects.UIA.UIA
+		consoleUIATextInfo fixes expand/collapse, implements word movement, and
+		bounds review to the visible text."""
+		return consoleUIATextInfo
 
 	def _get_caretMovementDetectionUsesEvents(self):
 		"""Using caret events in consoles sometimes causes the last character of the

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -235,6 +235,9 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
+	#: Use our custom textInfo for UIA consoles.
+	#: This fixes expand/collapse, implements word movement,
+	# and bounds review to the visible text.
 	TextInfo = consoleUIATextInfo
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10030. Related to #9614.

### Summary of the issue:
NVDA incorrectly reports an empty selection when focusing Windows consoles.

Since the `TextInfo` property on consoles was prefixed with an underscore, NVDA dynamically selected the wrong `TextInfo` implementation (see `NVDAObjects.UIA.UIA._getTextInfo`). This means that when a console is first focused, `UIATextInfo` is selected instead of `WinConsoleUIA.TextInfo`, so our patched `isCollapsed` logic isn't used and `speech.speakPreselectedText` is called (see lines 391–393 in `speech/__init__.py`).

### Description of how this pull request fixes the issue:
Assign the `textInfo` class as `WinConsoleUIA.TextInfo` rather than `WinConsoleUIA._TextInfo`.

### Testing performed:
Tested steps from the issue and confirmed that no superfluous selections are reported.

### Known issues with pull request:
None.

### Change log entry:
None.