### PR TITLE
No longer repeat focusing UIA consoles

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -250,17 +250,8 @@ class consoleUIATextInfo(UIATextInfo):
 
 
 class consoleUIAWindow(Window):
-	def _get_focusRedirect(self):
-		"""
-		Sometimes, attempting to interact with the console too quickly after
-		focusing the window can make NVDA unable to get any caret or review
-		information or receive new text events.
-		To work around this, we must redirect focus to the console text area.
-		"""
-		for child in self.children:
-			if isinstance(child, WinConsoleUIA):
-				return child
-		return None
+	# This is the parent of the console text area, which sometimes gets focus after the text area.
+	shouldAllowUIAFocusEvent = False
 
 
 class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):


### PR DESCRIPTION
### Link to issue number:
Fixes #10030
Another attempt that replaces #10180 

### Summary of the issue:
When focusing UIA consoles, the focus object is sometimes repeated.

### Description of how this pull request fixes the issue:
The parent window of the terminal text area sometimes steals the focus. This was fixed by adding a focusRedirect to that window, but it look like that was actually the cause of repeating the focus. Therefore, I removed the focus redirect and used shouldAllowUIAFocusEvent instead to avoid this window stealing the focus.

### Testing performed:
Started the UIA console several times, no focus repeating occurred.
I would like @codeofdusk to share his ideas about this pr, because it removes an assumption made by him.

### Known issues with pull request:
None

### Change log entry:
* Bug fixes
    + When focusing a Windows command console with UIA enabled, the terminal is no longer announced multiple times. (#10030)