### PR TITLE
What's new and user guide: refinements for 2019.3

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,11 +6,11 @@ What's New in NVDA
 = 2019.3 =
 
 == New Features ==
-- In Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 10 version 1809 and later:
- - Vastly improved performance and stability (#9771)
+- In Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 10 October 2018 Update and later:
+ - Vastly improved performance and stability. (#9771)
  - Reporting of typed text that does not appear onscreen (such as passwords) can now be enabled via an option in NVDA's advanced settings panel. (#9649)
 - The accuracy of the move mouse to navigator object command has been improved in text fields in Java applications. (#10157)
-- Screen curtain, which when enabled, makes the whole screen black on Windows 8 and above. (#7857)
+- Added screen curtain, which when enabled, makes the whole screen black on Windows 8 and later. (#7857)
 - Added support for  the following Handy Tech Braille displays (#8955):
  - Basic Braille Plus 40
  - Basic Braille Plus 32
@@ -26,7 +26,7 @@ What's New in NVDA
 
 == Changes ==
 - The user guide now describes how to use NVDA in the Windows Console. (#9957)
-- Running nvda.exe now defaults to replace an already running copy of NVDA. The -r|--replace command line parameter is still accepted, but ignored. (#8320)
+- Running nvda.exe now defaults to replacing an already running copy of NVDA. The -r|--replace command line parameter is still accepted, but ignored. (#8320)
 - On Windows 8 and later, NVDA will now report product name and version information for hosted apps such as apps downloaded from Microsoft Store using information provided by the app. (#4259, #10108)
 - When toggling track changes on and off with the keyboard in Microsoft Word, NVDA will announce the state of the setting. (#942) 
 - The NVDA version number is now logged as the first message in the log. This occurs even if logging has been disabled from the GUI. (#9803)
@@ -41,9 +41,9 @@ What's New in NVDA
 == Bug Fixes ==
 - Emoji and other 32 bit unicode characters now take less space on a braille display when they are shown as hexadecimal values. (#6695)
 - In Windows 10, NVDA will announce tooltips from universal apps if NVDA is configured to report tooltips in object presentation dialog. (#8118)
-- On Windows 10 version 1607 and later, typed text is now reported in Mintty. (#1348)
-- On Windows 10 version 1607 and later, output in the Windows Console that appears close to the caret is no longer spelled out. (#513)
-- controls in Audacitys compressor dialog are now announced when navigating the dialog. (#10103)
+- On Windows 10 Anniversary Update and later, typed text is now reported in Mintty. (#1348)
+- On Windows 10 Anniversary Update and later, output in the Windows Console that appears close to the caret is no longer spelled out. (#513)
+- Controls in Audacitys compressor dialog are now announced when navigating the dialog. (#10103)
 - NVDA no longer treats spaces as words in object review in Scintilla based editors such as Notepad++. (#8295)
 - NVDA will prevent the  system from entering sleep mode when scrolling through text with braille display gestures. (#9175)
 - On Windows 10, braille will now follow when editing cell contents in Microsoft Excel and in other UIA text controls where it was lagging behind. (#9749)
@@ -66,8 +66,8 @@ What's New in NVDA
 == Changes for Developers ==
 - Updated Python to 3.7. (#7105)
 - Updated pySerial to version 3.4. (#8815)
-- Updated wxPython to 4.0.3 to support Python 3.5+ (#9630)
-- Updated six to version 1.12.0 (#9630)
+- Updated wxPython to 4.0.3 to support Python 3.5 and later. (#9630)
+- Updated six to version 1.12.0. (#9630)
 - Updated py2exe to version 0.9.3.2 (in development, commit b372a8e from albertosottile/py2exe#13). (#9856)
 - Updated UIAutomationCore.dll comtypes module to version 10.0.18362. (#9829)
 - The tab-completion in the Python console only suggests attributes starting with an underscore if the underscore is first typed. (#9918)
@@ -105,7 +105,7 @@ What's New in NVDA
  - config.ConfigManager.getConfigValidationParameter has been replaced by getConfigValidation
  - inputCore.InputGesture.logIdentifier property has been removed.
    - Use _get_identifiers in inputCore.InputGesture instead.
- - synthDriverHandler.SynthDriver.speakText/speakCharacter, have been removed.
+ - synthDriverHandler.SynthDriver.speakText/speakCharacter have been removed.
  - Removed several synthDriverHandler.SynthSetting classes.
    - Previously kept for backwards compatibility (#8214), now considered obsolete.
    - Drivers that used the SynthSetting classes should be updated to use the DriverSetting classes.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2064,13 +2064,6 @@ On Windows 10, NVDA uses Windows OneCore voices by default ([[eSpeak NG #eSpeakN
 Please see this Microsoft article for a list of available voices and instructions to install them: https://support.microsoft.com/en-us/help/22797/windows-10-narrator-tts-voices
 
 
-++ Audiologic Tts3 ++[Audiologic]
-This is a commercial speech synthesizer specifically for the Italian language.
-You must have the synthesizer installed on your system in order for it to be used with NVDA.
-For more information, please visit the Audiologic website at www.audiologic.it.
-
-This synthesizer does not support [spelling functionality #SpeechSettingsUseSpelling].
-
 + Supported Braille Displays +[SupportedBrailleDisplays]
 This section contains information about the Braille displays supported by NVDA.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2023,7 +2023,7 @@ For an even more extensive list of  free and commercial synthesizers that you ca
 
 ++ eSpeak NG ++[eSpeakNG]
 The [eSpeak NG https://github.com/espeak-ng/espeak-ng] synthesizer is built directly into NVDA and does not require any other special drivers or components to be installed.
-NVDA starts using eSpeak NG by default.
+On Windows 7, 8 and 8.1, NVDA uses eSpeak NG by default ([Windows OneCore #OneCore] is used in Windows 10 by default).
 As this synthesizer is built into NVDA, this is a great choice for when running NVDA off a USB thumb drive on other systems.
 
 Each voice that comes with eSpeak NG speaks a different language.
@@ -2059,13 +2059,10 @@ To use these voices, you will need to install two components:
 ++ Windows OneCore Voices ++[OneCore]
 Windows 10 includes new voices known as "OneCore" or "mobile" voices.
 Voices are provided for many languages, and they are more responsive than the Microsoft voices available using Microsoft Speech API version 5.
+On Windows 10, NVDA uses Windows OneCore voices by default ([[eSpeak NG #eSpeakNG] is used in other releases).
 
 Please see this Microsoft article for a list of available voices and instructions to install them: https://support.microsoft.com/en-us/help/22797/windows-10-narrator-tts-voices
 
-Please note that the faster rates available with Narrator are not currently available with NVDA.
-Also, the speed you select in the Windows Settings affects the rate set in NVDA.
-These are issues we cannot resolve without changes to Windows.
-We are hopeful that these will be addressed in a future Windows update.
 
 ++ Audiologic Tts3 ++[Audiologic]
 This is a commercial speech synthesizer specifically for the Italian language.


### PR DESCRIPTION

### Link to issue number:
Fixes #10495 
Fixes #10496 

### Summary of the issue:
What's new and user guide were refined.

### Description of how this pull request fixes the issue:
What's new:

* Clarifications.
* Windows 10 version names.
* Punctuation and grammar.

User guide:

* Clarified sections 13.1 and 13.5 on Windows 10/OneCore default (#10495).
* Removed section 13.6 on Audiologic as the synth code is gone (#10496).

### Testing performed:
Tested by building these two documents and making sure information is accurate.

### Known issues with pull request:
None

### Change log entry:
None
