### PR TITLE
winConsole with UIA: ensure correct product name and version in appModule

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1410,6 +1410,15 @@ class UIA(Window):
 		raise NotImplementedError
 
 	def _get_processID(self):
+		if self.windowClassName == 'ConsoleWindowClass':
+			# #10115: The UIA implementation for Windows console windows exposes the process ID of conhost,
+			# not the actual app it is hosting.
+			# Therefore, to work around this, for console windows, we fallback to getting processID from the window
+			# rather than from UIA.
+			# Note that we can't do this hack in the WinConsoleUIA NVDAObject
+			# Because the appModule is already created and cached
+			# before the UIA NVDAObject is morphed into the specific WinConsoleUIA class.
+			return super().processID
 		return self.UIAElement.cachedProcessId
 
 	def _get_location(self):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10115 

### Summary of the issue:
When using Windows consoles with UIA, the app name, product name and version are either incorrect or missing in the created appModule.
This is because the UIA implementation provided by Windows consoles exposes a processID  for conhost, rather than the processID of the process currently taking input inside the console.
For example, developer info in the log, shows the following for a Windows console when UIA is enabled:
```
appModule: <'appModuleHandler' (appName 'conhost', process ID 10464) at address 5d792f0>
appModule.productName: exception: The file C:\Windows\System32\conhost.exe does not exist
appModule.productVersion: exception: The file C:\Windows\System32\conhost.exe does not exist
```
Where as it should be something like the following (when running Ubuntu Bash for example):
```
appModule: <'appModuleHandler' (appName 'ubuntu', process ID 13188) at address 93bb710>
appModule.productName: 'CanonicalGroupLimited.UbuntuonWindows'
appModule.productVersion: '1804.2019.521.0'
```


### Description of how this pull request fixes the issue:
in UIA NVDAObject's processID property: fallback to super if the window class is 'ConsoleWindowClass'.
Note that this can't be done in the WinconsoleUIA NVDAObject as it is an overlay class which is inserted after the appModule is already created using the processID property.

### Testing performed:
With UIA enabled for Windows Consoles in NVDA, and focused in a WSL bash prompt, checked the developer info in the NVDA log to ensure that the appModule product name and version mentioned Ubuntu, not connhost.

### Known issues with pull request:
None.

### Change log entry:
None.