### PR TITLE
Bundle the Java Access Bridge with NVDA.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "include/py2exe"]
 	path = include/py2exe
 	url = https://github.com/nvaccess/py2exe-bin
+[submodule "include/javaAccessBridge32"]
+	path = include/javaAccessBridge32
+	url = https://github.com/nvaccess/javaAccessBridge32-bin.git

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ For reference, the following run time dependencies are included in Git submodule
 * lilli.dll, version 2.1.0.0
 * [pySerial](https://pypi.python.org/pypi/pyserial), version 3.4
 * [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)
+* Java Access Bridge 32 bit, from Zulu Community OpenJDK build 13.0.1+10Zulu (13.28.11)
 
 Additionally, the following build time dependencies are included in Git submodules:
 

--- a/sconstruct
+++ b/sconstruct
@@ -198,6 +198,11 @@ envArm64['projectResFile'] = resFile
 
 #Fill sourceDir with anything provided for it by miscDeps
 env.recursiveCopy(sourceDir,Dir('miscdeps/source'))
+# Copy in some other dependencies.
+jabDll = "windowsaccessbridge-32.dll"
+Command(sourceLibDir.File(jabDll),
+	env.Dir("#include/javaAccessBridge32").File(jabDll),
+	Copy("$TARGET", "$SOURCE"))
 
 env.SConscript('source/comInterfaces_sconscript',exports=['env'])
 


### PR DESCRIPTION
### Link to issue number:
Fixes #7724.

### Summary of the issue:
NVDA is a 32 bit application and requires the 32 bit Java Access Bridge client dll. This will happily talk to 64 bit Java applications. However, since Java 10, official 32 bit builds are no longer provided. This means that users have to find and install an unofficial community 32 bit build of Java themselves if they wish to access Java applications.

### Description of how this pull request fixes the issue:
Bundle the JAB with NVDA:

1. Include the dll via a Git submodule.
2. Have SCons copy the dll into source/lib.
3. Modify JABHandler to load it from the versioned lib directory if appropriate. This meant reorganising initialisation somewhat, as we need NVDAHelper to get the versioned lib path, but trying to use it at module level breaks due to circular import.
4. Remove JABHandler's support for the legacy bridge, since it can no longer be used now that the proper 32 bit bridge is always present.

### Testing performed:
Ensured no JAB was present in c:\windows\syswow64 and started Android Studio. Android Studio was accessible via JAB.

### Known issues with pull request:
1. Theoretically, there might be problems if a user is running a different version of the Java VM. In practice, the JAB isn't updated very often. Regardless, it isn't really possible to mitigate this. Also, the user would probably hit similar problems if they installed their own JAB anyway, since some apps now bundle their own Java VM and don't let you easily use the system Java VM.
2. If the user has a 32 bit Java VM installed which is using the legacy JAB on the VM side, this might fail. (I'm not actually certain whether it will or not.) Now that 32 bit Java is no longer supported, this is highly unlikely. It was unlikely even before that, since this new JAB has been available for years now.
3. The user still has to enable the Java Access Bridge in the Java VM. This has always been the case; it's nothing new. It's still annoying, though, especially if the user doesn't have a Java VM installed which adds jabswitch to the Ease of Access Center. It should actually be possible for us to enable this ourselves - jabswitch seems to flip a switch in the user's profile - but we'd need to figure out when to do this and I think this should be handled separately.

### Change log entry:

Changes:
`- The Java Access Bridge is now included with NVDA to enable access to Java applications. (#7724)`