### PR TITLE
Disable caret events in all terminal programs

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -279,11 +279,6 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		bounds review to the visible text."""
 		return consoleUIATextInfo
 
-	def _get_caretMovementDetectionUsesEvents(self):
-		"""Using caret events in consoles sometimes causes the last character of the
-		prompt to be read when quickly deleting text."""
-		return False
-
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA
 		return (

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -367,6 +367,11 @@ class Terminal(LiveText, EditableText):
 		super(Terminal, self).event_loseFocus()
 		self.stopMonitoring()
 
+	def _get_caretMovementDetectionUsesEvents(self):
+		"""Using caret events in consoles sometimes causes the last character of the
+		prompt to be read when quickly deleting text."""
+		return False
+
 
 class KeyboardHandlerBasedTypedCharSupport(Terminal):
 	"""A Terminal object that also provides typed character support for

--- a/source/NVDAObjects/window/winConsole.py
+++ b/source/NVDAObjects/window/winConsole.py
@@ -79,11 +79,6 @@ class WinConsole(Terminal, EditableTextWithoutAutoSelectDetection, Window):
 				self.startMonitoring()
 		core.callLater(200,reconnect)
 
-	def _get_caretMovementDetectionUsesEvents(self):
-		"""Using caret events in consoles sometimes causes the last character of the
-		prompt to be read when quickly deleting text."""
-		return False
-
 	@script(gestures=[
 		"kb:enter",
 		"kb:numpadEnter",


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #1348.
Related to #9933, #9986.

### Summary of the issue:
In Mintty, the last character of the prompt is read when quickly deleting text, just as in Windows Console (see [this comment](https://github.com/nvaccess/nvda/issues/1348#issuecomment-520524222) and the "summary of the issue" section in #9986).

### Description of how this pull request fixes the issue:
This PR disables caret events for all `Terminal` objects by overriding `NVDAObjects.behaviors.Terminal._get_caretMovementDetectionUsesEvents`, instead of only Windows Console like in #9986.

### Testing performed:
Tested the steps to reproduce from #1348 in PuTTY and observed that extra characters are no longer read. Verified that caret movement and backspace reporting are still functional in PuTTY after the changes.

### Known issues with pull request:
None.

### Change log entry:
None (py3 regression).
