### PR TITLE
Fix-up of: "displayModel.getCaretRect: return a locationHelper.RectLTRB instance", fixes issue in PuTTY

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -185,7 +185,11 @@ def getCaretRect(obj):
 	)
 	if res != 0:
 		raise RuntimeError(f"displayModel_getCaretRect failed with res {res}")
-	return RectLTRB(left, top, right, bottom)
+	return RectLTRB(
+		left.value,
+		top.value,right.value,
+		bottom.value
+	)
 
 def getWindowTextInRect(bindingHandle, windowHandle, left, top, right, bottom,minHorizontalWhitespace,minVerticalWhitespace,stripOuterWhitespace=True,includeDescendantWindows=True):
 	text, cpBuf = watchdog.cancellableExecute(_getWindowTextInRect, bindingHandle, windowHandle, includeDescendantWindows, left, top, right, bottom,minHorizontalWhitespace,minVerticalWhitespace,stripOuterWhitespace)
@@ -565,7 +569,7 @@ class EditableTextDisplayModelTextInfo(DisplayModelTextInfo):
 	stripOuterWhitespace=False
 
 	def _findCaretOffsetFromLocation(
-			selff,
+			self,
 			caretRect: RectLTRB,
 			validateBaseline: bool = True,
 			validateDirection: bool = True

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -187,7 +187,8 @@ def getCaretRect(obj):
 		raise RuntimeError(f"displayModel_getCaretRect failed with res {res}")
 	return RectLTRB(
 		left.value,
-		top.value,right.value,
+		top.value,
+		right.value,
 		bottom.value
 	)
 


### PR DESCRIPTION
### Link to issue number:
Fixes regressions introduced in #10233

### Summary of the issue:
It turns out that when implementing #10233, I used the wrong test case, thereby not actually testing that the changes worked as expected. Therefore, this pr introduces two mistakes:

1. selff instead of self in a method signature
2. Passing ctypes instances to RectLTRB instead of the actual integer values.

### Description of how this pull request fixes the issue:
Fixes these issues.

### Testing performed:
1. Tested that the caret position is again properly detected and read in putty.
2. Used `displayModel.getCaretRect(api.getFocusObject())` in the python console, getting the caret rectangle of the python console input window using the display model.

### Known issues with pull request:
None

### Change log entry:
None
Sectio