### PR TITLE
IA2Web: report regions and figures in focus mode

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -98,6 +98,10 @@ class Article(Ia2Web):
 	role = controlTypes.ROLE_ARTICLE
 
 
+class Region(Ia2Web):
+	role = controlTypes.ROLE_REGION
+
+
 class Editor(Ia2Web, DocumentWithTableNavigation):
 	TextInfo = MozillaCompoundTextInfo
 
@@ -177,6 +181,8 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 		clsList.append(BlockQuote)
 	elif iaRole == oleacc.ROLE_SYSTEM_DOCUMENT and xmlRoles[0] == "article":
 		clsList.append(Article)
+	elif xmlRoles[0] == "region" and obj.name:
+		clsList.append(Region)
 	elif iaRole == oleacc.ROLE_SYSTEM_ALERT:
 		clsList.append(Dialog)
 	elif iaRole == oleacc.ROLE_SYSTEM_EQUATION:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -102,6 +102,10 @@ class Region(Ia2Web):
 	role = controlTypes.ROLE_REGION
 
 
+class Figure(Ia2Web):
+	role = controlTypes.ROLE_FIGURE
+
+
 class Editor(Ia2Web, DocumentWithTableNavigation):
 	TextInfo = MozillaCompoundTextInfo
 
@@ -183,6 +187,8 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 		clsList.append(Article)
 	elif xmlRoles[0] == "region" and obj.name:
 		clsList.append(Region)
+	elif xmlRoles[0] == "figure":
+		clsList.append(Figure)
 	elif iaRole == oleacc.ROLE_SYSTEM_ALERT:
 		clsList.append(Dialog)
 	elif iaRole == oleacc.ROLE_SYSTEM_EQUATION:


### PR DESCRIPTION
### Link to issue number:
Follow up of #10462 

### Summary of the issue:
Oversight from #10462. In Firefox and Chrome:

* Regions were reported as landmarks
* Figures were reported as groupings

### Description of how this pull request fixes the issue:
Added respective overlay classes to ia2web.

### Testing performed:
Tested that regions with name as well as figures are appropriately reported in focus mode.

### Known issues with pull request:
None known

### Change log entry:
None
