### PR TITLE
Fix double speaking label in angular checkbox

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1156,18 +1156,12 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 
 	auto labelId = getLabelIDCached();
 	if (labelId) {
-		auto labelIdentifier = VBufStorage_controlFieldNodeIdentifier_t(
-			docHandle,
-			labelId.value()
-		);
-		auto childIds = buffer->getAllChildIdsOfParent(parentNode->identifier);
-		auto findItr = std::find(
-			childIds.begin(),
-			childIds.end(),
-			labelIdentifier
-		);
-		if (childIds.end() != findItr) {
-			parentNode->addAttribute(L"labelledByContent", L"true");
+		auto labelControlFieldNode = buffer->getControlFieldNodeWithIdentifier(docHandle, labelId.value());
+		if (labelControlFieldNode) {
+			bool isDecendant = buffer->isDescendantNode(parentNode, labelControlFieldNode);
+			if (isDecendant) {
+				parentNode->addAttribute(L"labelledByContent", L"true");
+			}
 		}
 	}
 

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -27,7 +27,6 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	using Id_T = int;
 	using IdList = std::vector<Id_T>; // List of IDs
-	using IdMap = std::map<Id_T, IdList>; // Map an ID, and its list of child IDs
 	using OptionalID = std::experimental::optional<Id_T>;
 
 	VBufStorage_fieldNode_t* fillVBuf(

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -16,12 +16,22 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #define VIRTUALBUFFER_BACKENDS_EXAMPLE_H
 
 #include <vbufBase/backend.h>
+#include <vector>
+#include <map>
+#include <boost/optional.hpp>
 
 class GeckoVBufBackend_t: public VBufBackend_t {
 	private:
 
-	VBufStorage_fieldNode_t* fillVBuf(IAccessible2* pacc,
+	using Id_T = int;
+	using IdList = std::vector<Id_T>; // List of IDs
+	using IdMap = std::map<Id_T, IdList>; // Map an ID, and its list of child IDs
+	using OptionalID = std::experimental::optional<Id_T>;
+
+	VBufStorage_fieldNode_t* fillVBuf(
+		IAccessible2* pacc,
 		VBufStorage_buffer_t* buffer, VBufStorage_controlFieldNode_t* parentNode, VBufStorage_fieldNode_t* previousNode,
+		IdList parentIds, IdList& out_ids,
 		IAccessibleTable* paccTable=NULL, IAccessibleTable2* paccTable2=NULL, long tableID=0, const wchar_t* parentPresentationalRowNumber=NULL,
 		bool ignoreInteractiveUnlabelledGraphics=false
 	);
@@ -34,7 +44,7 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 	bool hasEncodedAccDescription;
 	std::wstring toolkitName;
 
-	bool isLabelVisible(IAccessible2* pacc2);
+	OptionalID getIdForVisibleLabel(IAccessible2* pacc2);
 	CComPtr<IAccessible2> getLabelElement(IAccessible2_2* element);
 	CComPtr<IAccessible2> getSelectedItem(IAccessible2* container,
 		const std::map<std::wstring, std::wstring>& attribs);

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -16,8 +16,6 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #define VIRTUALBUFFER_BACKENDS_EXAMPLE_H
 
 #include <vbufBase/backend.h>
-#include <vector>
-#include <map>
 #include <boost/optional.hpp>
 
 class LabelInfo;

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -25,15 +25,14 @@ class LabelInfo;
 class GeckoVBufBackend_t: public VBufBackend_t {
 	private:
 
-	using Id_T = int;
-	using IdList = std::vector<Id_T>; // List of IDs
-	using OptionalID = std::experimental::optional<Id_T>;
-
 	VBufStorage_fieldNode_t* fillVBuf(
 		IAccessible2* pacc,
-		VBufStorage_buffer_t* buffer, VBufStorage_controlFieldNode_t* parentNode, VBufStorage_fieldNode_t* previousNode,
-		IdList parentIds, IdList& out_ids,
-		IAccessibleTable* paccTable=NULL, IAccessibleTable2* paccTable2=NULL, long tableID=0, const wchar_t* parentPresentationalRowNumber=NULL,
+		VBufStorage_buffer_t* buffer,
+		VBufStorage_controlFieldNode_t* parentNode,
+		VBufStorage_fieldNode_t* previousNode,
+		IAccessibleTable* paccTable=NULL,
+		IAccessibleTable2* paccTable2=NULL,
+		long tableID=0, const wchar_t* parentPresentationalRowNumber=NULL,
 		bool ignoreInteractiveUnlabelledGraphics=false
 	);
 

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -20,6 +20,8 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <map>
 #include <boost/optional.hpp>
 
+class LabelInfo;
+
 class GeckoVBufBackend_t: public VBufBackend_t {
 	private:
 
@@ -44,7 +46,7 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 	bool hasEncodedAccDescription;
 	std::wstring toolkitName;
 
-	OptionalID getIdForVisibleLabel(IAccessible2* pacc2);
+	std::experimental::optional< LabelInfo > getLabelInfo(IAccessible2* pacc2);
 	CComPtr<IAccessible2> getLabelElement(IAccessible2_2* element);
 	CComPtr<IAccessible2> getSelectedItem(IAccessible2* container,
 		const std::map<std::wstring, std::wstring>& attribs);

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -51,21 +51,6 @@ bool VBufStorage_controlFieldNodeIdentifier_t::operator==(const VBufStorage_cont
 	return (this->docHandle==other.docHandle)&&(this->ID==other.ID);
 }
 
-VBufStorage_controlFieldNodeIdentifier_t&
-VBufStorage_controlFieldNodeIdentifier_t::operator=(const VBufStorage_controlFieldNodeIdentifier_t & other) {
-	const_cast<int&>(this->docHandle) = other.docHandle;
-	const_cast<int&>(this->ID) = other.ID;
-	return *this;
-}
-
-VBufStorage_controlFieldNodeIdentifier_t::VBufStorage_controlFieldNodeIdentifier_t(
-	const VBufStorage_controlFieldNodeIdentifier_t & other
-)
-	: docHandle(other.docHandle)
-	, ID(other.ID)
-{
-}
-
 //field  node implementation
 
 VBufStorage_fieldNode_t* VBufStorage_fieldNode_t::nextNodeInTree(int direction, VBufStorage_fieldNode_t* limitNode, int *relativeStartOffset) {
@@ -437,28 +422,6 @@ std::wstring VBufStorage_textFieldNode_t::getDebugInfo() const {
 
 //buffer implementation
 
-using NodeID = VBufStorage_controlFieldNodeIdentifier_t;
-std::vector<NodeID> VBufStorage_buffer_t::getAllChildIdsOfParent(NodeID parentId) {
-	std::vector<NodeID> parentIds{ parentId };
-	std::vector<NodeID> childIds;
-	while (!parentIds.empty()) {
-		NodeID parent = parentIds.back();
-		parentIds.pop_back();
-		auto directChildren = m_idHierarchy[parent];
-		parentIds.insert( // Check if they have their own children
-			parentIds.end(),
-			directChildren.begin(),
-			directChildren.end()
-		);
-		childIds.insert( // Include these child ID's
-			childIds.end(),
-			directChildren.begin(),
-			directChildren.end()
-		);
-	}
-	return childIds;
-}
-
 void VBufStorage_buffer_t::forgetControlFieldNode(VBufStorage_controlFieldNode_t* node) {
 	nhAssert(node); //Node can't be NULL
 	map<VBufStorage_controlFieldNodeIdentifier_t,VBufStorage_controlFieldNode_t*>::iterator i=controlFieldNodesByIdentifier.find(node->identifier);
@@ -597,9 +560,6 @@ VBufStorage_controlFieldNode_t*  VBufStorage_buffer_t::addControlFieldNode(VBufS
 	if(!insertNode(parent, previous, controlFieldNode)) {
 		LOG_DEBUGWARNING(L"Error inserting node at "<<controlFieldNode<<L". Returning NULL");
 		return NULL;
-	}
-	if (parent) { // controlFieldNode might be the root node and therefore parent is nullptr.
-		m_idHierarchy[parent->identifier].push_back(controlFieldNode->identifier);
 	}
 	controlFieldNodesByIdentifier[controlFieldNode->identifier]=controlFieldNode;
 	// If the node's new parent requires descendants to always be rerendered, copy this etting to the node as well.

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -51,6 +51,21 @@ bool VBufStorage_controlFieldNodeIdentifier_t::operator==(const VBufStorage_cont
 	return (this->docHandle==other.docHandle)&&(this->ID==other.ID);
 }
 
+VBufStorage_controlFieldNodeIdentifier_t&
+VBufStorage_controlFieldNodeIdentifier_t::operator=(const VBufStorage_controlFieldNodeIdentifier_t & other) {
+	const_cast<int&>(this->docHandle) = other.docHandle;
+	const_cast<int&>(this->ID) = other.ID;
+	return *this;
+}
+
+VBufStorage_controlFieldNodeIdentifier_t::VBufStorage_controlFieldNodeIdentifier_t(
+	const VBufStorage_controlFieldNodeIdentifier_t & other
+)
+	: docHandle(other.docHandle)
+	, ID(other.ID)
+{
+}
+
 //field  node implementation
 
 VBufStorage_fieldNode_t* VBufStorage_fieldNode_t::nextNodeInTree(int direction, VBufStorage_fieldNode_t* limitNode, int *relativeStartOffset) {
@@ -422,6 +437,28 @@ std::wstring VBufStorage_textFieldNode_t::getDebugInfo() const {
 
 //buffer implementation
 
+using NodeID = VBufStorage_controlFieldNodeIdentifier_t;
+std::vector<NodeID> VBufStorage_buffer_t::getAllChildIdsOfParent(NodeID parentId) {
+	std::vector<NodeID> parentIds{ parentId };
+	std::vector<NodeID> childIds;
+	while (!parentIds.empty()) {
+		NodeID parent = parentIds.back();
+		parentIds.pop_back();
+		auto directChildren = m_idHierarchy[parent];
+		parentIds.insert( // Check if they have their own children
+			parentIds.end(),
+			directChildren.begin(),
+			directChildren.end()
+		);
+		childIds.insert( // Include these child ID's
+			childIds.end(),
+			directChildren.begin(),
+			directChildren.end()
+		);
+	}
+	return childIds;
+}
+
 void VBufStorage_buffer_t::forgetControlFieldNode(VBufStorage_controlFieldNode_t* node) {
 	nhAssert(node); //Node can't be NULL
 	map<VBufStorage_controlFieldNodeIdentifier_t,VBufStorage_controlFieldNode_t*>::iterator i=controlFieldNodesByIdentifier.find(node->identifier);
@@ -560,6 +597,9 @@ VBufStorage_controlFieldNode_t*  VBufStorage_buffer_t::addControlFieldNode(VBufS
 	if(!insertNode(parent, previous, controlFieldNode)) {
 		LOG_DEBUGWARNING(L"Error inserting node at "<<controlFieldNode<<L". Returning NULL");
 		return NULL;
+	}
+	if (parent) { // controlFieldNode might be the root node and therefore parent is nullptr.
+		m_idHierarchy[parent->identifier].push_back(controlFieldNode->identifier);
 	}
 	controlFieldNodesByIdentifier[controlFieldNode->identifier]=controlFieldNode;
 	// If the node's new parent requires descendants to always be rerendered, copy this etting to the node as well.

--- a/nvdaHelper/vbufBase/storage.h
+++ b/nvdaHelper/vbufBase/storage.h
@@ -80,10 +80,6 @@ class VBufStorage_controlFieldNodeIdentifier_t {
 	bool operator<(const VBufStorage_controlFieldNodeIdentifier_t&) const;
 	bool operator!=(const VBufStorage_controlFieldNodeIdentifier_t&) const;
 	bool operator==(const VBufStorage_controlFieldNodeIdentifier_t&) const;
-
-	VBufStorage_controlFieldNodeIdentifier_t& operator=(const VBufStorage_controlFieldNodeIdentifier_t& other);
-	VBufStorage_controlFieldNodeIdentifier_t(const VBufStorage_controlFieldNodeIdentifier_t& other);
-
 };
 
 /**
@@ -445,13 +441,6 @@ class VBufStorage_buffer_t {
  */
 	std::map<VBufStorage_controlFieldNodeIdentifier_t,VBufStorage_controlFieldNode_t*> controlFieldNodesByIdentifier;
 
-
-	using NodeID = VBufStorage_controlFieldNodeIdentifier_t;
-	/**
-	/ Maps each Node ID to a list of it's direct children.
-	*/
-	std::map<NodeID, std::vector<NodeID>> m_idHierarchy;
-
 /**
  * the offset at where the current selection starts.
  */ 
@@ -515,12 +504,6 @@ class VBufStorage_buffer_t {
 	VBufStorage_controlFieldNode_t* addControlFieldNode(VBufStorage_controlFieldNode_t* parent, VBufStorage_fieldNode_t* previous, int docHandle, int ID, bool isBlock);
  
 	VBufStorage_controlFieldNode_t* addControlFieldNode(VBufStorage_controlFieldNode_t* parent, VBufStorage_fieldNode_t* previous, VBufStorage_controlFieldNode_t* node); 
-
-	/**
-	* Gets all child Ids for a node. This includes the childs children etc.
-	* Depends on rendering of children having been completed.
-	*/
-	std::vector<NodeID> getAllChildIdsOfParent(NodeID parentId);
 
 /**
  * Adds a text field in to the buffer.

--- a/nvdaHelper/vbufBase/storage.h
+++ b/nvdaHelper/vbufBase/storage.h
@@ -81,6 +81,9 @@ class VBufStorage_controlFieldNodeIdentifier_t {
 	bool operator!=(const VBufStorage_controlFieldNodeIdentifier_t&) const;
 	bool operator==(const VBufStorage_controlFieldNodeIdentifier_t&) const;
 
+	VBufStorage_controlFieldNodeIdentifier_t& operator=(const VBufStorage_controlFieldNodeIdentifier_t& other);
+	VBufStorage_controlFieldNodeIdentifier_t(const VBufStorage_controlFieldNodeIdentifier_t& other);
+
 };
 
 /**
@@ -442,6 +445,13 @@ class VBufStorage_buffer_t {
  */
 	std::map<VBufStorage_controlFieldNodeIdentifier_t,VBufStorage_controlFieldNode_t*> controlFieldNodesByIdentifier;
 
+
+	using NodeID = VBufStorage_controlFieldNodeIdentifier_t;
+	/**
+	/ Maps each Node ID to a list of it's direct children.
+	*/
+	std::map<NodeID, std::vector<NodeID>> m_idHierarchy;
+
 /**
  * the offset at where the current selection starts.
  */ 
@@ -505,6 +515,12 @@ class VBufStorage_buffer_t {
 	VBufStorage_controlFieldNode_t* addControlFieldNode(VBufStorage_controlFieldNode_t* parent, VBufStorage_fieldNode_t* previous, int docHandle, int ID, bool isBlock);
  
 	VBufStorage_controlFieldNode_t* addControlFieldNode(VBufStorage_controlFieldNode_t* parent, VBufStorage_fieldNode_t* previous, VBufStorage_controlFieldNode_t* node); 
+
+	/**
+	* Gets all child Ids for a node. This includes the childs children etc.
+	* Depends on rendering of children having been completed.
+	*/
+	std::vector<NodeID> getAllChildIdsOfParent(NodeID parentId);
 
 /**
  * Adds a text field in to the buffer.

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1655,20 +1655,18 @@ def getControlFieldSpeech(  # noqa: C901
 				)
 			valueSequence = placeholderSequence
 
-		# don't (effectively) speak name twice. This may happen if a checkbox has aria-labelledby pointing to an
-		# element in its content.
-		contentMustBeSpoken = role in [
-			controlTypes.ROLE_EDITABLETEXT,
-			controlTypes.ROLE_EDITBAR,
-		]
-		if contentMustBeSpoken or not (
-			# dont speak name when labelledByContent
+		# Avoid speaking name twice. Which may happen if this controlfield is labelled by
+		# one of it's internal fields. We determine this by checking for 'labelledByContent'.
+		# An example of this situation is a checkbox element that has aria-labelledby pointing to a child
+		# element.
+		if (
+			# Don't speak name when labelledByContent. It will be spoken by the subsequent controlFields instead.
 			attrs.get("IAccessible2::attribute_explicit-name", False)
 			and attrs.get("labelledByContent", False)
 		):
-			out.extend(nameSequence)
+			log.debug("Skipping name sequence: control field is labelled by content")
 		else:
-			log.debug("skipping name sequence, control field is labelled by content")
+			out.extend(nameSequence)
 
 		out.extend(stateTextSequence if speakStatesFirst else roleTextSequence)
 		out.extend(roleTextSequence if speakStatesFirst else stateTextSequence)

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1654,7 +1654,22 @@ def getControlFieldSpeech(  # noqa: C901
 					f"valueSequence: {valueSequence!r} placeholderSequence: {placeholderSequence!r}"
 				)
 			valueSequence = placeholderSequence
-		out.extend(nameSequence)
+
+		# don't (effectively) speak name twice. This may happen if a checkbox has aria-labelledby pointing to an
+		# element in its content.
+		contentMustBeSpoken = role in [
+			controlTypes.ROLE_EDITABLETEXT,
+			controlTypes.ROLE_EDITBAR,
+		]
+		if contentMustBeSpoken or not (
+			# dont speak name when labelledByContent
+			attrs.get("IAccessible2::attribute_explicit-name", False)
+			and attrs.get("labelledByContent", False)
+		):
+			out.extend(nameSequence)
+		else:
+			log.debug("skipping name sequence, control field is labelled by content")
+
 		out.extend(stateTextSequence if speakStatesFirst else roleTextSequence)
 		out.extend(roleTextSequence if speakStatesFirst else stateTextSequence)
 		out.append(containerContainsText)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
https://bugs.chromium.org/p/chromium/issues/detail?id=995603

### Summary of the issue:
The HTML for checkboxes on https://dart-lang.github.io/angular_components/#/material_checkbox have `aria-labelledby` pointing to a sub-element of the checkbox. Normally, we announce the accessible name as we descend then read the child elements. This results in double speaking the name.

### Description of how this pull request fixes the issue:
When rendering the virtual buffer, track the ID's of the nodes. If this node has a label, check if the ID for the label node matches any sub-node then set an attribute `labelledByContents`. Then in `speech.py` don't speak the name for a `controlField` if it has this attribute.

### Testing performed:
Simplified test case:
```
data:text/html,<button>begin</button><div tabindex="0" role="checkbox" aria-labelledby="inner-label"><div style="display:inline" id="inner-label">Simulate evil cat</div></div>
```

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

