### PR TITLE
Fix up of: Fix gui alignment issues (#6287) - addItem keywords

### DIFF
--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -248,14 +248,15 @@ class BoxSizerHelper(object):
 		if isinstance(item, ButtonHelper):
 			toAdd = item.sizer
 			buttonBorderAmount = 5
-			keywordArgs.update({'border':buttonBorderAmount, 'flag':wx.ALL})
+			keywordArgs["border"] = buttonBorderAmount
+			keywordArgs["flag"] = keywordArgs.get("flag", 0) | wx.ALL
 			shouldAddSpacer = False # no need to add a spacer, since the button border has been added.
 		elif isinstance(item, BoxSizerHelper):
 			toAdd = item.sizer
 		elif isinstance(item, PathSelectionHelper):
 			toAdd = item.sizer
 			if self.sizer.GetOrientation() == wx.VERTICAL:
-				keywordArgs['flag'] = wx.EXPAND
+				keywordArgs["flag"] = keywordArgs.get("flag", 0) | wx.EXPAND
 			else:
 				raise NotImplementedError("Adding PathSelectionHelper to a horizontal BoxSizerHelper is not implemented")
 		elif isinstance(item, LabeledControlHelper):
@@ -263,7 +264,7 @@ class BoxSizerHelper(object):
 
 		# a boxSizerHelper could contain a wx.StaticBoxSizer
 		if isinstance(toAdd, (wx.StaticBoxSizer, scrolledpanel.ScrolledPanel)):
-			keywordArgs['flag'] = wx.EXPAND
+			keywordArgs["flag"] = keywordArgs.get("flag", 0) | wx.EXPAND
 
 		if shouldAddSpacer:
 			self.sizer.AddSpacer(SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix up of PR #6287

### Summary of the issue:

The docstring for `BoxSizerHelper.addItem` claims to pass its keywords arguments to the `wx.Sizer.Add` method.

The current implementation as of 87ed4d17fe fails to do so.
When it has to force a particular flag - which is fine - it also overrides any other flag intentionally passed by the caller - which is not.

### Description of how this pull request fixes the issue:

Amend flags instead of overriding them.

### Testing performed:

### Known issues with pull request:

### Change log entry:

I do not think this deserves to be announced.