### PR TITLE
NVDA logging: add originating thread to log entry

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -229,7 +229,7 @@ class LiveText(NVDAObject):
 		if self._monitorThread:
 			return
 		thread = self._monitorThread = threading.Thread(
-			name=f"{self.__class__.__name__}Monitor",
+			name=f"{self.__class__.__qualname__}._monitorThread",
 			target=self._monitor
 		)
 		thread.daemon = True

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -228,7 +228,10 @@ class LiveText(NVDAObject):
 		"""
 		if self._monitorThread:
 			return
-		thread = self._monitorThread = threading.Thread(target=self._monitor)
+		thread = self._monitorThread = threading.Thread(
+			name=f"{self.__class__.__name__}Monitor",
+			target=self._monitor
+		)
 		thread.daemon = True
 		self._keepMonitoring = True
 		self._event.clear()

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -174,7 +174,7 @@ class UIAHandler(COMObject):
 		self.MTAThreadStopEvent=threading.Event()
 		self.MTAThreadInitException=None
 		self.MTAThread = threading.Thread(
-			name="UIAHandler.MTAThread",
+			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}.MTAThread",
 			target=self.MTAThreadFunc
 		)
 		self.MTAThread.daemon=True

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -173,7 +173,10 @@ class UIAHandler(COMObject):
 		self.MTAThreadInitEvent=threading.Event()
 		self.MTAThreadStopEvent=threading.Event()
 		self.MTAThreadInitException=None
-		self.MTAThread=threading.Thread(target=self.MTAThreadFunc)
+		self.MTAThread = threading.Thread(
+			name="UIAHandler.MTAThread",
+			target=self.MTAThreadFunc
+		)
 		self.MTAThread.daemon=True
 		self.MTAThread.start()
 		self.MTAThreadInitEvent.wait(2)

--- a/source/braille.py
+++ b/source/braille.py
@@ -2031,7 +2031,7 @@ class _BgThread:
 			return
 		cls.queuedWriteLock = threading.Lock()
 		thread = cls.thread = threading.Thread(
-			name="braille._BgThread",
+			name=f"{cls.__module__}.{cls.__qualname__}",
 			target=cls.func
 		)
 		thread.daemon = True

--- a/source/braille.py
+++ b/source/braille.py
@@ -2030,7 +2030,10 @@ class _BgThread:
 		if cls.thread:
 			return
 		cls.queuedWriteLock = threading.Lock()
-		thread = cls.thread = threading.Thread(target=cls.func)
+		thread = cls.thread = threading.Thread(
+			name="braille._BgThread",
+			target=cls.func
+		)
 		thread.daemon = True
 		thread.start()
 		cls.handle = ctypes.windll.kernel32.OpenThread(winKernel.THREAD_SET_CONTEXT, False, thread.ident)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -889,6 +889,7 @@ class ExecAndPump(threading.Thread):
 	"""Executes the given function with given args and kwargs in a background thread while blocking and pumping in the current thread."""
 
 	def __init__(self,func,*args,**kwargs):
+		self.name = f"{self.__class__.__name__}({func!r})"
 		self.func=func
 		self.args=args
 		self.kwargs=kwargs

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -889,7 +889,15 @@ class ExecAndPump(threading.Thread):
 	"""Executes the given function with given args and kwargs in a background thread while blocking and pumping in the current thread."""
 
 	def __init__(self,func,*args,**kwargs):
-		self.name = f"{self.__class__.__name__}({func!r})"
+		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
+			if hasattr(func, "__func__"):
+				fname = func.__func__.__module__
+			else:
+				fname = func.__module__
+			fname += f".{func.__qualname__}"
+		else:
+			fname = repr(func)
+		self.name = f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
 		self.func=func
 		self.args=args
 		self.kwargs=kwargs

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,8 +1,7 @@
-#logHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2019 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2019 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Utilities and classes to manage logging in NVDA"""
 
@@ -113,7 +112,18 @@ class Logger(logging.Logger):
 	DEBUGWARNING = 15
 	OFF = 100
 
-	def _log(self, level, msg, args, exc_info=None, extra=None, codepath=None, activateLogViewer=False, stack_info=None):
+	def _log(
+			self,
+			level,
+			msg,
+			args,
+			exc_info=None,
+			extra=None,
+			codepath=None,
+			thread=None,
+			activateLogViewer=False,
+			stack_info=None
+	):
 		if not extra:
 			extra={}
 
