### PR TITLE
Add appModule for Spring Tool Suite 4

### DIFF
--- a/source/appModules/springtoolsuite4.py
+++ b/source/appModules/springtoolsuite4.py
@@ -1,0 +1,11 @@
+# -*- coding: UTF-8 -*-
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019 NV Access Limited, Łukasz Golonka
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+""" App module for Spring Tool Suite version 4
+This simply uses the app module for Eclipse.
+"""
+
+from .eclipse import *

--- a/source/appModules/springtoolsuite4.py
+++ b/source/appModules/springtoolsuite4.py
@@ -10,4 +10,4 @@ This simply uses the app module for Eclipse.
 
 # Normally these Flake8 errors shouldn't be ignored but here we are simply reusing existing ap module.
 
-from .eclipse import *  # noqa: F403,F401
+from .eclipse import *  # noqa: F401, F403

--- a/source/appModules/springtoolsuite4.py
+++ b/source/appModules/springtoolsuite4.py
@@ -6,6 +6,7 @@
 
 """ App module for Spring Tool Suite version 4
 This simply uses the app module for Eclipse.
+Normally these Flake8 errors shouldn't be ignored but in this case we are simply reusing existing ap module.
 """
 
-from .eclipse import *
+from .eclipse import *  # noqa: F403,F401

--- a/source/appModules/springtoolsuite4.py
+++ b/source/appModules/springtoolsuite4.py
@@ -6,7 +6,8 @@
 
 """ App module for Spring Tool Suite version 4
 This simply uses the app module for Eclipse.
-Normally these Flake8 errors shouldn't be ignored but in this case we are simply reusing existing ap module.
 """
+
+# Normally these Flake8 errors shouldn't be ignored but here we are simply reusing existing ap module.
 
 from .eclipse import *  # noqa: F403,F401


### PR DESCRIPTION
### Link to issue number:
Fixes #10001 
### Summary of the issue:
Spring Tool Suite 4 changed name of its main executable. Because of this proper appModule wasn't loaded.
### Description of how this pull request fixes the issue:
Add app Module for a proper executable. This simply imports module for Eclipse.
### Testing performed:
Try build tested by @alexandretoco. He confirms that proper module is loaded. I cannot test myself because Spring Tool suite fails to start on my machine for some reason.
### Known issues with pull request:
None known
### Change log entry:

Section: Bug fixes

Spring Tool Suite Version 4 is now supported