### PR TITLE
Use uniscribe to calculate character offsets where allowed

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -51,6 +51,7 @@ EXPORTS
 	displayModel_getCaretRect
 	displayModel_requestTextChangeNotificationsForWindow
 	calculateWordOffsets
+	calculateCharacterOffsets
 	findWindowWithClassInThread
 	registerUIAProperty
 	dllImportTableHooks_hookSingle

--- a/nvdaHelper/local/textUtils.cpp
+++ b/nvdaHelper/local/textUtils.cpp
@@ -1,3 +1,17 @@
+/*
+This file is a part of the NVDA project.
+URL: http://www.nvda-project.org/
+Copyright 2008-2019 NV Access Limited.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2.0, as published by
+    the Free Software Foundation.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+This license can be found at:
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
 #include <windows.h>
 #include <usp10.h>
 

--- a/nvdaHelper/local/textUtils.cpp
+++ b/nvdaHelper/local/textUtils.cpp
@@ -75,3 +75,45 @@ bool calculateWordOffsets(wchar_t* text, int textLength, int offset, int* startO
 	return true;
 }
 
+bool calculateCharacterOffsets(wchar_t* text, int textLength, int offset, int* startOffset, int* endOffset) {
+	if(textLength<=0) return false;
+	if(offset<0) return false;
+	if(offset>=textLength) {
+		*startOffset=offset;
+		*endOffset=offset+1;
+		return true;
+	}
+	SCRIPT_ITEM* pItems=new SCRIPT_ITEM[textLength+1];
+	int numItems=0;
+	if(ScriptItemize(text,textLength,textLength,NULL,NULL,pItems,&numItems)!=S_OK||numItems==0) {
+		delete[] pItems;
+		return false;
+	}
+	SCRIPT_LOGATTR* logAttrArray=new SCRIPT_LOGATTR[textLength];
+	int nextICharPos=textLength;
+	for(int itemIndex=numItems-1;itemIndex>=0;--itemIndex) {
+		int iCharPos=pItems[itemIndex].iCharPos;
+		int iCharLength=nextICharPos-iCharPos;
+		if(ScriptBreak(text+iCharPos,iCharLength,&(pItems[itemIndex].a),logAttrArray+iCharPos)!=S_OK) {
+			delete[] pItems;
+			delete[] logAttrArray;
+			return false;
+		}
+	}
+	delete[] pItems;
+	for(int i=offset;i>=0;--i) {
+		if(logAttrArray[i].fCharStop) {
+			*startOffset=i;
+			break;
+		}
+	}
+	*endOffset=textLength;
+	for(int i=offset+1;i<textLength;++i) {
+		if(logAttrArray[i].fCharStop) {
+			*endOffset=i;
+			break;
+		}
+	}
+	delete[] logAttrArray;
+	return true;
+}

--- a/nvdaHelper/local/textUtils.cpp
+++ b/nvdaHelper/local/textUtils.cpp
@@ -14,8 +14,18 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 #include <windows.h>
 #include <usp10.h>
+#include <common/log.h>
 
-bool calculateWordOffsets(wchar_t* text, int textLength, int offset, int* startOffset, int* endOffset) {
+enum UNIT {
+	UNIT_CHARACTER,
+	UNIT_WORD
+};
+
+bool _calculateUniscribeOffsets(enum UNIT unit, wchar_t* text, int textLength, int offset, int* startOffset, int* endOffset) {
+	if(unit!=UNIT_CHARACTER&&unit!=UNIT_WORD) {
+		LOG_ERROR(L"Unsupported unit");
+		return false;
+	}
 	if(textLength<=0) return false;
 	if(offset<0) return false;
 	if(offset>=textLength) {
@@ -41,93 +51,73 @@ bool calculateWordOffsets(wchar_t* text, int textLength, int offset, int* startO
 		}
 	}
 	delete[] pItems;
-	for(int i=offset;i>=0;--i) {
-		if(logAttrArray[i].fWordStop) {
-			*startOffset=i;
-			break;
-		}
-	}
-	// #1656: fWordStop doesn't seem to stop on whitespace where punctuation follows the whitespace.
-	bool skipWhitespace=true;
-	for(int i=offset;i>=*startOffset;--i) {
-		if(iswspace(text[i])) {
-			if(skipWhitespace) {
-				// If we start in a block of whitespace, the word must start before this,
-				// as whitespace is included at the end of a word.
-				// Therefore, skip the whitespace and keep searching.
-				continue;
+	if(unit==UNIT_CHARACTER) {
+		for(int i=offset;i>=0;--i) {
+			if(logAttrArray[i].fCharStop) {
+				*startOffset=i;
+				break;
 			}
-			// This is whitespace. The word starts after it.
-			*startOffset=i+1;
-			break;
-		} else
-			skipWhitespace=false;
-	}
-	*endOffset=textLength;
-	for(int i=offset+1;i<textLength;++i) {
-		if(logAttrArray[i].fWordStop) {
-			*endOffset=i;
-			break;
 		}
-	}
-	// #1656: fWordStop doesn't seem to stop on whitespace where punctuation follows the whitespace.
-	for(int i=offset;i<*endOffset;++i) {
-		if(iswspace(text[i])) {
-			// This begins a block of whitespace. The word ends after it.
-			// Find the end of the whitespace.
-			for(;i<*endOffset;++i) {
-				if(!iswspace(text[i]))
-					break;
+		for(int i=offset+1;i<textLength;++i) {
+			if(logAttrArray[i].fCharStop) {
+				*endOffset=i;
+				break;
 			}
-			// We're now positioned on the first non-whitespace character,
-			// so the word ends here.
-			*endOffset=i;
-			break;
+		}
+	} else if(unit==UNIT_WORD) {
+		for(int i=offset;i>=0;--i) {
+			if(logAttrArray[i].fWordStop) {
+				*startOffset=i;
+				break;
+			}
+		}
+		// #1656: fWordStop doesn't seem to stop on whitespace where punctuation follows the whitespace.
+		bool skipWhitespace=true;
+		for(int i=offset;i>=*startOffset;--i) {
+			if(iswspace(text[i])) {
+				if(skipWhitespace) {
+					// If we start in a block of whitespace, the word must start before this,
+					// as whitespace is included at the end of a word.
+					// Therefore, skip the whitespace and keep searching.
+					continue;
+				}
+				// This is whitespace. The word starts after it.
+				*startOffset=i+1;
+				break;
+			} else
+				skipWhitespace=false;
+		}
+		*endOffset=textLength;
+		for(int i=offset+1;i<textLength;++i) {
+			if(logAttrArray[i].fWordStop) {
+				*endOffset=i;
+				break;
+			}
+		}
+		// #1656: fWordStop doesn't seem to stop on whitespace where punctuation follows the whitespace.
+		for(int i=offset;i<*endOffset;++i) {
+			if(iswspace(text[i])) {
+				// This begins a block of whitespace. The word ends after it.
+				// Find the end of the whitespace.
+				for(;i<*endOffset;++i) {
+					if(!iswspace(text[i]))
+						break;
+				}
+				// We're now positioned on the first non-whitespace character,
+				// so the word ends here.
+				*endOffset=i;
+				break;
+			}
 		}
 	}
 	delete[] logAttrArray;
 	return true;
 }
 
+bool calculateWordOffsets(wchar_t* text, int textLength, int offset, int* startOffset, int* endOffset) {
+	return _calculateUniscribeOffsets(UNIT_WORD, text, textLength, offset, startOffset, endOffset);
+}
+
 bool calculateCharacterOffsets(wchar_t* text, int textLength, int offset, int* startOffset, int* endOffset) {
-	if(textLength<=0) return false;
-	if(offset<0) return false;
-	if(offset>=textLength) {
-		*startOffset=offset;
-		*endOffset=offset+1;
-		return true;
-	}
-	SCRIPT_ITEM* pItems=new SCRIPT_ITEM[textLength+1];
-	int numItems=0;
-	if(ScriptItemize(text,textLength,textLength,NULL,NULL,pItems,&numItems)!=S_OK||numItems==0) {
-		delete[] pItems;
-		return false;
-	}
-	SCRIPT_LOGATTR* logAttrArray=new SCRIPT_LOGATTR[textLength];
-	int nextICharPos=textLength;
-	for(int itemIndex=numItems-1;itemIndex>=0;--itemIndex) {
-		int iCharPos=pItems[itemIndex].iCharPos;
-		int iCharLength=nextICharPos-iCharPos;
-		if(ScriptBreak(text+iCharPos,iCharLength,&(pItems[itemIndex].a),logAttrArray+iCharPos)!=S_OK) {
-			delete[] pItems;
-			delete[] logAttrArray;
-			return false;
-		}
-	}
-	delete[] pItems;
-	for(int i=offset;i>=0;--i) {
-		if(logAttrArray[i].fCharStop) {
-			*startOffset=i;
-			break;
-		}
-	}
-	*endOffset=textLength;
-	for(int i=offset+1;i<textLength;++i) {
-		if(logAttrArray[i].fCharStop) {
-			*endOffset=i;
-			break;
-		}
-	}
-	delete[] logAttrArray;
-	return true;
+	return _calculateUniscribeOffsets(UNIT_CHARACTER, text, textLength, offset, startOffset, endOffset);
 }

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -301,18 +301,51 @@ class OffsetsTextInfo(textInfos.TextInfo):
 				formatField["line-number"]=lineNum+1
 		return formatField,(startOffset,endOffset)
 
+	def _calculateUniscribeOffsets(self,lineText, unit, relOffset):
+		relStart=ctypes.c_int()
+		relEnd=ctypes.c_int()
+		# uniscribe does some strange things when you give it a string  with not more than two alphanumeric chars in a row.
+		# Inject two alphanumeric characters at the end to fix this 
+		uniscribeLineText = lineText + "xx"
+		# We can't rely on len(lineText) to calculate the length of the line.
+		offsetConverter = textUtils.WideStringOffsetConverter(lineText)
+		lineLength = offsetConverter.wideStringLength
+		if self.encoding != textUtils.WCHAR_ENCODING:
+			# We need to convert the str based line offsets to wide string offsets.
+			relOffset = offsetConverter.strToWideOffsets(relOffset, relOffset)[0]
+		uniscribeLineLength = lineLength + 2
+		if unit is textInfos.UNIT_WORD:
+			helperFunc = NVDAHelper.localLib.calculateWordOffsets
+		elif unit is textInfos.UNIT_CHARACTER:
+			helperFunc = NVDAHelper.localLib.calculateCharacterOffsets
+		else:
+			raise NotImplementedError(f"Unit: {unit}")
+		if helperFunc(
+			uniscribeLineText,
+			uniscribeLineLength,
+			relOffset,
+			ctypes.byref(relStart),
+			ctypes.byref(relEnd)
+		):
+			relStart = relStart.value
+			relEnd = min(lineLength, relEnd.value)
+			if self.encoding != textUtils.WCHAR_ENCODING:
+				# We need to convert the uniscribe based offsets to str offsets.
+				relStart, relEnd = offsetConverter.wideToStrOffsets(relStart, relEnd)
+			return (relStart, relEnd)
+		log.debugWarning(f"Uniscribe failed to calculate {unit} offsets for text {lineText!r}")
+
 	def _getCharacterOffsets(self,offset):
-		if self.encoding == textUtils.WCHAR_ENCODING:
-			lineStart,lineEnd=self._getLineOffsets(offset)
-			lineText=self._getTextRange(lineStart,lineEnd)
-			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
-			relOffset = offset - lineStart
-			relStrStart, relStrEnd = offsetConverter.wideToStrOffsets(relOffset, relOffset + 1)
-			relWideStringStart, relWideStringEnd = offsetConverter.strToWideOffsets(relStrStart, relStrEnd)
-			return (relWideStringStart + lineStart, relWideStringEnd + lineStart)
-		elif self.encoding not in (None, "utf_32_le", locale.getlocale()[1]):
+		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
 			raise NotImplementedError
-		return offset, offset + 1
+		lineStart, lineEnd = self._getLineOffsets(offset)
+		lineText = self._getTextRange(lineStart,lineEnd)
+		relOffset = offset - lineStart
+		if self.useUniscribe:
+			offsets = self._calculateUniscribeOffsets(lineText, textInfos.UNIT_CHARACTER, relOffset)
+			if offsets is not None:
+				return (offsets[0] + lineStart, offsets[1] + lineStart)
+		return (offset, offset+1)
 
 	def _getWordOffsets(self,offset):
 		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
@@ -323,33 +356,9 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		lineText = lineText.translate({0:u' ',0xa0:u' '})
 		relOffset = offset - lineStart
 		if self.useUniscribe:
-			relStart=ctypes.c_int()
-			relEnd=ctypes.c_int()
-			# uniscribe does some strange things when you give it a string  with not more than two alphanumeric chars in a row.
-			# Inject two alphanumeric characters at the end to fix this 
-			uniscribeLineText = lineText + "xx"
-			# We can't rely on len(lineText) to calculate the length of the line.
-			if self.encoding != textUtils.WCHAR_ENCODING:
-				# We need to convert the str based line offsets to wide string offsets.
-				offsetConverter = textUtils.WideStringOffsetConverter(lineText)
-				lineLength = offsetConverter.wideStringLength
-				relOffset = offsetConverter.strToWideOffsets(relOffset, relOffset)[0]
-			else:
-				lineLength = (lineEnd - lineStart)
-			uniscribeLineLength = lineLength + 2
-			if NVDAHelper.localLib.calculateWordOffsets(
-				uniscribeLineText,
-				uniscribeLineLength,
-				relOffset,
-				ctypes.byref(relStart),
-				ctypes.byref(relEnd)
-			):
-				relStart = relStart.value
-				relEnd = min(lineLength, relEnd.value)
-				if self.encoding != textUtils.WCHAR_ENCODING:
-					# We need to convert the uniscribe based offsets to str offsets.
-					relStart, relEnd = offsetConverter.wideToStrOffsets(relStart, relEnd)
-				return (relStart + lineStart , relEnd + lineStart)
+			offsets = self._calculateUniscribeOffsets(lineText, textInfos.UNIT_WORD, relOffset)
+			if offsets is not None:
+				return (offsets[0] + lineStart, offsets[1] + lineStart)
 		#Fall back to the older word offsets detection that only breaks on non alphanumeric
 		if self.encoding == textUtils.WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(lineText)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -354,6 +354,11 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			offsets = self._calculateUniscribeOffsets(lineText, textInfos.UNIT_CHARACTER, relOffset)
 			if offsets is not None:
 				return (offsets[0] + lineStart, offsets[1] + lineStart)
+		if self.encoding == textUtils.WCHAR_ENCODING:
+			offsetConverter = textUtils.WideStringOffsetConverter(lineText)
+			relStrStart, relStrEnd = offsetConverter.wideToStrOffsets(relOffset, relOffset + 1)
+			relWideStringStart, relWideStringEnd = offsetConverter.strToWideOffsets(relStrStart, relStrEnd)
+			return (relWideStringStart + lineStart, relWideStringEnd + lineStart)
 		return (offset, offset + 1)
 
 	def _getWordOffsets(self,offset):


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
When moving by character in an NVDA virtualBuffer, each and every unicode code point is treated as its own character, even if is is visually combined with another code point to create one composit character. Examples are:
* é: e with an acute
* ❤️: red heart with a variation selector
* 8⃣: number 8 inside a keycap 
Similarly, when moving by character in Notepad with the arrow keys, NVDA only reads the first code point in composit characters.

### Description of how this pull request fixes the issue:
Just like how we use the Windows uniscribe library to calculate word offsets in some places, use it to also calculate character offsets.
This involved:
* Abstracted code from nvdaHelperLocal's calculateWordOffsets into _calculateUniscribeOffsets which takes a unit argument of either character or word. For word the code is as it was. For character, it widens the offsets until hitting a code point marked with fCharStop. calculateCharacterOffsets has been added which just calls _calculateUniscribeOffsets with a unit of character.
* Abstract out all the uniscribe code from OffsetsTextInfo._getWordOffsets into a new _getUniscribeOffsets method, and use this also in _getCharacterOffsets.

### Testing performed:
* Using the example characters above in a virtualBuffer, moved throw them with the arrow keys making sure that they are all treated as single composit characters.
* Using the example characters above in a notepad document, move through them with left and right arrow and make sure that NVDA announces the entire composit character.

### Known issues with pull request:
Although NVDA now matches the behaviour of notepad and other standard edit controls, which includes  treating acutes, variation selectors and some other modifiers as being a part of the previous symbol, complex tied emojies that use  multiple unicode characters connected with a tie u+200d symbol, are still not treated as one single composit character. But if we did, this would differ from Windows' own standard edit control behaviour.

 ### Change log entry:
Bug fixes:
* NVDA will now treat certain composit unicode characters such as e-acute as one single character when moving through text.