### PR TITLE
Fix up of: Initial support for reporting revisions (track changes) in  Microsoft Word. Re #1670.

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1495,11 +1495,13 @@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni
 			textList.append(text)
 		revision=attrs.get("revision")
 		oldRevision=attrsCache.get("revision") if attrsCache is not None else None
-		if (revision or oldRevision is not None) and revision!=oldRevision:
-			# Translators: Reported when text is revised.
-			text=(_("revised %s"%revision) if revision
+		if (revision or oldRevision is not None) and revision != oldRevision:
+			if revision:
+				# Translators: Reported when text is revised.
+				text = _("revised %s") % revision
+			else:
 				# Translators: Reported when text is not revised.
-				else _("no revised %s")%oldRevision)
+				text = _("no revised %s") % oldRevision
 			textList.append(text)
 	if  formatConfig["reportEmphasis"]:
 		# marked text 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10261

### Summary of the issue:

In `speech/__init__.py`, line 1500: ` text=(_("revised %s"%revision)`
As `% revision` is inside the gettext call, the resulting string can't be translated.
This was introduced by commit 047519d6bc back in 2013.3rc1

### Description of how this pull request fixes the issue:

Replace by ` text = _("revised %s") % revision`, plus a little re-formatting.

### Testing performed:

### Known issues with pull request:

### Change log entry:

Section: Bug fixes

In Microsoft Word, the announce of revised text is now translatable. It used to be "revised", in English.