### PR TITLE
Browse mode: When the user moves the cursor, speak before setting selection.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -408,9 +408,12 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		except StopIteration:
 			ui.message(errorMessage)
 			return
-		item.moveTo()
+		# #8831: Report before moving because moving might change the focus, which
+		# might mutate the document, potentially invalidating info if it is
+		# offset-based.
 		if not gesture or not willSayAllResume(gesture):
 			item.report(readUnit=readUnit)
+		item.moveTo()
 
 	@classmethod
 	def addQuickNav(cls, itemType, key, nextDoc, nextError, prevDoc, prevError, readUnit=None):

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -142,11 +142,15 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 					pass
 				else:
 					info=self.makeTextInfo(textInfos.POSITION_FIRST if direction>0 else textInfos.POSITION_LAST)
-		self.selection=info
+		# #10343: Speak before setting selection because setting selection might
+		# move the focus, which might mutate the document, potentially invalidating
+		# info if it is offset-based.
+		selection = info.copy()
 		info.expand(unit)
 		if not willSayAllResume(gesture): speech.speakTextInfo(info,unit=unit,reason=controlTypes.REASON_CARET)
 		if not oldInfo.isCollapsed:
 			speech.speakSelectionChange(oldInfo,self.selection)
+		self.selection = selection
 
 	def doFindText(self,text,reverse=False,caseSensitive=False):
 		if not text:


### PR DESCRIPTION
### Link to issue number:
Fixes #8831. Fixes #10343.

### Summary of the issue:
In browse mode, if you move the cursor to something focusable and focusing it causes content earlier in the document to be removed, NVDA reports the wrong part of the document. See the issues linked above for test cases.

### Description of how this pull request fixes the issue:
Currently, for both normal cursor movement and quick navigation, we set the selection before speaking. However, setting selection might move the focus, which might mutate the document. For virtual buffers, the TextInfo is offset-based, so this could invalidate the offsets, causing the wrong part of the document to be spoken. To get around this, this change speaks before setting the selection instead of after.

### Testing performed:
Verified with the test cases in the issues linked above.

### Known issues with pull request:
If the newly focused element mutates its own content when focused, we won't speak the mutated content, since we speak before focusing. However, I think that's far less egregious than the problem we're fixing here and less likely to be a "real" problem.

We could fix this for quick nav by somehow re-fetching the TextInfo from the QuickNavItem between the moveTo and report calls. However, I don't think this can be done for normal cursor movement, since normal cursor movement isn't bounded by a single object. I don't think we want to be inconsistent here.

### Change log entry:

Bug fixes:
`- In browse mode, if moving the cursor or using quick navigation causes the document to change, NVDA no longer speaks incorrect content in some cases. (#8831, #10343)`