### PR TITLE
Refactor more speech functions

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -65,7 +65,7 @@ class _ObjectsReader(object):
 		if not obj:
 			return
 		# Call this method again when we start speaking this object.
-		callbackCommand = speech.CallbackCommand(self.next)
+		callbackCommand = speech.CallbackCommand(self.next, name="say-all:next")
 		speech.speakObject(obj, reason=controlTypes.REASON_SAYALL, _prefixSpeechCommand=callbackCommand)
 
 	def stop(self):
@@ -135,14 +135,17 @@ class _TextReader(object):
 			# No more text.
 			if isinstance(self.reader.obj, textInfos.DocumentWithPageTurns):
 				# Once the last line finishes reading, try turning the page.
-				cb = speech.CallbackCommand(self.turnPage)
+				cb = speech.CallbackCommand(self.turnPage, name="say-all:turnPage")
 				speech.speakWithoutPauses([cb, speech.EndUtteranceCommand()])
 			else:
 				self.finish()
 			return
 		# Call lineReached when we start speaking this line.
 		# lineReached will move the cursor and trigger reading of the next line.
-		cb = speech.CallbackCommand(lambda obj=self.reader.obj, state=self.speakTextInfoState.copy(): self.lineReached(obj,bookmark, state))
+		cb = speech.CallbackCommand(
+			lambda obj=self.reader.obj, state=self.speakTextInfoState.copy(): self.lineReached(obj, bookmark, state),
+			name="say-all:lineReached"
+		)
 		spoke = speech.speakTextInfo(self.reader, unit=textInfos.UNIT_READINGCHUNK,
 			reason=controlTypes.REASON_SAYALL, _prefixSpeechCommand=cb,
 			useCache=self.speakTextInfoState)
@@ -198,7 +201,7 @@ class _TextReader(object):
 		# Otherwise, if a different synth is being used for say all,
 		# we might switch synths too early and truncate the final speech.
 		# We do this by putting a CallbackCommand at the start of a new utterance.
-		cb = speech.CallbackCommand(self.stop)
+		cb = speech.CallbackCommand(self.stop, name="say-all:stop")
 		speech.speakWithoutPauses([speech.EndUtteranceCommand(), cb,
 			speech.EndUtteranceCommand()])
 

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -282,9 +282,6 @@ def getCharDescListFromText(text,locale):
 	return charDescList
 
 
-# C901 'speakObjectProperties' is too complex
-# Note: when working on speakObjectProperties, look for opportunities to simplify
-# and move logic out into smaller helper functions.
 def speakObjectProperties(  # noqa: C901
 		obj,
 		reason: str = controlTypes.REASON_QUERY,
@@ -292,6 +289,25 @@ def speakObjectProperties(  # noqa: C901
 		priority: Optional[Spri] = None,
 		**allowedProperties
 ):
+	speechSequence = getObjectPropertiesSpeech(
+		obj,
+		reason,
+		_prefixSpeechCommand,
+		**allowedProperties,
+	)
+	if speechSequence:
+		speak(speechSequence, priority=priority)
+
+
+# C901 'getObjectPropertiesSpeech' is too complex
+# Note: when working on getObjectPropertiesSpeech, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def getObjectPropertiesSpeech(  # noqa: C901
+		obj,
+		reason: str = controlTypes.REASON_QUERY,
+		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+		**allowedProperties
+) -> SpeechSequence:
 	#Fetch the values for all wanted properties
 	newPropertyValues={}
 	positionInfo=None
