### PR TITLE
Hide the mouse when screen curtain is on

### DIFF
--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -38,6 +38,8 @@ class Magnification:
 	_MagSetFullscreenColorEffectArgTypes = ((1, "effect"),)
 	_MagGetFullscreenColorEffectFuncType = WINFUNCTYPE(BOOL, POINTER(MAGCOLOREFFECT))
 	_MagGetFullscreenColorEffectArgTypes = ((2, "effect"),)
+	_MagShowSystemCursorFuncType = WINFUNCTYPE(BOOL, BOOL)
+	_MagShowSystemCursorArgTypes = ((1, "showCursor"),)
 
 	MagInitialize = _MagInitializeFuncType(("MagInitialize", _magnification))
 	MagInitialize.errcheck = _errCheck
@@ -57,6 +59,11 @@ class Magnification:
 	except AttributeError:
 		MagSetFullscreenColorEffect = None
 		MagGetFullscreenColorEffect = None
+	MagShowSystemCursor = _MagShowSystemCursorFuncType(
+		("MagShowSystemCursor", _magnification),
+		_MagShowSystemCursorArgTypes
+	)
+	MagShowSystemCursor.errcheck = _errCheck
 
 
 class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
@@ -73,10 +80,12 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 	def __init__(self):
 		super(VisionEnhancementProvider, self).__init__()
 		Magnification.MagInitialize()
+		Magnification.MagShowSystemCursor(False)
 		Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 
 	def terminate(self):
 		super(VisionEnhancementProvider, self).terminate()
+		Magnification.MagShowSystemCursor(True)
 		Magnification.MagUninitialize()
 
 	def registerEventExtensionPoints(self, extensionPoints):


### PR DESCRIPTION
### Link to issue number:
Fixes #10181 

### Summary of the issue:
When the screen curtain is on, the mouse is still visible.

### Description of how this pull request fixes the issue:
Use the MagShowSystemCursor function to hide the mouse. Also call the particular function with a True boolean value when terminating, though I think that's not strictly necessary.
@feerrenrut: may be you could quickly check this when reviewing this?

### Testing performed:
Asked a sighted person to verify that the mouse is now gone.

### Known issues with pull request:
None

### Change log entry:
None