@@ -226,6 +236,8 @@ class FileHandler(logging.FileHandler):
 		return super().handle(record)
 
 class Formatter(logging.Formatter):
+	default_time_format = "%H:%M:%S"
+	default_msec_format = "%s.%03d"
 
 	def formatException(self, ex):
 		return stripBasePathFromTracebackText(super(Formatter, self).formatException(ex))
@@ -295,9 +307,12 @@ def initialize(shouldDoRemoteLogging=False):
 	logging.addLevelName(Logger.OFF, "OFF")
 	if not shouldDoRemoteLogging:
 		# This produces log entries such as the following:
-		# IO - inputCore.InputManager.executeGesture (09:17:40.724):
+		# IO - inputCore.InputManager.executeGesture (09:17:40.724) - Thread-5 (13576):
 		# Input: kb(desktop):v
-		logFormatter=Formatter("%(levelname)s - %(codepath)s (%(asctime)s.%(msecs)03d):\n%(message)s", "%H:%M:%S")
+		logFormatter=Formatter(
+			fmt="{levelname!s} - {codepath!s} ({asctime}) - {threadName} ({thread}):\n{message}",
+			style="{"
+		)
 		if (globalVars.appArgs.secure or globalVars.appArgs.noLogging) and (not globalVars.appArgs.debugLogging and globalVars.appArgs.logLevel == 0):
 			# Don't log in secure mode.
 			# #8516: also if logging is completely turned off.
@@ -319,7 +334,10 @@ def initialize(shouldDoRemoteLogging=False):
 			logHandler = FileHandler(globalVars.appArgs.logFileName, mode="w",encoding="utf-8")
 	else:
 		logHandler = RemoteHandler()
-		logFormatter = Formatter("%(codepath)s:\n%(message)s")
+		logFormatter = Formatter(
+			fmt="{codepath!s}:\n{message}",
+			style="{"
+		)
 	logHandler.setFormatter(logFormatter)
 	log.addHandler(logHandler)
 	redirectStdout(log)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -112,18 +112,7 @@ class Logger(logging.Logger):
 	DEBUGWARNING = 15
 	OFF = 100
 
-	def _log(
-			self,
-			level,
-			msg,
-			args,
-			exc_info=None,
-			extra=None,
-			codepath=None,
-			thread=None,
-			activateLogViewer=False,
-			stack_info=None
-	):
+	def _log(self, level, msg, args, exc_info=None, extra=None, codepath=None, activateLogViewer=False, stack_info=None):
 		if not extra:
 			extra={}
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -309,7 +309,7 @@ def initialize(shouldDoRemoteLogging=False):
 		# This produces log entries such as the following:
 		# IO - inputCore.InputManager.executeGesture (09:17:40.724) - Thread-5 (13576):
 		# Input: kb(desktop):v
