### PR TITLE
Support for inline parameter and parameter description reading

### DIFF
--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -177,7 +177,7 @@ class AppModule(appModuleHandler.AppModule):
 				speech.cancelSpeech()
 
 				if len(objParameterName.name) > 0:
-					# Translators: In english and other languages the first item has a leading colon. The first is the parameter name and the second is the description.
+					# Translators: In english and other languages the parameter name ends with a colon.
 					ui.message(_("{parameterName} {parameterDescription}").format(
 						parameterName=objParameterName.name,
 						parameterDescription=objParameterDescription.name


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Related to #8336 but there is no direct (technical) relation.

### Summary of the issue:

Other screen readers read out the parameter information as it appears on the screen. However NVDA doesn't. It is good to have this information when coding.

### Description of how this pull request fixes the issue:

This PR adds an event handler for name changes. It performs logic to take and read the current parameter as it appears on the screen by handling this event.

To complement the handler there is a script that tries to find and reads documentation about selected intellisense item or the current selected overload.

### Testing performed:

Tested against Visual Studio 2017 and 2019, latest versions.

### Known issues with pull request:

I tried to find a way to read the documentation when it appears but didn't found a good way.

### Change log entry:

Section: New features
- In Visual Studio 2017 and 2019, parameter information is read as it appears.
