### PR TITLE
Gracefully handle regular expression errors in speech dictionaries

### DIFF
--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -47,6 +47,8 @@ class SpeechDictEntry:
 
 class SpeechDict(list):
 
+	fileName = None
+
 	def load(self, fileName):
 		self.fileName=fileName
 		comment=""
@@ -98,8 +100,16 @@ class SpeechDict(list):
 		file.close()
 
 	def sub(self, text):
-		for entry in self:
-			text = entry.sub(text)
+		invalidEntries=[]
+		for index,entry in enumerate(self):
+			try:
+				text = entry.sub(text)
+			except re.error as exc:
+				dictName=self.fileName or "temporary dictionary"
+				log.error(f"Invalid dictionary entry {index+1} in {dictName}: \"{entry.pattern}\", {exc}") 
+				invalidEntries.append(index)
+			for index in reversed(invalidEntries):
+				del self[index]
 		return text
 
 def processText(text):

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -100,13 +100,13 @@ class SpeechDict(list):
 		file.close()
 
 	def sub(self, text):
-		invalidEntries=[]
-		for index,entry in enumerate(self):
+		invalidEntries = []
+		for index, entry in enumerate(self):
 			try:
 				text = entry.sub(text)
 			except re.error as exc:
-				dictName=self.fileName or "temporary dictionary"
-				log.error(f"Invalid dictionary entry {index+1} in {dictName}: \"{entry.pattern}\", {exc}") 
+				dictName = self.fileName or "temporary dictionary"
+				log.error(f"Invalid dictionary entry {index+1} in {dictName}: \"{entry.pattern}\", {exc}")
 				invalidEntries.append(index)
 			for index in reversed(invalidEntries):
 				del self[index]


### PR DESCRIPTION
### Link to issue number:
Fixes #10334 

### Summary of the issue:
In Python 3, re.sub raises re.error if a numeric replacement group is specified yet there is no matching group in the pattern. Python 2, silently ignored this.
In the past, users have deliberetly or otherwise created entries that are invalid in this way, but in NVDA 2019.2.1 and lower were just silently ignored. Now, they break NVDA in a way such that no speech works while those entries exist.

### Description of how this pull request fixes the issue:
NVDA will now catch re.error, log the error, remove the entry from meory, and continue on processing other entries.

### Testing performed:
Tested with the default.dic provided in #10334. Plus created several other invalid and valid entries, both in the default dictionary and temporary dictionary.
The invalid entries were logged once and then no longer processed.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
Invalid regular expressions in speech dictionaries no longer completely break speech in NVDA. (#10334) 