### PR TITLE
Remove old library files for arm64

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -158,7 +158,7 @@ def removeOldLibFiles(destPath,rebootOK=False):
 	@param rebootOK: If true then files can be removed on next reboot if trying to do so now fails.
 	@type rebootOK: boolean
 	"""
-	for topDir in ('lib','lib64'):
+	for topDir in ('lib','lib64','libArm64'):
 		currentLibPath=os.path.join(destPath,topDir,versionInfo.version)
 		for parent,subdirs,files in os.walk(os.path.join(destPath,topDir),topdown=False):
 			if parent==currentLibPath:

--- a/source/installer.py
+++ b/source/installer.py
@@ -150,6 +150,7 @@ def copyUserConfig(destPath):
 			destFilePath=os.path.join(destPath,os.path.relpath(sourceFilePath,sourcePath))
 			tryCopyFile(sourceFilePath,destFilePath)
 
+
 def removeOldLibFiles(destPath, rebootOK=False):
 	"""
 	Removes library files from previous versions of NVDA.
@@ -159,21 +160,21 @@ def removeOldLibFiles(destPath, rebootOK=False):
 	@type rebootOK: boolean
 	"""
 	for topDir in ('lib', 'lib64', 'libArm64'):
-		currentLibPath=os.path.join(destPath, topDir, versionInfo.version)
-		for parent, subdirs, files in os.walk(os.path.join(destPath,topDir),topdown=False):
+		currentLibPath = os.path.join(destPath, topDir, versionInfo.version)
+		for parent, subdirs, files in os.walk(os.path.join(destPath, topDir), topdown=False):
 			if parent==currentLibPath:
 				# Lib dir for current installation. Don't touch this!
 				log.debug("Skipping current install lib path: %r"%parent)
 				continue
 			for d in subdirs:
-				path=os.path.join(parent, d)
+				path = os.path.join(parent, d)
 				log.debug("Removing old lib directory: %r"%path)
 				try:
 					os.rmdir(path)
 				except OSError:
 					log.warning("Failed to remove a directory no longer needed. This can be manually removed after a reboot or the  installer will try removing it again next time. Directory: %r"%path)
 			for f in files:
-				path=os.path.join(parent, f)
+				path = os.path.join(parent, f)
 				log.debug("Removing old lib file: %r"%path)
 				try:
 					tryRemoveFile(path, numRetries=2, rebootOK=rebootOK)

--- a/source/installer.py
+++ b/source/installer.py
@@ -150,7 +150,7 @@ def copyUserConfig(destPath):
 			destFilePath=os.path.join(destPath,os.path.relpath(sourceFilePath,sourcePath))
 			tryCopyFile(sourceFilePath,destFilePath)
 
-def removeOldLibFiles(destPath,rebootOK=False):
+def removeOldLibFiles(destPath, rebootOK=False):
 	"""
 	Removes library files from previous versions of NVDA.
 	@param destPath: The path where NVDA is installed.
@@ -158,25 +158,25 @@ def removeOldLibFiles(destPath,rebootOK=False):
 	@param rebootOK: If true then files can be removed on next reboot if trying to do so now fails.
 	@type rebootOK: boolean
 	"""
-	for topDir in ('lib','lib64','libArm64'):
-		currentLibPath=os.path.join(destPath,topDir,versionInfo.version)
-		for parent,subdirs,files in os.walk(os.path.join(destPath,topDir),topdown=False):
+	for topDir in ('lib', 'lib64', 'libArm64'):
+		currentLibPath=os.path.join(destPath, topDir, versionInfo.version)
+		for parent, subdirs, files in os.walk(os.path.join(destPath,topDir),topdown=False):
 			if parent==currentLibPath:
 				# Lib dir for current installation. Don't touch this!
 				log.debug("Skipping current install lib path: %r"%parent)
 				continue
 			for d in subdirs:
-				path=os.path.join(parent,d)
+				path=os.path.join(parent, d)
 				log.debug("Removing old lib directory: %r"%path)
 				try:
 					os.rmdir(path)
 				except OSError:
 					log.warning("Failed to remove a directory no longer needed. This can be manually removed after a reboot or the  installer will try removing it again next time. Directory: %r"%path)
 			for f in files:
-				path=os.path.join(parent,f)
+				path=os.path.join(parent, f)
 				log.debug("Removing old lib file: %r"%path)
 				try:
-					tryRemoveFile(path,numRetries=2,rebootOK=rebootOK)
+					tryRemoveFile(path, numRetries=2, rebootOK=rebootOK)
 				except RetriableFailure:
 					log.warning("A file no longer needed could not be removed. This can be manually removed after a reboot, or  the installer will try again next time. File: %r"%path)
 


### PR DESCRIPTION
### Link to issue number:
#10084
### Summary of the issue:
Old library files for libArm64 not cleaned like lib and lib64
### Description of how this pull request fixes the issue:
Add libArm64 in  removeOldLibFiles function
### Testing performed:
Old files are removed after updating with patched installer
### Known issues with pull request:
None
### Change log entry:
Remove old library files for arm64 (#10084)
Section: New features, Changes, Bug fixes

