### PR TITLE
WinVersion.isWin10: recognize build 18363 as Version 1909 (November 2019 Update)

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -1,4 +1,3 @@
-# winVersion.py
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2019 NV Access Limited
 # This file is covered by the GNU General Public License.
@@ -43,7 +42,7 @@ def isWin10(version=1507, atLeast=True):
 		1803: 17134,
 		1809: 17763,
 		1903: 18362,
-		1909: 18363
+		1909: 18363,
 	}
 	if atLeast and winVersion.major < 10:
 		return False

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -1,8 +1,8 @@
-#winVersion.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# winVersion.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2019 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import sys
 import os

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -42,7 +42,8 @@ def isWin10(version=1507, atLeast=True):
 		1709: 16299,
 		1803: 17134,
 		1809: 17763,
-		1903: 18362
+		1903: 18362,
+		1909: 18363
 	}
 	if atLeast and winVersion.major < 10:
 		return False


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
On November 12, 2019, Microsoft released Windows 10 Version 1909 (November 2019 Update/build 18363). Although 1903 and 1909 are identical releases, 1909 includes additional features for use by enterprises and assistive technologies. Therefore recognize the new release.

### Description of how this pull request fixes the issue:
Added build 18363 to list of Windows 10 versions map in winVersion.isWin10.

### Testing performed:
Tested on a system running Version 1909 and 20H1 builds to make sure the new release is recognized.

### Known issues with pull request:
None

### Change log entry:
None

### Additional context:
sys.getwindowsversion().platform_version is unreliable here, as it'll still say 18362 on systems running build 18363.
