### PR TITLE
Add an article role and allow quick navigation to articles

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -139,7 +139,7 @@ nodeNamesToNVDARoles={
 	"MATH":controlTypes.ROLE_MATH,
 	"NAV":controlTypes.ROLE_SECTION,
 	"SECTION":controlTypes.ROLE_SECTION,
-	"ARTICLE":controlTypes.ROLE_DOCUMENT,
+	"ARTICLE":controlTypes.ROLE_ARTICLE,
 }
 
 def getZoomFactorsFromHTMLDocument(HTMLDocument):
@@ -681,7 +681,7 @@ class MSHTML(IAccessible):
 			ariaRolesString = self.HTMLAttributes['role']
 			if ariaRolesString:
 				ariaRoles.append(ariaRolesString.split(" ")[0])
-			lRole = aria.htmlNodeNameToAriaLandmarkRoles.get(self.HTMLNodeName.lower())
+			lRole = aria.htmlNodeNameToAriaRoles.get(self.HTMLNodeName.lower())
 			if lRole:
 				ariaRoles.append(lRole)
 			if ariaRoles and ariaRoles[0] in aria.landmarkRoles:

--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -139,7 +139,7 @@ nodeNamesToNVDARoles={
 	"MATH":controlTypes.ROLE_MATH,
 	"NAV":controlTypes.ROLE_SECTION,
 	"SECTION":controlTypes.ROLE_SECTION,
-	"ARTICLE":controlTypes.ROLE_ARTICLE,
+	"ARTICLE": controlTypes.ROLE_ARTICLE,
 }
 
 def getZoomFactorsFromHTMLDocument(HTMLDocument):

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -184,11 +184,11 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 
 	if iaRole==oleacc.ROLE_SYSTEM_APPLICATION:
 		clsList.append(Application)
-	if iaRole==oleacc.ROLE_SYSTEM_DIALOG:
+	if iaRole == oleacc.ROLE_SYSTEM_DIALOG:
 		clsList.append(WebDialog)
 	if (
-		iaRole in (oleacc.ROLE_SYSTEM_APPLICATION, oleacc.ROLE_SYSTEM_DIALOG, oleacc.ROLE_SYSTEM_DOCUMENT)
-		and Article not in clsList
+		iaRole in (oleacc.ROLE_SYSTEM_APPLICATION, oleacc.ROLE_SYSTEM_DIALOG)
+		or (iaRole == oleacc.ROLE_SYSTEM_DOCUMENT and Article not in clsList)
 	):
 		clsList.append(documentClass)
 

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -93,6 +93,11 @@ class Application(Document):
 class BlockQuote(Ia2Web):
 	role = controlTypes.ROLE_BLOCKQUOTE
 
+
+class Article(Ia2Web):
+	role = controlTypes.ROLE_ARTICLE
+
+
 class Editor(Ia2Web, DocumentWithTableNavigation):
 	TextInfo = MozillaCompoundTextInfo
 
@@ -167,8 +172,11 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 		return
 
 	iaRole = obj.IAccessibleRole
+	xmlRoles = obj.IA2Attributes.get("xml-roles", "").split(" ")
 	if iaRole == IAccessibleHandler.IA2_ROLE_SECTION and obj.IA2Attributes.get("tag", None) == "blockquote":
 		clsList.append(BlockQuote)
+	elif iaRole == oleacc.ROLE_SYSTEM_DOCUMENT and xmlRoles[0] == "article":
+		clsList.append(Article)
 	elif iaRole == oleacc.ROLE_SYSTEM_ALERT:
 		clsList.append(Dialog)
 	elif iaRole == oleacc.ROLE_SYSTEM_EQUATION:
@@ -176,9 +184,12 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 
 	if iaRole==oleacc.ROLE_SYSTEM_APPLICATION:
 		clsList.append(Application)
-	elif iaRole==oleacc.ROLE_SYSTEM_DIALOG:
+	if iaRole==oleacc.ROLE_SYSTEM_DIALOG:
 		clsList.append(WebDialog)
