### PR TITLE
Add ability to reset all gestures to their factory default

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3416,7 +3416,7 @@ class InputGesturesDialog(SettingsDialog):
 
 	def onReset(self, evt):
 		if gui.messageBox(
-			# Translators: A prompt for comfirmation to reset all gestures in the Input Gestures dialog.
+			# Translators: A prompt for confirmation to reset all gestures in the Input Gestures dialog.
 			_("""Are you sure you want to reset all gestures to their factory defaults?
 			
 			All past and present user defined gestures will be lost.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3415,7 +3415,6 @@ class InputGesturesDialog(SettingsDialog):
 		self.tree.SetFocus()
 
 	def onReset(self, evt):
-		log.warning("doing it")
 		if gui.messageBox(
 			# Translators: A prompt for comfirmation to reset all gestures in the Input Gestures dialog.
 			_("""Are you sure you want to reset all gestures to their factory defaults?

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3248,7 +3248,7 @@ class InputGesturesDialog(SettingsDialog):
 		filterSizer = wx.BoxSizer(wx.HORIZONTAL)
 		# Translators: The label of a text field to search for gestures in the Input Gestures dialog.
 		filterLabel = wx.StaticText(self, label=pgettext("inputGestures", "&Filter by:"))
-		filter = wx.TextCtrl(self)
+		filter = self.filter = wx.TextCtrl(self)
 		filterSizer.Add(filterLabel, flag=wx.ALIGN_CENTER_VERTICAL)
 		filterSizer.AddSpacer(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
 		filterSizer.Add(filter, proportion=1)
@@ -3279,10 +3279,16 @@ class InputGesturesDialog(SettingsDialog):
 		self.removeButton.Bind(wx.EVT_BUTTON, self.onRemove)
 		self.removeButton.Disable()
 
+		bHelper.sizer.AddStretchSpacer()
+		# Translators: The label of a button to reset all gestures in the Input Gestures dialog.
+		resetButton = wx.Button(self, label=_("Reset to factory &defaults"))
+		bHelper.sizer.Add(resetButton, flag=wx.ALIGN_RIGHT)
+		resetButton.Bind(wx.EVT_BUTTON, self.onReset)
+
 		self.pendingAdds = set()
 		self.pendingRemoves = set()
 
-		settingsSizer.Add(bHelper.sizer)
+		settingsSizer.Add(bHelper.sizer, flag=wx.EXPAND)
 
 	def postInit(self):
 		self.tree.SetFocus()
@@ -3406,6 +3412,29 @@ class InputGesturesDialog(SettingsDialog):
 			self.pendingRemoves.add(entry)
 		self.tree.Delete(treeGes)
 		scriptInfo.gestures.remove(gesture)
+		self.tree.SetFocus()
+
+	def onReset(self, evt):
+		log.warning("doing it")
+		if gui.messageBox(
+			# Translators: A prompt for comfirmation to reset all gestures in the Input Gestures dialog.
+			_("""Are you sure you want to reset all gestures to their factory default?
+			
+			All past and present user defined gestures will be lost.
+			This cannot be undone."""),
+			style=wx.YES | wx.NO | wx.NO_DEFAULT
+		) != wx.YES:
+			return
+		self.pendingAdds.clear()
+		self.pendingRemoves.clear()
+		inputCore.manager.userGestureMap.clear()
+		inputCore.manager.userGestureMap.save()
+		self.gestures = inputCore.manager.getAllGestureMappings(
+			obj=gui.mainFrame.prevFocus,
+			ancestors=gui.mainFrame.prevFocusAncestors
+		)
+		self.tree.DeleteChildren(self.treeRoot)
+		self.populateTree(filter=self.filter.GetValue())
 		self.tree.SetFocus()
 
 	def onOk(self, evt):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3419,7 +3419,7 @@ class InputGesturesDialog(SettingsDialog):
 			# Translators: A prompt for confirmation to reset all gestures in the Input Gestures dialog.
 			_("""Are you sure you want to reset all gestures to their factory defaults?
 			
-			All past and present user defined gestures will be lost.
+			All of your user defined gestures, whether previously set or defined during this session, will be lost.
 			This cannot be undone."""),
 			style=wx.YES | wx.NO | wx.NO_DEFAULT
 		) != wx.YES:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3418,7 +3418,7 @@ class InputGesturesDialog(SettingsDialog):
 		log.warning("doing it")
 		if gui.messageBox(
 			# Translators: A prompt for comfirmation to reset all gestures in the Input Gestures dialog.
-			_("""Are you sure you want to reset all gestures to their factory default?
+			_("""Are you sure you want to reset all gestures to their factory defaults?
 			
 			All past and present user defined gestures will be lost.
 			This cannot be undone."""),

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3427,6 +3427,18 @@ class InputGesturesDialog(SettingsDialog):
 		self.pendingAdds.clear()
 		self.pendingRemoves.clear()
 		inputCore.manager.userGestureMap.clear()
+		try:
+			inputCore.manager.userGestureMap.save()
+		except:  # noqa: E722
+			log.debugWarning("", exc_info=True)
+			# Translators: An error displayed when saving user defined input gestures fails.
+			gui.messageBox(
+				_("Error saving user defined gestures - probably read only file system."),
+				caption=_("Error"),
+				style=wx.OK | wx.ICON_ERROR
+			)
+			self.onCancel(None)
+			return
 		inputCore.manager.userGestureMap.save()
 		self.gestures = inputCore.manager.getAllGestureMappings(
 			obj=gui.mainFrame.prevFocus,


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

None

### Summary of the issue:

As pointed out in https://github.com/nvaccess/nvda/issues/9688#issuecomment-535936509 there is currently no way in NVDA to reset all modifications a user made in the Input Gestures dialog to their factory defaults.
A user willing to do so has to manually locate and delete its `gestures.ini` file.

### Description of how this pull request fixes the issue:

Add a button in the Input Gestures dialog to reset to factory defaults, with due prompt for confirmation and warning that this cannot be undone.

### Testing performed:

Checked the user's `gestures.ini` file is indeed emptied out.
Checked the dialog correctly reflects the new settings, whether it was previously dirty or not.

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

