### PR TITLE
Fix mistakes in doc strings

### DIFF
--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -23,7 +23,7 @@ def registerServer(fileName,wow64=False):
 	"""
 	Registers the COM proxy dll with the given file name
 	Using regsvr32.
-	@ param fileName: the path to the dll
+	@param fileName: the path to the dll
 	@type fileName: str
 	@param wow64: If true then the 32 bit (wow64) version of regsvr32 will be used.
 	@type wow64: bool
@@ -40,7 +40,7 @@ def applyRegistryPatch(fileName,wow64=False):
 	"""
 	Applies the registry patch with the given file name
 	using regedit.
-	@ param fileName: the path to the dll
+	@param fileName: the path to the dll
 	@type fileName: str
 	"""
 	regedit=os.path.join(sysWow64 if wow64 else systemRoot,'regedit.exe')

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -135,7 +135,8 @@ class UIATextInfo(textInfos.TextInfo):
 		@param textRange: the text range whos formatting should be fetched.
 		@type textRange: L{UIAutomation.IUIAutomationTextRange}
 		@param formatConfig: the types of formatting requested.
-		@type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@type formatConfig: a dictionary of NVDA document formatting configuration keys
+			with values set to true for those types that should be fetched.
 		@param ignoreMixedValues: If True, formatting that is mixed according to UI Automation will not be included. If False, L{UIAUtils.MixedAttributeError} will be raised if UI Automation gives back a mixed attribute value signifying that the caller may want to try again with a smaller range. 
 		@type: bool
 		@return: The formatting for the given text range.
@@ -448,7 +449,8 @@ class UIATextInfo(textInfos.TextInfo):
 		@param textRange: the UI Automation text range to walk.
 		@type textRange: L{UIAHandler.IUIAutomationTextRange}
 		@param formatConfig: the types of formatting requested.
-		@type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@type formatConfig: a dictionary of NVDA document formatting configuration keys
+			with values set to true for those types that should be fetched.
 		@param UIAFormatUnits: the UI Automation text units (in order of resolution) that should be used to split the text so as to avoid mixed attribute values. This is None by default.
 			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter. 
 			If this parameter is an empty list, then formatting and text is fetched for the entire range, but any mixed attribute values are ignored and no splitting occures.
@@ -502,14 +504,16 @@ class UIATextInfo(textInfos.TextInfo):
 		@param textRange: the UI Automation text range whos content should be fetched.
 		@type textRange: L{UIAHandler.IUIAutomation}
 		@param formatConfig: the types of formatting requested.
-		@type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@type formatConfig: a dictionary of NVDA document formatting configuration keys
+			with values set to true for those types that should be fetched.
 		@param includeRoot: If true, then a control start and end will be yielded for the root element.
 		@type includeRoot: bool
 		@param alwaysWalkAncestors: If true then control fields will be yielded for any element enclosing the given text range, that is a descendant of the root element. If false then the root element may be  assumed to be the only ancestor.
 		@type alwaysWalkAncestors: bool
 		@param recurseChildren: If true, this function will be recursively called for each child of the given text range, clipped to the bounds of this text range. Formatted text between the children will also be yielded. If false, only formatted text will be yielded.
 		@type recurseChildren: bool
-		@param _rootElementClipped: Indicates if textRange represents all of the given rootElement, or is clipped at the start or end.
+		@param _rootElementClipped: Indicates if textRange represents all of the given rootElement,
+			or is clipped at the start or end.
 		@type _rootElementClipped: 2-tuple
 		@rtype: A generator that yields L{textInfo.FieldCommand} objects and text strings.
 		"""

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -132,10 +132,10 @@ class UIATextInfo(textInfos.TextInfo):
 	def _getFormatFieldAtRange(self,textRange,formatConfig,ignoreMixedValues=False):
 		"""
 		Fetches formatting for the given UI Automation Text range.
-		@ param textRange: the text range whos formatting should be fetched.
+		@param textRange: the text range whos formatting should be fetched.
 		@type textRange: L{UIAutomation.IUIAutomationTextRange}
 		@param formatConfig: the types of formatting requested.
-		@ type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
 		@param ignoreMixedValues: If True, formatting that is mixed according to UI Automation will not be included. If False, L{UIAUtils.MixedAttributeError} will be raised if UI Automation gives back a mixed attribute value signifying that the caller may want to try again with a smaller range. 
 		@type: bool
 		@return: The formatting for the given text range.
@@ -385,10 +385,10 @@ class UIATextInfo(textInfos.TextInfo):
 	def _getControlFieldForObject(self, obj,isEmbedded=False,startOfNode=False,endOfNode=False):
 		"""
 		Fetch control field information for the given UIA NVDAObject.