-		logFormatter=Formatter(
+		logFormatter = Formatter(
 			fmt="{levelname!s} - {codepath!s} ({asctime}) - {threadName} ({thread}):\n{message}",
 			style="{"
 		)

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -400,7 +400,7 @@ def playWaveFile(fileName, asynchronous=True):
 		if fileWavePlayerThread is not None:
 			fileWavePlayerThread.join()
 		fileWavePlayerThread = threading.Thread(
-			name=f"fileWavePlayerThread({os.path.basename(fileName)})",
+			name=f"{__name__}.playWaveFile({os.path.basename(fileName)})",
 			target=fileWavePlayer.idle
 		)
 		fileWavePlayerThread.start()

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -17,6 +17,7 @@ import winKernel
 import wave
 import config
 from logHandler import log
+import os.path
 
 __all__ = (
 	"WavePlayer", "getOutputDeviceNames", "outputDeviceIDToName", "outputDeviceNameToID",
@@ -398,7 +399,10 @@ def playWaveFile(fileName, asynchronous=True):
 	if asynchronous:
 		if fileWavePlayerThread is not None:
 			fileWavePlayerThread.join()
-		fileWavePlayerThread=threading.Thread(target=fileWavePlayer.idle)
+		fileWavePlayerThread = threading.Thread(
+			name=f"fileWavePlayerThread({os.path.basename(fileName)})",
+			target=fileWavePlayer.idle
+		)
 		fileWavePlayerThread.start()
 	else:
 		fileWavePlayer.idle()

--- a/source/remotePythonConsole.py
+++ b/source/remotePythonConsole.py
@@ -74,7 +74,10 @@ def initialize():
 	global server
 	server = socketserver.TCPServer(("", PORT), RequestHandler)
 	server.daemon_threads = True
-	thread = threading.Thread(target=server.serve_forever)
+	thread = threading.Thread(
+		name=__name__,  # remotePythonConsole
+		target=server.serve_forever
+	)
 	thread.daemon = True
 	thread.start()
 

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -177,10 +177,8 @@ def callback(wav,numsamples,event):
 		log.error("callback", exc_info=True)
 
 class BgThread(threading.Thread):
-	name = "espeakBgThread"
-
 	def __init__(self):
-		threading.Thread.__init__(self)
+		super().__init__(name=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
 		self.setDaemon(True)
 
 	def run(self):

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -177,6 +177,8 @@ def callback(wav,numsamples,event):
 		log.error("callback", exc_info=True)
 
 class BgThread(threading.Thread):
+	name = "espeakBgThread"
+
 	def __init__(self):
 		threading.Thread.__init__(self)
 		self.setDaemon(True)

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -206,6 +206,7 @@ class TouchInputGesture(inputCore.InputGesture):
 inputCore.registerGestureSource("ts", TouchInputGesture)
 
 class TouchHandler(threading.Thread):
+	name = __name__
 
 	def __init__(self):
 		self.pendingEmitsTimer=gui.NonReEntrantTimer(core.requestPump)

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -206,11 +206,9 @@ class TouchInputGesture(inputCore.InputGesture):
 inputCore.registerGestureSource("ts", TouchInputGesture)
 
 class TouchHandler(threading.Thread):
-	name = __name__
-
 	def __init__(self):
 		self.pendingEmitsTimer=gui.NonReEntrantTimer(core.requestPump)
-		super(TouchHandler,self).__init__()
+		super().__init__(name=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
 		self._curTouchMode='object'
 		self.initializedEvent=threading.Event()
 		self.threadExc=None

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -226,7 +226,7 @@ class UpdateChecker(object):
 		"""Check for an update.
 		"""
 		t = threading.Thread(
-			name=self.__class__.__qualname__,
+			name=f"{self.__class__.__module__}.{self.check.__qualname__}",
 			target=self._bg
 		)
 		t.daemon = True
@@ -584,7 +584,7 @@ class UpdateDownloader(object):
 			parent=gui.mainFrame)
 		self._progressDialog.Raise()
 		t = threading.Thread(
-			name=self.__class__.__qualname__,
+			name=f"{self.__class__.__module__}.{self.start.__qualname__}",
 			target=self._bg
 		)
 		t.daemon = True

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -225,7 +225,10 @@ class UpdateChecker(object):
 	def check(self):
 		"""Check for an update.
 		"""
-		t = threading.Thread(target=self._bg)
+		t = threading.Thread(
+			name=self.__class__.__qualname__,
+			target=self._bg
+		)
 		t.daemon = True
 		self._started()
 		t.start()
@@ -580,7 +583,10 @@ class UpdateDownloader(object):
 			style=wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME | wx.PD_REMAINING_TIME | wx.PD_AUTO_HIDE,
 			parent=gui.mainFrame)
 		self._progressDialog.Raise()
-		t = threading.Thread(target=self._bg)
+		t = threading.Thread(
+			name=self.__class__.__qualname__,
+			target=self._bg
+		)
 		t.daemon = True
 		t.start()
 

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -433,7 +433,10 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 	def loadBuffer(self):
 		self.isLoading = True
 		self._loadProgressCallLater = wx.CallLater(1000, self._loadProgress)
-		threading.Thread(target=self._loadBuffer).start()
+		threading.Thread(
+			name=f"{self.__class__.__qualname__}BufferLoader",
+			target=self._loadBuffer).start(
+		)
 
 	def _loadBuffer(self):
 		try:

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -434,7 +434,7 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		self.isLoading = True
 		self._loadProgressCallLater = wx.CallLater(1000, self._loadProgress)
 		threading.Thread(
-			name=f"{self.__class__.__qualname__}BufferLoader",
+			name=f"{self.__class__.__module__}.{self.loadBuffer.__qualname__}",
 			target=self._loadBuffer).start(
 		)
 

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -241,7 +241,10 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 		self.contextToRectMap = {}
 		winGDI.gdiPlusInitialize()
 		self.window = None
-		self._highlighterThread = threading.Thread(target=self._run)
+		self._highlighterThread = threading.Thread(
+			name="NVDAHighlighterThread",
+			target=self._run
+		)
 		self._highlighterThread.daemon = True
 		self._highlighterThread.start()
 

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -242,7 +242,7 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 		winGDI.gdiPlusInitialize()
 		self.window = None
 		self._highlighterThread = threading.Thread(
-			name="NVDAHighlighterThread",
+			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}",
 			target=self._run
 		)
 		self._highlighterThread.daemon = True

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -210,7 +210,7 @@ def initialize():
 	# Handle cancelled SendMessage calls.
 	NVDAHelper._setDllFuncPointer(NVDAHelper.localLib, "_notifySendMessageCancelled", _notifySendMessageCancelled)
 	_watcherThread = threading.Thread(
-		name="watcherThread",
+		name=__name__,
 		target=_watcher
 	)
 	alive()
@@ -257,7 +257,15 @@ class CancellableCallThread(threading.Thread):
 		self.isUsable = True
 
 	def execute(self, func, *args, pumpMessages=True, **kwargs):
-		self.name = f"{self.__class__.__name__}({func!r})"
+		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
+			if hasattr(func, "__func__"):
+				fname = func.__func__.__module__
+			else:
+				fname = func.__module__
+			fname += f".{func.__qualname__}"
+		else:
+			fname = repr(func)
+		self.name = f"{self.__class__.__module__}.{self.execute.__qualname__}({fname})"
 		# Don't even bother making the call if the core is already dead.
 		if isAttemptingRecovery:
 			raise CallCancelled

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -209,7 +209,10 @@ def initialize():
 		"cancelCallEvent")
 	# Handle cancelled SendMessage calls.
 	NVDAHelper._setDllFuncPointer(NVDAHelper.localLib, "_notifySendMessageCancelled", _notifySendMessageCancelled)
