### PR TITLE
UI Automation in Windows Console: backport some UIA console fixes to Python 2 (2019.2.1)

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -244,7 +244,7 @@ class WinConsoleUIA(Terminal):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
-	_TextInfo = consoleUIATextInfo
+	TextInfo = consoleUIATextInfo
 	#: A queue of typed characters, to be dispatched on C{textChange}.
 	#: This queue allows NVDA to suppress typed passwords when needed.
 	_queuedChars = []

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -244,10 +244,6 @@ class WinConsoleUIA(Terminal):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
-	#: Use our custom textInfo for UIA consoles.
-	#: This fixes expand/collapse, implements word movement,
-	# and bounds review to the visible text.
-	TextInfo = consoleUIATextInfo
 	#: A queue of typed characters, to be dispatched on C{textChange}.
 	#: This queue allows NVDA to suppress typed passwords when needed.
 	_queuedChars = []
@@ -256,6 +252,12 @@ class WinConsoleUIA(Terminal):
 	_hasNewLines = False
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
+
+	# Overriding _get_TextInfo and thus the TextInfo property on NVDAObjects.UIA.UIA
+	# consoleUIATextInfo fixes expand/collapse, implements word movement, and 
+	# bounds review to the visible text.
+	def _get_TextInfo(self):
+		return consoleUIATextInfo
 
 	def _reportNewText(self, line):
 		# Additional typed character filtering beyond that in LiveText

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -12,6 +12,7 @@ import time
 import textInfos
 import UIAHandler
 
+from comtypes import COMError
 from scriptHandler import script
 from UIAUtils import isTextRangeOffscreen
 from winVersion import isWin10
@@ -108,7 +109,6 @@ class consoleUIATextInfo(UIATextInfo):
 					lineInfo.expand(textInfos.UNIT_LINE)
 					offset = self._getCurrentOffsetInThisLine(lineInfo)
 				# Finally using the new offset,
-
 				# Calculate the current word offsets and move to the start of
 				# this word if we are not already there.
 				start, end = self._getWordOffsetsInThisLine(offset, lineInfo)
@@ -122,13 +122,16 @@ class consoleUIATextInfo(UIATextInfo):
 		else:  # moving by a unit other than word
 			res = super(consoleUIATextInfo, self).move(unit, direction,
 														endPoint)
-		if (
-			oldRange
-			and isTextRangeOffscreen(self._rangeObj, visiRanges)
-			and not isTextRangeOffscreen(oldRange, visiRanges)
-		):
-			self._rangeObj = oldRange
-			return 0
+		try:
+			if (
+				oldRange
+				and isTextRangeOffscreen(self._rangeObj, visiRanges)
+				and not isTextRangeOffscreen(oldRange, visiRanges)
+			):
+				self._rangeObj = oldRange
+				return 0
+		except COMError, RuntimeError:
+			pass
 		return res
 
 	def expand(self, unit):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -27,6 +27,21 @@ class consoleUIATextInfo(UIATextInfo):
 	#: to do much good either.
 	_expandCollapseBeforeReview = False
 
+	def __init__(self,obj,position,_rangeObj=None):
+		super(consoleUIATextInfo, self).__init__(obj, position, _rangeObj)
+		# Re-implement POSITION_FIRST and POSITION_LAST in terms of
+		# visible ranges to fix review top/bottom scripts.
+		if position==textInfos.POSITION_FIRST:
+			visiRanges = self.obj.UIATextPattern.GetVisibleRanges()
+			firstVisiRange = visiRanges.GetElement(0)
+			self._rangeObj = firstVisiRange
+			self.collapse()
+		elif position==textInfos.POSITION_LAST:
+			visiRanges = self.obj.UIATextPattern.GetVisibleRanges()
+			lastVisiRange = visiRanges.GetElement(visiRanges.length - 1)
+			self._rangeObj = lastVisiRange
+			self.collapse(True)
+
 	def collapse(self,end=False):
 		"""Works around a UIA bug on Windows 10 1903 and later."""
 		if not isWin10(1903):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -244,6 +244,9 @@ class WinConsoleUIA(Terminal):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
