### PR TITLE
Update CLDR to version 36

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
 * [liblouis](http://www.liblouis.org/), version 3.10.0 commit 146c0757
-* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 35.0
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * Adobe FlashAccessibility interface typelib


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Version 36 of the Unicode Common Locale Data Repository [has been released](http://cldr.unicode.org/index/downloads/cldr-36).

### Description of how this pull request fixes the issue:
Update the emoji annotations submodule to version 36. 

### Testing performed:
Tested building and running the pr

### Known issues with pull request:
None

### Change log entry:
* Changes
    + Updated Unicode Common Locale Data Repository emoji annotations to version 36.0.
