### PR TITLE
winConsoleUIA: Greatly speed up move by word

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -204,10 +204,11 @@ class consoleUIATextInfo(UIATextInfo):
 		This is necessary since Uniscribe requires indices into the text to
 		find word boundaries, but UIA only allows for relative movement.
 		"""
-		charInfo = self.copy()
-		charInfo.setEndPoint(lineInfo, "startToStart")
+		# position a textInfo from the start of the line up to the current position.
+		charInfo = lineInfo.copy()
+		charInfo.setEndPoint(self, "endToStart")
 		text = charInfo.text
-		offset = textUtils.WideStringOffsetConverter(text).wideStringLength - 1
+		offset = textUtils.WideStringOffsetConverter(text).wideStringLength
 		return offset
 
 	def _getWordOffsetsInThisLine(self, offset, lineInfo):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -7,6 +7,7 @@
 import ctypes
 import NVDAHelper
 import textInfos
+import textUtils
 import UIAHandler
 
 from comtypes import COMError
@@ -204,22 +205,10 @@ class consoleUIATextInfo(UIATextInfo):
 		find word boundaries, but UIA only allows for relative movement.
 		"""
 		charInfo = self.copy()
-		res = 0
-		chars = None
-		while charInfo.compareEndPoints(
-			lineInfo,
-			"startToEnd"
-		) <= 0:
-			charInfo.expand(textInfos.UNIT_CHARACTER)
-			chars = charInfo.move(textInfos.UNIT_CHARACTER, -1) * -1
-			if chars != 0 and charInfo.compareEndPoints(
-				lineInfo,
-				"startToStart"
-			) >= 0:
-				res += chars
-			else:
-				break
-		return res
+		charInfo.setEndPoint(lineInfo,"startToStart")
+		text=charInfo.text
+		offset = textUtils.WideStringOffsetConverter(text).wideStringLength-1
+		return offset
 
 	def _getWordOffsetsInThisLine(self, offset, lineInfo):
 		lineText = lineInfo.text or u" "
@@ -232,16 +221,17 @@ class consoleUIATextInfo(UIATextInfo):
 		# not more than two alphanumeric chars in a row.
 		# Inject two alphanumeric characters at the end to fix this.
 		lineText += "xx"
+		lineTextLen = textUtils.WideStringOffsetConverter(lineText).wideStringLength
 		NVDAHelper.localLib.calculateWordOffsets(
 			lineText,
-			len(lineText),
+			lineTextLen,
 			offset,
 			ctypes.byref(start),
 			ctypes.byref(end)
 		)
 		return (
 			start.value,
-			min(end.value, max(1, len(lineText) - 2))
+			min(end.value, max(1, lineTextLen - 2))
 		)
 
 	def __ne__(self, other):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -205,9 +205,9 @@ class consoleUIATextInfo(UIATextInfo):
 		find word boundaries, but UIA only allows for relative movement.
 		"""
 		charInfo = self.copy()
-		charInfo.setEndPoint(lineInfo,"startToStart")
-		text=charInfo.text
-		offset = textUtils.WideStringOffsetConverter(text).wideStringLength-1
+		charInfo.setEndPoint(lineInfo, "startToStart")
+		text = charInfo.text
+		offset = textUtils.WideStringOffsetConverter(text).wideStringLength - 1
 		return offset
 
 	def _getWordOffsetsInThisLine(self, offset, lineInfo):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
In Windows consoles with UIA enabled, moving the review cursor by word is extremely slow, especially at the end of long lines. Sometimes it can take more than 250 ms to find the next or previous word.
The reason for this slowness is that NVDA must manually calculate word positions within a line because the UIA implementation for consoles in Windows does not support moving by word, and within NVDA's calculation, it needs to work out the current character offset within a line, for which it currently calls IUIAutomationTextRange::move with unit character, over and over again until reaching the start of the line. This call to move could happen up to 80 times before finding the start of the line.

### Description of how this pull request fixes the issue:
Rather than calling move over and over again to find the start of the line, just fetch the text from the start of the line up to the current position, and use the number of characters. Specifically, the number of utf16 characters (using WideStringOffsetConvertor), as each character cell in the console holds one utf16 character.
 
### Testing performed:
In wsl, ran the 'ls' command in a big directory, and reviewed the lines by moving by previous and next word.
Echoed several strings to the console using the 'echo' command, including emoji characters, and moved through them with next and previous word, ensuring that  the review cursor correctly moved by word, not getting stuck or jumping too far.

### Known issues with pull request:
None.

### Change log entry:
None.
