### PR TITLE
Two explanations in user guide: gathering user stats and help balloons unified with notifications to be consistent with settings dialog

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -78,7 +78,7 @@ roleLabels = {
 	controlTypes.ROLE_GRAPHIC: _("gra"),
 	# Translators: Displayed in braille for toast notifications and for an object which is a
 	# help balloon.
-	controlTypes.ROLE_HELPBALLOON: _("ntfc"),
+	controlTypes.ROLE_HELPBALLOON: _("hlp"),
 	# Translators: Displayed in braille for an object which is a
 	# tool tip.
 	controlTypes.ROLE_TOOLTIP: _("tltip"),

--- a/source/braille.py
+++ b/source/braille.py
@@ -76,9 +76,9 @@ roleLabels = {
 	# Translators: Displayed in braille for an object which is a
 	# graphic.
 	controlTypes.ROLE_GRAPHIC: _("gra"),
-	# Translators: Displayed in braille for an object which is a
+	# Translators: Displayed in braille for toast notifications and for an object which is a
 	# help balloon.
-	controlTypes.ROLE_HELPBALLOON: _("hlp"),
+	controlTypes.ROLE_HELPBALLOON: _("ntfc"),
 	# Translators: Displayed in braille for an object which is a
 	# tool tip.
 	controlTypes.ROLE_TOOLTIP: _("tltip"),

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -171,6 +171,13 @@ The first checkbox lets you control if NVDA should use the Caps Lock as an NVDA 
 The second specifies whether NVDA should start automatically after you log on to Windows and is only available for installed copies of NVDA.
 The third lets you control if this Welcome dialog should appear each time NVDA starts.
 
++++ Data usage statistics dialog +++[UsageStatsDialog]
+Since NVDA 2018.3, NV Access asks the NVDA users to provide usage data in order to develop NVDA in the way that is convenient to most users.
+When starting NVDA for the first time, a dialog will appear which will ask you if you want to accept sending data to NV Access while using NVDA.
+You can read more info about the data gathered by NV Access in Chapter 11 below.
+Note: pressing on "yes" or "no" will save this setting and the dialog will never appear again unless you reinstall NVDA.
+However, you can enable or disable the data gathering process manually in the general settings of NVDA. For changing this setting manually, you can check or uncheck the checkbox called [Allow the NVDA project to gather NVDA usage statistics #GeneralSettingsGatherUsageStats].
+
 ++ About NVDA keyboard commands ++[AboutNVDAKeyboardCommands]
 
 +++ The NVDA Modifier Key +++[TheNVDAModifierKey]
@@ -672,7 +679,6 @@ In order to fit as much information as possible on a braille display, the follow
 | gra | graphic |
 | grp | grouping |
 | hN | heading at level n, e.g. h1, h2. |
-| hlp | help baloon |
 | lmk | landmark |
 | lnk | link |
 | vlnk | visited link |
@@ -681,6 +687,7 @@ In order to fit as much information as possible on a braille display, the follow
 | mnubar | menu bar |
 | mnubtn | menu button |
 | mnuitem | menu item |
+| ntfc | notification |
 | pnl | panel |
 | prgbar | progress bar |
 | rbtn | radio button |
@@ -1531,9 +1538,10 @@ This category contains the following options:
 A checkbox that when checked tells NVDA to report tooltips as they appear.
 Many Windows and controls show a small message (or tooltip) when you move the mouse pointer over them, or sometimes when you move the focus to them.
 
-==== Report Help Balloons ====[ObjectPresentationReportBalloons]
-This checkbox when checked tells NVDA to report help balloons as they appear.
-Help Balloons are like tooltips, but are usually larger in size, and are associated with system events such as a network cable being unplugged, or perhaps to alert you about Windows security issues.
+==== Report notifications ====[ObjectPresentationReportNotifications]
+This checkbox, when checked, tells NVDA to report help balloons and toast notifications as they appear.
+- Help Balloons are like tooltips, but are usually larger in size, and are associated with system events such as a network cable being unplugged, or perhaps to alert you about Windows security issues.
+- Toast notifications have been introduced in Windows 10 and appear in the notification center in the system tray, informing about several events (i.e. if an update has been downloaded, a new e-mail arived in your inbox, etc.).
 
 ==== Report Object Shortcut Keys ====[ObjectPresentationShortcutKeys]
 When this checkbox is checked, NVDA will include the shortcut key that is associated with a certain object or control when it is reported.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -679,6 +679,7 @@ In order to fit as much information as possible on a braille display, the follow
 | gra | graphic |
 | grp | grouping |
 | hN | heading at level n, e.g. h1, h2. |
+| hlp | help balloon |
 | lmk | landmark |
 | lnk | link |
 | vlnk | visited link |
@@ -687,7 +688,6 @@ In order to fit as much information as possible on a braille display, the follow
 | mnubar | menu bar |
 | mnubtn | menu button |
 | mnuitem | menu item |
-| ntfc | notification |
 | pnl | panel |
 | prgbar | progress bar |
 | rbtn | radio button |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -176,7 +176,7 @@ Starting from NVDA 2018.3, the user is asked if they want to allow usage data to
 When starting NVDA for the first time, a dialog will appear which will ask you if you want to accept sending data to NV Access while using NVDA.
 You can read more info about the data gathered by NV Access in Chapter 11 below.
 Note: pressing on "yes" or "no" will save this setting and the dialog will never appear again unless you reinstall NVDA.
-However, you can enable or disable the data gathering process manually in the general settings of NVDA. For changing this setting manually, you can check or uncheck the checkbox called [Allow the NVDA project to gather NVDA usage statistics #GeneralSettingsGatherUsageStats].
+However, you can enable or disable the data gathering process manually in NVDA's general settings panel. For changing this setting manually, you can check or uncheck the checkbox called [Allow the NVDA project to gather NVDA usage statistics #GeneralSettingsGatherUsageStats].
 
 ++ About NVDA keyboard commands ++[AboutNVDAKeyboardCommands]
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -172,7 +172,7 @@ The second specifies whether NVDA should start automatically after you log on to
 The third lets you control if this Welcome dialog should appear each time NVDA starts.
 
 +++ Data usage statistics dialog +++[UsageStatsDialog]
-Since NVDA 2018.3, NV Access asks the NVDA users to provide usage data in order to develop NVDA in the way that is convenient to most users.
+Starting from NVDA 2018.3, the user is asked if they want to allow usage data to be sent to NV Access in order to help improve NVDA in the future. 
 When starting NVDA for the first time, a dialog will appear which will ask you if you want to accept sending data to NV Access while using NVDA.
 You can read more info about the data gathered by NV Access in Chapter 11 below.
 Note: pressing on "yes" or "no" will save this setting and the dialog will never appear again unless you reinstall NVDA.


### PR DESCRIPTION
### Link to issue number:
fixes #9131
fixes #8689

### Summary of the issue:
#9131: NVDA's user guide still references help balloons although the coresponding setting in the settings dialog is called "notifications". The braille abbreviation is still "hlp".
#8689:  There is no explanation about the data usage statistics dialog at first start of NVDA after installing.

### Description of how this pull request fixes the issue:
#9131: Changed the coresponding parts in the user guide. The braille abbreviation will remain hlp since the role is spoken as "help balloon" also for toast notifications.
#8689: added section 4.1.2 to the user guide explaining the data usage statistics dialog.

### Testing performed:
Tested that the information is shown correctly in the user guide.

### Known issues with pull request:
none

### Change log entry:
not needed.
