### PR TITLE
Rename getBrailleTextForProperties to getPropertiesBraille

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1487,8 +1487,8 @@ class UIA(Window):
 		Skype for business toast notifications being one example.
 		"""
 		speech.speakObject(self, reason=controlTypes.REASON_FOCUS)
-		# Ideally, we wouldn't use getBrailleTextForProperties directly.
-		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
+		# Ideally, we wouldn't use getPropertiesBraille directly.
+		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 
 	def event_UIA_notification(self, notificationKind=None, notificationProcessing=UIAHandler.NotificationProcessing_CurrentThenMostRecent, displayString=None, activityId=None):
 		"""
@@ -1708,7 +1708,9 @@ class SuggestionListItem(UIA):
 			api.setNavigatorObject(self, isFocus=True)
 			self.reportFocus()
 			# Display results as flash messages.
-			braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role, positionInfo=self.positionInfo))
+			braille.handler.message(braille.getPropertiesBraille(
+				name=self.name, role=self.role, positionInfo=self.positionInfo
+			))
 
 # NetUIDropdownAnchor comboBoxes (such as in the MS Office Options dialog)
 class NetUIDropdownAnchor(UIA):

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -751,8 +751,8 @@ class ToolTip(NVDAObject):
 		if not config.conf["presentation"]["reportTooltips"]:
 			return
 		speech.speakObject(self, reason=controlTypes.REASON_FOCUS)
-		# Ideally, we wouldn't use getBrailleTextForProperties directly.
-		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
+		# Ideally, we wouldn't use getPropertiesBraille directly.
+		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 
 class Notification(NVDAObject):
 	"""Informs the user of non-critical information that does not require immediate action.
@@ -764,8 +764,8 @@ class Notification(NVDAObject):
 		if not config.conf["presentation"]["reportHelpBalloons"]:
 			return
 		speech.speakObject(self, reason=controlTypes.REASON_FOCUS)
-		# Ideally, we wouldn't use getBrailleTextForProperties directly.
-		braille.handler.message(braille.getBrailleTextForProperties(name=self.name, role=self.role))
+		# Ideally, we wouldn't use getPropertiesBraille directly.
+		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 
 	event_show = event_alert
 

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -143,12 +143,13 @@ class AutocompletionListItem(IAccessible):
 			# Reporting as focused should be sufficient
 			self.reportFocus()
 
-			# I picked up this from UIA SuggestionItem for rendering in braille.
-			# Simply calling `reportFocus` doesn't outputs the text to braille devices
+			# Simply calling `reportFocus` doesn't output the text in braille
 			# and reporting with `ui.message` needs an extra translation string when reporting position info
-			braille.handler.message(
-				braille.getBrailleTextForProperties(name=self.name,
-					role=self.role, position=self.positionInfo))
+			braille.handler.message(braille.getPropertiesBraille(
+				name=self.name,
+				role=self.role,
+				positionInfo=self.positionInfo
+			))
 
 class AppModule(appModuleHandler.AppModule):
 	LIST_VIEW_CLASS = "SysListView32"

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -54,7 +54,11 @@ class AppModule(appModuleHandler.AppModule):
 		if obj is not None:
 			api.setNavigatorObject(obj)
 			obj.reportFocus()
-			braille.handler.message(braille.getBrailleTextForProperties(name=obj.name, role=obj.role, positionInfo=obj.positionInfo))
+			braille.handler.message(braille.getPropertiesBraille(
+				name=obj.name,
+				role=obj.role,
+				positionInfo=obj.positionInfo
+			))
 			# Cache selected item.
 			self._recentlySelected = obj.name
 		else:

--- a/source/braille.py
+++ b/source/braille.py
@@ -471,7 +471,11 @@ class TextRegion(Region):
 		super(TextRegion, self).__init__()
 		self.rawText = text
 
-def getBrailleTextForProperties(**propertyValues):
+
+# C901 'getPropertiesBraille' is too complex
+# Note: when working on getPropertiesBraille, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 	textList = []
 	name = propertyValues.get("name")
 	if name:
@@ -573,6 +577,7 @@ def getBrailleTextForProperties(**propertyValues):
 		textList.append(cellCoordsText)
 	return TEXT_SEPARATOR.join([x for x in textList if x])
 
+
 class NVDAObjectRegion(Region):
 	"""A region to provide a braille representation of an NVDAObject.
 	This region will update based on the current state of the associated NVDAObject.
@@ -597,7 +602,7 @@ class NVDAObjectRegion(Region):
 		placeholderValue = obj.placeholder
 		if placeholderValue and not obj._isTextEmpty:
 			placeholderValue = None
-		text = getBrailleTextForProperties(
+		text = getPropertiesBraille(
 			name=obj.name,
 			role=role,
 			roleText=obj.roleTextBraille,
@@ -651,7 +656,7 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	if presCat == field.PRESCAT_LAYOUT:
 		text = []
 		if current:
-			text.append(getBrailleTextForProperties(current=current))
+			text.append(getPropertiesBraille(current=current))
 		return TEXT_SEPARATOR.join(text) if len(text) != 0 else None
 
 	elif role in (controlTypes.ROLE_TABLECELL, controlTypes.ROLE_TABLECOLUMNHEADER, controlTypes.ROLE_TABLEROWHEADER) and field.get("table-id"):
@@ -669,7 +674,7 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 		}
 		if reportTableHeaders:
 			props["columnHeaderText"] = field.get("table-columnheadertext")
-		return getBrailleTextForProperties(**props)
+		return getPropertiesBraille(**props)
 
 	elif reportStart:
 		props = {
@@ -689,7 +694,7 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 		level = field.get("level")
 		if level:
 			props["positionInfo"] = {"level": level}
-		text = getBrailleTextForProperties(**props)
+		text = getPropertiesBraille(**props)
 		content = field.get("content")
 		if content:
 			if text:
@@ -710,8 +715,11 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 	else:
 		# Translators: Displayed in braille at the end of a control field such as a list or table.
 		# %s is replaced with the control's role.
-		return (_("%s end") %
-			getBrailleTextForProperties(role=role,roleText=roleText))
+		return (_("%s end") % getPropertiesBraille(
+			role=role,
+			roleText=roleText
+		))
+
 
 def getFormatFieldBraille(field, fieldCache, isAtStart, formatConfig):
 	"""Generates the braille text for the given format field.


### PR DESCRIPTION
### Link to issue number:
Mentioned in #10371 

### Summary of the issue:
In #10371, getSpeechTextForProperties was renamed to getPropertiesSpeech.

### Description of how this pull request fixes the issue:
Do the same for braille: getBrailleTextForProperties > getPropertiesBraille

I noticed that in the eclipse module, the position kwarg was passed to it. This is wrong, I fixed this to be positionInfo.

### Testing performed:
Made sure that NVDA and braille still works.

### Known issues with pull request:
NOne

### Change log entry:
* Changes for developers
    + The braille function getBrailleTextForProperties has been renamed to getPropertiesBraille.