### PR TITLE
Silence the volume meters in the Windows 10 System Settings app

### DIFF
--- a/source/appModules/systemsettings.py
+++ b/source/appModules/systemsettings.py
@@ -1,0 +1,29 @@
+# App module for Windows 10 Settings app
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+""" AppModule for the Windows System Settings app.
+"""
+
+import appModuleHandler
+import controlTypes
+from NVDAObjects.UIA import UIA
+from NVDAObjects.behaviors import ProgressBar
+
+
+class VolumeMeter(UIA):
+	role = controlTypes.ROLE_METER
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if isinstance(obj, UIA):
+			if obj.UIAElement.CurrentAutomationId == "SystemSettings_Audio_Output_VolumeValue_ProgressBar":
+				# Volume meters have a role of progressBar
+				# which causes their value to be reported via beeps and speech inappropriately.
+				# Therefore force the role to something other than progressBar.
+				clsList.remove(ProgressBar)
+				clsList.insert(0, VolumeMeter)

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -493,6 +493,8 @@ roleLabels={
 	ROLE_DELETED_CONTENT:_("deleted"),
 	# Translators: Identifies inserted content. 
 	ROLE_INSERTED_CONTENT:_("inserted"),
+	# Translators: Identifies a value meter
+	# Such as for checking input volume
 	ROLE_METER: _("meter"),
 }
 

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -152,6 +152,7 @@ ROLE_AUDIO=145
 ROLE_CHARTELEMENT=146
 ROLE_DELETED_CONTENT=147
 ROLE_INSERTED_CONTENT=148
+ROLE_METER = 149
 
 STATE_UNAVAILABLE=0X1
 STATE_FOCUSED=0X2
@@ -492,6 +493,7 @@ roleLabels={
 	ROLE_DELETED_CONTENT:_("deleted"),
 	# Translators: Identifies inserted content. 
 	ROLE_INSERTED_CONTENT:_("inserted"),
+	ROLE_METER: _("meter"),
 }
 
 stateLabels={


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:

When on the Sound page of the Windows 10 System Settings app, NVDA constantly plays progress bar beeps due to the volume meter being treated as a progress bar.
 
### Description of how this pull request fixes the issue:
This pr adds a new 'meter' role, and forces these volume meters to  have the meter role, and not use the ProgressBar NVDAObject behavior.

### Testing performed:
Opened the sound page in the Settings app. Ensured that NVDA no longer played progress bar beeps.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* NVDA no longer constantly plays progress bar beeps when on the Sound page of the Windows 10 Settings app.