-	if iaRole in (oleacc.ROLE_SYSTEM_APPLICATION,oleacc.ROLE_SYSTEM_DIALOG,oleacc.ROLE_SYSTEM_DOCUMENT):
+	if (
+		iaRole in (oleacc.ROLE_SYSTEM_APPLICATION, oleacc.ROLE_SYSTEM_DIALOG, oleacc.ROLE_SYSTEM_DOCUMENT)
+		and Article not in clsList
+	):
 		clsList.append(documentClass)
 
 	if obj.IA2States & IAccessibleHandler.IA2_STATE_EDITABLE:
@@ -188,7 +199,6 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 			clsList.append(EditorChunk)
 
 	if iaRole in (oleacc.ROLE_SYSTEM_DIALOG,oleacc.ROLE_SYSTEM_PROPERTYPAGE):
-		xmlRoles = obj.IA2Attributes.get("xml-roles", "").split(" ")
 		if "dialog" in xmlRoles or "tabpanel" in xmlRoles:
 			# #2390: Don't try to calculate text for ARIA dialogs.
 			# #4638: Don't try to calculate text for ARIA tab panels.

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -136,7 +136,12 @@ class EdgeTextInfo(UIATextInfo):
 		role=field.get('role')
 		# Fields should be treated as block for certain roles.
 		# This can affect whether the field is presented as a container (e.g.  announcing entering and exiting) 
-		if role in (controlTypes.ROLE_GROUPING,controlTypes.ROLE_SECTION,controlTypes.ROLE_PARAGRAPH):
+		if role in (
+			controlTypes.ROLE_GROUPING,
+			controlTypes.ROLE_SECTION,
+			controlTypes.ROLE_PARAGRAPH,
+			controlTypes.ROLE_ARTICLE,
+		):
 			field['isBlock']=True
 		# ARIA roledescription and landmarks
 		field['roleText']=obj.roleText

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -9,7 +9,13 @@ from comtypes.automation import VARIANT
 import array
 import winUser
 import UIAHandler
-from UIAUtils import *
+from UIAUtils import (
+	createUIAMultiPropertyCondition,
+	isUIAElementInWalker,
+	getDeepestLastChildUIAElementInWalker,
+	getUIATextAttributeValueFromRange,
+	iterUIARangeByUnit
+)
 import documentBase
 import treeInterceptorHandler
 import cursorManager
@@ -390,7 +396,7 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ListControlTypeId,UIAHandler.UIA_IsKeyboardFocusablePropertyId:False})
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		elif nodeType=="container":
-			condition=createUIAMultiPropertyCondition(
+			condition = createUIAMultiPropertyCondition(
 				{
 					UIAHandler.UIA.UIA_ControlTypePropertyId: UIAHandler.UIA.UIA_ListControlTypeId,
 					UIAHandler.UIA.UIA_IsKeyboardFocusablePropertyId: False
@@ -416,12 +422,12 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 		elif nodeType=="landmark":
 			condition=UIAHandler.handler.clientObject.createNotCondition(UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_LandmarkTypePropertyId,0))
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
-		elif nodeType=="article":
-			condition=createUIAMultiPropertyCondition({
+		elif nodeType == "article":
+			condition = createUIAMultiPropertyCondition({
 				UIAHandler.UIA_ControlTypePropertyId: UIAHandler.UIA.UIA_GroupControlTypeId,
 				UIAHandler.UIA_AriaRolePropertyId: ["article"]
 			})
-			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
+			return UIAControlQuicknavIterator(nodeType, self, pos, condition, direction)
 		elif nodeType=="nonTextContainer":
 			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ListControlTypeId,UIAHandler.UIA_IsKeyboardFocusablePropertyId:True},{UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ComboBoxControlTypeId})
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)

--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -390,7 +390,22 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ListControlTypeId,UIAHandler.UIA_IsKeyboardFocusablePropertyId:False})
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		elif nodeType=="container":
-			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ListControlTypeId,UIAHandler.UIA_IsKeyboardFocusablePropertyId:False},{UIAHandler.UIA_ControlTypePropertyId:[UIAHandler.UIA_TableControlTypeId,UIAHandler.UIA_DataGridControlTypeId]})
+			condition=createUIAMultiPropertyCondition(
+				{
+					UIAHandler.UIA.UIA_ControlTypePropertyId: UIAHandler.UIA.UIA_ListControlTypeId,
+					UIAHandler.UIA.UIA_IsKeyboardFocusablePropertyId: False
+				},
+				{
+					UIAHandler.UIA.UIA_ControlTypePropertyId: [
+						UIAHandler.UIA.UIA_TableControlTypeId,
+						UIAHandler.UIA.UIA_DataGridControlTypeId
+					]
+				},
+				{
+					UIAHandler.UIA_ControlTypePropertyId: UIAHandler.UIA.UIA_GroupControlTypeId,
+					UIAHandler.UIA_AriaRolePropertyId: ["article"]
+				}
+			)
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		elif nodeType=="edit":
 			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_EditControlTypeId,UIAHandler.UIA_ValueIsReadOnlyPropertyId:False},{UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ComboBoxControlTypeId,UIAHandler.UIA_IsTextPatternAvailablePropertyId:True})