-		@ param obj: the NVDAObject the control field is for.
+		@param obj: the NVDAObject the control field is for.
 		@type obj: L{UIA}
 		@param isEmbedded: True if this NVDAObject is for a leaf node (has no useful children).
-		@ type isEmbedded: bool
+		@type isEmbedded: bool
 		@param startOfNode: True if the control field represents the very start of this object.
 		@type startOfNode: bool
 		@param endOfNode: True if the control field represents the very end of this object.
@@ -448,7 +448,7 @@ class UIATextInfo(textInfos.TextInfo):
 		@param textRange: the UI Automation text range to walk.
 		@type textRange: L{UIAHandler.IUIAutomationTextRange}
 		@param formatConfig: the types of formatting requested.
-		@ type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
 		@param UIAFormatUnits: the UI Automation text units (in order of resolution) that should be used to split the text so as to avoid mixed attribute values. This is None by default.
 			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter. 
 			If this parameter is an empty list, then formatting and text is fetched for the entire range, but any mixed attribute values are ignored and no splitting occures.
@@ -502,9 +502,9 @@ class UIATextInfo(textInfos.TextInfo):
 		@param textRange: the UI Automation text range whos content should be fetched.
 		@type textRange: L{UIAHandler.IUIAutomation}
 		@param formatConfig: the types of formatting requested.
-		@ type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
+		@type formatConfig: a dictionary of NVDA document formatting configuration keys with values set to true for those types that should be fetched.
 		@param includeRoot: If true, then a control start and end will be yielded for the root element.
-		@ type includeRoot: bool
+		@type includeRoot: bool
 		@param alwaysWalkAncestors: If true then control fields will be yielded for any element enclosing the given text range, that is a descendant of the root element. If false then the root element may be  assumed to be the only ancestor.
 		@type alwaysWalkAncestors: bool
 		@param recurseChildren: If true, this function will be recursively called for each child of the given text range, clipped to the bounds of this text range. Formatted text between the children will also be yielded. If false, only formatted text will be yielded.

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -328,7 +328,8 @@ class ExcelQuicknavIterator(object):
 	def __init__(self, itemType , document , direction , includeCurrent):
 		"""
 		See L{QuickNavItemIterator} for itemType, document and direction definitions.
-		@param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
+		@param includeCurrent: if true then any item at the initial position will be also emitted
+			rather than just further ones.
 		"""
 		self.document=document
 		self.itemType=itemType
@@ -1106,7 +1107,8 @@ class ExcelCellInfoQuicknavIterator(object, metaclass=abc.ABCMeta):
 	def __init__(self, itemType , document , direction , includeCurrent):
 		"""
 		See L{QuickNavItemIterator} for itemType, document and direction definitions.
-		@param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
+		@param includeCurrent: if true then any item at the initial position will be also emitted
+			rather than just further ones.
 		"""
 		self.document=document
 		self.itemType=itemType

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -328,7 +328,7 @@ class ExcelQuicknavIterator(object):
 	def __init__(self, itemType , document , direction , includeCurrent):
 		"""
 		See L{QuickNavItemIterator} for itemType, document and direction definitions.
-		@ param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
+		@param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
 		"""
 		self.document=document
 		self.itemType=itemType
