### PR TITLE
Send buildVersion when checking for updates.

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -16,6 +16,7 @@ elif config.isAppX:
 import versionInfo
 if not versionInfo.updateVersionType:
 	raise RuntimeError("No update version type, update checking not supported")
+import buildVersion
 import addonAPIVersion
 
 import winVersion
@@ -102,6 +103,7 @@ def checkForUpdate(auto=False):
 		"autoCheck": auto,
 		"allowUsageStats":allowUsageStats,
 		"version": versionInfo.version,
+		"buildVersion":buildVersion.formatBuildVersionString(),
 		"versionType": versionInfo.updateVersionType,
 		"osVersion": winVersion.winVersionText,
 		"x64": os.environ.get("PROCESSOR_ARCHITEW6432") == "AMD64",


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The update server will need to ensure that users update to a version of NVDA with add-on compatibility code before updating to 2019.3.
Although the friendly version string is sent to the update server, the actual build version (year.major.minor.build) is not.
The buildVersion can more safely be used for ordering of versions.

### Description of how this pull request fixes the issue:
UpdateCheck now also sends the buildVersion when checking for updates.
The update server in future will be able to restrict updates based on the build version, or lack there of.

### Testing performed:
A try build of this branch, with updateVersionType as "stable" was still able to check for updates.

### Known issues with pull request:
None.

### Change log entry:
None.