@@ -400,6 +415,12 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		elif nodeType=="landmark":
 			condition=UIAHandler.handler.clientObject.createNotCondition(UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_LandmarkTypePropertyId,0))
+			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
+		elif nodeType=="article":
+			condition=createUIAMultiPropertyCondition({
+				UIAHandler.UIA_ControlTypePropertyId: UIAHandler.UIA.UIA_GroupControlTypeId,
+				UIAHandler.UIA_AriaRolePropertyId: ["article"]
+			})
 			return UIAControlQuicknavIterator(nodeType,self,pos,condition,direction)
 		elif nodeType=="nonTextContainer":
 			condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ListControlTypeId,UIAHandler.UIA_IsKeyboardFocusablePropertyId:True},{UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_ComboBoxControlTypeId})

--- a/source/aria.py
+++ b/source/aria.py
@@ -1,8 +1,7 @@
-#aria.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2009-2014 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2009-2019 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import controlTypes
 
@@ -11,6 +10,7 @@ ariaRolesToNVDARoles={
 	"search":controlTypes.ROLE_SECTION,
 	"alert":controlTypes.ROLE_ALERT,
 	"alertdialog":controlTypes.ROLE_DIALOG,
+	"article": controlTypes.ROLE_ARTICLE,
 	"application":controlTypes.ROLE_APPLICATION,
 	"button":controlTypes.ROLE_BUTTON,
 	"checkbox":controlTypes.ROLE_CHECKBOX,
@@ -84,9 +84,10 @@ landmarkRoles = {
 	"region": pgettext("aria", "region"),
 }
 
-htmlNodeNameToAriaLandmarkRoles = {
+htmlNodeNameToAriaRoles = {
 	"header": "banner",
 	"nav": "navigation",
 	"main": "main",
 	"footer": "contentinfo",
+	"article": "article",
 }

--- a/source/aria.py
+++ b/source/aria.py
@@ -90,4 +90,7 @@ htmlNodeNameToAriaRoles = {
 	"main": "main",
 	"footer": "contentinfo",
 	"article": "article",
+	"section": "region",
+	"aside": "complementary",
+	"dialog": "dialog",
 }

--- a/source/braille.py
+++ b/source/braille.py
@@ -171,6 +171,8 @@ roleLabels = {
 	controlTypes.ROLE_INSERTED_CONTENT: _("ins"),
 	# Translators: Displayed in braille for a landmark.
 	controlTypes.ROLE_LANDMARK: _("lmk"),
+	# Translators: Displayed in braille for an object which is an article.
+	controlTypes.ROLE_ARTICLE: _("art"),
 }
 
 positiveStateLabels = {

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -821,7 +821,8 @@ qn("error", key="w",
 	prevDoc=_("moves to the previous error"),
 	# Translators: Message presented when the browse mode element is not found.
 	prevError=_("no previous error"))
-qn("article", key=None,
+qn(
+	"article", key=None,
 	# Translators: Input help message for a quick navigation command in browse mode.
 	nextDoc=_("moves to the next article"),
 	# Translators: Message presented when the browse mode element is not found.

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -821,6 +821,15 @@ qn("error", key="w",
 	prevDoc=_("moves to the previous error"),
 	# Translators: Message presented when the browse mode element is not found.
 	prevError=_("no previous error"))
+qn("article", key=None,
+	# Translators: Input help message for a quick navigation command in browse mode.
+	nextDoc=_("moves to the next article"),
+	# Translators: Message presented when the browse mode element is not found.
+	nextError=_("no next article"),
+	# Translators: Input help message for a quick navigation command in browse mode.
+	prevDoc=_("moves to the previous article"),
+	# Translators: Message presented when the browse mode element is not found.
+	prevError=_("no previous article"))
 del qn
 
 class ElementsListDialog(wx.Dialog):

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -428,6 +428,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			readUnit: Optional[str] = None
 	):
 		"""Adds a script for the given quick nav item.
+		@param itemType: The type of item, I.E. "heading" "Link" ...
 		@param key: The quick navigation key to bind to the script.
 			Shift is automatically added for the previous item gesture. E.G. h for heading.
 			If C{None} is provided, the script is unbound by default.

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -36,6 +36,7 @@ import api
 import gui.guiHelper
 from NVDAObjects import NVDAObject
 from abc import ABCMeta, abstractmethod
+from typing import Optional
 
 REASON_QUICKNAV = "quickNav"
 
@@ -416,10 +417,20 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		item.moveTo()
 
 	@classmethod
-	def addQuickNav(cls, itemType, key, nextDoc, nextError, prevDoc, prevError, readUnit=None):
+	def addQuickNav(
+			cls,
+			itemType: str,
+			key: Optional[str],
+			nextDoc: str,
+			nextError: str,
+			prevDoc: str,
+			prevError: str,
+			readUnit: Optional[str] = None
+	):
 		"""Adds a script for the given quick nav item.
-		@param itemType: The type of item, I.E. "heading" "Link" ...
-		@param key: The quick navigation key to bind to the script. Shift is automatically added for the previous item gesture. E.G. h for heading
+		@param key: The quick navigation key to bind to the script.
+			Shift is automatically added for the previous item gesture. E.G. h for heading.
+			If C{None} is provided, the script is unbound by default.
 		@param nextDoc: The command description to bind to the script that yields the next quick nav item.
 		@param nextError: The error message if there are no more quick nav items of type itemType in this direction.
 		@param prevDoc: The command description to bind to the script that yields the previous quick nav item.
@@ -436,7 +447,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		script.__name__ = funcName
 		script.resumeSayAllMode=sayAllHandler.CURSOR_CARET
 		setattr(cls, funcName, script)
-		cls.__gestures["kb:%s" % key] = scriptName
+		if key is not None:
+			cls.__gestures["kb:%s" % key] = scriptName
 		scriptName = "previous%s" % scriptSuffix
 		funcName = "script_%s" % scriptName
 		script = lambda self,gesture: self._quickNavScript(gesture, itemType, "previous", prevError, readUnit)
@@ -444,7 +456,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		script.__name__ = funcName
 		script.resumeSayAllMode=sayAllHandler.CURSOR_CARET
 		setattr(cls, funcName, script)
-		cls.__gestures["kb:shift+%s" % key] = scriptName
+		if key is not None:
+			cls.__gestures["kb:shift+%s" % key] = scriptName
 
 	def script_elementsList(self,gesture):
 		# We need this to be a modal dialog, but it mustn't block this script.

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -182,6 +182,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	reportHeadings = boolean(default=true)
 	reportBlockQuotes = boolean(default=true)
 	reportLandmarks = boolean(default=true)
+	reportArticles = boolean(default=true)
 	reportFrames = boolean(default=true)
 	reportClickable = boolean(default=true)
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -182,7 +182,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	reportHeadings = boolean(default=true)
 	reportBlockQuotes = boolean(default=true)
 	reportLandmarks = boolean(default=true)
-	reportArticles = boolean(default=true)
+	reportArticles = boolean(default=false)
 	reportFrames = boolean(default=true)
 	reportClickable = boolean(default=true)
 

--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -153,6 +153,7 @@ ROLE_CHARTELEMENT=146
 ROLE_DELETED_CONTENT=147
 ROLE_INSERTED_CONTENT=148
 ROLE_LANDMARK = 149
+ROLE_ARTICLE = 150
 
 STATE_UNAVAILABLE=0X1
 STATE_FOCUSED=0X2
@@ -495,6 +496,8 @@ roleLabels={
 	ROLE_INSERTED_CONTENT:_("inserted"),
 	# Translators: Identifies a landmark.
 	ROLE_LANDMARK: _("landmark"),
+	# Translators: Identifies an article.
+	ROLE_ARTICLE: _("article"),
 }
 
 stateLabels={

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -656,15 +656,15 @@ class GlobalCommands(ScriptableObject):
 		description=_("Toggles on and off the reporting of articles"),
 		category=SCRCAT_DOCUMENTFORMATTING
 	)
-	def script_toggleReportArticles(self,gesture):
+	def script_toggleReportArticles(self, gesture):
 		if config.conf["documentFormatting"]["reportArticles"]:
 			# Translators: The message announced when toggling the report articles document formatting setting.
 			state = _("report articles off")
-			config.conf["documentFormatting"]["reportArticles"]=False
+			config.conf["documentFormatting"]["reportArticles"] = False
 		else:
 			# Translators: The message announced when toggling the report articles document formatting setting.
 			state = _("report articles on")
-			config.conf["documentFormatting"]["reportArticles"]=True
+			config.conf["documentFormatting"]["reportArticles"] = True
 		ui.message(state)
 
 	def script_toggleReportFrames(self,gesture):

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -651,6 +651,22 @@ class GlobalCommands(ScriptableObject):
 	script_toggleReportLandmarks.__doc__=_("Toggles on and off the reporting of landmarks")
 	script_toggleReportLandmarks.category=SCRCAT_DOCUMENTFORMATTING
 
+	@script(
+		# Translators: Input help mode message for toggle report articles command.
+		description=_("Toggles on and off the reporting of articles"),
+		category=SCRCAT_DOCUMENTFORMATTING
+	)
+	def script_toggleReportArticles(self,gesture):
+		if config.conf["documentFormatting"]["reportArticles"]:
+			# Translators: The message announced when toggling the report articles document formatting setting.
+			state = _("report articles off")
+			config.conf["documentFormatting"]["reportArticles"]=False
+		else:
+			# Translators: The message announced when toggling the report articles document formatting setting.
+			state = _("report articles on")
+			config.conf["documentFormatting"]["reportArticles"]=True
+		ui.message(state)
+
 	def script_toggleReportFrames(self,gesture):
 		if config.conf["documentFormatting"]["reportFrames"]:
 			# Translators: The message announced when toggling the report frames document formatting setting.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1920,6 +1920,11 @@ class DocumentFormattingPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
+		self.articlesCheckBox=elementsGroup.addItem(wx.CheckBox(self,label=_("Arti&cles")))
+		self.articlesCheckBox.SetValue(config.conf["documentFormatting"]["reportArticles"])
+
+		# Translators: This is the label for a checkbox in the
+		# document formatting settings panel.
 		self.framesCheckBox=elementsGroup.addItem(wx.CheckBox(self,label=_("Fra&mes")))
 		self.framesCheckBox.Value=config.conf["documentFormatting"]["reportFrames"]
 
@@ -1965,6 +1970,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		config.conf["documentFormatting"]["reportLists"]=self.listsCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportBlockQuotes"]=self.blockQuotesCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportLandmarks"]=self.landmarksCheckBox.IsChecked()
+		config.conf["documentFormatting"]["reportArticles"] = self.articlesCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportFrames"]=self.framesCheckBox.Value
 		config.conf["documentFormatting"]["reportClickable"]=self.clickableCheckBox.Value
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1920,7 +1920,7 @@ class DocumentFormattingPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
-		self.articlesCheckBox=elementsGroup.addItem(wx.CheckBox(self,label=_("Arti&cles")))
+		self.articlesCheckBox = elementsGroup.addItem(wx.CheckBox(self, label=_("Arti&cles")))
 		self.articlesCheckBox.SetValue(config.conf["documentFormatting"]["reportArticles"])
 
 		# Translators: This is the label for a checkbox in the

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -69,6 +69,7 @@ class ControlField(Field):
 			or (role == controlTypes.ROLE_BLOCKQUOTE and not formatConfig["reportBlockQuotes"])
 			or (role in (controlTypes.ROLE_TABLE, controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLEROWHEADER, controlTypes.ROLE_TABLECOLUMNHEADER) and not formatConfig["reportTables"])
 			or (role in (controlTypes.ROLE_LIST, controlTypes.ROLE_LISTITEM) and controlTypes.STATE_READONLY in states and not formatConfig["reportLists"])
+			or (role == controlTypes.ROLE_ARTICLE and not formatConfig["reportArticles"])
 			or (role in (controlTypes.ROLE_FRAME, controlTypes.ROLE_INTERNALFRAME) and not formatConfig["reportFrames"])
 			or (role in (controlTypes.ROLE_DELETED_CONTENT,controlTypes.ROLE_INSERTED_CONTENT) and not formatConfig["reportRevisions"])
 			or (
@@ -131,6 +132,7 @@ class ControlField(Field):
 				controlTypes.ROLE_MENUBAR,
 				controlTypes.ROLE_POPUPMENU,
 				controlTypes.ROLE_TABLE,
+				controlTypes.ROLE_ARTICLE,
 			)
 			or (role == controlTypes.ROLE_EDITABLETEXT and (
 				controlTypes.STATE_READONLY not in states

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -140,13 +140,11 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			# MSHTML puts the unavailable state on all graphics when the showing of graphics is disabled.
 			# This is rather annoying and irrelevant to our users, so discard it.
 			states.discard(controlTypes.STATE_UNAVAILABLE)
-		lRole = aria.htmlNodeNameToAriaLandmarkRoles.get(nodeName.lower())
+		lRole = aria.htmlNodeNameToAriaRoles.get(nodeName.lower())
 		if lRole:
 			ariaRoles.append(lRole)
 		# If the first role is a landmark role, use it.
 		landmark = ariaRoles[0] if ariaRoles[0] in aria.landmarkRoles else None
-		if ariaRoles[0] == "article":
-			role = controlTypes.ROLE_ARTICLE
 		ariaLevel=attrs.get('HTMLAttrib::aria-level',None)
 		ariaLevel=int(ariaLevel) if ariaLevel is not None else None
 		if ariaLevel:
@@ -302,8 +300,11 @@ class MSHTML(VirtualBuffer):
 				{"HTMLAttrib::role": [VBufStorage_findMatch_word(lr) for lr in aria.landmarkRoles if lr != "region"]},
 				{"HTMLAttrib::role": [VBufStorage_findMatch_word("region")],
 					"name": [VBufStorage_findMatch_notEmpty]},
-				{"IHTMLDOMNode::nodeName": [VBufStorage_findMatch_word(lr.upper()) for lr in aria.htmlNodeNameToAriaLandmarkRoles]}
-				]
+				{"IHTMLDOMNode::nodeName": [
+					VBufStorage_findMatch_word(lr.upper()) for lr in aria.htmlNodeNameToAriaRoles
+					if lr in aria.landmarkRoles
+				]}
+			]
 		elif nodeType == "embeddedObject":
 			attrs = [
 				{"IHTMLDOMNode::nodeName": ["OBJECT","EMBED","APPLET","AUDIO","VIDEO"]},

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -305,7 +305,7 @@ class MSHTML(VirtualBuffer):
 					if lr in aria.landmarkRoles
 				]}
 			]
-		elif nodeType=="article":
+		elif nodeType == "article":
 			attrs = [
 				{"HTMLAttrib::role": [VBufStorage_findMatch_word("article")]},
 				{"IHTMLDOMNode::nodeName": [VBufStorage_findMatch_word("ARTICLE")]},

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -145,6 +145,8 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			ariaRoles.append(lRole)
 		# If the first role is a landmark role, use it.
 		landmark = ariaRoles[0] if ariaRoles[0] in aria.landmarkRoles else None
+		if ariaRoles[0] == "article":
+			role = controlTypes.ROLE_ARTICLE
 		ariaLevel=attrs.get('HTMLAttrib::aria-level',None)
 		ariaLevel=int(ariaLevel) if ariaLevel is not None else None
 		if ariaLevel:

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -305,6 +305,11 @@ class MSHTML(VirtualBuffer):
 					if lr in aria.landmarkRoles
 				]}
 			]
