### PR TITLE
Fix another wordOffsets bug causing java text ranges to fail

### DIFF
--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -345,7 +345,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 				ctypes.byref(relEnd)
 			):
 				relStart = relStart.value
-				relEnd = relEnd.value
+				relEnd = min(lineLength, relEnd.value)
 				if self.encoding != textUtils.WCHAR_ENCODING:
 					# We need to convert the uniscribe based offsets to str offsets.
 					relStart, relEnd = offsetConverter.wideToStrOffsets(relStart, relEnd)


### PR DESCRIPTION
### Link to issue number:
Fixes #9997 
Follow up of #10152 

### Summary of the issue:
The last word in a java text range isn't read when using per word navigation.

### Description of how this pull request fixes the issue:
In #10152, I fixed a regression for uniscribe text in non UTF-16 content. In UTF-16 content however, to high offsets for a uniscribe workaround could still leak into the output of _getWordOffsets. This particular pr makes sure that word offsets retrieved using uniscribe are properly bounded to the last offset of the line we're using to calculate word offsets.

### Testing performed:
Tested arrowing with ctrl+left/right through the text fields in the about dialog in the Java control panel.

### Known issues with pull request:
Word offset calculation with and without uniscribe both don't match how Java treats word boundaries. As the Java access bridge doesn't offer us the ability to retrieve word boundaries, there's nothing we could do about this.

### Change log entry:
None