### PR TITLE
Windows Search: renamed from searchui to searchapp in build 18965

### DIFF
--- a/source/appModules/searchapp.py
+++ b/source/appModules/searchapp.py
@@ -1,0 +1,10 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Windows Search app module for Windows 10 build 18965 and later.
+"""
+
+# Flake8/F403: this is an alias for SearchUI app module.
+from .searchui import * # NOQA


### PR DESCRIPTION
Hi,

Required by Windows Search PR's:

### Link to issue number:
Fixes #10350 

### Summary of the issue:
Executable for Windows Search has been renamed from SearchUI.exe to SearchApp.exe in build 18965.

### Description of how this pull request fixes the issue:
Several Windows Search features will not work in Windows 10 build 18965 and later because executable has been renamed from searchui to searchapp. Therefore add an alias app module for SearchApp.exe that imports everything from searchui app module.

### Testing performed:
Tested with build 18995 and via Windows 10 App Essentials add-on.

### Known issues with pull request:
None

### Change log entry:
Technically none, although if going into new features:

Added support for Windows Search features in Windows 10 build 18965 and later. (#10350)

Thanks.