### PR TITLE
V2 of UI Automation in Windows Console: fix setEndPoint/compareEndPoints

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -160,9 +160,9 @@ class consoleUIATextInfo(UIATextInfo):
 		# past the start.
 		# Compare to the start (not the end) when collapsed.
 		selfEndPoint, otherEndPoint = which.split("To")
-		if selfEndPoint == "end" and not self._isCollapsed:
+		if selfEndPoint == "end" and not self._isCollapsed():
 			selfEndPoint = "start"
-		if otherEndPoint == "End" and not other._isCollapsed:
+		if otherEndPoint == "End" and not other._isCollapsed():
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().compareEndPoints(other, which=which)
@@ -177,12 +177,12 @@ class consoleUIATextInfo(UIATextInfo):
 		# In this case, there is no need to check if self is collapsed
 		# since the point of this method is to change its text range, modifying the "end" endpoint of a collapsed
 		# text range is fine.
-		if otherEndPoint == "End" and not other._isCollapsed:
+		if otherEndPoint == "End" and not other._isCollapsed():
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().setEndPoint(other, which=which)
 
-	def _get__isCollapsed(self):
+	def _isCollapsed(self):
 		"""Works around a UIA bug on Windows 10 1803 and later that means we
 		cannot trust the "end" endpoint of a collapsed (empty) text range
 		for comparisons.

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -168,19 +168,23 @@ class consoleUIATextInfo(UIATextInfo):
 		return super().compareEndPoints(other, which=which)
 
 	def setEndPoint(self, other, which):
-		"""Works around a UIA bug on Windows 10 1803 and later."""
+		"""Override of L{textInfos.TextInfo.setEndPoint}.
+		Works around a UIA bug on Windows 10 1803 and later that means we can not trust 
+		the "end" endpoint of a collapsed (empty) text range for comparisons.
+		"""
 		# Even when a console textRange's start and end have been moved to the
 		# same position, the console incorrectly reports the end as being
 		# past the start.
 		selfEndPoint, otherEndPoint = which.split("To")
-		# In this case, there is no need to check selfEndPoint
-		# since it is about to be overwritten in the super call.
+		# In this case, there is no need to check if self is collapsed
+		# since the point of this method is to change its text range, modifying the "end" endpoint of a collapsed
+		# textrange is fine.
 		if otherEndPoint == "End" and not other.hasNoText:
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().setEndPoint(other, which=which)
 
-	def _get_hasNoText(self):
+	def _get__isCollapsed(self):
 		return not bool(self._rangeObj.getText(1))
 
 	def _get_isCollapsed(self):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -167,6 +167,12 @@ class consoleUIATextInfo(UIATextInfo):
 			self._endPointHelper(other, which, normalizeSrc=False)
 		)
 
+	def _get_isCollapsed(self):
+		"""Works around a UIA bug on Windows 10 1803 and later."""
+		# To decide if the textRange is collapsed,
+		# Check if it has no text.
+		return not bool(self._rangeObj.getText(1))
+
 	def _endPointHelper(self, other, which, normalizeSrc=True):
 		"""
 		Even when a console textRange's start and end have been moved to the
@@ -175,9 +181,9 @@ class consoleUIATextInfo(UIATextInfo):
 		Returns normalized endPoints to work around this."""
 		# Compare to the start (not the end) when collapsed.
 		src, target = which.split("To")
-		if normalizeSrc and src == "end" and not self._rangeObj.GetText(1):
+		if normalizeSrc and src == "end" and not self.isCollapsed:
 			src = "start"
-		if target == "End" and not other._rangeObj.GetText(1):
+		if target == "End" and not other.isCollapsed:
 			target = "Start"
 		return f"{src}To{target}"
 

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -168,12 +168,12 @@ class consoleUIATextInfo(UIATextInfo):
 		)
 
 	def _endPointHelper(self, other, which, normalizeSrc=True):
-		"""Returns normalized endPoints to work around a Windows bug."""
-		# Even when a console textRange's start and end have been moved to the
-		# same position, the console incorrectly reports the end as being
-		# past the start.
-		# To work around this, compare to the start, not the end,
-		# when collapsed.
+		"""
+		Even when a console textRange's start and end have been moved to the
+		same position, the console incorrectly reports the end as being
+		past the start.
+		Returns normalized endPoints to work around this."""
+		# Compare to the start (not the end) when collapsed.
 		src, target = which.split("To")
 		if normalizeSrc and src == "end" and not self._rangeObj.GetText(1):
 			src = "start"

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -169,8 +169,9 @@ class consoleUIATextInfo(UIATextInfo):
 
 	def setEndPoint(self, other, which):
 		"""Override of L{textInfos.TextInfo.setEndPoint}.