+	#: Use our custom textInfo for UIA consoles.
+	#: This fixes expand/collapse, implements word movement,
+	# and bounds review to the visible text.
 	TextInfo = consoleUIATextInfo
 	#: A queue of typed characters, to be dispatched on C{textChange}.
 	#: This queue allows NVDA to suppress typed passwords when needed.

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -253,10 +253,10 @@ class WinConsoleUIA(Terminal):
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
 
-	# Overriding _get_TextInfo and thus the TextInfo property on NVDAObjects.UIA.UIA
-	# consoleUIATextInfo fixes expand/collapse, implements word movement, and 
-	# bounds review to the visible text.
 	def _get_TextInfo(self):
+		"""Overriding _get_TextInfo and thus the TextInfo property on NVDAObjects.UIA.UIA
+		consoleUIATextInfo fixes expand/collapse, implements word movement, and 
+		bounds review to the visible text."""
 		return consoleUIATextInfo
 
 	def _reportNewText(self, line):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -312,9 +312,12 @@ class WinConsoleUIA(Terminal):
 
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA
-		ptr = self.UIATextPattern.GetVisibleRanges()
-		res = [ptr.GetElement(i).GetText(-1) for i in range(ptr.length)]
-		return res
+		return (
+			self.makeTextInfo(textInfos.POSITION_ALL)
+			._rangeObj.getText(-1)
+			.rstrip()
+			.split("\r\n")
+		)
 
 	def _calculateNewText(self, newLines, oldLines):
 		self._hasNewLines = (

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -13,6 +13,7 @@ import textInfos
 import UIAHandler
 
 from scriptHandler import script
+from UIAUtils import isTextRangeOffscreen
 from winVersion import isWin10
 from . import UIATextInfo
 from ..behaviors import Terminal
@@ -50,8 +51,6 @@ class consoleUIATextInfo(UIATextInfo):
 			visiRanges = self.obj.UIATextPattern.GetVisibleRanges()
 			visiLength = visiRanges.length
 			if visiLength > 0:
-				firstVisiRange = visiRanges.GetElement(0)
-				lastVisiRange = visiRanges.GetElement(visiLength - 1)
 				oldRange = self._rangeObj.clone()
 		if unit == textInfos.UNIT_WORD and direction != 0:
 			# UIA doesn't implement word movement, so we need to do it manually.
@@ -108,13 +107,11 @@ class consoleUIATextInfo(UIATextInfo):
 		else:  # moving by a unit other than word
 			res = super(consoleUIATextInfo, self).move(unit, direction,
 														endPoint)
-		if oldRange and (
-			self._rangeObj.CompareEndPoints(
-				UIAHandler.TextPatternRangeEndpoint_Start, firstVisiRange,
-				UIAHandler.TextPatternRangeEndpoint_Start) < 0
-			or self._rangeObj.CompareEndPoints(
-				UIAHandler.TextPatternRangeEndpoint_Start, lastVisiRange,
-				UIAHandler.TextPatternRangeEndpoint_End) >= 0):
+		if (
+			oldRange
+			and isTextRangeOffscreen(self._rangeObj, visiRanges)
+			and not isTextRangeOffscreen(oldRange, visiRanges)
+		):
 			self._rangeObj = oldRange
 			return 0
 		return res

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -172,6 +172,24 @@ def getChildrenWithCacheFromUIATextRange(textRange,cacheRequest):
 	c=CacheableUIAElementArray(c)
 	return c
 
+def isTextRangeOffscreen(range, visiRanges):
+	"""Given a UIA text range and a visible ranges array (returned from obj.UIATextPattern.GetVisibleRanges), determines if the given range is not within the visible ranges."""
+	visiLength = visiRanges.length
+	if visiLength > 0:
+		firstVisiRange = visiRanges.GetElement(0)
+		lastVisiRange = visiRanges.GetElement(visiLength - 1)
+		return range.CompareEndPoints(
+			UIAHandler.TextPatternRangeEndpoint_Start, firstVisiRange,
+			UIAHandler.TextPatternRangeEndpoint_Start
+		) < 0 or range.CompareEndPoints(
+			UIAHandler.TextPatternRangeEndpoint_Start, lastVisiRange,
+			UIAHandler.TextPatternRangeEndpoint_End) >= 0
+	else:
+		# Visible ranges not available, so fail gracefully.
+		log.warning("UIA visible ranges not available.")
+		return True
+
+
 class UIATextRangeAttributeValueFetcher(object):
 
 	def __init__(self,textRange):

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -185,9 +185,8 @@ def isTextRangeOffscreen(range, visiRanges):
 			UIAHandler.TextPatternRangeEndpoint_Start, lastVisiRange,
 			UIAHandler.TextPatternRangeEndpoint_End) >= 0
 	else:
