### PR TITLE
Use our comInterfaces directory for nvda_slave

### DIFF
--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -8,6 +8,14 @@
 Performs miscellaneous tasks which need to be performed in a separate process.
 """
 
+# Initialise comtypes.client.gen_dir and the comtypes.gen search path 
+# and Append our comInterfaces directory to the comtypes.gen search path.
+import comtypes
+import comtypes.client
+import comtypes.gen
+import comInterfaces
+comtypes.gen.__path__.append(comInterfaces.__path__[0])
+
 import gettext
 import locale
 #Localization settings


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The functionality of nvda_slave has increased over time. Some actions involve interaction with com interfaces. However, nvda_slave doesn't use our comInterfaces directory, generating typelib wrappers on the fly. I've seen several in %temp%\comtypes_cache

### Description of how this pull request fixes the issue:
Make sure comtypes within nvda_slave knows about our prepopulated directory with cominterfaces

### Testing performed:
This is a bit hard to test, as I'm not sure what steps are required to reproduce this. It might be related to installation.

### Known issues with pull request:
None

### Change log entry:
None needed