### PR TITLE
Fix vision dialog

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3163,7 +3163,7 @@ class VisionProviderStateControl(vision.providerBase.VisionProviderStateControl)
 			providerInfo: vision.providerInfo.ProviderInfo
 	):
 		self._providerInfo = providerInfo
-		self._parent = parent
+		self._parent = weakref.ref(parent)  # don't keep parent dialog alive with a circular reference.
 
 	def getProviderInfo(self) -> vision.providerInfo.ProviderInfo:
 		return self._providerInfo
@@ -3181,7 +3181,7 @@ class VisionProviderStateControl(vision.providerBase.VisionProviderStateControl)
 		"""
 		success = self._doStartProvider()
 		if not success and shouldPromptOnError:
-			showStartErrorForProviders(self._parent, [self._providerInfo, ])
+			showStartErrorForProviders(self._parent(), [self._providerInfo, ])
 		return success
 
 	def terminateProvider(
@@ -3194,7 +3194,7 @@ class VisionProviderStateControl(vision.providerBase.VisionProviderStateControl)
 		"""
 		success = self._doTerminate()
 		if not success and shouldPromptOnError:
-			showTerminationErrorForProviders(self._parent, [self._providerInfo, ])
+			showTerminationErrorForProviders(self._parent(), [self._providerInfo, ])
 		return success
 
 	def _doStartProvider(self) -> bool:
@@ -3295,8 +3295,7 @@ class VisionSettingsPanel(SettingsPanel):
 		"""
 		errorProviders: List[vision.providerInfo.ProviderInfo] = []
 		for provider in providers:
-			with VisionProviderStateControl(self, provider) as control:
-				success = control.startProvider(shouldPromptOnError=False)
+			success = VisionProviderStateControl(self, provider).startProvider(shouldPromptOnError=False)
 			if not success:
 				errorProviders.append(provider)
 		showStartErrorForProviders(self, errorProviders)

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -99,10 +99,30 @@ class VisionHandler(AutoPropertyObject):
 
 	_allProviders: List[providerInfo.ProviderInfo] = []
 
+	def _getBuiltInProviderIds(self):
+		from visionEnhancementProviders.NVDAHighlighter import NVDAHighlighterSettings
+		from visionEnhancementProviders.screenCurtain import ScreenCurtainSettings
+		return [
+			NVDAHighlighterSettings.getId(),
+			ScreenCurtainSettings.getId()
+		]
+
 	def _updateAllProvidersList(self):
-		self._allProviders = list(_getProvidersFromFileSystem())
-		# Sort the providers alphabetically by name.
-		self._allProviders.sort(key=lambda info: info.displayName.lower())
+		# Sort the providers alphabetically by id.
+		# id is used because it will not vary by locale
+		all = sorted(
+			_getProvidersFromFileSystem(),
+			key=lambda info: info.providerId.lower()
+		)
+		# Built in providers should come first
+		# Python list.sort is stable sort again by 'built-in'
+		builtInProviderIds = self._getBuiltInProviderIds()
+		all = sorted(
+			all,
+			key=lambda info: info.providerId in builtInProviderIds,
+			reverse=True  # Because False comes before True, we want built-ins first.
+		)
+		self._allProviders = list(all)
 
 	def getProviderList(
 			self,

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -251,8 +251,14 @@ class VisionHandler(AutoPropertyObject):
 				raise exceptions.ProviderInitException(
 					f"Trying to initialize provider {providerId} which reported being unable to start"
 				)
-			# Initialize the provider.
-			providerInst = providerCls()
+			try:
+				# Initialize the provider.
+				providerInst = providerCls()
+			except Exception as e:
+				# Disable the provider, so that it does not error every startup.
+				providerCls.enableInConfig(False)
+				log.warning(f"Error initialising {providerId}. Disabling in config.")
+				raise e
 			# Register extension points.
 			try:
 				providerInst.registerEventExtensionPoints(self.extensionPoints)

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -110,19 +110,19 @@ class VisionHandler(AutoPropertyObject):
 	def _updateAllProvidersList(self):
 		# Sort the providers alphabetically by id.
 		# id is used because it will not vary by locale
-		all = sorted(
+		allProviders = sorted(
 			_getProvidersFromFileSystem(),
 			key=lambda info: info.providerId.lower()
 		)
 		# Built in providers should come first
 		# Python list.sort is stable sort again by 'built-in'
 		builtInProviderIds = self._getBuiltInProviderIds()
-		all = sorted(
-			all,
+		allProviders = sorted(
+			allProviders,
 			key=lambda info: info.providerId in builtInProviderIds,
 			reverse=True  # Because False comes before True, we want built-ins first.
 		)
-		self._allProviders = list(all)
+		self._allProviders = list(allProviders)
 
 	def getProviderList(
 			self,


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10705 

### Summary of the issue:
- #10705  Exposed an error in a less frequently hit code path. `VisionProviderStateControl` were being incorrectly used as context managers.
- `VisionProviderStateControl` may keep alive a dialog due to a circular reference with the `self._parent` attribute.
- When the names of vision providers are translated, the ordering in the dialog changes. (See thread: https://groups.io/g/nvda-translations/message/1825)
- When an exception is thrown from `visionEnhancementProviders.NVDAHighlighter.HighlightWindow.__init__` no error dialog is shown.
- When a vision provider initialization fails during startup of NVDA, the addon is not disabled. It will error again on every startup. Because these errors may causes instability, the provider should be disabled.
- When an error occurred during enabling the NVDA hightlighter via the GUI the addon was not properly disabled. 


### Description of how this pull request fixes the issue:
- Stopped using `VisionProviderStateControl` as a context manger.
- Made `self._parent` a weak reference
- Used `providerId` rather than `disaplayName` to order the providers. Additionally ensured that "built-in" providers will come before providers from addons.
- Allow errors in `visionEnhancementProviders.NVDAHighlighter.HighlightWindow.__init__` to propagate, and error dialog be shown.


### Testing performed:
- Purposefully caused an error in `visionEnhancementProviders.NVDAHighlighter.HighlightWindow.__init__` by raising a `RuntimeError` exception.
- Ran locally, tested many permutations of enabled and disabling with and without errors. 

### Known issues with pull request:
None

### Change log entry:

Section: New features, Changes, Bug fixes

