### PR TITLE
displayModel, compensate for left coordinates greater than right

### DIFF
--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -200,7 +200,15 @@ def getWindowTextInRect(bindingHandle, windowHandle, left, top, right, bottom,mi
 	characterLocations = []
 	cpBufIt = iter(cpBuf)
 	for cp in cpBufIt:
-		characterLocations.append(RectLTRB(wcharToInt(cp), wcharToInt(next(cpBufIt)), wcharToInt(next(cpBufIt)), wcharToInt(next(cpBufIt))))
+		left, top, right, bottom = (
+			wcharToInt(cp),
+			wcharToInt(next(cpBufIt)),
+			wcharToInt(next(cpBufIt)),
+			wcharToInt(next(cpBufIt)
+		)
+		if right < left:
+			left, right = right, left
+		characterLocations.append(RectLTRB(left, top, right, bottom))
 	return text, characterLocations
 
 def getFocusRect(obj):

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -204,7 +204,7 @@ def getWindowTextInRect(bindingHandle, windowHandle, left, top, right, bottom,mi
 			wcharToInt(cp),
 			wcharToInt(next(cpBufIt)),
 			wcharToInt(next(cpBufIt)),
-			wcharToInt(next(cpBufIt)
+			wcharToInt(next(cpBufIt))
 		)
 		if right < left:
 			left, right = right, left


### PR DESCRIPTION
### Link to issue number:
Split from #9269 
fixes #9931

### Summary of the issue:
In the display model, sometimes the left coordinate is greater than the right coordinate. This causes issues when translating in poedit.

### Description of how this pull request fixes the issue:
When left is greater than right, swap the coordinates.

### Testing performed:
Tested the str from #9931

### Known issues with pull request:
This could be considered a work around. It could be that something is wrong in the C++ part of the display model code.

### Change log entry:
* Bug fixes
    + In Poedit, it is once again possible to view some translations for right to left languages. (#9931)