### PR TITLE
VBufStorage:  do not delete reference nodes prematurely when replacing subtrees

### DIFF
--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -276,9 +276,7 @@ VBufStorage_controlFieldNode_t* VBufBackend_t::reuseExistingNodeInRender(VBufSto
 		LOG_DEBUG(L"Existing node refuses to be reused");
 		return nullptr;
 	}
-	// We only allow reusing nodes that share the same parent. 
-	// I.e. we don't allow reusing a node that existed in an entirely different part of the tree. 
-	// If we did, this could possibly cause corruption in the virtualBuffer as a node might move between two unrelated updates.
+	// Don't reuse the node if it has no parent (is the root of the buffer).
 	auto existingParent=existingNode->getParent();
 	if(!existingParent) {
 		LOG_DEBUG(L"existing node has no parent. Not reusing.");

--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -284,10 +284,6 @@ VBufStorage_controlFieldNode_t* VBufBackend_t::reuseExistingNodeInRender(VBufSto
 		LOG_DEBUG(L"existing node has no parent. Not reusing.");
 		return nullptr;
 	}
-	if(existingParent->identifier!=parent->identifier) {
-		LOG_DEBUG(L"Cannot reuse a node moved from within another parent.");
-		return nullptr;
-	}
 	if(existingNode->denyReuseIfPreviousSiblingsChanged) {
 		// This node is not allowed to be reused if any of its previous siblings have changed.
 		// We work this out by walking back to the previous controlFieldNode in its siblings, and ensuring that it is a reference node that references the existing node's first previous controlFieldNode.

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -646,14 +646,14 @@ bool VBufStorage_buffer_t::replaceSubtrees(map<VBufStorage_fieldNode_t*,VBufStor
 	// Reverse iterate over all reference nodes, replacing them with the existing nodes in the original buffer they point to.
 	// We must iterate in reverse as new nodes are always inserted using parent and previous as the location,
 	// iterating forward would cause a future reference node's previous to be come invalid as it had been replaced. 
-	for(map<VBufStorage_fieldNode_t*,VBufStorage_buffer_t*>::iterator i=m.begin();i!=m.end();++i) {
-		VBufStorage_fieldNode_t* node=i->first;
-		VBufStorage_buffer_t* buffer=i->second;
-		for(auto i=buffer->referenceNodes.rbegin();i!=buffer->referenceNodes.rend();++i) {
-			VBufStorage_controlFieldNode_t* parent=(*i)->parent;
-			VBufStorage_fieldNode_t* previous=(*i)->previous;
-			VBufStorage_controlFieldNode_t* referenced=(*i)->referenceNode;
-			buffer->removeFieldNode(*i);
+	for(auto subtreeEntryIter=m.cbegin();subtreeEntryIter!=m.cend();++subtreeEntryIter) {
+		auto node=subtreeEntryIter->first;
+		auto buffer=subtreeEntryIter->second;
+		for(auto referenceNodeIter=buffer->referenceNodes.rbegin();referenceNodeIter!=buffer->referenceNodes.rend();++referenceNodeIter) {
+			auto parent=(*referenceNodeIter)->parent;
+			auto previous=(*referenceNodeIter)->previous;
+			auto referenced=(*referenceNodeIter)->referenceNode;
+			buffer->removeFieldNode(*referenceNodeIter);
 			this->unlinkFieldNode(referenced);
 			buffer->insertNode(parent,previous,referenced);
 		}

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -642,9 +642,25 @@ bool VBufStorage_buffer_t::replaceSubtrees(map<VBufStorage_fieldNode_t*,VBufStor
 			for(previous=parent->previous;previous!=NULL;relativeSelectionStart+=previous->length,previous=previous->previous);
 		}
 	}
+	// For each buffer in the map,
+	// Reverse iterate over all reference nodes, replacing them with the existing nodes in the original buffer they point to.
+	// We must iterate in reverse as new nodes are always inserted using parent and previous as the location,
+	// iterating forward would cause a future reference node's previous to be come invalid as it had been replaced. 
+	for(map<VBufStorage_fieldNode_t*,VBufStorage_buffer_t*>::iterator i=m.begin();i!=m.end();++i) {
+		VBufStorage_fieldNode_t* node=i->first;
+		VBufStorage_buffer_t* buffer=i->second;
+		for(auto i=buffer->referenceNodes.rbegin();i!=buffer->referenceNodes.rend();++i) {
+			VBufStorage_controlFieldNode_t* parent=(*i)->parent;
+			VBufStorage_fieldNode_t* previous=(*i)->previous;
+			VBufStorage_controlFieldNode_t* referenced=(*i)->referenceNode;
+			buffer->removeFieldNode(*i);
+			this->unlinkFieldNode(referenced);
+			buffer->insertNode(parent,previous,referenced);
+		}
+	}
 	//For each node in the map,
 	//Replace the node on this buffer, with the content of the buffer in the map for that node
-	//Note that controlField info will automatically be removed, but not added again
+	//Note that controlField info will automatically be removed, but not added again.
 	bool failedBuffers=false;
 	for(map<VBufStorage_fieldNode_t*,VBufStorage_buffer_t*>::iterator i=m.begin();i!=m.end();) {
 		VBufStorage_fieldNode_t* node=i->first;
@@ -654,17 +670,6 @@ bool VBufStorage_buffer_t::replaceSubtrees(map<VBufStorage_fieldNode_t*,VBufStor
 			failedBuffers=true;
 			m.erase(i++);
 			continue;
-		}
-		// Reverse iterate over all reference nodes, replacing them with the existing nodes in the original buffer they point to.
-		// We must iterate in reverse as new nodes are always inserted using parent and previous as the location,
-		 // iterating forward would cause a future reference node's previous to be come invalid as it had been replaced. 
-		for(auto i=buffer->referenceNodes.rbegin();i!=buffer->referenceNodes.rend();++i) {
-			VBufStorage_controlFieldNode_t* parent=(*i)->parent;
-			VBufStorage_fieldNode_t* previous=(*i)->previous;
-			VBufStorage_controlFieldNode_t* referenced=(*i)->referenceNode;
-			buffer->removeFieldNode(*i);
-			this->unlinkFieldNode(referenced);
-			buffer->insertNode(parent,previous,referenced);
 		}
 		parent=node->parent;
 		previous=node->previous;


### PR DESCRIPTION
### Link to issue number:
Fixes #10175 
Fixes #9402
Fixes #8924
Replaces pr #8930

### Summary of the issue:
NVDA could crash the web browser if a page moved an accessibility node from one subtree on the page to another, either by moving a DOM node directly, or when setting aria-owns dynamically. The crash became much more likely if two nodes were swapped with each other at the same time, such as in issue #10175 .
The crash was occuring because VBufStorage_buffer_t::replaceSubtrees would move reference nodes for reuse, and then straight away remove the old subtree and replace it with the content of the temporary buffer, However reference nodes in other subtrees may be further replaced, containing their own reference nodes which may reference nodes that have already been removed. 
 
### Description of how this pull request fixes the issue:
VBufsTorage_buffer_t::replaceSubtrees now moves reference nodes on all temp buffers first, and only then removes the old subtrees and replaces them with the content of the temp buffers.
This pr also reverts code in pr #8930 which removes the limitation in VBufBackend_t::reuseExistingNodeInRender where it would refuse to return an existing node if it did not share the same parent. This particular code was flawed as it never took descendants into account. For example in issue #10175:  If item1 was moved from container2 to container1, although item1 itself wouldn't be reused as the parents differ, item1's child div would be reused, therefore not avoiding a possible crash. Now the underlying issue is addressed, it is now hopefully safe enough to reuse nodes from differing parents, though we could obviously reinstate that code if we wanted.

### Testing performed:
Performed testcase in #10175. Firefox no longer crashes.
 Performed testcase in #9402. Firefox no longer crashes.
 Performed testcase in #8924. Firefox no longer crashes.

### Known issues with pull request:
None known.

### Change log entry:
Addressed several crashes in Gmail seen in both Firefox and Chrome when interacting with  particular popup menus such as when creating filters or changing certain Gmail settings.
