### PR TITLE
Redirect the http link referenced by most readme files to https

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,21 +5,21 @@ It is developed by NV Access in collaboration with a global community of contrib
 To learn more about NVDA or download a copy, visit the main [NV Access](http://www.nvaccess.org/) website.
 
 ## Key Project Links
-* [NV Access](http://www.nvaccess.org/): The main home of NVDA
+* [NV Access](https://www.nvaccess.org/): The main home of NVDA
 * [NVDA on GitHub](https://github.com/nvaccess/nvda)
 * [NVDA issues on GitHub](https://github.com/nvaccess/nvda/issues): Bug reports, feature requests, etc.
-* [NVDA development snapshots](http://www.nvda-project.org/snapshots): Automatically generated builds of the project in its current state of development
-* [NVDA add-ons](http://addons.nvda-project.org/): Get add-ons to enhance NVDA
+* [NVDA development snapshots](https://www.nvaccess.org/files/nvda/snapshots/): Automatically generated builds of the project in its current state of development
+* [NVDA add-ons](https://addons.nvda-project.org/): Get add-ons to enhance NVDA
 * [Translating NVDA](https://github.com/nvaccess/nvda/wiki/Translating): Information about how to translate NVDA into another language
 * [NVDA community wiki](https://github.com/nvaccess/nvda-community/wiki): Articles contributed by the community
 * [NVDA Controller Client](http://www.nvda-project.org/nvdaControllerClient/nvdaControllerClient_20100219.7z) (2010-02-19): NVDA API for external applications to directly speak or braille messages, etc.
-* [NVDA Developer Guide](http://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
+* [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
 * [Contributing to NVDA](https://github.com/nvaccess/nvda/wiki/Contributing): Guidelines for contributing to the NVDA source code
 * [NVDA development email list](https://nvda-devel.groups.io/) ([Old archives](http://nabble.nvda-project.org/Development-f1.html)): Discussion about NVDA development
-* [NVDA commits email list](http://lists.sourceforge.net/lists/listinfo/nvda-commits): Notifications for all commits to the Git repository
+* [NVDA commits email list](https://lists.sourceforge.net/lists/listinfo/nvda-commits): Notifications for all commits to the Git repository
 
 ## Getting the Source Code
-The NVDA project uses the [Git](http://www.git-scm.com/) version control system for its source code and documentation.
+The NVDA project uses the [Git](https://www.git-scm.com/) version control system for its source code and documentation.
 
 The NVDA Git repository is located at https://github.com/nvaccess/nvda.git. You can clone it with the following command, which will place files in a directory named `nvda`:
 
@@ -35,7 +35,7 @@ The NVDA source depends on several other packages to run correctly.
 ### Installed Dependencies
 The following dependencies need to be installed on your system:
 
-* [Python](http://www.python.org/), version 3.7, 32 bit
+* [Python](https://www.python.org/), version 3.7, 32 bit
 	* Use latest minor version if possible.
 * Microsoft Visual Studio 2017 Community, Version 15.3 or later:
 	* Download from https://visualstudio.microsoft.com/downloads/
@@ -45,7 +45,7 @@ The following dependencies need to be installed on your system:
 			* Desktop development with C++
 		* Then in the Installation details section, under Desktop for C++, Optional grouping, ensure the following are selected:
 			* VC++ 2017 v141 toolset (x86,x64)
-			* Windows 10 SDK (10.0.17134.0) for Desktop C++ x86 and x64
+			* Windows 10 SDK (10.0.18362.0) for Desktop C++ x86 and x64
 			* Visual C++ ATL for x86 and x64
 		* In the Installation details section, under Individual components, ensure the following are selected:
 			* Visual C++ compilers and libraries for ARM64
@@ -61,32 +61,32 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 For reference, the following run time dependencies are included in Git submodules:
 
 * [comtypes](https://github.com/enthought/comtypes), version 1.1.7
-* [wxPython](http://www.wxpython.org/), version 4.0.3
+* [wxPython](https://www.wxpython.org/), version 4.0.3
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 86e67a
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
-* [IAccessible2](http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2), commit 21bbb176
+* [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
 * [liblouis](http://www.liblouis.org/), version 3.10.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
 * NVDA images and sounds
-* [Adobe Acrobat accessibility interface, version XI](http://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
+* [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * Adobe FlashAccessibility interface typelib
 * [MinHook](https://github.com/RaMMicHaeL/minhook), tagged version 1.2.2
-* brlapi Python bindings, version 0.7.0 or later, distributed with [BRLTTY for Windows](http://brl.thefreecat.org/brltty/), version 4.2-2
+* brlapi Python bindings, version 0.7.0 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html/brltty/), version 4.2-2
 * lilli.dll, version 2.1.0.0
-* [pySerial](http://pypi.python.org/pypi/pyserial), version 3.4
+* [pySerial](https://pypi.python.org/pypi/pyserial), version 3.4
 * [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)
 
 Additionally, the following build time dependencies are included in Git submodules:
 
-* [Py2Exe](http://github.com/albertosottile/py2exe/), version 0.9.3.2 commit b372a8e
-* [Python Windows Extensions](http://sourceforge.net/projects/pywin32/ ), build 224, required by py2exe
-* [txt2tags](http://txt2tags.sourceforge.net/), version 2.5
-* [SCons](http://www.scons.org/), version 3.0.4
-* [Nulsoft Install System](http://nsis.sourceforge.net/), version 2.51
-* [NSIS UAC plug-in](http://nsis.sourceforge.net/UAC_plug-in), version 0.2.4, ansi
-* xgettext and msgfmt from [GNU gettext](http://sourceforge.net/projects/cppcms/files/boost_locale/gettext_for_windows/)
+* [Py2Exe](https://github.com/albertosottile/py2exe/), version 0.9.3.2 commit b372a8e
+* [Python Windows Extensions](https://sourceforge.net/projects/pywin32/ ), build 224, required by py2exe
+* [txt2tags](https://txt2tags.org/), version 2.5
+* [SCons](https://www.scons.org/), version 3.0.4
+* [Nulsoft Install System](https://nsis.sourceforge.io/Main_Page/), version 2.51
+* [NSIS UAC plug-in](https://nsis.sourceforge.io/UAC_plug-in), version 0.2.4, ansi
+* xgettext and msgfmt from [GNU gettext](https://sourceforge.net/projects/cppcms/files/boost_locale/gettext_for_windows/)
 * [epydoc](http://epydoc.sourceforge.net/), version 3.0.1 with patch for bug #303
 * [Boost Optional (stand-alone header)](https://github.com/akrzemi1/Optional), from commit [3922965](https://github.com/akrzemi1/Optional/commit/3922965396fc455c6b1770374b9b4111799588a9)
 

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ The following dependencies need to be installed on your system:
 			* Desktop development with C++
 		* Then in the Installation details section, under Desktop for C++, Optional grouping, ensure the following are selected:
 			* VC++ 2017 v141 toolset (x86,x64)
-			* Windows 10 SDK (10.0.18362.0) for Desktop C++ x86 and x64
+			* Windows 10 SDK (10.0.17134.0) for Desktop C++ x86 and x64
 			* Visual C++ ATL for x86 and x64
 		* In the Installation details section, under Individual components, ensure the following are selected:
 			* Visual C++ compilers and libraries for ARM64


### PR DESCRIPTION

### Link to issue number:
#10314   
### Summary of the issue:
Most of the links introduced by the current NVDA readme.md are still http
### Description of how this pull request fixes the issue:
Redirect most http links introduced by readme.md to https
### Testing performed:
Tested using clone's NVDA codebase
### Known issues with pull request:
Redirect the http link referenced by most readme files to https
### Change log entry:
Redirect the http link referenced by most readme files to https #10314 
Section: Bug fixes ,Changes
thanks