### PR TITLE
Add a script to report focus context

### DIFF
--- a/source/api.py
+++ b/source/api.py
@@ -151,7 +151,7 @@ def getFocusDifferenceLevel():
 	return globalVars.focusDifferenceLevel
 
 def getFocusAncestors():
-	"""An array of NVDAObjects that are all parents of the object which currently has focus"""
+	"""A list of NVDAObjects that are all parents of the object which currently has focus"""
 	return globalVars.focusAncestors
 
 def getMouseObject():

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -298,7 +298,8 @@ When [Focus Highlight #VisionFocusHighlight] is enabled, the location of the cur
 There are some key commands that are useful when moving with the System focus:
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Description |
-| Report current focus | NVDA+tab | NVDA+tab | announces the current object or control that has the System focus. Pressing twice will spell the information |
+| Report current focus | NVDA+tab | NVDA+tab | Announces the current object or control that has the System focus. Pressing twice will spell the information |
+| Report current focus context | NVDA+shift+tab | NVDA+shift+tab | Announces the current object or control that has the system focus along with its context, such as the parent objects. If pressed twice, the objects are spoken in more detail |
 | Report title | NVDA+t | NVDA+t | Reports the title of the currently active window. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
 | Read active window | NVDA+b | NVDA+b | reads all the controls in the currently active window (useful for dialogs) |
 | Report Status Bar | NVDA+end | NVDA+shift+end | Reports the Status Bar if NVDA finds one. It also moves the navigator object to this location. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |


### PR DESCRIPTION
### Link to issue number:
Closes #9147

### Summary of the issue:
In some cases, you want to have the current focus object reported along with its context, i.e. the ancestry of the focus object. NVDA+tab doesn't offer this ability while NVDA+t doesn't report the focus object. There is currently no way to report the relevant ancestors up to the focus.

### Description of how this pull request fixes the issue:
Added a new script for this, assigned to NVDA+shift+tab. Abstracted this in such a way that the screen curtain script could use it.

### Testing performed:
Tested that the script works as expected.

### Known issues with pull request:
None

### Change log entry:
* New features
    + You can now report the current object with focus along with its context, i.e. the focus ancestry, with NVDA+shift+tab. (#9147)