### PR TITLE
Fix bullet reading in Word

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -332,15 +332,15 @@ formatConfigFlag_includeLayoutTables=0x20000
 # Doesn't care about the actual font, so can give incorrect Unicode in rare cases.
 mapPUAToUnicode = {
 	# from : to # fontname
-	u'\uF06E' : u'\u25A0', # Wingdings (black square)
-	u'\uF076' : u'\u2756', # Wingdings (black diamond minus white x
-	u'\uF0A7' : u'\u25AA', # Symbol (black small square)
-	u'\uF0A8' : u'\u2666', # Symbol (black diamond suit)
-	u'\uF0B7' : u'\u2022', # Symbol (bullet)
-	u'\uF0D8' : u'\u2B9A', # Wingdings (three-D top-lighted RIGHTWARDS equilateral arrowhead) 
-	u'\uF0E8' : u'\U0001f87a', # Wingdings (wide-headed rightwards heavy barb arrow)
-	u'\uF0F0' : u'\u21E8', # Wingdings (right white arrow)
-	u'\uF0FC' : u'\u2714', # Wingdings (heavy check mark)
+	u'\uF06E': u'\u25A0',  # Wingdings (black square)
+	u'\uF076': u'\u2756',  # Wingdings (black diamond minus white x
+	u'\uF0A7': u'\u25AA',  # Symbol (black small square)
+	u'\uF0A8': u'\u2666',  # Symbol (black diamond suit)
+	u'\uF0B7': u'\u2022',  # Symbol (bullet)
+	u'\uF0D8': u'\u2B9A',  # Wingdings (three-D top-lighted RIGHTWARDS equilateral arrowhead)
+	u'\uF0E8': u'\U0001f87a',  # Wingdings (wide-headed rightwards heavy barb arrow)
+	u'\uF0F0': u'\u21E8',  # Wingdings (right white arrow)
+	u'\uF0FC': u'\u2714',  # Wingdings (heavy check mark)
 }
 
 class WordDocumentHeadingQuickNavItem(browseMode.TextInfoQuickNavItem):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -328,19 +328,19 @@ formatConfigFlagsMap={
 }
 formatConfigFlag_includeLayoutTables=0x20000
 
-# Map some characters from PUA to Unicode. Meant to be used with bullets only.
+# Map some characters from 0 to Unicode. Meant to be used with bullets only.
 # Doesn't care about the actual font, so can give incorrect Unicode in rare cases.
 mapPUAToUnicode = {
 	# from : to # fontname
-	u'\uF06E' : u'\u25A0', # Wingdings
-	u'\uF076' : u'\u2756', # Wingdings
-	u'\uF0A7' : u'\u2663', # Symbol
-	u'\uF0A8' : u'\u2666', # Symbol
-	u'\uF0B7' : u'\u2022', # Symbol
-	u'\uF0D8' : u'\u27A2', # Wingdings
-	u'\uF0E8' : u'\u21D2', # Wingdings
-	u'\uF0F0' : u'\u21E8', # Wingdings
-	u'\uF0FC' : u'\u2714', # Wingdings
+	u'\uF06E' : u'\u25A0', # Wingdings (black square)
+	u'\uF076' : u'\u2756', # Wingdings (black diamond minus white x
+	u'\uF0A7' : u'\u25AA', # Symbol (black small square)
+	u'\uF0A8' : u'\u2666', # Symbol (black diamond suit)
+	u'\uF0B7' : u'\u2022', # Symbol (bullet)
+	u'\uF0D8' : u'\u2B9A', # Wingdings (three-D top-lighted RIGHTWARDS equilateral arrowhead) 
+	u'\uF0E8' : u'\U0001f87a', # Wingdings (wide-headed rightwards heavy barb arrow)
+	u'\uF0F0' : u'\u21E8', # Wingdings (right white arrow)
+	u'\uF0FC' : u'\u2714', # Wingdings (heavy check mark)
 }
 
 class WordDocumentHeadingQuickNavItem(browseMode.TextInfoQuickNavItem):

--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -99,6 +99,7 @@ _	line	most
 ⇒	right double arrow	some
 ⇨	right white arrow	some
 ➢	right arrowhead	some
+⮚	right arrowhead	some
 ❖	black diamond minus white X	some
 ♣	black club	some
 ♦	black diamond	some
@@ -122,6 +123,7 @@ _	line	most
 ↓	down arrow	some
 ✓	check	some
 ✔	check	some
+🡺	right arrow	some
 
 #Mathematical Operators U+2200 to U+220F
 ∀	for all	none


### PR DESCRIPTION
<!--**
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10399

### Summary of the issue:

Some bullets characters are not announced correctly ("black club" instead of "black square" and "double right arrow" instead of "right arrow"). Moreover, PUA mapping is not correct for u+F0D8 and u+F0E8 (checked visually and with matching tables found on http://www.alanwood.net).

### Description of how this pull request fixes the issue:

Remapped the following bullet characters in the mapPUAToUnicode dictionary:

* u+F0A7, previously announced as "black club" to u+25AA (black small square)
* u+F0E8, previously announced as "right double arrow" to u+0001f87a (wide-headed rightwards heavy barb arrow)
* u+F0D8 to u+2B9A (three-D top-lighted RIGHTWARDS equilateral arrowhead) 

And modified symbols.dic files consequently.

Note: all the lines of mapPUAToUnicode dictionary show a change in the diff since I have added the name of each character in the end line comment. However, only the 3 mapping value have been modified.

### Testing performed:

Checked in the document [PRBullets.docx](https://github.com/nvaccess/nvda/files/3747217/PRBullets.docx) that bullets are correctly announced.


### Known issues with pull request:

None

### Change log entry:

Bug fixes
`Some bullet names in Microsoft Word have been corrected. (#10399)`
