### PR TITLE
Update NVDA eSpeak NG to 1.51-dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ For reference, the following run time dependencies are included in Git submodule
 
 * [comtypes](https://github.com/enthought/comtypes), version 1.1.7
 * [wxPython](https://www.wxpython.org/), version 4.0.3
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit 86e67a
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), - 1.51-dev
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ What's New in NVDA
 - When focussing a grouping in browse mode, the description is now also read. (#10095)
 - The Java Access Bridge is now included with NVDA to enable access to Java applications, including for 64 bit Java VMs. (#7724)
 - If the Java Access Bridge is not enabled for the user, NVDA automatically enables it at NVDA startup. (#7952)
+- Update eSpeak NG to 1.51-dev
 
 
 == Bug Fixes ==


### PR DESCRIPTION
### Link to issue number:
none
### Summary of the issue:
A few hours ago eSpeak NG was updated to the latest 1.51-dev version
### Description of how this pull request fixes the issue:
Update eSpeak NG 1.49.3 development board to the latest 1.51-dev version
### Testing performed:
none
### Known issues with pull request:
none
### Change log entry:

Section: Changes

thanks