### PR TITLE
Prevent system sleep when reading lon pieces of text with braille only

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2018 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
+#Copyright (C) 2008-2019 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
 
 import itertools
 import os
@@ -2411,6 +2411,8 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 	Subclasses can also inherit from L{brailleInput.BrailleInputGesture} if the display has a braille keyboard.
 	If the braille display driver is a L{baseObject.ScriptableObject}, it can provide scripts specific to input gestures from this display.
 	"""
+
+	shouldPreventSystemIdle = True
 
 	def _get_source(self):
 		"""The string used to identify all gestures from this display.

--- a/source/braille.py
+++ b/source/braille.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#braille.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2008-2019 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
+# braille.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2008-2019 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
 
 import itertools
 import os

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#brailleInput.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2012-2019 NV Access Limited, Rui Batista, Babbage B.V.
+# brailleInput.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2012-2019 NV Access Limited, Rui Batista, Babbage B.V.
 
 import os.path
 import time

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -3,7 +3,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2012-2017 NV Access Limited, Rui Batista, Babbage B.V.
+#Copyright (C) 2012-2019 NV Access Limited, Rui Batista, Babbage B.V.
 
 import os.path
 import time
@@ -468,6 +468,8 @@ class BrailleInputGesture(inputCore.InputGesture):
 	#: Whether the space bar is pressed.
 	#: @type: bool
 	space = False
+
+	shouldPreventSystemIdle = True
 
 	def _makeDotsId(self):
 		items = ["dot%d" % (i+1) for i in range(8) if self.dots & (1 << i)]

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -70,8 +70,7 @@ class InputGesture(baseObject.AutoPropertyObject):
 	#: For example, the system is unaware of C{BrailleDisplayGesture} execution,
 	#: and might even get into sleep mode when reading a long portion of text in braille.
 	#: In contrast, the system is aware of C{KeyboardInputGesture} execution itself.
-	#: @type: bool
-	shouldPreventSystemIdle=False
+	shouldPreventSystemIdle: bool = False
 
 	_abstract_identifiers = True
 	def _get_identifiers(self):

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -444,7 +444,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
 		if gesture.shouldPreventSystemIdle:
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
 			self._lastInputTime = time.time()

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -31,6 +31,7 @@ import globalVars
 import languageHandler
 import controlTypes
 import keyLabels
+import winKernel
 
 #: Script category for emulated keyboard keys.
 # Translators: The name of a category of NVDA commands.
@@ -64,6 +65,13 @@ class InputGesture(baseObject.AutoPropertyObject):
 	#: Indicates that this gesture should be reported in Input help mode. This would only be false for floodding Gestures like touch screen hovers.
 	#: @type: bool
 	reportInInputHelp=True
+
+	#: Indicates whether executing this gesture should explicitly prevent the system from being idle.
+	#: For example, the system is unaware of C{BrailleDisplayGesture} execution,
+	#: and might even get into sleep mode when reading a long portion of text in braille.
+	#: In contrast, the system is aware of C{KeyboardInputGesture} execution itself.
+	#: @type: bool
+	shouldPreventSystemIdle=False
 
 	_abstract_identifiers = True
 	def _get_identifiers(self):
@@ -435,6 +443,9 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech)
 		elif speechEffect in (gesture.SPEECHEFFECT_PAUSE, gesture.SPEECHEFFECT_RESUME):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
+
+		if gesture.shouldPreventSystemIdle:
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
 			self._lastInputTime = time.time()

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -132,8 +132,6 @@ def openProcess(*args):
 def closeHandle(*args):
 	return kernel32.CloseHandle(*args)
 
-#added by Rui Batista to use on Say_battery_status script 
-#copied from platform sdk documentation (with required changes to work in python) 
 class SYSTEM_POWER_STATUS(ctypes.Structure):
 	_fields_ = [("ACLineStatus", ctypes.c_byte), ("BatteryFlag", ctypes.c_byte), ("BatteryLifePercent", ctypes.c_byte), ("Reserved1", ctypes.c_byte), ("BatteryLifeTime", ctypes.wintypes.DWORD), ("BatteryFullLiveTime", ctypes.wintypes.DWORD)]
 
@@ -397,3 +395,15 @@ def moveFileEx(lpExistingFileName: str, lpNewFileName: str, dwFlags: int):
 	# If MoveFileExW fails, Windows will raise appropriate errors.
 	if not kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags):
 		raise ctypes.WinError()
+
+# Thread execution states
+ES_CONTINUOUS = 0x80000000
+ES_DISPLAY_REQUIRED = 0x2
+ES_SYSTEM_REQUIRED = 0x1
+
+kernel32.SetThreadExecutionState.restype = ctypes.wintypes.DWORD
+def SetThreadExecutionState(esFlags):
+	res = kernel32.SetThreadExecutionState(esFlags)
+	if not res:
+		raise WinError()
+	return res

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -9,6 +9,7 @@
 import contextlib
 import ctypes
 import ctypes.wintypes
+from ctypes import WinError
 from ctypes import *
 from ctypes.wintypes import *
 
@@ -132,6 +133,8 @@ def openProcess(*args):
 def closeHandle(*args):
 	return kernel32.CloseHandle(*args)
 
+#added by Rui Batista to use on Say_battery_status script 
+#copied from platform sdk documentation (with required changes to work in python) 
 class SYSTEM_POWER_STATUS(ctypes.Structure):
 	_fields_ = [("ACLineStatus", ctypes.c_byte), ("BatteryFlag", ctypes.c_byte), ("BatteryLifePercent", ctypes.c_byte), ("Reserved1", ctypes.c_byte), ("BatteryLifeTime", ctypes.wintypes.DWORD), ("BatteryFullLiveTime", ctypes.wintypes.DWORD)]
 
@@ -396,12 +399,15 @@ def moveFileEx(lpExistingFileName: str, lpNewFileName: str, dwFlags: int):
 	if not kernel32.MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags):
 		raise ctypes.WinError()
 
+
 # Thread execution states
 ES_CONTINUOUS = 0x80000000
 ES_DISPLAY_REQUIRED = 0x2
 ES_SYSTEM_REQUIRED = 0x1
 
 kernel32.SetThreadExecutionState.restype = ctypes.wintypes.DWORD
+
+
 def SetThreadExecutionState(esFlags):
 	res = kernel32.SetThreadExecutionState(esFlags)
 	if not res:


### PR DESCRIPTION
### Link to issue number:
Fixes #9175

### Summary of the issue:
When reading long parts of text in braille with braille display gestures, the system isn't getting any input from a normal input device. Therefore, the system idle timer isn't reset, and at some point, the system goes into stand by.

### Description of how this pull request fixes the issue:
Added a new `shouldPreventSystemIdle` attribute on gestures. If True, NVDA resets the system idle timer when processing the gesture.

### Testing performed:
If I understand @CBC33000 correctly, in https://github.com/nvaccess/nvda/issues/9175#issuecomment-456527322, this fixes the issue.

### Known issues with pull request:
This pr doesn't prevent the screen saver to activate. Unfortunately, the docs for [SetThreadExecutionState](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-setthreadexecutionstate) explicitly state that preventing screen saver activation is not supported.

### Change log entry:
* Bug fixes
    + The system no longer enter sleep mode when scrolling through text with braille display gestures. (#9175)