### PR TITLE
Fix up of: Launcher: Default to replacing an already running NVDA (#8320, #9827, #10179)

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -103,12 +103,12 @@ parser.add_argument('--portable-path',dest='portablePath',default=None,type=str,
 parser.add_argument('--launcher',action="store_true",dest='launcher',default=False,help="Started from the launcher")
 parser.add_argument('--enable-start-on-logon',metavar="True|False",type=stringToBool,dest='enableStartOnLogon',default=None,
 	help="When installing, enable NVDA's start on the logon screen")
-# This option currently doesn't actually do anything.
-# It is passed by Ease of Access so that if someone downgrades without uninstalling (despite our discouragement),
-# the downgraded copy won't be started in non-secure mode on secure desktops.
+# This option is passed by Ease of Access so that if someone downgrades without uninstalling
+# (despite our discouragement), the downgraded copy won't be started in non-secure mode on secure desktops.
 # (Older versions always required the --secure option to start in secure mode.)
 # If this occurs, the user will see an obscure error,
 # but that's far better than a major security hazzard.
+# If this option is provided, NVDA will not replace an already running instance (#10179) 
 parser.add_argument('--ease-of-access',action="store_true",dest='easeOfAccess',default=False,help="Started by Windows Ease of Access")
 (globalVars.appArgs,globalVars.appArgsExtra)=parser.parse_known_args()
 
@@ -144,7 +144,7 @@ except:
 	oldAppWindowHandle=0
 if not winUser.isWindow(oldAppWindowHandle):
 	oldAppWindowHandle=0
-if oldAppWindowHandle:
+if oldAppWindowHandle and not globalVars.appArgs.easeOfAccess:
 	if globalVars.appArgs.check_running:
 		# NVDA is running.
 		sys.exit(0)
@@ -152,7 +152,7 @@ if oldAppWindowHandle:
 		terminateRunningNVDA(oldAppWindowHandle)
 	except:
 		sys.exit(1)
-if globalVars.appArgs.quit:
+if globalVars.appArgs.quit or (oldAppWindowHandle and globalVars.appArgs.easeOfAccess):
 	sys.exit(0)
 elif globalVars.appArgs.check_running:
 	# NVDA is not running.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10179
Fix up of #9827

### Summary of the issue:

Regression introduced in #9827: in installed copy of NVDA, whenever one exits secure screens, NVDA restarts.

### Description of how this pull request fixes the issue:

Do not automatically replace an existing instance of NVDA if the `--ease-of-access` command line parameter is provided.

### Testing performed:

Tested with Windows 10 64 bits version 1903.
I could reproduce the faulty behavior reported by @josephsl in #10179 by installing alpha build 18574.
I do not reproduce anymore with the try build 18579 for this PR.

### Known issues with pull request:

### Change log entry:

N/A