@@ -1106,7 +1106,7 @@ class ExcelCellInfoQuicknavIterator(object, metaclass=abc.ABCMeta):
 	def __init__(self, itemType , document , direction , includeCurrent):
 		"""
 		See L{QuickNavItemIterator} for itemType, document and direction definitions.
-		@ param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
+		@param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
 		"""
 		self.document=document
 		self.itemType=itemType

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -444,7 +444,7 @@ class WinWordCollectionQuicknavIterator(object):
 		"""
 		See L{QuickNavItemIterator} for itemType, document and direction definitions.
 		@param rangeObj: a Microsoft Word range object where the collection should be fetched from.
-		@ param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
+		@param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
 		"""
 		self.document=document
 		self.itemType=itemType

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -444,7 +444,8 @@ class WinWordCollectionQuicknavIterator(object):
 		"""
 		See L{QuickNavItemIterator} for itemType, document and direction definitions.
 		@param rangeObj: a Microsoft Word range object where the collection should be fetched from.
-		@param includeCurrent: if true then any item at the initial position will be also emitted rather than just further ones. 
+		@param includeCurrent: if true then any item at the initial position will be also emitted
+			rather than just further ones.
 		"""
 		self.document=document
 		self.itemType=itemType

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -276,7 +276,7 @@ class AddonBase(object):
 class Addon(AddonBase):
 	""" Represents an Add-on available on the file system."""
 	def __init__(self, path):
-		""" Constructs an L[Addon} from.
+		""" Constructs an L{Addon} from.
 		@param path: the base directory for the addon data.
 		@type path: string
 		"""
@@ -431,7 +431,7 @@ class Addon(AddonBase):
 		""" loads a python module from the addon directory
 		@param name: the module name
 		@type name: string
-		@returns the python module with C[name}
+		@returns the python module with C{name}
 		@rtype python module
 		"""
 		log.debug("Importing module %s from plugin %s", name, self.name)

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -171,7 +171,8 @@ class AudioDucker(object):
 		"""Tells NVDA that you require that background audio be ducked from now until you call disable.
 		This method may block for a short time while background audio ducks to a suitable level.
 		It is safe to call this method more than once.
-		@returns: True if ducking was enabled, false if ducking was subsiquently disabled while waiting for the background audio to drop.
+		@returns: True if ducking was enabled,
+			false if ducking was subsiquently disabled while waiting for the background audio to drop.
 		"""
 		debug = _isDebug()
 		with self._lock:

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -171,7 +171,7 @@ class AudioDucker(object):
 		"""Tells NVDA that you require that background audio be ducked from now until you call disable.
 		This method may block for a short time while background audio ducks to a suitable level.
 		It is safe to call this method more than once.
-		@ returns: True if ducking was enabled, false if ducking was subsiquently disabled while waiting for the background audio to drop.
+		@returns: True if ducking was enabled, false if ducking was subsiquently disabled while waiting for the background audio to drop.
 		"""
 		debug = _isDebug()
 		with self._lock:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -105,8 +105,8 @@ class QuickNavItem(object, metaclass=ABCMeta):
 	def __init__(self,itemType,document):
 		"""
 		@param itemType: the type that was searched for (e.g. link, heading, table etc)
-		@ type itemType: string
-		@ param document: the browse mode document this item is a part of.
+		@type itemType: string
+		@param document: the browse mode document this item is a part of.
 		@type document: L{BrowseModeTreeInterceptor}
 		"""
 		self.itemType=itemType
@@ -385,7 +385,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		@param itemType: the type being searched for (e.g. link, heading, table etc)
 		@type itemType: string
 		@param direction: the direction in which to search (next, previous, up)
-		@ type direction: string
+		@type direction: string
 		@param pos: the position in the document from where to start the search.
 		@type pos: Usually an L{textInfos.TextInfo} 
 		@raise NotImplementedError: This type is not supported by this BrowseMode implementation

--- a/source/installer.py
+++ b/source/installer.py
@@ -155,7 +155,7 @@ def removeOldLibFiles(destPath, rebootOK=False):
 	"""
 	Removes library files from previous versions of NVDA.
 	@param destPath: The path where NVDA is installed.
-	@ type destPath: string
+	@type destPath: string
 	@param rebootOK: If true then files can be removed on next reboot if trying to do so now fails.
 	@type rebootOK: boolean
 	"""


### PR DESCRIPTION
### Link to issue number:
Split from #9968 

### Summary of the issue:
Some doc strings contain mistakes, particularly spaces within epydoc directives.

### Description of how this pull request fixes the issue:
Fix these mistakes.
