### PR TITLE
Windows 10/File Explorer: recognize ApplicationFrameWindow as UIA object so first selected emoji and cloud clipboard item can be announced in May 2019 Update and later

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -5,7 +5,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-"""App module for Windows Explorer (aka Windows shell).
+"""App module for Windows Explorer (aka Windows shell and renamed to File Explorer in Windows 8).
 Provides workarounds for controls such as identifying Start button, notification area and others.
 """
 
@@ -13,6 +13,7 @@ from comtypes import COMError
 import time
 import appModuleHandler
 import controlTypes
+import winVersion
 import winUser
 import winVersion
 import api
@@ -323,4 +324,25 @@ class AppModule(appModuleHandler.AppModule):
 			# #6671: Never allow WorkerW thread to send gain focus event, as it causes 'pane" to be announced when minimizing windows or moving to desktop.
 			return
 
+		nextHandler()
+
+	def isGoodUIAWindow(self, hwnd):
+		# #9204: shell raises window open event for emoji panel in build 18305 and later.
+		if winVersion.isWin10(version=1903) and winUser.getClassName(hwnd) == "ApplicationFrameWindow":
+			return True
+		return False
+
+	def event_UIA_window_windowOpen(self, obj, nextHandler):
+		# Send UIA window open event to input app window.
+		if isinstance(obj, UIA) and obj.UIAElement.cachedClassName == "ApplicationFrameWindow":
+			inputPanelWindow = obj.firstChild
+			inputPanelAppName = (
+				# 19H2 and earlier
+				"windowsinternal_composableshell_experiences_textinput_inputapp",
+				# 20H1 and later
+				"textinputhost"
+			)
+			if inputPanelWindow and inputPanelWindow.appModule.appName in inputPanelAppName:
+				eventHandler.executeEvent("UIA_window_windowOpen", inputPanelWindow)
+				return
 		nextHandler()

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -13,7 +13,6 @@ from comtypes import COMError
 import time
 import appModuleHandler
 import controlTypes
-import winVersion
 import winUser
 import winVersion
 import api

--- a/source/appModules/textinputhost.py
+++ b/source/appModules/textinputhost.py
@@ -1,4 +1,4 @@
-# App module for Text Inpur Hoar (formerly Composable Shell (CShell) input panel)
+# App module for Text Input Host (formerly Composable Shell (CShell) input panel)
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2019 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.


### PR DESCRIPTION
Hi,

Note: this is a smaller version of #9205 

### Link to issue number:
Fixes #9204 

### Summary of the issue:
In Windows 10 Version 1903 (May 2019 Update) and later, when emoji panel or cloud clipboard opens, first selected item is not announced because UIA window open event is fired by File Explorer.

### Description of how this pull request fixes the issue:
Allow ApplicationFrameWindow in File Explorer to be recognized as a UIA object so UIA window open event can be detected for it, which will then be forwarded to modern keyboard so first selected item can be announced for emoji panel and clipboard history.

### Testing performed:
Tested via Windows 10 App Essentials on Version 1903 and later.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

In Windows 10 May 2019 Update and later, NVDA will once again announce first selected emoji or clipboard item when emoji panel and clipboard history opens, respectively. (#9204)
