### PR TITLE
Avoid Screen Curtain error on Windows 7

### DIFF
--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -74,14 +74,15 @@ class Magnification:
 			_MagGetFullscreenColorEffectArgTypes
 		)
 		MagGetFullscreenColorEffect.errcheck = _errCheck
+		MagShowSystemCursor = _MagShowSystemCursorFuncType(
+			("MagShowSystemCursor", _magnification),
+			_MagShowSystemCursorArgTypes
+		)
+		MagShowSystemCursor.errcheck = _errCheck
 	except AttributeError:
 		MagSetFullscreenColorEffect = None
 		MagGetFullscreenColorEffect = None
-	MagShowSystemCursor = _MagShowSystemCursorFuncType(
-		("MagShowSystemCursor", _magnification),
-		_MagShowSystemCursorArgTypes
-	)
-	MagShowSystemCursor.errcheck = _errCheck
+		MagShowSystemCursor = None
 
 
 # Translators: Description of a vision enhancement provider that disables output to the screen,

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -63,6 +63,8 @@ class Magnification:
 	MagUninitialize = _MagUninitializeFuncType(("MagUninitialize", _magnification))
 	MagUninitialize.errcheck = _errCheck
 
+	# These magnification functions are not available on versions of Windows prior to Windows 8,
+	# and therefore looking them up from the magnification library will raise an AttributeError.
 	try:
 		MagSetFullscreenColorEffect = _MagSetFullscreenColorEffectFuncType(
 			("MagSetFullscreenColorEffect", _magnification),


### PR DESCRIPTION
### Link to issue number:
Fixes #10502 

### Summary of the issue:
The structure of the Screen Curtain was changed when merging #10082. It tried to find a function in the Magnification.dll that wasn't available on Windows 7, without catching that error.

### Description of how this pull request fixes the issue:
Mag_ShowSystemCursor is no longer looked up on Windows 7.

### Testing performed:
I have no windows 7 system to test this. @lukaszgo1, could you test the pr build, please?

### Known issues with pull request:
None

### Change log entry:
None
