### PR TITLE
Send typedCharacter events for Braille when using ToUnicodeEx

### DIFF
--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -400,11 +400,10 @@ class BrailleInputHandler(AutoPropertyObject):
 				input.ii.ki.dwFlags = winUser.KEYEVENTF_UNICODE|direction
 				inputs.append(input)
 		winUser.SendInput(inputs)
-		from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
 		focusObj = api.getFocusObject()
-		if isinstance(focusObj, KeyboardHandlerBasedTypedCharSupport):
-			# #10569: KeyboardHandlerBasedTypedCharSupport uses ToUnicodeEx,
-			# which can't read emulated keyboard events.
+		if keyboardHandler.shouldUseToUnicodeEx(focusObj):
+			# #10569: When we use ToUnicodeEx to detect typed characters,
+			# emulated keypresses aren't detected.
 			# Send TypedCharacter events manually.
 			for ch in chars:
 				focusObj.event_typedCharacter(ch=ch)

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -22,6 +22,7 @@ import api
 from baseObject import AutoPropertyObject
 import keyLabels
 
+
 """Framework for handling braille input from the user.
 All braille input is represented by a {BrailleInputGesture}.
 Normally, all that is required is to create and execute a L{BrailleInputGesture},
@@ -399,6 +400,14 @@ class BrailleInputHandler(AutoPropertyObject):
 				input.ii.ki.dwFlags = winUser.KEYEVENTF_UNICODE|direction
 				inputs.append(input)
 		winUser.SendInput(inputs)
+		from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
+		focusObj = api.getFocusObject()
+		if isinstance(focusObj, KeyboardHandlerBasedTypedCharSupport):
+			# #10569: KeyboardHandlerBasedTypedCharSupport uses ToUnicodeEx,
+			# which can't read emulated keyboard events.
+			# Send TypedCharacter events manually.
+			for ch in chars:
+				focusObj.event_typedCharacter(ch=ch)
 
 	def handleGainFocus(self, obj):
 		""" Clear all state when the focus changes.

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -108,7 +108,7 @@ def shouldUseToUnicodeEx(focus=None):
 	return (
 		# This is only possible in Windows 10 1607 and above
 		winVersion.isWin10(1607)
-		and ( #  Either of
+		and (  # Either of
 			# We couldn't inject in-process, and its not a legacy console window without keyboard support.
 			# console windows have their own specific typed character support.
 			(not focus.appModule.helperLocalBindingHandle and focus.windowClassName != 'ConsoleWindowClass')

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -99,6 +99,27 @@ def getNVDAModifierKeys():
 		keys.append(vkCodes.byName["capslock"])
 	return keys
 
+
+def shouldUseToUnicodeEx(focus=None):
+	"Returns whether to use ToUnicodeEx to determine typed characters."
+	if not focus:
+		focus=api.getFocusObject()
+	from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
+	return (
+		# This is only possible in Windows 10 1607 and above
+		winVersion.isWin10(1607)
+		and ( # Either of
+			# We couldn't inject in-process, and its not a legacy console window without keyboard support.
+			# console windows have their own specific typed character support.
+			(not focus.appModule.helperLocalBindingHandle and focus.windowClassName!='ConsoleWindowClass')
+			# or the focus is within a UWP app, where WM_CHAR never gets sent 
+			or focus.windowClassName.startswith('Windows.UI.Core')
+			#Or this is a console with keyboard support, where WM_CHAR messages are doubled
+			or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)
+			)
+		)
+
+
 def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 	"""Event called by winInputHook when it receives a keyDown.
 	"""
@@ -197,23 +218,12 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 		# #6017: handle typed characters in Win10 RS2 and above where we can't detect typed characters in-process 
 		# This code must be in the 'finally' block as code above returns in several places yet we still want to execute this particular code.
 		focus=api.getFocusObject()
-		from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
 		if (
-			# This is only possible in Windows 10 1607 and above
-			winVersion.isWin10(1607)
+			shouldUseToUnicodeEx(focus)
 			# And we only want to do this if the gesture did not result in an executed action 
 			and not gestureExecuted 
 			# and not if this gesture is a modifier key
 			and not isNVDAModifierKey(vkCode,extended) and not vkCode in KeyboardInputGesture.NORMAL_MODIFIER_KEYS
-			and ( # Either of
-				# We couldn't inject in-process, and its not a legacy console window without keyboard support.
-				# console windows have their own specific typed character support.
-				(not focus.appModule.helperLocalBindingHandle and focus.windowClassName!='ConsoleWindowClass')
-				# or the focus is within a UWP app, where WM_CHAR never gets sent 
-				or focus.windowClassName.startswith('Windows.UI.Core')
-				#Or this is a console with keyboard support, where WM_CHAR messages are doubled
-				or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)
-			)
 		):
 			keyStates=(ctypes.c_byte*256)()
 			for k in range(256):

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -103,21 +103,21 @@ def getNVDAModifierKeys():
 def shouldUseToUnicodeEx(focus=None):
 	"Returns whether to use ToUnicodeEx to determine typed characters."
 	if not focus:
-		focus=api.getFocusObject()
+		focus = api.getFocusObject()
 	from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
 	return (
 		# This is only possible in Windows 10 1607 and above
 		winVersion.isWin10(1607)
-		and ( # Either of
+		and ( #  Either of
 			# We couldn't inject in-process, and its not a legacy console window without keyboard support.
 			# console windows have their own specific typed character support.
-			(not focus.appModule.helperLocalBindingHandle and focus.windowClassName!='ConsoleWindowClass')
-			# or the focus is within a UWP app, where WM_CHAR never gets sent 
+			(not focus.appModule.helperLocalBindingHandle and focus.windowClassName != 'ConsoleWindowClass')
+			# or the focus is within a UWP app, where WM_CHAR never gets sent
 			or focus.windowClassName.startswith('Windows.UI.Core')
-			#Or this is a console with keyboard support, where WM_CHAR messages are doubled
+			# Or this is a console with keyboard support, where WM_CHAR messages are doubled
 			or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)
-			)
 		)
+	)
 
 
 def internal_keyDownEvent(vkCode,scanCode,extended,injected):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10569.

### Summary of the issue:
The `toUnicodeEx` approach of typed character detection doesn't work for Braille keyboards.

### Description of how this pull request fixes the issue:
Manually sends typed character events to objects using `toUnicodeEx` if focused. We must send all keys after they are typed to avoid unintentionally speaking passwords in Windows Console. A new `keyboardHandler.shouldUseToUnicodeEx` function has been added for this detection.

### Testing performed:
Tested that typed characters are reported from a 5th-generation Freedom Scientific Focus keyboard, and that password reporting works as expected.

### Known issues with pull request:
None.

### Change log entry:
== Bug fixes ==
- On Windows 10 version 1607 and later, typed characters from Braille keyboards are spoken in more situations. (#10569)