### PR TITLE
Vision framework fix-up: when changing a synthesizer, make the setting controls reflect the new synth

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1075,7 +1075,11 @@ class AutoSettingsMixin(metaclass=ABCMeta):
 		# because settings instances can be of type L{Driver} as well, we have to handle
 		# showing settings for non-instances. Because of this, we must reacquire a reference
 		# to the settings class whenever we wish to use it (via L{getSettings}) in case the instance changes.
-		self._currentSettingsRef = weakref.ref(self.getSettings())
+		# We also use the weakref to refresh the gui when an instance dies.
+		self._currentSettingsRef = weakref.ref(
+			self.getSettings(),
+			lambda ref: wx.CallAfter(self.refreshGui)
+		)
 
 	settingsSizer: wx.BoxSizer
 
@@ -1302,7 +1306,10 @@ class AutoSettingsMixin(metaclass=ABCMeta):
 				log.debug("refreshing panel")
 			self.sizerDict.clear()
 			self.settingsSizer.Clear(delete_windows=True)
-			self._currentSettingsRef = weakref.ref(self.getSettings())
+			self._currentSettingsRef = weakref.ref(
+				self.getSettings(),
+				lambda ref: wx.CallAfter(self.refreshGui)
+			)
 			self.makeSettings(self.settingsSizer)
 
 	def onPanelActivated(self):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1195,10 +1195,11 @@ class AutoSettingsMixin(metaclass=ABCMeta):
 		"""
 		checkbox = wx.CheckBox(self, label=setting.displayNameWithAccelerator)
 		setattr(self, f"{setting.id}Checkbox", checkbox)
+		settingsStorageProxy = weakref.proxy(settingsStorage)
 
 		def _onCheckChanged(evt: wx.CommandEvent):
 			evt.Skip()  # allow other handlers to also process this event.
-			setattr(settingsStorage, setting.id, evt.IsChecked())
+			setattr(settingsStorageProxy, setting.id, evt.IsChecked())
 
 		checkbox.Bind(wx.EVT_CHECKBOX, _onCheckChanged)
 		checkbox.SetValue(getattr(


### PR DESCRIPTION
### Link to issue number:
Fix-up of #10082 

### Summary of the issue:
The vision framework gui introduced a bug that caused the speech synthesizer controls not being updated correctly after choosing another synth.

### Description of how this pull request fixes the issue:
After some investigation by @feerrenrut and me, we started using a weakref.proxy in a nested function to avoid a reference to be kept indefinitely.

As a bonus, I also made sure that when the weak reference to a driver is destroyed, the panel is refreshed. This has the nice benefit of controls being automatically updated when using braille display auto detection while the braille panel is focused. I think we shouldn't list this as a new feature though, since the text control that contains the name of the current braille display isn't updated correctly.

### Testing performed:
1. Tested braille display autodetection with a focused braille panel. Made sure that settings apear and disapear when connecting a handy tech display,
2. Made sure that when changing the synthesizer, the setting controls are properly updated.

### Known issues with pull request:
None

### Change log entry:
None
Sectio