### PR TITLE
IA2 vbuf: IAccessible2::attribute_src: Truncate base64 data yet preserve the MIME type

### DIFF
--- a/nvdaHelper/common/ia2utils.cpp
+++ b/nvdaHelper/common/ia2utils.cpp
@@ -46,6 +46,20 @@ void IA2AttribsToMap(const wstring &attribsString, map<wstring, wstring> &attrib
 	// If there was no trailing semi-colon, we need to handle the last attribute.
 	if (!key.empty())
 		attribsMap[key] = str;
+	// Truncate the value of "src" if it contains base64 data
+	map<wstring,wstring>::const_iterator attribsMapIt;
+	if ((attribsMapIt = attribsMap.find(L"src")) != attribsMap.end()) {
+		str = attribsMapIt->second;
+		const wstring prefix = L"data:";
+		if (str.substr(0, prefix.length()) == prefix) {
+			const wstring needle = L"base64,";
+			wstring::size_type pos = str.find(needle);
+			if (pos != wstring::npos) {
+				str.replace(pos + needle.length(), wstring::npos, L"<truncated>");
+				attribsMap[L"src"] = str;
+			}
+		}
+	}
 }
 
 CComPtr<IAccessibleHyperlink> HyperlinkGetter::next() {


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Follow up of #10231

### Summary of the issue:

When the `src` attribute of an `img` elements contains huge base64 data, the virtual buffer is uselessly filled with potentially lengthy content that impact performance.

### Description of how this pull request fixes the issue:

When the value of the `src` starts with "data:", locate "base64," and truncate everything onward, replacing it with "\<truncated\>".

### Testing performed:

Tested against [the test case of #10227](https://github.com/nvaccess/nvda/files/3645959/i10227.html.txt).

### Known issues with pull request:

### Change log entry:

I'm not sure this deserves to be announced.
Otherwise:

Section: Changes for developers

Firefox and Chrome: In the `src` attribute of an `img` element, base64 data are now truncated from the virtual buffer.