-		# Visible ranges not available, so fail gracefully.
-		log.warning("UIA visible ranges not available.")
-		return True
+		# Visible ranges not available.
+		raise RuntimeError("Visible ranges array is empty or invalid.")
 
 
 class UIATextRangeAttributeValueFetcher(object):

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -172,21 +172,21 @@ def getChildrenWithCacheFromUIATextRange(textRange,cacheRequest):
 	c=CacheableUIAElementArray(c)
 	return c
 
-def isTextRangeOffscreen(range, visiRanges):
-	"""Given a UIA text range and a visible ranges array (returned from obj.UIATextPattern.GetVisibleRanges), determines if the given range is not within the visible ranges."""
+def isTextRangeOffscreen(textRange, visiRanges):
+	"""Given a UIA text range and a visible textRanges array (returned from obj.UIATextPattern.GetVisibleRanges), determines if the given textRange is not within the visible textRanges."""
 	visiLength = visiRanges.length
 	if visiLength > 0:
 		firstVisiRange = visiRanges.GetElement(0)
 		lastVisiRange = visiRanges.GetElement(visiLength - 1)
-		return range.CompareEndPoints(
+		return textRange.CompareEndPoints(
 			UIAHandler.TextPatternRangeEndpoint_Start, firstVisiRange,
 			UIAHandler.TextPatternRangeEndpoint_Start
-		) < 0 or range.CompareEndPoints(
+		) < 0 or textRange.CompareEndPoints(
 			UIAHandler.TextPatternRangeEndpoint_Start, lastVisiRange,
 			UIAHandler.TextPatternRangeEndpoint_End) >= 0
 	else:
-		# Visible ranges not available.
-		raise RuntimeError("Visible ranges array is empty or invalid.")
+		# Visible textRanges not available.
+		raise RuntimeError("Visible textRanges array is empty or invalid.")
 
 
 class UIATextRangeAttributeValueFetcher(object):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1092,9 +1092,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_startOfLine(self,gesture):
 		info=api.getReviewPosition().copy()
-		if info._expandCollapseBeforeReview:
-			info.expand(textInfos.UNIT_LINE)
-			info.collapse()
+		info.expand(textInfos.UNIT_LINE)
+		info.collapse()
 		api.setReviewPosition(info)
 		info.expand(textInfos.UNIT_CHARACTER)
 		ui.reviewMessage(_("Left"))


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Backports #9944, #9957 (without user guide updates and py3 syntax), and #10052. This PR intentionally does not include #9771 or #9915 as they significantly alter NVDA functionality.

### Summary of the issue:
Various issues with the UIA console implementation in 2019.2 (see linked PRs above).

### Description of how this pull request fixes the issue:
Backported above PRs from `master`.

### Testing performed:
See PRs mentioned above.

### Known issues with pull request:
* Attempting to merge this branch back to `master` will result in merge conflicts, but their resolution should be fairly obvious.

### Change log entry:
None.