### PR TITLE
Start menu suggestions: announce result details

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -869,6 +869,7 @@ class UIA(Window):
 			# Nested block here in order to catch value error and variable binding error when attempting to access automation ID for invalid elements.
 			try:
 				# #6241: Raw UIA base tree walker is better than simply looking at self.parent when locating suggestion list items.
+				# #10329: 2019 Windows Search results require special handling due to UI redesign.
 				parentElement=UIAHandler.handler.baseTreeWalker.GetParentElementBuildCache(self.UIAElement,UIAHandler.handler.baseCacheRequest)
 				# Sometimes, fetching parent (list control) via base tree walker fails, especially when dealing with suggestions in Windows10 Start menu.
 				# Oddly, we need to take care of context menu for Start search suggestions as well.

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -7,8 +7,9 @@
 """
 
 import appModuleHandler
+import controlTypes
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
-from NVDAObjects.UIA import UIA, SearchField
+from NVDAObjects.UIA import UIA, SearchField, SuggestionListItem
 
 class StartMenuSearchField(SearchField):
 
@@ -28,3 +29,7 @@ class AppModule(appModuleHandler.AppModule):
 		elif isinstance(obj, UIA):
 			if obj.UIAElement.cachedAutomationID == "SearchTextBox":
 				clsList.insert(0, StartMenuSearchField)
+			# #10329: Since 2019, some suggestion items are grouped inside another suggestions list item.
+			# Because of this, result details will not be announced like in the past.
+			elif obj.role == controlTypes.ROLE_LISTITEM and isinstance(obj.parent, SuggestionListItem):
+				clsList.insert(0, SuggestionListItem)

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -1,7 +1,10 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2015-2017 NV Access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2015-2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""App module for Start menu/Windows Search/Cortana user interface in Windows 10 Version 1909 and earlier.
+"""
 
 import appModuleHandler
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
@@ -9,7 +12,7 @@ from NVDAObjects.UIA import UIA, SearchField
 
 class StartMenuSearchField(SearchField):
 
-		# #7370: do not announce text when start menu (searchui) closes.
+	# #7370: do not announce text when start menu (searchui) closes.
 	announceNewLineText = False
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -19,7 +19,7 @@ class StartMenuSearchField(SearchField):
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
-		if isinstance(obj,IAccessible):
+		if isinstance(obj, IAccessible):
 			try:
 				# #5288: Never use ContentGenericClient, as this uses displayModel
 				# which will freeze if the process is suspended.


### PR DESCRIPTION
Hi,

First of a series of pull requests on updating Start menu support routines:

### Link to issue number:
Fixes #10329 

### Summary of the issue:
Details for search results are not announced like in the past.

### Description of how this pull request fixes the issue:
Due to restructured UIA tree for Start menu (applicable in Version 1607/Anniversary Update with updated Windows Search design), search results are housed inside search categories, with categories themselves reported as suggestions list items. Therefore recognize result entries as seen in newer Windows Search experience.

### Testing performed:
Tested via Windows 10 App Essentials on Version 1607 and later (no need to look into 1507 and 1511 because they retain the original Windows 10 Start menu experience).

### Known issues with pull request:
Results will be announced twice due to caret movement script (see #10336 and a follow-up PR for a fix).

### Change log entry:
Bug fixes:

In Start menu for Windows 10 Anniversary Update and later, NVDA will announce details of search results. (#10232 
