### PR TITLE
Run initial display for braille on the main thread

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -37,6 +37,7 @@ import extensionPoints
 import hwPortUtils
 import bdDetect
 import winUser
+import queueHandler
 
 roleLabels = {
 	# Translators: Displayed in braille for an object which is a
@@ -1692,7 +1693,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			else: # detected:
 				self._disableDetection()
 			log.info("Loaded braille display driver %s, current display has %d cells." %(name, self.displaySize))
-			wx.CallAfter(self.initialDisplay)
+			queueHandler.queueFunction(queueHandler.eventQueue, self.initialDisplay)
 			if detected and 'bluetoothName' in detected.deviceInfo:
 				self._enableDetection(bluetooth=False, keepCurrentDisplay=True, limitToDevices=[name])
 			return True


### PR DESCRIPTION
### Link to issue number:
fixes #9982 

### Summary of the issue:
If the braille display auto-detection feature is enabled and large braille table(s) (> 1 MB) are loaded on NVDA startup, the braille table(s) couldn't be completely loaded respectively compiled. Sometimes also the include opcode no longer operates and the braille output keeps blank after NVDA startup unless the braille output was updated (e.g. by opening the NVDA menu). Or only parts of the braille tables are loaded. A "Can't translate" runtime Error was logged on startup.
This issue was confirmed by @DrSooom.

The likely cause for this is that with auto detection, liblouis translation is executed from the background detection thread, rather than the main thread.

### Description of how this pull request fixes the issue:
Queue initial displaying to the main thread.

### Testing performed:
Tests by @DrSooom in a try build.

### Known issues with pull request:
None known

### Change log entry:
* Bug fixes
    + Some rare braille translation issues and errors with liblouis have been resolved. (#9982)