### PR TITLE
VisionProviderSubPanel_Settings.hasOptions now returns False based on supportedSettings instead of sizerDict

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1095,6 +1095,10 @@ class AutoSettingsMixin(metaclass=ABCMeta):
 		""" Override to change storage object for setting values."""
 		return self.getSettings()
 
+	@property
+	def hasOptions(self) -> bool:
+		return bool(self.getSettings().supportedSettings)
+
 	@classmethod
 	def _setSliderStepSizes(cls, slider, setting):
 		slider.SetLineSize(setting.minStep)
@@ -3400,10 +3404,6 @@ class VisionProviderSubPanel_Settings(
 	def makeSettings(self, settingsSizer):
 		# Construct vision enhancement provider settings
 		self.updateDriverSettings()
-
-	@property
-	def hasOptions(self) -> bool:
-		return bool(self.sizerDict)
 
 
 class VisionProviderSubPanel_Wrapper(


### PR DESCRIPTION
### Link to issue number:
Follow up of #10082

### Summary of the issue:
For a provider that only has runtime settings and uses the VisionProviderSubPanel_Wrapper, the VisionProviderSubPanel_Settings would be properly hidden if the provider is disabled. After enabling and disabling the provider, the empty panel is still shown and can receive keyboard access.

### Description of how this pull request fixes the issue:
Whether a panel had options was based on the sizerDict. However, for performance reasons, the sizerDict isn't cleared when updating the driver settings, the sizers for unsupported settings are only hidden. the sizerDict still remains populated.

This pr bases the hasOptions property on the supportedSettings property of the AutoSettings instance. It also moves the property to AutoSettingsMixin, since it's abstract enough to live there.

### Testing performed:
Tested enabling and disabling of a provider with only runtime settings. Ensured that after disabling, the whole panel disappeared. Enabling the provider again reintroduced the panel along with its settings.

### Known issues with pull request:
None

### Change log entry:
None
