### PR TITLE
Fix major bug in Hims display driver

### DIFF
--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -398,7 +398,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			# Data block 1 start
 			b"\xf0",
 			# Data block 1 length
-			d1Len.to_bytes(2, "little", signed=False),
+			d1Len.to_bytes(length=2, byteorder="little", signed=False),
 			# Data block 1
 			data1,
 			# Data block 1 end
@@ -407,21 +407,24 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			# Data block 2 start
 			b"\xf2",
 			# Data block 1 length
-			d2Len.to_bytes(2, "little", signed=False),
+			d2Len.to_bytes(length=2, byteorder="little", signed=False),
 			# Data block 2
 			data2,
 			# Data block 2 end
 			b"\xf3",
 			# Reserved bytes
-			b"\x00"*4,
+			b"\x00" * 4,
 			# Reserved space for checksum
+			# Note that the checksum has the -3rd position in the final packet bytearray,
+			# whereas it has the -2nd position in the packet list
 			b"\x00",
 			# Packet end
 			b"\xfd"*2,
 		]
 		packetB = bytearray(b"".join(packet))
+		checksumIndexInPacketB: int = -3
 		checksum: int = 0xff & sum(packetB)
-		packetB[-3] = checksum
+		packetB[checksumIndexInPacketB] = checksum
 
 		# check that the packet is the size we expect:
 		ptLen = len(packetType)

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -419,7 +419,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			# whereas it has the -2nd position in the packet list
 			b"\x00",
 			# Packet end
-			b"\xfd"*2,
+			b"\xfd" * 2,
 		]
 		packetB = bytearray(b"".join(packet))
 		checksumIndexInPacketB: int = -3

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -422,6 +422,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			b"\xfd" * 2,
 		]
 		packetB = bytearray(b"".join(packet))
+		#  checksum is the 3rd index from the end because 'packet end' takes up
+		# two bytes and 'packetB' is a bytearray
 		checksumIndexInPacketB: int = -3
 		checksum: int = 0xff & sum(packetB)
 		packetB[checksumIndexInPacketB] = checksum

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -381,8 +381,11 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			return
 
 	def _sendPacket(
-			self, packetType: bytes, mode: bytes,
-			data1: bytes, data2: bytes = b""
+			self,
+			packetType: bytes,
+			mode: bytes,
+			data1: bytes,
+			data2: bytes = b""
 	):
 		d1Len = len(data1)
 		d2Len = len(data2)
@@ -418,7 +421,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		]
 		packetB = bytearray(b"".join(packet))
 		checksum: int = 0xff & sum(packetB)
-		packetB[-2] = checksum
+		packetB[-3] = checksum
 
 		# check that the packet is the size we expect:
 		ptLen = len(packetType)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Hims driver didn't work for the Hims QBraille. When converting this driver to Python 3, a mistake was made in the _sendPacket method.

### Description of how this pull request fixes the issue:
Fixed the mistake. In the Python 2 version of the driver, we made a list of bytes objects, calculated a checksum and then inserted the checksum in the list before constructing a packet from the list. However, in the Python 3 version, we converted the packet to a bytearray, then calculated the checksum and changed the checksum in the bytearray. However, the position of the checksum in the bytearray is -3, whereas in the list, it was -2.

### Testing performed:
Tested with the QBraille, packet was no longer malformed and display worked correctly.

### Known issues with pull request:
None

### Change log entry:
None
