### PR TITLE
Make NVDA less verbose when  searching in Windows 7 start menu

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -292,6 +292,15 @@ class AppModule(appModuleHandler.AppModule):
 		# Lets hide that
 		if windowClass=="msctls_progress32" and winUser.getClassName(winUser.getAncestor(obj.windowHandle,winUser.GA_PARENT))=="Address Band Root":
 			obj.presentationType=obj.presType_layout
+			return
+
+		if windowClass == "DirectUIHWND" and role == controlTypes.ROLE_LIST:
+			parent = obj.parent.parent.parent
+			if parent is not None and parent.windowClassName == "Desktop Search Open View":
+				# List containing search results in Windows 7 start menu.
+				# Its name is not useful so discard it.
+				obj.name = None
+				return
 
 	def event_gainFocus(self, obj, nextHandler):
 		wClass = obj.windowClassName

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -296,12 +296,13 @@ class AppModule(appModuleHandler.AppModule):
 			return
 
 		if windowClass == "DirectUIHWND" and role == controlTypes.ROLE_LIST:
-			parent = obj.parent.parent.parent
-			if parent is not None and parent.windowClassName == "Desktop Search Open View":
-				# List containing search results in Windows 7 start menu.
-				# Its name is not useful so discard it.
-				obj.name = None
-				return
+			if obj.parent and obj.parent.parent:
+				parent = obj.parent.parent.parent
+				if parent is not None and parent.windowClassName == "Desktop Search Open View":
+					# List containing search results in Windows 7 start menu.
+					# Its name is not useful so discard it.
+					obj.name = None
+					return
 
 	def event_gainFocus(self, obj, nextHandler):
 		wClass = obj.windowClassName


### PR DESCRIPTION
### Link to issue number:
Fixes #2020
### Summary of the issue:
When performing a search in Windows 7 start menu NVDA is a little bit too verbose.
### Description of how this pull request fixes the issue:
The search results are inside a list which name is 'Items view'. As the name adds no useful information I've removed it as discussed in #2020.
### Testing performed:
- Ensured that all important information's are still spoken when search results are shown.
- Ensured that the name is really gone.
- Ensured that no other list is affected by this change.
### Known issues with pull request:
None known
### Change log entry:
I don't think that such entry is needed here.