### PR TITLE
UI Automation in Windows Console: report space for blank console characters

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -243,7 +243,7 @@ class consoleUIATextInfo(UIATextInfo):
 		# #10036: return a space if the text range is empty.
 		# Consoles don't actually store spaces, the character is merely left blank.
 		res = super(consoleUIATextInfo, self)._get_text()
-		if len(res) < 1:
+		if not res:
 			return ' '
 		else:
 			return res

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -239,6 +239,15 @@ class consoleUIATextInfo(UIATextInfo):
 		"""Support more accurate caret move detection."""
 		return not self == other
 
+	def _get_text(self):
+		# #10036: return a space if the text range is empty.
+		# Consoles don't actually store spaces, the character is merely left blank.
+		res = super(consoleUIATextInfo, self)._get_text()
+		if len(res) < 1:
+			return ' '
+		else:
+			return res
+
 
 class consoleUIAWindow(Window):
 	# This is the parent of the console text area, which sometimes gets focus after the text area.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10036.

### Summary of the issue:
Inline spaces are announced as "blank" in Windows Console, due to the underlying implementation.

### Description of how this pull request fixes the issue:
Report "space" for empty console text ranges, as suggested by @MichaelDCurran in the issue.

### Testing performed:
Tested that inline spaces are reported as "space" when deleting text.

### Known issues with pull request:
None.

### Change log entry:
None.