### PR TITLE
Stop using MS Edge specific code for Internet Explorer edit fields.

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -853,7 +853,11 @@ class UIA(Window):
 		# Windows 8.x toast, although a form of tool tip, is covered separately.
 		elif UIAControlType==UIAHandler.UIA_ToolTipControlTypeId:
 			clsList.append(ToolTip)
-		elif self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge"):
+		elif(
+			self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge")
+			# But not for Internet Explorer
+			and not self.appModule.appName == 'iexplore'
+		):
 			from . import edge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
 				clsList.append(edge.EdgeHTMLRootContainer)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -854,7 +854,7 @@ class UIA(Window):
 		elif UIAControlType==UIAHandler.UIA_ToolTipControlTypeId:
 			clsList.append(ToolTip)
 		elif(
-			self.UIAElement.cachedFrameworkID in ("InternetExplorer","MicrosoftEdge")
+			self.UIAElement.cachedFrameworkID in ("InternetExplorer", "MicrosoftEdge")
 			# But not for Internet Explorer
 			and not self.appModule.appName == 'iexplore'
 		):


### PR DESCRIPTION
This is opened against beta.
### Link to issue number:
Fixes #10613
### Summary of the issue:
When support for Microsoft Edge was introduced in 2015 we started using Edge specific code for some controls in Internet Explorer. It started to be problematic when support for landmarks was introduced, as Edge specific code for landmarks was failing in IE.
### Description of how this pull request fixes the issue:
The edgeNode is not used when in IE.
### Testing performed:
With braille display connected:
1. Opened IE 11 on Windows 7
2. went to tyfloswiat.pl 
3. moved to the last edit field and pressed NVDA+space,

Without this change the focus mode sound was not played, whereas  now it plays.

### Known issues with pull request:
None known
### Change log entry:
None needed this is not in a release.