### PR TITLE
ExitDialog: Align OK and Cancel buttons to the right

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -841,7 +841,10 @@ class ExitDialog(wx.Dialog):
 		self.actionsList = contentSizerHelper.addLabeledControl(labelText, wx.Choice, choices=self.actions)
 		self.actionsList.SetSelection(0)
 
-		contentSizerHelper.addItem( self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		contentSizerHelper.addItem(
+			self.CreateButtonSizer(wx.OK | wx.CANCEL),
+			flag=wx.ALIGN_RIGHT
+		)
 
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Improves #6468.

### Summary of the issue:
Unlike in most NVDA dialogs, the OK and Cancel buttons of the exit dialog are left aligned.

### Description of how this pull request fixes the issue:
Those two buttons have been aligned to the right so that this dialog looks like all other Windows and NVDA ones.

### Testing performed:
Simply closed NVDA and verified that the visual appearance of the dialog was correct.

### Known issues with pull request:
None.

### Change log entry:
None needed.