### PR TITLE
Emoji panel and clipboard history: locate correct items if controls are different due to recent changes

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,8 +1,8 @@
 # App module for Composable Shell (CShell) input panel
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017-2018 NV Access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2017-2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """App module for Windows 10 Modern Keyboard aka new touch keyboard panel.
 The chief feature is allowing NVDA to announce selected emoji when using the keyboard to search for and select one.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -79,11 +79,20 @@ class AppModule(appModuleHandler.AppModule):
 		inputPanelAutomationID = inputPanel.UIAElement.cachedAutomationID
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
-		if winVersion.winVersion.build <= 17134 and inputPanelAutomationID in ("TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl", "TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"):
+		if (
+			winVersion.winVersion.build <= 17134
+			and inputPanelAutomationID in (
+				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
+				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
+			)
+		):
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
-		elif inputPanelAutomationID == "CandidateWindowControl" and config.conf["inputComposition"]["autoReportAllCandidates"]:
+		elif (
+			inputPanelAutomationID == "CandidateWindowControl"
+			and config.conf["inputComposition"]["autoReportAllCandidates"]
+		):
 			try:
 				self.event_UIA_elementSelected(inputPanel.firstChild.firstChild, nextHandler)
 			except AttributeError:
@@ -92,8 +101,12 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel in build 17666 and later (unless this changes).
 		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
-			# #10377: on some systems, there is something else besides grouping controls, so another child control must be used.
-			emojisIndex = -3 if inputPanel.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView" else -2
+			# #10377: on some systems, there is something else besides grouping controls,
+			# so another child control must be used.
+			if inputPanel.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
+				emojisIndex = -3
+			else:
+				emojisIndex = -2
 			try:
 				self.event_UIA_elementSelected(inputPanel.children[emojisIndex].firstChild.firstChild, nextHandler)
 			except AttributeError:
@@ -103,8 +116,12 @@ class AppModule(appModuleHandler.AppModule):
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
 		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
-			# Under some cases, clipboard tip text isn't shown on screen, causing clipboard history title to be announced instead of most recently copied item.
-			clipboardItemsIndex = -2 if obj.children[-2].UIAElement.cachedAutomationID != inputPanelAutomationID else -1
+			# Under some cases, clipboard tip text isn't shown on screen,
+			# causing clipboard history title to be announced instead of most recently copied item.
+			if obj.children[-2].UIAElement.cachedAutomationID != inputPanelAutomationID:
+				clipboardItemsIndex = -2
+			else:
+				clipboardItemsIndex = -1
 			self.event_UIA_elementSelected(obj.children[clipboardItemsIndex], nextHandler)
 		nextHandler()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -72,34 +72,35 @@ class AppModule(appModuleHandler.AppModule):
 		# However, in build 17666 and later, child count is the same for both emoji panel and hardware keyboard candidates list.
 		# Thankfully first child automation ID's are different for each modern input technology.
 		# However this event is raised when the input panel closes.
-		if obj.firstChild is None:
+		inputPanel = obj.firstChild
+		if inputPanel is None:
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
-		childAutomationID = obj.firstChild.UIAElement.cachedAutomationID
+		inputPanelAutomationID = inputPanel.UIAElement.cachedAutomationID
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
-		if winVersion.winVersion.build <= 17134 and childAutomationID in ("TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl", "TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"):
+		if winVersion.winVersion.build <= 17134 and inputPanelAutomationID in ("TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl", "TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"):
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
-		elif childAutomationID == "CandidateWindowControl" and config.conf["inputComposition"]["autoReportAllCandidates"]:
+		elif inputPanelAutomationID == "CandidateWindowControl" and config.conf["inputComposition"]["autoReportAllCandidates"]:
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(inputPanel.firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# Because this is dictation window.
 				pass
 		# Emoji panel in build 17666 and later (unless this changes).
-		elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
+		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.children[-2].firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(inputPanel.children[-2].firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
 		# Clipboard history.
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
-		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
+		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
 			self.event_UIA_elementSelected(obj.children[-2], nextHandler)
 		nextHandler()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -67,6 +67,12 @@ class AppModule(appModuleHandler.AppModule):
 			ui.message(_("No emoji"))
 		nextHandler()
 
+	# Emoji panel for build 16299 and 17134.
+	_classicEmojiPanelAutomationID = (
+		"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
+		"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
+	)
+
 	def event_UIA_window_windowOpen(self, obj, nextHandler):
 		# Make sure to announce most recently used emoji first in post-1709 builds.
 		# Fake the announcement by locating 'most recently used" category and calling selected event on this.
@@ -82,10 +88,7 @@ class AppModule(appModuleHandler.AppModule):
 		# This event is properly raised in build 17134.
 		if (
 			not winVersion.isWin10(version=1809)
-			and inputPanelAutomationID in (
-				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
-				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
-			)
+			and inputPanelAutomationID in self._classicEmojiPanelAutomationID
 		):
 			eventHandler.executeEvent("UIA_elementSelected", obj.lastChild.firstChild)
 		# Handle hardware keyboard suggestions.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -80,7 +80,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
-			winVersion.winVersion.build <= 17134
+			not winVersion.isWin10(version=1809)
 			and inputPanelAutomationID in (
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -16,6 +16,7 @@ import braille
 import ui
 import config
 import winVersion
+import eventHandler
 from NVDAObjects.UIA import UIA
 
 class AppModule(appModuleHandler.AppModule):
@@ -86,7 +87,7 @@ class AppModule(appModuleHandler.AppModule):
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
 			)
 		):
-			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
+			eventHandler.executeEvent("UIA_elementSelected", obj.lastChild.firstChild)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
 		elif (
@@ -94,7 +95,7 @@ class AppModule(appModuleHandler.AppModule):
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
-				self.event_UIA_elementSelected(inputPanel.firstChild.firstChild, nextHandler)
+				eventHandler.executeEvent("UIA_elementSelected", inputPanel.firstChild.firstChild)
 			except AttributeError:
 				# Because this is dictation window.
 				pass
@@ -107,7 +108,7 @@ class AppModule(appModuleHandler.AppModule):
 			if emojisList.UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
 				emojisList = emojisList.previous
 			try:
-				self.event_UIA_elementSelected(emojisList.firstChild.firstChild, nextHandler)
+				eventHandler.executeEvent("UIA_elementSelected", emojisList.firstChild.firstChild)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
@@ -120,7 +121,7 @@ class AppModule(appModuleHandler.AppModule):
 			clipboardHistory = obj.children[-2]
 			if clipboardHistory.UIAElement.cachedAutomationID == inputPanelAutomationID:
 				clipboardHistory = clipboardHistory.next
-			self.event_UIA_elementSelected(clipboardHistory, nextHandler)
+			eventHandler.executeEvent("UIA_elementSelected", clipboardHistory)
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -103,12 +103,11 @@ class AppModule(appModuleHandler.AppModule):
 			self._emojiPanelJustOpened = True
 			# #10377: on some systems, there is something else besides grouping controls,
 			# so another child control must be used.
-			if inputPanel.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
-				emojisIndex = -3
-			else:
-				emojisIndex = -2
+			emojisList = inputPanel.children[-2]
+			if emojisList.UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
+				emojisList = emojisList.previous
 			try:
-				self.event_UIA_elementSelected(inputPanel.children[emojisIndex].firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(emojisList.firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
@@ -118,11 +117,10 @@ class AppModule(appModuleHandler.AppModule):
 		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
 			# Under some cases, clipboard tip text isn't shown on screen,
 			# causing clipboard history title to be announced instead of most recently copied item.
-			if obj.children[-2].UIAElement.cachedAutomationID != inputPanelAutomationID:
-				clipboardItemsIndex = -2
-			else:
-				clipboardItemsIndex = -1
-			self.event_UIA_elementSelected(obj.children[clipboardItemsIndex], nextHandler)
+			clipboardHistory = obj.children[-2]
+			if clipboardHistory.UIAElement.cachedAutomationID == inputPanelAutomationID:
+				clipboardHistory = clipboardHistory.next
+			self.event_UIA_elementSelected(clipboardHistory, nextHandler)
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -92,8 +92,10 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel in build 17666 and later (unless this changes).
 		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
+			# #10377: on some systems, there is something else besides grouping controls, so another child control must be used.
+			emojisIndex = -3 if inputPanel.children[-2].UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView" else -2
 			try:
-				self.event_UIA_elementSelected(inputPanel.children[-2].firstChild.firstChild, nextHandler)
+				self.event_UIA_elementSelected(inputPanel.children[emojisIndex].firstChild.firstChild, nextHandler)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
@@ -101,7 +103,9 @@ class AppModule(appModuleHandler.AppModule):
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
 		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
-			self.event_UIA_elementSelected(obj.children[-2], nextHandler)
+			# Under some cases, clipboard tip text isn't shown on screen, causing clipboard history title to be announced instead of most recently copied item.
+			clipboardItemsIndex = -2 if obj.children[-2].UIAElement.cachedAutomationID != inputPanelAutomationID else -1
+			self.event_UIA_elementSelected(obj.children[clipboardItemsIndex], nextHandler)
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.


### PR DESCRIPTION
### Link to issue number:
Fixes #10377 

### Summary of the issue:
In May 2019 Update, wrong item is announced when emoji panel and clipboard history opens due to UIA tree changes.

### Description of how this pull request fixes the issue:
Depending on UIA automation ID, select the right child from emoji panel/clipboard history panel so the correct item can be announced when it opens.

### Testing performed:
Tested via Windows 10 App Essentials add-on.

### Known issues with pull request:
None

### Change log entry:
None
