### PR TITLE
2019.2: Revert "Update liblouis to version 3.10 (#9678)"

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -40,7 +40,7 @@ if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
 # Ignore all warnings as the code is not ours
-env.Append(CCFLAGS='/W0')
+env.Replace(CCFLAGS='/W0')
 
 env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir,espeakSrcDir.Dir('ucd-tools/src/include')])
 

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -40,7 +40,7 @@ if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
 # Ignore all warnings as the code is not ours
-env.Replace(CCFLAGS='/W0')
+env.Append(CCFLAGS='/W0')
 
 env.Append(CPPPATH=['#nvdaHelper/espeak',espeakIncludeDir,espeakIncludeDir.Dir('compat'),sonicSrcDir,espeakSrcDir.Dir('ucd-tools/src/include')])
 

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -41,9 +41,6 @@ env = env.Clone()
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
-# Ignore some warnings as the code is not ours
-env.Replace(CCFLAGS='/W2')
-
 env.Append(CPPDEFINES=[
 	# The Visual C++ C Runtime deprecates several standard library functions in
 	# preference for _s variants that are specific to Visual C++. This removes

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ For reference, the following dependencies are included in Git submodules:
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
-* [liblouis](http://www.liblouis.org/), version 3.10.0
+* [liblouis](http://www.liblouis.org/), version 3.9.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
 * System dlls not present on many systems: mfc90.dll, msvcp90.dll, msvcr90.dll, Microsoft.VC90.CRT.manifest


### PR DESCRIPTION
This reverts commit d5ed95ce01d3d1d79a0367b2cded83cfd1527df8.

### Link to issue number:
Fixes #9982 

### Summary of the issue:
Large chinese braille tables are unable to load in some cases when using Liblouis 3.10. Downgrading to Liblouis 3.9 seems to fix this according to https://github.com/nvaccess/nvda/issues/9982#issuecomment-525925925

### Description of how this pull request fixes the issue:
Downgrades to liblouis 3.9 by reverting the 3.10 pr

### Testing performed:
Tested in a try build that the issues for Chinese no longer occurred.

### Known issues with pull request:
* I had a branch that was based on rc, and when I rebased on beta, I noticed that there are commits in rc not in beta.
* In https://github.com/nvaccess/nvda/issues/9982#issuecomment-526208475, @josephsl expressed concerns about a downgrade
* We probably have to be very careful when merging beta into master.

### Change log entry:
* Downgraded liblouis to version 3.9 to solve issues when loading Chinese braille tables. (#9982) 