### PR TITLE
Fix typo in UIABrowseMode causing landmark quicknav to fail

### DIFF
--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -422,7 +422,7 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 		elif nodeType == "landmark":
 			condition = UIAHandler.handler.clientObject.createNotCondition(
 				UIAHandler.handler.clientObject.createPropertyCondition(
-					UIAHandler.uia.UIA_LandmarkTypePropertyId,
+					UIAHandler.UIA.UIA_LandmarkTypePropertyId,
 					0
 				)
 			)


### PR DESCRIPTION
### Link to issue number:
fixes #10543 

### Summary of the issue:
Quicknav to landmark failed in edge.

### Description of how this pull request fixes the issue:
Fixed a typo, uia had to be UIA.

### Testing performed:
Tested with Edge that landmark nav works again.

### Known issues with pull request:
Landmark quicknav in Edge is still pretty broken, but I compared behavior at babbage.com and nvaccess.org with the behavior of NVDA 2019.2.1 and couldn't spot any difference.

### Change log entry:
None
