### PR TITLE
Vision framework fix-up: prevend disabling highlighter from locking up the system

### DIFF
--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -343,6 +343,14 @@ class NVDAHighlighterGuiPanel(
 		providerInst: Optional[NVDAHighlighter] = self._providerControl.getProviderInstance()
 		if providerInst:
 			providerInst.refresh()
+		elif evt.IsChecked():
+			# One or more check boxes are enabled, so the provider instance must be there.
+			# Yet, there is no instance. This must be a case where initialization failed.
+			settingsStorage.highlightBrowseMode = False
+			settingsStorage.highlightFocus = False
+			settingsStorage.highlightNavigator = False
+			self.updateDriverSettings()
+			self._updateEnabledState()
 
 
 class NVDAHighlighter(providerBase.VisionEnhancementProvider):

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -412,7 +412,10 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 		window = self.window = self.customWindowClass(self)
 		self.timer = winUser.WinTimer(window.handle, 0, self._refreshInterval, None)
 		msg = MSG()
-		while winUser.getMessage(byref(msg), None, 0, 0):
+		# Python 3.8 note, Change this to use an Assignment expression to catch a return value of -1.
+		# See the remarks section of
+		# https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessage
+		while winUser.getMessage(byref(msg), None, 0, 0) > 0:
 			winUser.user32.TranslateMessage(byref(msg))
 			winUser.user32.DispatchMessageW(byref(msg))
 		if vision._isDebug():

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -401,10 +401,10 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 		self._highlighterRunningEvent = threading.Event()
 		self._highlighterThread.daemon = True
 		self._highlighterThread.start()
-		# Make sure the highlgihter thread doesn't exit early.
+		# Make sure the highlighter thread doesn't exit early.
 		waitResult = self._highlighterRunningEvent.wait(0.2)
-		if not waitResult or not self._highlighterThread.is_alive():
-			raise RuntimeError("Highlighter thread terminated after initialization")
+		if waitResult is False or not self._highlighterThread.is_alive():
+			raise RuntimeError("Highlighter thread wasn't able to initialize correctly")
 
 	def terminate(self):
 		log.debug("Terminating NVDAHighlighter")

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -362,7 +362,7 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 	_refreshInterval = 100
 	customWindowClass = HighlightWindow
 	_settings = NVDAHighlighterSettings()
-	window: Optional[customWindowClass] = None
+	_window: Optional[customWindowClass] = None
 	enabledContexts: Tuple[Context]  # type info for autoprop: L{_get_enableContexts}
 
 	@classmethod  # override
@@ -408,7 +408,7 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 
 	def terminate(self):
 		log.debug("Terminating NVDAHighlighter")
-		if self._highlighterThread and self.window and self.window.handle:
+		if self._highlighterThread and self._window and self._window.handle:
 			if not winUser.user32.PostThreadMessageW(self._highlighterThread.ident, winUser.WM_QUIT, 0, 0):
 				raise WinError()
 			else:
@@ -423,7 +423,7 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 			if vision._isDebug():
 				log.debug("Starting NVDAHighlighter thread")
 			try:
-				window = self.window = self.customWindowClass(self)
+				window = self._window = self.customWindowClass(self)
 				timer = winUser.WinTimer(window.handle, 0, self._refreshInterval, None)
 			finally:
 				self._highlighterRunningEvent.set()
@@ -471,8 +471,8 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 	def refresh(self):
 		"""Refreshes the screen positions of the enabled highlights.
 		"""
-		if self.window and self.window.handle:
-			self.window.refresh()
+		if self._window and self._window.handle:
+			self._window.refresh()
 
 	def _get_enabledContexts(self):
 		"""Gets the contexts for which the highlighter is enabled.

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -141,6 +141,7 @@ class CustomWindow(AutoPropertyObject):
 	The window will be destroyed when the instance is deleted,
 	but it can be explicitly destroyed using L{destroy}.
 	"""
+	handle: Optional[int] = None
 
 	@classmethod
 	def _get__wClass(cls):

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -144,6 +144,13 @@ class CustomWindow(AutoPropertyObject):
 	handle: Optional[int] = None
 
 	@classmethod
+	def __new__(cls, *args, **kwargs):
+		for instance in cls._hwndsToInstances.values():
+			if type(instance) is cls:
+				raise RuntimeError(f"Only one instance of {cls.__qualname__} may exist at a time")
+		return super().__new__(cls, *args, **kwargs)
+
+	@classmethod
 	def _get__wClass(cls):
 		return WNDCLASSEXW(
 			cbSize=ctypes.sizeof(WNDCLASSEXW),


### PR DESCRIPTION
### Link to issue number:
Fixes #10509 

### Summary of the issue:
When disabling the NVDA Highlighter, NVDA sometimes locked up. This was because the thread is joined before it wastold to terminate. See also https://github.com/nvaccess/nvda/pull/10520#issuecomment-558067371 for a more in depth explanation.

### Description of how this pull request fixes the issue:
Changed the following:

* The highlighter no longer has the NVDA main window as its parent to ensure we're never blocked by wx
* CustomWindow classes now only could have one instance. This is because the window class is created with the window and destroyed with it. Debugging this issue revealed that sometimes, multiple instances were created when reinitializing to quickly, but that should never happen.
* The highlighter now fails to initialize if something goes wrong in the highlighter thread

### Testing performed:
* Focused vision panel, hold the e key for around 10 seconds without crashing or errors in the log.
* **Edit** _(Reef)_: Tested that the highlighter still displays correctly.

### Known issues with pull request:
None

### Change log entry:
None