### PR TITLE
Support for out-of-process iframes in Firefox

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -4,6 +4,7 @@
 #See the file COPYING for more details.
 # Copyright (C) 2008-2020 NV Access Limited, Babbage B.V., Mozilla Corporation
 
+import weakref
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
 import controlTypes
@@ -20,6 +21,8 @@ from comtypes import COMError
 import aria
 import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
+
+IA2_RELATION_CONTAINING_DOCUMENT = "containingDocument"
 
 class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 
@@ -122,6 +125,12 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 class Gecko_ia2(VirtualBuffer):
 
 	TextInfo=Gecko_ia2_TextInfo
+	#: Maps NVDAObjects to a list of iframes/frames in that object's ancestry,
+	#: ordered from deepest to shallowest. The key is held as a weak reference so
+	#: that the cache for an object is cleaned up when that object dies. Each
+	#: frame/iframe in the lists is a tuple of (IAccessible2_2, uniqueId). This
+	#: cache is used across instances.
+	_framesCache = weakref.WeakKeyDictionary()
 
 	def __init__(self,rootNVDAObject):
 		super(Gecko_ia2,self).__init__(rootNVDAObject,backendName="gecko_ia2")
@@ -135,18 +144,87 @@ class Gecko_ia2(VirtualBuffer):
 			return False
 		return True
 
+	@staticmethod
+	def _getEmbedderFrame(acc):
+		"""Get the iframe/frame (if any) which contains the given object.
+		For example, if acc is a button inside an iframe, this will return the iframe.
+		"""
+		try:
+			# 1. Get the containing document.
+			if not isinstance(acc, IAccessibleHandler.IAccessible2_2):
+				# IAccessible NVDAObjects currently fetch IA2, but we need IA2_2 for relationTargetsOfType.
+				# (Out-of-process, for a single relation, this is cheaper than IA2::relations.)
+				acc = acc.QueryInterface(IAccessibleHandler.IAccessible2_2)
+			targets, count = acc.relationTargetsOfType(IA2_RELATION_CONTAINING_DOCUMENT, 1)
+			if count == 0:
+				return None
+			doc = targets[0].QueryInterface(IAccessibleHandler.IAccessible2_2)
+			# 2. Get its parent (the embedder); e.g. iframe.
+			embedder = doc.accParent
+			if not embedder:
+				return None
+			embedder = embedder.QueryInterface(IAccessibleHandler.IAccessible2_2)
+			# 3. Make sure this is an iframe/frame.
+			attribs = embedder.attributes
+			if "tag:browser;" in attribs:
+				# This is a top level browser, not an iframe/frame.
+				return None
+			return embedder
+		except COMError:
+			return None
+
+	@classmethod
+	def _iterIdsToTryWithAccChild(cls, obj):
+		"""Return the child ids we should try with accChild in order to determine
+		whether this object is a descendant of a particular document.
+		"""
+		# 1. Try the object itself.
+		acc = obj.IAccessibleObject
+		accId = obj.IA2UniqueID
+		yield accId
+		# 2. If this fails, this might be because the object is in an
+		# out-of-process frame, in which case the embedder document won't know
+		# about it. Try embedder frames.
+		# 2.1. Try cached frames. We cache because walking frames is expensive,
+		# and when trying to work out what TreeInterceptor this object belongs to,
+		# we'll need to query these frames for each TreeInterceptor.
+		cache = cls._framesCache.setdefault(obj, [])
+		for acc, accId in cache:
+			if not acc:
+				# All frames were cached in a previous run. There are no more.
+				return
+			yield accId
+		# 2.2. Walk remaining ancestor embedder frames, filling the cache as we go.
+		while True:
+			acc = cls._getEmbedderFrame(acc)
+			if not acc:
+				# No more. Signal this in the cache.
+				cache.append((None, None))
+				return
+			try:
+				accId = acc.uniqueID
+			except COMError:
+				# Dead object.
+				cache.append((None, None))
+				return
+			cache.append((acc, accId))
+			yield accId
+
 	def __contains__(self,obj):
 		if not (isinstance(obj,NVDAObjects.IAccessible.IAccessible) and isinstance(obj.IAccessibleObject,IAccessibleHandler.IAccessible2)) or not obj.windowClassName.startswith('Mozilla') or not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle,obj.windowHandle):
 			return False
