### PR TITLE
displayModel.getCaretRect: return a locationHelper.RectLTRB instance

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -4,6 +4,7 @@
 #See the file COPYING for more details.
 #Copyright (C) 2006-2017 NV Access Limited, Babbage B.V.
 
+import ctypes
 from ctypes import *
 from ctypes.wintypes import RECT
 from comtypes import BSTR
@@ -169,14 +170,22 @@ def initialize():
 	_requestTextChangeNotificationsForWindow=NVDAHelper.localLib.displayModel_requestTextChangeNotificationsForWindow
 
 def getCaretRect(obj):
-	left=c_long()
-	top=c_long()
-	right=c_long()
-	bottom=c_long()
-	res=watchdog.cancellableExecute(NVDAHelper.localLib.displayModel_getCaretRect, obj.appModule.helperLocalBindingHandle, obj.windowThreadID, byref(left),byref(top),byref(right),byref(bottom))
-	if res!=0:
-			raise RuntimeError("displayModel_getCaretRect failed with res %d"%res)
-	return RECT(left,top,right,bottom)
+	left = ctypes.c_long()
+	top = ctypes.c_long()
+	right = ctypes.c_long()
+	bottom = ctypes.c_long()
+	res = watchdog.cancellableExecute(
+		NVDAHelper.localLib.displayModel_getCaretRect,
+		obj.appModule.helperLocalBindingHandle,
+		obj.windowThreadID,
+		ctypes.byref(left),
+		ctypes.byref(top),
+		ctypes.byref(right),
+		ctypes.byref(bottom)
+	)
+	if res != 0:
+		raise RuntimeError(f"displayModel_getCaretRect failed with res {res}")
+	return RectLTRB(left, top, right, bottom)
 
 def getWindowTextInRect(bindingHandle, windowHandle, left, top, right, bottom,minHorizontalWhitespace,minVerticalWhitespace,stripOuterWhitespace=True,includeDescendantWindows=True):
 	text, cpBuf = watchdog.cancellableExecute(_getWindowTextInRect, bindingHandle, windowHandle, includeDescendantWindows, left, top, right, bottom,minHorizontalWhitespace,minVerticalWhitespace,stripOuterWhitespace)
@@ -555,7 +564,12 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 	minVerticalWhitespace=4
 	stripOuterWhitespace=False
 
-	def _findCaretOffsetFromLocation(self,caretRect,validateBaseline=True,validateDirection=True):
+	def _findCaretOffsetFromLocation(
+			selff,
+			caretRect: RectLTRB,
+			validateBaseline: bool = True,
+			validateDirection: bool = True
+	):
 		# Accepts logical coordinates.
 		for charOffset, ((charLeft, charTop, charRight, charBottom),charBaseline,charDirection) in enumerate(self._getStoryOffsetLocations()):
 			# Skip any character that does not overlap the caret vertically
@@ -577,17 +591,10 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 		raise LookupError
 
 	def _getCaretOffset(self):
-		caretRect=getCaretRect(self.obj)
-		objLocation=self.obj.location
-		objRect=RECT(objLocation[0],objLocation[1],objLocation[0]+objLocation[2],objLocation[1]+objLocation[3])
-		objRect.left,objRect.top=windowUtils.physicalToLogicalPoint(
-			self.obj.windowHandle,objRect.left,objRect.top)
-		objRect.right,objRect.bottom=windowUtils.physicalToLogicalPoint(
-			self.obj.windowHandle,objRect.right,objRect.bottom)
-		caretRect.left=max(objRect.left,caretRect.left)
-		caretRect.top=max(objRect.top,caretRect.top)
-		caretRect.right=min(objRect.right,caretRect.right)
-		caretRect.bottom=min(objRect.bottom,caretRect.bottom)
+		caretRect = getCaretRect(self.obj)
+		objLocation = self.obj.location
+		objRect = objLocation.toLTRB().toLogical(self.obj.windowHandle)
+		caretRect = caretRect.intersection(objRect)
 		# Find a character offset where the caret overlaps vertically, overlaps horizontally, overlaps the baseline and is totally within or on the correct side for the reading order
 		try:
 			return self._findCaretOffsetFromLocation(caretRect,validateBaseline=True,validateDirection=True)

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -595,6 +595,8 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 		objLocation = self.obj.location
 		objRect = objLocation.toLTRB().toLogical(self.obj.windowHandle)
 		caretRect = caretRect.intersection(objRect)
+		if not any(caretRect):
+			raise RuntimeError("The caret rectangle does not overlap with the window")
 		# Find a character offset where the caret overlaps vertically, overlaps horizontally, overlaps the baseline and is totally within or on the correct side for the reading order
 		try:
 			return self._findCaretOffsetFromLocation(caretRect,validateBaseline=True,validateDirection=True)

--- a/source/vision/util.py
+++ b/source/vision/util.py
@@ -27,11 +27,11 @@ def getCaretRect(obj: Optional[TextContainerObject] = None) -> locationHelper.Re
 		obj = obj.treeInterceptor
 	if api.isNVDAObject(obj):
 		# Import late to avoid circular import
-		from displayModel import getCaretRect
+		import displayModel
 		# Check whether there is a caret in the window.
 		# Note that, even windows that don't have navigable text could have a caret, such as in Excel.
 		try:
-			return locationHelper.RectLTRB.fromCompatibleType(getCaretRect(obj))
+			return displayModel.getCaretRect(obj)
 		except RuntimeError:
 			if not obj._hasNavigableText:
 				raise LookupError


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
As part of the Python 3 migration, we removed textInfos.Rect and textInfos.Point in favor of the locationHelper classes. However, it turns out that displayModel.getCaretRect still returned a ctypes.wintypes.RECT. This function is used by the vision framework, where it has to be reconverted to a RectLTRB. It also does not benefit from other locationHelper advantages, such as point conversion and intersection calculation.

### Description of how this pull request fixes the issue:
1. displayModel.getCaretRect now returns a locationHelper.RectLTRB. This change is backwards compatible on the class level, not on the attribute level, i.e. both classes have left, top, right and bottom attributes
2. When finding an offset for the caret, the intersection is now calculated by locationHelper instead of manually. Note that the code of the intersection method is roughly the same as the code that has been removed from the displayModel module. I also added a check that raises a RuntimeError when the caret rectangle does not overlap with the window the caret belongs to, something that will probably never happen.

### Testing performed:
Tested that the caret offset can still be detected in EditableTextDisplayModelTextInfo

### Known issues with pull request:
None

### Change log entry:
* Changes for developers, probably near the section about the removal of textInfos.* classes
    + displayModel.getCaretRect now returns an instance of locationHelper.RectLTRB.