### PR TITLE
Make accessibleObjectFromEvent failure log at level debug instead

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -345,7 +345,9 @@ def accessibleObjectFromEvent(window,objectID,childID):
 	try:
 		pacc,childID=oleacc.AccessibleObjectFromEvent(window,objectID,childID)
 	except Exception as e:
-		log.debugWarning("oleacc.AccessibleObjectFromEvent with window %s, objectID %s and childID %s: %s"%(window,objectID,childID,e))
+		log.debug(
+			f"oleacc.AccessibleObjectFromEvent with window {window}, objectID {objectID} and childID {childID}: {e}"
+		)
 		return None
 	return (normalizeIAccessible(pacc,childID),childID)
 


### PR DESCRIPTION
### Link to issue number:
None

### Steps to reproduce the issue
1. Log at level debug warning
2. Open the log viewer
3. Navigate to the bottom of the log
4. Press f5 to refresh

result: Many of these errors at the bottom:

```
DEBUGWARNING - IAccessibleHandler.accessibleObjectFromEvent (07:00:26.932) - MainThread (12624):
oleacc.AccessibleObjectFromEvent with window 656544, objectID 32 and childID 0: [WinError -2147467259] Niet nader omschreven fout
```

### Description of how this pull request fixes the issue:
We haven't been doing something with this warning for ages. Log it at level debug instead to make debug warning logging less verbose', being able to focus on the more important debug warnings.

### Testing performed:
Tested that we're now logging at level debug instead.

### Known issues with pull request:
None

### Change log entry:
None needed
