### PR TITLE
Add missing spaces in Find dialog layout

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -14,6 +14,7 @@ import core
 import baseObject
 import documentBase
 import gui
+from gui import guiHelper
 import sayAllHandler
 import review
 from scriptHandler import willSayAllResume
@@ -38,21 +39,16 @@ class FindDialog(wx.Dialog):
 		# Have a copy of the active cursor manager, as this is needed later for finding text.
 		self.activeCursorManager = cursorManager
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
-
-		findSizer = wx.BoxSizer(wx.HORIZONTAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		# Translators: Dialog text for NvDA's find command.
-		textToFind = wx.StaticText(self, wx.ID_ANY, label=_("Type the text you wish to find"))
-		findSizer.Add(textToFind)
-		self.findTextField = wx.TextCtrl(self, wx.ID_ANY)
-		self.findTextField.SetValue(text)
-		findSizer.Add(self.findTextField)
-		mainSizer.Add(findSizer,border=20,flag=wx.LEFT|wx.RIGHT|wx.TOP)
+		findLabelText = _("Type the text you wish to find")
+		self.findTextField = sHelper.addLabeledControl(findLabelText, wx.TextCtrl, value=text)
 		# Translators: An option in find dialog to perform case-sensitive search.
 		self.caseSensitiveCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Case &sensitive"))
 		self.caseSensitiveCheckBox.SetValue(caseSensitivity)
-		mainSizer.Add(self.caseSensitiveCheckBox,border=10,flag=wx.BOTTOM)
-
-		mainSizer.Add(self.CreateButtonSizer(wx.OK|wx.CANCEL), flag=wx.ALIGN_RIGHT)
+		sHelper.addItem(self.caseSensitiveCheckBox)
+		sHelper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK | wx.CANCEL))
+		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Bind(wx.EVT_BUTTON,self.onOk,id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON,self.onCancel,id=wx.ID_CANCEL)
 		mainSizer.Fit(self)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10353

### Summary of the issue:

Find dialog (NVDA+Ctrl+F) has a layout that misses the following spaces:

* No space between the "Type the text you wish to find" label and the corresponding field
* No space between the "Case sensitive" check box and the dialog edge
* No space between "OK"/"Cancel" buttons and the dialog's edge

This leads to an unusual design of the dialog. This is more difficult for visually impaired people to get visually the expected information from this dialog. E.g. difficulty to read the text to find in the edit box because it is not properly separated from the label.

### Description of how this pull request fixes the issue:

Rework this dialog by using BoxSizerHelper to manage automatically spaces between elements.

### Testing performed:

* Checked that the size of the edit field (height and width) is remained the same.
* Checked visually that spaces are at the correct position with UI in English and in !french. Maybe another check from someone that can see better than me is required. Cc: @JulienCochuyt 

### Known issues with pull request:
None

### Change log entry:

None
