### PR TITLE
Fix up of: NVDA logging: add originating thread to log entry (#10259, #10266)

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -888,7 +888,10 @@ class ExitDialog(wx.Dialog):
 class ExecAndPump(threading.Thread):
 	"""Executes the given function with given args and kwargs in a background thread while blocking and pumping in the current thread."""
 
-	def __init__(self,func,*args,**kwargs):
+	def __init__(self, func, *args, **kwargs):
+		self.func = func
+		self.args = args
+		self.kwargs = kwargs
 		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
 			if hasattr(func, "__func__"):
 				fname = func.__func__.__module__
@@ -897,12 +900,8 @@ class ExecAndPump(threading.Thread):
 			fname += f".{func.__qualname__}"
 		else:
 			fname = repr(func)
-		self.name = f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
-		self.func=func
-		self.args=args
-		self.kwargs=kwargs
-		super(ExecAndPump,self).__init__()
-		self.threadExc=None
+		super().__init__(name=f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})")
+		self.threadExc = None
 		self.start()
 		time.sleep(0.1)
 		threadHandle=ctypes.c_int()


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10266 
Fix up of #10259
Alternative to PR #10267 

### Summary of the issue:

PR #10259 introduced a regression by setting the name of thread `gui.ExecAndPump` before initializing it.

### Description of how this pull request fixes the issue:

Pass the name of the thread in the initializer super call.

### Testing performed:

Reproduced the issue described in #10266 without this fix.
Checked this does not reproduce once the present fix is applied.

### Known issues with pull request:

### Change log entry:

N/A

cc @leonardder 
cc @michaelDCurran 