### PR TITLE
Fix-up of: "Add support for IA2_ROLE_LANDMARK #10110"

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -426,7 +426,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		No string is provided by default, meaning that NVDA will fall back to using role.
 		Examples of where this property might be overridden are shapes in Powerpoint, or ARIA role descriptions.
 		"""
-		if self.landmark:
+		if self.landmark and (self.landmark != "region" or self.name):
 			return aria.getLandmarkRoleText(self.landmark)
 		return None
 
@@ -436,7 +436,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		which will override the standard label for this object's role property as well as the value of roleText.
 		By default, NVDA falls back to using roleText.
 		"""
-		if self.landmark:
+		if self.landmark and (self.landmark != "region" or self.name):
 			roleTextBraille = aria.getLandmarkRoleTextBraille(self.landmark)
 			if roleTextBraille:
 				return roleTextBraille

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -426,8 +426,8 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		No string is provided by default, meaning that NVDA will fall back to using role.
 		Examples of where this property might be overridden are shapes in Powerpoint, or ARIA role descriptions.
 		"""
-		if self.landmark and self.landmark in aria.landmarkRoles:
-			return f"{aria.landmarkRoles[self.landmark]} {controlTypes.roleLabels[controlTypes.ROLE_LANDMARK]}"
+		if self.landmark:
+			return aria.getLandmarkRoleText(self.landmark)
 		return None
 
 	def _get_roleTextBraille(self):
@@ -436,8 +436,8 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		which will override the standard label for this object's role property as well as the value of roleText.
 		By default, NVDA falls back to using roleText.
 		"""
-		if self.landmark and self.landmark in braille.landmarkLabels:
-			return f"{braille.roleLabels[controlTypes.ROLE_LANDMARK]} {braille.landmarkLabels[self.landmark]}"
+		if self.landmark:
+			return aria.getLandmarkRoleTextBraille(self.landmark)
 		return self.roleText
 
 	def _get_value(self):

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -437,7 +437,9 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		By default, NVDA falls back to using roleText.
 		"""
 		if self.landmark:
-			return aria.getLandmarkRoleTextBraille(self.landmark)
+			roleTextBraille = aria.getLandmarkRoleTextBraille(self.landmark)
+			if roleTextBraille:
+				return roleTextBraille
 		return self.roleText
 
 	def _get_value(self):

--- a/source/aria.py
+++ b/source/aria.py
@@ -94,3 +94,25 @@ htmlNodeNameToAriaRoles = {
 	"aside": "complementary",
 	"dialog": "dialog",
 }
+
+
+def getLandmarkRoleText(landmark: str) -> str:
+	""""Gets the role text to speak for a particular landmark."""
+	landmarkLabel = landmarkRoles.get(landmark)
+	if landmarkLabel is None:
+		return None
+	if landmark == "region":
+		return landmarkLabel
+	return f"{landmarkLabel} {controlTypes.roleLabels[controlTypes.ROLE_LANDMARK]}"
+
+
+def getLandmarkRoleTextBraille(landmark):
+	""""Gets the role text to braille for a particular landmark."""
+	# Import late to avoid circular import
+	import braille
+	landmarkLabel = braille.landmarkLabels.get(landmark)
+	if landmarkLabel is None:
+		return None
+	if landmark == "region":
+		return landmarkLabel
+	return f"{braille.roleLabels[controlTypes.ROLE_LANDMARK]} {landmarkLabel}"

