### PR TITLE
UI Automation in Windows Console: only diff visible text ranges during autoread

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -281,12 +281,9 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 
 	def _getTextLines(self):
 		# Filter out extraneous empty lines from UIA
-		return (
-			self.makeTextInfo(textInfos.POSITION_ALL)
-			._rangeObj.getText(-1)
-			.rstrip()
-			.split("\r\n")
-		)
+		ptr = self.UIATextPattern.GetVisibleRanges()
+		res = [ptr.GetElement(i).GetText(-1) for i in range(ptr.length)]
+		return res
 
 
 def findExtraOverlayClasses(obj, clsList):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10406. Partial regression of #9891 (for the autoread case).

### Summary of the issue:
Windows Console crashed when large amounts of new text were written.

### Description of how this pull request fixes the issue:
Reverts commit 9fbd6b49015eba744dc2294642d96c481194930d as discussed in the issue.

### Testing performed:
The test case no longer reproduces the bug.

### Known issues with pull request:
Partially re-introduces #9891 (text review behaves properly, but autoread does not in some cases).

### Change log entry:
None.

