### PR TITLE
Fix for NVDAObjects.window.winword.WordDocument - increaseDecreaseFontSize fr gestures.ini

### DIFF
--- a/source/locale/fr/gestures.ini
+++ b/source/locale/fr/gestures.ini
@@ -10,6 +10,6 @@
 
 [NVDAObjects.window.winword.WordDocument]
 	None = kb:control+b, kb:control+[, kb:control+], "kb:control+shift+,", kb:control+shift+., kb:control+l, kb:control+r
-	increaseDecreaseFontSize = kb:control+shift+<, kb:control+shift+>, kb:control+alt+<, kb:control+alt+>
+	increaseDecreaseFontSize = kb:control+shift+<, kb:control+<, kb:control+alt+<, kb:control+alt+shift+<
 	toggleBold = kb:control+g, kb:control+shift+b
 	toggleAlignment = kb:control+shift+g, kb:control+shift+d


### PR DESCRIPTION
### Link to issue number:
fixes #9962 

### Summary of the issue:
Some shortcuts to increase/decrease font size in MS Word do not speak the resulting font size.

### Description of how this pull request fixes the issue:
Change the gestures for increaseDecreaseFontSize script in the local fr gestures.ini to match MS Word native gestures (cf. #9962 for details)

### Testing performed:
On MS Word (French) and with French keyboard layout: seletcted text, pressed the 4 gestures to modify font size (ctrl+<, ctrl+shift+<, ctrl+alt+< and ctrl+shift+<) and checked each time that font size was spoken.

### Known issues with pull request:
None

### Change log entry:
*Bug fixes*
`On French MS Word, all the shortcuts to increase or decrease font size are now spoken. (#9962)`
Section: Bug fixes

