### PR TITLE
When creating NVDAObjects, make sure external modules can't disrupt object creation

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
 # Davy Kager

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,9 +1,8 @@
-# -*- coding: UTF-8 -*-
-#appModuleHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee, Babbage B.V., Mozilla Corporation
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
+# Babbage B.V., Mozilla Corporation
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Manages appModules.
 @var runningTable: a dictionary of the currently running appModules, using their application's main window handle as a key.
@@ -25,7 +24,6 @@ import baseObject
 import globalVars
 from logHandler import log
 import NVDAHelper
-import ui
 import winUser
 import winKernel
 import config
@@ -172,9 +170,15 @@ def fetchAppModule(processID,appName):
 		try:
 			return importlib.import_module("appModules.%s" % modName, package="appModules").AppModule(processID, appName)
 		except:
-			log.error("error in appModule %r"%modName, exc_info=True)
-			# Translators: This is presented when errors are found in an appModule (example output: error in appModule explorer).
-			ui.message(_("Error in appModule %s")%modName)
+			log.exception(f"error in appModule {modName!r}")
+			import ui
+			import speech
+			ui.message(
+				# Translators: This is presented when errors are found in an appModule
+				# (example output: error in appModule explorer).
+				_("Error in appModule %s") % modName,
+				speechPriority=speech.priorities.SPRI_NOW
+			)
 
 	# Use the base AppModule.
 	return AppModule(processID, appName)

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -172,7 +172,7 @@ def fetchAppModule(processID,appName):
 		except:
 			log.exception(f"error in appModule {modName!r}")
 			import ui
-			import speech
+			import speech.priorities
 			ui.message(
 				# Translators: This is presented when errors are found in an appModule
 				# (example output: error in appModule explorer).

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
 # Babbage B.V., Mozilla Corporation


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When creating NVDAObjects, external modules such as appModules and global plugins can kick in to add overlay classes to the object. Exceptions for these methods weren't caught, which could allow an appModule or globalPlugin to disrupt object creation in a major and very harmful way, sometimes making a system even unusable.

### Description of how this pull request fixes the issue:
Catch exceptions for functions on external modules (appModules and global plugins) when constructing an NVDAObject.

As a bonus, when appModules fail to initialize, a message is no spoken at a higher speech priority, making it less likely that the message gets lost in a flood of speech. I considered this to be related.

### Testing performed:
used a global plugin module with the following contents:

```
import globalPluginHandler

class GlobalPlugin(globalPluginHandler.GlobalPlugin):

	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
		raise RuntimeError
```

### Known issues with pull request:
Theoretically, it could be that performance degrades somehow.

### Change log entry:
* Changes for developers
    + External modules (appModules and globalPlugins) are now less likely to be able to break the creation of NVDAObjects.
        * Exceptions caused by the "chooseNVDAObjectOverlayClasses" and "event_NVDAObject_init" methods are now properly caught and logged.
