### PR TITLE
EdgeHTML-based Edge: do not treat address omnibar as a search field

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -863,8 +863,7 @@ class UIA(Window):
 		if isDialog:
 			clsList.append(Dialog)
 		# #6241: Try detecting all possible suggestions containers and search fields scattered throughout Windows 10.
-		# In Windows 10, allow Start menu search box and Edge's address omnibar to participate in announcing appearance of auto-suggestions.
-		if self.UIAElement.cachedAutomationID in ("SearchTextBox", "TextBox", "addressEditBox"):
+		if self.UIAElement.cachedAutomationID in ("SearchTextBox", "TextBox"):
 			clsList.append(SearchField)
 		try:
 			# Nested block here in order to catch value error and variable binding error when attempting to access automation ID for invalid elements.


### PR DESCRIPTION
### Link to issue number:
Fixes #10002
Fixes #9110

### Summary of the issue:
Classic (EdgeHTML-based) Edge's address omnibar is treated as a search field, causing it to fire controller for event when Edge window is maximized.

### Description of how this pull request fixes the issue:
Removes Edge's address omnibar from being treated as a search field.

### Testing performed:
Tested with Windows 10 App Essentials add-on for several months.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

In Microsoft Edge based on EdgeHTML, NVDA will no longer play search suggestion sound when the window becomes maximized. (#9110, #10002)

Thanks.