### PR TITLE
Update liblouis to 3.12, compile with Clang on Visual Studio 2019

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -14,6 +14,8 @@
 
 import os
 import re
+import glob
+from SCons.Tool.MSCommon.vc import find_vc_pdir
 
 Import([
 	"env",
@@ -37,6 +39,19 @@ def getLouisVersion():
 
 env = env.Clone()
 
+# Liblouis is build with Clang, as Microsoft Visual C++ is unable to build C99 code.
+clangDirs = glob.glob(os.path.join(
+    find_vc_pdir(env.get("MSVC_VERSION")),
+    r"Tools\Llvm\bin"
+))
+if len(clangDirs) == 0:
+	raise RuntimeError(
+		"Could not find the Clang compiler. "
+		"Perhaps the C++ Clang tools for Windows component in visual Studio is not installed"
+	) 
+env['ENV']['PATH'] += "".join(f";{d}" for d in clangDirs)
+env['CC'] = 'clang-cl'
+
 # Don't analyze the code as not our project
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
@@ -45,10 +60,6 @@ if 'analyze' in env['nvdaHelperDebugFlags']:
 env.Replace(CCFLAGS='/W2')
 
 env.Append(CPPDEFINES=[
-	# The Visual C++ C Runtime deprecates several standard library functions in
-	# preference for _s variants that are specific to Visual C++. This removes
-	# those deprecation warnings.
-	"_CRT_SECURE_NO_WARNINGS",
 	# The Visual C++ C Runtime deprecates standard POSIX APIs that conflict with
 	# reserved ISO C names (like strdup) in favour of non-portable conforming
 	# variants that start with an '_'. This removes those deprecation warnings. */

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
-* [liblouis](http://www.liblouis.org/), version 3.10.0 commit 146c0757
+* [liblouis](http://www.liblouis.org/), version 3.12.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -160,6 +160,9 @@ addTable("en-gb-g1.utb", _("English (U.K.) grade 1"))
 addTable("en-GB-g2.ctb", _("English (U.K.) grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("en-nabcc.utb", _("English North American Braille Computer Code"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("en-ueb-g1.ctb", _("Unified English Braille Code grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -304,10 +304,13 @@ addTable("mn-MN-g2.ctb", _("Mongolian grade 2"), contracted=True)
 addTable("mr-in-g1.utb", _("Marathi grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("nl-BE-g0.utb", _("Dutch (Belgium)"))
+addTable("nl-BE-g0.utb", _("Dutch (Belgium) 6 dot"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("nl-NL-g0.utb", _("Dutch (Netherlands)"))
+addTable("nl-NL-g0.utb", _("Dutch (Netherlands) 6 dot"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("nl-comp8.utb", _("Dutch 8 dot"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("no-no-8dot.utb", _("Norwegian 8 dot computer braille"))


### PR DESCRIPTION
Note: this draft is based on #10169 and can be rebased on master when that pr is merged.

### Link to issue number:
Closes #10161
Closes #10094 
Closes #9526 

### Summary of the issue:
Liblouis 3.12.0 has been released. Unfortunately, starting from version 3.11, liblouis drops compatibility with Microsoft Visual C++ as it now uses C99 dynamic arrays, which are not supported on MSVC

### Description of how this pull request fixes the issue:
Use the clang toolset to build Liblouis instead. Note that, where msvc does assume the sdcall calling convention, clang does not.

### Testing performed:
Tested locally AS WELL AS ON APPVEYOR WITH A TRY BUILD

### Known issues with pull request:
None known, though as this is a major under the hood change, it needs to be tested carefully.

### Change log entry:
* Changes
    + Updated liblouis braille translator to version 3.12 (#10161)
