### PR TITLE
App modules/product name and version: use kernel32::GetPackageFullName to obtain product info for immersive (hosted) apps

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -344,19 +344,55 @@ class AppModule(baseObject.ScriptableObject):
 
 	def _setProductInfo(self):
 		"""Set productName and productVersion attributes.
+		There are at least two ways of obtaining product info for an app:
+		* Package info for hosted apps
+		* File version info for other apps and for some hosted apps
 		"""
 		# Sometimes (I.E. when NVDA starts) handle is 0, so stop if it is the case
 		if not self.processHandle:
 			raise RuntimeError("processHandle is 0")
-		# Create the buffer to get the executable name
-		exeFileName = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
-		length = ctypes.wintypes.DWORD(ctypes.wintypes.MAX_PATH)
-		if not ctypes.windll.Kernel32.QueryFullProcessImageNameW(self.processHandle, 0, exeFileName, ctypes.byref(length)):
-			raise ctypes.WinError()
-		fileName = exeFileName.value
-		fileinfo = getFileVersionInfo(fileName, "ProductName", "ProductVersion")
-		self.productName = fileinfo["ProductName"]
-		self.productVersion = fileinfo["ProductVersion"]
+		# Use an internal function for obtaining file name and version for the executable.
+		# This is needed in case immersive app package returns an error,
+		# dealing with a native app, or a converted desktop app.
+
+		def _executableFileInfo():
+			# Create the buffer to get the executable name
+			exeFileName = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
+			length = ctypes.wintypes.DWORD(ctypes.wintypes.MAX_PATH)
+			if not ctypes.windll.Kernel32.QueryFullProcessImageNameW(
+				self.processHandle, 0, exeFileName, ctypes.byref(length)
+			):
+				raise ctypes.WinError()
+			fileName = exeFileName.value
+			fileinfo = getFileVersionInfo(fileName, "ProductName", "ProductVersion")
+			return (fileinfo["ProductName"], fileinfo["ProductVersion"])
+
+		# No need to worry about immersive (hosted) apps and friends until Windows 8.
+		# Python 3.7 introduces platform_version to sys.getwindowsversion tuple,
+		# which returns major, minor, build.
+		if winVersion.winVersion.platform_version >= (6, 2, 9200):
+			# Some apps such as File Explorer says it is an immersive process but error 15700 is shown.
+			# Therefore resort to file version info behavior becuase it is not a hosted app.
+			# Others such as Store version of Office are not truly hosted apps,
+			# yet reutnrs an internal version anyway.
+			# For immersive apps, default implementation is generic - returns Windows version information.
+			# Thus probe package full name and parse the serialized representation of package info structure.
+			length = ctypes.c_uint()
+			buf = ctypes.windll.kernel32.GetPackageFullName(self.processHandle, ctypes.byref(length), None)
+			packageFullName = ctypes.create_unicode_buffer(buf)
+			if ctypes.windll.kernel32.GetPackageFullName(
+				self.processHandle, ctypes.byref(length), packageFullName
+			) == 0:
+				# Product name is of the form publisher.name for a hosted app.
+				productInfo = packageFullName.value.split("_")
+			else:
+				# File Explorer and friends which are really native aps.
+				productInfo = _executableFileInfo()
+		else:
+			# Not only native apps, but also converted desktop aps such as Office.
+			productInfo = _executableFileInfo()
+		self.productName = productInfo[0]
+		self.productVersion = productInfo[1]
 
 	def _get_productName(self):
 		self._setProductInfo()

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -355,7 +355,7 @@ class AppModule(baseObject.ScriptableObject):
 		# This is needed in case immersive app package returns an error,
 		# dealing with a native app, or a converted desktop app.
 
-		def _executableFileInfo():
+		def _getExecutableFileInfo():
 			# Create the buffer to get the executable name
 			exeFileName = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
 			length = ctypes.wintypes.DWORD(ctypes.wintypes.MAX_PATH)
@@ -387,10 +387,10 @@ class AppModule(baseObject.ScriptableObject):
 				productInfo = packageFullName.value.split("_")
 			else:
 				# File Explorer and friends which are really native aps.
-				productInfo = _executableFileInfo()
+				productInfo = _getExecutableFileInfo()
 		else:
 			# Not only native apps, but also converted desktop aps such as Office.
-			productInfo = _executableFileInfo()
+			productInfo = _getExecutableFileInfo()
 		self.productName = productInfo[0]
 		self.productVersion = productInfo[1]
 

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -372,9 +372,9 @@ class AppModule(baseObject.ScriptableObject):
 		# which returns major, minor, build.
 		if winVersion.winVersion.platform_version >= (6, 2, 9200):
 			# Some apps such as File Explorer says it is an immersive process but error 15700 is shown.
-			# Therefore resort to file version info behavior becuase it is not a hosted app.
+			# Therefore resort to file version info behavior because it is not a hosted app.
 			# Others such as Store version of Office are not truly hosted apps,
-			# yet reutnrs an internal version anyway.
+			# yet returns an internal version anyway.
 			# For immersive apps, default implementation is generic - returns Windows version information.
 			# Thus probe package full name and parse the serialized representation of package info structure.
 			length = ctypes.c_uint()


### PR DESCRIPTION
### Link to issue number:
Fixes #4259
Fixes #10108 

### Summary of the issue:
Product information for immersive (hosted) apps (including those hosted by WWAHost) are incorrect or seen by NVDA as nonexistent. In some cases, converted desktop apps do not expose correct app info.

### Description of how this pull request fixes the issue:
On Windows 8 and later, some apps can run inside a container. This is the case for WinRT/UWP apps, some web apps hosted by WWAHost, and converted desktop apps (such as Microsoft Office 365 downloaded from Microsoft Store). For these apps, kernel32.dll::GetPackageFullName returns the 'real' product info such as name and version. Because it'll be returned in a serialized string representation, parse the first two values (name and version).

To accomodate this change, the former method of obtaining product name and version via file version info has been moved to an internal function inside product info setter method. This function will be invoked if:

* This is Windows 7/Server 2008 R2 (no support for containers yet).
* An immersive app that is really a native app (such as File Explorer).
* Converted desktop apps that will not expose version info via file version info structure (such as Notepad in 20H1 Preview build 18963 and later).

For consistency with immersive app info structure, the modified function will return a 2-tuple that records product name and version in that order.

### Testing performed:
Tested with native and hosted apps, including NVDA from source, Outlook 365, Windows 10 Calculator and Store, Twitter web app and many others (also tested via Windows 10 App Essentials add-on). On Windows 8.1, WWAHost apps were used.

### Known issues with pull request:
For some converted desktop apps, there will be product info conflict: file version info says one thing and package name says something else. This is most prominent in Office 365 apps (package version starts with 16051 but file info says 16.0), but can be worked around by modifying app modules to favor one approach over another.

### Change log entry:
Changes:

On Windows 8 and later, NVDA will now report product name and version information for hosted apps such as apps downloaded from Microsoft Store using information provided by the app. (#4259, #10108)

Thanks.