### PR TITLE
Fix up of: IA2: Do not treat huge base64 data as NVDA might freeze in Google Chrome (PR #10231)

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -1008,7 +1008,10 @@ def getRecursiveTextFromIAccessibleTextObject(obj,startOffset=0,endOffset=-1):
 	return "".join(textList).replace('  ',' ')
 
 
-ATTRIBS_STRING_BASE64_PATTERN = re.compile(r"base64\\,[A-Za-z0-9+/=]+")
+ATTRIBS_STRING_BASE64_PATTERN = re.compile(
+	r"(([^\\](\\\\)*);src:data\\:[^\\;]+\\;base64)\\,[A-Za-z0-9+/=]+"
+)
+ATTRIBS_STRING_BASE64_REPL = r"\1<truncated>"
 ATTRIBS_STRING_BASE64_THRESHOLD = 4096
 
 
@@ -1023,7 +1026,7 @@ def splitIA2Attribs(attribsString):
 	"""
 	# Do not treat huge base64 data as it might freeze NVDA in Google Chrome (#10227)
 	if len(attribsString) >= ATTRIBS_STRING_BASE64_THRESHOLD:
-		attribsString = ATTRIBS_STRING_BASE64_PATTERN.sub("base64,<truncated>", attribsString)
+		attribsString = ATTRIBS_STRING_BASE64_PATTERN.sub(ATTRIBS_STRING_BASE64_REPL, attribsString)
 		if len(attribsString) >= ATTRIBS_STRING_BASE64_THRESHOLD:
 			log.debugWarning(f"IA2 attributes string exceeds threshold: {attribsString}")
 	attribsDict = {}

--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -1009,7 +1009,7 @@ def getRecursiveTextFromIAccessibleTextObject(obj,startOffset=0,endOffset=-1):
 
 
 ATTRIBS_STRING_BASE64_PATTERN = re.compile(
-	r"(([^\\](\\\\)*);src:data\\:[^\\;]+\\;base64)\\,[A-Za-z0-9+/=]+"
+	r"(([^\\](\\\\)*);src:data\\:[^\\;]+\\;base64\\,)[A-Za-z0-9+/=]+"
 )
 ATTRIBS_STRING_BASE64_REPL = r"\1<truncated>"
 ATTRIBS_STRING_BASE64_THRESHOLD = 4096


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix up of PR #10231

### Summary of the issue:

 As mentioned by @michaelDCurran in https://github.com/nvaccess/nvda/pull/10231#issuecomment-535254306 `IAccessibleHandler.splitIA2Attribs` might also receive IAccessibleText as argument.

### Description of how this pull request fixes the issue:

Alter the regex as to ensure to truncate base64 data only in the `src` attribute, and not in an eventual
text content (eg. in and inline editor).

### Testing performed:

Tested against [the test case of #10227](https://github.com/nvaccess/nvda/files/3645959/i10227.html.txt).

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

