### PR TITLE
Add reportCellBorder script to input gestures.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -567,6 +567,11 @@ class GlobalCommands(ScriptableObject):
 	script_toggleReportTableCellCoords.__doc__=_("Toggles on and off the reporting of table cell coordinates")
 	script_toggleReportTableCellCoords.category=SCRCAT_DOCUMENTFORMATTING
 
+	@script(
+		# Translators: Input help mode message for toggle report cell borders command.
+		description=_("Cycles through cell borders settings")
+		category=SCRCAT_DOCUMENTFORMATTING
+	)
 	def script_toggleReportCellBorders(self, gesture):
 		if not config.conf["documentFormatting"]["reportBorderStyle"] and not config.conf["documentFormatting"]["reportBorderColor"]:
 			# Translators: A message reported when cycling through cell borders settings.
@@ -581,9 +586,6 @@ class GlobalCommands(ScriptableObject):
 			ui.message(_("Report cell borders off."))
 			config.conf["documentFormatting"]["reportBorderStyle"] = False
 			config.conf["documentFormatting"]["reportBorderColor"] = False
-	# Translators: Input help mode message for toggle report cell borders command.
-	script_toggleReportCellBorders.__doc__=_("Cycles through cell borders settings")
-	script_toggleReportCellBorders.category=SCRCAT_DOCUMENTFORMATTING
 
 	def script_toggleReportLinks(self,gesture):
 		if config.conf["documentFormatting"]["reportLinks"]:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -327,7 +327,7 @@ class GlobalCommands(ScriptableObject):
 			config.conf["documentFormatting"]["reportFontName"]=True
 		ui.message(state)
 	# Translators: Input help mode message for toggle report font name command.
-	script_toggleReportFontName.__doc__=_("Toggles on and off the reporting of font changes")
+	script_toggleReportFontName.__doc__=_("Toggles on and off the reporting of font name changes")
 	script_toggleReportFontName.category=SCRCAT_DOCUMENTFORMATTING
 
 	def script_toggleReportFontSize(self,gesture):
@@ -566,6 +566,24 @@ class GlobalCommands(ScriptableObject):
 	# Translators: Input help mode message for toggle report table cell coordinates command.
 	script_toggleReportTableCellCoords.__doc__=_("Toggles on and off the reporting of table cell coordinates")
 	script_toggleReportTableCellCoords.category=SCRCAT_DOCUMENTFORMATTING
+
+	def script_toggleReportCellBorders(self, gesture):
+		if not config.conf["documentFormatting"]["reportBorderStyle"] and not config.conf["documentFormatting"]["reportBorderColor"]:
+			# Translators: A message reported when cycling through cell borders settings.
+			ui.message(_("Report styles of cell borders"))
+			config.conf["documentFormatting"]["reportBorderStyle"] = True
+		elif config.conf["documentFormatting"]["reportBorderStyle"] and not config.conf["documentFormatting"]["reportBorderColor"]:
+			# Translators: A message reported when cycling through cell borders settings.
+			ui.message(_("Report colors and styles of cell borders"))
+			config.conf["documentFormatting"]["reportBorderColor"] = True
+		else:
+			# Translators: A message reported when cycling through cell borders settings.
+			ui.message(_("Report cell borders off."))
+			config.conf["documentFormatting"]["reportBorderStyle"] = False
+			config.conf["documentFormatting"]["reportBorderColor"] = False
+	# Translators: Input help mode message for toggle report cell borders command.
+	script_toggleReportCellBorders.__doc__=_("Cycles through cell borders settings")
+	script_toggleReportCellBorders.category=SCRCAT_DOCUMENTFORMATTING
 
 	def script_toggleReportLinks(self,gesture):
 		if config.conf["documentFormatting"]["reportLinks"]:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -569,7 +569,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Input help mode message for toggle report cell borders command.
 		description=_("Cycles through cell borders settings")
-		category=SCRCAT_DOCUMENTFORMATTING
+		category=SCRCAT_DOCUMENTFORMATTING,
 	)
 	def script_toggleReportCellBorders(self, gesture):
 		if not config.conf["documentFormatting"]["reportBorderStyle"] and not config.conf["documentFormatting"]["reportBorderColor"]:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-#globalCommands.py
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2006-2018 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee, Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka
+#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee, Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Jakub Lukowicz
 
 import time
 import itertools

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -568,14 +568,14 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Input help mode message for toggle report cell borders command.
-		description=_("Cycles through cell borders settings")
+		description=_("Cycles through cell borders settings"),
 		category=SCRCAT_DOCUMENTFORMATTING,
 	)
 	def script_toggleReportCellBorders(self, gesture):
 		if not config.conf["documentFormatting"]["reportBorderStyle"] and not config.conf["documentFormatting"]["reportBorderColor"]:
 			# Translators: A message reported when cycling through cell borders settings.
-			ui.message(_("Report styles of cell borders"))
 			config.conf["documentFormatting"]["reportBorderStyle"] = True
+			ui.message(_("Report styles of cell borders"))
 		elif config.conf["documentFormatting"]["reportBorderStyle"] and not config.conf["documentFormatting"]["reportBorderColor"]:
 			# Translators: A message reported when cycling through cell borders settings.
 			ui.message(_("Report colors and styles of cell borders"))


### PR DESCRIPTION
### Link to issue number:
closes #9507 
### Summary of the issue:
Currently script for reporting cell borders is not present in input gestures dialog so it is impossible to add a gesture for that one.
### Description of how this pull request fixes the issue:
It adds reportCellBorders script to globalCommands.
I also changed message for reportFontName script changes as it was suggested in related issue.
### Testing performed:
I Opened document formatting group in input gestures and found added script there. Then assigned gesture and checked that it works.
### Known issues with pull request:
None.
### Change log entry:
It is now possible to assign gesture to script reporting cell borders.
Section: Bug fixes
