### PR TITLE
Remove scriptHandler.isCurrentScript which is never called

### DIFF
--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -224,31 +224,6 @@ def getLastScriptRepeatCount():
 def isScriptWaiting():
 	return bool(_numScriptsQueued)
 
-def isCurrentScript(scriptFunc):
-	"""Finds out if the given script is equal to the script that L{isCurrentScript} is being called from.
-	@param scriptFunc: the script retreaved from ScriptableObject.getScript(gesture)
-	@type scriptFunc: Instance method
-	@returns: True if they are equal, False otherwise
-	@rtype: boolean
-	"""
-	try:
-	 	givenFunc=getattr(scriptFunc.im_self.__class__,scriptFunc.__name__)
-	except AttributeError:
-		log.debugWarning("Could not get unbound method from given script",exc_info=True) 
-		return False
-	parentFrame=inspect.currentframe().f_back
-	try:
-		realObj=parentFrame.f_locals['self']
-	except KeyError:
-		log.debugWarning("Could not get self instance from parent frame instance method",exc_info=True)
-		return False
-	try:
-		realFunc=getattr(realObj.__class__,parentFrame.f_code.co_name)
-	except AttributeError:
-		log.debugWarning("Could not get unbound method from parent frame instance",exc_info=True)
-		return False
-	return givenFunc==realFunc
-
 def script(
 	description="",
 	category=None,


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8677 

### Summary of the issue:
scriptHandler.isCurrentScript was the only place left where  old attribute names remain from Python2. Namely im_self. If this function were called it would fail on Python3.

### Description of how this pull request fixes the issue:
Remove scriptHandler.isCurrentScript, as it is never called from NVDA's codebase, and has never been used in an add-on to our best knowledge.

### Testing performed:
NVDA still runs. Scripts such as speak current line (pressed, once, twice, 3 times) function correctly.

### Known issues with pull request:
There could be an add-on out there in the wild that did use this function. However, many other changes have been made in 2019.3 which would break these add-ons anyway. It will be listed as a change for developers. 

### Change log entry:
Changes for developers:
* scriptHandler.isCurrentScript has been removed due to lack of use. There is no replacement. (#8677) 
