### PR TITLE
Touch gestures: add right mouse click (tap and hold) command

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2229,7 +2229,11 @@ class GlobalCommands(ScriptableObject):
 	script_touch_hoverUp.category=SCRCAT_TOUCH
 
 	def script_touch_rightClick(self, gesture):
-		obj=api.getNavigatorObject() 
+		obj=api.getNavigatorObject()
+		# Ignore invisible or offscreen objects as they cannot even be navigated with touch gestures.
+		if controlTypes.STATE_INVISIBLE in obj.states or controlTypes.STATE_OFFSCREEN in obj.states:
+			return
+		
 		try:
 			p=api.getReviewPosition().pointAtStart
 		except (NotImplementedError, LookupError):
@@ -2244,12 +2248,15 @@ class GlobalCommands(ScriptableObject):
 				# Translators: Reported when the object has no location for the mouse to move to it.
 				ui.message(_("object has no location"))
 				return
+			# Don't bother clicking when parts or the entire object is offscreen.
+			if min(left,top,width,height)<0:
+				return
 			x=left+(width/2)
 			y=top+(height/2)
 		winUser.setCursorPos(x,y)
 		self.script_rightMouseClick(gesture)
 	# Translators: Input help mode message for touch right click command.
-	script_touch_rightClick.__doc__=_("Performs right mouse click action at the current touch position")
+	script_touch_rightClick.__doc__=_("Clicks the right mouse button at the current touch position. This is generally used to activate a context menu.")
 	script_touch_rightClick.category=SCRCAT_TOUCH
 
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2228,6 +2228,31 @@ class GlobalCommands(ScriptableObject):
 				obj.doAction()
 	script_touch_hoverUp.category=SCRCAT_TOUCH
 
+	def script_touch_rightClick(self, gesture):
+				obj=api.getNavigatorObject() 
+		try:
+			p=api.getReviewPosition().pointAtStart
+		except (NotImplementedError, LookupError):
+			p=None
+		if p:
+			x=p.x
+			y=p.y
+		else:
+			try:
+				(left,top,width,height)=obj.location
+			except:
+				# Translators: Reported when the object has no location for the mouse to move to it.
+				ui.message(_("object has no location"))
+				return
+			x=left+(width/2)
+			y=top+(height/2)
+		winUser.setCursorPos(x,y)
+		self.script_rightMouseClick(gesture)
+	# Translators: Input help mode message for touch right click command.
+	script_touch_rightClick.__doc__=_("Performs right mouse click action at the current touch position")
+	script_touch_rightClick.category=SCRCAT_TOUCH
+
+
 	def script_activateConfigProfilesDialog(self, gesture):
 		wx.CallAfter(gui.mainFrame.onConfigProfilesCommand, None)
 	# Translators: Describes the command to open the Configuration Profiles dialog.
@@ -2389,6 +2414,8 @@ class GlobalCommands(ScriptableObject):
 		"ts:3finger_tap":"touch_changeMode",
 		"ts:2finger_double_tap":"showGui",
 		"ts:hoverUp":"touch_hoverUp",
+		"ts:tapAndHold":"touch_rightClick",
+
 		# Review cursor
 		"kb:shift+numpad7": "review_top",
 		"kb(laptop):NVDA+control+home": "review_top",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2229,35 +2229,35 @@ class GlobalCommands(ScriptableObject):
 	script_touch_hoverUp.category=SCRCAT_TOUCH
 
 	def script_touch_rightClick(self, gesture):
-		obj=api.getNavigatorObject()
+		obj = api.getNavigatorObject()
 		# Ignore invisible or offscreen objects as they cannot even be navigated with touch gestures.
 		if controlTypes.STATE_INVISIBLE in obj.states or controlTypes.STATE_OFFSCREEN in obj.states:
 			return
 		try:
-			p=api.getReviewPosition().pointAtStart
+			p = api.getReviewPosition().pointAtStart
 		except (NotImplementedError, LookupError):
-			p=None
+			p = None
 		if p:
-			x=p.x
-			y=p.y
+			x = p.x
+			y = p.y
 		else:
 			try:
-				(left,top,width,height)=obj.location
-			except:
+				(left, top, width, height) = obj.location
+			# Flake8/E722: stems from object location script.
+			except: # noqa
 				# Translators: Reported when the object has no location for the mouse to move to it.
 				ui.message(_("object has no location"))
 				return
 			# Don't bother clicking when parts or the entire object is offscreen.
-			if min(left,top,width,height)<0:
+			if min(left, top, width, height) < 0:
 				return
