### PR TITLE
Fix-up of: "New handy tech display models (#9691)"

### DIFF
--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -592,8 +592,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def __init__(self, port="auto"):
 		super(BrailleDisplayDriver, self).__init__()
-		# Create the message window on the ui thread.
-		wx.CallAfter(self.create_message_window)
 		self.numCells = 0
 		self._model = None
 		self._ignoreKeyReleases = False
@@ -638,12 +636,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 				self._model.postInit()
 				log.info("Found {device} connected via {type} ({port})".format(
 					device=self._model.name, type=portType, port=port))
+				# Create the message window on the ui thread.
+				wx.CallAfter(self.create_message_window)
 				break
 			self._dev.close()
 
 		else:
-			# Make sure this is called on the ui thread
-			wx.CallAfter(self.destroy_message_window)
 			raise RuntimeError("No Handy Tech display found")
 
 	def create_message_window(self):


### PR DESCRIPTION
### Link to issue number:
Fixes issue introduced in #9691

### Summary of the issue:
Pr #9691 introduced a message window specific to the handy tech driver. This window is initialized at the very beginning of driver initialisation, and killed again if no device could be found or when the driver terminates.

However, initializing a window and then directly killing it again could result in weird message window errors if a display couldn't be initialized. This is most noticeable when having a modular evolution 88 attached to the system which is switched off. This device is detected by the driver, but as it does not respond, attempts to connect to the display are ceased. When the message window is uninitialized, uninitialization fails with WindowsError 87

### Description of how this pull request fixes the issue:
Rather than initializing the window at the very beginning of initialization and killing it again if init fails, it is now only initialized when a connection to a display has been successfully made.

### Testing performed:
Tested that the message window no longer causes errors when a non responding handy tech display is detected using auto detection.

### Known issues with pull request:
None

### Change log entry:
Probably too trivial to list here, as the issue is not noticeable in release builds.