### PR TITLE
Add reference to visual studio code project repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ source/_buildVersion.py
 user_docs/*/keyCommands.t2t
 output
 testOutput
-source/brailleDisplayDrivers/handyTech
 ./developerGuide.html
 user_docs/build.t2tConf
 launcher/nvda_logo.wav
@@ -40,3 +39,5 @@ uninstaller/UAC.nsh
 *.dmp
 tests/unit/nvda.ini
 source/locale/*/cldr.dic
+.vscode
+.vs

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,3 @@
 [submodule "include/py2exe"]
 	path = include/py2exe
 	url = https://github.com/nvaccess/py2exe-bin
-[submodule ".vscode"]
-	path = .vscode
-	url = https://github.com/nvaccess/vscode-nvda
-	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,7 @@
 [submodule "include/py2exe"]
 	path = include/py2exe
 	url = https://github.com/nvaccess/py2exe-bin
+[submodule ".vscode"]
+	path = .vscode
+	url = https://github.com/nvaccess/vscode-nvda
+	ignore = dirty

--- a/readme.md
+++ b/readme.md
@@ -103,9 +103,7 @@ The following dependencies aren't needed by most people, and are not included in
 * When you are using Visual Studio Code as your integrated development environment of preference, you can make use of our [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/) for [Visual Studio Code](https://code.visualstudio.com/).
 	While this VSCode project is not included as a submodule in the NVDA repository, you can easily check out the workspace configuration in your repository by executing the following from the root of the repository.
 
-	```
-	git clone https://github.com/nvaccess/vscode-nvda.git .vscode
-	```
+	```git clone https://github.com/nvaccess/vscode-nvda.git .vscode```
 
 ## Preparing the Source Tree
 Before you can run the NVDA source code, you must prepare the source tree.

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ The following dependencies aren't needed by most people, and are not included in
 	While this VSCode project is not included as a submodule in the NVDA repository, you can easily check out the workspace configuration in your repository by executing the following from the root of the repository.
 
 	```
-	git clone https://github.com/nvaccess/vscode-nvda.git
+	git clone https://github.com/nvaccess/vscode-nvda.git .vscode
 	```
 
 ## Preparing the Source Tree

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,8 @@ Additionally, the following build time dependencies are included in Git submodul
 * [epydoc](http://epydoc.sourceforge.net/), version 3.0.1 with patch for bug #303
 * [Boost Optional (stand-alone header)](https://github.com/akrzemi1/Optional), from commit [3922965](https://github.com/akrzemi1/Optional/commit/3922965396fc455c6b1770374b9b4111799588a9)
 
+There is also a [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/) for [Visual Studio Code](https://code.visualstudio.com/) included for convenience.
+
 ### Other Dependencies
 To lint using Flake 8 locally using our SCons integration, some dependencies are installed (automatically) via pip.
 Although this [must be run manually](#linting-your-changes), developers may wish to first configure a Python Virtual Environment to ensure their general install is not affected.
@@ -263,6 +265,7 @@ scons lint base=origin/master
 ```
 
 To be warned about linting errors faster, you may wish to integrate Flake8 other development tools you are using.
+The NVDA repository contains a submodule with a workspace configuration for Visual Studio Code that has support for NVDA's Flake8 configuration built in.
 For more details, see `tests/lint/readme.md`
 
 ### System Tests

--- a/readme.md
+++ b/readme.md
@@ -90,8 +90,6 @@ Additionally, the following build time dependencies are included in Git submodul
 * [epydoc](http://epydoc.sourceforge.net/), version 3.0.1 with patch for bug #303
 * [Boost Optional (stand-alone header)](https://github.com/akrzemi1/Optional), from commit [3922965](https://github.com/akrzemi1/Optional/commit/3922965396fc455c6b1770374b9b4111799588a9)
 
-There is also a [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/) for [Visual Studio Code](https://code.visualstudio.com/) included for convenience.
-
 ### Other Dependencies
 To lint using Flake 8 locally using our SCons integration, some dependencies are installed (automatically) via pip.
 Although this [must be run manually](#linting-your-changes), developers may wish to first configure a Python Virtual Environment to ensure their general install is not affected.
@@ -102,6 +100,12 @@ Although this [must be run manually](#linting-your-changes), developers may wish
 The following dependencies aren't needed by most people, and are not included in Git submodules:
 
 * To generate developer documentation for nvdaHelper: [Doxygen Windows installer](http://www.doxygen.nl/download.html), version 1.8.15:
+* When you are using Visual Studio Code as your integrated development environment of preference, you can make use of our [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/) for [Visual Studio Code](https://code.visualstudio.com/).
+	While this VSCode project is not included as a submodule in the NVDA repository, you can easily check out the workspace configuration in your repository by executing the following from the root of the repository.
+
+	```
+	git clone https://github.com/nvaccess/vscode-nvda.git
+	```
 
 ## Preparing the Source Tree
 Before you can run the NVDA source code, you must prepare the source tree.
@@ -265,7 +269,6 @@ scons lint base=origin/master
 ```
 
 To be warned about linting errors faster, you may wish to integrate Flake8 other development tools you are using.
-The NVDA repository contains a submodule with a workspace configuration for Visual Studio Code that has support for NVDA's Flake8 configuration built in.
 For more details, see `tests/lint/readme.md`
 
 ### System Tests
@@ -281,3 +284,7 @@ This filter accepts wildcard characters.
 ```
 scons systemTests filter="Read welcome dialog"
 ```
+
+## Contributing to NVDA
+
+If you would like to contribute code or documentation to NVDA, you can read more information in our [contributing guide](https://github.com/nvaccess/nvda/wiki/Contributing).


### PR DESCRIPTION
### Link to issue number:
Depends on https://github.com/nvaccess/vscode-nvda/pull/1
Closes #9971 

### Summary of the issue:
Visual Studio Code is currently well known for its accessibility and ease of use. Especially since the NVDA repository has a linting configuration built in, using Visual Studio Code's linter support is pretty handy for non visually working programmers.

### Description of how this pull request fixes the issue:
Added a reference in the readme to a [preconfigured VSCode workspace](https://github.com/nvaccess/vscode-nvda/). This has to be checked out in the main source directory of NVDA. `.gitignore` deals with this.

Several settings a configured in this project, see also https://github.com/nvaccess/vscode-nvda/pull/1:

* Accessibility support is enabled
* Linting is enabled based on the Flake8 configuration bundled with the NVDA repository
* Auto complete extra paths are added for the several external submodules
* When saving a file, a final new line is added to it, and extra new lines are trimmed from the end of the file when applicable. This ensures a uniform style across the project
* De default indentation is set to use tabs instead of spaces
* Testing within Code is enabled using the unittest framework

The current NVDA build environment is set up in such a way that it doesn't require a virtual Python environment.
This VSCode project does not define the python interrpetter setting by default.

### Testing performed:
Tested that tests run from VS Code and that extra include directories are recognized.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
   + The ReadMe of the NVDA development repository now contains instructions on how to use a pre populated workspace configuration for Visual Studio Code for NVDA development. This workspace is configured to use the linting configuration provided with the repository. (#9971)