-			x=left+(width//2)
-			y=top+(height//2)
-		winUser.setCursorPos(x,y)
+			x = left + (width // 2)
+			y = top + (height // 2)
+		winUser.setCursorPos(x, y)
 		self.script_rightMouseClick(gesture)
 	# Translators: Input help mode message for touch right click command.
-	script_touch_rightClick.__doc__=_("Clicks the right mouse button at the current touch position. This is generally used to activate a context menu.")
-	script_touch_rightClick.category=SCRCAT_TOUCH
-
+	script_touch_rightClick.__doc__ = _("Clicks the right mouse button at the current touch position. This is generally used to activate a context menu.") # noqa Flake8/E501
+	script_touch_rightClick.category = SCRCAT_TOUCH
 
 	def script_activateConfigProfilesDialog(self, gesture):
 		wx.CallAfter(gui.mainFrame.onConfigProfilesCommand, None)
@@ -2420,7 +2420,7 @@ class GlobalCommands(ScriptableObject):
 		"ts:3finger_tap":"touch_changeMode",
 		"ts:2finger_double_tap":"showGui",
 		"ts:hoverUp":"touch_hoverUp",
-		"ts:tapAndHold":"touch_rightClick",
+		"ts:tapAndHold": "touch_rightClick", # noqa (Flake8/ET121)
 
 		# Review cursor
 		"kb:shift+numpad7": "review_top",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2250,8 +2250,8 @@ class GlobalCommands(ScriptableObject):
 			# Don't bother clicking when parts or the entire object is offscreen.
 			if min(left,top,width,height)<0:
 				return
-			x=left+(width/2)
-			y=top+(height/2)
+			x=left+(width//2)
+			y=top+(height//2)
 		winUser.setCursorPos(x,y)
 		self.script_rightMouseClick(gesture)
 	# Translators: Input help mode message for touch right click command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2233,7 +2233,6 @@ class GlobalCommands(ScriptableObject):
 		# Ignore invisible or offscreen objects as they cannot even be navigated with touch gestures.
 		if controlTypes.STATE_INVISIBLE in obj.states or controlTypes.STATE_OFFSCREEN in obj.states:
 			return
-		
 		try:
 			p=api.getReviewPosition().pointAtStart
 		except (NotImplementedError, LookupError):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2229,7 +2229,7 @@ class GlobalCommands(ScriptableObject):
 	script_touch_hoverUp.category=SCRCAT_TOUCH
 
 	def script_touch_rightClick(self, gesture):
-				obj=api.getNavigatorObject() 
+		obj=api.getNavigatorObject() 
 		try:
 			p=api.getReviewPosition().pointAtStart
 		except (NotImplementedError, LookupError):

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -460,15 +460,15 @@ The further left or right the mouse is located on the screen, the further left o
 These extra mouse features are not turned on by default in NVDA.
 If you wish to take advantage of them, you can configure them from the [Mouse settings #MouseSettings] category of the [NVDA Settings #NVDASettings] dialog, found in the NVDA Preferences menu.
 
-Although a physical mouse or trackpad should be used to navigate with the mouse, NVDA has a few key commands related to the mouse:
+Although a physical mouse or trackpad should be used to navigate with the mouse, NVDA provides some commands related to the mouse:
 %kc:beginInclude
-|| Name | Desktop key | Laptop key | Description |
-| Left mouse button click | numpadDivide | NVDA+[ | clicks the left mouse button once. The common double click can be performed by pressing this key twice in quick succession |
-| Left mouse button lock | shift+numpadDivide | NVDA+control+[ | Locks the left mouse button down. Press again to release it. To drag the mouse, press this key to lock the left button down and then move the mouse either physically or use one of the other mouse routing commands |
-| Right mouse click | numpadMultiply | NVDA+] | Clicks the right mouse button once. |
-| Right mouse button lock | shift+numpadMultiply | NVDA+control+] | Locks the right mouse button down. Press again to release it. To drag the mouse, press this key to lock the right button down and then move the mouse either physically or use one of the other mouse routing commands |
-| Move mouse to current navigator object | NVDA+numpadDivide | NVDA+shift+m | Moves the mouse to the location of the current navigator object and review cursor |
-| Navigate to the object under the mouse | NVDA+numpadMultiply | NVDA+shift+n | Set the navigator object to the object located at the position of the mouse |
+|| Name | Desktop key | Laptop key | Touch | Description |
+| Left mouse button click | numpadDivide | NVDA+[ | none | Clicks the left mouse button once. The common double click can be performed by pressing this key twice in quick succession |
+| Left mouse button lock | shift+numpadDivide | NVDA+control+[ | none | Locks the left mouse button down. Press again to release it. To drag the mouse, press this key to lock the left button down and then move the mouse either physically or use one of the other mouse routing commands |
+| Right mouse click | numpadMultiply | NVDA+] | tap and hold | Clicks the right mouse button once, mostly used to open context menu at the location of the mouse. |
+| Right mouse button lock | shift+numpadMultiply | NVDA+control+] | none | Locks the right mouse button down. Press again to release it. To drag the mouse, press this key to lock the right button down and then move the mouse either physically or use one of the other mouse routing commands |
+| Move mouse to current navigator object | NVDA+numpadDivide | NVDA+shift+m | none | Moves the mouse to the location of the current navigator object and review cursor |
+| Navigate to the object under the mouse | NVDA+numpadMultiply | NVDA+shift+n | none | Set the navigator object to the object located at the position of the mouse |
 %kc:endInclude
 
 + Browse Mode +[BrowseMode]


### PR DESCRIPTION
Hi,

Another pull request that was buried for a very long time, now resurrected:

### Link to issue number:
Fixes #3886 

### Summary of the issue:
There is no mouse commands for touch users.

### Description of how this pull request fixes the issue:
Adds a right mouse click command for touch users: tap and hold.

### Testing performed:
Tested as part of Enhanced Touch Gestures add-on.

### Known issues with pull request:
None

### Change log entry:
New features:

You can now perform right mouse clicks on touch devices by doing a one finger tap and hold. (#3886)

