### PR TITLE
Update espeak

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ For reference, the following run time dependencies are included in Git submodule
 
 * [comtypes](https://github.com/enthought/comtypes), version 1.1.7
 * [wxPython](https://www.wxpython.org/), version 4.0.3
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.50
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit ca65812a
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

### Summary of the issue:
We have had some requests to update eSpeak to include a merged PR (espeak-ng/espeak-ng/pull#682) that missed out on being included in the 1.50 eSpeak releas. This PR only updates rules for Shan language.

### Description of how this pull request fixes the issue:
Updates eSpeak to commit ca65812ac6019926f2fbd7f12c92d7edd3701e0c
Updates the readme to point to this changed dependency.

### Testing performed:
Built and ran NVDA from source with espeak synthesizer.

### Known issues with pull request:
None

### Change log entry:
`eSpeak has been updated to version 1.51-dev, commit ca65812ac6019926f2fbd7f12c92d7edd3701e0c`
