### PR TITLE
Modern keyboard: add support for 20H1 Text Input Host

### DIFF
--- a/source/appModules/textinputhost.py
+++ b/source/appModules/textinputhost.py
@@ -1,0 +1,11 @@
+# App module for Text Inpur Hoar (formerly Composable Shell (CShell) input panel)
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""App module for Windows 10 Modern Keyboard aka new touch keyboard panel.
+This is for 20H1 text input host window."""
+
+# Flake8/F403: alias of Composable Shell modern keyboard app module.
+from .windowsinternal_composableshell_experiences_textinput_inputapp import * # NOQA


### PR DESCRIPTION
### Link to issue number:
Fixes #10359 

### Summary of the issue:
Modern keyboard app has been renamed in Windows 10 20H1.

### Description of how this pull request fixes the issue:
In build 18963, modern keyboard executable has been renamed to textinputhost.exe, breaking support for emoji panel, clipboard history and other modern input features. Thus add an alias app module for Txt Input Host.

### Testing performed:
Tested on build 18999 via Windows 10 App Essentials add-on.

### Known issues with pull request:
None

### Change log entry:
Technically none.
