### PR TITLE
Prevent system sleep when reading lon pieces of text in say all

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -12,6 +12,7 @@ import controlTypes
 import api
 import textInfos
 import queueHandler
+import winKernel
 
 CURSOR_CARET = 0
 CURSOR_REVIEW = 1
@@ -60,6 +61,7 @@ class _ObjectsReader(object):
 		if self.prevObj:
 			# We just started speaking this object, so move the navigator to it.
 			api.setNavigatorObject(self.prevObj, isFocus=lastSayAllMode==CURSOR_CARET)
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
 		# Move onto the next object.
 		self.prevObj = obj = next(self.walker, None)
 		if not obj:
@@ -176,6 +178,7 @@ class _TextReader(object):
 			updater.updateCaret()
 		if self.cursor != CURSOR_CARET or config.conf["reviewCursor"]["followCaret"]:
 			api.setReviewPosition(updater, isCaret=self.cursor==CURSOR_CARET)
+		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
 		if self.numBufferedLines == 0:
 			# This was the last line spoken, so move on.
 			self.nextLine()


### PR DESCRIPTION
### Link to issue number:
Follow up of #10111 

### Summary of the issue:
When a system is set up to lock or go to sleep within one minute, say all is interrupted when reading long paragraphs in virtual buffers. Possibly in other cases as well.

### Description of how this pull request fixes the issue:
Similar as in #10111. We instruct the system not to sleep. This happens on every line we reach.

### Testing performed:
Tested with a long paragraph of text in Firefox browse mode. My system no longer locks within one minute.

### Known issues with pull request:
In theory, say all could still be interrupted when reading a very long line at a very slow rate.

### Change log entry:
* Changes
    + NVDA prevents the system from locking or going to sleep when in say all.
