### PR TITLE
Fix up of: Abstract vision framework with included support for focus, navigator object and browse mode caret highlighting (PR #9064)

### DIFF
--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -206,11 +206,11 @@ class VisionHandler(AutoPropertyObject):
 	def handleConfigProfileSwitch(self) -> None:
 		configuredProviders = set(config.conf['vision']['providers'])
 		curProviders = set(self.providers)
-		rovidersToInitialize = configuredProviders - curProviders
+		providersToInitialize = configuredProviders - curProviders
 		providersToTerminate = curProviders - configuredProviders
 		for provider in providersToTerminate:
 			self.terminateProvider(provider)
-		for provider in rovidersToInitialize:
+		for provider in providersToInitialize:
 			self.initializeProvider(provider)
 
 	def initialFocus(self) -> None:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix up of PR #9064

### Summary of the issue:

Commit 5ad32bf4e7 contains a small typo in `VisionHandler.handleConfigProfileSwitch`: A local variable is named `rovidersToInitialize` while it seems obvious the intention was to name it `providersToInitialize`.

### Description of how this pull request fixes the issue:

Rename the local variable.

### Testing performed:

None

### Known issues with pull request:

### Change log entry:

N/A