### PR TITLE
Bundle all *.dll files required for BrlApi when creating launcher on the system with BRLTTY installed

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -230,6 +230,7 @@ setup(
 		("images", glob("images/*.ico")),
 		("louis/tables",glob("louis/tables/*")),
 		("COMRegistrationFixes", glob("COMRegistrationFixes/*.reg")),
+		(".", glob("../miscDeps/python/*.dll")),
 		(".", ['message.html' ])
 	] + (
 		getLocaleDataFiles()


### PR DESCRIPTION
### Link to issue number:
Fixes #10238 
### Summary of the issue:
When creating launcher with Py2exe on a system on which BRLTTY is installed BrlAPI dll's are excluded from the distribution. I believe that it is actually a Py2exe bug, because when building with Python 2 version of it and BRLTTY bundling BrlAPI 0.5 is installed the required libraries are correctly included.
### Description of how this pull request fixes the issue:
All *.dll files from folder containing BrlAPI are explicitly copied to the dist folder during P2exe execution.
### Considered alternatives:
1. Performing copy operation as part of SCons - has the same disadvantages and requires more code.
2. Including BrlAPI dll in determine_dll_type function - this was not working. While BrlApi dll was correctly bundled libgcc_s_dw2-1.dll was not.
3. Writing hook for BrlApi. In my opinion it isn't worth the  trouble. Current approach isn't very clean but works.
 ### Testing performed:
Created launcher with BRLTTY installed and without it. In both cases tested that brlAPI files are correctly bundled, and BRLTTY appears in braille displays list.
### Known issues with pull request:
These dll's are unconditionally copied even if they would be included, so when BRLTTY is not installed they are copied twice. I don't consider this to be a big problem.
### Change log entry:
None needed.