### PR TITLE
I10582 fix tab traversal in speech viewer

### DIFF
--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -53,38 +53,45 @@ class BrailleViewerFrame(wx.Frame):
 		self._brailleOutputLastSet = BRAILLE_INIT_CHARACTER * numCells
 		self._rawTextOutputLastSet = SPACE_CHARACTER
 
-		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		self.frameContentsSizer = wx.BoxSizer(wx.HORIZONTAL)
+		self.SetSizer(self.frameContentsSizer)
+		self.panel = wx.Panel(self)
+		self.frameContentsSizer.Add(self.panel, proportion=1, flag=wx.EXPAND)
+
+		self.panelContentsSizer = wx.BoxSizer(wx.VERTICAL)
+		self.panel.SetSizer(self.panelContentsSizer)
+
 		borderSizer = wx.BoxSizer(wx.VERTICAL)
-		mainSizer.Add(
+		self.panelContentsSizer .Add(
 			borderSizer,
 			proportion=1,
 			flag=wx.EXPAND | wx.ALL,
 			border=5,
 		)
-		self._brailleOutput = wx.StaticText(self, label=self._brailleOutputLastSet)
+		self._createControls(borderSizer, self.panel)
+		self.ShowWithoutActivating()
+
+	def _createControls(self, sizer, parent):
+		self._brailleOutput = wx.StaticText(parent, label=self._brailleOutputLastSet)
 		self._brailleOutput.Font = self._setBrailleFont(self._brailleOutput.GetFont())
 		log.debug(f"Font for braille: {self._brailleOutput.Font.GetNativeFontInfoUserDesc()}")
-		borderSizer.Add(self._brailleOutput, flag=wx.EXPAND, proportion=1)
+		sizer.Add(self._brailleOutput, flag=wx.EXPAND, proportion=1)
 
-		self._rawTextOutput = wx.StaticText(self, label=self._rawTextOutputLastSet)
+		self._rawTextOutput = wx.StaticText(parent, label=self._rawTextOutputLastSet)
 		self._rawTextOutput.Font = self._setRawTextFont(self._rawTextOutput.Font)
 		log.debug(f"Font for raw text: {self._rawTextOutput.Font.GetNativeFontInfoUserDesc()}")
-		borderSizer.Add(self._rawTextOutput, flag=wx.EXPAND, proportion=1)
+		sizer.Add(self._rawTextOutput, flag=wx.EXPAND, proportion=1)
 
 		# Translators: The label for a setting in the braille viewer that controls
 		# whether the braille viewer is shown at startup or not.
 		showOnStartupCheckboxLabel = _("&Show Braille Viewer on Startup")
 		self._shouldShowOnStartupCheckBox = wx.CheckBox(
-			parent=self,
+			parent=parent,
 			label=showOnStartupCheckboxLabel)
 		self._shouldShowOnStartupCheckBox.SetValue(config.conf["brailleViewer"]["showBrailleViewerAtStartup"])
 		self._shouldShowOnStartupCheckBox.Bind(wx.EVT_CHECKBOX, self._onShouldShowOnStartupChanged)
-		borderSizer.AddSpacer(5)
-		borderSizer.Add(self._shouldShowOnStartupCheckBox)
-
-		mainSizer.Fit(self)
-		self.Sizer = mainSizer
-		self.ShowWithoutActivating()
+		sizer.AddSpacer(5)
+		sizer.Add(self._shouldShowOnStartupCheckBox)
 
 	def _onShouldShowOnStartupChanged(self, evt):
 		config.conf["brailleViewer"]["showBrailleViewerAtStartup"] = self._shouldShowOnStartupCheckBox.IsChecked()

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -11,10 +11,10 @@ from logHandler import log
 from speech import SpeechSequence
 
 
-# Inherit from wx.Frame because these windows show in the alt+tab menu (where miniFrame does not)
 # wx.Dialog causes a crash on destruction when multiple were created at the same time (brailleViewer
 # may start at the same time)
-class SpeechViewerFrame(wx.Frame):
+# Use wx.Dialog because it provides tab ordering of controls
+class SpeechViewerFrame(wx.Dialog):
 
 	def __init__(self, onDestroyCallBack):
 		dialogSize=wx.Size(500, 500)
@@ -24,21 +24,35 @@ class SpeechViewerFrame(wx.Frame):
 			speechViewSection = config.conf["speechViewer"]
 			dialogSize = wx.Size(speechViewSection["width"], speechViewSection["height"])
 			dialogPos = wx.Point(x=speechViewSection["x"], y=speechViewSection["y"])
-		super(SpeechViewerFrame, self).__init__(gui.mainFrame, wx.ID_ANY, _("NVDA Speech Viewer"), size=dialogSize, pos=dialogPos, style=wx.CAPTION | wx.RESIZE_BORDER | wx.STAY_ON_TOP)
+		super().__init__(
+			gui.mainFrame,
+			title=_("NVDA Speech Viewer"),
+			size=dialogSize,
+			pos=dialogPos,
+			style=wx.CAPTION | wx.RESIZE_BORDER | wx.STAY_ON_TOP
+		)
 		self.onDestroyCallBack = onDestroyCallBack
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.Bind(wx.EVT_WINDOW_DESTROY, self.onDestroy)
 		sizer = wx.BoxSizer(wx.VERTICAL)
-		self.textCtrl = wx.TextCtrl(self, -1,style=wx.TE_RICH2|wx.TE_READONLY|wx.TE_MULTILINE)
+		self.textCtrl = wx.TextCtrl(self, style=wx.TE_RICH2 | wx.TE_READONLY | wx.TE_MULTILINE)
 		sizer.Add(self.textCtrl, proportion=1, flag=wx.EXPAND)
-		# Translators: The label for a setting in the speech viewer that controls whether the speech viewer is shown at startup or not.
-		self.shouldShowOnStartupCheckBox = wx.CheckBox(self,wx.ID_ANY,label=_("&Show Speech Viewer on Startup"))
+		# Translators: The label for a setting in the speech viewer that controls
+		# whether the speech viewer is shown at startup or not.
+		self.shouldShowOnStartupCheckBox = wx.CheckBox(self, label=_("&Show Speech Viewer on Startup"))
 		self.shouldShowOnStartupCheckBox.SetValue(config.conf["speechViewer"]["showSpeechViewerAtStartup"])
 		self.shouldShowOnStartupCheckBox.Bind(wx.EVT_CHECKBOX, self.onShouldShowOnStartupChanged)
 		sizer.Add(self.shouldShowOnStartupCheckBox, border=5, flag=wx.ALL)
-		# set the check box as having focus, by default the textCtrl has focus which stops the speechviewer output (even if another window is in focus)
+		# Set the check box as having focus, by default the textCtrl has focus which
+		# stops the speechviewer output (even if another window is in focus)
 		self.shouldShowOnStartupCheckBox.SetFocus()
-		self.SetSizer(sizer)
+		self.SetSizerAndFit(sizer)
+		# The initial size needs to be set again, otherwise the dialog is reduced to it's minimum size.
+		# This seems like a bug in WX.
+		self.SetInitialSize(dialogSize)
+		self.FitInside()
+		# Dont let speech viewer to steal keyboard focus, though when opening from tools menu, it STILL steals
+		# keyboard focus.
 		self.ShowWithoutActivating()
 
 	def onClose(self, evt):

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -11,19 +11,24 @@ from logHandler import log
 from speech import SpeechSequence
 
 
+# Inherit from wx.Frame because these windows show in the alt+tab menu (where miniFrame does not)
+# We have to manually add a wx.Panel to get correct tab ordering behaviour.
 # wx.Dialog causes a crash on destruction when multiple were created at the same time (brailleViewer
 # may start at the same time)
-# Use wx.Dialog because it provides tab ordering of controls
-class SpeechViewerFrame(wx.Dialog):
+class SpeechViewerFrame(wx.Frame):
 
-	def __init__(self, onDestroyCallBack):
-		dialogSize=wx.Size(500, 500)
-		dialogPos=wx.DefaultPosition
+	def _getDialogSizeAndPosition(self):
+		dialogSize = wx.Size(500, 500)
+		dialogPos = wx.DefaultPosition
 		if not config.conf["speechViewer"]["autoPositionWindow"] and self.doDisplaysMatchConfig():
 			log.debug("Setting speechViewer window position")
 			speechViewSection = config.conf["speechViewer"]
 			dialogSize = wx.Size(speechViewSection["width"], speechViewSection["height"])
 			dialogPos = wx.Point(x=speechViewSection["x"], y=speechViewSection["y"])
+		return dialogSize, dialogPos
+
+	def __init__(self, onDestroyCallBack):
+		dialogSize, dialogPos = self._getDialogSizeAndPosition()
 		super().__init__(
 			gui.mainFrame,
 			title=_("NVDA Speech Viewer"),
@@ -31,29 +36,61 @@ class SpeechViewerFrame(wx.Dialog):
 			pos=dialogPos,
 			style=wx.CAPTION | wx.RESIZE_BORDER | wx.STAY_ON_TOP
 		)
+		self._isDestroyed = False
 		self.onDestroyCallBack = onDestroyCallBack
 		self.Bind(wx.EVT_CLOSE, self.onClose)
 		self.Bind(wx.EVT_WINDOW_DESTROY, self.onDestroy)
-		sizer = wx.BoxSizer(wx.VERTICAL)
-		self.textCtrl = wx.TextCtrl(self, style=wx.TE_RICH2 | wx.TE_READONLY | wx.TE_MULTILINE)
-		sizer.Add(self.textCtrl, proportion=1, flag=wx.EXPAND)
-		# Translators: The label for a setting in the speech viewer that controls
-		# whether the speech viewer is shown at startup or not.
-		self.shouldShowOnStartupCheckBox = wx.CheckBox(self, label=_("&Show Speech Viewer on Startup"))
-		self.shouldShowOnStartupCheckBox.SetValue(config.conf["speechViewer"]["showSpeechViewerAtStartup"])
-		self.shouldShowOnStartupCheckBox.Bind(wx.EVT_CHECKBOX, self.onShouldShowOnStartupChanged)
-		sizer.Add(self.shouldShowOnStartupCheckBox, border=5, flag=wx.ALL)
-		# Set the check box as having focus, by default the textCtrl has focus which
-		# stops the speechviewer output (even if another window is in focus)
-		self.shouldShowOnStartupCheckBox.SetFocus()
-		self.SetSizerAndFit(sizer)
-		# The initial size needs to be set again, otherwise the dialog is reduced to it's minimum size.
-		# This seems like a bug in WX.
-		self.SetInitialSize(dialogSize)
-		self.FitInside()
-		# Dont let speech viewer to steal keyboard focus, though when opening from tools menu, it STILL steals
-		# keyboard focus.
+		self.Bind(wx.EVT_ACTIVATE, self._onDialogActivated, source=self)
+
+		self.frameContentsSizer = wx.BoxSizer(wx.HORIZONTAL)
+		self.SetSizer(self.frameContentsSizer)
+		self.panel = wx.Panel(self)
+		self.frameContentsSizer.Add(self.panel, proportion=1, flag=wx.EXPAND)
+
+		self.panelContentsSizer = wx.BoxSizer(wx.VERTICAL)
+		self.panel.SetSizer(self.panelContentsSizer)
+
+		self._createControls(sizer=self.panelContentsSizer, parent=self.panel)
+
+		# Don't let speech viewer to steal keyboard focus when opened
 		self.ShowWithoutActivating()
+
+	def _createControls(self, sizer, parent):
+		self.textCtrl = wx.TextCtrl(
+			parent,
+			style=wx.TE_RICH2 | wx.TE_READONLY | wx.TE_MULTILINE
+		)
+		sizer.Add(
+			self.textCtrl,
+			proportion=1,
+			flag=wx.EXPAND
+		)
+
+		self.shouldShowOnStartupCheckBox = wx.CheckBox(
+			parent,
+			# Translators: The label for a setting in the speech viewer that controls
+			# whether the speech viewer is shown at startup or not.
+			label=_("&Show Speech Viewer on Startup")
+		)
+		sizer.Add(
+			self.shouldShowOnStartupCheckBox,
+			border=5,
+			flag=wx.EXPAND | wx.ALL
+		)
+		self.shouldShowOnStartupCheckBox.SetValue(config.conf["speechViewer"]["showSpeechViewerAtStartup"])
+		self.shouldShowOnStartupCheckBox.Bind(
+			wx.EVT_CHECKBOX,
+			self.onShouldShowOnStartupChanged
+		)
+
+	def _onDialogActivated(self, evt):
+		# Check for destruction, if the speechviewer window has focus when we exit NVDA it regains focus briefly
+		# when the quit NVDA dialog disappears. Then shouldShowOnStartupCheckBox is a deleted window when we
+		# try to setFocus
+		if not self._isDestroyed:
+			# focus is normally set to the first child, however,
+			# the checkbox gives more context, and makes it obvious how to stop showing the dialog.
+			self.shouldShowOnStartupCheckBox.SetFocus()
 
 	def onClose(self, evt):
 		if not evt.CanVeto():
@@ -64,7 +101,10 @@ class SpeechViewerFrame(wx.Dialog):
 	def onShouldShowOnStartupChanged(self, evt):
 		config.conf["speechViewer"]["showSpeechViewerAtStartup"] = self.shouldShowOnStartupCheckBox.IsChecked()
 
+	_isDestroyed: bool
+
 	def onDestroy(self, evt):
+		self._isDestroyed = True
 		log.debug("SpeechViewer destroyed")
 		self.onDestroyCallBack()
 		evt.Skip()


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#10582 

### Summary of the issue:
wx.Frame does not handle tab ordering automatically. 

### Description of how this pull request fixes the issue:
Use a wx.panel to provide this.

### Testing performed:
Ran from source.

### Known issues with pull request:
None

### Change log entry:
None necessary.