-	_watcherThread=threading.Thread(target=_watcher)
+	_watcherThread = threading.Thread(
+		name="watcherThread",
+		target=_watcher
+	)
 	alive()
 	_watcherThread.start()
 
@@ -254,6 +257,7 @@ class CancellableCallThread(threading.Thread):
 		self.isUsable = True
 
 	def execute(self, func, *args, pumpMessages=True, **kwargs):
+		self.name = f"{self.__class__.__name__}({func!r})"
 		# Don't even bother making the call if the core is already dead.
 		if isAttemptingRecovery:
 			raise CallCancelled

--- a/source/winInputHook.py
+++ b/source/winInputHook.py
@@ -1,8 +1,7 @@
-#winInputHook.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2008 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2019 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import threading
 import comtypes.client
@@ -88,7 +87,10 @@ def initialize():
 	global hookThread, hookThreadRefCount
 	hookThreadRefCount+=1
 	if hookThreadRefCount==1:
-		hookThread=threading.Thread(target=hookThreadFunc)
+		hookThread = threading.Thread(
+			name=__name__,  # winInputHook
+			target=hookThreadFunc
+		)
 		hookThread.start()
 
 def setCallbacks(keyUp=None,keyDown=None,mouse=None):


### PR DESCRIPTION
### Link to issue number:
None. Hopefully helps debugging #10247 

### Summary of the issue:
As NVDA is getting a larger application, there are multiple threads involved in its operation. Logging can also be initiated from multiple threads. However, in the current situation,, we do not know from what thread a log entry is coming. Knowing the originating thread helps in following the flow in a log file.

### Description of how this pull request fixes the issue:
1. Add the thread name and thread number to the log entry. It is added after the timestamp, so people who aren't interested in the thread won't be bothered by it
2. Give every thread that is created within NVDA a name, so it can be identified in the log
3. Update the log formatter to use new functionality in python 3. In particular, there is now a clearer method to format the timestamp. We are also using Python string formatting syntax {msg} instead of %(msg)s. THe latter is more difficult to read.

### Testing performed:
Tested that NVDA still runs and appropriate thread info is logged. Paid extra attention to watchdog.CancellableCallThread to set the name of the thread to the function it is being executed with.

### Known issues with pull request:
None

### Change log entry:
* Changes
    + For every entry in the NVDA log, information about the originating thread is now logged.