### PR TITLE
Remove UIAHandler.isUIAAvailable, as it is always available

### DIFF
--- a/source/NVDAObjects/IAccessible/sysTreeView32.py
+++ b/source/NVDAObjects/IAccessible/sysTreeView32.py
@@ -12,7 +12,7 @@ import controlTypes
 import speech
 import UIAHandler
 from . import IAccessible
-if UIAHandler.isUIAAvailable: from ..UIA import UIA
+from ..UIA import UIA
 from .. import NVDAObject
 from logHandler import log
 import watchdog

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -90,7 +90,7 @@ class UIATextInfo(textInfos.TextInfo):
 		UIAHandler.UIA_AriaPropertiesPropertyId,
 		UIAHandler.UIA_LevelPropertyId,
 		UIAHandler.UIA_IsEnabledPropertyId,
-	} if UIAHandler.isUIAAvailable else set()
+	}
 
 	def _get__controlFieldUIACacheRequest(self):
 		""" The UIA cacheRequest object that will be used when fetching all UIA elements needed when generating control fields for this TextInfo's content."""
@@ -108,7 +108,7 @@ class UIATextInfo(textInfos.TextInfo):
 		UIAHandler.TextUnit_Format,
 		UIAHandler.TextUnit_Word,
 		UIAHandler.TextUnit_Character
-	] if UIAHandler.isUIAAvailable else []
+	]
 
 	def find(self,text,caseSensitive=False,reverse=False):
 		tempRange=self._rangeObj.clone()
@@ -379,7 +379,7 @@ class UIATextInfo(textInfos.TextInfo):
 		UIAHandler.UIA_TabItemControlTypeId,
 		UIAHandler.UIA_TextControlTypeId,
 		UIAHandler.UIA_SplitButtonControlTypeId
-	} if UIAHandler.isUIAAvailable else None
+	}
 
 
 	def _getControlFieldForObject(self, obj,isEmbedded=False,startOfNode=False,endOfNode=False):
@@ -1186,7 +1186,7 @@ class UIA(Window):
 		UIAHandler.UIA_IsSelectionItemPatternAvailablePropertyId,
 		UIAHandler.UIA_IsEnabledPropertyId,
 		UIAHandler.UIA_IsOffscreenPropertyId,
-	}  if UIAHandler.isUIAAvailable else set()
+	}
 
 	def _get_states(self):
 		states=set()

--- a/source/UIAHandler.py
+++ b/source/UIAHandler.py
@@ -23,7 +23,7 @@ def initialize():
 		handler=UIAHandler()
 	except COMError:
 		handler=None
-		raise RuntimeError("UIA not available")
+		raise
 
 def terminate():
 	global handler

--- a/source/UIAHandler.py
+++ b/source/UIAHandler.py
@@ -7,27 +7,18 @@
 from comtypes import COMError
 import config
 from logHandler import log
+from _UIAHandler import *
 
 # Make the _UIAHandler._isDebug function available to this module,
 # ignoring the fact that it is not used here directly.
 from _UIAHandler import _isDebug   # noqa: F401
 
 handler=None
-isUIAAvailable=False
-
-if config.conf and config.conf["UIA"]["enabled"]:
-	# Because Windows 7 SP1 (NT 6.1) or later is supported, just assume UIA can be used unless told otherwise.
-	try:
-		from _UIAHandler import *
-		isUIAAvailable=True
-	except ImportError:
-		log.debugWarning("Unable to import _UIAHandler",exc_info=True)
-		pass
 
 def initialize():
 	global handler
-	if not isUIAAvailable:
-		raise NotImplementedError
+	if not config.conf["UIA"]["enabled"]:
+		raise RuntimeError("UIA forcefully disabled in configuration")
 	try:
 		handler=UIAHandler()
 	except COMError:

--- a/source/UIAHandler.py
+++ b/source/UIAHandler.py
@@ -7,7 +7,8 @@
 from comtypes import COMError
 import config
 from logHandler import log
-from _UIAHandler import *
+# Import everything from _UIAHandler, ignoring F403 linter warning.
+from _UIAHandler import *  # noqa: F403
 
 # Make the _UIAHandler._isDebug function available to this module,
 # ignoring the fact that it is not used here directly.