--- a/source/aria.py
+++ b/source/aria.py
@@ -6,8 +6,7 @@
 import controlTypes
 
 ariaRolesToNVDARoles={
-	"description":controlTypes.ROLE_STATICTEXT,
-	"search":controlTypes.ROLE_SECTION,
+	"description": controlTypes.ROLE_STATICTEXT,  # Not in ARIA 1.1 spec
 	"alert":controlTypes.ROLE_ALERT,
 	"alertdialog":controlTypes.ROLE_DIALOG,
 	"article": controlTypes.ROLE_ARTICLE,
@@ -42,6 +41,7 @@ ariaRolesToNVDARoles={
 	"row":controlTypes.ROLE_TABLEROW,
 	"rowgroup":controlTypes.ROLE_GROUPING,
 	"rowheader":controlTypes.ROLE_TABLEROWHEADER,
+	"search": controlTypes.ROLE_LANDMARK,
 	"separator":controlTypes.ROLE_SEPARATOR,
 	"scrollbar":controlTypes.ROLE_SCROLLBAR,
 	"slider":controlTypes.ROLE_SLIDER,

--- a/source/braille.py
+++ b/source/braille.py
@@ -37,6 +37,7 @@ import extensionPoints
 import hwPortUtils
 import bdDetect
 import winUser
+import aria
 
 roleLabels = {
 	# Translators: Displayed in braille for an object which is a
@@ -650,7 +651,7 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	roleText = field.get('roleTextBraille', field.get('roleText'))
 	landmark = field.get("landmark")
 	if not roleText and landmark:
-		roleText = f"{roleLabels[controlTypes.ROLE_LANDMARK]} {landmarkLabels[landmark]}"
+		roleText = aria.getLandmarkRoleTextBraille(landmark)
 
 	if presCat == field.PRESCAT_LAYOUT:
 		text = []

--- a/source/braille.py
+++ b/source/braille.py
@@ -633,14 +633,15 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	presCat = field.getPresentationCategory(ancestors, formatConfig)
 	# Cache this for later use.
 	field._presCat = presCat
+	landmark = field.get("landmark")
 	if reportStart:
 		# If this is a container, only report it if this is the start of the node.
 		if presCat == field.PRESCAT_CONTAINER and not field.get("_startOfNode"):
 			return None
 	else:
-		# We only report ends for containers
+		# We only report ends for containers that are not landmarks
 		# and only if this is the end of the node.
-		if presCat != field.PRESCAT_CONTAINER or not field.get("_endOfNode"):
+		if presCat != field.PRESCAT_CONTAINER or not field.get("_endOfNode") or landmark:
 			return None
 
 	role = field.get("role", controlTypes.ROLE_UNKNOWN)
@@ -649,7 +650,6 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	current=field.get('current', None)
 	placeholder=field.get('placeholder', None)
 	roleText = field.get('roleTextBraille', field.get('roleText'))
-	landmark = field.get("landmark")
 	if not roleText and landmark:
 		roleText = aria.getLandmarkRoleTextBraille(landmark)
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -648,6 +648,10 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	current=field.get('current', None)
 	placeholder=field.get('placeholder', None)
 	roleText = field.get('roleTextBraille', field.get('roleText'))
+	landmark = field.get("landmark")
+	if not roleText and landmark:
+		roleText = f"{roleLabels[controlTypes.ROLE_LANDMARK]} {landmarkLabels[landmark]}"
+
 	if presCat == field.PRESCAT_LAYOUT:
 		text = []
 		if current:
@@ -676,8 +680,13 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 			# Don't report the role for math here.
 			# However, we still need to pass it (hence "_role").
 			"_role" if role == controlTypes.ROLE_MATH else "role": role,
-			"states": states,"value":value, "current":current, "placeholder":placeholder,"roleText":roleText}
-		if formatConfig["reportLandmarks"] and field.get("landmark") and field.get("_startOfNode"):
+			"states": states,
+			"value": value,
+			"current": current,
+			"placeholder": placeholder,
+			"roleText": roleText
+		}
+		if formatConfig["reportLandmarks"] and landmark:
 			# Ensure that the name of the field gets presented even if normally it wouldn't.
 			name = field.get("name")
 			if name:

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1238,7 +1238,7 @@ def getControlFieldSpeech(attrs,ancestorAttrs,fieldType,formatConfig=None,extraD
 		if not landmark:
 			roleText = getSpeechTextForProperties(reason=reason, role=role)
 		elif speakLandmark:
-			roleText = f"{aria.landmarkRoles[landmark]} {controlTypes.roleLabels[controlTypes.ROLE_LANDMARK]}"
+			roleText = aria.getLandmarkRoleText(landmark)
 	stateText=getSpeechTextForProperties(reason=reason,states=states,_role=role)
 	keyboardShortcutText=getSpeechTextForProperties(reason=reason,keyboardShortcut=keyboardShortcut) if config.conf["presentation"]["reportKeyboardShortcuts"] else ""
 	ariaCurrentText=getSpeechTextForProperties(reason=reason,current=ariaCurrent)

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -107,15 +107,12 @@ class ControlField(Field):
 			or (role == controlTypes.ROLE_LIST and controlTypes.STATE_READONLY not in states)
 		):
 			return self.PRESCAT_SINGLELINE
-		elif (
-			role in (
-				controlTypes.ROLE_SEPARATOR,
-				controlTypes.ROLE_FOOTNOTE,
-				controlTypes.ROLE_ENDNOTE,
-				controlTypes.ROLE_EMBEDDEDOBJECT,
-				controlTypes.ROLE_MATH
-			)
-			or (role == controlTypes.ROLE_LANDMARK or landmark)
+		elif role in (
+			controlTypes.ROLE_SEPARATOR,
+			controlTypes.ROLE_FOOTNOTE,
+			controlTypes.ROLE_ENDNOTE,
+			controlTypes.ROLE_EMBEDDEDOBJECT,
+			controlTypes.ROLE_MATH
 		):
 			return self.PRESCAT_MARKER
 		elif role in (controlTypes.ROLE_APPLICATION, controlTypes.ROLE_DIALOG):
@@ -139,6 +136,7 @@ class ControlField(Field):
 				or controlTypes.STATE_FOCUSABLE in states
 			) and controlTypes.STATE_MULTILINE in states)
 			or (role == controlTypes.ROLE_LIST and controlTypes.STATE_READONLY in states)
