### PR TITLE
winConsoleUIATextInfo: use rangeFromPoint instead of broken getVisibleRanges

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -124,6 +124,11 @@ class consoleUIATextInfo(UIATextInfo):
 		else:  # moving by a unit other than word
 			res = super(consoleUIATextInfo, self).move(unit, direction,
 														endPoint)
+		if not endPoint:
+			# #10191: IUIAutomationTextRange::move in consoles does not correctly produce a collapsed range
+			# after moving.
+			# Therefore manually collapse.
+			self.collapse()
 		try:
 			if (
 				oldInfo

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -131,7 +131,7 @@ class consoleUIATextInfo(UIATextInfo):
 		# Console textRanges have access to the entire console buffer.
 		# However, we want to limit ourselves to onscreen text.
 		# Therefore, if the textInfo was originally visible,
-		# but we are now aboe or below the visible range,
+		# but we are now above or below the visible range,
 		# Restore the original textRange and pretend the move didn't work.
 		if oldInfo:
 			try:

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -221,12 +221,12 @@ class consoleUIATextInfo(UIATextInfo):
 		# position a textInfo from the start of the line up to the current position.
 		charInfo = lineInfo.copy()
 		charInfo.setEndPoint(self, "endToStart")
-		text = charInfo.text
+		text = charInfo._rangeObj.getText(-1)
 		offset = textUtils.WideStringOffsetConverter(text).wideStringLength
 		return offset
 
 	def _getWordOffsetsInThisLine(self, offset, lineInfo):
-		lineText = lineInfo.text or u" "
+		lineText = lineInfo._rangeObj.getText(-1)
 		# Convert NULL and non-breaking space to space to make sure
 		# that words will break on them
 		lineText = lineText.translate({0: u' ', 0xa0: u' '})

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -280,6 +280,14 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		bounds review to the visible text."""
 		return consoleUIATextInfo
 
+	def _getTextLines(self):
+		# This override of _getTextLines takes advantage of the fact that 
+		# the console text contains linefeeds for every line
+		# Thus a simple string splitlines is much faster than splitting by unit line.
+		ti = self.makeTextInfo(textInfos.POSITION_ALL)
+		text = ti.text or ""
+		return text.splitlines()
+
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":
 		clsList.append(WinConsoleUIA)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -36,11 +36,11 @@ class consoleUIATextInfo(UIATextInfo):
 		elif position is textInfos.POSITION_LAST:
 			# Asking for the range at the bottom right of the window
 			# Seems to sometimes ignore the x coordinate.
-			# Therefore use the bottom left, then move the  to last character on that line. 
+			# Therefore use the bottom left, then move the  to last character on that line.
 			tempInfo = self.__class__(obj, obj.location.bottomLeft)
 			tempInfo.expand(textInfos.UNIT_LINE)
-			UIATextInfo.move(tempInfo,textInfos.UNIT_CHARACTER,-1,endPoint="end")
-			tempInfo.setEndPoint(tempInfo,"startToEnd")
+			UIATextInfo.move(tempInfo, textInfos.UNIT_CHARACTER, -1, endPoint="end")
+			tempInfo.setEndPoint(tempInfo, "startToEnd")
 			_rangeObj = tempInfo._rangeObj
 		elif position is textInfos.POSITION_ALL:
 			first = self.__class__(obj, textInfos.POSITION_FIRST)
@@ -128,12 +128,12 @@ class consoleUIATextInfo(UIATextInfo):
 			if (
 				oldInfo
 				and (
-					self.compareEndPoints(boundingInfo, "startToStart") < 0 or
-					self.compareEndPoints(boundingInfo, "startToEnd") >= 0
+					self.compareEndPoints(boundingInfo, "startToStart") < 0
+					or self.compareEndPoints(boundingInfo, "startToEnd") >= 0
 				)
 				and not (
-					oldInfo.compareEndPoints(boundingInfo, "startToStart") < 0 or
-					oldInfo.compareEndPoints(boundingInfo, "startToEnd") >= 0
+					oldInfo.compareEndPoints(boundingInfo, "startToStart") < 0
+					or oldInfo.compareEndPoints(boundingInfo, "startToEnd") >= 0
 				)
 			):
 				self._rangeObj = oldInfo._rangeObj

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -18,11 +18,6 @@ from ..window import Window
 
 
 class consoleUIATextInfo(UIATextInfo):
-	#: At least on Windows 10 1903, expanding then collapsing the text info
-	#: caused review to get stuck, so disable it.
-	#: There may be no need to disable this anymore, but doing so doesn't seem
-	#: to do much good either.
-	_expandCollapseBeforeReview = False
 
 	def __init__(self, obj, position, _rangeObj=None):
 		# We want to limit  textInfos to just the visible part of the console.

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -281,7 +281,7 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		return consoleUIATextInfo
 
 	def _getTextLines(self):
-		# This override of _getTextLines takes advantage of the fact that 
+		# This override of _getTextLines takes advantage of the fact that
 		# the console text contains linefeeds for every line
 		# Thus a simple string splitlines is much faster than splitting by unit line.
 		ti = self.makeTextInfo(textInfos.POSITION_ALL)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -35,7 +35,7 @@ class consoleUIATextInfo(UIATextInfo):
 			_rangeObj = self.__class__(obj, obj.location.topLeft)._rangeObj
 		elif position is textInfos.POSITION_LAST:
 			tempInfo = self.__class__(obj, obj.location.bottomRight)
-			# Consoles sometimes do not honor the x coordinate, 
+			# Consoles sometimes do not honor the x coordinate,
 			# so therefore ensure we are really at the end of the line.
 			tempInfo.expand(textInfos.UNIT_LINE)
 			tempInfo.collapse(end=True)
@@ -43,7 +43,7 @@ class consoleUIATextInfo(UIATextInfo):
 		elif position is textInfos.POSITION_ALL:
 			first = self.__class__(obj, textInfos.POSITION_FIRST)
 			last = self.__class__(obj, textInfos.POSITION_LAST)
-			first.setEndPoint(last,"endToEnd")
+			first.setEndPoint(last, "endToEnd")
 			_rangeObj = first._rangeObj
 		super(consoleUIATextInfo, self).__init__(obj, position, _rangeObj)
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1026,9 +1026,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_previousLine(self,gesture):
 		info=api.getReviewPosition().copy()
-		if info._expandCollapseBeforeReview:
-			info.expand(textInfos.UNIT_LINE)
-			info.collapse()
+		info.expand(textInfos.UNIT_LINE)
+		info.collapse()
 		res=info.move(textInfos.UNIT_LINE,-1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the top line of the current navigator object.
@@ -1058,9 +1057,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_nextLine(self,gesture):
 		info=api.getReviewPosition().copy()
-		if info._expandCollapseBeforeReview:
-			info.expand(textInfos.UNIT_LINE)
-			info.collapse()
+		info.expand(textInfos.UNIT_LINE)
+		info.collapse()
 		res=info.move(textInfos.UNIT_LINE,1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
@@ -1086,9 +1084,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_previousWord(self,gesture):
 		info=api.getReviewPosition().copy()
-		if info._expandCollapseBeforeReview:
-			info.expand(textInfos.UNIT_WORD)
-			info.collapse()
+		info.expand(textInfos.UNIT_WORD)
+		info.collapse()
 		res=info.move(textInfos.UNIT_WORD,-1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the top line of the current navigator object.
@@ -1117,9 +1114,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_nextWord(self,gesture):
 		info=api.getReviewPosition().copy()
-		if info._expandCollapseBeforeReview:
-			info.expand(textInfos.UNIT_WORD)
-			info.collapse()
+		info.expand(textInfos.UNIT_WORD)
+		info.collapse()
 		res=info.move(textInfos.UNIT_WORD,1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
@@ -1148,9 +1144,8 @@ class GlobalCommands(ScriptableObject):
 		lineInfo=api.getReviewPosition().copy()
 		lineInfo.expand(textInfos.UNIT_LINE)
 		charInfo=api.getReviewPosition().copy()
-		if charInfo._expandCollapseBeforeReview:
-			charInfo.expand(textInfos.UNIT_CHARACTER)
-			charInfo.collapse()
+		charInfo.expand(textInfos.UNIT_CHARACTER)
+		charInfo.collapse()
 		res=charInfo.move(textInfos.UNIT_CHARACTER,-1)
 		if res==0 or charInfo.compareEndPoints(lineInfo,"startToStart")<0:
 			# Translators: a message reported when review cursor is at the leftmost character of the current navigator object's text.
@@ -1195,9 +1190,8 @@ class GlobalCommands(ScriptableObject):
 		lineInfo=api.getReviewPosition().copy()
 		lineInfo.expand(textInfos.UNIT_LINE)
 		charInfo=api.getReviewPosition().copy()
-		if charInfo._expandCollapseBeforeReview:
-			charInfo.expand(textInfos.UNIT_CHARACTER)
-			charInfo.collapse()
+		charInfo.expand(textInfos.UNIT_CHARACTER)
+		charInfo.collapse()
 		res=charInfo.move(textInfos.UNIT_CHARACTER,1)
 		if res==0 or charInfo.compareEndPoints(lineInfo,"endToEnd")>=0:
 			# Translators: a message reported when review cursor is at the rightmost character of the current navigator object's text.

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -280,10 +280,6 @@ class TextInfo(baseObject.AutoPropertyObject):
 	@type bookmark: L{Bookmark}
 	"""
 
-	#: whether this textInfo should be expanded then collapsed around its enclosing unit before review.
-	#: This can be problematic for some implementations.
-	_expandCollapseBeforeReview = True
-
 	def __init__(self,obj,position):
 		"""Constructor.
 		Subclasses must extend this, calling the superclass method first.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10191 
Fixes #10119

### Summary of the issue:
In Windows consoles with UIA, NVDA currently makes use of IUIAutomationTextPattern::getVisibleRanges to find the bounds of what is visibly on screen. This is both for bounding the review cursor, and for collecting the on-screen text for diffing, in order to speak what has changed.
However, IUIAutomationTextPattern:getVisibleRanges can eventually start giving back junk text ranges that are positioned way above, and outside of the real visible bounds. This seems to start happening once a great deal of text has been scrolled up the screen.
This not only causes the review cursor to act strangely or get stuck when moving to the top or bottom, but it causes very old and invalid text to be spoken when things change on screen.
 
### Description of how this pull request fixes the issue:
Instead of getVisibleRanges, use IUIAutomationTextPattern::rangeFromPoint at the top left and bottom right of the console window.

### Testing performed:
Tested in both wsl (Ubuntu) and cmd.
Tested when older alpha builds of NVDA got into a state where the console no longer made sence with getVisibleRanges; this approach seemed to give back correct text and the review cursor no longer got stuck.

### Known issues with pull request:
Like the older legacy winConsole support, if moving to the bottom with the review cursor and then going up by line, if there are blank lines in the console, these are not skipped. this is a little annoying for efficiency, but it is the same behaviour we originally had for many years, and blank lines are certainly better than  invalid text or getting stuck.

### Change log entry:
None.
