### PR TITLE
Fix up of: New addon api versioning approach (PR #9151)

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -717,6 +717,8 @@ docFileName = string(default=None)
 
 def validate_apiVersionString(value):
 	from configobj.validate import ValidateError
+	if not value or value == "None":
+		return (0, 0, 0)
 	if not isinstance(value, string_types):
 		raise ValidateError('Expected an apiVersion in the form of a string. EG "2019.1.0"')
 	try:

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -292,6 +292,9 @@ class Addon(AddonBase):
 					translatedInput = open(p, 'rb')
 					break
 			self.manifest = AddonManifest(f, translatedInput)
+			if self.manifest.errors is not None:
+				_report_manifest_errors(self.manifest)
+				raise AddonError("Manifest file has errors.")
 
 	@property
 	def isPendingInstall(self):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix up of PR #9151


This PR addresses two issues regarding add-on manifests:

### Report manifest validation errors also for add-ons already installed.

#### Summary of the issue:

Validation errors in an add-on manifest are currently only reported upon installation from a bundle or when (re-)creating a bundle from an exploded directory.
For add-on already installed, in some situations, this does not help much in understanding validation issues due to an update of the manifest specification.

Example log before this PR:
```
ERROR - addonHandler._getAvailableAddonsFromPath (23:02:04.972) - MainThread (8180):
Error loading Addon from path: C:\Users\Julien\AppData\Roaming\nvda\addons\failer_missingNVDAVersion
Traceback (most recent call last):
  File "addonHandler\__init__.pyc", line 206, in _getAvailableAddonsFromPath
  File "addonHandler\addonVersionCheck.pyc", line 32, in isAddonCompatible
  File "addonHandler\addonVersionCheck.pyc", line 13, in hasAddonGotRequiredSupport
TypeError: '<=' not supported between instances of 'str' and 'tuple'
```

#### Description of how this pull request fixes the issue:

Example log after this PR as of commit 967b90a549:
```
WARNING - addonHandler._report_manifest_errors (22:59:11.930) - MainThread (1960):
Error loading manifest:
{'name': True, 'summary': True, 'description': True, 'author': True, 'version': True, 'minimumNVDAVersion': ValidateError('"None" is not a valid API Version string: None'), 'lastTestedNVDAVersion': ValidateError('"None" is not a valid API Version string: None'), 'url': True, 'docFileName': True}
ERROR - addonHandler._getAvailableAddonsFromPath (22:59:11.930) - MainThread (1960):
Error loading Addon from path: C:\Users\Julien\AppData\Roaming\nvda\addons\failer_missingNVDAVersion
Traceback (most recent call last):
  File "addonHandler\__init__.py", line 195, in _getAvailableAddonsFromPath
    a = Addon(addon_path)
  File "addonHandler\__init__.py", line 297, in __init__
    raise AddonError("Manifest file has errors.")
addonHandler.AddonError: Manifest file has errors.
```

Thus, an add-on with an invalid manifest now produces the same log when already installed than when attempting to install it fro ma bundle.

### Flag add-on as incompatible if lastTestedNVDAVersion is literally set to "None"

#### Summary of the issue:

The add-on template nvdaaddons/AddonTemplate, when not modified, produces a manifest with lastTestedNVDAVersion literally set to the string "None".
One may argue whether this template is an authoritative source or not, but it is definitely an advisable starting point used by many add-on authors.
While it is obvious that add-on authors should modify the provided `buildVars.py` file to set an appropriate value for this entry of the manifest, several add-ons are already out in the wild with the incriminated literal string "None".

The current master behaves differently with such add-ons than 2019.2 does.
With 2019.2, the value "None" is replaced for evaluation by the default "0.0.0" and these add-ons are properly reported as incompatible.

On the current master, however, these add-ons are just missing from the list, without much notice except in the log (see example log above).

#### Description of how this pull request fixes the issue:

Commit 0739a06b4c makes the add-on manifest validator consider "None" as the default 0.0.0, and these add-ons are again properly reported as incompatible.


### Testing performed:

- Loaded a valid compatible installed add-on.
- Attempted to load a valid incompatible installed add-on.
- Attempted to load an invalid installed add-on.
- Installed a valid compatible add-on.
- Attempted to install a valid incompatible add-on.
- Attempted to install an invalid add-on.

### Known issues with pull request:

This PR groups two related fixes.
Please let me know if you prefer I file two separate PR for easier evaluation.

### Change log entry:

I do not think the first fix deserves much attention, or maybe:
Bug fixes: Errors in the manifest of add-ons already installed are now properly reported in the log.

The second fix restores the behavior as of the last release, and thus IMHO should not be announced.

cc @feerrenrut 