### PR TITLE
Fixup of: 'NVDA logging: add originating thread to log entry'

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -889,19 +889,13 @@ class ExecAndPump(threading.Thread):
 	"""Executes the given function with given args and kwargs in a background thread while blocking and pumping in the current thread."""
 
 	def __init__(self,func,*args,**kwargs):
-		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
-			if hasattr(func, "__func__"):
-				fname = func.__func__.__module__
-			else:
-				fname = func.__module__
-			fname += f".{func.__qualname__}"
-		else:
-			fname = repr(func)
-		self.name = f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
 		self.func=func
 		self.args=args
 		self.kwargs=kwargs
-		super(ExecAndPump,self).__init__()
+		fname = repr(func)
+		super().__init__(
+			name=		f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
+		)
 		self.threadExc=None
 		self.start()
 		time.sleep(0.1)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -894,7 +894,7 @@ class ExecAndPump(threading.Thread):
 		self.kwargs=kwargs
 		fname = repr(func)
 		super().__init__(
-			name=		f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
+			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
 		)
 		self.threadExc=None
 		self.start()

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -257,14 +257,7 @@ class CancellableCallThread(threading.Thread):
 		self.isUsable = True
 
 	def execute(self, func, *args, pumpMessages=True, **kwargs):
-		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
-			if hasattr(func, "__func__"):
-				fname = func.__func__.__module__
-			else:
-				fname = func.__module__
-			fname += f".{func.__qualname__}"
-		else:
-			fname = repr(func)
+		fname = repr(func)
 		self.name = f"{self.__class__.__module__}.{self.execute.__qualname__}({fname})"
 		# Don't even bother making the call if the core is already dead.
 		if isAttemptingRecovery:


### PR DESCRIPTION
### Link to issue number:
Fixes #10266 

### Summary of the issue:
Pr #10259 introduces two issues;

1. In gui.ExecAndPump, we were setting a name on a thread that was not yet initialized.
2. For functions defined on the python console, the __module__ property is empty.

### Description of how this pull request fixes the issue:
1. In gui.ExecAndPump, provide the name as an argument to the super call of __init__, rather than using the setter for the name property.
2. Just use the repr of the function for gui.ExecAndPump and watchdog.CancellableCallThread. I know it's not the most readable presentation, but it is at least reliable.

### Testing performed:
Tested that logs initiated from a function running in a gui.ExecAndPump log the proper thread identifier.

### Known issues with pull request:
None

### Change log entry:
None