### PR TITLE
Update liblouis to commit 58d67e63

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
-* [liblouis](http://www.liblouis.org/), version 3.10.0 commit 58d67e63
+* [liblouis](http://www.liblouis.org/), version 3.10.0 commit 146c0757
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
-* [liblouis](http://www.liblouis.org/), version 3.10.0
+* [liblouis](http://www.liblouis.org/), version 3.10.0 commit 58d67e63
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -1,8 +1,7 @@
-#brailleTables.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2008-2019 NV Access Limited, Joseph Lee
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2008-2019 NV Access Limited, Joseph Lee, Babbage B.V.
 
 """Manages information about available braille translation tables.
 """
@@ -69,6 +68,7 @@ RENAMED_TABLES = {
 	"en-us-comp8.ctb" : "en-us-comp8-ext.utb",
 	"fr-ca-g1.utb":"fr-bfu-comp6.utb",
 	"Fr-Ca-g2.ctb":"fr-bfu-g2.ctb",
+	"gr-bb.ctb": "grc-international-en.utb",
 	"gr-gr-g1.utb":"el.ctb",
 	"hr.ctb":"hr-comp8.utb",
 	"mn-MN.utb":"mn-MN-g1.utb",
@@ -226,7 +226,7 @@ addTable("ga-g2.ctb", _("Irish grade 2"), contracted=True)
 addTable("gu-in-g1.utb", _("Gujarati grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("gr-bb.ctb", _("Koine Greek"))
+addTable("grc-international-en.utb", _("Greek international braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("he.ctb", _("Hebrew 8 dot computer braille"))


### PR DESCRIPTION
### Link to issue number:
Fixes #10094

### Summary of the issue:
The python 3 transition caused a regression for liblouis, printing unicode surrogate characters like \ud83d cause an UnicodeEncodeError.

### Description of how this pull request fixes the issue:
Updates liblouis to a commit that has a fix for this. This is a commit post 3.10, also applying the following fixes:

- Don't let a caps passage end on a word with no letters
- Handle word resets in the last word of an caps or emphasis passage if the end indicator was placed before the word- Never convert to lowercase if capsletter is not defined
- Fix position mapping for back-translation when noUndefinedDots mode is active
- Fix an issue with ordinal numbers inside caps passages in Dutch braille
- Improved back-translation for Mongolian

### Testing performed:
Tested that liblouis prints the hexadecimal representation of a surrogate character, when printed to a python console.

### Known issues with pull request:
This *does not* update to liblouis 3.11, see #10161 

### Change log entry:
* Changes
    + Updated Liblouis braille translator to commit 58d67e63. (#10094)
