### PR TITLE
GUI: Allow to maximize settings dialogs that are already resizable (#6332)

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -136,7 +136,9 @@ class SettingsDialog(wx.Dialog, DpiScalingHelperMixin, metaclass=guiHelper.SIPAB
 		"""
 		if gui._isDebug():
 			startTime = time.time()
-		windowStyle = wx.DEFAULT_DIALOG_STYLE | (wx.RESIZE_BORDER if resizeable else 0)
+		windowStyle = wx.DEFAULT_DIALOG_STYLE
+		if resizeable:
+			windowStyle |= wx.RESIZE_BORDER | wx.MAXIMIZE_BOX
 		wx.Dialog.__init__(self, parent, title=self.title, style=windowStyle)
 		DpiScalingHelperMixin.__init__(self, self.GetHandle())
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Related to #6332

### Summary of the issue:

#6332 aims at allowing to resize dialogs that support it for the sake of visual readability.
The quickest way to enlarge a dialog using the keyboard is to maximize it using `windows+upArrow`.
Currently, the resizable dialogs in NVDA cannot be maximized.

### Description of how this pull request fixes the issue:

Add the maximize functionality to the base settings dialog class whenever the dialog is set to be resizable.

### Testing performed:

Checked the dialogs currently resizable behave correctly when maximized.

### Known issues with pull request:

### Change log entry:

I do not think this deserves to be announced.