@@ -338,7 +354,7 @@ def speakObjectProperties(  # noqa: C901
 	obj._speakObjectPropertiesCache=cachedPropertyValues
 	#If we should only cache we can stop here
 	if reason==controlTypes.REASON_ONLYCACHE:
-		return
+		return []
 	#If only speaking change, then filter out all values that havn't changed
 	if reason==controlTypes.REASON_CHANGE:
 		for name in set(newPropertyValues)&set(oldCachedPropertyValues):
@@ -384,7 +400,7 @@ def speakObjectProperties(  # noqa: C901
 	if speechSequence:
 		if _prefixSpeechCommand is not None:
 			speechSequence.insert(0, _prefixSpeechCommand)
-		speak(speechSequence, priority=priority)
+	return speechSequence
 
 
 def _speakPlaceholderIfEmpty(

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -517,41 +517,43 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		"columnSpan": True,
 		"current": True
 	}
-
-	if reason==controlTypes.REASON_FOCUSENTERED:
-		allowProperties["value"]=False
-		allowProperties["keyboardShortcut"]=False
-		allowProperties["positionInfo_level"]=False
+	if reason == controlTypes.REASON_FOCUSENTERED:
+		allowProperties["value"] = False
+		allowProperties["keyboardShortcut"] = False
+		allowProperties["positionInfo_level"] = False
 	if not config.conf["presentation"]["reportObjectDescriptions"]:
-		allowProperties["description"]=False
+		allowProperties["description"] = False
 	if not config.conf["presentation"]["reportKeyboardShortcuts"]:
-		allowProperties["keyboardShortcut"]=False
+		allowProperties["keyboardShortcut"] = False
 	if not config.conf["presentation"]["reportObjectPositionInformation"]:
-		allowProperties["positionInfo_level"]=False
-		allowProperties["positionInfo_indexInGroup"]=False
-		allowProperties["positionInfo_similarItemsInGroup"]=False
-	if reason!=controlTypes.REASON_QUERY:
-		allowProperties["rowCount"]=False
-		allowProperties["columnCount"]=False
-	formatConf=config.conf["documentFormatting"]
+		allowProperties["positionInfo_level"] = False
+		allowProperties["positionInfo_indexInGroup"] = False
+		allowProperties["positionInfo_similarItemsInGroup"] = False
+	if reason != controlTypes.REASON_QUERY:
+		allowProperties["rowCount"] = False
+		allowProperties["columnCount"] = False
+	formatConf = config.conf["documentFormatting"]
 	if not formatConf["reportTableCellCoords"]:
-		allowProperties["cellCoordsText"]=False
+		allowProperties["cellCoordsText"] = False
 		# rowNumber and columnNumber might be needed even if we're not reporting coordinates.
-		allowProperties["includeTableCellCoords"]=False
+		allowProperties["includeTableCellCoords"] = False
 	if not formatConf["reportTableHeaders"]:
-		allowProperties["rowHeaderText"]=False
-		allowProperties["columnHeaderText"]=False
+		allowProperties["rowHeaderText"] = False
+		allowProperties["columnHeaderText"] = False
 	if (
 		not formatConf["reportTables"]
-		or (not formatConf["reportTableCellCoords"] and not formatConf["reportTableHeaders"])
+		or (
+			not formatConf["reportTableCellCoords"]
+			and not formatConf["reportTableHeaders"]
+		)
 	):
 		# We definitely aren't reporting any table info at all.
-		allowProperties["rowNumber"]=False
-		allowProperties["columnNumber"]=False
-		allowProperties["rowSpan"]=False
-		allowProperties["columnSpan"]=False
+		allowProperties["rowNumber"] = False
+		allowProperties["columnNumber"] = False
+		allowProperties["rowSpan"] = False
+		allowProperties["columnSpan"] = False
 	if shouldReportTextContent:
-		allowProperties['value']=False
+		allowProperties['value'] = False
 	return allowProperties
 
 

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -899,7 +899,7 @@ class SpeakTextInfoState(object):
 		return self.__class__(self)
 
 
-def _speakTextInfo_addMath(
+def _extendSpeechSequence_addMathForTextInfo(
 		speechSequence: SpeechSequence, info: textInfos.TextInfo, field: textInfos.Field
 ) -> None:
 	import mathPres
@@ -1048,7 +1048,7 @@ def speakTextInfo(  # noqa: C901
 				shouldConsiderTextInfoBlank = False
 			if field.get("role")==controlTypes.ROLE_MATH:
 				shouldConsiderTextInfoBlank = False
-				_speakTextInfo_addMath(speechSequence,info,field)
+				_extendSpeechSequence_addMathForTextInfo(speechSequence, info, field)
 
 	# When true, we are inside a clickable field, and should therefore not announce any more new clickable fields
 	inClickable=False
@@ -1077,7 +1077,7 @@ def speakTextInfo(  # noqa: C901
 			shouldConsiderTextInfoBlank = False
 		if field.get("role")==controlTypes.ROLE_MATH:
 			shouldConsiderTextInfoBlank = False
-			_speakTextInfo_addMath(speechSequence,info,field)
+			_extendSpeechSequence_addMathForTextInfo(speechSequence, info, field)
 		commonFieldCount+=1
 
 	#Fetch the text for format field attributes that have changed between what was previously cached, and this textInfo's initialFormatField.
@@ -1201,7 +1201,7 @@ def speakTextInfo(  # noqa: C901
 						lastLanguage=None
 					relativeSpeechSequence.extend(fieldSequence)
 				if command.command=="controlStart" and command.field.get("role")==controlTypes.ROLE_MATH:
-					_speakTextInfo_addMath(relativeSpeechSequence,info,command.field)
+					_extendSpeechSequence_addMathForTextInfo(relativeSpeechSequence, info, command.field)
 				if autoLanguageSwitching and newLanguage!=lastLanguage:
 					relativeSpeechSequence.append(LangChangeCommand(newLanguage))
 					lastLanguage=newLanguage

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -51,8 +51,8 @@ from .commands import (  # noqa: F401
 )
 
 from . import types
-from .types import SpeechSequence
-from typing import Optional, Dict, List, Any
+from .types import SpeechSequence, SequenceItemT
+from typing import Optional, Dict, List, Any, Generator
 from logHandler import log
 import config
 import aria
@@ -196,7 +196,7 @@ def getSpeechForSpelling(  # noqa: C901
 		text: str,
 		locale: Optional[str] = None,
 		useCharacterDescriptions: bool = False
-):
+) -> Generator[SequenceItemT, None, None]:
 	defaultLanguage=getCurrentLanguage()
 	if not locale or (not config.conf['speech']['autoDialectSwitching'] and locale.split('_')[0]==defaultLanguage.split('_')[0]):
 		locale=defaultLanguage

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -721,13 +721,33 @@ def speakPreselectedText(
 	inform a user that the newly focused control has content that is selected,
 	which they may unintentionally overwrite.
 
-	@remarks: Implemented using L{speakSelectionMessage}, which allows for
-		speaking text with an arbitrary attached message.
+	@remarks: Implemented using L{getPreselectedTextSpeech}
 	"""
-	# Translators: This is spoken to indicate that some text is already selected.
-	# 'selected' preceding text is intentional.
-	# For example 'selected hello world'
-	speakSelectionMessage(_("selected %s"), text, priority)
+	seq = getPreselectedTextSpeech(text)
+	if seq:
+		speak(seq, symbolLevel=None, priority=priority)
+
+
+def getPreselectedTextSpeech(
+		text: str
+) -> SpeechSequence:
+	""" Helper method to get the speech sequence to announce a newly focused control already has
+	text selected.
+	This method will speak the word "selected" with the provided text appended.
+	The announcement order is different from L{speakTextSelected} in order to
+	inform a user that the newly focused control has content that is selected,
+	which they may unintentionally overwrite.
+
+	@remarks: Implemented using L{_getSelectionMessageSpeech}, which allows for
+		creating a speech sequence with an arbitrary attached message.
+	"""
+	return _getSelectionMessageSpeech(
+		# Translators: This is spoken to indicate that some text is already selected.
+		# 'selected' preceding text is intentional.
+		# For example 'selected hello world'
+		_("selected %s"),
+		text
+	)
 
 
 def speakTextSelected(
@@ -752,12 +772,21 @@ def speakSelectionMessage(
 		text: str,
 		priority: Optional[Spri] = None
 ):
-	if len(text) < 512:
-		speakMessage(message % text,priority=priority)
-	else:
-		# Translators: This is spoken when the user has selected a large portion of text. Example output "1000 characters"
-		speakMessage(message % _("%d characters") % len(text),priority=priority)
+	seq = _getSelectionMessageSpeech(message, text)
+	if seq:
+		speak(seq, symbolLevel=None, priority=priority)
 
+
+def _getSelectionMessageSpeech(
+		message: str,
+		text: str,
+) -> SpeechSequence:
+	if len(text) < 512:
+		return _getSpeakMessageSpeech(message % text)
+	# Translators: This is spoken when the user has selected a large portion of text.
+	# Example output "1000 characters"
+	numCharactersText = _("%d characters") % len(text)
+	return _getSpeakMessageSpeech(message % numCharactersText)
 
 # C901 'speakSelectionChange' is too complex
 # Note: when working on speakSelectionChange, look for opportunities to simplify

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -135,6 +135,22 @@ def pauseSpeech(switch):
 	beenCanceled=False
 
 
+def _getSpeakMessageSpeech(
+		text: str,
+) -> SpeechSequence:
+	"""Gets the speech sequence for a given message.
+	@param text: the message to speak
+	"""
+	if text is None:
+		return []
+	if isBlank(text):
+		return [
+			# Translators: This is spoken when the line is considered blank.
+			_("blank"),
+		]
+	return [text, ]
+
+
 def speakMessage(
 		text: str,
 		priority: Optional[Spri] = None
@@ -143,7 +159,9 @@ def speakMessage(
 	@param text: the message to speak
 	@param priority: The speech priority.
 	"""
-	speakText(text, reason=controlTypes.REASON_MESSAGE, priority=priority)
+	seq = _getSpeakMessageSpeech(text)
+	if seq:
+		speak(seq, symbolLevel=None, priority=priority)
 
 
 def getCurrentLanguage():
@@ -538,16 +556,13 @@ def speakText(
 ):
 	"""Speaks some text.
 	@param text: The text to speak.
-	@param reason: The reason for this speech; one of the controlTypes.REASON_* constants.
+	@param reason: Unused
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
-	if text is None:
-		return
-	if isBlank(text):
-		# Translators: This is spoken when the line is considered blank.
-		text=_("blank")
-	speak([text], symbolLevel=symbolLevel, priority=priority)
+	seq = _getSpeakMessageSpeech(text)
+	if seq:
+		speak(seq, symbolLevel=symbolLevel, priority=priority)
 
 
 RE_INDENTATION_SPLIT = re.compile(r"^([^\S\r\n\f\v]*)(.*)$", re.UNICODE | re.DOTALL)

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2308,8 +2308,7 @@ class SpeechWithoutPauses:
 					if after:
 						pendingSpeechSequence.append(after)
 					if before:
-						finalSpeechSequence.extend(self._pendingSpeechSequence)
-						self._pendingSpeechSequence = []
+						finalSpeechSequence.extend(self._flushPendingSpeech())
 						finalSpeechSequence.extend(speechSequence[0:index])
 						finalSpeechSequence.append(before)
 						# Apply the last language change to the pending sequence.

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2242,6 +2242,12 @@ class SpeechWithoutPauses:
 			finalSpeechSequence = self._flushPendingSpeech()
 		else:  # Handling normal speech
 			finalSpeechSequence = self._getSpeech(speechSequence)
+		return self._doSpeechIfValid(finalSpeechSequence)
+
+	def _doSpeechIfValid(
+			self,
+			finalSpeechSequence: SpeechSequence
+	) -> bool:
 		if finalSpeechSequence:
 			self.speak(finalSpeechSequence)
 			return True
@@ -2257,12 +2263,20 @@ class SpeechWithoutPauses:
 		for index in range(sequenceLen):
 			if isinstance(speechSequence[index], EndUtteranceCommand):
 				if index > 0 and lastStartIndex < index:
-					self.speakWithoutPauses(speechSequence[lastStartIndex:index], detectBreaks=False)
-				self.speakWithoutPauses(None)
+					subSequence = speechSequence[lastStartIndex:index]
+					self._doSpeechIfValid(
+						self._getSpeech(subSequence)
+					)
+				self._doSpeechIfValid(
+					self._flushPendingSpeech()
+				)
 				spoke = True
 				lastStartIndex = index + 1
 		if lastStartIndex < sequenceLen:
-			spoke = self.speakWithoutPauses(speechSequence[lastStartIndex:], detectBreaks=False)
+			subSequence = speechSequence[lastStartIndex:]
+			spoke = self._doSpeechIfValid(
+				self._getSpeech(subSequence)
+			)
 		return spoke
 
 	def _flushPendingSpeech(self) -> SpeechSequence:
@@ -2315,6 +2329,7 @@ class SpeechWithoutPauses:
 			pendingSpeechSequence.reverse()
 			self._pendingSpeechSequence.extend(pendingSpeechSequence)
 		return finalSpeechSequence
+
 
 _speakWithoutPauses = SpeechWithoutPauses(speakFunc=speak)
 

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -185,14 +185,14 @@ def speakSpelling(
 		useCharacterDescriptions: bool = False,
 		priority: Optional[Spri] = None
 ) -> None:
-	seq = list(getSpeechForSpelling(text, locale=locale, useCharacterDescriptions=useCharacterDescriptions))
+	seq = list(getSpellingSpeech(text, locale=locale, useCharacterDescriptions=useCharacterDescriptions))
 	speak(seq, priority=priority)
 
 
-# C901 'getSpeechForSpelling' is too complex
-# Note: when working on getSpeechForSpelling, look for opportunities to simplify
+# C901 'getSpellingSpeech' is too complex
+# Note: when working on getSpellingSpeech, look for opportunities to simplify
 # and move logic out into smaller helper functions.
-def getSpeechForSpelling(  # noqa: C901
+def getSpellingSpeech(  # noqa: C901
 		text: str,
 		locale: Optional[str] = None,
 		useCharacterDescriptions: bool = False
@@ -252,6 +252,12 @@ def getSpeechForSpelling(  # noqa: C901
 			yield PitchCommand()
 		yield EndUtteranceCommand()
 
+
+# 'getSpeechForSpelling' should be considered deprecated, use getSpellingSpeech instead.
+# The name 'getSpeechForSpelling' was introduced during the 2019.3 release.
+# The decision was made to rename it to be consistent with the other functions (get*Speech) which create
+# speech sequences.
+getSpeechForSpelling = getSpellingSpeech
 
 def getCharDescListFromText(text,locale):
 	"""This method prepares a list, which contains character and its description for all characters the text is made up of, by checking the presence of character descriptions in characterDescriptions.dic of that locale for all possible combination of consecutive characters in the text.

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -253,11 +253,17 @@ class CallbackCommand(BaseCallbackCommand):
 		otherwise it will block production of further speech and or other functionality in NVDA.
 	"""
 
-	def __init__(self, callback):
+	def __init__(self, callback, name: Optional[str] = None):
 		self._callback = callback
+		self._name = name if name else repr(callback)
 
 	def run(self,*args, **kwargs):
 		return self._callback(*args,**kwargs)
+
+	def __repr__(self):
+		return "CallbackCommand(name={name})".format(
+			name=self._name
+		)
 
 class BeepCommand(BaseCallbackCommand):
 	"""Produce a beep.

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -13,7 +13,8 @@ import config
 from logHandler import log
 from .commands import SpeechCommand
 
-SpeechSequence = List[Union[SpeechCommand, str]]
+SequenceItemT = Union[SpeechCommand, str]
+SpeechSequence = List[SequenceItemT]
 
 
 def _isDebugForSpeech() -> bool:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -309,13 +309,13 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
-	def getTextWithFields(self,formatConfig=None):
-		"""Retreaves the text in this range, as well as any control/format fields associated therewith.
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> List[Union[str, FieldCommand]]:
+		"""Retrieves the text in this range, as well as any control/format fields associated therewith.
 		Subclasses may override this. The base implementation just returns the text.
-		@param formatConfig: Document formatting configuration, useful if you wish to force a particular configuration for a particular task.
+		@param formatConfig: Document formatting configuration, useful if you wish to force a particular
+			configuration for a particular task.
 		@type formatConfig: dict
 		@return: A sequence of text strings interspersed with associated field commands.
-		@rtype: list of str and L{FieldCommand}
 		""" 
 		return [self.text]
 

--- a/tests/unit/test_SpeechWithoutPauses.py
+++ b/tests/unit/test_SpeechWithoutPauses.py
@@ -1,0 +1,225 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2019 NV Access Limited
+
+"""Unit tests for speechWithoutPauses"""
+
+import unittest
+from typing import List
+
+from speech.types import SpeechSequence
+from speech.commands import EndUtteranceCommand, LangChangeCommand, CallbackCommand
+from speech import re_last_pause, SpeechWithoutPauses
+from logHandler import log
+
+
+class SpeechSpy:
+	"""Simple class to collect SpeechSequences as they are 'spoken'
+	"""
+	spokenSequences: List[
+		SpeechSequence
+	]
+
+	def __init__(self):
+		self.spokenSequences = []
+
+	def speak(
+			self,
+			speechSeqence: SpeechSequence
+	):
+		self.spokenSequences.append(speechSeqence)
+
+
+_spokenSequences: List[
+	SpeechSequence
+] = []
+
+
+def speak(seq: SpeechSequence):
+	_spokenSequences.append(seq)
+
+
+def resetSpeakDest():
+	""" Save calls to speak.
+	:return the new destination for the speak function
+	"""
+	global _spokenSequences
+	_spokenSequences = []
+	return _spokenSequences
+
+
+def old_speakWithoutPauses(  # noqa: C901
+		speechSequence: SpeechSequence,
+		detectBreaks: bool = True
+) -> bool:
+	"""
+	Speaks the speech sequences given over multiple calls, only sending to the synth at acceptable phrase or
+	sentence boundaries, or when given None for the speech sequence.
+	@return: C{True} if something was actually spoken,
+		C{False} if only buffering occurred.
+	"""
+	speakWithoutPauses = old_speakWithoutPauses
+	lastStartIndex = 0
+	# Break on all explicit break commands
+	if detectBreaks and speechSequence:
+		log.debug(f"start with seq: {speechSequence}\n and pending: {speakWithoutPauses._pendingSpeechSequence}")
+		sequenceLen = len(speechSequence)
+		spoke = False
+		for index in range(sequenceLen):
+			if isinstance(speechSequence[index], EndUtteranceCommand):
+				if index > 0 and lastStartIndex < index:
+					speakWithoutPauses(speechSequence[lastStartIndex:index], detectBreaks=False)
+				speakWithoutPauses(None)
+				spoke = True
+				lastStartIndex = index + 1
+		if lastStartIndex < sequenceLen:
+			spoke = speakWithoutPauses(speechSequence[lastStartIndex:], detectBreaks=False)
+		return spoke
+	finalSpeechSequence = []  # To be spoken now
+	pendingSpeechSequence = []  # To be saved off for speaking  later
+	if speechSequence is None:  # Requesting flush
+		if speakWithoutPauses._pendingSpeechSequence:
+			# Place the last incomplete phrase in to finalSpeechSequence to be spoken now
+			finalSpeechSequence = speakWithoutPauses._pendingSpeechSequence
+			speakWithoutPauses._pendingSpeechSequence = []
+	else:  # Handling normal speech
+		# Scan the given speech and place all completed phrases in finalSpeechSequence to be spoken,
+		# And place the final incomplete phrase in pendingSpeechSequence
+		for index in range(len(speechSequence) - 1, -1, -1):
+			item = speechSequence[index]
+			if isinstance(item, str):
+				m = re_last_pause.match(item)
+				if m:
+					before, after = m.groups()
+					if after:
+						pendingSpeechSequence.append(after)
+					if before:
+						finalSpeechSequence.extend(speakWithoutPauses._pendingSpeechSequence)
+						speakWithoutPauses._pendingSpeechSequence = []
+						finalSpeechSequence.extend(speechSequence[0:index])
+						finalSpeechSequence.append(before)
+						# Apply the last language change to the pending sequence.
+						# This will need to be done for any other speech change commands introduced in future.
+						for changeIndex in range(index - 1, -1, -1):
+							change = speechSequence[changeIndex]
+							if not isinstance(change, LangChangeCommand):
+								continue
+							pendingSpeechSequence.append(change)
+							break
+						break
+				else:
+					pendingSpeechSequence.append(item)
+			else:
+				pendingSpeechSequence.append(item)
+		if pendingSpeechSequence:
+			pendingSpeechSequence.reverse()
+			speakWithoutPauses._pendingSpeechSequence.extend(pendingSpeechSequence)
+	if finalSpeechSequence:
+		speak(finalSpeechSequence)
+		return True
+	return False
+
+
+old_speakWithoutPauses._pendingSpeechSequence = []
+
+
+class TestOldImplVsNew(unittest.TestCase):
+	"""A test that verifies that the new implementation of SpeechWithoutPauses matches the old behavior.
+	"""
+	def test_stopsSpeakingCase(self):
+		callbackCommand = CallbackCommand(name="dummy", callback=None)
+		lang_en = LangChangeCommand('en')
+		lang_default = LangChangeCommand(None)
+
+		def createInputSequences():
+			"""Speech sequences that are input to 'speechWithoutPauses' when triggering the 'read-all' command
+			on the wxPython wiki page.
+			"""
+			return [
+				[
+					callbackCommand,
+					lang_en,
+					'The purpose of the wxPyWiki is to provide documentation, examples, how-tos, etc. for helping people ',
+					lang_default
+				],
+				[
+					callbackCommand,
+					lang_en,
+					'learn, understand and use ',
+					lang_default
+				],
+				[
+					callbackCommand,
+					'visited',
+					'link',
+					'',
+					lang_en,
+					'wxPython',
+					lang_default,
+					lang_en,
+					'. Anything that falls within those guidelines is fair game. ',
+					lang_default
+				],
+				[
+					EndUtteranceCommand(),
+					callbackCommand,
+					lang_en,
+					'Note: To get to the main wxPython site click ',
+					lang_default
+				]
+			]
+
+		expectedSpeech = repr(
+			[
+				[
+					callbackCommand,
+					lang_en,
+					'The purpose of the wxPyWiki is to provide documentation, examples, how-tos, etc. ',
+				],
+				'spoke:True',
+				'spoke:False',
+				[
+					lang_en,
+					'for helping people ',
+					lang_default,
+					callbackCommand,
+					lang_en,
+					'learn, understand and use ',
+					lang_default,
+					callbackCommand,
+					'visited',
+					'link',
+					'',
+					lang_en,
+					'wxPython',
+					lang_default,
+					lang_en,
+					'. Anything that falls within those guidelines is fair game. '
+				],
+				'spoke:True',
+				[
+					# this sequence seems incorrect, however it persists the "old" behavior:
+					# - it is missing a callback command
+					# - it has no speech, just a meaningless pair of lang change commands
+					lang_en, lang_default
+				],
+				'spoke:False'
+			]
+		)
+
+		oldSpeech = resetSpeakDest()
+		for seq in createInputSequences():
+			spoke = old_speakWithoutPauses(seq)
+			oldSpeech.append(f"spoke:{spoke}")
+
+		self.maxDiff = 5000  # text comparison is quite long, and it is handy to be able to see it in the output.
+		self.assertMultiLineEqual(repr(oldSpeech), expectedSpeech, "generated old speech vs expected")
+
+		newSpeech = resetSpeakDest()
+		_speakWithoutPauses = SpeechWithoutPauses(speak)
+		for inSeq in createInputSequences():
+			spoke = _speakWithoutPauses.speakWithoutPauses(inSeq)
+			newSpeech.append(f"spoke:{spoke}")
+
+		self.assertMultiLineEqual(repr(newSpeech), expectedSpeech, "generated new speech vs expected")

--- a/tests/unit/test_cursorManager.py
+++ b/tests/unit/test_cursorManager.py
@@ -17,6 +17,18 @@ class CursorManager(cursorManager.CursorManager, BasicTextProvider):
 
 class TestMove(unittest.TestCase):
 
+	def setUp(self):
+		import speechDictHandler
+		speechDictHandler.initialize()  # setting the synth depends on dictionary["voice"]
+		import synthDriverHandler
+		# Some speech functions (speakTextInfo due to calling getSpellingSpeech) rely on getting config for a
+		# synth, they first get the synth, then synth.name.
+		# Previously this wasn't necessary since speech.speak and speech.speakSpelling are a no-op
+		# (see tests/unit/__init__.py), however, since logic from these methods has moved to get*Speech methods
+		# the logic is now executed, and the following dependencies need to be met.
+		assert synthDriverHandler.setSynth("silence")
+		assert synthDriverHandler.getSynth()
+
 	def test_nextChar(self):
 		cm = CursorManager(text="abc") # Caret at "a"
 		cm.script_moveByCharacter_forward(None)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:
Returning sequences from these functions allows us greater flexibility for affecting all speech that is caused by a call to speakObject.

### Description of how this pull request fixes the issue:
Split several functions into a speakX and getXspeech

This PR maintains backwards compatibility

### Testing performed:
Ran NVDA from source.

### Known issues with pull request:
- Todo: rename getSpeechForSpelling to getSpellingSpeech

### Change log entry:

Section: New features, Changes, Bug fixes

