### PR TITLE
I10578 fix braille viewer

### DIFF
--- a/source/brailleViewer/__init__.py
+++ b/source/brailleViewer/__init__.py
@@ -77,7 +77,7 @@ def _destroyGUI():
 	d: Optional[BrailleViewerFrame] = _brailleGui
 	_brailleGui = None
 	if d and not d.isDestroyed:
-		d.Destroy()
+		d.saveInfoAndDestroy()
 
 
 def destroyBrailleViewer():

--- a/source/brailleViewer/__init__.py
+++ b/source/brailleViewer/__init__.py
@@ -72,28 +72,23 @@ def update(cells: List[int], rawText: str):
 		)
 
 
-def _destroyGUI():
+def destroyBrailleViewer():
 	global _brailleGui
 	d: Optional[BrailleViewerFrame] = _brailleGui
-	_brailleGui = None
+	_brailleGui = None  # protect against re-entrance
 	if d and not d.isDestroyed:
 		d.saveInfoAndDestroy()
-
-
-def destroyBrailleViewer():
-	_destroyGUI()
-	postBrailleViewerToolToggledAction.notify(created=False)
 
 
 def _onGuiDestroyed():
 	""" Used as a callback from L{BrailleViewerFrame}, lets us know that the GUI initiated a destruction.
 	"""
-	global _brailleGui
-	if _brailleGui:
-		# Destruction wasn't initiated from L{_destroyGUI} ie not through direct user action.
-		# It's likely that the window received a shutdown event that could not be skipped.
-		# Continue to destroy the braille viewer.
-		destroyBrailleViewer()
+	# In case this destruction wasn't initiated by L{destroyBrailleViewer}, do any necessary clean up.
+	# the destruction may have been triggered by alt+F4 on the window,
+	# or selecting close from the taskbar jumplist.
+	destroyBrailleViewer()
+	# Ensure that the GUI knows about it
+	postBrailleViewerToolToggledAction.notify(created=False)
 
 
 def _getDisplaySize():
@@ -112,7 +107,7 @@ def createBrailleViewerTool():
 
 	global _brailleGui
 	if _brailleGui:
-		_destroyGUI()
+		destroyBrailleViewer()
 
 	_brailleGui = BrailleViewerFrame(
 		_getDisplaySize(),

--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -185,17 +185,20 @@ class BrailleViewerFrame(wx.Frame):
 
 	isDestroyed: bool = False
 
+	def saveInfoAndDestroy(self):
+		self._savePositionInformation()
+		self.isDestroyed = True
+		self.Destroy()
+
 	def _onClose(self, evt):
 		log.debug("braille viewer gui onclose")
 		if not evt.CanVeto():
-			self.isDestroyed = True
-			self.Destroy()
+			self.saveInfoAndDestroy()
 			return
 		evt.Veto()
 
 	def _onDestroy(self, evt):
 		log.debug("braille viewer gui destroyed")
-		self._savePositionInformation()
 		self.isDestroyed = True
 		self._notifyOfDestroyed()
 		evt.Skip()

--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -192,13 +192,10 @@ class BrailleViewerFrame(wx.Frame):
 
 	def _onClose(self, evt):
 		log.debug("braille viewer gui onclose")
-		if not evt.CanVeto():
-			self.saveInfoAndDestroy()
-			return
-		evt.Veto()
+		self.saveInfoAndDestroy()
 
 	def _onDestroy(self, evt):
-		log.debug("braille viewer gui destroyed")
+		log.debug("braille viewer gui onDestroy")
 		self.isDestroyed = True
 		self._notifyOfDestroyed()
 		evt.Skip()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -571,6 +571,9 @@ def initialize():
 	wx.GetApp().SetTopWindow(mainFrame)
 
 def terminate():
+	import brailleViewer
+	brailleViewer.destroyBrailleViewer()
+
 	for instance, state in gui.SettingsDialog._instances.items():
 		if state is gui.SettingsDialog._DIALOG_DESTROYED_STATE:
 			log.error(

--- a/source/setup.py
+++ b/source/setup.py
@@ -228,6 +228,7 @@ setup(
 		("libArm64/%s"%version, glob("libArm64/*.dll") + glob("libArm64/*.exe")),
 		("waves", glob("waves/*.wav")),
 		("images", glob("images/*.ico")),
+		("fonts", glob("fonts/*.ttf")),
 		("louis/tables",glob("louis/tables/*")),
 		("COMRegistrationFixes", glob("COMRegistrationFixes/*.reg")),
 		(".", glob("../miscDeps/python/*.dll")),


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10578 

### Summary of the issue:
- Font files were not included in the installer.
- Font files were not released when NVDA exits.
- An error occurs when using tools menu to close the braille viewer

### Description of how this pull request fixes the issue:
- Add font files to installer, in `setup.py` `data_files`.
- Use `AddFontResourceExW` with `FR_PRIVATE` argument to specify that fonts are just for this process and the system should unload them when the process exits.
- Some jiggling of the order for saving data / cleanup during destruction.

### Testing performed:
1. Ran NVDA from launcher, verified that the font is correct.
1. Ran NVDA from source, verified that the font file could be deleted from the `source/fonts` directory after exiting NVDA.
1. Ran NVDA from source with "show braille viewer on startup", moved the braille viewer window, restarted NVDA. Window was in the same position.
1. Ran NVDA from source with "show braille viewer on startup", moved the braille viewer window, closed then opened braille viewer via tools menu. Window was in the same position.
1. Ran NVDA from source without "show braille viewer on startup", opened, moved window, then closed braille viewer via tools menu. Window was in the same position.

### Known issues with pull request:

### Change log entry:

None

