### PR TITLE
Windows 10 Settings: remove progress bar behavior from System/Sound/input and output volume meters

### DIFF
--- a/source/appModules/systemsettings.py
+++ b/source/appModules/systemsettings.py
@@ -1,0 +1,36 @@
+# appModules/systemsettings.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""App module for Windows 10 Settings app (aka Immersive Control Panel)."""
+
+import appModuleHandler
+from NVDAObjects.UIA import UIA
+from NVDAObjects.behaviors import ProgressBar
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if isinstance(obj, UIA):
+			# #10411: In build 17035, Settings/System/Sound has been added, but has an anoying volume meter.
+			if obj.UIAElement.cachedClassName == "ProgressBar" and isinstance(obj.next, UIA):
+				# Due to Storage Sense UI redesign in build 18277,
+				# the progress bar's sibling might not be a UIA object at all.
+				try:
+					if (
+						obj.next.UIAElement.cachedAutomationID.startswith(
+							"SystemSettings_Audio_Output_VolumeValue_"
+						)
+						or obj.simplePrevious.UIAElement.cachedAutomationID.startswith(
+							"SystemSettings_Audio_Input_VolumeValue_"
+						)
+					):
+						try:
+							clsList.remove(ProgressBar)
+						except ValueError:
+							pass
+				except AttributeError:
+					pass


### PR DESCRIPTION
### Link to issue number:
Fixes #10411 
Follow-up to #10410 

### Summary of the issue:
NVDA announces progress bar information in System/Sound in Windows 10 Settings app in Version 1803 and later.

### Description of how this pull request fixes the issue:
In Windows 10 Version 1803 (April 2018 Update, specifically with build 17035) and later, Windows 10's Settings app added System/Sound page, moving Sound property sheet from Control Panel to Settings. However, this page includes an annoying progress bar which is really a volume meter, causing NVDA to announce progress bar information. Thus remove progress bar behavior so NVDA can remain silent.

### Testing performed:
Tested via Windows 10 App Essentials add-on and on Version 1909 (build 18363) and other builds.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

In Settings app in Windows 10 April 2018 Update and later, NVDA will no longer announce progress bar information for volume meter found in System/Sound page. (#10284 
