### PR TITLE
Windows 10 Start menu: NVDA will no longer announce "blank" when pressing up or down arrow from an empty search box

### DIFF
--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -12,6 +12,14 @@ class StartMenuSearchField(SearchField):
 		# #7370: do not announce text when start menu (searchui) closes.
 	announceNewLineText = False
 
+	# #10336: "blank" is announced when up or down arrow is pressed from an empty search box,
+	# as well as causing repetitions for search results.
+	__gestures = {
+		"kb:downArrow": None,
+		"kb:upArrow": None,
+	}
+
+
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):


### PR DESCRIPTION
### Link to issue number:
Fixes #10336 

### Summary of the issue:
NVDA announces 'blank' from an empty search box in Start menu. This is caused by caret movement script where NVDA will try its best to detect and announce caret movements. Thus suppress scripts for up or down arrows by assigning them to None.

### Description of how this pull request fixes the issue:
Up and down arrows are assigned to None in StartMenuSearchField class.

### Testing performed:
Tested via Windows 10 App Essentials and on Windows 10 Version 1909.

### Known issues with pull request:
Search results (at least search box content) will not be announced. This issue goes away if #10341 PR is merged first.

### Change log entry:
Bug fixes:

In Start menu in Windows 10 Anniversary Update and later, NVDA will no longer announce "blank" when pressing up or down arrows to open All Apps. (#10232 

Thanks.