### PR TITLE
Speak typed characters in Windows consoles in the correct language (second try)

### DIFF
--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -1107,8 +1107,9 @@ def isMarshalledIAccessible(IAccessibleObject):
 	windll.kernel32.GetModuleFileNameW(handle,buf,1024)
 	return not buf.value.lower().endswith('oleacc.dll')
 
+
 #: Maps from console windows (ConsoleWindowClass) to thread IDs
-# Windows hacks GetWindowThreadProcessId to return the input thread of the first attached process in a console,
+# Windows hacks GetWindowThreadProcessId to return the input thread of the first attached process in a console
 # But NVDA really requires to know the actual thread the window was created in,
 # I.e. inside conhost,
 # In order to handle speaking of typed characters etc.

--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -575,6 +575,10 @@ def winEventCallback(handle,eventID,window,objectID,childID,threadID,timestamp):
 				window=tempWindow
 
 		windowClassName=winUser.getClassName(window)
+		if windowClassName == "ConsoleWindowClass":
+			# #10113: we need to use winEvents to track the real thread for console windows.
+			consoleWindowsToThreadIDs[window] = threadID
+
 		# Modern IME candidate list windows fire menu events which confuse us
 		# and can't be used properly in conjunction with input composition support.
 		if windowClassName=="Microsoft.IME.UIManager.CandidateWindow.Host" and eventID in MENU_EVENTIDS:
@@ -1102,3 +1106,12 @@ def isMarshalledIAccessible(IAccessibleObject):
 	windll.kernel32.GetModuleHandleExW(6,addr,byref(handle))
 	windll.kernel32.GetModuleFileNameW(handle,buf,1024)
 	return not buf.value.lower().endswith('oleacc.dll')
+
+#: Maps from console windows (ConsoleWindowClass) to thread IDs
+# Windows hacks GetWindowThreadProcessId to return the input thread of the first attached process in a console,
+# But NVDA really requires to know the actual thread the window was created in,
+# I.e. inside conhost,
+# In order to handle speaking of typed characters etc.
+# winEventCallback adds these when ever it sees an event for ConsoleWindowClass windows,
+# As winEvents always contain the true thread ID.
+consoleWindowsToThreadIDs = {}

--- a/source/IAccessibleHandler.py
+++ b/source/IAccessibleHandler.py
@@ -4,6 +4,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+from typing import Dict
 import heapq
 import itertools
 import struct
@@ -1113,6 +1114,6 @@ def isMarshalledIAccessible(IAccessibleObject):
 # But NVDA really requires to know the actual thread the window was created in,
 # I.e. inside conhost,
 # In order to handle speaking of typed characters etc.
-# winEventCallback adds these when ever it sees an event for ConsoleWindowClass windows,
+# winEventCallback adds these whenever it sees an event for ConsoleWindowClass windows,
 # As winEvents always contain the true thread ID.
-consoleWindowsToThreadIDs = {}
+consoleWindowsToThreadIDs: Dict[int, int] = {}

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -256,11 +256,11 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 
 	def _get_windowThreadID(self):
 		# #10113: Windows forces the thread of console windows to match the thread of the first attached process.
-		# However, To correctly handle speaking of typed characters, 
+		# However, To correctly handle speaking of typed characters,
 		# NVDA really requires the real thread the window was created in,
 		# I.e. a thread inside conhost.
 		from IAccessibleHandler import consoleWindowsToThreadIDs
-		threadID = consoleWindowsToThreadIDs.get(self.windowHandle,0)
+		threadID = consoleWindowsToThreadIDs.get(self.windowHandle, 0)
 		if not threadID:
 			threadID = super().windowThreadID
 		return threadID

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -254,6 +254,17 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
 	_caretMovementTimeoutMultiplier = 1.5
 
