### PR TITLE
No longer warn for abstract class properties, as they are now supported

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -16,7 +16,7 @@ class Getter(object):
 	def __init__(self,fget, abstract=False):
 		self.fget=fget
 		if abstract:
-			self._abstract = self.__isabstractmethod__=abstract
+			self._abstract = self.__isabstractmethod__ = abstract
 
 	def __get__(self,instance,owner):
 		if isinstance(self.fget, classmethod):

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -16,11 +16,7 @@ class Getter(object):
 	def __init__(self,fget, abstract=False):
 		self.fget=fget
 		if abstract:
-			if isinstance(fget, classmethod):
-				log.warning("Abstract class properties are not supported.")
-				self._abstract = False
-			else:
-				self._abstract = self.__isabstractmethod__=abstract
+			self._abstract = self.__isabstractmethod__=abstract
 
 	def __get__(self,instance,owner):
 		if isinstance(self.fget, classmethod):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When we introduced abstract auto (class) properties in baseObject (#8393), we introduced an exception for abstract class properties, as they aren't supported by Python 2. In Python 3, abstract class properties are supported.

### Description of how this pull request fixes the issue:
When creating a magic auto property, don't check whether the method is a class method.

### Testing performed:
Tested the following case:

```
class Test(baseObject.AutoPropertyObject):
	_abstract_test = True
	@classmethod
	def _get_test(cls):
		return(42)

Test()
```

As expected, this raises `TypeError: Can't instantiate abstract class Test with abstract methods test
`

### Known issues with pull request:
The TypeError is raised when initializing an instance of the class. This is by design of Python itself.

### Change log entry:
* Changes for developers
    + Abstract class properties are now supported on objects that inherit from baseObject.AutoPropertyObject (e.g. NVDAObjects and TextInfos)