-		Works around a UIA bug on Windows 10 1803 and later that means we can not trust 
-		the "end" endpoint of a collapsed (empty) text range for comparisons.
+		Works around a UIA bug on Windows 10 1803 and later that means we can
+		not trust the "end" endpoint of a collapsed (empty) text range
+		for comparisons.
 		"""
 		selfEndPoint, otherEndPoint = which.split("To")
 		# In this case, there is no need to check if self is collapsed
@@ -182,8 +183,12 @@ class consoleUIATextInfo(UIATextInfo):
 		return super().setEndPoint(other, which=which)
 
 	def _get__isCollapsed(self):
-		"""Works around a UIA bug on Windows 10 1803 and later that means we can not trust the "end" endpoint of a collapsed (empty) text range for comparisons.
-		Instead we check to see if we can get the first character from the text range. A collapsed range will not have any characters and will return an empty string."""
+		"""Works around a UIA bug on Windows 10 1803 and later that means we
+		cannot trust the "end" endpoint of a collapsed (empty) text range
+		for comparisons.
+		Instead we check to see if we can get the first character from the
+		text range. A collapsed range will not have any characters
+		and will return an empty string."""
 		return not bool(self._rangeObj.getText(1))
 
 	def _get_isCollapsed(self):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -160,9 +160,9 @@ class consoleUIATextInfo(UIATextInfo):
 		# past the start.
 		# Compare to the start (not the end) when collapsed.
 		selfEndPoint, otherEndPoint = which.split("To")
-		if selfEndPoint == "end" and not self.hasNoText:
+		if selfEndPoint == "end" and not self._isCollapsed:
 			selfEndPoint = "start"
-		if otherEndPoint == "End" and not other.hasNoText:
+		if otherEndPoint == "End" and not other._isCollapsed:
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().compareEndPoints(other, which=which)
@@ -172,26 +172,24 @@ class consoleUIATextInfo(UIATextInfo):
 		Works around a UIA bug on Windows 10 1803 and later that means we can not trust 
 		the "end" endpoint of a collapsed (empty) text range for comparisons.
 		"""
-		# Even when a console textRange's start and end have been moved to the
-		# same position, the console incorrectly reports the end as being
-		# past the start.
 		selfEndPoint, otherEndPoint = which.split("To")
 		# In this case, there is no need to check if self is collapsed
 		# since the point of this method is to change its text range, modifying the "end" endpoint of a collapsed
-		# textrange is fine.
-		if otherEndPoint == "End" and not other.hasNoText:
+		# text range is fine.
+		if otherEndPoint == "End" and not other._isCollapsed:
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().setEndPoint(other, which=which)
 
 	def _get__isCollapsed(self):
+		"""Works around a UIA bug on Windows 10 1803 and later that means we can not trust the "end" endpoint of a collapsed (empty) text range for comparisons.
+		Instead we check to see if we can get the first character from the text range. A collapsed range will not have any characters and will return an empty string."""
 		return not bool(self._rangeObj.getText(1))
 
 	def _get_isCollapsed(self):
-		"""Works around a UIA bug on Windows 10 1803 and later."""
 		# To decide if the textRange is collapsed,
 		# Check if it has no text.
-		return self.hasNoText
+		return self._isCollapsed
 
 	def _getCurrentOffsetInThisLine(self, lineInfo):
 		"""

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -153,14 +153,20 @@ class consoleUIATextInfo(UIATextInfo):
 		else:
 			return super(consoleUIATextInfo, self).expand(unit)
 
-	def _get_isCollapsed(self):
+	def compareEndPoints(self, other, which):
 		"""Works around a UIA bug on Windows 10 1803 and later."""
 		# Even when a console textRange's start and end have been moved to the
 		# same position, the console incorrectly reports the end as being
 		# past the start.
-		# Therefore to decide if the textRange is collapsed,
-		# Check if it has no text.
-		return not bool(self._rangeObj.getText(1))
+		# To work around this, compare to the start, not the end,
+		# when collapsed.
+		src, target = which.split("To")
+		if src == "end" and not self._rangeObj.GetText(1):
+			src = "Start"
+		if target == "End" and not other._rangeObj.GetText(1):
+			target = "Start"
+		which = f"{src}To{target}"
+		return super().compareEndPoints(other, which)
 
 	def _getCurrentOffsetInThisLine(self, lineInfo):
 		"""

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -164,11 +164,10 @@ class consoleUIATextInfo(UIATextInfo):
 		"""Works around a UIA bug on Windows 10 1803 and later."""
 		return super().compareEndPoints(
 			other,
-			self._endPointHelper(other, which),
-			normalizeSrc=False
+			self._endPointHelper(other, which, normalizeSrc=False)
 		)
 
