### PR TITLE
Change how enabled providers are saved in the config spec

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -73,10 +73,10 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 # Vision enhancement provider settings
 [vision]
-	providers = string_list(=default=list())
 
 	# Vision enhancement provider settings
 	[[__many__]]
+		enabled = boolean(default=false)
 
 # Presentation settings
 [presentation]

--- a/source/vision/providerBase.py
+++ b/source/vision/providerBase.py
@@ -8,7 +8,7 @@
 """
 
 from abc import abstractmethod
-
+import config
 from autoSettingsUtils.autoSettings import AutoSettings
 from baseObject import AutoPropertyObject
 from .visionHandlerExtensionPoints import EventExtensionPoints
@@ -154,3 +154,17 @@ class VisionEnhancementProvider(AutoPropertyObject):
 	def canStart(cls) -> bool:
 		"""Returns whether this provider is able to start."""
 		return False
+
+	@classmethod
+	def enableInConfig(cls, enable: bool) -> None:
+		"""Enables or disables the provider in the current configuration.
+		@param enable: Whether to enable (C{True}) or disable (C{False}) the provider in the configuration.
+		"""
+		settings = cls.getSettings()
+		config.conf[settings._getConfigSection()][settings.getId()]["enabled"] = enable
+
+	@classmethod
+	def isEnabledInConfig(cls) -> bool:
+		"""Returns whether the provider is enabled in the configuration."""
+		settings = cls.getSettings()
+		return config.conf[settings._getConfigSection()][settings.getId()]["enabled"]

--- a/source/vision/providerInfo.py
+++ b/source/vision/providerInfo.py
@@ -11,7 +11,7 @@ ModuleNameT = str
 DisplayNameT = str
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProviderInfo:
 	providerId: ProviderIdT
 	moduleName: ModuleNameT

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -296,20 +296,20 @@ class VisionHandler(AutoPropertyObject):
 		curProviders: Set[providerInfo.ProviderInfo] = set(self.getActiveProviderInfos())
 		providersToInitialize = configuredProviders - curProviders
 		providersToTerminate = curProviders - configuredProviders
-		for providerInfo in providersToTerminate:
+		for info in providersToTerminate:
 			try:
-				self.terminateProvider(providerInfo)
+				self.terminateProvider(info)
 			except Exception:
 				log.error(
-					f"Could not terminate the {providerId} vision enhancement providerId",
+					f"Could not terminate the {info.providerId} vision enhancement provider",
 					exc_info=True
 				)
-		for providerInfo in providersToInitialize:
+		for info in providersToInitialize:
 			try:
-				self.initializeProvider(providerInfo)
+				self.initializeProvider(info)
 			except Exception:
 				log.error(
-					f"Could not initialize the {providerId} vision enhancement providerId",
+					f"Could not initialize the {info.providerId} vision enhancement provider",
 					exc_info=True
 				)
 

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -21,7 +21,7 @@ import config
 from logHandler import log
 import visionEnhancementProviders
 import queueHandler
-from typing import Type, Dict, List, Optional
+from typing import Type, Dict, List, Optional, Set
 from . import exceptions
 
 
@@ -147,6 +147,13 @@ class VisionHandler(AutoPropertyObject):
 		]
 		return list(activeProviderInfos)
 
+	def getConfiguredProviderInfos(self) -> List[providerInfo.ProviderInfo]:
+		configuredProviderInfos: List[providerInfo.ProviderInfo] = [
+			p for p in self._allProviders
+			if p.providerClass.isEnabledInConfig()
+		]
+		return configuredProviderInfos
+
 	def getProviderInstance(
 			self,
 			provider: providerInfo.ProviderInfo
@@ -185,14 +192,7 @@ class VisionHandler(AutoPropertyObject):
 			# A provider can raise whatever exception,
 			# therefore it is unknown what to expect.
 			exception = e
-		# Copy the configured providers before mutating the list.
-		# If we don't, configobj won't be aware of changes in the list.
-		configuredProviders: List = config.conf['vision']['providers'][:]
-		try:
-			configuredProviders.remove(providerId)
-			config.conf['vision']['providers'] = configuredProviders
-		except ValueError:
-			pass
+		providerInstance.enableInConfig(False)
 		# As we cant rely on providers to de-register themselves from extension points when terminating them,
 		# Re-create our extension points instance and ask active providers to reregister.
 		self.extensionPoints = EventExtensionPoints()
@@ -246,8 +246,8 @@ class VisionHandler(AutoPropertyObject):
 					log.error(
 						f"Error terminating provider {providerId} after registering to extension points", exc_info=True)
 				raise registerEventExtensionPointsException
-		if not temporary and providerId not in config.conf['vision']['providers']:
-			config.conf['vision']['providers'] = config.conf['vision']['providers'][:] + [providerId]
+		if not temporary:
+			providerInst.enableInConfig(True)
 		self._providers[providerId] = providerInst
 		try:
 			self.initialFocus()
@@ -292,22 +292,20 @@ class VisionHandler(AutoPropertyObject):
 		self.extensionPoints.post_mouseMove.notify(obj=obj, x=x, y=y)
 
 	def handleConfigProfileSwitch(self) -> None:
-		configuredProviders = set(config.conf['vision']['providers'])
-		curProviders = set(self._providers)
+		configuredProviders: Set[providerInfo.ProviderInfo] = set(self.getConfiguredProviderInfos())
+		curProviders: Set[providerInfo.ProviderInfo] = set(self.getActiveProviderInfos())
 		providersToInitialize = configuredProviders - curProviders
 		providersToTerminate = curProviders - configuredProviders
-		for providerId in providersToTerminate:
+		for providerInfo in providersToTerminate:
 			try:
-				providerInfo = self.getProviderInfo(providerId)
 				self.terminateProvider(providerInfo)
 			except Exception:
 				log.error(
 					f"Could not terminate the {providerId} vision enhancement providerId",
 					exc_info=True
 				)
-		for providerId in providersToInitialize:
+		for providerInfo in providersToInitialize:
 			try:
-				providerInfo = self.getProviderInfo(providerId)
 				self.initializeProvider(providerInfo)
 			except Exception:
 				log.error(

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -292,24 +292,28 @@ class VisionHandler(AutoPropertyObject):
 		self.extensionPoints.post_mouseMove.notify(obj=obj, x=x, y=y)
 
 	def handleConfigProfileSwitch(self) -> None:
-		configuredProviders: Set[providerInfo.ProviderInfo] = set(self.getConfiguredProviderInfos())
-		curProviders: Set[providerInfo.ProviderInfo] = set(self.getActiveProviderInfos())
+		configuredProviders: Set[providerInfo.ProviderIdT] = set(
+			info.providerId for info in self.getConfiguredProviderInfos()
+		)
+		curProviders: Set[providerInfo.ProviderIdT] = set(self._providers)
 		providersToInitialize = configuredProviders - curProviders
 		providersToTerminate = curProviders - configuredProviders
-		for info in providersToTerminate:
+		for providerId in providersToTerminate:
 			try:
+				info = self.getProviderInfo(providerId)
 				self.terminateProvider(info)
 			except Exception:
 				log.error(
-					f"Could not terminate the {info.providerId} vision enhancement provider",
+					f"Could not terminate the {providerId} vision enhancement provider",
 					exc_info=True
 				)
-		for info in providersToInitialize:
+		for providerId in providersToInitialize:
 			try:
+				info = self.getProviderInfo(providerId)
 				self.initializeProvider(info)
 			except Exception:
 				log.error(
-					f"Could not initialize the {info.providerId} vision enhancement provider",
+					f"Could not initialize the {providerId} vision enhancement provider",
 					exc_info=True
 				)
 

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -244,6 +244,22 @@ class NVDAHighlighterGuiPanel(
 			providerControl: VisionProviderStateControl
 	):
 		self._providerControl = providerControl
+		initiallyEnabledInConfig = providerControl._providerInfo.providerClass.isEnabledInConfig()
+		if not initiallyEnabledInConfig:
+			settingsStorage = self._getSettingsStorage()
+			settingsToCheck = [
+				settingsStorage.highlightBrowseMode,
+				settingsStorage.highlightFocus,
+				settingsStorage.highlightNavigator,
+			]
+			if any(settingsToCheck):
+				log.debugWarning(
+					"Highlighter disabled in config while some of its settings are enabled. "
+					"This will be corrected"
+				)
+				settingsStorage.highlightBrowseMode = False
+				settingsStorage.highlightFocus = False
+				settingsStorage.highlightNavigator = False
 		super().__init__(parent)
 
 	def _buildGui(self):

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -297,7 +297,7 @@ class NVDAHighlighterGuiPanel(
 			settings.highlightFocus,
 			settings.highlightNavigator,
 		]
-		if NVDAHighlighter.isEnabledInConfig() and any(settingsToTriggerActivation):
+		if any(settingsToTriggerActivation):
 			if all(settingsToTriggerActivation):
 				self._enabledCheckbox.Set3StateValue(wx.CHK_CHECKED)
 			else:

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -297,7 +297,7 @@ class NVDAHighlighterGuiPanel(
 			settings.highlightFocus,
 			settings.highlightNavigator,
 		]
-		if any(settingsToTriggerActivation):
+		if NVDAHighlighter.isEnabledInConfig() and any(settingsToTriggerActivation):
 			if all(settingsToTriggerActivation):
 				self._enabledCheckbox.Set3StateValue(wx.CHK_CHECKED)
 			else:


### PR DESCRIPTION
### Link to issue number:
Follow up of #10082
Related to #10476

### Summary of the issue:
Currently, active vision enhancement providers are saved in a list. Therefore, the state of active providers is saved on a list basis, not per provider. This means that, once a profile changes the list of active vision enhancement providers, the full list is saved in that profile, rather than just the provider for which the state was changed in that profile.

### Description of how this pull request fixes the issue:
Save enabled/disabled state of the provider in the provider section itself, as an enabled boolean.

### Testing performed:
1. Tested tat activation/deactivation still works as expected.
2. Tested the following steps:

	1. Enable highlighter and screen curtain
	2. Switch profile
	3. Disable screen curtain.
	4. Switch back to default profile
	5. Ensure screen curtain and highlighter are both enabled
	6. Disable highlighter
	7. Switch back to the custom profile
	8. Ensure that both providers are disabled in the profile. Disabled state of the highlighter is inherrited from the default config, rather than saved in the profile.

### Known issues with pull request:
This does not solve the concern from #10476. I feel we should discuss this further before coming up with a solution.

### Change log entry:
None
