### PR TITLE
Fix-up of: "Compile NVDA with the Windows 10 SDK (#7568)"

### DIFF
--- a/nvdaHelper/sconscript
+++ b/nvdaHelper/sconscript
@@ -32,6 +32,6 @@ archClientInstallDirs={
 
 #Build nvdaHelper for needed architectures
 for arch in env['targetArchitectures']: 
-	archEnv=env.Clone(TARGET_ARCH=arch,HOST_ARCH='x86',tools=['default','windowsSdk','midl','msrpc'])
+	archEnv=env.Clone(TARGET_ARCH=arch,HOST_ARCH='x86',tools=['default', 'midl', 'msrpc'])
 	archEnv.SConscript('archBuild_sconscript',exports={'env':archEnv,'clientInstallDir':archClientInstallDirs[arch],'libInstallDir':archLibInstallDirs[arch]},variant_dir='build/%s'%arch)
 

--- a/nvdaHelper/sconscript
+++ b/nvdaHelper/sconscript
@@ -32,6 +32,6 @@ archClientInstallDirs={
 
 #Build nvdaHelper for needed architectures
 for arch in env['targetArchitectures']: 
-	archEnv=env.Clone(TARGET_ARCH=arch,HOST_ARCH='x86',tools=['default', 'midl', 'msrpc'])
+	archEnv = env.Clone(TARGET_ARCH = arch, HOST_ARCH = 'x86', tools = ['default', 'midl', 'msrpc'])
 	archEnv.SConscript('archBuild_sconscript',exports={'env':archEnv,'clientInstallDir':archClientInstallDirs[arch],'libInstallDir':archLibInstallDirs[arch]},variant_dir='build/%s'%arch)
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When NVDA still supported versions of Windows older than Windows 7 it was necessary to build it with Windows SDK 7.1A. This required special tool for SCons. In #7568 the tool itself was removed, however it was still imported in default sconscript for NVDAHelper.
### Description of how this pull request fixes the issue:
The import is removed.
### Testing performed:
Created a launcher from a clean repo with this change, ensured that launcher still works.
### Known issues with pull request:
None known
### Change log entry:
None needed.