### PR TITLE
Fix error when navigation landmark is encountered in EdgeHTML content

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -1,6 +1,6 @@
 # _UIAHandler.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2011-2019 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2011-2020 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -149,7 +149,7 @@ UIAPropertyIdsToNVDAEventNames={
 
 UIALandmarkTypeIdsToLandmarkNames: Dict[int, str] = {
 	UIA.UIA_FormLandmarkTypeId: "form",
-	UIA.UIA_NavigationLandmarkTypeId: "nav",
+	UIA.UIA_NavigationLandmarkTypeId: "navigation",
 	UIA.UIA_MainLandmarkTypeId: "main",
 	UIA.UIA_SearchLandmarkTypeId: "search",
 }


### PR DESCRIPTION
### Link to issue number:
Fixes #10698 

### Summary of the issue:
In the UIA Handler, a faulty mapping was made from the UIA Navigation Landmark property to the landmark name `nav`, which ought to be `navigation`.

### Description of how this pull request fixes the issue:
Changed `nav` into `navigation`

### Testing performed:
T.b.d. @francipvb, could you have a try?

### Known issues with pull request:
Idially, we'd have unit tests to avoid issues like these in future.

### Change log entry:
None
