### PR TITLE
UI Automation in Windows Console: Fix annoying focus repeating

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2019 Bill Dengler
+# Copyright (C) 2019 NV Access Limited, Bill Dengler, Babbage B.V.
 
 import ctypes
 import NVDAHelper
@@ -250,6 +250,7 @@ class consoleUIATextInfo(UIATextInfo):
 
 
 class consoleUIAWindow(Window):
+
 	def _get_focusRedirect(self):
 		"""
 		Sometimes, attempting to interact with the console too quickly after
@@ -259,9 +260,13 @@ class consoleUIAWindow(Window):
 		"""
 		for child in self.children:
 			if isinstance(child, WinConsoleUIA):
+				self.focusRedirect = child
 				return child
 		return None
 
+	def _get_shouldAllowUIAFocusEvent(self):
+		#return not isinstance(api.getFocusObject(), WinConsoleUIA)
+		return api.getFocusObject() != self.focusRedirect
 
 class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Disable the name as it won't be localized


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When starting an UIA console, speech output could go like this:

```
C:\WINDOWS\system32\cmd.exe  window
terminal
C:\Users\Leonard de Ruijter>
terminal
C:\Users\Leonard de Ruijter>
terminal
C:\Users\Leonard de Ruijter>
```

This is because the parent of the actual console window gets focus first and redirects its focus to the actual terminal. However, it looks like focus bounces back from parent to child around twice.

### Description of how this pull request fixes the issue:
Don't let a consoleUIAWindow take focus if its focus redirect currently has focus. For this, we also cache the focus redirect.

### Testing performed:
Tested that focus repeating does no longer occur.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + In UIA in Windows consoles, focus announcements are no longer repeated unnecessarily.