### PR TITLE
No longer report content of edit fields which are going to lose focus.

### DIFF
--- a/source/editableText.py
+++ b/source/editableText.py
@@ -135,7 +135,7 @@ class EditableText(TextContainerObject,ScriptableObject):
 		return (False,newInfo)
 
 	def _caretScriptPostMovedHelper(self, speakUnit, gesture, info=None):
-		if isScriptWaiting():
+		if isScriptWaiting() or eventHandler.isPendingEvents("gainFocus"):
 			return
 		if not info:
 			try:


### PR DESCRIPTION
### Link to issue number:
Fixes #4317
### Summary of the issue:
When moving caret in edit field which  was just about to lose focus content of the fields was reported before newly focused object. It was particularly common when moving from search box in Windows 7 start menu.
### Description of how this pull request fixes the issue:
If something else is going to gain focus reporting of edit field content is suppressed.
### Testing performed:
In Windows 7 start menu tested that blank and new line are not reported when moving from search box. Ensured that its content is still reported when navigating in it.
### Known issues with pull request:
None known
### Change log entry:
None needed