### PR TITLE
No longer use UIA rangeFromPoint in windows 7 to avoid explorer crash in start menu

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -33,6 +33,7 @@ from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDete
 import braille
 import locationHelper
 import ui
+import winVersion
 
 class UIATextInfo(textInfos.TextInfo):
 
@@ -312,7 +313,9 @@ class UIATextInfo(textInfos.TextInfo):
 			# sometimes rangeFromChild can return a NULL range
 			if not self._rangeObj: raise LookupError
 		elif isinstance(position,locationHelper.Point):
-			#rangeFromPoint used to cause a freeze in UIA client library!
+			if (winVersion.winVersion.major, winVersion.winVersion.minor) == (6, 1):
+				# #9435: RangeFromPoint causes a freeze in UIA client library in the Windows 7 start menu!
+				raise NotImplementedError("RangeFromPoint not supported on Windows 7")
 			self._rangeObj=self.obj.UIATextPattern.RangeFromPoint(position.toPOINT())
 		elif isinstance(position,UIAHandler.IUIAutomationTextRange):
 			self._rangeObj=position.clone()


### PR DESCRIPTION
### Link to issue number:
Fixes #9435 

### Summary of the issue:
In #8572, we introduced much more reliable mouse tracking for UIA text ranges. However, it seems that mouse tracking in the Windows 7 start menu search field causes a crash in the UIA client library, crashing explorer and causing NVDA to freeze.

### Description of how this pull request fixes the issue:
As before, no longer allow UIA rangeFromPoint to be called when on Windows 7.

### Testing performed:
T.b.d.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + In Windows 7, NVDA no longer causes Windows Explorer to crash when the mouse is used in the start menu. (##9435)