### PR TITLE
Use legacy winConsole support by default for 2019.3

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -209,7 +209,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [UIA]
 	enabled = boolean(default=true)
 	useInMSWordWhenAvailable = boolean(default=false)
-	winConsoleImplementation= option("auto", "legacy", "UIA", default="auto")
+	winConsoleImplementation= option("auto", "legacy", "UIA", default="legacy")
 
 [terminals]
 	speakPasswords = boolean(default=false)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,9 +6,6 @@ What's New in NVDA
 = 2019.3 =
 
 == New Features ==
-- In Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 10 October 2018 Update and later:
- - Vastly improved performance and stability. (#9771)
- - Reporting of typed text that does not appear onscreen (such as passwords) can now be enabled via an option in NVDA's advanced settings panel. (#9649)
 - The accuracy of the move mouse to navigator object command has been improved in text fields in Java applications. (#10157)
 - Added support for  the following Handy Tech Braille displays (#8955):
  - Basic Braille Plus 40


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Temporarily addresses #10600  and #10618 

### Summary of the issue:
Dispite lots of work from @codeofdusk , myself and others on the new UIA winConsole support, there are still bugs in Microsoft's implementation which we cannot work around. Specifically some people are still experiencing issues when reviewing text on some builds of Windows,  users are complaining of lags, and if the screen is flooded with text, new text announcement may stop all together due to UIA core receiving too many events.

### Description of how this pull request fixes the issue:
For 2019.3, make legacy the default. Users can still choose to use the UIA implementation  from NVDA's advanced settings if they wish.
I personally will continue to use the UIA implementation as I experience no issues with it in the way I use it on a day to day basis. However, we need to release 2019.3 as soon as possible, and we would prefer to minimize the amount of extra changes. We hope to work with Microsoft to address the issues in their UIA implementation in the near future, so that we can again make UIA in Windows consoles the default.

### Testing performed:
Ran a copy of NVDA on Windows 10 2004 with a new configuration, ensuring that NVDA used the legacy console support.  Switched to UIA Prefered in NVDA's advanced settings, and ensured that UIA winConsole support was being used.

### Known issues with pull request:
None.

### Change log entry:
None needed.