### PR TITLE
Fix up of: Add filtering functionality to the symbols list (#8790, #10216) - Py2

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2955,7 +2955,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 
 		# Translators: The label for the edit field in symbol pronunciation dialog to change the replacement text of a symbol.
 		replacementText = _("&Replacement")
-		self.replacementEdit = sHelper.addLabeledControl(
+		self.replacementEdit = changeSymbolHelper.addLabeledControl(
 			labelText=replacementText,
 			wxCtrlClass=wx.TextCtrl,
 			size=self.scaleSize((300, -1)),


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10216
Fix up of #8790
Backport of #10217 from master to beta

### Summary of the issue:

On the Speech Symbols dialog, the Replacement field has visually moved but remains at the same tab index.
On some systems, probably depending on display scale settings, the field is not visible at all.

### Description of how this pull request fixes the issue:

Restore the visual position of the field.

### Testing performed:

### Known issues with pull request:

### Change log entry:

I do not think this deserves to be announced.