### PR TITLE
Fix translatable strings using f strings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2887,7 +2887,7 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			gui.messageBox(
 				# Translators: The message in a dialog presented when NVDA is unable to load the selected
 				# braille display.
-				message=_(f"Could not load the {display} display."),
+				message=_("Could not load the {display} display.").format(display=display),
 				# Translators: The title in a dialog presented when NVDA is unable to load the selected
 				# braille display.
 				caption=_("Braille Display Error"),
@@ -3131,12 +3131,16 @@ def showStartErrorForProviders(
 		providerName = providers[0].displayName
 		# Translators: This message is presented when
 		# NVDA is unable to load a single vision enhancement provider.
-		message = _(f"Could not load the {providerName} vision enhancement provider")
+		message = _("Could not load the {providerName} vision enhancement provider").format(
+			providerName=providerName
+		)
 	else:
 		providerNames = ", ".join(provider.displayName for provider in providers)
 		# Translators: This message is presented when NVDA is unable to
 		# load multiple vision enhancement providers.
-		message = _(f"Could not load the following vision enhancement providers:\n{providerNames}")
+		message = _("Could not load the following vision enhancement providers:\n{providerNames}").format(
+			providerNames=providerNames
+		)
 	gui.messageBox(
 		message,
 		# Translators: The title of the vision enhancement provider error message box.
@@ -3157,15 +3161,17 @@ def showTerminationErrorForProviders(
 		providerName = providers[0].displayName
 		# Translators: This message is presented when
 		# NVDA is unable to gracefully terminate a single vision enhancement provider.
-		message = _(f"Could not gracefully terminate the {providerName} vision enhancement provider")
+		message = _("Could not gracefully terminate the {providerName} vision enhancement provider").format(
+			providerName=providerName
+		)
 	else:
 		providerNames = ", ".join(provider.displayName for provider in providers)
 		# Translators: This message is presented when
 		# NVDA is unable to terminate multiple vision enhancement providers.
 		message = _(
 			"Could not gracefully terminate the following vision enhancement providers:\n"
-			f"{providerNames }"
-		)
+			"{providerNames}"
+		).format(providerNames=providerNames)
 	gui.messageBox(
 		message,
 		# Translators: The title of the vision enhancement provider error message box.

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -94,7 +94,9 @@ screenCurtainTranslatedName = _("Screen Curtain")
 warnOnLoadCheckBoxText = (
 	# Translators: Description for a screen curtain setting that shows a warning when loading
 	# the screen curtain.
-	_(f"Always &show a warning when loading {screenCurtainTranslatedName}")
+	_("Always &show a warning when loading {screenCurtainTranslatedName}").format(
+		screenCurtainTranslatedName=screenCurtainTranslatedName
+	)
 )
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #10532 

### Summary of the issue:
Translatable strings using the f literal are not supported, yet we use them in the vision framework.

### Description of how this pull request fixes the issue:
Use the format function on these strings instead.

### Testing performed:
T.b.d.

### Known issues with pull request:
None known

### Change log entry:
None