### PR TITLE
UI Automation in Windows Console: Don't automatically enable UIA in consoles on Windows 10 version 1803

### DIFF
--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -239,4 +239,4 @@ it is retrieved from config).
 	# ignore it.
 	# It does not implement caret/selection, and probably has no
 	# new text events.
-	return isWin10(1803)
+	return isWin10(1809)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,7 +6,7 @@ What's New in NVDA
 = 2019.3 =
 
 == New Features ==
-- In Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 10 version 1803 and later:
+- In Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 10 version 1809 and later:
  - Vastly improved performance and stability (#9771)
  - Reporting of typed text that does not appear onscreen (such as passwords) can now be enabled via an option in NVDA's advanced settings panel. (#9649)
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1689,7 +1689,7 @@ It does not affect the modern Windows Terminal.
 In Windows 10 version 1709, Microsoft [added support for its UI Automation API to the console https://devblogs.microsoft.com/commandline/whats-new-in-windows-console-in-windows-10-fall-creators-update/], bringing vastly improved performance and stability for screen readers that support it.
 In situations where UI Automation is unavailable or known to result in an inferior user experience, NVDA's legacy console support is available as a fallback.
 The Windows Console support combo box has three options:
-- Automatic: Uses UI Automation in consoles on Windows 10 version 1803 and later. This option is recommended and set by default.
+- Automatic: Uses UI Automation in consoles on Windows 10 version 1809 and later. This option is recommended and set by default.
 - Prefer UIA: Uses UI Automation in consoles if available, even on Windows versions with incomplete or buggy implementations. While this limited functionality may be useful (and even sufficient for your usage), use of this option is entirely at your own risk and no support for it will be provided.
 - Legacy: UI Automation in the Windows Console will be completely disabled, so the legacy fallback will always be used.
 -
@@ -1702,7 +1702,7 @@ However, you may wish to enable it if you experience performance issues or insta
 ==== Use the new typed character support in legacy Windows consoles when available ====[AdvancedSettingsKeyboardSupportInLegacy]
 This option enables an alternative method for detecting typed characters in legacy Windows consoles.
 While it improves performance and prevents some console output from being spelled out, it may be incompatible with some terminal programs.
-This feature is available and enabled by default on Windows 10 versions 1607, 1703 and 1709 as well as on newer Windows 10 releases when UI Automation is unavailable or disabled.
+This feature is available and enabled by default on Windows 10 versions 1607, 1703, 1709 and 1803 as well as on newer Windows 10 releases when UI Automation is unavailable or disabled.
 Warning: with this option enabled, typed characters that do not appear onscreen, such as passwords, will not be suppressed.
 In untrusted environments, you may temporarily disable [speak typed characters #KeyboardSettingsSpeakTypedCharacters] and [speak typed words #KeyboardSettingsSpeakTypedWords] when entering passwords.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10120.
Related to #9614, #9771, #10119.

### Summary of the issue:
In Windows Console on Windows 10 version 1803:

* Review by character and word are sometimes unreliable.
* The "review bottom line" script causes the review cursor to be placed outside the visible text.

At least for now, it may be worth considering limiting UIA by default to Windows 10 1809 and later, where it works very well. Advanced users on earlier Windows versions can always enable it if they wish.

### Description of how this pull request fixes the issue:
This PR changes the functionality of the automatic Windows Console support option: UIA is enabled on Windows 10 1809 and later, legacy otherwise. The user guide and what's new have been updated accordingly.

### Testing performed:
Tested that UIA console is still automatically enabled on Windows 10 version 1903.

### Known issues with pull request:
None.

### Change log entry:
None.