### PR TITLE
Fix some formatting issues in English user guide and some misspellings in the vision section.

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -761,7 +761,7 @@ Pressing dot 7 + dot 8 translates any braille input, but without adding a space 
 %kc:endInclude
 
 + Vision +[Vision]
-While NVDA is primairly aimed at blind or vision impaired people how primarily use speech and/or braille to operate a computer, it also provides built-in facilities to change the contents of the screen.
+While NVDA is primarily aimed at blind or vision impaired people who primarily use speech and/or braille to operate a computer, it also provides built-in facilities to change the contents of the screen.
 Within NVDA, such a visual aid is called a vision enhancement provider.
 
 NVDA offers several built-in vision enhancement providers which are described below.
@@ -1061,7 +1061,7 @@ The available logging levels are:
  - If you are concerned about privacy, do not set the logging level to this option.
 - Debug: In addition to info, warning, and input/output messages, additional debug messages will be logged.
  - Just like input/output, if you are concerned about privacy, you should not set the logging level to this option.
--
+
 
 ==== Automatically start NVDA after I log on to Windows ====[GeneralSettingsStartAfterLogOn]
 If this option is enabled, NVDA will start automatically as soon as you log on to Windows.
@@ -1543,6 +1543,7 @@ Many Windows and controls show a small message (or tooltip) when you move the mo
 This checkbox, when checked, tells NVDA to report help balloons and toast notifications as they appear.
 - Help Balloons are like tooltips, but are usually larger in size, and are associated with system events such as a network cable being unplugged, or perhaps to alert you about Windows security issues.
 - Toast notifications have been introduced in Windows 10 and appear in the notification center in the system tray, informing about several events (i.e. if an update has been downloaded, a new e-mail arived in your inbox, etc.).
+
 
 ==== Report Object Shortcut Keys ====[ObjectPresentationShortcutKeys]
 When this checkbox is checked, NVDA will include the shortcut key that is associated with a certain object or control when it is reported.


### PR DESCRIPTION

### Link to issue number:
Fixes #10587 
### Summary of the issue:
#10130 introduced some errors in T2T syntax in the User guide causing some headings and lists not to be formatted correctly.
Additionally there were some spelling mistakes in the vision section.
### Description of how this pull request fixes the issue:
T2T syntax has been fixed along with spelling mistakes in the vision section.

### Testing performed:
Compiled user guide to html. Ensured that headings and lists are rendered correctly.

### Known issues with pull request:
None known
### Change log entry:
None needed.