### PR TITLE
General Settings GUI: Disable log level drop-down when log level is disabled or forced (#10209)

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -794,7 +794,7 @@ class GeneralSettingsPanel(SettingsPanel):
 		config.conf["general"]["askToExit"]=self.askToExitCheckBox.IsChecked()
 		config.conf["general"]["playStartAndExitSounds"]=self.playStartAndExitSoundsCheckBox.IsChecked()
 		logLevel=self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
-		if not logHandler.isLogLevelForced:
+		if not logHandler.isLogLevelForced():
 			config.conf["general"]["loggingLevel"] = logging.getLevelName(logLevel)
 			logHandler.setLogLevelFromConfig()
 		if self.startAfterLogonCheckBox.IsEnabled():

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -684,6 +684,8 @@ class GeneralSettingsPanel(SettingsPanel):
 		logLevelChoices = [name for level, name in self.LOG_LEVELS]
 		self.logLevelList = settingsSizerHelper.addLabeledControl(logLevelLabelText, wx.Choice, choices=logLevelChoices)
 		curLevel = log.getEffectiveLevel()
+		if logHandler.isLogLevelForced():
+			self.logLevelList.Disable()
 		for index, (level, name) in enumerate(self.LOG_LEVELS):
 			if level == curLevel:
 				self.logLevelList.SetSelection(index)
@@ -792,7 +794,8 @@ class GeneralSettingsPanel(SettingsPanel):
 		config.conf["general"]["askToExit"]=self.askToExitCheckBox.IsChecked()
 		config.conf["general"]["playStartAndExitSounds"]=self.playStartAndExitSoundsCheckBox.IsChecked()
 		logLevel=self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
-		config.conf["general"]["loggingLevel"]=logging.getLevelName(logLevel)
+		if not logHandler.isLogLevelForced:
+			config.conf["general"]["loggingLevel"] = logging.getLevelName(logLevel)
 		logHandler.setLogLevelFromConfig()
 		if self.startAfterLogonCheckBox.IsEnabled():
 			config.setStartAfterLogon(self.startAfterLogonCheckBox.GetValue())

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -796,7 +796,7 @@ class GeneralSettingsPanel(SettingsPanel):
 		logLevel=self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
 		if not logHandler.isLogLevelForced:
 			config.conf["general"]["loggingLevel"] = logging.getLevelName(logLevel)
-		logHandler.setLogLevelFromConfig()
+			logHandler.setLogLevelFromConfig()
 		if self.startAfterLogonCheckBox.IsEnabled():
 			config.setStartAfterLogon(self.startAfterLogonCheckBox.GetValue())
 		if self.startOnLogonScreenCheckBox.IsEnabled():

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -348,7 +348,7 @@ def isLogLevelForced() -> bool:
 def setLogLevelFromConfig():
 	"""Set the log level based on the current configuration.
 	"""
-	if isLogLevelForced:
+	if isLogLevelForced():
 		return
 	import config
 	levelName=config.conf["general"]["loggingLevel"]

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -317,6 +317,12 @@ def initialize(shouldDoRemoteLogging=False):
 			except (IOError, WindowsError):
 				pass # Probably log does not exist, don't care.
 			logHandler = FileHandler(globalVars.appArgs.logFileName, mode="w",encoding="utf-8")
+			logLevel = globalVars.appArgs.logLevel
+			if globalVars.appArgs.debugLogging:
+				logLevel = Logger.DEBUG
+			elif logLevel <= 0:
+				logLevel = Logger.INFO
+			log.setLevel(logLevel)
 	else:
 		logHandler = RemoteHandler()
 		logFormatter = Formatter("%(codepath)s:\n%(message)s")
@@ -327,12 +333,22 @@ def initialize(shouldDoRemoteLogging=False):
 	warnings.showwarning = _showwarning
 	warnings.simplefilter("default", DeprecationWarning)
 
+
+def isLogLevelForced() -> bool:
+	"""Check if the log level was overridden either from the command line or because of secure mode.
+	"""
+	return (
+		globalVars.appArgs.secure
+		or globalVars.appArgs.debugLogging
+		or globalVars.appArgs.logLevel != 0
+		or globalVars.appArgs.noLogging
+	)
+
+
 def setLogLevelFromConfig():
 	"""Set the log level based on the current configuration.
 	"""
-	if globalVars.appArgs.debugLogging or globalVars.appArgs.logLevel != 0 or globalVars.appArgs.secure or globalVars.appArgs.noLogging:
-		# Log level was overridden on the command line or we're running in secure mode,
-		# so don't set it.
+	if isLogLevelForced:
 		return
 	import config
 	levelName=config.conf["general"]["loggingLevel"]

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -194,17 +194,8 @@ if isSecureDesktop:
 # #8516: because config manager isn't ready yet, we must let start and exit messages be logged unless disabled via --no-logging switch.
 # However, do log things if debug logging or log level other than 0 (not set) is requested from command line switches.
 
-logLevel=globalVars.appArgs.logLevel
-if globalVars.appArgs.noLogging and (not globalVars.appArgs.debugLogging and logLevel == 0):
-	logLevel = log.OFF
-else:
-	if logLevel<=0:
-		logLevel=log.INFO
-	if globalVars.appArgs.debugLogging:
-		logLevel=log.DEBUG
 logHandler.initialize()
-logHandler.log.setLevel(logLevel)
-if logLevel is log.DEBUG:
+if logHandler.log.getEffectiveLevel() is log.DEBUG:
 	log.debug("Provided arguments: {}".format(sys.argv[1:]))
 import buildVersion
 log.info("Starting NVDA version %s" % buildVersion.version)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10209

### Summary of the issue:

When logging is disabled - either because of secure mode or command line parameters - or when the log level is forced from the command line, the log level drop-down in the General Settings panel can still be operated.
It even shows "info" as the currently selected level while in secure mode.
In these conditions, the apparently possible change only impacts configuration: It does not effectively change the current log level of the running instance of NVDA.

As stated in https://github.com/nvaccess/nvda/issues/10209#issue-493035199 @Qchristensen had contact from one IT administrator trying to setup NVDA securely on their system, concerned that although they have disabled logging, this drop-down can be changed, which gives the appearance that the log level can be changed.

### Description of how this pull request fixes the issue:

- Disable the drop-down when logging is disabled or the log level is forced from the command line.
- Ensure that in secure mode the disabled drop-down shows "disabled" instead of "info".

### Testing performed:

Ran a source copy with `--no-logging` / `--debug-logging` / `--log-level` / `--secure` / no parameter and checked the state and value of the drop-down.

### Known issues with pull request:

### Change log entry:

Section: Changes
The settings dialog no longer allows for changing the configured log level if it has been overridden from the command line.

Section: Bug fixes
The settings dialog no longer shows "info" as the current log level when in secure mode.