### PR TITLE
Allow JAB messages through the Windows message filter before initialising JAB.

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -746,13 +746,13 @@ def initialize():
 	except WindowsError:
 		raise NotImplementedError("dll not available")
 	_fixBridgeFuncs()
-	bridgeDll.Windows_run()
 	# Accept wm_copydata and any wm_user messages from other processes even if running with higher privileges
 	if not windll.user32.ChangeWindowMessageFilter(winUser.WM_COPYDATA, 1):
 		raise WinError()
 	for msg in range(winUser.WM_USER + 1, 0xffff):
 		if not windll.user32.ChangeWindowMessageFilter(msg, 1):
 			raise WinError()
+	bridgeDll.Windows_run()
 	# Register java events
 	bridgeDll.setFocusGainedFP(internal_event_focusGained)
 	bridgeDll.setPropertyActiveDescendentChangeFP(internal_event_activeDescendantChange)


### PR DESCRIPTION
### Link to issue number:
Fixes #10296.

### Summary of the issue:
If you start NVDA after a Java app has already started, the Java app is inaccessible to NVDA.

### Description of how this pull request fixes the issue:
Internally, the JAB client dll keeps track of Java VMs. This is done via window messages. If a JAB client dll is initialised after a VM, it needs to learn about existing VMs. It does this by broadcasting a message, which is picked up by Java VMs. VMs in turn send a message back to the client DLL. Previously, we allowed messages through the message filter *after* initialising the JAB. That meant that messages from existing Java VMs might be rejected if they were received before the function returned. To fix this, we allow messages through the filter before initialising the JAB.

### Testing performed:
Started Android Studio.
Without the patch, started a source copy of NVDA as admin and confirmed that Android Studio was inaccessible.
With the patch, ran a source copy of NVDA as admin and confirmed that Android Studio was accessible.

### Known issues with pull request:
None known. However, it does surprise me that setting up the filter immediately after initialising was breaking things. I would have thought that we'd need a message pump before messages were blocked, and JAB Windows_run doesn't pump as far as I know. Perhaps the filtering actually happens when the message is queued by the VM and that happens before Windows_run returns.

### Change log entry:

Bug fixes:
`- Java applications started before NVDA are now accessible without the need to restart the Java app. (#10296)`