### PR TITLE
Python 3: change remaining next method in objidl.IEnumMoniker

### DIFF
--- a/source/objidl.py
+++ b/source/objidl.py
@@ -189,7 +189,7 @@ class IEnumMoniker(IUnknown):
 	def __iter__(self):
 		return self
 
-	def next(self):
+	def __next__(self):
 		item, fetched = self.Next(1)
 		if fetched:
 			return item


### PR DESCRIPTION
### Link to issue number:
Slightly related to #9535 

### Summary of the issue:
`objidl.IEnumMoniker` is used as an iterable in the visual studio appModule. However, due to python 2/3 change (`next` method should be `__next__`), this part of the code did not work as expected.

### Description of how this pull request fixes the issue:
Change `next` into `__next__` as expected.

### Testing performed:
Tested the following code snipped, based on the devenv appModule

```
ROT = objbase.GetRunningObjectTable()
list(ROT)
```

### Known issues with pull request:
None

### Change log entry:
None needed
