### PR TITLE
Remove Mozilla specific setFocus implementation which waits for a focus event before returning.

### DIFF
--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -17,38 +17,10 @@ from logHandler import log
 import textInfos.offsets
 from NVDAObjects.behaviors import RowWithFakeNavigation
 from virtualBuffers import VirtualBuffer
-import api
 from . import IA2TextTextInfo
 from . import ia2Web
 
 class Mozilla(ia2Web.Ia2Web):
-
-	def _getPhysicalFocus(self):
-		try:
-			paccParent=self.IAccessibleObject.accParent
-		except COMError:
-			paccParent=None
-		if not paccParent:
-			return
-		try:
-			paccFocus=paccParent.accFocus
-		except COMError:
-			paccFocus=None
-		if not paccFocus:
-			return
-		return IAccessible(IAccessibleObject=IAccessibleHandler.normalizeIAccessible(paccFocus),IAccessibleChildID=0)
-
-	def setFocus(self):
-		oldFocus=self._getPhysicalFocus()
-		super(Mozilla,self).setFocus()
-		# Although all versions of Firefox block inSetFocus or in accFocus until    the physical focus has moved,
-		# Firefox 57 and above return before they fire a focus winEvent communicating the focus change to ATs.
-		# Therefore, If the call to setFocus did change the physical focus,
-		# Wait for a focus event to be queued to NVDA before returning.
-		newFocus=self._getPhysicalFocus()
-		if newFocus and newFocus!=oldFocus:
-			while not eventHandler.isPendingEvents("gainFocus"):
-				api.processPendingEvents(processEventQueue=False)
 
 	def _get_parent(self):
 		#Special code to support Mozilla node_child_of relation (for comboboxes)


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
This setFocus override was added in #8678 to mitigate focus "rubber-banding" and spurious switching to focus mode when moving fast in browse mode. However, this degrades performance in Firefox.

### Description of how this pull request fixes the issue:
This PR simply removes this code. We (@MarcoZehe and I) tested with this code removed for several hours in both normal daily usage and intentionally rapid usage. The rubber-banding/spurious focus mode switching no longer seem to be a problem.

It's likely that changes in Firefox, NVDA or both mitigated this. The changes to Firefox to avoid extraneous tree re-creation are a likely candidate, though I know there was also some refactoring of NVDA's focus handling code for browse mode.

### Testing performed:
See above.

### Known issues with pull request:
It's possible that we'll see the same issues this code was originally added to mitigate. However, it's worth noting that Chrome also sets focus asynchronously. I confirmed this by calling setFocus and then checking the focused state immediately afterwards. My best guess is that extraneous tree re-creation in older Firefox versions was causing enough of a perf hit to trigger these problems in Firefox... or perhaps Firefox was actually generating a new accessible for the focus when this occurred, which would have been even worse.

### Change log entry:
Bug fixes:
`- In Mozilla Firefox, moving focus in browse mode is faster. This makes moving the cursor in browse mode more responsive in many cases.`