### PR TITLE
UIA/SearchField: catch COMError when attempting to look for search fields

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -867,7 +867,7 @@ class UIA(Window):
 			if self.UIAElement.cachedAutomationID in ("SearchTextBox", "TextBox"):
 				clsList.append(SearchField)
 		except COMError:
-			log.debug("Failed to locate UIA search field",exc_info=True)
+			log.debug("Failed to locate UIA search field", exc_info=True)
 		try:
 			# Nested block here in order to catch value error and variable binding error when attempting to access automation ID for invalid elements.
 			try:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -867,7 +867,7 @@ class UIA(Window):
 			if self.UIAElement.cachedAutomationID in ("SearchTextBox", "TextBox"):
 				clsList.append(SearchField)
 		except COMError:
-			pass
+			log.debug("Failed to locate UIA search field",exc_info=True)
 		try:
 			# Nested block here in order to catch value error and variable binding error when attempting to access automation ID for invalid elements.
 			try:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -863,8 +863,11 @@ class UIA(Window):
 		if isDialog:
 			clsList.append(Dialog)
 		# #6241: Try detecting all possible suggestions containers and search fields scattered throughout Windows 10.
-		if self.UIAElement.cachedAutomationID in ("SearchTextBox", "TextBox"):
-			clsList.append(SearchField)
+		try:
+			if self.UIAElement.cachedAutomationID in ("SearchTextBox", "TextBox"):
+				clsList.append(SearchField)
+		except COMError:
+			pass
 		try:
 			# Nested block here in order to catch value error and variable binding error when attempting to access automation ID for invalid elements.
 			try:


### PR DESCRIPTION

### Link to issue number:
Fixes #10422 

### Summary of the issue:
In Windows 10, error tone is heard when navigating through pages in Settings, as well as when opening emoji panel.

### Description of how this pull request fixes the issue:
Catch COMError thrown when attempting to add overlay class for search fields.

### Testing performed:
Tested via Windows 10 App Essentials add-on and on source code version to make sure error tone is no longer heard.

### Known issues with pull request:
None

### Change log entry:
None

### Additional context:
Although #10397 will catch this and resolve this at the UIA handler thread level, it is sometimes useful to figure out the root cause of issues, hence this pull request.
