### PR TITLE
UI Automation in Windows Console: don't prefer UIA in consoles when a Braille display is in use

### DIFF
--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -242,7 +242,7 @@ it is retrieved from config).
 		return False
 	elif setting == "UIA":
 		return True
-	#10191: Text review in the UIA console does not function properly
+	# #10191: Text review in the UIA console does not function properly
 	# in Braille, so don't prefer it when a display is connected until we
 	# can find a workaround.
 	if braille.handler.enabled:

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -3,12 +3,15 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+
+import braille
 import operator
 from comtypes import COMError
 import config
 import ctypes
 import UIAHandler
 from winVersion import isWin10
+
 
 def createUIAMultiPropertyCondition(*dicts):
 	"""
@@ -239,6 +242,11 @@ it is retrieved from config).
 		return False
 	elif setting == "UIA":
 		return True
+	#10191: Text review in the UIA console does not function properly
+	# in Braille, so don't prefer it when a display is connected until we
+	# can find a workaround.
+	if braille.handler.enabled:
+		return False
 	# #7497: Windows 10 Fall Creators Update has an incomplete UIA
 	# implementation for console windows, therefore for now we should
 	# ignore it.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1766,8 +1766,8 @@ It does not affect the modern Windows Terminal.
 In Windows 10 version 1709, Microsoft [added support for its UI Automation API to the console https://devblogs.microsoft.com/commandline/whats-new-in-windows-console-in-windows-10-fall-creators-update/], bringing vastly improved performance and stability for screen readers that support it.
 In situations where UI Automation is unavailable or known to result in an inferior user experience, NVDA's legacy console support is available as a fallback.
 The Windows Console support combo box has three options:
-- Automatic: Uses UI Automation in consoles on Windows 10 version 1809 and later. This option is recommended and set by default.
-- Prefer UIA: Uses UI Automation in consoles if available, even on Windows versions with incomplete or buggy implementations. While this limited functionality may be useful (and even sufficient for your usage), use of this option is entirely at your own risk and no support for it will be provided.
+- Automatic: Uses UI Automation in consoles on Windows 10 version 1809 and later when a Braille display is not connected. This option is recommended and set by default.
+- Prefer UIA: Uses UI Automation in consoles if possible, even in cases where implementation is incomplete or buggy. While this limited functionality may be useful (and even sufficient for your usage), use of this option is entirely at your own risk and no support for it will be provided.
 - Legacy: UI Automation in the Windows Console will be completely disabled, so the legacy fallback will always be used.
 -
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10477. Works around #10191.

### Summary of the issue:
When using the Windows Console with a Braille display, text review is cut off.

### Description of how this pull request fixes the issue:
When the Windows Console implementation setting is set to "auto", fall back to legacy when a Braille display is connected.

### Testing performed:
Tested that with default settings, legacy is used when a 5th-generation Freedom Scientific Focus is connected over USB, UIA otherwise.

### Known issues with pull request:
This merely works around the issue. If a fix for this issue can be found before the 2019.3 release this PR should be superseded.

### Change log entry:
None.
