### PR TITLE
Fix up of #10463

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -169,6 +169,11 @@ class EditableText(editableText.EditableText, NVDAObject):
 			self.bindGesture("kb:enter","caret_newLine")
 			self.bindGesture("kb:numpadEnter","caret_newLine")
 
+	def _caretScriptPostMovedHelper(self, speakUnit, gesture, info=None):
+		if eventHandler.isPendingEvents("gainFocus"):
+			return
+		super()._caretScriptPostMovedHelper(speakUnit, gesture, info)
+
 class EditableTextWithAutoSelectDetection(EditableText):
 	"""In addition to L{EditableText}, handles reporting of selection changes for objects which notify of them.
 	To have selection changes reported, the object must notify of selection changes via the caret event.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -137,22 +137,6 @@ class EditableText(TextContainerObject,ScriptableObject):
 	def _caretScriptPostMovedHelper(self, speakUnit, gesture, info=None):
 		if isScriptWaiting():
 			return
-		if eventHandler.isPendingEvents("gainFocus"):
-			# #10536: Normally we would just return here to avoid reading content of the edit field,
-			# as it is going to lose focus.
-			# However in Libre Office each paragraph of the text is included in a separate contro,
-			# which gains focus when moving with arrow keys.
-			# Therefore we have to be sure  that focus is moved to a different control.
-			if hasattr(self, 'caretObject'):
-				prevFocusClass = eventHandler.lastQueuedFocusObject.windowClassName
-				prevFocusRole = eventHandler.lastQueuedFocusObject.role
-			else:
-				prevFocusClass = self.windowClassName
-				prevFocusRole = self.role
-			api.processPendingEvents()
-			currFocusedObj = api.getFocusObject()
-			if prevFocusClass != currFocusedObj.windowClassName or prevFocusRole != currFocusedObj.role:
-				return
 		if not info:
 			try:
 				info = self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -135,8 +135,22 @@ class EditableText(TextContainerObject,ScriptableObject):
 		return (False,newInfo)
 
 	def _caretScriptPostMovedHelper(self, speakUnit, gesture, info=None):
-		if isScriptWaiting() or eventHandler.isPendingEvents("gainFocus"):
+		if isScriptWaiting():
 			return
+		if eventHandler.isPendingEvents("gainFocus"):
+			# #10536: Normally we would just return here to avoid reading content of the edit field as it is going to lose focus.
+			# However in Libre Office each paragraph of the text is included in a separate control which gains focus when moving with arrow keys.
+			# Therefore we have to be sure  that focus is moved to a different control.
+			if hasattr(self, 'caretObject'):
+				prevFocusClass = eventHandler.lastQueuedFocusObject.windowClassName
+				prevFocusRole = eventHandler.lastQueuedFocusObject.role
+			else:
+				prevFocusClass = self.windowClassName
+				prevFocusRole = self.role
+			api.processPendingEvents()
+			currFocusedObj = api.getFocusObject()
+			if prevFocusClass != currFocusedObj.windowClassName or prevFocusRole != currFocusedObj.role:
+				return
 		if not info:
 			try:
 				info = self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -138,8 +138,10 @@ class EditableText(TextContainerObject,ScriptableObject):
 		if isScriptWaiting():
 			return
 		if eventHandler.isPendingEvents("gainFocus"):
-			# #10536: Normally we would just return here to avoid reading content of the edit field as it is going to lose focus.
-			# However in Libre Office each paragraph of the text is included in a separate control which gains focus when moving with arrow keys.
+			# #10536: Normally we would just return here to avoid reading content of the edit field,
+			# as it is going to lose focus.
+			# However in Libre Office each paragraph of the text is included in a separate contro,
+			# which gains focus when moving with arrow keys.
 			# Therefore we have to be sure  that focus is moved to a different control.
 			if hasattr(self, 'caretObject'):
 				prevFocusClass = eventHandler.lastQueuedFocusObject.windowClassName


### PR DESCRIPTION
### Link to issue number:
Fixes #10536
### Summary of the issue:
In #10463 we stopped announcing content of edit fields if they are going to lose focus. Unfortunately it broke reading documents in LibreOffice Writer. It turns out that in LibreOffice Writer each paragraph is included in a separate control which gains focus when caret is moved to it. 
### Description of how this pull request fixes the issue:
The check for pending events has been moved to NVDAObjects.behaviors.EditableText which is not used by LibreOffice text info.
### Testing performed:
1. Ensured that sample document can again be read in Libre Office Writer 6.3.3 X64
2. Ensured that #4317 remains fixed.
### Known issues with pull request:
None known
### Change log entry:
None needed. This is not in a release yet.