### PR TITLE
Ensure that no reference is kept to sapi4 synth on terminate

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -21,8 +21,8 @@ import weakref
 class SynthDriverBufSink(COMObject):
 	_com_interfaces_ = [ITTSBufNotifySink]
 
-	def __init__(self, synthDriver):
-		self.synthRef = weakref.ref(synthDriver)
+	def __init__(self, synthRef: weakref.ReferenceType):
+		self.synthRef = synthRef
 		self._allowDelete = True
 		super(SynthDriverBufSink,self).__init__()
 
@@ -75,7 +75,7 @@ class SynthDriver(SynthDriver):
 
 	def __init__(self):
 		self._finalIndex=None
-		self._bufSink=SynthDriverBufSink(self)
+		self._bufSink = SynthDriverBufSink(weakref.ref(self))
 		self._bufSinkPtr=self._bufSink.QueryInterface(ITTSBufNotifySink)
 		# HACK: Some buggy engines call Release() too many times on our buf sink.
 		# Therefore, don't let the buf sink be deleted before we release it ourselves.

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -105,8 +105,8 @@ class SapiSink(object):
 	See https://msdn.microsoft.com/en-us/library/ms723587(v=vs.85).aspx
 	"""
 
-	def __init__(self, synth):
-		self.synthRef = weakref.ref(synth)
+	def __init__(self, synthRef: weakref.ReferenceType):
+		self.synthRef = synthRef
 
 	def Bookmark(self, streamNum, pos, bookmark, bookmarkId):
 		synth = self.synthRef()
@@ -230,7 +230,7 @@ class SynthDriver(SynthDriver):
 		outputDeviceID=nvwave.outputDeviceNameToID(config.conf["speech"]["outputDevice"], True)
 		if outputDeviceID>=0:
 			self.tts.audioOutput=self.tts.getAudioOutputs()[outputDeviceID]
-		self._eventsConnection = comtypes.client.GetEvents(self.tts, SapiSink(self))
+		self._eventsConnection = comtypes.client.GetEvents(self.tts, SapiSink(weakref.ref(self)))
 		self.tts.EventInterests = constants.SVEBookmark | constants.SVEEndInputStream
 		from comInterfaces.SpeechLib import ISpAudio
 		try:


### PR DESCRIPTION
### Link to issue number:
fixes #10074 

### Summary of the issue:
When switching from SAPI4 to another synth, a reference to the sapi4 object is kept alive by a circular reference on the com Sink.

### Description of how this pull request fixes the issue:
Changed hard reference into a weak ref instead.

### Testing performed:
Tested that switching from SAPI4 to another synth now shows the correct voices after switching.

### Known issues with pull request:
None

### Change log entry:
This is actually a bug since multi category settings, it has never been discovered earlier on.

* Bug fixes
    + When switching from the SAPI4 synthesizer driver to another synthesizer, the speech settings panel now lists the correct voices and controls after switching, (#10074)