### PR TITLE
Ensure pickle files can be read by earlier versions of NVDA (#7105)

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -72,7 +72,7 @@ def saveState():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "wb") as f:
-			pickle.dump(state, f)
+			pickle.dump(state, f, protocol=0)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -744,7 +744,7 @@ def saveState():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(_stateFilename, "wb") as f:
-			pickle.dump(state, f)
+			pickle.dump(state, f, protocol=0)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 


### PR DESCRIPTION
Impacts both the add-ons state and the updater state files.
Both are now written using pickle protocol 0 so that Python 2 version of NVDA
can read them in case of downgrading.

Re https://github.com/nvaccess/nvda/pull/10224#issuecomment-533459119

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Pointed out in https://github.com/nvaccess/nvda/pull/10224#issuecomment-533459119

### Summary of the issue:

NVDA 2019.2 cannot read pickle files written by latest Python 3 master.
When testing with the default user configuration, this as the potential nasty effect of activating add-ons that were manually disabled.

### Description of how this pull request fixes the issue:

Use pickle protocol 0 instead of the default protocol 3.
This has the advantage of being readable by earlier versions of NVDA that open files in text mode before unpickling.
Both the add-ons state and the updater state files are impacted.

### Testing performed:

Ran a source copy, pointing to the installed 2019.2 configuration.
Checked that manually disabled compatible add-ons were still indeed marked as such.
Manually disabled a running add-on.
Saved the configuration, and launched installed 2019.2 to check the add-on state was preserved.

### Known issues with pull request:

Impacting the updater state file is maybe superfluous in this context.
For the better or the worse, it makes the updater behave the same when sharing a configuration between 2019.2 and master as between any other versions.

### Change log entry:

I don't think this deserves to be announced.

cc @leonardder