### PR TITLE
remove pyd file in installation folder

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -23,7 +23,7 @@ import addonHandler
 import easeOfAccess
 import COMRegistrationFixes
 import winKernel
-
+import importlib.machinery
 _wsh=None
 def _getWSH():
 	global _wsh
@@ -210,7 +210,7 @@ def removeOldProgramFiles(destPath):
 	# in a newer version of NVDA.
 	for curDestDir,subDirs,files in os.walk(destPath):
 		for f in files:
-			if f.endswith((".pyc", ".pyo", ".pyd")):
+			if f.endswith((".pyc", ".pyo", ".pyd")) and not f.endswith(importlib.machinery.EXTENSION_SUFFIXES[0]):
 				# This also removes compiled files from system config,
 				# but that is fine.
 				path=os.path.join(curDestDir, f)

--- a/source/installer.py
+++ b/source/installer.py
@@ -210,7 +210,7 @@ def removeOldProgramFiles(destPath):
 	# in a newer version of NVDA.
 	for curDestDir,subDirs,files in os.walk(destPath):
 		for f in files:
-			if f.endswith((".pyc", ".pyo")):
+			if f.endswith((".pyc", ".pyo", ".pyd")):
 				# This also removes compiled files from system config,
 				# but that is fine.
 				path=os.path.join(curDestDir, f)


### PR DESCRIPTION
### Link to issue number:
Fixes #10063 
### Summary of the issue:
If you upgrade from NVDA python 2 to NVDA python 3, it is necessary to remove pyc, pyo, pyd files. 
The problem is that the current alpha version of nvda removes just pyc, pyd files. 
### Description of how this pull request fixes the issue:
This PR adds the ability to the installer to remove pyd files. 
### Testing performed:
Placed a handyTech.pyd file in C:\Program Files (x86)\NVDA\brailleDisplayDrivers. Made sure it disappeared after installing the try build for this pr.
### Known issues with pull request:
None
### Change log entry:
None