### PR TITLE
Import languageHandler in speech package

### DIFF
--- a/source/mathPres/mathPlayer.py
+++ b/source/mathPres/mathPlayer.py
@@ -13,6 +13,7 @@ import comtypes.client
 from comtypes import COMError
 from comtypes.gen.MathPlayer import MPInterface, IMathSpeech, IMathSpeechSettings, IMathNavigation, IMathBraille
 import speech
+from synthDriverHandler import getSynth
 from keyboardHandler import KeyboardInputGesture
 import braille
 import mathPres
@@ -41,7 +42,7 @@ PROSODY_COMMANDS = {
 def _processMpSpeech(text, language):
 	# MathPlayer's default rate is 180 wpm.
 	# Assume that 0% is 80 wpm and 100% is 450 wpm and scale accordingly.
-	synth = speech.getSynth()
+	synth = getSynth()
 	wpm = synth._percentToParam(synth.rate, 80, 450)
 	breakMulti = 180.0 / wpm
 	out = []

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -16,11 +16,12 @@ import api
 import controlTypes
 import tones
 import synthDriverHandler
-from synthDriverHandler import *
+from synthDriverHandler import getSynth, setSynth
 import re
 import textInfos
 import speechDictHandler
 import characterProcessing
+import languageHandler
 from .commands import (
 	# Commands that are used in this file.
 	SpeechCommand,
@@ -87,7 +88,7 @@ def initialize():
 	setSynth(config.conf["speech"]["synth"])
 
 def terminate():
-	setSynth(None)
+	synthDriverHandler.setSynth(None)
 	speechViewerObj=None
 
 #: If a chunk of text contains only these characters, it will be considered blank.
@@ -143,7 +144,7 @@ def speakMessage(text,priority=None):
 	speakText(text,reason=controlTypes.REASON_MESSAGE,priority=priority)
 
 def getCurrentLanguage():
-	synth=getSynth()
+	synth = getSynth()
 	language=None
 	if  synth:
 		try:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -33,7 +33,8 @@ import ctypes.wintypes
 import ssl
 import wx
 import languageHandler
-import synthDriverHandler
+# Avoid a E402 'module level import not at top of file' warning, because several checks are performed above.
+import synthDriverHandler  # noqa: E402
 import braille
 import gui
 from gui import guiHelper

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -33,7 +33,7 @@ import ctypes.wintypes
 import ssl
 import wx
 import languageHandler
-import speech
+import synthDriverHandler
 import braille
 import gui
 from gui import guiHelper
@@ -110,8 +110,8 @@ def checkForUpdate(auto=False):
 		"x64": os.environ.get("PROCESSOR_ARCHITEW6432") == "AMD64",
 	}
 	if auto and allowUsageStats:
-		synthDriverClass=speech.getSynth().__class__
-		brailleDisplayClass=braille.handler.display.__class__ if braille.handler else None
+		synthDriverClass = synthDriverHandler.getSynth().__class__
+		brailleDisplayClass = braille.handler.display.__class__ if braille.handler else None
 		# Following are parameters sent purely for stats gathering.
 		#  If new parameters are added here, they must be documented in the userGuide for transparency.
 		extraParams={


### PR DESCRIPTION
### Link to issue number:
Fix-up of #10371

### Summary of the issue:
#10371 removed the languageHandler import from speech. However, the languageHandler was still used. Turns out that languageHandler was still imported by means of `from synthDriverHandler import *`

### Description of how this pull request fixes the issue:
1. Only import getSynth and setSynth from synthDriverHandler. I'd rather not do this, but some add-ons seem to rely on this, and also our own code assumed this
2. Where getSynth is used throughout the code, import it from synthDriverHandler instead of speech.

### Testing performed:
Tested that NVDA still runs from source.

### Known issues with pull request:
None

### Change log entry:
None needed