### PR TITLE
UI Automation in Windows Console: fix bugs in the set/compare endPoint overrides

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -160,9 +160,9 @@ class consoleUIATextInfo(UIATextInfo):
 		# past the start.
 		# Compare to the start (not the end) when collapsed.
 		selfEndPoint, otherEndPoint = which.split("To")
-		if selfEndPoint == "end" and not self._isCollapsed():
+		if selfEndPoint == "end" and self._isCollapsed():
 			selfEndPoint = "start"
-		if otherEndPoint == "End" and not other._isCollapsed():
+		if otherEndPoint == "End" and other._isCollapsed():
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().compareEndPoints(other, which=which)
@@ -177,7 +177,7 @@ class consoleUIATextInfo(UIATextInfo):
 		# In this case, there is no need to check if self is collapsed
 		# since the point of this method is to change its text range, modifying the "end" endpoint of a collapsed
 		# text range is fine.
-		if otherEndPoint == "End" and not other._isCollapsed():
+		if otherEndPoint == "End" and other._isCollapsed():
 			otherEndPoint = "Start"
 		which = f"{selfEndPoint}To{otherEndPoint}"
 		return super().setEndPoint(other, which=which)
@@ -194,7 +194,7 @@ class consoleUIATextInfo(UIATextInfo):
 	def _get_isCollapsed(self):
 		# To decide if the textRange is collapsed,
 		# Check if it has no text.
-		return self._isCollapsed
+		return self._isCollapsed()
 
 	def _getCurrentOffsetInThisLine(self, lineInfo):
 		"""


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Follow-up of #10057, #10088.
Related to #9614.

### Summary of the issue:
Character and word review functionality in Windows Console does not work as intended.

As found by @leonardder in #10088, we were checking for uncollapsed `textInfo`s when we meant to check for collapsed ones. Additionally, `_ghet_isCollapsed` returned a copy of the `_isCollapsed` method object rather than calling it.

### Description of how this pull request fixes the issue:
* In `ConsoleUIATextInfo._get_isCollapsed`, we now call and return the value of `_isCollapsed` rather than the method object.
* Flipped the conditions in `compareEdPoints` and `setEndPoint` (removed the `not`).

### Testing performed:
Tested character and word review and verified that functionality has been restored.

### Known issues with pull request:
None.

### Change log entry:
None.