### PR TITLE
MSHTML vbuf: HTMLAttrib::src: Truncate base64 data, yet preserve the MIME type

### DIFF
--- a/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/mshtml.cpp
@@ -459,6 +459,20 @@ inline void getAttributesFromHTMLDOMNode(IHTMLDOMNode* pHTMLDOMNode,wstring& nod
 	macro_addHTMLAttributeToMap(L"alt",true,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"title",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"src",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
+	// Truncate the value of "src" if it contains base64 data
+	map<wstring,wstring>::iterator attribsMapIt;
+	if ((attribsMapIt = attribsMap.find(L"HTMLAttrib::src")) != attribsMap.end()) {
+		wstring str = attribsMapIt->second;
+		const wstring prefix = L"data:";
+		if (str.substr(0, prefix.length()) == prefix) {
+			const wstring needle = L"base64,";
+			wstring::size_type pos = str.find(needle);
+			if (pos != wstring::npos) {
+				str.replace(pos + needle.length(), wstring::npos, L"<truncated>");
+				attribsMap[L"HTMLAttrib::src"] = str;
+			}
+		}
+	}
 	macro_addHTMLAttributeToMap(L"onclick",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"onmousedown",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);
 	macro_addHTMLAttributeToMap(L"onmouseup",false,pHTMLAttributeCollection2,attribsMap,tempVar,tempAttribNode);


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Follow up to PR #10231

### Summary of the issue:

When the `src` attribute of an `img` elements contains huge base64 data, the virtual buffer is uselessly filled with potentially lengthy content that impact performance.

### Description of how this pull request fixes the issue:

When the value of the `src` starts with "data:", locate "base64," and truncate everything onward, replacing it with "\<truncated\>".

### Testing performed:

Tested against [the test case of #10227](https://github.com/nvaccess/nvda/files/3645959/i10227.html.txt).

### Known issues with pull request:

This PR only impacts the virtual buffer C++ implementation as used in browse mode.
Regarding focus mode, if I understand correctly the logic in `NVDAObjects.IAccessible.MSHTML`, attribute values are only fetched on demand. Thus, I suppose truncating the value of the "src" attribute there is of lesser interest.

### Change log entry:

I'm not sure this deserves to be announced.
Otherwise:

Section: Changes for developers

MSHTML: In the `src` attribute of an `img` element, base64 data are now truncated from the virtual buffer.