### PR TITLE
GUI: Make the Addons dialogs resizable and maximizable (#6332)

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -737,7 +737,7 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 
 		self.refreshAddonsList()
 		self.SetMinSize(mainSizer.GetMinSize())
-		# Historical initial size, result of L{self.addonsList} being (550, 350) as of 1364839447.
+		# Historical initial size, result of L{self.addonsList} being (550, 350) as of PR #8006.
 		# Setting an initial size on L{self.addonsList} by passing a L{size} argument when
 		# creating the control would also set its minimum size and thus block the dialog from being shrunk.
 		self.SetSize(self.scaleSize((606, 525)))

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -738,8 +738,8 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		self.refreshAddonsList()
 		self.SetMinSize(mainSizer.GetMinSize())
 		# Historical initial size, result of L{self.addonsList} being (550, 350) as of 1364839447.
-		# Setting an initial size on L{self.addonsList} directly would also sets its minimum size
-		# and thus forbid to shrink the dialog.
+		# Setting an initial size on L{self.addonsList} by passing a L{size} argument when
+		# creating the control would also set its minimum size and thus block the dialog from being shrunk.
 		self.SetSize(self.scaleSize((606, 525)))
 		self.CentreOnScreen()
 		self.addonsList.SetFocus()

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -681,8 +681,13 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			# this dialog is not designed to show an empty list.
 			raise RuntimeError("No incompatible addons.")
 
-		# Translators: The title of the Incompatible Addons Dialog
-		wx.Dialog.__init__(self, parent, title=_("Incompatible Add-ons"))
+		wx.Dialog.__init__(
+			self,
+			parent,
+			# Translators: The title of the Incompatible Addons Dialog
+			title=_("Incompatible Add-ons"),
+			style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+		)
 		DpiScalingHelperMixin.__init__(self, self.GetHandle())
 
 		mainSizer=wx.BoxSizer(wx.VERTICAL)
@@ -704,7 +709,6 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			entriesLabel,
 			nvdaControls.AutoWidthColumnListCtrl,
 			style=wx.LC_REPORT|wx.LC_SINGLE_SEL,
-			size=self.scaleSize((maxControlWidth, 350))
 		)
 
 		# Translators: The label for a column in add-ons list used to identify add-on package name (example: package is OCR).
@@ -723,7 +727,7 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		button = buttonSizer.addButton(self, label=_("&Close"), id=wx.ID_CLOSE)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		sHelper.addDialogDismissButtons(buttonSizer)
-		mainSizer.Add(settingsSizer, border=20, flag=wx.ALL)
+		mainSizer.Add(settingsSizer, border=20, flag=wx.ALL | wx.EXPAND, proportion=1)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 
@@ -732,8 +736,13 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		button.Bind(wx.EVT_BUTTON, self.onClose)
 
 		self.refreshAddonsList()
-		self.addonsList.SetFocus()
+		self.SetMinSize(mainSizer.GetMinSize())
+		# Historical initial size, result of L{self.addonsList} being (550, 350) as of 1364839447.
+		# Setting an initial size on L{self.addonsList} directly would also sets its minimum size
+		# and thus forbid to shrink the dialog.
+		self.SetSize(self.scaleSize((606, 525)))
 		self.CentreOnScreen()
