### PR TITLE
Fix table movement commands in list skipping empty cells

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -577,11 +577,14 @@ class RowWithFakeNavigation(NVDAObject):
 	def script_moveToNextColumn(self, gesture):
 		cur = api.getNavigatorObject()
 		if cur == self:
-			new = self.simpleFirstChild
+			new = self.firstChild
 		elif cur.parent != self:
-			new = self
+			self._moveToColumn(self)
+			return
 		else:
-			new = cur.simpleNext
+			new = cur.next
+		while new and new.hasIrrelevantLocation:
+			new = new.next
 		self._moveToColumn(new)
 	script_moveToNextColumn.canPropagate = True
 	# Translators: The description of an NVDA command.
@@ -591,10 +594,12 @@ class RowWithFakeNavigation(NVDAObject):
 		cur = api.getNavigatorObject()
 		if cur == self:
 			new = None
-		elif cur.parent != self or not cur.simplePrevious:
+		elif cur.parent != self or not cur.previous:
 			new = self
 		else:
-			new = cur.simplePrevious
+			new = cur.previous
+			while new and new.hasIrrelevantLocation:
+				new = new.previous
 		self._moveToColumn(new)
 	script_moveToPreviousColumn.canPropagate = True
 	# Translators: The description of an NVDA command.


### PR DESCRIPTION
### Link to issue number:
Fixes #10615

### Summary of the issue:
In #9873, we started ignoring columns that were taking no space. For this to work with table navigation as well, I changed the object commands to their simple equivalents, i.e. next to simpleNext, firstChild to simpleFirstChild. This logic relies on presentationType, which is set to layout for objects without name. Therefore, if cells don't have a name and reporting of cell coords is off, these empty cells are skipped when using table nav.

### Description of how this pull request fixes the issue:
Reverted back to next/previous/firstChild and use a loop to skip cells that are invisible.

### Testing performed:
Tested in the list view control as in #10615. Set the width of the second column to 0. Made sure that invisible columns are still skipped.

### Known issues with pull request:
None

### Change log entry:
None needed.