-		if self.rootNVDAObject.windowHandle==obj.windowHandle:
-			ID=obj.IA2UniqueID
-			if not ID:
-				# Dead object.
-				return False
+		for accId in self._iterIdsToTryWithAccChild(obj):
+			if accId == self.rootID:
+				return True
 			try:
-				self.rootNVDAObject.IAccessibleObject.accChild(ID)
+				self.rootNVDAObject.IAccessibleObject.accChild(accId)
+				# The object is definitely a descendant of the document.
+				break
 			except COMError:
-				return ID==self.rootNVDAObject.IA2UniqueID
+				pass
+		else:
+			# The object is definitely not a descendant of the document.
+			return False
 
 		return not self._isNVDAObjectInApplication(obj)
 

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2017 NV Access Limited, Babbage B.V., Mozilla Corporation
+# Copyright (C) 2008-2020 NV Access Limited, Babbage B.V., Mozilla Corporation
 
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
@@ -172,13 +172,8 @@ class Gecko_ia2(VirtualBuffer):
 			isDefunct=True
 		return not isDefunct
 
-
 	def getNVDAObjectFromIdentifier(self, docHandle, ID):
-		try:
-			pacc=self.rootNVDAObject.IAccessibleObject.accChild(ID)
-		except COMError:
-			return None
-		return NVDAObjects.IAccessible.IAccessible(windowHandle=docHandle,IAccessibleObject=IAccessibleHandler.normalizeIAccessible(pacc),IAccessibleChildID=0)
+		return NVDAObjects.IAccessible.getNVDAObjectFromEvent(docHandle, winUser.OBJID_CLIENT, ID)
 
 	def getIdentifierFromNVDAObject(self,obj):
 		docHandle=obj.windowHandle


### PR DESCRIPTION
### Link to issue number:
None. This supersedes an earlier attempt at this (#9672) that was reverted (#10538) due to severe performance problems.

### Summary of the issue:
Firefox is adding support for out-of-process iframes; i.e. iframes rendered in a separate process to their embedder document. For an out-of-process iframe, the embedder has no knowledge of children in the embedded document and cannot communicate with the embedded document at all. This means that accChild for accessibles in the embedded document fails. This requires some changes to the gecko_ia2 virtual buffer.

### Description of how this pull request fixes the issue:
In the gecko_ia2 vbuf:

1. getNVDAObjectFromIdentifier: Use getNVDAObjectFromEvent instead of accChild on the document. This was changed some time ago to use accChild on the document in the theoretical hope that it might be slightly faster, since it doesn't need to go via the parent process. However, this was never proved to be a performance benefit in real terms. The root accessible is in the parent process and can fetch children in all content documents, so using AccessibleObjectFromEvent works as expected.
2. `__contains__`: If accChild fails, get the embedder iframe and try accChild with the iframe's id. There can be nested out-of-process iframes, so we keep trying this until there are no more iframes in the hierarchy (or until we hit the buffer's root id). We cache iframes because walking iframes is expensive, and when trying to work out what TreeInterceptor an object belongs to, we'll need to query the iframes for each TreeInterceptor.

### Testing performed:

1. Loaded a document with two out-of-process iframes in one tab and a document with no iframes in another tab. In the Python console, saved the former document's TreeInterceptor as ti1 and the latter document's TreeInterceptor as ti2; e.g. `ti1 = nav.treeInterceptor`.
2. Moved the navigator object to a node in the innermost iframe and pressed NVDA+control+z to take a console snapshot.
3. Confirmed that `nav in ti1` is True and `nav in ti2` is False.
4. Moved the navigator object to a node in the document with no iframes and pressed NVDA+control+z.
5. Confirmed that `nav in ti1` is False and `nav in ti2` is True.

Also used a build with this change for a while doing some daily browsing with Gmail, GitHub, etc.

Finally, the performance problems that caused #9672 to be reverted occurred when there were several tabs loaded. I tried with 15 tabs open (focusing each to create a TreeInterceptor for it) and did not observe this performance degradation while browsing.

### Known issues with pull request:
There will be some additional COM calls for objects in out-of-process iframes. However, the iframes for each object are cached while the object is alive, since getTreeInterceptor will call `__contains__` on each TreeInterceptor until a match is found. There don't tend to be many levels of nested iframes, so filling the cache shouldn't be too expensive.

### Other avenues explored:
See #9672.

### Change log entry:

Changes:

`- Support for out-of-process iframes in Mozilla Firefox.`