### PR TITLE
Store speech priorities in an enum

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1469,10 +1469,10 @@ the NVDAObject for IAccessible
 			api.processPendingEvents()
 		if self in api.getFocusAncestors():
 			return
-		speech.speakObject(self, reason=controlTypes.REASON_FOCUS,priority=speech.SPRI_NOW)
+		speech.speakObject(self, reason=controlTypes.REASON_FOCUS, priority=speech.Spri.NOW)
 		for child in self.recursiveDescendants:
 			if controlTypes.STATE_FOCUSABLE in child.states:
-				speech.speakObject(child, reason=controlTypes.REASON_FOCUS,priority=speech.SPRI_NOW)
+				speech.speakObject(child, reason=controlTypes.REASON_FOCUS, priority=speech.Spri.NOW)
 
 	def event_caret(self):
 		focus = api.getFocusObject()

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -178,7 +178,7 @@ def fetchAppModule(processID,appName):
 				# Translators: This is presented when errors are found in an appModule
 				# (example output: error in appModule explorer).
 				_("Error in appModule %s") % modName,
-				speechPriority=speech.priorities.SPRI_NOW
+				speechPriority=speech.priorities.Spri.NOW
 			)
 
 	# Use the base AppModule.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2385,7 +2385,7 @@ class GlobalCommands(ScriptableObject):
 						message = _("Screen curtain enabled")
 		finally:
 			if message is not None:
