### PR TITLE
Fix comInterfaces_sconscript to no longer fail on wrapper module creation

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -38,6 +38,7 @@ def recursiveCopy(env,targetDir,sourceDir):
 import gettext
 gettext.install("nvda")
 sys.path.append("source")
+import comtypesMonkeyPatches
 import versionInfo
 del sys.path[-1]
 

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -24,6 +24,8 @@ def interfaceAction(target,source,env):
 		source=(clsid,env['majorVersion'],env['minorVersion'])
 	else:
 		source=str(source[0])
+	# Make sure the importlib cache is empty as a new module will be generated.
+	importlib.invalidate_caches()
 	comtypes.client.GetModule(source)
 
 interfaceBuilder=env.Builder(
@@ -31,11 +33,9 @@ interfaceBuilder=env.Builder(
 )
 env['BUILDERS']['comtypesInterface']=interfaceBuilder
 
-	#Bit of a dance to force comtypes generated interfaces in to our directory
+# Force comtypes generated interfaces in to our directory
 import comtypes.client
 comtypes.client.gen_dir=Dir('comInterfaces').abspath
-import sys
-sys.modules['comtypes.gen']=comtypes.gen=__import__("comInterfaces",globals(),locals(),[])
 
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -24,8 +24,6 @@ def interfaceAction(target,source,env):
 		source=(clsid,env['majorVersion'],env['minorVersion'])
 	else:
 		source=str(source[0])
-	# Make sure the importlib cache is empty as a new module will be generated.
-	importlib.invalidate_caches()
 	comtypes.client.GetModule(source)
 
 interfaceBuilder=env.Builder(

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -1,10 +1,12 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2009-2016 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2009-2019 NV Access Limited, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import ctypes
 import _ctypes
+import importlib
+import comtypes.client._generate
 
 # A version of ctypes.WINFUNCTYPE 
 # that produces a WinFunctionType class whose instance will convert COMError into a CallCancelled exception when called as a function.
@@ -125,3 +127,15 @@ def _check_version(actual):
 	if actual != required:
 		raise ImportError("Wrong version")
 comtypes._check_version = _check_version
+
+
+# Monkeypatch comtypes to clear the importlib cache when importing a new module
+old_my_import = comtypes.client._generate._my_import
+
+
+def new_my_import(fullname):
+	importlib.invalidate_caches()
+	return old_my_import(fullname)
+
+
+comtypes.client._generate._my_import = new_my_import


### PR DESCRIPTION
### Link to issue number:
Fixes #10228 

### Summary of the issue:
Comtypes wrapper module creation sometimes fails as the Python import mechanism creates a cache of paths we can import from, and that cache doesn't like frequent updates. See also https://github.com/enthought/comtypes/pull/172

### Description of how this pull request fixes the issue:
Monkeypatch comtypes.client._generate._my_import to clear the importlib cache first. Make sure comtypes is monkeypatches in our scons environment.

It also simplifies the patch that changes the wrapper generation directory, i.e. it no longer fiddles with sys.modules. Testing revealed that this is no longer necessary. Code revealed that thit is now done by comtypes.client._generate._my_import .

### Testing performed:
Tested as part of #10169 appveyor build. See also #10228 

### Known issues with pull request:
None

### Change log entry:
None
