### PR TITLE
No longer crash Windows Explorer on Windows 7 when focusing metadata edit fields

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -180,12 +180,17 @@ class ReadOnlyEditBox(IAccessible):
 		return windowText
 
 
-class metadataEditField(RichEdit50):
+class MetadataEditField(RichEdit50):
 	""" Used for metadata edit fields in Windows Explorer in Windows 7.
 	By default these fields would use ITextDocumentTextInfo ,
 	but to avoid Windows Explorer crashes we need to use EditTextInfo here. """
-	def _get_TextInfo(self):
-		return EditTextInfo
+	@classmethod
+	def _get_TextInfo(cls):
+		if ((winVersion.winVersion.major, winVersion.winVersion.minor) == (6, 1)):
+			cls.TextInfo = EditTextInfo
+		else:
+			cls.TextInfo = super().TextInfo
+		return cls.TextInfo
 
 class AppModule(appModuleHandler.AppModule):
 
@@ -226,11 +231,8 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, StartButton)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
-		if(
-			(winVersion.winVersion.major, winVersion.winVersion.minor) == (6, 1)
-			and windowClass == 'RICHEDIT50W'
-		):
-			clsList.insert(0, metadataEditField)
+		if windowClass == 'RICHEDIT50W' and obj.windowControlID == 256:
+			clsList.insert(0, MetadataEditField)
 			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if isinstance(obj, UIA):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -14,6 +14,7 @@ import time
 import appModuleHandler
 import controlTypes
 import winUser
+import winVersion
 import api
 import speech
 import eventHandler
@@ -21,6 +22,7 @@ import mouseHandler
 from NVDAObjects.window import Window
 from NVDAObjects.IAccessible import sysListView32, IAccessible, List
 from NVDAObjects.UIA import UIA
+from NVDAObjects.window.edit import RichEdit50, EditTextInfo
 
 # Suppress incorrect Win 10 Task switching window focus
 class MultitaskingViewFrameWindow(UIA):
@@ -177,6 +179,13 @@ class ReadOnlyEditBox(IAccessible):
 			return windowText.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 		return windowText
 
+class metadataEditField(RichEdit50):
+	""" Used for metadata edit fields in Windows Explorer in Windows 7.
+	By default these fields would use ITextDocumentTextInfo ,
+	but to avoid Windows Explorer crashes we need to use EditTextInfo here. """
+	def _get_TextInfo(self):
+		return EditTextInfo
+
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
@@ -214,6 +223,13 @@ class AppModule(appModuleHandler.AppModule):
 			if role == controlTypes.ROLE_LIST:
 				clsList.remove(List)
 			clsList.insert(0, StartButton)
+			return # Optimization: return early to avoid comparing class names and roles that will never match.
+
+		if(
+			(winVersion.winVersion.major, winVersion.winVersion.minor) == (6, 1)
+			and windowClass == 'RICHEDIT50W'
+		):
+			clsList.insert(0, metadataEditField)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if isinstance(obj, UIA):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -179,6 +179,7 @@ class ReadOnlyEditBox(IAccessible):
 			return windowText.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 		return windowText
 
+
 class metadataEditField(RichEdit50):
 	""" Used for metadata edit fields in Windows Explorer in Windows 7.
 	By default these fields would use ITextDocumentTextInfo ,
@@ -230,7 +231,7 @@ class AppModule(appModuleHandler.AppModule):
 			and windowClass == 'RICHEDIT50W'
 		):
 			clsList.insert(0, metadataEditField)
-			return # Optimization: return early to avoid comparing class names and roles that will never match.
+			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if isinstance(obj, UIA):
 			uiaClassName = obj.UIAElement.cachedClassName


### PR DESCRIPTION
### Link to issue number:
Fixes #5337
### Summary of the issue:
In 89dd4b7 we started using ITextDocumentTextInfo for RichEdit on Windows 7 and above to fix some braille bugs. This however causes crashes in metadata fields in Windows Explorer under Windows 7.
### Description of how this pull request fixes the issue:
For these particular edit fields EditTextInfo is used instead.
### Testing performed:
Focused some mp3 files with tags, and an xlsx file with author and title. Tabbed to the metadata fields, ensured that the crash is gone.
### Known issues with pull request:
Content of these edit boxes isn't always accessible, Even if it would be these controls aren't keyboard navigable so it isn't a big loss.
### Change log entry:

Section: Bug fixes
Windows Explorer on Windows 7 would no longer crash when accessing metadata edit fields.
