### PR TITLE
Restore missing import for Word causing setting row and column headers to fail

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -15,7 +15,7 @@ import speech
 import controlTypes
 import textInfos
 import eventHandler
-
+import scriptHandler
 from . import IAccessible
 from displayModel import EditableTextDisplayModelTextInfo
 from NVDAObjects.window import DisplayModelEditableText


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Trying to set a column or row header in Word (NVDA+Shift+C/NVDA+Shift+R, respectively) fails because scriptHandler isn't defined.

```
Input: kb(desktop):shift+NVDA+c
ERROR - scriptHandler.executeScript (16:05:26.643) - MainThread (16824):
error executing script: <bound method WordDocument.script_setColumnHeader of <NVDAObjects.IAccessible.winword.WordDocument object at 0x0405CAF0>> with gesture 'shift+NVDA+c'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 205, in executeScript
  File "NVDAObjects\IAccessible\winword.pyc", line 204, in script_setColumnHeader
NameError: name 'scriptHandler' is not defined
```

### Description of how this pull request fixes the issue:
Restore the scriptHandler import

### Testing performed:
Tested that setting row and column headers works again

### Known issues with pull request:
I don't know where this issue was introduced.

### Change log entry:
Not sure whether this was introduced in 2019.3, but it likely is
