### PR TITLE
Implement new displayChunk unit for display model

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -22,6 +22,7 @@ from logHandler import log
 import windowUtils
 from locationHelper import RectLTRB, RectLTWH
 import textUtils
+from typing import Union, List, Tuple
 
 #: A text info unit constant for a single chunk in a display model
 UNIT_DISPLAYCHUNK = "displayChunk"
@@ -269,7 +270,13 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 		super(DisplayModelTextInfo, self).__init__(obj, position)
 
 	_cache__storyFieldsAndRects = True
-	def _get__storyFieldsAndRects(self):
+
+	def _get__storyFieldsAndRects(self) -> Tuple[
+		List[Union[str, textInfos.FieldCommand]],
+		List[RectLTRB],
+		List[int],
+		List[int]
+	]:
 		# All returned coordinates are logical coordinates.
 		if self._location:
 			left, top, right, bottom = self._location
@@ -278,18 +285,18 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 				left, top, width, height = self.obj.location
 			except TypeError:
 				# No location; nothing we can do.
-				return [],[],[]
+				return [], [], [], []
 			right = left + width
 			bottom = top + height
 		bindingHandle=self.obj.appModule.helperLocalBindingHandle
 		if not bindingHandle:
 			log.debugWarning("AppModule does not have a binding handle")
-			return [],[],[]
+			return [], [], [], []
 		left,top=windowUtils.physicalToLogicalPoint(self.obj.windowHandle,left,top)
 		right,bottom=windowUtils.physicalToLogicalPoint(self.obj.windowHandle,right,bottom)
 		text,rects=getWindowTextInRect(bindingHandle, self.obj.windowHandle, left, top, right, bottom, self.minHorizontalWhitespace, self.minVerticalWhitespace,self.stripOuterWhitespace,self.includeDescendantWindows)
 		if not text:
-			return [],[],[]
+			return [], [], [], []
 		text="<control>%s</control>"%text
 		commandList=XMLFormatting.XMLTextParser().parse(text)
 		curFormatField=None


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In a display model, pieces of text are saved as separate chunks. This information is currently not available from NVDA APIs itself.
However, when trying to label text fields or combo boxes in an inaccessible application using a display model, this information is still pretty important, as a label is usually stored in one chunk.

#### Example
1. Make a DisplayModelTextInfo for the desktop using `displayModel.DisplayModelTextInfo(fg, "all")`
2. Using the `getTextInChunks` method on the textInfo, iterate through the text.
3. You will notice that it is not possible to find out where the boundaries are between the several desktop icons. For example, using word offsets cuts the `this pc` icon into two words, whereas using line offsets gives you an entire row of "desktop icons.

### Description of how this pull request fixes the issue:
I implemented support to get the distinc display model chunks from the display model. This is mapped to a new unit constant, displayModel.UNIT_DISPLAYCHUNK.

### Testing performed:
1. Tested on the desktop that desktop icons are treated as single chunks, also when their names contain spaces. Note that icon names spanning multiple lines (having a hard line break) are still treated as two chunks.
2. Tested in a delphi application that text field labels containing spaces are treated as single chunks.

### Known issues with pull request:
1. In many cases, white space is treated as a single chunk, for example the white space between desktop icons. However, when getting text chunks per line, the line separator is also stored in a separate 
2. See also limitations mentioned by @michaelDCurran in https://github.com/nvaccess/nvda/pull/10165#issuecomment-529244236

### Change log entry:
* Changes for developers
    + Introduced displayModel.UNIT_DISPLAYCHUNK as a textInfos unit constant specific to DisplayModelTextInfo.
        * This new constant allows walking over the text in a DisplayModelTextInfo in a way that more closely resembles how the text chunks are saved in the underlying model.