### PR TITLE
Ignore duplicate focus events emitted by Windows 7 desktop items

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -20,7 +20,7 @@ import speech
 import eventHandler
 import mouseHandler
 from NVDAObjects.window import Window
-from NVDAObjects.IAccessible import sysListView32, IAccessible, List
+from NVDAObjects.IAccessible import IAccessible, List
 from NVDAObjects.UIA import UIA
 from NVDAObjects.window.edit import RichEdit50, EditTextInfo
 
@@ -55,16 +55,18 @@ class SearchBoxClient(IAccessible):
 
 
 # Class for menu items  for Windows Places and Frequently used Programs (in start menu)
-class SysListView32MenuItem(sysListView32.ListItemWithoutColumnSupport):
+# Also used for desktop items
+class SysListView32EmittingDuplicateFocusEvents(IAccessible):
 
 	# #474: When focus moves to these items, an extra focus is fired on the parent
 	# However NVDA redirects it to the real focus.
 	# But this means double focus events on the item, so filter the second one out
+	# #2988: Also seen when coming back to the Windows 7 desktop from different applications.
 	def _get_shouldAllowIAccessibleFocusEvent(self):
-		res=super(SysListView32MenuItem,self).shouldAllowIAccessibleFocusEvent
+		res = super().shouldAllowIAccessibleFocusEvent
 		if not res:
 			return False
-		focus=eventHandler.lastQueuedFocusObject
+		focus = eventHandler.lastQueuedFocusObject
 		if type(focus)!=type(self) or (self.event_windowHandle,self.event_objectID,self.event_childID)!=(focus.event_windowHandle,focus.event_objectID,focus.event_childID):
 			return True
 		return False
@@ -221,8 +223,17 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, ReadOnlyEditBox)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
-		if windowClass == "SysListView32" and role == controlTypes.ROLE_MENUITEM:
-			clsList.insert(0, SysListView32MenuItem)
+		if windowClass == "SysListView32":
+			if(
+				role == controlTypes.ROLE_MENUITEM
+				or(
+					role == controlTypes.ROLE_LISTITEM
+					and obj.simpleParent
+					and obj.simpleParent.simpleParent
+					and obj.simpleParent.simpleParent == api.getDesktopObject()
+				)
+			):
+				clsList.insert(0, SysListView32EmittingDuplicateFocusEvents)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		# #5178: Start button in Windows 8.1 and 10 should not have been a list in the first place.


### PR DESCRIPTION
 ### Link to issue number:
Fixes #2988
### Summary of the issue:
When coming back to Windows 7 desktop from different programs by alt+tab or  with Windows+D from start menu selected icon was often announced twice. It was caused by the fact that Similarly to #474 additional focus event was fired on the parrent of these items.
### Description of how this pull request fixes the issue:
The class created to fix #474 is now used for these icons.
### Testing performed:
1. Tested that in situations in which selected icon was announced twice it no longer is.
2. Ensured that fix for #474 is still functional.
### Known issues with pull request:
None known
### Change log entry:
None needed