### PR TITLE
Avoid StopIteration error when navigating through non link text

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1751,9 +1751,10 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 	def _iterNotLinkBlock(self, direction="next", pos=None):
 		links = self._iterNodesByType("link", direction=direction, pos=pos)
 		# We want to compare each link against the next link.
-		item1 = next(links)
-		while True:
-			item2 = next(links)
+		item1 = next(links, None)
+		if item1 is None:
+			return
+		for item2 in links:
 			# If the distance between the links is small, this is probably just a piece of non-link text within a block of links; e.g. an inactive link of a nav bar.
 			if direction=="previous":
 				textRange=item1.textInfo.copy()

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -407,7 +407,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			# Translators: a message when a particular quick nav command is not supported in the current document.
 			ui.message(_("Not supported in this document"))
 			return
-		except (StopIteration, RuntimeError):
+		except StopIteration:
 			ui.message(errorMessage)
 			return
 		# #8831: Report before moving because moving might change the focus, which

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -407,7 +407,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			# Translators: a message when a particular quick nav command is not supported in the current document.
 			ui.message(_("Not supported in this document"))
 			return
-		except StopIteration:
+		except (StopIteration, RuntimeError):
 			ui.message(errorMessage)
 			return
 		# #8831: Report before moving because moving might change the focus, which


### PR DESCRIPTION
### Link to issue number:
Closes #10038 
### Summary of the issue:
In alpha versions powered by Python 3 when user reaches last non link text instead of normal message an error sound is played and message about StopIteration error appears in the log.
### Description of how this pull request fixes the issue:
Currently during iteration through quick navigation items a StopIteration exception is caught to inform that there is no next element to iterate and then a proper message is displayed.
But, according to this article
https://www.python.org/dev/peps/pep-0479/
handling of this exception was modified and RuntimeError is now produced instead.
First I've replaced StopIteration with RuntimeError but it somehow broke quick navigation to other elements in chrome.
Finally I combined both errors in one catch to ensure that iteration through non link text and other elements will work properly.
### Testing performed:
Checked in chrome, firefox and edge that iteration through non link text and other quick navigation elements works without errors.
### Known issues with pull request:
It's unclear to me, how non link text differs from others and my knowledge about generators and iterators is limited so I hope somebody with better understanding of those confirms it is a right approach.
### Change log entry:
