### PR TITLE
IA2: Do not treat huge base64 data as NVDA might freeze in Google Chrome (#10227)

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -1021,7 +1021,7 @@ def splitIA2Attribs(attribsString):
 	@return: A dict of the attribute keys and values, where values are strings or dicts.
 	@rtype: {str: str or {str: str}}
 	"""
-	# Do not treat huge base64 data as it might freeze Google Chrome (#10227)
+	# Do not treat huge base64 data as it might freeze NVDA in Google Chrome (#10227)
 	if len(attribsString) >= ATTRIBS_STRING_BASE64_THRESHOLD:
 		attribsString = ATTRIBS_STRING_BASE64_PATTERN.sub("base64,<truncated>", attribsString)
 		if len(attribsString) >= ATTRIBS_STRING_BASE64_THRESHOLD:

--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -29,6 +29,8 @@ import mouseHandler
 import controlTypes
 import keyboardHandler
 import core
+import re
+
 
 MAX_WINEVENTS=500
 MAX_WINEVENTS_PER_THREAD=10
@@ -1005,6 +1007,11 @@ def getRecursiveTextFromIAccessibleTextObject(obj,startOffset=0,endOffset=-1):
 		textList.append(t)
 	return "".join(textList).replace('  ',' ')
 
+
+ATTRIBS_STRING_BASE64_PATTERN = re.compile(r"base64\\,[A-Za-z0-9+/=]+")
+ATTRIBS_STRING_BASE64_THRESHOLD = 4096
+
+
 def splitIA2Attribs(attribsString):
 	"""Split an IAccessible2 attributes string into a dict of attribute keys and values.
 	An invalid attributes string does not cause an error, but strange results may be returned.
@@ -1014,6 +1021,11 @@ def splitIA2Attribs(attribsString):
 	@return: A dict of the attribute keys and values, where values are strings or dicts.
 	@rtype: {str: str or {str: str}}
 	"""
+	# Do not treat huge base64 data as it might freeze Google Chrome (#10227)
+	if len(attribsString) >= ATTRIBS_STRING_BASE64_THRESHOLD:
+		attribsString = ATTRIBS_STRING_BASE64_PATTERN.sub("base64,<truncated>", attribsString)
+		if len(attribsString) >= ATTRIBS_STRING_BASE64_THRESHOLD:
+			log.debugWarning(f"IA2 attributes string exceeds threshold: {attribsString}")
 	attribsDict = {}
 	tmp = ""
 	key = ""


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Python side of #10227

### Summary of the issue:

Huge base64 embedded in the `src` attribute of an `img` element can freeze Google Chrome.

### Description of how this pull request fixes the issue:

When the IA2 attribute string exceeds a threshold of 4096 characters, truncate the base64 from the text passed to `IAccessibleHandler.splitIA2Attribs` before treating it.

### Testing performed:

### Known issues with pull request:

The huge base64 is still uselessly present in the Virtual Buffer data.
The NVDAHelper thus would probably benefit from an impact on that regard.

### Change log entry:

Section: Bug fixes

NVDA no longer crashes in Google Chrome when an image contains huge base64 data.