### PR TITLE
Don't unconditionally report aria-current for all property changes.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -18,6 +18,8 @@ from NVDAObjects.behaviors import Dialog, WebDialog
 from . import IAccessible
 from .ia2TextMozilla import MozillaCompoundTextInfo
 import aria
+import api
+import speech
 
 class Ia2Web(IAccessible):
 	IAccessibleTableUsesTableCellIndexAttrib=True
@@ -79,6 +81,15 @@ class Ia2Web(IAccessible):
 		if landmark:
 			return landmark
 		return super().landmark
+
+	def event_IA2AttributeChange(self):
+		super().event_IA2AttributeChange()
+		if self is api.getFocusObject():
+			# Report aria-current if it changed.
+			speech.speakObjectProperties(
+				self, current=True, reason=controlTypes.REASON_CHANGE)
+		# super calls event_stateChange which updates braille, so no need to
+		# update braille here.
 
 
 class Document(Ia2Web):

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -297,6 +297,10 @@ def speakObjectProperties(  # noqa: C901
 		elif name.startswith('positionInfo_') and value:
 			if positionInfo is None:
 				positionInfo=obj.positionInfo
+		elif value and name == "current":
+			# getPropertiesSpeech names this "current", but the NVDAObject property is
+			# named "isCurrent".
+			newPropertyValues['current'] = obj.isCurrent
 		elif value:
 			# Certain properties such as row and column numbers have presentational versions, which should be used for speech if they are available.
 			# Therefore redirect to those values first if they are available, falling back to the normal properties if not.
@@ -350,7 +354,6 @@ def speakObjectProperties(  # noqa: C901
 			newPropertyValues["_tableID"]=obj.tableID
 		except NotImplementedError:
 			pass
-	newPropertyValues['current']=obj.isCurrent
 	if allowedProperties.get('placeholder', False):
 		newPropertyValues['placeholder']=obj.placeholder
 	# When speaking an object due to a focus change, the 'selected' state should not be reported if only one item is selected.
@@ -437,7 +440,8 @@ def speakObject(  # noqa: C901
 		"rowHeaderText": True,
 		"columnHeaderText": True,
 		"rowSpan": True,
-		"columnSpan": True
+		"columnSpan": True,
+		"current": True
 	}
 
 	if reason==controlTypes.REASON_FOCUSENTERED:


### PR DESCRIPTION
### Link to issue number:
Fixes #8960.

### Summary of the issue:
aria-current changes are spoken multiple times. In addition, other property changes, such as a name change, incorrectly spoke aria-current.

### Description of how this pull request fixes the issue:
1. Previously, speech.speakObjectProperties unconditionally forced reporting of aria-current, regardless of whether it was enabled in the allowedProperties argument. This meant it was reported for all property changes, including name and state changes. aria-current also wasn't checking the cache for property changes, so we couldn't determine whether it had changed or not, resulting in double reporting in some cases. This has been fixed and speakObject enables this so it's still reported on focus, query, etc.
2. Now that aria-current is no longer unconditionally reported, the call from event_IA2AttributeChange to event_stateChange no longer reports aria-current. This wasn't appropriate anyway. Now, Ia2Web.event_IA2AttributeChange explicitly requests that aria-current changes be spoken.

### Testing performed:
Test case:
`data:text/html,<button onclick="this.setAttribute('aria-current', 'page');">Make current</button><hr><button aria-current="page" onClick="this.setAttribute('aria-label', 'New label');">Change label</button>`
Tests performed in Firefox (other browsers don't report aria-current changes).

1. Press the Make current button.
    - Before patch: "current page" is spoken twice.
    - After patch: "current page" is spoken only once.
    - Both: Braille is updated correctly.
2. press the "Change label" button.
    - Before patch: NVDA says "New label  current page"
    - After patch: NVDA says just "current page"
    - Both: Braille is updated correctly.

### Known issues with pull request:
None.

### Change log entry:

Bug fixes:
`- In Mozilla Firefox, when the focused element becomes marked as current (aria-current), this change is no longer spoken multiple times. (#8960)`