### PR TITLE
UIA in MS Word: Stop announcing the next bullet on the previous line

### DIFF
--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -126,6 +126,10 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 		if pastEnd:
 			return
 		tempRange.MoveEndpointByRange(Endpoint_relativeStart,tempRange,Endpoint_relativeEnd)
+		if relativeGTOperator(tempRange.CompareEndpoints(Endpoint_relativeStart,rangeObj,Endpoint_relativeEnd),-1):
+			# tempRange is now already entirely passed the end of the given range.
+			# Can be seen with MS Word bullet points: #9613
+			return
 	# Ensure that we always reach the end of the outer range, even if the units seem to stop somewhere inside
 	if relativeLTOperator(tempRange.CompareEndpoints(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd),0):
 		tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd)

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -126,7 +126,8 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 		if pastEnd:
 			return
 		tempRange.MoveEndpointByRange(Endpoint_relativeStart,tempRange,Endpoint_relativeEnd)
-		if relativeGTOperator(tempRange.CompareEndpoints(Endpoint_relativeStart,rangeObj,Endpoint_relativeEnd),-1):
+		delta = tempRange.CompareEndpoints(Endpoint_relativeStart, rangeObj, Endpoint_relativeEnd)
+		if relativeGTOperator(delta, -1):
 			# tempRange is now already entirely passed the end of the given range.
 			# Can be seen with MS Word bullet points: #9613
 			return

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -128,7 +128,7 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 		tempRange.MoveEndpointByRange(Endpoint_relativeStart,tempRange,Endpoint_relativeEnd)
 		delta = tempRange.CompareEndpoints(Endpoint_relativeStart, rangeObj, Endpoint_relativeEnd)
 		if relativeGTOperator(delta, -1):
-			# tempRange is now already entirely passed the end of the given range.
+			# tempRange is now already entirely past the end of the given range.
 			# Can be seen with MS Word bullet points: #9613
 			return
 	# Ensure that we always reach the end of the outer range, even if the units seem to stop somewhere inside


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #9613 

### Summary of the issue:
When reading in MS Word 2016/365 with UIA enabled, the bullet or number of the next list item is announced when reading the previous line.

### Description of how this pull request fixes the issue:
Tightned up UIAUtils.iterUIARangeByUnit to doubley make sure that we do not start emitting a chunk whos end is at or beyond the end of the requested range to split.
On MS Word list items it seems that when splitting by the Format unit, If you try to clip the end of a chunk to the end of the previous line, the bullet for the next line is still included. Yet, checking the start of the chunk can get around this as it reports being equal or passed the end already.
Certainly a bug in MS Word, but very complex as the caret itself never lands on the bullet text, thus some confusion there.
 
### Testing performed:
Read by line in a document that contained bulletted paragraphs. The next bullet was no longer inappropriately announced. 
Created a document that contained format changes within a line. Ensured that the entire line was still read, including all format changes.

### Known issues with pull request:
None.


### Change log entry:
Bug fixes:
When reading bulleted items in Microsoft Word with UIA enabled, the bullet from the next list item is no longer inappropriately announced. (#9613)
