### PR TITLE
speechManager: Ensure handling of skipped indexes

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -8,6 +8,7 @@ from logHandler import log
 import queueHandler
 import synthDriverHandler
 from .commands import *
+from commands import IndexCommand
 from .priorities import Spri, SPEECH_PRIORITIES
 
 class ParamChangeTracker(object):
@@ -148,7 +149,7 @@ class SpeechManager(object):
 		#: Maps indexes to BaseCallbackCommands.
 		self._indexesToCallbacks = {}
 		#: a list of indexes currently being spoken by the synthesizer
-		self._indexesSpeaking=[]
+		self._indexesSpeaking = []
 		#: Whether to push more speech when the synth reports it is done speaking.
 		self._shouldPushWhenDoneSpeaking = False
 
@@ -292,7 +293,7 @@ class SpeechManager(object):
 			# Record all indexes that will be sent to the synthesizer
 			# So that we can handle any accidentally skipped indexes.
 			for item in seq:
-				if isinstance(item,IndexCommand):
+				if isinstance(item, IndexCommand):
 					self._indexesSpeaking.append(item.index)
 			getSynth().speak(seq)
 
@@ -373,20 +374,19 @@ class SpeechManager(object):
 		return True, endOfUtterance
 
 	def _handleIndex(self, index, handleSkippedIndexes=True):
-		print("_handleIndex: %s"%index)
 		try:
 			self._indexesSpeaking.remove(index)
 		except ValueError:
-			log.debugWarning("Unknown index %s"%index)
+			log.debugWarning("Unknown index %s" % index)
 			return
 		# A synth (such as OneCore) may skip indexes
 		# If before another index, with no text content in between.
 		# Therefore, detect this and ensure we handle all skipped indexes.
 		if handleSkippedIndexes:
 			for oldIndex in list(self._indexesSpeaking):
-				if oldIndex<index:
-					log.debugWarning("Handling skipped index %s"%oldIndex)
-					self._handleIndex(oldIndex,False)
+				if oldIndex < index:
+					log.debugWarning("Handling skipped index %s" % oldIndex)
+					self._handleIndex(oldIndex, False)
 		valid, endOfUtterance = self._removeCompletedFromQueue(index)
 		if not valid:
 			return

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -147,6 +147,8 @@ class SpeechManager(object):
 		self._curPriQueue = None
 		#: Maps indexes to BaseCallbackCommands.
 		self._indexesToCallbacks = {}
+		#: a list of indexes currently being spoken by the synthesizer
+		self._indexesSpeaking=[]
 		#: Whether to push more speech when the synth reports it is done speaking.
 		self._shouldPushWhenDoneSpeaking = False
 
@@ -287,6 +289,11 @@ class SpeechManager(object):
 			return self._pushNextSpeech(True)
 		seq = self._buildNextUtterance()
 		if seq:
+			# Record all indexes that will be sent to the synthesizer
+			# So that we can handle any accidentally skipped indexes.
+			for item in seq:
+				if isinstance(item,IndexCommand):
+					self._indexesSpeaking.append(item.index)
 			getSynth().speak(seq)
 
 	def _getNextPriority(self):
@@ -365,7 +372,21 @@ class SpeechManager(object):
 		del self._curPriQueue.pendingSequences[:seqIndex + 1]
 		return True, endOfUtterance
 
-	def _handleIndex(self, index):
+	def _handleIndex(self, index, handleSkippedIndexes=True):
+		print("_handleIndex: %s"%index)
+		try:
+			self._indexesSpeaking.remove(index)
+		except ValueError:
+			log.debugWarning("Unknown index %s"%index)
+			return
+		# A synth (such as OneCore) may skip indexes
+		# If before another index, with no text content in between.
+		# Therefore, detect this and ensure we handle all skipped indexes.
+		if handleSkippedIndexes:
+			for oldIndex in list(self._indexesSpeaking):
+				if oldIndex<index:
+					log.debugWarning("Handling skipped index %s"%oldIndex)
+					self._handleIndex(oldIndex,False)
 		valid, endOfUtterance = self._removeCompletedFromQueue(index)
 		if not valid:
 			return

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -8,7 +8,7 @@ from logHandler import log
 import queueHandler
 import synthDriverHandler
 from .commands import *
-from commands import IndexCommand
+from .commands import IndexCommand
 from .priorities import Spri, SPEECH_PRIORITIES
 
 class ParamChangeTracker(object):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10292 

### Summary of the issue:
Synths such as OneCore and sapi5 seem to fail to fire callbacks for bookmarks in speech that directly preceed another bookmark, with no text content in between.
This can happen if doing a sayAll which contains blank lines in the middle.
SpeechManager currently expects that each and every index will be received. But in this case, the index for the blank line is not recieved, and therefore speech stops.
This was not an issue with 2019.2 and below, presumably because we didn't care so much about indexes for each and every utterance.

### Description of how this pull request fixes the issue:
A list of indexes currently sent to the synth is now tracked. I.e. the index value of all IndexCommand objects that are in the sequence that go to synth.speak go into a indexesSpeaking instance variable on SpeechManager.
_handleIndex now has an optional handleSkippedIndexes argument, which is True by default. If true, then it looks back through indexesSpeaking, and calls _handleIndex manually for any index lower than the current index.
_handleIndex also removes index from indexesSpeaking.
_reset also clears indexesSpeaking.

### Testing performed:
With Onecore, sapi5 and espeak: did a say All on the following content:
```
1.
2.
3.
4.

5.
6.
7.
8.
```
Before the fix, NVDa would stop reading at 5.
After the fix, it reaches the end.

### Known issues with pull request:
None known.

### Change log entry:
None needed.
