### PR TITLE
Fix up of: Hide the mouse when screen curtain is on (PR #10182)

### DIFF
--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -84,9 +84,13 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 		Magnification.MagShowSystemCursor(False)
 
 	def terminate(self):
-		super(VisionEnhancementProvider, self).terminate()
-		Magnification.MagShowSystemCursor(True)
-		Magnification.MagUninitialize()
+		try:
+			super(VisionEnhancementProvider, self).terminate()
+			Magnification.MagUninitialize()
+		except:  # noqa: E722
+			raise
+		finally:
+			Magnification.MagShowSystemCursor(True)
 
 	def registerEventExtensionPoints(self, extensionPoints):
 		# The screen curtain isn't interested in any events

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -80,8 +80,8 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 	def __init__(self):
 		super(VisionEnhancementProvider, self).__init__()
 		Magnification.MagInitialize()
-		Magnification.MagShowSystemCursor(False)
 		Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
+		Magnification.MagShowSystemCursor(False)
 
 	def terminate(self):
 		super(VisionEnhancementProvider, self).terminate()

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -86,11 +86,9 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 	def terminate(self):
 		try:
 			super(VisionEnhancementProvider, self).terminate()
-			Magnification.MagUninitialize()
-		except:  # noqa: E722
-			raise
 		finally:
 			Magnification.MagShowSystemCursor(True)
+			Magnification.MagUninitialize()
 
 	def registerEventExtensionPoints(self, extensionPoints):
 		# The screen curtain isn't interested in any events


### PR DESCRIPTION
Only hide the mouse when screen curtain effectively turned on.
This prevents the mouse to disappear if the screen curtain could no be turned
on because the Windows Magnifier is started.

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix up of PR #9982 

### Summary of the issue:

If the Windows Magnifier is on, Screen Curtain fails to turn on but the mouse is hidden.
To show the mouse again, one has to turn Windows Magnifier off then turn Screen Curtain on and off then turn Windows Magnifier back on.

### Description of how this pull request fixes the issue:

Hide the mouse only when Screen Curtain effectively turned on.

### Testing performed:

Checked the mouse is not hidden if Screen Curtain failed to turn on.
Checked the mouse is hidden if Screen Curtain succeeded to turn on.
Checked the mouse is shown again when Screen Curtain is turned off.

### Known issues with pull request:

### Change log entry:

N/A