### PR TITLE
Allow screen curtain to be enabled permanently when warning dialog is…

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2459,10 +2459,13 @@ class GlobalCommands(ScriptableObject):
 					enableMessage = _("Temporary Screen curtain, enabled until next restart")
 
 				try:
-					vision.handler.initializeProvider(
-						screenCurtainProviderInfo,
-						temporary=tempEnable,
-					)
+					if alreadyRunning:
+						screenCurtainProviderInfo.providerClass.enableInConfig(True)
+					else:
+						vision.handler.initializeProvider(
+							screenCurtainProviderInfo,
+							temporary=tempEnable,
+						)
 				except Exception:
 					log.error("Screen curtain initialization error", exc_info=True)
 					# Translators: Reported when the screen curtain could not be enabled.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2459,11 +2459,10 @@ class GlobalCommands(ScriptableObject):
 					enableMessage = _("Temporary Screen curtain, enabled until next restart")
 
 				try:
-					if not alreadyRunning:
-						vision.handler.initializeProvider(
-							screenCurtainProviderInfo,
-							temporary=tempEnable,
-						)
+					vision.handler.initializeProvider(
+						screenCurtainProviderInfo,
+						temporary=tempEnable,
+					)
 				except Exception:
 					log.error("Screen curtain initialization error", exc_info=True)
 					# Translators: Reported when the screen curtain could not be enabled.


### PR DESCRIPTION
… not shown

* Not check if not isAlreadyRunning in _enableScreenCurtain().

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10717

### Summary of the issue:
If the warning dialog before enabling screen curtain is disabled, and the assigned keystroke is pressed twice to enable this feature permanently, it doesn't remain enabled after restarting NVDA, even if NVDA is set to save configuration on exit.

### Description of how this pull request fixes the issue:
In `source/globalCommands.py`, function `_enableScreenCurtain`, don't check if `isAlreadyRunning`, to avoid that NVDA enables it the first time that the keystroke is pressed, and disables it when the script is repeated, even when it announces that screen curtain is enabled.
This problem does not happen when the warning dialog is shown, since in this last case NVDA waits before enabling screen curtain, temporarily or saving this in the configuration.

### Testing performed:
Toggle screen curtain and restart NVDA, ensuring that this is enabled even when the warning dialog is not shown.

### Known issues with pull request:

### Change log entry:
None.
