### PR TITLE
Implement bounding rectangle support for java text ranges

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-#javaAccessBridgeHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2018 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2019 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import queue
 from ctypes import *
@@ -258,6 +257,15 @@ if bridgeDll:
 	_fixBridgeFunc(BOOL,'getAccessibleTextItems',c_long,JOBJECT64,POINTER(AccessibleTextItemsInfo),jint,errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextSelectionInfo',c_long,JOBJECT64,POINTER(AccessibleTextSelectionInfo),errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextAttributes',c_long,JOBJECT64,jint,POINTER(AccessibleTextAttributesInfo),errcheck=True)
+	_fixBridgeFunc(
+		BOOL,
+		'getAccessibleTextRect',
+		c_long,
+		JOBJECT64,
+		POINTER(AccessibleTextRectInfo),
+		jint,
+		errcheck=True
+	)
 	_fixBridgeFunc(BOOL,'getAccessibleTextLineBounds',c_long,JOBJECT64,jint,POINTER(jint),POINTER(jint),errcheck=True)
 	_fixBridgeFunc(BOOL,'getAccessibleTextRange',c_long,JOBJECT64,jint,jint,POINTER(c_char),c_short,errcheck=True)
 	_fixBridgeFunc(BOOL,'getCurrentAccessibleValueFromContext',c_long,JOBJECT64,POINTER(c_wchar),c_short,errcheck=True)
@@ -493,6 +501,11 @@ class JABContext(object):
 		length = c_short()
 		bridgeDll.getTextAttributesInRange(self.vmID, self.accContext, startIndex, endIndex, byref(attributes), byref(length))
 		return attributes, length.value
+
+	def getAccessibleTextRect(self, index):
+		rect = AccessibleTextRectInfo()
+		bridgeDll.getAccessibleTextRect(self.vmID, self.accContext, byref(rect), index)
+		return rect
 
 	def getAccessibleRelationSet(self):
 		relations = AccessibleRelationSetInfo()

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -97,7 +97,7 @@ class JABTextInfo(textInfos.offsets.OffsetsTextInfo):
 		offset=max(min(info.indexAtPoint,info.charCount-1),0)
 		return offset
 
-	def _getBoundingRectFromOffset(self,offset):
+	def _getBoundingRectFromOffset(self, offset):
 		rect = self.obj.jabContext.getAccessibleTextRect(offset)
 		try:
 			return RectLTWH(rect.x, rect.y, rect.width, rect.height).toLTRB()

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -97,6 +97,13 @@ class JABTextInfo(textInfos.offsets.OffsetsTextInfo):
 		offset=max(min(info.indexAtPoint,info.charCount-1),0)
 		return offset
 
+	def _getBoundingRectFromOffset(self,offset):
+		rect = self.obj.jabContext.getAccessibleTextRect(offset)
+		try:
+			return RectLTWH(rect.x, rect.y, rect.width, rect.height).toLTRB()
+		except ValueError:
+			raise LookupError
+
 	def _getCaretOffset(self):
 		textInfo=self.obj.jabContext.getAccessibleTextInfo(self.obj._JABAccContextInfo.x,self.obj._JABAccContextInfo.y)
 		offset=textInfo.caretIndex

--- a/source/core.py
+++ b/source/core.py
@@ -428,6 +428,7 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 	log.debug("initializing Java Access Bridge support")
 	try:
 		JABHandler.initialize()
+		log.info("Java Access Bridge support initialized")
 	except NotImplementedError:
 		log.warning("Java Access Bridge not available")
 	except:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Java text ranges expose a rectangle for every offset in a text range. We currently don't use this information.

### Description of how this pull request fixes the issue:
Implement _getBoundingRectFromOffset on JABTextInfo.
As a bonus, this pr also adds an info log message when the java access bridge was succesfully initialized.

### Testing performed:
Tested in the about java dialog that using move mouse to navigator object properly positions the mouse at the position of the selected unit.

### Known issues with pull request:
None

### Change log entry:
* New features
    + The accuracy of the move mouse to navigator object command has been improved in text fields in Java applications.