### PR TITLE
2019.2 backport: No longer use UIA rangeFromPoint in windows 7

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -32,6 +32,7 @@ from NVDAObjects.behaviors import ProgressBar, EditableTextWithoutAutoSelectDete
 import braille
 from locationHelper import RectLTWH
 import ui
+import winVersion
 
 class UIATextInfo(textInfos.TextInfo):
 
@@ -309,7 +310,9 @@ class UIATextInfo(textInfos.TextInfo):
 			# sometimes rangeFromChild can return a NULL range
 			if not self._rangeObj: raise LookupError
 		elif isinstance(position,textInfos.Point):
-			#rangeFromPoint used to cause a freeze in UIA client library!
+			if (winVersion.winVersion.major, winVersion.winVersion.minor) == (6, 1):
+				# #9435: RangeFromPoint causes a freeze in UIA client library in the Windows 7 start menu!
+				raise NotImplementedError("RangeFromPoint not supported on Windows 7")
 			p=POINT(position.x,position.y)
 			self._rangeObj=self.obj.UIATextPattern.RangeFromPoint(p)
 		elif isinstance(position,UIAHandler.IUIAutomationTextRange):


### PR DESCRIPTION
Backport of pr #10104 to 2019.2.