+	def _get_windowThreadID(self):
+		# #10113: Windows forces the thread of console windows to match the thread of the first attached process.
+		# However, To correctly handle speaking of typed characters, 
+		# NVDA really requires the real thread the window was created in,
+		# I.e. a thread inside conhost.
+		from IAccessibleHandler import consoleWindowsToThreadIDs
+		threadID = consoleWindowsToThreadIDs.get(self.windowHandle,0)
+		if not threadID:
+			threadID = super().windowThreadID
+		return threadID
+
 	def _get_TextInfo(self):
 		"""Overriding _get_TextInfo and thus the TextInfo property
 		on NVDAObjects.UIA.UIA

--- a/source/NVDAObjects/window/winConsole.py
+++ b/source/NVDAObjects/window/winConsole.py
@@ -26,6 +26,17 @@ class WinConsole(Terminal, EditableTextWithoutAutoSelectDetection, Window):
 		if isinstance(self, KeyboardHandlerBasedTypedCharSupport):
 			self._supportsTextChange = False
 
+	def _get_windowThreadID(self):
+		# #10113: Windows forces the thread of console windows to match the thread of the first attached process.
+		# However, To correctly handle speaking of typed characters, 
+		# NVDA really requires the real thread the window was created in,
+		# I.e. a thread inside conhost.
+		from IAccessibleHandler import consoleWindowsToThreadIDs
+		threadID = consoleWindowsToThreadIDs.get(self.windowHandle,0)
+		if not threadID:
+			threadID = super().windowThreadID
+		return threadID
+
 	def _get_TextInfo(self):
 		consoleObject=winConsoleHandler.consoleObject
 		if consoleObject and self.windowHandle == consoleObject.windowHandle:

--- a/source/NVDAObjects/window/winConsole.py
+++ b/source/NVDAObjects/window/winConsole.py
@@ -28,11 +28,11 @@ class WinConsole(Terminal, EditableTextWithoutAutoSelectDetection, Window):
 
 	def _get_windowThreadID(self):
 		# #10113: Windows forces the thread of console windows to match the thread of the first attached process.
-		# However, To correctly handle speaking of typed characters, 
+		# However, To correctly handle speaking of typed characters,
 		# NVDA really requires the real thread the window was created in,
 		# I.e. a thread inside conhost.
 		from IAccessibleHandler import consoleWindowsToThreadIDs
-		threadID = consoleWindowsToThreadIDs.get(self.windowHandle,0)
+		threadID = consoleWindowsToThreadIDs.get(self.windowHandle, 0)
 		if not threadID:
 			threadID = super().windowThreadID
 		return threadID


### PR DESCRIPTION
Replaces pr #10551 
 
### Link to issue number:
Fixes #10113 

### Summary of the issue:
With the work to support Windows consoles via UIA, NVDA moved to speaking typed characters in consoles by detecting keyboard input and then using ToUnicodeEx to convert the keyboard input into a character for speaking. We had already been taking this approach for Microsoft Edge and other places in Windows 10 where we could not inject in-process.
ToUnicodeEx requires a keyboard layout to use the correct language. Therefore, we would call GetKeyboardLayout, giving it the thread ID of the focused window.
However, it seems that Windows console windows report the wrong thread ID, and therefore, GetKeyboardLayout fails, returning 0 instead of a valid keyboard layout.
Passing this 0 to ToUnicodeEx, it would generate characters in the user's system language (I think). At least, on my system it was always english US no matter what input language I was currently using.
 
### Description of how this pull request fixes the issue:
Override the windowThreadID property on both UIA and legacy WinConsole NVDAObjects, to reflect the true thread ID of the window. This thread ID is found in a new cache of console windows to thread IDs in IAccessibleHandler, filled in by received winEvents for ConsoleWindowClass windows.
Received winEvents always contain an ID of the true thread that NotifyWinEvent was called in. In the case of ConsoleWindowClass winEvents, this is from inside conhost.
this thread happens to be the true input (focus thread) for consoles, and therefore GetKeyboardLayout returns the correct input language for the console, when given this threadID.
We can garantee that there will at least either be a focus winEvent, or a locationChange winEvent (for the caret) for consoles, when moving to a console and or starting NVDA within a console. This is enough to make sure that we have a threadID for that console window when we need it.

### Testing performed:
* Installed the Arabic keyboard layout.
* Opened a Windows console and ensured NVDA was using UIA.
* With speak typed characters on, first typed some characters, confirming they were being announced in english. backspacing them also confirming they were english characters written to the console.
* Switched keyboard layouts to Arabic.
* Again typed some characters, confirming that NVDA was speaking them as Arabic. Backspacing them, confirmed that actual arabic characters were written to the console.
  
### Known issues with pull request:
It is possible that the very first typed character when starting NVDA from within a console will be announced in the wrong language, as the caret has not yet moved once. But this is rather rare.

### Change log entry:
None
