### PR TITLE
Add unicode minus symbol

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -15,7 +15,7 @@ complexSymbols:
 # Others
 decimal point	(?<![^\d -])\.(?=\d)
 in-word '	(?<=[^\W_])['’]
-negative number	(?<!\w)-(?=[$£€¥.]?\d)
+negative number	(?<!\w)[-−]{1}(?=[$£€¥.]?\d)
 
 symbols:
 # identifier	replacement[[	level][	preserve]][	# display name]
@@ -56,6 +56,7 @@ $	dollar	all	norep
 )	right paren	most	always
 *	star	some
 +	plus	some
+−	minus	some
 ,	comma	all	always
 -	dash	most
 .	dot	some


### PR DESCRIPTION
Adds support for the unicode minus symbol, including when used for a negative number.

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10633

### Summary of the issue:
NVDA does not identify negative numbers (including currencies) that use the unicode minus symbol, or announce unicode minus symbol in general.
[Information on the minus symbol (U+2212)](https://en.wikipedia.org/wiki/Plus_and_minus_signs#Minus_sign)

### Description of how this pull request fixes the issue:
- Updates negative number regex to work with unicode minus in addition to existing dash
- Adds minus to symbol list

### Testing performed:
- Existing unit tests
- Confirmed working with:
    - Chrome 79
    - Firefox 72.0b7
    - IE11
    - MS Edge 44 (EdgeHTML)
    - MS Edge 80 (Chromium)
- Also confirmed negative numbers still work with dash in addition to minus

### Known issues with pull request:
None

### Change log entry:
*Bug Fixes*
`Fixed not announcing Unicode minus symbol (U+2212) (#10633) `