-	def _endPointHelper(self, other, which, normalizeSource=True):
+	def _endPointHelper(self, other, which, normalizeSrc=True):
 		"""Returns normalized endPoints to work around a Windows bug."""
 		# Even when a console textRange's start and end have been moved to the
 		# same position, the console incorrectly reports the end as being

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -162,7 +162,7 @@ class consoleUIATextInfo(UIATextInfo):
 
 	def setEndPoint(self, other, which):
 		"""Works around a UIA bug on Windows 10 1803 and later."""
-		return super().compareEndPoints(
+		return super().setEndPoint(
 			other,
 			self._endPointHelper(other, which, normalizeSrc=False)
 		)
@@ -176,7 +176,7 @@ class consoleUIATextInfo(UIATextInfo):
 		# when collapsed.
 		src, target = which.split("To")
 		if normalizeSrc and src == "end" and not self._rangeObj.GetText(1):
-			src = "Start"
+			src = "start"
 		if target == "End" and not other._rangeObj.GetText(1):
 			target = "Start"
 		return f"{src}To{target}"

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -164,10 +164,11 @@ class consoleUIATextInfo(UIATextInfo):
 		"""Works around a UIA bug on Windows 10 1803 and later."""
 		return super().compareEndPoints(
 			other,
-			self._endPointHelper(other, which)
+			self._endPointHelper(other, which),
+			normalizeSrc=False
 		)
 
-	def _endPointHelper(self, other, which):
+	def _endPointHelper(self, other, which, normalizeSource=True):
 		"""Returns normalized endPoints to work around a Windows bug."""
 		# Even when a console textRange's start and end have been moved to the
 		# same position, the console incorrectly reports the end as being
@@ -175,7 +176,7 @@ class consoleUIATextInfo(UIATextInfo):
 		# To work around this, compare to the start, not the end,
 		# when collapsed.
 		src, target = which.split("To")
-		if src == "end" and not self._rangeObj.GetText(1):
+		if normalizeSrc and src == "end" and not self._rangeObj.GetText(1):
 			src = "Start"
 		if target == "End" and not other._rangeObj.GetText(1):
 			target = "Start"

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -155,6 +155,20 @@ class consoleUIATextInfo(UIATextInfo):
 
 	def compareEndPoints(self, other, which):
 		"""Works around a UIA bug on Windows 10 1803 and later."""
+		return super().compareEndPoints(
+			other,
+			self._endPointHelper(other, which)
+		)
+
+	def setEndPoint(self, other, which):
+		"""Works around a UIA bug on Windows 10 1803 and later."""
+		return super().compareEndPoints(
+			other,
+			self._endPointHelper(other, which)
+		)
+
+	def _endPointHelper(self, other, which):
+		"""Returns normalized endPoints to work around a Windows bug."""
 		# Even when a console textRange's start and end have been moved to the
 		# same position, the console incorrectly reports the end as being
 		# past the start.
@@ -165,8 +179,7 @@ class consoleUIATextInfo(UIATextInfo):
 			src = "Start"
 		if target == "End" and not other._rangeObj.GetText(1):
 			target = "Start"
-		which = f"{src}To{target}"
-		return super().compareEndPoints(other, which)
+		return f"{src}To{target}"
 
 	def _getCurrentOffsetInThisLine(self, lineInfo):
 		"""


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10035. Related to #9614. Identical to #10043.

### Summary of the issue:
Braille does not properly track the system caret in Windows Console.

### Description of how this pull request fixes the issue:
#9802 introduced a patched implementation of `_get_isCollapsed`. As suggested by @leonardder, this code has been factored out into a new `_endPointHelper` method which normalizes endPoints for `compareEndPoints` and `setEndPoint` (used by `_get_isCollapsed`, Braille support, and possibly others).

### Testing performed:
Tested that the `isCollapsed` property behaves as expected (in the Python console). Testing by @leonardder indicates that Braille behaves as expected after the change.

### Known issues with pull request:
None.

### Change log entry:
None.