### PR TITLE
Speak typed characters in windows consoles in the correct language

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -336,6 +336,10 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 	#Simple case where there is no change
 	if languageID==lastLanguageID and layoutString==lastLayoutString:
 		return 0
+	fg = api.getForegroundObject()
+	# Cache the new keyboard layout on the foreground object,
+	# Which may be used by keyboardHandler when speaking typed characters in situations where it cannot be fetched directly from the focus.
+	fg._lastDetectedKeyboardLayoutChange = hkl
 	focus=api.getFocusObject()
 	#This callback can be called before NVDa is fully initialized
 	#So also handle focus object being None as well as checking for sleepMode

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -338,7 +338,8 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 		return 0
 	fg = api.getForegroundObject()
 	# Cache the new keyboard layout on the foreground object,
-	# Which may be used by keyboardHandler when speaking typed characters in situations where it cannot be fetched directly from the focus.
+	# Which may be used by keyboardHandler
+	# when speaking typed characters in situations where it cannot be fetched directly from the focus.
 	fg._lastDetectedKeyboardLayoutChange = hkl
 	focus=api.getFocusObject()
 	#This callback can be called before NVDa is fully initialized

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -225,12 +225,13 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 				log.debug("Failed to fetch keyboard layout from focus, trying layout from last detected change")
 				# Some threads, such as for Windows consoles
 				# Do not allow getKeyboardLayout to work.
-				# Therefore, use the cached keyboard layout from the last inputLangChange detected by NVDA on the foreground object. 
-				hkl = getattr(api.getForegroundObject(),'_lastDetectedKeyboardLayoutChange',0)
+				# Therefore, use the cached keyboard layout from the last inputLangChange detected by NVDA
+				# on the foreground object.
+				hkl = getattr(api.getForegroundObject(), '_lastDetectedKeyboardLayoutChange', 0)
 				if not hkl:
 					log.debug("No layout cached, falling back to layout of NVDA main thread")
 					# As a last resort, use the keyboard layout of NVDA's main thread.
-					hkl=ctypes.windll.user32.GetKeyboardLayout(core.mainThreadId)
+					hkl = ctypes.windll.user32.GetKeyboardLayout(core.mainThreadId)
 			# In previous Windows builds, calling ToUnicodeEx would destroy keyboard buffer state and therefore cause the app to not produce the right WM_CHAR message.
 			# However, ToUnicodeEx now can take a new flag of 0x4, which stops it from destroying keyboard state, thus allowing us to safely call it here.
 			res=ctypes.windll.user32.ToUnicodeEx(vkCode,scanCode,keyStates,charBuf,len(charBuf),0x4,hkl)

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -219,7 +219,18 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 			for k in range(256):
 				keyStates[k]=ctypes.windll.user32.GetKeyState(k)
 			charBuf=ctypes.create_unicode_buffer(5)
+			# First try getting the keyboard layout from the thread with the focus (input thread)
 			hkl=ctypes.windll.user32.GetKeyboardLayout(focus.windowThreadID)
+			if not hkl:
+				log.debug("Failed to fetch keyboard layout from focus, trying layout from last detected change")
+				# Some threads, such as for Windows consoles
+				# Do not allow getKeyboardLayout to work.
+				# Therefore, use the cached keyboard layout from the last inputLangChange detected by NVDA on the foreground object. 
+				hkl = getattr(api.getForegroundObject(),'_lastDetectedKeyboardLayoutChange',0)
+				if not hkl:
+					log.debug("No layout cached, falling back to layout of NVDA main thread")
+					# As a last resort, use the keyboard layout of NVDA's main thread.
+					hkl=ctypes.windll.user32.GetKeyboardLayout(core.mainThreadId)
 			# In previous Windows builds, calling ToUnicodeEx would destroy keyboard buffer state and therefore cause the app to not produce the right WM_CHAR message.
 			# However, ToUnicodeEx now can take a new flag of 0x4, which stops it from destroying keyboard state, thus allowing us to safely call it here.
 			res=ctypes.windll.user32.ToUnicodeEx(vkCode,scanCode,keyStates,charBuf,len(charBuf),0x4,hkl)


### PR DESCRIPTION
### Link to issue number:
Fixes #10113 

### Summary of the issue:
With the work to support Windows consoles via UIA, NVDA moved to speaking typed characters in consoles by detecting keyboard input and then using ToUnicodeEx to convert the keyboard input into a character for speaking. We had already been taking this approach for Microsoft Edge and other places in Windows 10 where we could not inject in-process.
ToUnicodeEx requires a keyboard layout to use the correct language. Therefore, we would call GetKeyboardLayout, giving it the thread ID of the focused window.
However, it seems that Windows console windows report the wrong thread ID, and therefore, GetKeyboardLayout fails, returning 0 instead of a valid keyboard layout.
Passing this 0 to ToUnicodeEx, it would generate characters in the user's system language (I think). At least, on my system it was always english US no matter what input language I was currently using.
 
### Description of how this pull request fixes the issue:
We now try multiple things to get a valid keyboard layout:
* Firstly we try getting it from the focus as usual.
* If that fails, we instead use the keyboard layout detected from the last input language change for the foreground window. This keyboard layout is now cached on the foreground object when detected by nvdaControlerInternal_inputLangChange in NVDAHelper.py.
* Finally, if there is no cached keyboard layout, we fallback to calling GetKeyboardLayout for NVDA's main thread. 

### Testing performed:
* Installed the Arabic keyboard layout.
* Opened a Windows console and ensured NVDA was using UIA.
* With speak typed characters on, first typed some characters, confirming they were being announced in english. backspacing them also confirming they were english characters written to the console.
* Switched keyboard layouts to Arabic.
* Again typed some characters, confirming that NVDA was speaking them as Arabic. Backspacing them, confirmed that actual arabic characters were written to the console.
  
### Known issues with pull request:
None.

### Change log entry:
None