### PR TITLE
Report hidden formatting in MS Word

### DIFF
--- a/nvdaHelper/remote/WinWord/Constants.h
+++ b/nvdaHelper/remote/WinWord/Constants.h
@@ -44,6 +44,7 @@ constexpr int wdDISPID_FIELDS_ITEM_TYPE = 1;
 constexpr int wdDISPID_FONT_BOLD = 130;
 constexpr int wdDISPID_FONT_COLOR = 159;
 constexpr int wdDISPID_FONT_DOUBLESTRIKETHROUGH = 136;
+constexpr int wdDISPID_FONT_HIDDEN = 132;
 constexpr int wdDISPID_FONT_ITALIC = 131;
 constexpr int wdDISPID_FONT_NAME = 142;
 constexpr int wdDISPID_FONT_SIZE = 141;

--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -645,6 +645,9 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 				} else if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_DOUBLESTRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"strikethrough=\"double\" ";
 				}
+				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_HIDDEN,VT_I4,&iVal)==S_OK&&iVal) {
+					formatAttribsStream<<L"hidden=\"1\" ";
+				}			
 			}
 		}
 	}

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1574,10 +1574,12 @@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni
 		hidden = attrs.get("hidden")
 		oldHidden = attrsCache.get("hidden") if attrsCache is not None else None
 		if (hidden or oldHidden is not None) and hidden != oldHidden:
-			# Translators: Reported when text is hidden.
-			text = (_("hidden") if hidden
+			text = (
+				# Translators: Reported when text is hidden.
+				_("hidden")if hidden
 				# Translators: Reported when text is not hidden.
-				else _("not hidden"))
+				else _("not hidden")
+			)
 			textList.append(text)
 		textPosition=attrs.get("text-position")
 		oldTextPosition=attrsCache.get("text-position") if attrsCache is not None else None

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1577,7 +1577,7 @@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni
 			# Translators: Reported when text is hidden.
 			text = (_("hidden") if hidden
 				# Translators: Reported when text is not hidden.
-				else _("no hidden"))
+				else _("not hidden"))
 			textList.append(text)
 		textPosition=attrs.get("text-position")
 		oldTextPosition=attrsCache.get("text-position") if attrsCache is not None else None

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1571,6 +1571,14 @@ def getFormatFieldSpeech(attrs,attrsCache=None,formatConfig=None,reason=None,uni
 				# Translators: Reported when text is not underlined.
 				else _("not underlined"))
 			textList.append(text)
+		hidden = attrs.get("hidden")
+		oldHidden = attrsCache.get("hidden") if attrsCache is not None else None
+		if (hidden or oldHidden is not None) and hidden != oldHidden:
+			# Translators: Reported when text is hidden.
+			text = (_("hidden") if hidden
+				# Translators: Reported when text is not hidden.
+				else _("no hidden"))
+			textList.append(text)
 		textPosition=attrs.get("text-position")
 		oldTextPosition=attrsCache.get("text-position") if attrsCache is not None else None
 		if (textPosition or oldTextPosition is not None) and textPosition!=oldTextPosition:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8713

### Summary of the issue:
Hidden font formatting is not reported in MS Word (when nonprinting characters are displayed)

### Description of how this pull request fixes the issue:
Get the hidden attribute of character at the cursor as done for italic or bold for example.

### Testing performed:
Tested under Word 2016 and Outlook 2016 message with nonprinting characters displayed:

* put the cursor in hidden text and press NVDA+F one or two times: hidden is reported correctly
* put the cursor in non hidden text (normal) and press NVDA+F one or two times: hidden is not reported as expected
* with font attributes reporting enabled, move the cursor with left/right arrow keys into or out of hidden text: "hidden" and "no hidden" is reported when expected

### Known issues with pull request:
None

### Change log entry:

*Changes*
`Hidden font formatting is now reported in Microsoft Word. (#8713)`

