### PR TITLE
Bundle Universal CRT libraries when creating NVDA distribution

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -19,6 +19,7 @@ from glob import glob
 import sourceEnv
 from py2exe.dllfinder import pydll
 import importlib.util
+import winreg
 
 def recursiveCopy(env,targetDir,sourceDir):
 	targets=[]
@@ -278,6 +279,19 @@ def NVDADistGenerator(target, source, env, for_signature):
 	# However, Py2exe currently tries to add a string resource to it, invalidating the signature and possibly currupting the certificate.
 	# Therefore, copy a fresh version  of the dll one more time once py2exe has completed.
 	action.append(Copy(target[0],pydll))
+
+	# #10031: Apps written in Python 3 require Universal CRT to be installed. We cannot assume users have it on their systems.
+	# Therefore , copy required libraries from Windows 10 SDK.
+	try:
+		with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0', 0,winreg.KEY_READ|winreg.KEY_WOW64_32KEY) as SDKKey:
+			CRTDir = os.path.join(winreg.QueryValueEx(SDKKey, 'InstallationFolder')[0], "Redist", "ucrt", "DLLs", "x86")
+	except WindowsError:
+		raise RuntimeError("Windows 10 SDK not found")
+	if os.path.isdir(CRTDir):
+		with os.scandir(CRTDir) as dir:
+			for file in dir:
+				if file.name.endswith(".dll") and file.is_file():
+					action.append(Copy(target[0], file.path))
 
 	if certFile:
 		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "nvda_eoaProxy.exe":


### PR DESCRIPTION
### Link to issue number:
Fixes #10031 
### Summary of the issue:
After migration to Python 3 it was no longer possible to start NVDA under  anything older than Windows 10 as long as update containing Universal CRT was not installed.
### Description of how this pull request fixes the issue:
During scons dist all Universal CRT libraries are copied from Windows 10 SDk to the dist folder.
### Testing performed:
TBD. When investigating #10031 I've copied exactly the same set of DLLs manually to the NVDA folder and it fixed the problem, so I am quite confident about this fix.
### Known issues with pull request:
1. I've chosen to detect Windows 10 SDK path using the registry rather than hard coding it. I hope this would account for situations in which it is installed to some custom location, but I haven't tested this.
2. Building on 32-bit wasn't tested with this fix. It is not a big deal because building under 32-bit Windows is currently broken (see #9990). I'll test this as soon as we update to VS 2019. This shouldn't block this pr.
3. I am not entirely happy with the code. My SCons knowledge is very limited, so it probably could be accomplished in a more elegant way.
### Change log entry:
None needed as this fixes regression not yet in a release.