### PR TITLE
CLDR link is http only https is not reachable

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1162,7 +1162,7 @@ If you find that NVDA is reading punctuation in the wrong language for a particu
 
 ==== Include Unicode Consortium data (including emoji) when processing characters and symbols ====[SpeechSettingsCLDR]
 When this checkbox is checked, NVDA will include additional symbol pronunciation dictionaries when pronouncing characters and symbols.
-These dictionaries contain descriptions for symbols (particularly emoji) that are provided by the [Unicode Consortium https://www.unicode.org/consortium/] as part of their [Common Locale Data Repository https://cldr.unicode.org/].
+These dictionaries contain descriptions for symbols (particularly emoji) that are provided by the [Unicode Consortium https://www.unicode.org/consortium/] as part of their [Common Locale Data Repository http://cldr.unicode.org/].
 If you want NVDA to speak descriptions of emoji characters based on this data, you should enable this option.
 However, if you are using a speech synthesizer that supports speaking emoji descriptions natively, you may wish to turn this off.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/10725
### Summary of the issue:
One link in user guide is http only but changed to https in a previous pull request
### Description of how this pull request fixes the issue:
Change that link back to http
### Testing performed:
Open new link successfully in user doc 
### Known issues with pull request:
None
### Change log entry:
None
Section: New features, Changes, Bug fixes

