### PR TITLE
UIAHandler: Do not use UIA for Chrome_RenderWidgetHostHWND windows

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -51,25 +51,25 @@ goodUIAWindowClassNames=[
 badUIAWindowClassNames=[
 	# UIA events of candidate window interfere with MSAA events.
 	"Microsoft.IME.CandidateWindow.View",
-"SysTreeView32",
-"WuDuiListView",
-"ComboBox",
-"msctls_progress32",
-"Edit",
-"CommonPlacesWrapperWndClass",
-"SysMonthCal32",
-"SUPERGRID", #Outlook 2010 message list
-"RichEdit",
-"RichEdit20",
-"RICHEDIT50W",
-"SysListView32",
-"EXCEL7",
-"Button",
-# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
-"FoxitDocWnd",
-# All Chromium implementations (including Edge) should not be UIA,
-# As their IA2 implementation is still better at the moment.
-"Chrome_RenderWidgetHostHWND",
+	"SysTreeView32",
+	"WuDuiListView",
+	"ComboBox",
+	"msctls_progress32",
+	"Edit",
+	"CommonPlacesWrapperWndClass",
+	"SysMonthCal32",
+	"SUPERGRID",  # Outlook 2010 message list
+	"RichEdit",
+	"RichEdit20",
+	"RICHEDIT50W",
+	"SysListView32",
+	"EXCEL7",
+	"Button",
+	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
+	"FoxitDocWnd",
+	# All Chromium implementations (including Edge) should not be UIA,
+	# As their IA2 implementation is still better at the moment.
+	"Chrome_RenderWidgetHostHWND",
 ]
 
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -67,6 +67,9 @@ badUIAWindowClassNames=[
 "Button",
 # #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 "FoxitDocWnd",
+# All Chromium implementations (including Edge) should not be UIA,
+# As their IA2 implementation is still better at the moment.
+"Chrome_RenderWidgetHostHWND",
 ]
 
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

This is based on beta as Edge (with Chrome) will become stable very soon.

### Link to issue number:
Fixes #10638 

### Summary of the issue:
The new Microsoft Edge browser (that uses Chrome) has turned on their UI automation implementation by default. However, NVDA seems to freeze when accessing document content in the browser. Although these freezes should be addressed, they do seem specifically related to the UIA implementation in Chrome, and NvDA already works very well with the existing IAccessible2 implementation, thus NVDA for now should avoid using UIA for any Chromium document content.

### Description of how this pull request fixes the issue:
NVDA now refuses to use UIA coming from any window with a class of Chrome_RenderWidgetHostHWND, thus falling back to IAccessible2 for any Chroium document content.
Note that in Edge, the outer chrome (address bar etc) will still use UIA, but documents themselves will use IAccessible2.

### Testing performed:
Launched Edge dev with its UIA implementation enabled. Visited www.nvaccess.org/. Ensured that once the document loaded, NVDA started reading the document, and the user could move around the document in browse mode, and interact with links etc.
 
### Known issues with pull request:
None.

### Change log entry:
None needed.