+		elif nodeType=="article":
+			attrs = [
+				{"HTMLAttrib::role": [VBufStorage_findMatch_word("article")]},
+				{"IHTMLDOMNode::nodeName": [VBufStorage_findMatch_word("ARTICLE")]},
+			]
 		elif nodeType == "embeddedObject":
 			attrs = [
 				{"IHTMLDOMNode::nodeName": ["OBJECT","EMBED","APPLET","AUDIO","VIDEO"]},

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -292,6 +292,10 @@ class Gecko_ia2(VirtualBuffer):
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("region")],
 					"name": [VBufStorage_findMatch_notEmpty]}
 				]
+		elif nodeType=="article":
+			attrs = [
+				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("article")]}
+			]
 		elif nodeType=="embeddedObject":
 			attrs=[
 				{"IAccessible2::attribute_tag":self._searchableTagValues(["embed","object","applet","audio","video"])},

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -96,6 +96,8 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 		if landmark and role != controlTypes.ROLE_LANDMARK and landmark != xmlRoles[0]:
 			# Ignore the landmark role
 			landmark = None
+		if role==controlTypes.ROLE_DOCUMENT and xmlRoles[0] == "article":
+			role = controlTypes.ROLE_ARTICLE
 		attrs['role']=role
 		attrs['states']=states
 		if level is not "" and level is not None:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -96,7 +96,7 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 		if landmark and role != controlTypes.ROLE_LANDMARK and landmark != xmlRoles[0]:
 			# Ignore the landmark role
 			landmark = None
-		if role==controlTypes.ROLE_DOCUMENT and xmlRoles[0] == "article":
+		if role == controlTypes.ROLE_DOCUMENT and xmlRoles[0] == "article":
 			role = controlTypes.ROLE_ARTICLE
 		attrs['role']=role
 		attrs['states']=states
@@ -292,7 +292,7 @@ class Gecko_ia2(VirtualBuffer):
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("region")],
 					"name": [VBufStorage_findMatch_notEmpty]}
 				]
