### PR TITLE
Fix up of: Fix up of: Don't announce 'selected' when the focus moves in Google sheets if the focused cell is the only cell selected (#8898)

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -954,7 +954,7 @@ class MSHTML(IAccessible):
 
 	def _get_table(self):
 		if self.role not in (controlTypes.ROLE_TABLECELL,controlTypes.ROLE_TABLEROW) or not self.HTMLNode:
-			raise NotImplementedError
+			return None
 		HTMLNode=self.HTMLNode
 		while HTMLNode:
 			nodeName=HTMLNode.nodeName
@@ -962,7 +962,7 @@ class MSHTML(IAccessible):
 				nodeName=nodeName.upper()
 			if nodeName=="TABLE": return MSHTML(HTMLNode=HTMLNode)
 			HTMLNode=HTMLNode.parentNode
-		raise NotImplementedError
+		return None
 
 	def _get_HTMLNodeUniqueNumber(self):
 		if not hasattr(self,'_HTMLNodeUniqueNumber'):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9520
Fixes https://github.com/nvaccess/nvda/issues/7292#issuecomment-485195771 (only the error log in the comment, not the whole issue).
Faulty behavior introduced as of b02ed2d (#8898)

### Summary of the issue:

`MSHTML._get_table` historically raises a `NotImplementedError` when there is no surrounding table.
`IAccessible._get_table`, on the other hand, returns `None` in the same situation.
`IAccessible._get_selectionContainer`, introduced by b02ed2d, calls `self.table` which can lead to the following error log:

```
ERROR - queueHandler.flushQueue (13:44:56.473):
Error in func _loadBufferDone from eventQueue
Traceback (most recent call last):
  File "queueHandler.pyo", line 53, in flushQueue
  File "virtualBuffers\__init__.pyo", line 464, in _loadBufferDone
  File "browseMode.pyo", line 1190, in event_treeInterceptor_gainFocus
  File "browseMode.pyo", line 1513, in event_gainFocus
  File "browseMode.pyo", line 1190, in <lambda>
  File "NVDAObjects\__init__.pyo", line 1030, in event_gainFocus
  File "NVDAObjects\__init__.pyo", line 918, in reportFocus
  File "speech.pyo", line 416, in speakObject
  File "speech.pyo", line 340, in speakObjectProperties
  File "baseObject.pyo", line 47, in __get__
  File "baseObject.pyo", line 147, in _getPropertyViaCache
  File "NVDAObjects\IAccessible\__init__.pyo", line 1265, in _get_selectionContainer
  File "baseObject.pyo", line 47, in __get__
  File "baseObject.pyo", line 147, in _getPropertyViaCache
  File "NVDAObjects\IAccessible\MSHTML.pyo", line 957, in _get_table
NotImplementedError
```

### Description of how this pull request fixes the issue:

Return `None` instead of raising `NotImplementedError` in `MSHTML._get_table`, in coherence with its base class.

### Testing performed:

Browsed with IE11 under Windows 10 to http://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html (which is the test case of #9520 and report focus on the example tab header.

### Known issues with pull request:

This approach can theoretically break existing assumption of the method raising the exception, but other IAccessible implementation have been recently much more tested and return `None` in the same case.
So, I guess it is safer to apply the proposed change than to track every single call to `_get_table` and enclose in a `try...except` block, with the risk of missing a few of them in the process.

### Change log entry:

Section: Bug fixes

NVDA is no longer silent when focusing an HTML tab header in Internet Explorer.