+		self.addonsList.SetFocus()
 
 	def _getIncompatReason(self, addon):
 		if not addonVersionCheck.hasAddonGotRequiredSupport(

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -275,8 +275,8 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		self.refreshAddonsList()
 		self.SetMinSize(mainSizer.GetMinSize())
 		# Historical initial size, result of L{self.addonsList} being (550, 350) as of 1364839447.
-		# Setting an initial size on L{self.addonsList} directly would also sets its minimum size
-		# and thus forbid to shrink the dialog.
+		# Setting an initial size on L{self.addonsList} by passing a L{size} argument when
+		# creating the control would also set its minimum size and thus block the dialog from being shrunk.
 		self.SetSize(self.scaleSize((763, 509)))
 		self.CentreOnScreen()
 		self.addonsList.SetFocus()

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -274,7 +274,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		self.SetSizer(mainSizer)
 		self.refreshAddonsList()
 		self.SetMinSize(mainSizer.GetMinSize())
-		# Historical initial size, result of L{self.addonsList} being (550, 350) as of 1364839447.
+		# Historical initial size, result of L{self.addonsList} being (550, 350) as of commit 1364839447.
 		# Setting an initial size on L{self.addonsList} by passing a L{size} argument when
 		# creating the control would also set its minimum size and thus block the dialog from being shrunk.
 		self.SetSize(self.scaleSize((763, 509)))

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -162,7 +162,8 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		wx.Dialog.__init__(
 			self,
 			parent,
-			title=title if not globalVars.appArgs.disableAddons else titleWhenAddonsAreDisabled
+			title=title if not globalVars.appArgs.disableAddons else titleWhenAddonsAreDisabled,
+			style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
 		)
 		DpiScalingHelperMixin.__init__(self, self.GetHandle())
 
@@ -191,8 +192,9 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 			nvdaControls.AutoWidthColumnListCtrl(
 				parent=self,
 				style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
-				size=self.scaleSize((550, 350))
-			)
+			),
+			flag=wx.EXPAND,
+			proportion=1,
 		)
 		# Translators: The label for a column in add-ons list used to identify add-on package name (example: package is OCR).
 		self.addonsList.InsertColumn(0, _("Package"), width=self.scaleSize(150))
@@ -229,7 +231,8 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		mainSizer.Add(
 			listAndButtonsSizerHelper.sizer,
 			border=guiHelper.BORDER_FOR_DIALOGS,
-			flag=wx.ALL
+			flag=wx.ALL | wx.EXPAND,
+			proportion=1,
 		)
 
 		# the following buttons are more general and apply regardless of the current selection.
@@ -270,8 +273,13 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
 		self.refreshAddonsList()
-		self.addonsList.SetFocus()
+		self.SetMinSize(mainSizer.GetMinSize())
+		# Historical initial size, result of L{self.addonsList} being (550, 350) as of 1364839447.
+		# Setting an initial size on L{self.addonsList} directly would also sets its minimum size
+		# and thus forbid to shrink the dialog.
+		self.SetSize(self.scaleSize((763, 509)))
 		self.CentreOnScreen()
+		self.addonsList.SetFocus()
 
 	def onAddClick(self, evt):
 		# Translators: The message displayed in the dialog that allows you to choose an add-on package for installation.

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -127,7 +127,7 @@ def associateElements( firstElement, secondElement):
 		sizer = wx.BoxSizer(wx.VERTICAL)
 		sizer.Add(firstElement)
 		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_VERTICAL)
-		sizer.Add(secondElement, flag=wx.EXPAND)
+		sizer.Add(secondElement, flag=wx.EXPAND, proportion=1)
 	# button and checkBox
 	elif isinstance(firstElement, wx.Button) and isinstance(secondElement, wx.CheckBox):
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -284,7 +284,7 @@ class BoxSizerHelper(object):
 		"""
 		labeledControl = LabeledControlHelper(self._parent, labelText, wxCtrlClass, **kwargs)
 		if(isinstance(labeledControl.control, (wx.ListCtrl,wx.ListBox,wx.TreeCtrl))):
-			self.addItem(labeledControl.sizer, flag=wx.EXPAND)
+			self.addItem(labeledControl.sizer, flag=wx.EXPAND, proportion=1)
 		else:
 			self.addItem(labeledControl.sizer)
 		return labeledControl.control


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Progress on #6332

### Summary of the issue:

As stated by @feerrenrut in https://github.com/nvaccess/nvda/issues/6332#issue-175024733

> Some of the dialogs would benefit from being resizable. Dialogs with list controls (single or multi-column) or tree views often have entries that are much bigger than the space allocated to them. This can make them more difficult to read. While ideally all dialogs would have a layout that finds the balance between ease to read and not looking oversized, a fairly simple fallback option is to make the dialogs resizable. A user can just resize the dialog in order to fit the content they are interested in on the screen.

### Description of how this pull request fixes the issue:

Make both the Addons and the Incompatible Addons dialogs resizeable and maximizable.

### Testing performed:

Shrunk and enlarged the dialog with different proportions to ensure its layout stays coherent.

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

I do not think this change deserves to be announced.