### PR TITLE
Fix-up of: Browse mode: When the user moves the cursor, speak before setting selection. (PR #10389)

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1125,8 +1125,11 @@ class ElementsListDialog(wx.Dialog):
 		else:
 			def move():
 				speech.cancelSpeech()
-				item.moveTo()
+				# #8831: Report before moving because moving might change the focus, which
+				# might mutate the document, potentially invalidating info if it is
+				# offset-based.
 				item.report()
+				item.moveTo()
 			# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
 			# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
 			core.callLater(100, move)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix-up of PR #10389

### Summary of the issue:

PR #10389 reports before moving in `BrowseModeTreeInterceptor._quickNavScript` but misses to do the same in `ElementsListDialog.onAction`. I guess the same conditions apply there.
@jcsteh can you please confirm?

### Description of how this pull request fixes the issue:

Apply the same change in `ElementsListDialog.onAction` to also cover moves made from the Elements List dialog.

### Testing performed:

Tested from source with Firefox and MS Word as part of my work on PR #10454.

### Known issues with pull request:

### Change log entry:

N/A

