### PR TITLE
GUI: Make Input Gestures Dialog resizeable (#6332)

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -177,6 +177,8 @@ class SettingsDialog(wx.Dialog, DpiScalingHelperMixin, metaclass=guiHelper.SIPAB
 		self.Bind(wx.EVT_WINDOW_DESTROY, self._onWindowDestroy)
 
 		self.postInit()
+		if resizeable:
+			self.SetMinSize(self.mainSizer.GetMinSize())
 		self.CentreOnScreen()
 		if gui._isDebug():
 			log.debug("Loading %s took %.2f seconds"%(self.__class__.__name__, time.time() - startTime))

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3236,6 +3236,11 @@ class InputGesturesDialog(SettingsDialog):
 
 	def __init__(self, parent):
 		super().__init__(parent, resizeable=True)
+		# Historical initial size, result of L{self.tree} being (600, 400) as of #6349.
+		# Setting an initial size on L{self.tree} directly would also sets its minimum size
+		# and thus forbid to shrink the dialog.
+		self.SetSize(626, 554)
+		self.CentreOnScreen()
 
 	def makeSettings(self, settingsSizer):
 		filterSizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -3249,7 +3254,10 @@ class InputGesturesDialog(SettingsDialog):
 		settingsSizer.AddSpacer(5)
 		filter.Bind(wx.EVT_TEXT, self.onFilterChange, filter)
 
-		tree = self.tree = wx.TreeCtrl(self, size=wx.Size(600, 400), style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE )
+		tree = self.tree = wx.TreeCtrl(
+			self,
+			style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE
+		)
 
 		self.treeRoot = tree.AddRoot("root")
 		tree.Bind(wx.EVT_TREE_SEL_CHANGED, self.onTreeSelect)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3236,11 +3236,6 @@ class InputGesturesDialog(SettingsDialog):
 
 	def __init__(self, parent):
 		super().__init__(parent, resizeable=True)
-		# Historical initial size, result of L{self.tree} being (600, 400) as of #6349.
-		# Setting an initial size on L{self.tree} directly would also sets its minimum size
-		# and thus forbid to shrink the dialog.
-		self.SetSize(626, 554)
-		self.CentreOnScreen()
 
 	def makeSettings(self, settingsSizer):
 		filterSizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -3254,10 +3249,7 @@ class InputGesturesDialog(SettingsDialog):
 		settingsSizer.AddSpacer(5)
 		filter.Bind(wx.EVT_TEXT, self.onFilterChange, filter)
 
-		tree = self.tree = wx.TreeCtrl(
-			self,
-			style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE
-		)
+		tree = self.tree = wx.TreeCtrl(self, size=wx.Size(600, 400), style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE )
 
 		self.treeRoot = tree.AddRoot("root")
 		tree.Bind(wx.EVT_TREE_SEL_CHANGED, self.onTreeSelect)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3232,6 +3232,9 @@ class InputGesturesDialog(SettingsDialog):
 	# Translators: The title of the Input Gestures dialog where the user can remap input gestures for commands.
 	title = _("Input Gestures")
 
+	def __init__(self, parent):
+		super().__init__(parent, resizeable=True)
+
 	def makeSettings(self, settingsSizer):
 		filterSizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a text field to search for gestures in the Input Gestures dialog.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Progress on #6332

### Summary of the issue:

As stated by @feerrenrut in https://github.com/nvaccess/nvda/issues/6332#issue-175024733

> Some of the dialogs would benefit from being resizable. Dialogs with list controls (single or multi-column) or tree views often have entries that are much bigger than the space allocated to them. This can make them more difficult to read. While ideally all dialogs would have a layout that finds the balance between ease to read and not looking oversized, a fairly simple fallback option is to make the dialogs resizable. A user can just resize the dialog in order to fit the content they are interested in on the screen.

### Description of how this pull request fixes the issue:

Make the Input Gestures dialog resizeable.

### Testing performed:

Shrunk and enlarged the dialog with different proportions to ensure its layout stays coherent.

### Known issues with pull request:

### Change log entry:

I do not think this change deserves to be announced.

