### PR TITLE
Uninitialize Magnifier API if Screen curtain initialization fails.

### DIFF
--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -317,8 +317,12 @@ class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 		super().__init__()
 		log.debug(f"Starting ScreenCurtain")
 		Magnification.MagInitialize()
-		Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
-		Magnification.MagShowSystemCursor(False)
+		try:
+			Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
+			Magnification.MagShowSystemCursor(False)
+		except Exception as e:
+			Magnification.MagUninitialize()
+			raise e
 		if self.getSettings().playToggleSounds:
 			try:
 				nvwave.playWaveFile(r"waves\screenCurtainOn.wav")


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:

If screen curtain activation fails one time, the screen curtain cannot be activated anymore on future requests. An example of screen curtain activation failing is described in #10545.
Activation may fail because Windows Magnifier is already active with color inversion. But activation also fails when you try again to activate screen curtain, even if you have disabled color inversion or exited Windows Magnifier.

### Description of how this pull request fixes the issue:

If screen curtain activation has previously failed due to Windows Magnifier's color inversion, it should not fail anymore once color inversion is disabled or Magnifier is off.

The issue is due to the fact that when screen curtain activation fails, Magnifier API is not properly uniiitialized as requested on [Magnification API Overview | Microsoft Docs](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/magapi/magapi-intro#initializing-the-magnifier-run-time-library) webpage:

> Initializing the Magnifier Run-time LibraryInitializing the Magnifier Run-time Library 
> Before you can call any other magnifier API functions, you must create and initialize the magnifier run-time objects by calling the MagInitialize function. Similarly, after you finish using the magnifier API, call the MagUninitialize function to destroy the magnifier run-time objects and free the associated system resources.
> 

### Testing performed:

* Activate Windows Magnifier with color inversion on
* Try to activate screen curtain; as expected, this fails
* Deactivate Magnifier's color inversion or quit Magnifier
* Activate and deactivate many times screen curtain: checked that this activation/deactivation does not cause any error and that screen curtain is correctly activated after request.


### Known issues with pull request:

None

### Change log entry:

None. This PR is a fix on screen curtain that was not yet published in a stable version.

