### PR TITLE
Ensure that UIA focus event handler doesn't fail if comparison with current focus object fails

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -368,10 +368,14 @@ class UIAHandler(COMObject):
 			# Ignore duplicate focus events.
 			# It seems that it is possible for compareElements to return True, even though the objects are different.
 			# Therefore, don't ignore the event if the last focus object has lost its hasKeyboardFocus state.
-			if self.clientObject.compareElements(sender,lastFocus) and lastFocus.currentHasKeyboardFocus:
+			try:
+				if self.clientObject.compareElements(sender,lastFocus) and lastFocus.currentHasKeyboardFocus:
+					if _isDebug():
+						log.debugWarning("HandleFocusChangedEvent: Ignoring duplicate focus event")
+					return
+			except COMError:
 				if _isDebug():
-					log.debugWarning("HandleFocusChangedEvent: Ignoring duplicate focus event")
-				return
+					log.debugWarning("HandleFocusChangedEvent: Couldn't check for duplicate focus event", exc_info=True)
 		window = self.getNearestWindowHandle(sender)
 		if window and not eventHandler.shouldAcceptEvent("gainFocus", windowHandle=window):
 			if _isDebug():

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -8,6 +8,7 @@ from ctypes import *
 from ctypes.wintypes import *
 import comtypes.client
 from comtypes.automation import VT_EMPTY
+from comtypes import COMError
 from comtypes import *
 import weakref
 import threading
@@ -369,13 +370,19 @@ class UIAHandler(COMObject):
 			# It seems that it is possible for compareElements to return True, even though the objects are different.
 			# Therefore, don't ignore the event if the last focus object has lost its hasKeyboardFocus state.
 			try:
-				if self.clientObject.compareElements(sender,lastFocus) and lastFocus.currentHasKeyboardFocus:
+				if (
+					self.clientObject.compareElements(sender, lastFocus)
+					and lastFocus.currentHasKeyboardFocus
+				):
 					if _isDebug():
 						log.debugWarning("HandleFocusChangedEvent: Ignoring duplicate focus event")
 					return
 			except COMError:
 				if _isDebug():
-					log.debugWarning("HandleFocusChangedEvent: Couldn't check for duplicate focus event", exc_info=True)
+					log.debugWarning(
+						"HandleFocusChangedEvent: Couldn't check for duplicate focus event",
+						exc_info=True
+					)
 		window = self.getNearestWindowHandle(sender)
 		if window and not eventHandler.shouldAcceptEvent("gainFocus", windowHandle=window):
 			if _isDebug():


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The following error is written to the log:

```
ERROR - comtypes._comobject.call_without_this (16:10:46.788) - Dummy-3 (14420):
Exception in IUIAutomationFocusChangedEventHandler.HandleFocusChangedEvent implementation:
Traceback (most recent call last):
  File "comtypes\_comobject.pyc", line 147, in call_without_this
  File "_UIAHandler.pyc", line 371, in IUIAutomationFocusChangedEventHandler_HandleFocusChangedEvent
  File "comtypes\__init__.pyc", line 279, in __getattr__
  File "comtypesMonkeyPatches.pyc", line 26, in __call__
_ctypes.COMError: (-2147220991, 'Een gebeurtenis kan geen van de abonnees aanroepen', (None, None, None, 0, None))
```

### Description of how this pull request fixes the issue:
Catch this error and let the focus handler continue as weren't this a duplicate focus event.

### Testing performed:
This is hard to reproduce and therefore not very trivial to test. I suggest merging this approach and look at what it does, but I think it is more likely to fix things than to break them.

### Known issues with pull request:
None

### Change log entry:
None
