### PR TITLE
Again ensure comtypes calls raise CallCancelled when cancelled by watchdog 

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -38,7 +38,6 @@ def recursiveCopy(env,targetDir,sourceDir):
 import gettext
 gettext.install("nvda")
 sys.path.append("source")
-import comtypesMonkeyPatches
 import versionInfo
 del sys.path[-1]
 

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -18,6 +18,14 @@ Import(
 
 import importlib.util
 
+# Monkeypatch comtypes to clear the importlib cache when importing a new module
+import comtypes.client._generate
+old_my_import = comtypes.client._generate._my_import
+def new_my_import(fullname):
+	importlib.invalidate_caches()
+	return old_my_import(fullname)
+comtypes.client._generate._my_import = new_my_import
+
 def interfaceAction(target,source,env):
 	clsid=env.get('clsid')
 	if clsid:

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -3,10 +3,12 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+# Warning: no comtypes modules can be imported until ctypes.WINFUNCTYPE has been replaced further down.
+
 import ctypes
 import _ctypes
 import importlib
-import comtypes.client._generate
+
 
 # A version of ctypes.WINFUNCTYPE 
 # that produces a WinFunctionType class whose instance will convert COMError into a CallCancelled exception when called as a function.
@@ -45,6 +47,8 @@ try:
 	import comtypes
 finally:
 	ctypes.WINFUNCTYPE=old_WINFUNCTYPE
+
+# It is safe to import any comtypes modules from here on down.
 
 from logHandler import log
 
@@ -130,6 +134,7 @@ comtypes._check_version = _check_version
 
 
 # Monkeypatch comtypes to clear the importlib cache when importing a new module
+import comtypes.client._generate
 old_my_import = comtypes.client._generate._my_import
 
 

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -134,7 +134,10 @@ comtypes._check_version = _check_version
 
 
 # Monkeypatch comtypes to clear the importlib cache when importing a new module
-import comtypes.client._generate
+
+# We must import comtypes.client._generate here as it must be done after other monkeypatching
+import comtypes.client._generate  # noqa: E402
+
 old_my_import = comtypes.client._generate._my_import
 
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10276 

### Summary of the issue:
In pr #9795 code was added to ensure that CallCancel was raised rather than COMError when a comtypes call was cancelled by watchdog in Python3. In Python2 we did this by overriding ```__call__``` on _ctypes.COMError, however in Python3 this is read-only and can't be done. Therefore in pr #9795 we monkeypatched ctypes.WINFUNCTYPE to return a class with a custom ```__call__``` that converted COMError to CallCancelled if it was a cancelled call. We monkeypatched this just before comtypes was imported for the first time and then removed it once the import was done, there by ensuring that comtypes got our custom WINFUNCTYPE.
However, in pr #10235, a comtypes.client module was imported at the top of comtypesMonekyPatches.py which forced comtypes to be imported before the WINFUNCTYPE monkeypatching could occur, therefore, comtypes calls no longer would raise CallCancelled when cancelled via watchdog.
 
### Description of how this pull request fixes the issue:
In comtypesMonkeyPatches.py: Moved the import of comtypes.client._generate down to where it is actually needed, below the monkeypatching of WINFUNCTYPE and the initial import of comtypes.
Extra comments have been also added above and below where it is unsafe to import any comtypes modules.
This change did however break builds on appveyor because when comInterfaces_sonscript tried to generate interfaces, our monkeypatched WINFUNCTYPE kicked into action, due to comtypesMonkeyPatches being imported by sconsctruct, and then in some COMErrors further exceptions were raised because core.CallCancelled could not be imported.
Therefore, rather than importing comtypesMonkeypatches in sonstruct, we now just manually do the comtypes.client._generate monkeypatch in comInterfaces_sconscript, specifically where it is needed.

### Testing performed:
Performed testcase from issue #10276 and CallCancelled is again correctly raised.

### Known issues with pull request:
None.

### Change log entry:
None.