### PR TITLE
remove unneeded space

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2008,7 +2008,7 @@ class DocumentFormattingPanel(SettingsPanel):
 			#Translators: A choice in a combo box in the document formatting dialog  to report indentation with tones.
 			_("Tones"),
 			#Translators: A choice in a combo box in the document formatting dialog  to report indentation with both  Speech and tones.
-			_("Both  Speech and Tones")
+			_("Both Speech and Tones")
 		]
 		self.lineIndentationCombo = pageAndSpaceGroup.addLabeledControl(lineIndentationText, wx.Choice, choices=indentChoices)
 		#We use bitwise operations because it saves us a four way if statement.


### PR DESCRIPTION

### Link to issue number:

None

### Summary of the issue:


in gui/settingsDialogs.py, we somehow added an extra space between both and speech in "both Speech and Tones." Remove it.

### Description of how this pull request fixes the issue:

Removes the extra space. This originally came from the translations list.

### Testing performed:

Kicked the tires, honked the horn, made sure things compiled and ran it to check the gui option.

### Known issues with pull request:

### Change log entry:

None needed, likely wasn't user visible in a release.