### PR TITLE
GUI: Allow the Speech Symbols dialog to be enlarged vertically (#6332)

### DIFF
--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -127,7 +127,7 @@ def associateElements( firstElement, secondElement):
 		sizer = wx.BoxSizer(wx.VERTICAL)
 		sizer.Add(firstElement)
 		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
-		sizer.Add(secondElement, flag=wx.EXPAND)
+		sizer.Add(secondElement, flag=wx.EXPAND, proportion=1)
 	# button and checkBox
 	elif isinstance(firstElement, wx.Button) and isinstance(secondElement, wx.CheckBox):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -284,7 +284,7 @@ class BoxSizerHelper(object):
 		"""
 		labeledControl = LabeledControlHelper(self._parent, labelText, wxCtrlClass, **kwargs)
 		if(isinstance(labeledControl.control, (wx.ListCtrl,wx.ListBox,wx.TreeCtrl))):
-			self.addItem(labeledControl.sizer, flag=wx.EXPAND)
+			self.addItem(labeledControl.sizer, flag=wx.EXPAND, proportion=1)
 		else:
 			self.addItem(labeledControl.sizer)
 		return labeledControl.control

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -177,6 +177,8 @@ class SettingsDialog(wx.Dialog, DpiScalingHelperMixin, metaclass=guiHelper.SIPAB
 		self.Bind(wx.EVT_WINDOW_DESTROY, self._onWindowDestroy)
 
 		self.postInit()
+		if resizeable:
+			self.SetMinSize(self.mainSizer.GetMinSize())
 		self.CentreOnScreen()
 		if gui._isDebug():
 			log.debug("Loading %s took %.2f seconds"%(self.__class__.__name__, time.time() - startTime))

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3053,12 +3053,6 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.filter()
 
 	def postInit(self):
-		size = self.GetBestSize()
-		self.SetSizeHints(
-			minW=size.GetWidth(),
-			minH=size.GetHeight(),
-			maxH=size.GetHeight(),
-		)
 		self.symbolsList.SetFocus()
 
 	def filter(self, filterText=''):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Progress on #6332

### Summary of the issue:

As stated by @feerrenrut in https://github.com/nvaccess/nvda/issues/6332#issue-175024733

> Some of the dialogs would benefit from being resizable. Dialogs with list controls (single or multi-column) or tree views often have entries that are much bigger than the space allocated to them. This can make them more difficult to read. While ideally all dialogs would have a layout that finds the balance between ease to read and not looking oversized, a fairly simple fallback option is to make the dialogs resizable. A user can just resize the dialog in order to fit the content they are interested in on the screen.

The Speech Symbols dialog is currently only resizable horizontally.

### Description of how this pull request fixes the issue:

Make the Speech Settings dialog also expandable vertically.

### Testing performed:

Shrunk and enlarged the dialog with different proportions to ensure its layout stays coherent.

### Known issues with pull request:

### Change log entry:

I do not think this change deserves to be announced.

