### PR TITLE
While reading text, play a sound for spelling errors instead of saying "spelling error".

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1013,7 +1013,7 @@ def speakTextInfo(  # noqa: C901
 
 	if onlyInitialFields or (unit in (textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD) and len(textWithFields)>0 and len(textWithFields[0])==1 and all((isinstance(x,textInfos.FieldCommand) and x.command=="controlEnd") for x in itertools.islice(textWithFields,1,None) )): 
 		if not onlyCache:
-			if onlyInitialFields or any(isinstance(x,str) for x in speechSequence):
+			if onlyInitialFields or speechSequence:
 				speak(speechSequence,priority=priority)
 			if not onlyInitialFields: 
 				speakSpelling(textWithFields[0],locale=language if autoLanguageSwitching else None,priority=priority)
@@ -2020,8 +2020,7 @@ def getFormatFieldSpeech(  # noqa: C901
 		oldInvalidSpelling=attrsCache.get("invalid-spelling") if attrsCache is not None else None
 		if (invalidSpelling or oldInvalidSpelling is not None) and invalidSpelling!=oldInvalidSpelling:
 			if invalidSpelling:
-				# Translators: Reported when text contains a spelling error.
-				text=_("spelling error")
+				text = WaveFileCommand(r"waves\textError.wav")
 			elif extraDetail:
 				# Translators: Reported when moving out of text containing a spelling error.
 				text=_("out of spelling error")


### PR DESCRIPTION
### Link to issue number:
Fixes #4233 .

### Summary of the issue:
We already use a sound to indicate spelling errors while typing. However, while reading text, we currently report "spelling error". It is more efficient to use a sound instead, since the sound can be played in parallel and is also not conflated with the text itself.

### Description of how this pull request fixes the issue:
1. Update getFormatFieldSpeech to produce a WaveFileCommand instead of "spelling error".
2. Tweak speakTextInfo so that when reporting a single character, it reports initial fields for a non-empty sequence, regardless of whether the sequence contains text strings. Without this change, when moving by character into a spelling error (with no other initial fields), the sound was not played because the sequence didn't contain any text strings.

### Testing performed:
1. Opened this test case in Firefox:
    `data:text/html,<textarea>This is some textt. Each sentence contanes a single spelling error. Coming up with theese errors is quite amusing.`
2. Focused the textarea.
3. Read through the textarea by line, say all and word. Heard the buzz sound alongside each spelling error.

### Known issues with pull request:
1. This currently completely replaces the "spelling error" text. I guess some users might not like this. However, we don't currently have a mechanism for configuring sounds instead of spoken messages. We do have the "Play sound for spelling errors while typing" option, but that lives in Keyboard Settings and it's probably odd to have that setting control this functionality.
2. I'm not quite sure why speakTextInfo was testing for strings in the initial fields sequence. I can't think of a reason for this now. This was implemented 8 years ago in 82c4bdc8. Testing for a non-empty sequence should be sufficient.

### Change log entry:

New features:
`- While reading text, NVDA now plays a sound to indicate spelling errors instead of saying "spelling error".`

