### PR TITLE
Ensure short single lines before a prompt are still spoken in terminals 

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -3,7 +3,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Joseph Lee
+# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Joseph Lee, Bill Dengler
 
 """Mix-in classes which provide common behaviour for particular types of controls across different APIs.
 Behaviors described in this mix-in include providing table navigation commands for certain table rows, terminal input and output support, announcing notifications and suggestion items and so on.
@@ -264,6 +264,8 @@ class LiveText(NVDAObject):
 	def _reportNewLines(self, lines):
 		"""
 		Reports new lines of text using _reportNewText for each new line.
+		Subclasses may override this method to provide custom filtering of new text,
+		where logic depends on multiple lines.
 		"""
 		for line in lines:
 			self._reportNewText(line)

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#NVDAObjects/behaviors.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Joseph Lee
+# NVDAObjects/behaviors.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Joseph Lee
 
 """Mix-in classes which provide common behaviour for particular types of controls across different APIs.
 Behaviors described in this mix-in include providing table navigation commands for certain table rows, terminal input and output support, announcing notifications and suggestion items and so on.
@@ -261,6 +261,13 @@ class LiveText(NVDAObject):
 		"""
 		return list(self.makeTextInfo(textInfos.POSITION_ALL).getTextInChunks(textInfos.UNIT_LINE))
 
+	def _reportNewLines(self, lines):
+		"""
+		Reports new lines of text using _reportNewText for each new line.
+		"""
+		for line in lines:
+			self._reportNewText(line)
+
 	def _reportNewText(self, line):
 		"""Report a line of new text.
 		"""
@@ -294,8 +301,8 @@ class LiveText(NVDAObject):
 						# which probably means it is just a typed character,
 						# so ignore it.
 						del outLines[0]
-					for line in outLines:
-						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewText, line)
+					if outLines:
+						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewLines, outLines)
 				oldLines = newLines
 			except:
 				log.exception("Error getting lines or calculating new text")
@@ -397,14 +404,15 @@ class KeyboardHandlerBasedTypedCharSupport(Terminal):
 	#: be short.
 	_hasTab = False
 
-	def _reportNewText(self, line):
+	def _reportNewLines(self, lines):
 		# Perform typed character filtering, as typed characters are handled with events.
 		if (
-			not self._hasTab
-			and len(line.strip()) < max(len(speech.curWordChars) + 1, 3)
+			len(lines) == 1
+			and not self._hasTab
+			and len(lines[0].strip()) < max(len(speech.curWordChars) + 1, 3)
 		):
 			return
-		super()._reportNewText(line)
+		super()._reportNewLines(lines)
 
 	def event_typedCharacter(self, ch):
 		if ch == '\t':


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10166 

### Summary of the issue:
Currently in terminals that use the KeyboardHandlerBasedTypedCharSupport class, such as Windows command consoles in Windows 10, a new short single line of text before a prompt is not spoken, as it is filtered out as possibly being a typed character.
For example:
In a WSL bash prompt: typing:
```
echo x
```
and pressing enter, causes only the bash prompt to be spoken and not the 'x'.
Although we still need to filter out a line that only consists of 1 to 3 characters, we should only do it if there are no other new lines to be spoken at the same time.

### Description of how this pull request fixes the issue:
* In the LiveText NVDAObject: add a new _reportNewLines method which takes the new lines to be spoken and calls _reportNewText on each.
* in KeyboardHandlerBasedTypedCharSupport, handle the filtering of possible typed characters in _reportNewLines rather than _reportNewText, and only filter if only one line is given.
 
### Testing performed:
Opened a wsl terminal in Windows 10 1903. Typed ```echo x``` and pressed enter. NVDA announced 'x' and the bash prompt.
To be honest I could not come up with a testcase where new text wold be treeted as a typed character, as _monitor already gets rid of single characters on one new line by itself before this.
 
### Known issues with pull request:
None known.

### Change log entry:
Bug fixes:
* NVDA will no longer fail to announce a short line of new text before a prompt in terminals such as Windows command consoles. 