### PR TITLE
winUser.py: Add missing mouse related constants

### DIFF
--- a/source/winUser.py
+++ b/source/winUser.py
@@ -66,6 +66,7 @@ class GUITHREADINFO(Structure):
 
 #constants
 ERROR_OLD_WIN_VERSION=1150
+MOUSEEVENTF_MOVE = 0x0001  # Movement occurred.
 MOUSEEVENTF_LEFTDOWN=0x0002 
 MOUSEEVENTF_LEFTUP=0x0004 
 MOUSEEVENTF_RIGHTDOWN=0x0008
@@ -74,6 +75,10 @@ MOUSEEVENTF_MIDDLEDOWN=0x0020
 MOUSEEVENTF_MIDDLEUP=0x0040
 MOUSEEVENTF_XDOWN=0x0080
 MOUSEEVENTF_XUP=0x0100
+MOUSEEVENTF_WHEEL = 0x0800  # The wheel button is rotated.
+MOUSEEVENTF_HWHEEL = 0x1000  # The wheel button is tilted.
+WHEEL_DELTA = 120  # One wheel click. Negate to scroll down.
+MOUSEEVENTF_ABSOLUTE = 0x8000  # The dx and dy parameters contain normalized absolute coordinates (0..65535).
 GUI_CARETBLINKING=0x00000001
 GUI_INMOVESIZE=0x00000002
 GUI_INMENUMODE=0x00000004
@@ -663,7 +668,9 @@ class Input(Structure):
     _fields_ = [("type", c_ulong),
              ("ii", Input_I)]
 
-INPUT_KEYBOARD = 1
+
+INPUT_MOUSE = 0  # The event is a mouse event. Use the mi structure of the union.
+INPUT_KEYBOARD = 1  # The event is a keyboard event. Use the ki structure of the union.
 KEYEVENTF_KEYUP = 0x0002
 KEYEVENTF_UNICODE = 0x04
 # END SENDINPUT TYPE DECLARATIONS


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

None.

### Summary of the issue:

While developing a custom WebAccess webModule for a customer, I've come across the need to send a mouse scroll wheel event and realized that the required constants are missing from `winUser.py`.
I also noticed a few mouse-related constants were missing to properly use `SendInput` instead of `mouse_event`.

Of course, one could define these constants in their own modules, but as `winUser.py` already contains eg. the `MouseInput` structure, I thought this was the right place to add them for completeness.
Furthermore, these constants will be needed if we wish to implement mouse gesture for use eg. by the vision framework.

### Description of how this pull request fixes the issue:

Add the following constants in `winUser.py`

Mouse wheel related:
- MOUSEEVENTF_WHEEL (0x0800)
- MOUSEEVENTF_HWHEEL (0x1000)
- WHEEL_DELTA (120)

`SendInput` / mouse related:
- MOUSEEVENTF_MOVE (0x0001)
- MOUSEEVENTF_ABSOLUTE (0x8000)
- INPUT_MOUSE (0)

References:
 - https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mouse_event
 - https://docs.microsoft.com/fr-fr/windows/win32/api/winuser/ns-winuser-input

### Testing performed:

### Known issues with pull request:

### Change log entry:

I do not think this deserves a change log entry.