### PR TITLE
No longer fail to present UI elements in Audacity compressor dialog

### DIFF
--- a/source/appModules/audacity.py
+++ b/source/appModules/audacity.py
@@ -11,8 +11,8 @@ class AppModule(appModuleHandler.AppModule):
 
 	def event_NVDAObject_init(self,obj):
 		if (
-			obj.windowClassName=="Button"
-			and not obj.role in [controlTypes.ROLE_MENUBAR, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_POPUPMENU]
+			obj.windowClassName == "Button"
+			and obj.role not in [controlTypes.ROLE_MENUBAR, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_POPUPMENU]
 			and obj.name is not None
 		):
 			obj.name=obj.name.replace('&','')

--- a/source/appModules/audacity.py
+++ b/source/appModules/audacity.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-#appModules/audacity.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Robert Hänggi
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2019 NV Access Limited, Robert Hänggi, Łukasz Golonka
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import appModuleHandler
 import controlTypes
@@ -11,5 +10,9 @@ import controlTypes
 class AppModule(appModuleHandler.AppModule):
 
 	def event_NVDAObject_init(self,obj):
-		if obj.windowClassName=="Button" and not obj.role in [controlTypes.ROLE_MENUBAR, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_POPUPMENU]:
+		if (
+			obj.windowClassName=="Button"
+			and not obj.role in [controlTypes.ROLE_MENUBAR, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_POPUPMENU]
+			and obj.name is not None
+		):
 			obj.name=obj.name.replace('&','')


### PR DESCRIPTION
### Link to issue number:
Fixes #10103 
### Summary of the issue:
In Audacitys compressor dialog all elements are inside a group with class button, and no name. In its app module ampersand sign in name of every object with class button is removed. This unsurprisingly fails for object without name.
### Description of how this pull request fixes the issue:
If the object has no name do not perform a replacement.

### Testing performed:
Performed str from #10103. Ensured that elements of the dialog are read.
### Known issues with pull request:
None
### Change log entry:

Section: Bug fixes

controls in Audacitys compressor dialog are now announced when navigating the dialog.