+			or (role == controlTypes.ROLE_LANDMARK or landmark)
 			or (controlTypes.STATE_FOCUSABLE in states and controlTypes.STATE_EDITABLE in states)
 		):
 			return self.PRESCAT_CONTAINER

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -62,6 +62,8 @@ class ControlField(Field):
 					table = None
 			if not table or (not formatConfig["includeLayoutTables"] and table.get("table-layout", None)) or table.get('isHidden',False):
 				return self.PRESCAT_LAYOUT
+
+		name = self.get("name")
 		landmark = self.get("landmark")
 		if reason in (controlTypes.REASON_CARET, controlTypes.REASON_SAYALL, controlTypes.REASON_FOCUS) and (
 			(role == controlTypes.ROLE_LINK and not formatConfig["reportLinks"])
@@ -74,7 +76,10 @@ class ControlField(Field):
 			or (role in (controlTypes.ROLE_DELETED_CONTENT,controlTypes.ROLE_INSERTED_CONTENT) and not formatConfig["reportRevisions"])
 			or (
 				(role == controlTypes.ROLE_LANDMARK or landmark)
-				and not formatConfig["reportLandmarks"]
+				and (
+					not formatConfig["reportLandmarks"]
+					or (landmark == "region" and not name)
+				)
 			)
 		):
 			# This is just layout as far as the user is concerned.


### PR DESCRIPTION
### Link to issue number:
Fixes issues introduced by #10110

### Summary of the issue:
The following issues arose after merging #10110

1. In braille, the landmark type was no longer shown.
2. In braille, when at the start of the line, the braille cursor was positioned at the landmark role text and not at the actual start of the content. This was caused by landmarks being treated as markers, not as containers
3. The landmark role was announces for regions

### Description of how this pull request fixes the issue:
1. The code that calculates the roleText for a landmark is now abstracted in the aria module. It also covers suppressing of the landmark role for regions
2. Landmarks now have presentation type container. In the braille module, an exception is made not to show the end of landmarks, as in speech. There is currently some debate on whether this is appropriate, see #10420 

### Testing performed:
Tested the following example:

`data:text/html, <p>paragraph</p><div role="region">Region without label</div><div role="region" aria-label="this is a label">Region with a label</div><div role="main">This is a main landmark</div><article>This is an article</article><p>This is a paragraph, again</p>`

I've only been able to do it in Firefox yet.

### Known issues with pull request:
We now announce end of article, we don't announce end of landmark. DO we agree this is OK?

### Change log entry:
None
