### PR TITLE
readme.md: Update Visual Studio 2017 download link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ The following dependencies need to be installed on your system:
 * [Python](https://www.python.org/), version 3.7, 32 bit
 	* Use latest minor version if possible.
 * Microsoft Visual Studio 2017 Community, Version 15.3 or later:
-	* Download from https://visualstudio.microsoft.com/downloads/
+	* Download from https://visualstudio.microsoft.com/vs/older-downloads/
 	* When installing Visual Studio, you need to enable the following:
 		On the Workloads tab, in the Windows group:
 			* Universal Windows Platform Development


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

### Summary of the issue:

Visual Studio 2017 is now an older release.

### Description of how this pull request fixes the issue:

Point directly to the older downloads page.

### Testing performed:

### Known issues with pull request:

Downloading older releases of Visual Studio requires signing in with a (free) Microsoft account.
The Community Edition, despite being advertised on this page, might not be available on all accounts: Mine (paid) only shows the free Build Tools or Professional Edition and higher.
We'd better be suited with an official direct link to the installer, but I do not know if one still exists.
Anyway, this is only until PR #10169 gets merged.

### Change log entry:

N/A