### PR TITLE
Announce live region changes with high priority speech

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1035,7 +1035,7 @@ Tries to force this object to take the focus.
 		"""
 		name=self.name
 		if name:
-			ui.message(name)
+			ui.message(name, speechPriority=speech.priorities.Spri.NOW)
 
 	def event_typedCharacter(self,ch):
 		if config.conf["documentFormatting"]["reportSpellingErrors"] and config.conf["keyboard"]["alertForSpellingErrors"] and (


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Live region changes are currently reported at normal speech priority.

### Description of how this pull request fixes the issue:
Change the priority to high to ensure that live region messages are queued before any other speech.

### Testing performed:
T.b.d.

### Known issues with pull request:
None

### Change log entry:
* Changes
    + Live region changes, mainly fired by UIA, are now announced with higher speech priority.