-				ui.message(message, speechPriority=speech.priorities.SPRI_NOW)
+				ui.message(message, speechPriority=speech.priorities.Spri.NOW)
 
 	__gestures = {
 		# Basic

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -55,6 +55,7 @@ from typing import Optional, Dict, List, Any
 from logHandler import log
 import config
 import aria
+from .priorities import Spri
 
 speechMode_off=0
 speechMode_beeps=1
@@ -133,14 +134,16 @@ def pauseSpeech(switch):
 	isPaused=switch
 	beenCanceled=False
 
-def speakMessage(text,priority=None):
+def speakMessage(
+		text: str,
+		priority: Optional[Spri] = None
+) -> None:
 	"""Speaks a given message.
-@param text: the message to speak
-@type text: string
-@param priority: The speech priority.
-@type priority: One of the C{SPRI_*} constants.
-"""
-	speakText(text,reason=controlTypes.REASON_MESSAGE,priority=priority)
+	@param text: the message to speak
+	@param priority: The speech priority.
+	"""
+	speakText(text, reason=controlTypes.REASON_MESSAGE, priority=priority)
+
 
 def getCurrentLanguage():
 	synth=getSynth()
@@ -156,7 +159,11 @@ def getCurrentLanguage():
 		language=languageHandler.getLanguage()
 	return language
 
-def spellTextInfo(info,useCharacterDescriptions=False,priority=None):
+def spellTextInfo(
+		info: textInfos.TextInfo,
+		useCharacterDescriptions: bool = False,
+		priority: Optional[Spri] = None
+) -> None:
 	"""Spells the text from the given TextInfo, honouring any LangChangeCommand objects it finds if autoLanguageSwitching is enabled."""
 	if not config.conf['speech']['autoLanguageSwitching']:
 		speakSpelling(info.text,useCharacterDescriptions=useCharacterDescriptions)
@@ -168,11 +175,22 @@ def spellTextInfo(info,useCharacterDescriptions=False,priority=None):
 		elif isinstance(field,textInfos.FieldCommand) and field.command=="formatChange":
 			curLanguage=field.field.get('language')
 
-def speakSpelling(text, locale=None, useCharacterDescriptions=False,priority=None):
-	seq = list(getSpeechForSpelling(text, locale=locale, useCharacterDescriptions=useCharacterDescriptions))
-	speak(seq,priority=priority)
 
-def getSpeechForSpelling(text, locale=None, useCharacterDescriptions=False):
+def speakSpelling(
+		text: str,
+		locale: Optional[str] = None,
+		useCharacterDescriptions: bool = False,
+		priority: Optional[Spri] = None
+) -> None:
+	seq = list(getSpeechForSpelling(text, locale=locale, useCharacterDescriptions=useCharacterDescriptions))
+	speak(seq, priority=priority)
+
+
+def getSpeechForSpelling(
+		text: str,
+		locale: Optional[str] = None,
+		useCharacterDescriptions: bool = False
+):
 	defaultLanguage=getCurrentLanguage()
 	if not locale or (not config.conf['speech']['autoDialectSwitching'] and locale.split('_')[0]==defaultLanguage.split('_')[0]):
 		locale=defaultLanguage
@@ -228,6 +246,7 @@ def getSpeechForSpelling(text, locale=None, useCharacterDescriptions=False):
 			yield PitchCommand()
 		yield EndUtteranceCommand()
 
+
 def getCharDescListFromText(text,locale):
 	"""This method prepares a list, which contains character and its description for all characters the text is made up of, by checking the presence of character descriptions in characterDescriptions.dic of that locale for all possible combination of consecutive characters in the text.
 	This is done to take care of conjunct characters present in several languages such as Hindi, Urdu, etc.
@@ -251,7 +270,14 @@ def getCharDescListFromText(text,locale):
 			i = i - 1
 	return charDescList
 
-def speakObjectProperties(obj, reason=controlTypes.REASON_QUERY, priority=None, _prefixSpeechCommand=None, **allowedProperties):
+
+def speakObjectProperties(
+		obj,
+		reason: str = controlTypes.REASON_QUERY,
+		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+		priority: Optional[Spri] = None,
+		**allowedProperties
+):
 	#Fetch the values for all wanted properties
 	newPropertyValues={}
 	positionInfo=None
@@ -343,7 +369,10 @@ def speakObjectProperties(obj, reason=controlTypes.REASON_QUERY, priority=None, 
 			speechSequence.insert(0, _prefixSpeechCommand)
 		speak(speechSequence, priority=priority)
 
-def _speakPlaceholderIfEmpty(info, obj, reason,priority=None):
+
+def _speakPlaceholderIfEmpty(
+		info: textInfos.TextInfo,
+		obj, reason,priority=None):
 	""" attempt to speak placeholder attribute if the textInfo 'info' is empty
 	@return: True if info was considered empty, and we attempted to speak the placeholder value.
 	False if info was not considered empty.
@@ -354,7 +383,12 @@ def _speakPlaceholderIfEmpty(info, obj, reason,priority=None):
 		return True
 	return False
 
-def speakObject(obj, reason=controlTypes.REASON_QUERY, _prefixSpeechCommand=None,priority=None):
+def speakObject(
+		obj,
+		reason: str = controlTypes.REASON_QUERY,
+		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+		priority: Optional[Spri] = None
+):
 	from NVDAObjects import NVDAObjectTextInfo
 	role=obj.role
 	# Choose when we should report the content of this object's textInfo, rather than just the object's value
@@ -454,23 +488,30 @@ def speakObject(obj, reason=controlTypes.REASON_QUERY, _prefixSpeechCommand=None
 			except (NotImplementedError, LookupError):
 				pass
 
-def speakText(text,reason=controlTypes.REASON_MESSAGE,symbolLevel=None,priority=None):
+
+def speakText(
+		text: str,
+		reason: str = controlTypes.REASON_MESSAGE,
+		symbolLevel: Optional[int] = None,
+		priority: Optional[Spri] = None
+):
 	"""Speaks some text.
 	@param text: The text to speak.
-	@type text: str
 	@param reason: The reason for this speech; one of the controlTypes.REASON_* constants.
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
-	@type priority: One of the C{SPRI_*} constants.
 	"""
 	if text is None:
 		return
 	if isBlank(text):
 		# Translators: This is spoken when the line is considered blank.
 		text=_("blank")
-	speak([text],symbolLevel=symbolLevel,priority=priority)
+	speak([text], symbolLevel=symbolLevel, priority=priority)
+
 
 RE_INDENTATION_SPLIT = re.compile(r"^([^\S\r\n\f\v]*)(.*)$", re.UNICODE | re.DOTALL)
+
+
 def splitTextIndentation(text):
 	"""Splits indentation from the rest of the text.
 	@param text: The text to split.
@@ -479,6 +520,7 @@ def splitTextIndentation(text):
 	@rtype: (str, str)
 	"""
 	return RE_INDENTATION_SPLIT.match(text).groups()
+
 
 RE_INDENTATION_CONVERT = re.compile(r"(?P<char>\s)(?P=char)*", re.UNICODE)
 IDT_BASE_FREQUENCY = 220 #One octave below middle A.
@@ -533,8 +575,6 @@ def getIndentationSpeech(indentation: str, formatConfig: Dict[str, bool]) -> Spe
 			speak = True
 	return [" ".join(res)] if speak else []
 
-from .priorities import *
-
 
 # C901 'speak' is too complex
 # Note: when working on speak, look for opportunities to simplify
@@ -542,17 +582,16 @@ from .priorities import *
 def speak(  # noqa: C901
 		speechSequence: SpeechSequence,
 		symbolLevel: Optional[int] = None,
-		priority: Optional[int] = None
+		priority: Optional[Spri] = None
 ):
 	"""Speaks a sequence of text and speech commands
 	@param speechSequence: the sequence of text and L{SpeechCommand} objects to speak
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
-	@type priority: One of the C{SPRI_*} constants.
 	"""
 	types.logBadSequenceTypes(speechSequence)
 	if priority is None:
-		priority=SPRI_NORMAL
+		priority = Spri.NORMAL
 	if not speechSequence: #Pointless - nothing to speak 
 		return
 	import speechViewer
@@ -613,7 +652,11 @@ def speak(  # noqa: C901
 				speechSequence[index]+=CHUNK_SEPARATOR
 	_manager.speak(speechSequence, priority)
 
-def speakPreselectedText(text, priority=None):
+
+def speakPreselectedText(
+		text: str,
+		priority: Optional[Spri] = None
+):
 	""" Helper method to announce that a newly focused control already has
 	text selected. This method is in contrast with L{speakTextSelected}.
 	The method will speak the word "selected" with the provided text appended.
@@ -629,7 +672,11 @@ def speakPreselectedText(text, priority=None):
 	# For example 'selected hello world'
 	speakSelectionMessage(_("selected %s"), text, priority)
 
-def speakTextSelected(text, priority=None):
+
+def speakTextSelected(
+		text: str,
+		priority: Optional[Spri] = None
+):
 	""" Helper method to announce that the user has caused text to be selected.
 	This method is in contrast with L{speakPreselectedText}.
 	The method will speak the provided text with the word "selected" appended.
@@ -642,23 +689,32 @@ def speakTextSelected(text, priority=None):
 	# For example 'hello world selected'
 	speakSelectionMessage(_("%s selected"), text, priority)
 
-def speakSelectionMessage(message,text,priority=None):
+
+def speakSelectionMessage(
+		message: str,
+		text: str,
+		priority: Optional[Spri] = None
+):
 	if len(text) < 512:
 		speakMessage(message % text,priority=priority)
 	else:
 		# Translators: This is spoken when the user has selected a large portion of text. Example output "1000 characters"
 		speakMessage(message % _("%d characters") % len(text),priority=priority)
 
-def speakSelectionChange(oldInfo,newInfo,speakSelected=True,speakUnselected=True,generalize=False,priority=None):
+
+def speakSelectionChange(
+		oldInfo: textInfos.TextInfo,
+		newInfo: textInfos.TextInfo,
+		speakSelected: bool = True,
+		speakUnselected: bool = True,
+		generalize: bool = False,
+		priority: Optional[Spri] = None
+):
 	"""Speaks a change in selection, either selected or unselected text.
 	@param oldInfo: a TextInfo instance representing what the selection was before
-	@type oldInfo: L{textInfos.TextInfo}
 	@param newInfo: a TextInfo instance representing what the selection is now
-	@type newInfo: L{textInfos.TextInfo}
 	@param generalize: if True, then this function knows that the text may have changed between the creation of the oldInfo and newInfo objects, meaning that changes need to be spoken more generally, rather than speaking the specific text, as the bounds may be all wrong.
-	@type generalize: boolean
 	@param priority: The speech priority.
-	@type priority: One of the C{SPRI_*} constants.
 	"""
 	selectedTextList=[]
 	unselectedTextList=[]
@@ -725,20 +781,23 @@ def speakSelectionChange(oldInfo,newInfo,speakSelected=True,speakUnselected=True
 				# Translators: Reported when selection is removed.
 				speakMessage(_("selection removed"),priority=priority)
 
+
 #: The number of typed characters for which to suppress speech.
 _suppressSpeakTypedCharactersNumber = 0
 #: The time at which suppressed typed characters were sent.
 _suppressSpeakTypedCharactersTime = None
-def _suppressSpeakTypedCharacters(number):
+
+
+def _suppressSpeakTypedCharacters(number: int):
 	"""Suppress speaking of typed characters.
 	This should be used when sending a string of characters to the system
 	and those characters should not be spoken individually as if the user were typing them.
 	@param number: The number of characters to suppress.
-	@type number: int
 	"""
 	global _suppressSpeakTypedCharactersNumber, _suppressSpeakTypedCharactersTime
 	_suppressSpeakTypedCharactersNumber += number
 	_suppressSpeakTypedCharactersTime = time.time()
+
 
 #: The character to use when masking characters in protected fields.
 PROTECTED_CHAR = "*"
@@ -746,7 +805,9 @@ PROTECTED_CHAR = "*"
 #: This is used to test whether a character should be spoken as a typed character;
 #: i.e. it should have a visual or spatial representation.
 FIRST_NONCONTROL_CHAR = u" "
-def speakTypedCharacters(ch):
+
+
+def speakTypedCharacters(ch: str):
 	global curWordChars
 	typingIsProtected=api.isTypingProtected()
 	if typingIsProtected:
@@ -782,6 +843,7 @@ def speakTypedCharacters(ch):
 		suppress = False
 	if not suppress and config.conf["keyboard"]["speakTypedCharacters"] and ch >= FIRST_NONCONTROL_CHAR:
 		speakSpelling(realChar)
+
 
 class SpeakTextInfoState(object):
 	"""Caches the state of speakTextInfo such as the current controlField stack, current formatfield and indentation."""
@@ -831,14 +893,14 @@ def _speakTextInfo_addMath(
 # and move logic out into smaller helper functions.
 def speakTextInfo(  # noqa: C901
 		info: textInfos.TextInfo,
-		useCache=True,
-		formatConfig=None,
+		useCache: bool = True,
+		formatConfig: Dict[str, bool] = None,
 		unit: Optional[str] = None,
-		reason=controlTypes.REASON_QUERY,
-		_prefixSpeechCommand=None,
-		onlyInitialFields=False,
-		suppressBlanks=False,
-		priority=None
+		reason: str = controlTypes.REASON_QUERY,
+		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+		onlyInitialFields: bool = False,
+		suppressBlanks: bool = False,
+		priority: Optional[Spri] = None
 ) -> bool:
 	onlyCache=reason==controlTypes.REASON_ONLYCACHE
 	if isinstance(useCache,SpeakTextInfoState):
@@ -1186,7 +1248,7 @@ def speakTextInfo(  # noqa: C901
 # Note: when working on getPropertiesSpeech, look for opportunities to simplify
 # and move logic out into smaller helper functions.
 def getPropertiesSpeech(  # noqa: C901
-		reason=controlTypes.REASON_QUERY,
+		reason: str = controlTypes.REASON_QUERY,
 		**propertyValues
 ) -> SpeechSequence:
 	global oldTreeLevel, oldTableID, oldRowNumber, oldRowSpan, oldColumnNumber, oldColumnSpan
@@ -2092,14 +2154,18 @@ def getTableInfoSpeech(
 	types.logBadSequenceTypes(textList)
 	return textList
 
+
 re_last_pause=re.compile(r"^(.*(?<=[^\s.!?])[.!?][\"'”’)]?(?:\s+|$))(.*$)",re.DOTALL|re.UNICODE)
 
-def speakWithoutPauses(speechSequence,detectBreaks=True):
+
+def speakWithoutPauses(
+		speechSequence: SpeechSequence,
+		detectBreaks: bool = True
+) -> bool:
 	"""
 	Speaks the speech sequences given over multiple calls, only sending to the synth at acceptable phrase or sentence boundaries, or when given None for the speech sequence.
 	@return: C{True} if something was actually spoken,
 		C{False} if only buffering occurred.
-	@rtype: bool
 	"""
 	lastStartIndex=0
 	#Break on all explicit break commands
@@ -2159,6 +2225,8 @@ def speakWithoutPauses(speechSequence,detectBreaks=True):
 		speak(finalSpeechSequence)
 		return True
 	return False
+
+
 speakWithoutPauses._pendingSpeechSequence=[]
 
 from .manager import SpeechManager
@@ -2166,7 +2234,8 @@ from .manager import SpeechManager
 #: @type: L{_SpeechManager}
 _manager = SpeechManager()
 
-def clearTypedWordBuffer():
+
+def clearTypedWordBuffer() -> None:
 	"""
 	Forgets any word currently being built up with typed characters for speaking. 
 	This should be called when the user's context changes such that they could no longer 

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -134,6 +134,7 @@ def pauseSpeech(switch):
 	isPaused=switch
 	beenCanceled=False
 
+
 def speakMessage(
 		text: str,
 		priority: Optional[Spri] = None
@@ -158,6 +159,7 @@ def getCurrentLanguage():
 	if not language:
 		language=languageHandler.getLanguage()
 	return language
+
 
 def spellTextInfo(
 		info: textInfos.TextInfo,
@@ -186,7 +188,10 @@ def speakSpelling(
 	speak(seq, priority=priority)
 
 
-def getSpeechForSpelling(
+# C901 'getSpeechForSpelling' is too complex
+# Note: when working on getSpeechForSpelling, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def getSpeechForSpelling(  # noqa: C901
 		text: str,
 		locale: Optional[str] = None,
 		useCharacterDescriptions: bool = False
@@ -271,7 +276,10 @@ def getCharDescListFromText(text,locale):
 	return charDescList
 
 
-def speakObjectProperties(
+# C901 'speakObjectProperties' is too complex
+# Note: when working on speakObjectProperties, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def speakObjectProperties(  # noqa: C901
 		obj,
 		reason: str = controlTypes.REASON_QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
@@ -372,7 +380,10 @@ def speakObjectProperties(
 
 def _speakPlaceholderIfEmpty(
 		info: textInfos.TextInfo,
-		obj, reason,priority=None):
+		obj,
+		reason: str,
+		priority: Optional[Spri] = None
+) -> bool:
 	""" attempt to speak placeholder attribute if the textInfo 'info' is empty
 	@return: True if info was considered empty, and we attempted to speak the placeholder value.
 	False if info was not considered empty.
@@ -383,7 +394,11 @@ def _speakPlaceholderIfEmpty(
 		return True
 	return False
 
-def speakObject(
+
+# C901 'speakObject' is too complex
+# Note: when working on speakObject, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def speakObject(  # noqa: C901
 		obj,
 		reason: str = controlTypes.REASON_QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
@@ -702,7 +717,10 @@ def speakSelectionMessage(
 		speakMessage(message % _("%d characters") % len(text),priority=priority)
 
 
-def speakSelectionChange(
+# C901 'speakSelectionChange' is too complex
+# Note: when working on speakSelectionChange, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def speakSelectionChange(  # noqa: C901
 		oldInfo: textInfos.TextInfo,
 		newInfo: textInfos.TextInfo,
 		speakSelected: bool = True,
@@ -2158,7 +2176,7 @@ def getTableInfoSpeech(
 re_last_pause=re.compile(r"^(.*(?<=[^\s.!?])[.!?][\"'”’)]?(?:\s+|$))(.*$)",re.DOTALL|re.UNICODE)
 
 
-def speakWithoutPauses(
+def speakWithoutPauses(  # noqa: C901
 		speechSequence: SpeechSequence,
 		detectBreaks: bool = True
 ) -> bool:

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -8,7 +8,7 @@ from logHandler import log
 import queueHandler
 import synthDriverHandler
 from .commands import *
-from .priorities import *
+from .priorities import Spri, SPEECH_PRIORITIES
 
 class ParamChangeTracker(object):
 	"""Keeps track of commands which change parameters from their defaults.
@@ -171,8 +171,8 @@ class SpeechManager(object):
 			queue = self._priQueues[priority] = _ManagerPriorityQueue(priority)
 		first = len(queue.pendingSequences) == 0
 		queue.pendingSequences.extend(outSeq)
-		if priority is SPRI_NOW and first:
-			# If this is the first sequence at SPRI_NOW, interrupt speech.
+		if priority is Spri.NOW and first:
+			# If this is the first sequence at Spri.NOW, interrupt speech.
 			return True
 		return False
 

--- a/source/speech/priorities.py
+++ b/source/speech/priorities.py
@@ -1,19 +1,27 @@
 # -*- coding: UTF-8 -*-
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2019 NV Access Limited
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2017-2019 NV Access Limited, Babbage B.V.
 
-"""Speech priority constants. """
+"""Speech priority enumeration."""
 
-#: Indicates that a speech sequence should have normal priority.
-SPRI_NORMAL = 0
-#: Indicates that a speech sequence should be spoken after the next utterance of lower priority is complete.
-SPRI_NEXT = 1
-#: Indicates that a speech sequence is very important and should be spoken right now,
-#: interrupting low priority speech.
-#: After it is spoken, interrupted speech will resume.
-#: Note that this does not interrupt previously queued speech at the same priority.
-SPRI_NOW = 2
+from enum import IntEnum
+
+
+class SpeechPriority(IntEnum):
+	#: Indicates that a speech sequence should have normal priority.
+	NORMAL = 0
+	#: Indicates that a speech sequence should be spoken after the next utterance of lower priority is complete.
+	NEXT = 1
+	#: Indicates that a speech sequence is very important and should be spoken right now,
+	#: interrupting low priority speech.
+	#: After it is spoken, interrupted speech will resume.
+	#: Note that this does not interrupt previously queued speech at the same priority.
+	NOW = 2
+
+
+#: Easy shorthand for the Speechpriority class
+Spri = SpeechPriority
 #: The speech priorities ordered from highest to lowest.
-SPEECH_PRIORITIES = (SPRI_NOW, SPRI_NEXT, SPRI_NORMAL)
+SPEECH_PRIORITIES = tuple(reversed(SpeechPriority))

--- a/source/ui.py
+++ b/source/ui.py
@@ -68,23 +68,21 @@ def browseableMessage(message,title=None,isHtml=False):
 	gui.mainFrame.postPopup() 
 
 
-def message(text: str, speechPriority: Optional[int] = None):
+def message(text: str, speechPriority: Optional[speech.Spri] = None):
 	"""Present a message to the user.
 	The message will be presented in both speech and braille.
 	@param text: The text of the message.
 	@param speechPriority: The speech priority.
-		One of the C{speech.priorities.SPRI_*} constants.
 	"""
 	speech.speakMessage(text, priority=speechPriority)
 	braille.handler.message(text)
 
 
-def reviewMessage(text: str, speechPriority: Optional[int] = None):
+def reviewMessage(text: str, speechPriority: Optional[speech.Spri] = None):
 	"""Present a message from review or object navigation to the user.
 	The message will always be presented in speech, and also in braille if it is tethered to review or when auto tethering is on.
 	@param text: The text of the message.
 	@param speechPriority: The speech priority.
-		One of the C{speech.priorities.SPRI_*} constants.
 	"""
 	speech.speakMessage(text, priority=speechPriority)
 	if braille.handler.shouldAutoTether or braille.handler.getTether() == braille.handler.TETHER_REVIEW:


### PR DESCRIPTION
### Link to issue number:
Briefly discussed in #10371 

### Summary of the issue:
Speech refactor introduced speech priorities, which were constants.

### Description of how this pull request fixes the issue:
As Python 3 has an Enum type and this code is new to the Python 3 version of NVDA, use an enum instead.

This allso adds some type hints to speech functions.

### Testing performed:
Tested running from source. Tested that speech priorities still work, i.e. that higher prio speech interrupts lower prio speech.

### Known issues with pull request:
None

### Change log entry:
None needed. 