--- a/source/UIAHandler.py
+++ b/source/UIAHandler.py
@@ -7,7 +7,7 @@
 from comtypes import COMError
 import config
 from logHandler import log
-# Import everything from _UIAHandler, ignoring F403 linter warning.
+# Maintain backwards compatibility: F403 (unable to detect undefined names) flake8 warning.
 from _UIAHandler import *  # noqa: F403
 
 # Make the _UIAHandler._isDebug function available to this module,

--- a/source/appModules/logonui.py
+++ b/source/appModules/logonui.py
@@ -13,8 +13,7 @@ from NVDAObjects.behaviors import Dialog
 import appModuleHandler
 import eventHandler
 import UIAHandler
-if UIAHandler.isUIAAvailable:
-	from NVDAObjects.UIA import UIA
+from NVDAObjects.UIA import UIA
 
 """App module for the Windows Logon screen
 """
@@ -35,16 +34,15 @@ class LogonDialog(Dialog):
 
 		return super(LogonDialog, self).event_gainFocus()
 
-if UIAHandler.isUIAAvailable:
-	class Win8PasswordField(UIA):
+class Win8PasswordField(UIA):
 
-		#This UIA object has no invoke pattern, at least set focus.
-		# #6024: Affects both Windows 8.x and 10.
-		def doAction(self,index=None):
-			if not index:
-				self.setFocus()
-			else:
-				super(Win8PasswordField,self).doAction(index)
+	#This UIA object has no invoke pattern, at least set focus.
+	# #6024: Affects both Windows 8.x and 10.
+	def doAction(self,index=None):
+		if not index:
+			self.setFocus()
+		else:
+			super(Win8PasswordField,self).doAction(index)
 
 class XPPasswordField(IAccessible):
 
@@ -82,7 +80,7 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		windowClass = obj.windowClassName
 
-		if UIAHandler.isUIAAvailable:
+		if UIAHandler.handler:
 			if isinstance(obj,UIA) and obj.UIAElement.cachedClassName in ("TouchEditInner", "PasswordBox") and obj.role==controlTypes.ROLE_EDITABLETEXT:
 				clsList.insert(0,Win8PasswordField)
 		# #6010: Allow Windows 10 version to be recognized as well.

--- a/source/appModules/logonui.py
+++ b/source/appModules/logonui.py
@@ -34,15 +34,17 @@ class LogonDialog(Dialog):
 
 		return super(LogonDialog, self).event_gainFocus()
 
+
 class Win8PasswordField(UIA):
 
-	#This UIA object has no invoke pattern, at least set focus.
+	# This UIA object has no invoke pattern, at least set focus.
 	# #6024: Affects both Windows 8.x and 10.
-	def doAction(self,index=None):
+	def doAction(self, index=None):
 		if not index:
 			self.setFocus()
 		else:
-			super(Win8PasswordField,self).doAction(index)
+			super().doAction(index)
+
 
 class XPPasswordField(IAccessible):
 

--- a/source/core.py
+++ b/source/core.py
@@ -435,8 +435,8 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 	log.debug("Initializing UIA support")
 	try:
 		UIAHandler.initialize()
-	except NotImplementedError:
-		log.warning("UIA not available")
+	except RuntimeError:
+		log.warning("UIA disabled in configuration")
 	except:
 		log.error("Error initializing UIA support", exc_info=True)
 	import IAccessibleHandler


### PR DESCRIPTION
### Link to issue number:
Split from #9968 
Fixes #10300 

### Summary of the issue:
In Windows XP and possibly older versions of Vista, UIA was not always available. Therefore,, the UIAHandler contained logic to deal with UIA not available.

### Description of how this pull request fixes the issue:
UIAHandler.isUIAAvailable has been removed, since it was always True, i.e. it depended on the comtypes wrapper being available. We only imported the contents of the comtypes wrapper when UIAHandler.isUIAAvailable was True. Code that used UIAHandler.isUIAAvailable now uses uiaHandler.handler or simply assumes that UIA is always there.

This is a necessary change for #9968, as Sphinx won't run otherwise.
More importantly though, while disabling UIA on ALPHA seemed to fail on my system, it no longer does now.

### Testing performed:
Tested running from source, with UIA enabled and disabled from config.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
    + UIAHandler.isUIAAvailable has been removed.