-		elif nodeType=="article":
+		elif nodeType == "article":
 			attrs = [
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("article")]}
 			]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1626,6 +1626,7 @@ You can configure reporting of:
  - Lists
  - Block quotes
  - Landmarks
+ - Articles
  - Frames
  - Clickable
  -


### PR DESCRIPTION
### Link to issue number:
Fixes #9227 

### Summary of the issue:
It has been a long standing request to allow quick navigation from/to articles. Also, articles should be able to mentioned as such.

### Description of how this pull request fixes the issue:
1. Added a new article role, which is set to articles in virtual buffers and on NVDAObjects that are articles.
2. Added the possibility for quick navigation scripts to be unbound by default.
3. Added a quicknav script for articles, working in MSHTML and IA2 based browsers.

### Testing performed:
Tested the following in Firefox, Chrome and IE:

1. Articles are mentioned at such when using the <article> tag or the article aria role when reporting of articles is enabled
2. Quicknav works after assigning keys to the scripts.

### Known issues with pull request:
The implementation for EdgeHTML is limited in that it works for nodes that have been marked up with the aria role of article. Articles marked up as such with the `<article>` tag aren't recognized, because they have the grouping role and the only way to detect whether it's an article is by means of the `LocalizedControlType`. Bah!

### Change log entry:
* New features
    + In Internet Explorer, Google Chrome and Mozilla Firefox, You can now navigate by article using quick navigation scripts. These scripts are unbound by default and can be assigned in the Input Gestures dialog when the dialog is opened from a browse mode document. (#9227)
* Changes for developers
    + The aria.htmlNodeNameToAriaLandmarkRoles dictionary has been renamed to aria.htmlNodeNameToAriaRoles. It now also contains roles that aren't landmarks.