### PR TITLE
_rawWindowProc should be a static method.

### DIFF
--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -154,12 +154,14 @@ class CustomWindow(AutoPropertyObject):
 	def _get__wClass(cls):
 		return WNDCLASSEXW(
 			cbSize=ctypes.sizeof(WNDCLASSEXW),
-			lpfnWndProc=cls._rawWindowProc,
+			lpfnWndProc=_rawWindowProc,
 			hInstance=appInstance,
 			lpszClassName=cls.className,
 		)
 
 	_abstract_className = True
+
+	className: str
 
 	@classmethod
 	def _get_className(cls) -> str:
@@ -253,17 +255,18 @@ class CustomWindow(AutoPropertyObject):
 		"""
 		return None
 
-	@WNDPROC
-	def _rawWindowProc(hwnd, msg, wParam, lParam):
-		try:
-			inst = CustomWindow._hwndsToInstances[hwnd]
-		except KeyError:
-			log.debug("CustomWindow rawWindowProc called for unknown window %d" % hwnd)
-			return ctypes.windll.user32.DefWindowProcW(hwnd, msg, wParam, lParam)
-		try:
-			res = inst.windowProc(hwnd, msg, wParam, lParam)
-			if res is not None:
-				return res
-		except:
-			log.exception("Error in wndProc")
+
+@WNDPROC
+def _rawWindowProc(hwnd, msg, wParam, lParam):
+	try:
+		inst = CustomWindow._hwndsToInstances[hwnd]
+	except KeyError:
+		log.debug("CustomWindow rawWindowProc called for unknown window %d" % hwnd)
 		return ctypes.windll.user32.DefWindowProcW(hwnd, msg, wParam, lParam)
+	try:
+		res = inst.windowProc(hwnd, msg, wParam, lParam)
+		if res is not None:
+			return res
+	except:
+		log.exception("Error in wndProc")
+	return ctypes.windll.user32.DefWindowProcW(hwnd, msg, wParam, lParam)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:
I ran into this while working on something else, it was confusing enough to cost me some time.
The indentation level for `_rawWindowProc` makes it seem like a class / instance method of `CustomWindow`, however it does not take a `cls` or `self` argument, and does not need access to anything.
It is then registered as a window proc callback.

I don't think this causes any errors, though it is confusing.

### Description of how this pull request fixes the issue:
Make the  _rawWindowProc a static method of CustomWindow. It does not need to be a class or instance method (and can't be), but it is tightly coupled to CustomWindow.

Added type hints for `_wClass` and `className`

### Testing performed:
Ran NVDA with some debug logging to ensure that `_rawWindowProc` is still being called

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

