### PR TITLE
Add textInfos unit mappings for UIA document, page and format field, make FORMATFIELD and CONTROLFIELD units global

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -27,6 +27,8 @@ from logHandler import log
 import UIAUtils
 from comtypes.gen import UIAutomationClient as UIA
 from comtypes.gen.UIAutomationClient import *
+import textInfos
+from typing import Dict
 
 #Some newer UIA constants that could be missing
 ItemIndex_Property_GUID=GUID("{92A053DA-2969-4021-BF27-514CFC2E4A69}")
@@ -76,12 +78,15 @@ UIADialogClassNames=[
 	"Shell_SystemDialog", # Various dialogs in Windows 10 Settings app
 ]
 
-NVDAUnitsToUIAUnits={
-	"character":TextUnit_Character,
-	"word":TextUnit_Word,
-	"line":TextUnit_Line,
-	"paragraph":TextUnit_Paragraph,
-	"readingChunk":TextUnit_Line,
+NVDAUnitsToUIAUnits: Dict[str, int] = {
+	textInfos.UNIT_CHARACTER: UIA.TextUnit_Character,
+	textInfos.UNIT_WORD: UIA.TextUnit_Word,
+	textInfos.UNIT_LINE: UIA.TextUnit_Line,
+	textInfos.UNIT_PARAGRAPH: UIA.TextUnit_Paragraph,
+	textInfos.UNIT_PAGE: UIA.TextUnit_Page,
+	textInfos.UNIT_READINGCHUNK: UIA.TextUnit_Line,
+	textInfos.UNIT_STORY: UIA.TextUnit_Document,
+	textInfos.UNIT_FORMATFIELD: UIA.TextUnit_Format,
 }
 
 UIAControlTypesToNVDARoles={

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1323,7 +1323,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		# We've hit the edge of the focused control.
 		# Therefore, move the virtual caret to the same edge of the field.
 		info = self.makeTextInfo(textInfos.POSITION_CARET)
-		info.expand(info.UNIT_CONTROLFIELD)
+		info.expand(textInfos.UNIT_CONTROLFIELD)
 		if gesture.mainKeyName in ("leftArrow", "upArrow", "pageUp"):
 			info.collapse()
 		else:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -1,8 +1,7 @@
-#textInfos/__init__.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2018 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2019 NV Access Limited, Babbage B.V.
 
 """Framework for accessing text content in widgets.
 The core component of this framework is the L{TextInfo} class.
@@ -189,21 +188,24 @@ class Bookmark(baseObject.AutoPropertyObject):
 	def __ne__(self,other):
 		return not self==other
 
+
 #Unit constants
-UNIT_CHARACTER="character"
-UNIT_WORD="word"
-UNIT_LINE="line"
-UNIT_SENTENCE="sentence"
-UNIT_PARAGRAPH="paragraph"
-UNIT_PAGE="page"
-UNIT_TABLE="table"
-UNIT_ROW="row"
-UNIT_COLUMN="column"
-UNIT_CELL="cell"
-UNIT_SCREEN="screen"
-UNIT_STORY="story"
-UNIT_READINGCHUNK="readingChunk"
-UNIT_OFFSET="offset"
+UNIT_CHARACTER = "character"
+UNIT_WORD = "word"
+UNIT_LINE = "line"
+UNIT_SENTENCE = "sentence"
+UNIT_PARAGRAPH = "paragraph"
+UNIT_PAGE = "page"
+UNIT_TABLE = "table"
+UNIT_ROW = "row"
+UNIT_COLUMN = "column"
+UNIT_CELL = "cell"
+UNIT_SCREEN = "screen"
+UNIT_STORY = "story"
+UNIT_READINGCHUNK = "readingChunk"
+UNIT_OFFSET = "offset"
+UNIT_CONTROLFIELD = "controlField"
+UNIT_FORMATFIELD = "formatField"
 
 MOUSE_TEXT_RESOLUTION_UNITS = (UNIT_CHARACTER,UNIT_WORD,UNIT_LINE,UNIT_PARAGRAPH)
 

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -136,9 +136,6 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 
 	allowMoveToOffsetPastEnd=False #: no need for end insertion point as vbuf is not editable. 
 
-	UNIT_CONTROLFIELD = "controlField"
-	UNIT_FORMATFIELD = "formatField"
-
 	def _getControlFieldAttribs(self,  docHandle, id):
 		info = self.copy()
 		info.expand(textInfos.UNIT_CHARACTER)
@@ -362,7 +359,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		return self._getFieldIdentifierFromOffset( self._startOffset)
 
 	def _getUnitOffsets(self, unit, offset):
-		if unit == self.UNIT_CONTROLFIELD:
+		if unit == textInfos.UNIT_CONTROLFIELD:
 			startOffset=ctypes.c_int()
 			endOffset=ctypes.c_int()
 			docHandle=ctypes.c_int()
@@ -370,7 +367,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 			node=VBufRemote_nodeHandle_t()
 			NVDAHelper.localLib.VBuf_locateControlFieldNodeAtOffset(self.obj.VBufHandle,offset,ctypes.byref(startOffset),ctypes.byref(endOffset),ctypes.byref(docHandle),ctypes.byref(ID),ctypes.byref(node))
 			return startOffset.value,endOffset.value
-		elif unit == self.UNIT_FORMATFIELD:
+		elif unit == textInfos.UNIT_FORMATFIELD:
 			startOffset=ctypes.c_int()
 			endOffset=ctypes.c_int()
 			node=VBufRemote_nodeHandle_t()

--- a/source/virtualBuffers/adobeAcrobat.py
+++ b/source/virtualBuffers/adobeAcrobat.py
@@ -19,7 +19,7 @@ import languageHandler
 class AdobeAcrobat_TextInfo(VirtualBufferTextInfo):
 
 	def _getBoundingRectFromOffset(self,offset):
-		formatFieldStart, formatFieldEnd = self._getUnitOffsets(self.UNIT_FORMATFIELD, offset)
+		formatFieldStart, formatFieldEnd = self._getUnitOffsets(textInfos.UNIT_FORMATFIELD, offset)
 		# The format field starts at the first character.
 		for field in reversed(self._getFieldsInRange(formatFieldStart, formatFieldStart+1)):
 			if not (isinstance(field, textInfos.FieldCommand) and field.command == "formatChange"):

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -24,7 +24,7 @@ from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
 class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 
 	def _getBoundingRectFromOffset(self,offset):
-		formatFieldStart, formatFieldEnd = self._getUnitOffsets(self.UNIT_FORMATFIELD, offset)
+		formatFieldStart, formatFieldEnd = self._getUnitOffsets(textInfos.UNIT_FORMATFIELD, offset)
 		# The format field starts at the first character.
 		for field in reversed(self._getFieldsInRange(formatFieldStart, formatFieldStart+1)):
 			if not (isinstance(field, textInfos.FieldCommand) and field.command == "formatChange"):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The _UIAHandler.NVDAUnitsToUIAUnits mapping is incomplete, not containing document and page.

### Description of how this pull request fixes the issue:
I added these units. I also discovered that we have TextUNitFormat, which is equivalent to NVDA format fields. Therefore, I moved the UNIT_CONTROLFIELD and UNIT_FORMATFIELD units from VirtualBufferTextINfo to the textInfos package. This should make the code more consistent and also fixes a theoretical bug where BrowseModeDocumentTreeInterceptor.event_caretMovementFailed tried to use UNIT_CONTROLFIELD on a TextInfo that didn't have this constant.

### Testing performed:
Tested that in Word with UIA enabled, I can expand to page, story and format field.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
    + The UNIT_CONTROLFIELD and UNIT_FORMATFIELD constants have been moved from virtualBuffers.VirtualBufferTextInfo to the textInfos package.
    + UIA TextInfo objects can now be moved/expanded by the page, story and formatField text units.