### PR TITLE
Fix up of: Implement new displayChunk unit for display model

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -506,7 +506,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 	def getTextInChunks(self,unit):
 		# Specifically handle the line and display chunk units.
 		# We have the line offsets pre-calculated, and we can not guarantee lines end with \n
-		if unit is textInfos.UNIT_DISPLAYCHUNK:
+		if unit is UNIT_DISPLAYCHUNK:
 			for x in self._getFieldsInRange(self._startOffset, self._endOffset):
 				if not isinstance(x, str):
 					continue


### PR DESCRIPTION
### Link to issue number:
Fixes #10187 
Fixup of #10165 

### Summary of the issue:
A bad search/replace added a reference to non-existent textInfos.UNIT_DISPLAYCHUNK, which is a variable in the displayModel module itself.

### Description of how this pull request fixes the issue:
Removed `textInfos.`

### Testing performed:
Made sure that there is no other reference to textInfos.UNIT_DISPLAYCHUNK

### Known issues with pull request:
None

### Change log entry:
None
