### PR TITLE
Vocalize MS Word change tracking activation and deactivation.

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1360,13 +1360,17 @@ class WordDocument(Window):
 		# Translators: a message when increasing or decreasing font size in Microsoft Word
 		ui.message(_("{size:g} point font").format(size=val))
 
-	def script_toggleChangeTracking(self,gesture):
+	def script_toggleChangeTracking(self, gesture):
 		if not self.WinwordDocumentObject:
 			# We cannot fetch the Word object model, so we therefore cannot report the status change.
-			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail, or its within Windows Defender Application Guard.
-			# In this case, just let the gesture through and don't erport anything.
+			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,
+			# or it's within Windows Defender Application Guard.
+			# In this case, just let the gesture through and don't report anything.
 			return gesture.send()
-		val=self._WaitForValueChangeForAction(lambda: gesture.send(),lambda: self.WinwordDocumentObject.TrackRevisions)
+		val = self._WaitForValueChangeForAction(
+			lambda: gesture.send(),
+			lambda: self.WinwordDocumentObject.TrackRevisions
+		)
 		if val:
 			# Translators: a message when toggling change tracking in Microsoft word
 			ui.message(_("Change tracking on"))
@@ -1478,7 +1482,7 @@ class WordDocument(Window):
 		"kb:control+1":"changeLineSpacing",
 		"kb:control+2":"changeLineSpacing",
 		"kb:control+5":"changeLineSpacing",
-		"kb:control+shift+e":"toggleChangeTracking",
+		"kb:control+shift+e": "toggleChangeTracking",
 		"kb:tab": "tab",
 		"kb:shift+tab": "tab",
 		"kb:control+pageUp": "caret_moveByLine",

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1368,10 +1368,10 @@ class WordDocument(Window):
 			return gesture.send()
 		val=self._WaitForValueChangeForAction(lambda: gesture.send(),lambda: self.WinwordDocumentObject.TrackRevisions)
 		if val:
-			# Translators: a message when toggling track changes in Microsoft word
+			# Translators: a message when toggling change tracking in Microsoft word
 			ui.message(_("Change tracking on"))
 		else:
-			# Translators: a message when toggling track changes in Microsoft word
+			# Translators: a message when toggling change tracking in Microsoft word
 			ui.message(_("Change tracking off"))
 	
 	def script_tab(self,gesture):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1360,6 +1360,20 @@ class WordDocument(Window):
 		# Translators: a message when increasing or decreasing font size in Microsoft Word
 		ui.message(_("{size:g} point font").format(size=val))
 
+	def script_toggleChangeTracking(self,gesture):
+		if not self.WinwordDocumentObject:
+			# We cannot fetch the Word object model, so we therefore cannot report the status change.
+			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail, or its within Windows Defender Application Guard.
+			# In this case, just let the gesture through and don't erport anything.
+			return gesture.send()
+		val=self._WaitForValueChangeForAction(lambda: gesture.send(),lambda: self.WinwordDocumentObject.TrackRevisions)
+		if val:
+			# Translators: a message when toggling track changes in Microsoft word
+			ui.message(_("Change tracking on"))
+		else:
+			# Translators: a message when toggling track changes in Microsoft word
+			ui.message(_("Change tracking off"))
+	
 	def script_tab(self,gesture):
 		"""
 		A script for the tab key which:
@@ -1464,6 +1478,7 @@ class WordDocument(Window):
 		"kb:control+1":"changeLineSpacing",
 		"kb:control+2":"changeLineSpacing",
 		"kb:control+5":"changeLineSpacing",
+		"kb:control+shift+e":"toggleChangeTracking",
 		"kb:tab": "tab",
 		"kb:shift+tab": "tab",
 		"kb:control+pageUp": "caret_moveByLine",


### PR DESCRIPTION
### Link to issue number:
fixes #942

### Summary of the issue:
In MS Word, the toggle shortcut control+shift+E to enable or disable change tracking is not vocalized.

### Description of how this pull request fixes the issue:
This PR allows to have the change tracking state announced when the change tracking gesture is executed.
This PR does not include the possibly required changes in each local gestures.ini files to match the word localized shortcut to toggle change tracking activation. This need to be done by translators.

### Testing performed:
Test on French MS Word where change tracking toggle shortcut is Ctrl+Shift+R insstead of Ctrl+Shift+E.
1. Modify fr local gestures.ini file as follow:
```
@@ -9,7 +9,8 @@
        toggleRightMouseButton = kb(laptop):nvda+control+*

 [NVDAObjects.window.winword.WordDocument]
-       None = kb:control+b, kb:control+[, kb:control+], "kb:control+shift+,", kb:control+shift+., kb:control+l, kb:cont
rol+r
+       None = kb:control+b, kb:control+[, kb:control+], "kb:control+shift+,", kb:control+shift+., kb:control+l, kb:cont
rol+r, kb:control+shift+e^M
        increaseDecreaseFontSize = kb:control+shift+<, kb:control+shift+>, kb:control+alt+<, kb:control+alt+>
        toggleBold = kb:control+g, kb:control+shift+b
        toggleAlignment = kb:control+shift+g, kb:control+shift+d
+       toggleChangeTracking = kb:control+shift+r^M
```
2. Open a new document in word and start typing "Hello "
3. Press Ctrl+Shift+R
4. Type "the "
5. Press Ctrl+Shift+R
6. Type "world !"
7. Go back with left arrow to see what is marked as inserted.

Checked that the shortcut is correctly vocalized at step 3 and 5 and that the word "the" is marked as inserted at step 7.

### Known issues with pull request:
None

### Change log entry:
*Changes*
`The shortcut to toggle change tracking state now announce the new change tracking state in Microsoft Word . (#942)`


