### PR TITLE
Vocalize the shortcut to toggle displaying nonprintable characcters i…

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1392,10 +1392,10 @@ class WordDocument(Window):
 		)
 		if val:
 			# Translators: a message when toggling Display Nonprinting Characters in Microsoft word
-			ui.message(_("Display Nonprinting Characters on"))
+			ui.message(_("Display nonprinting characters"))
 		else:
 			# Translators: a message when toggling Display Nonprinting Characters in Microsoft word
-			ui.message(_("Display Nonprinting Characters off"))
+			ui.message(_("Hide nonprinting characters"))
 
 	@script(gestures=["kb:tab", "kb:shift+tab"])
 	def script_tab(self,gesture):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1378,6 +1378,7 @@ class WordDocument(Window):
 			# Translators: a message when toggling change tracking in Microsoft word
 			ui.message(_("Change tracking off"))
 
+	@script(gesture="kb:control+shift+8")
 	def script_toggleDisplayNonprintingCharacters(self, gesture):
 		if not self.WinwordWindowObject:
 			# We cannot fetch the Word object model, so we therefore cannot report the status change.
@@ -1502,7 +1503,6 @@ class WordDocument(Window):
 		"kb:control+2":"changeLineSpacing",
 		"kb:control+5":"changeLineSpacing",
 		"kb:control+shift+e": "toggleChangeTracking",
-		"kb:control+shift+8": "toggleDisplayNonprintingCharacters",
 		"kb:control+pageUp": "caret_moveByLine",
 		"kb:control+pageDown": "caret_moveByLine",
 	}

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1377,7 +1377,25 @@ class WordDocument(Window):
 		else:
 			# Translators: a message when toggling change tracking in Microsoft word
 			ui.message(_("Change tracking off"))
-	
+
+	def script_toggleDisplayNonprintingCharacters(self, gesture):
+		if not self.WinwordWindowObject:
+			# We cannot fetch the Word object model, so we therefore cannot report the status change.
+			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,
+			# or it's within Windows Defender Application Guard.
+			# In this case, just let the gesture through and don't report anything.
+			return gesture.send()
+		val = self._WaitForValueChangeForAction(
+			lambda: gesture.send(),
+			lambda: self.WinwordWindowObject.ActivePane.View.ShowAll
+		)
+		if val:
+			# Translators: a message when toggling Display Nonprinting Characters in Microsoft word
+			ui.message(_("Display Nonprinting Characters on"))
+		else:
+			# Translators: a message when toggling Display Nonprinting Characters in Microsoft word
+			ui.message(_("Display Nonprinting Characters off"))
+
 	@script(gestures=["kb:tab", "kb:shift+tab"])
 	def script_tab(self,gesture):
 		"""
@@ -1484,6 +1502,7 @@ class WordDocument(Window):
 		"kb:control+2":"changeLineSpacing",
 		"kb:control+5":"changeLineSpacing",
 		"kb:control+shift+e": "toggleChangeTracking",
+		"kb:control+shift+8": "toggleDisplayNonprintingCharacters",
 		"kb:control+pageUp": "caret_moveByLine",
 		"kb:control+pageDown": "caret_moveByLine",
 	}


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10241

### Summary of the issue:
In an MS Word Document, look at the end of a paragraph and press Ctrl+Shift+8 (main keyboard) 2 or 3 times. You will see the end of paragraph mark appear and disappear but NVDA does not give a vocal feedback of this action.


### Description of how this pull request fixes the issue:
NVDA announces the state of displaying nonprinting characters when the toggle shortcut Ctrl+Shift+8 is executed.

### Testing performed:
In a Word document pressed Ctrl+Shift+8 various times.

#### Blind check
NVDA announce "Display nonprinting character on" or "off" when the shortcut is executed. After each gesture, I have checked in the Home  ribbon, group paragraph that the state of "Show all" button is in accordance with the previously announced state.

#### Visual check
I have checked that NVDA announce "Display nonprinting character on" or "off" when end of paragraph and space marks appear and disappear at the same time.

### Known issues with pull request:
None

### Change log entry:

*Changes*
`NVDA now announces the state of display non printing character when pressing the toggle shortcut Ctrl+Shift+8 . (#10241)`

