### PR TITLE
Initialize tones with a dedicated initialize method

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -146,6 +146,7 @@ def resetConfiguration(factoryDefaults=False):
 	import vision
 	import languageHandler
 	import inputCore
+	import tones
 	log.debug("Terminating vision")
 	vision.terminate()
 	log.debug("Terminating braille")
@@ -154,6 +155,8 @@ def resetConfiguration(factoryDefaults=False):
 	brailleInput.terminate()
 	log.debug("terminating speech")
 	speech.terminate()
+	log.debug("terminating tones")
+	tones.terminate()
 	log.debug("terminating addonHandler")
 	addonHandler.terminate()
 	log.debug("Reloading config")
@@ -165,6 +168,8 @@ def resetConfiguration(factoryDefaults=False):
 	languageHandler.setLanguage(lang)
 	# Addons
 	addonHandler.initialize()
+	# Tones
+	tones.initialize()
 	#Speech
 	log.debug("initializing speech")
 	speech.initialize()
@@ -227,9 +232,6 @@ def main():
 		except:
 			pass
 	logHandler.setLogLevelFromConfig()
-	log.debug("Initializing tones")
-	import tones
-	tones.initialize()
 	try:
 		lang = config.conf["general"]["language"]
 		import languageHandler
@@ -255,6 +257,9 @@ def main():
 	import NVDAHelper
 	log.debug("Initializing NVDAHelper")
 	NVDAHelper.initialize()
+	log.debug("Initializing tones")
+	import tones
+	tones.initialize()
 	import speechDictHandler
 	log.debug("Speech Dictionary processing")
 	speechDictHandler.initialize()
@@ -541,9 +546,6 @@ def main():
 	if updateCheck:
 		_terminate(updateCheck)
 
-	# Terminate tones early.
-	import tones
-	_terminate(tones)
 	_terminate(watchdog)
 	_terminate(globalPluginHandler, name="global plugin handler")
 	_terminate(gui)
@@ -567,6 +569,7 @@ def main():
 	_terminate(winConsoleHandler, name="Legacy winConsole support")
 	_terminate(JABHandler, name="Java Access Bridge support")
 	_terminate(appModuleHandler, name="app module handler")
+	_terminate(tones)
 	_terminate(NVDAHelper)
 	_terminate(touchHandler)
 	_terminate(keyboardHandler, name="keyboard handler")

--- a/source/core.py
+++ b/source/core.py
@@ -201,8 +201,11 @@ def _setInitialFocus():
 
 def main():
 	"""NVDA's core main loop.
-This initializes all modules such as audio, IAccessible, keyboard, mouse, and GUI. Then it initialises the wx application object and sets up the core pump, which checks the queues and executes functions when requested. Finally, it starts the wx main loop.
-"""
+	This initializes all modules such as audio, IAccessible, keyboard, mouse, and GUI.
+	Then it initialises the wx application object and sets up the core pump,
+	which checks the queues and executes functions when requested.
+	Finally, it starts the wx main loop.
+	"""
 	log.debug("Core starting")
 
 	ctypes.windll.user32.SetProcessDPIAware()
@@ -224,6 +227,9 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 		except:
 			pass
 	logHandler.setLogLevelFromConfig()
+	log.debug("Initializing tones")
+	import tones
+	tones.initialize()
 	try:
 		lang = config.conf["general"]["language"]
 		import languageHandler
@@ -535,6 +541,9 @@ This initializes all modules such as audio, IAccessible, keyboard, mouse, and GU
 	if updateCheck:
 		_terminate(updateCheck)
 
+	# Terminate tones early.
+	import tones
+	_terminate(tones)
 	_terminate(watchdog)
 	_terminate(globalPluginHandler, name="global plugin handler")
 	_terminate(gui)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1000,6 +1000,11 @@ class SynthesizerSelectionDialog(SettingsDialog):
 			config.conf['audio']['audioDuckingMode']=index
 			audioDucking.setAudioDuckingMode(index)
 
+		# Reinitialize the tones module to update the audio device
+		import tones
+		tones.terminate()
+		tones.initialize()
+
 		if self.IsModal():
 			# Hack: we need to update the synth in our parent window before closing.
 			# Otherwise, NVDA will report the old synth even though the new synth is reflected visually.

--- a/source/tones.py
+++ b/source/tones.py
@@ -1,8 +1,7 @@
-#tones.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Utilities to generate and play tones"""
 
@@ -15,16 +14,27 @@ from ctypes import create_string_buffer, byref
 
 SAMPLE_RATE = 44100
 
-try:
-	player = nvwave.WavePlayer(channels=2, samplesPerSec=int(SAMPLE_RATE), bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
-except:
-	log.warning("Failed to initialize audio for tones")
-	player = None
+player = None
+
+
+def initialize():
+	global player
+	try:
+		player = nvwave.WavePlayer(
+			channels=2,
+			samplesPerSec=int(SAMPLE_RATE),
+			bitsPerSample=16,
+			outputDevice=config.conf["speech"]["outputDevice"],
+			wantDucking=False
+		)
+	except Exception:
+		log.warning("Failed to initialize audio for tones", exc_info=True)
+		player = None
 
 # When exiting, ensure player is deleted before modules get cleaned up.
 # Otherwise, WavePlayer.__del__ will fail with an exception.
 @atexit.register
-def _cleanup():
+def terminate():
 	global player
 	player = None
 
@@ -38,7 +48,7 @@ def beep(hz,length,left=50,right=50):
 	@type left: integer
 	@param right: volume of the right channel (0 to 100)
 	@type right: integer
-	""" 
+	"""
 	log.io("Beep at pitch %s, for %s ms, left volume %s, right volume %s"%(hz,length,left,right))
 	if not player:
 		return


### PR DESCRIPTION
### Link to issue number:
Split from #9968 
Fixes #2167 

### Summary of the issue:
The tones module initializes at the module level, importing the module triggers initialization. This causes sphinx to spit warnings about it not being able to initialize tones. Theoretically while unit testing, this is also the case because the tones module is imported by several other modules used within the unit testing framework.

### Description of how this pull request fixes the issue:
Added a initialize method to tones. Rename the cleanup method to terminate. Made sure that initialization and termination takes place in core.

This change allows us to reinitialize tones when we change the audio output device.

### Testing performed:
Make sure that tones still play.

### Known issues with pull request:
None known

### Change log entry:
* Bug fixes
    + When changing the audio output device, tones played by NVDA will now play through the newly selected device. (#2167)
