### PR TITLE
Remove screen curtain name variable from translation strings for other settings.

### DIFF
--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -88,23 +88,16 @@ class Magnification:
 		MagShowSystemCursor = None
 
 
-# Translators: Description of a vision enhancement provider that disables output to the screen,
+# Translators: Name for a vision enhancement provider that disables output to the screen,
 # making it black.
 screenCurtainTranslatedName = _("Screen Curtain")
 
-warnOnLoadCheckBoxText = (
-	# Translators: Description for a screen curtain setting that shows a warning when loading
-	# the screen curtain.
-	_("Always &show a warning when loading {screenCurtainTranslatedName}").format(
-		screenCurtainTranslatedName=screenCurtainTranslatedName
-	)
-)
-
+# Translators: Description for a Screen Curtain setting that shows a warning when loading
+# the screen curtain.
+warnOnLoadCheckBoxText = _("Always &show a warning when loading Screen Curtain")
 
 # Translators: Description for a screen curtain setting to play sounds when enabling/disabling the curtain
-playToggleSoundsCheckBoxText = _("&Play sound when toggling {screenCurtainTranslatedName}").format(
-	screenCurtainTranslatedName=screenCurtainTranslatedName
-)
+playToggleSoundsCheckBoxText = _("&Play sound when toggling Screen Curtain")
 
 
 class ScreenCurtainSettings(providerBase.VisionEnhancementProviderSettings):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Didn't find any issues, but there is discussion about this on the nvda-translations mailing list.

### Summary of the issue:
Inserting the name of the screen curtain in these strings makes them difficult to translate for some languages. 

### Description of how this pull request fixes the issue:
The name is not something that will change, these strings can be translated independently.

### Testing performed:
Ran pot tests.
Checked labels on the vision settings dialog.

### Known issues with pull request:
None.

### Change log entry:
None

Section: New features, Changes, Bug fixes

