### PR TITLE
Restore fetch of selected item in listboxes

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -342,13 +342,6 @@ bool hasAriaHiddenAttribute(const map<wstring,wstring>& IA2AttribsMap){
 CComPtr<IAccessible2> GeckoVBufBackend_t::getSelectedItem(
 	IAccessible2* container, const map<wstring, wstring>& attribs
 ) {
-	if (this->toolkitName.compare(L"Chrome") == 0) {
-		// #9364: Google Chrome crashes when fetching the currently selected item from some listboxes.
-		// Specifically when calling IEnumVARIANT::next.
-		// Due to this, and other issues around incorrect focus state setting, it is best to disable fetching of currently selected item in listboxes in Chrome all together.
-		return nullptr;
-	}
-
 	CComVariant selection;
 	HRESULT hr = container->get_accSelection(&selection);
 	if (FAILED(hr)) {


### PR DESCRIPTION
### Link to issue number:
Original issue #9364
And original fix 
- For RC: #9458 
- For Master: #9430

Chrome bug tracker: https://crbug.com/947898

### Summary of the issue:
Due to #9364, fetching of selected item for list boxes was disabled. The issue in Chrome has been fixed since Version 77, we are now able to restore this functionality.

### Description of how this pull request fixes the issue:
Remove Chrome specific code avoiding fetching selected items for listboxes.

### Testing performed:
Followed STR from #9364.

### Known issues with pull request:

### Change log entry:

 New features:
`The currently selected item in listboxes is again presented in browse mode in Chrome, similar to NVDA 2019.1.`

