### PR TITLE
Fix elements list dialog on low resolution screens

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -35,6 +35,7 @@ import treeInterceptorHandler
 import inputCore
 import api
 import gui.guiHelper
+from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 from NVDAObjects import NVDAObject
 from abc import ABCMeta, abstractmethod
 from typing import Optional
@@ -847,7 +848,8 @@ qn(
 )
 del qn
 
-class ElementsListDialog(wx.Dialog):
+
+class ElementsListDialog(DpiScalingHelperMixinWithoutInit, wx.Dialog):
 	ELEMENT_TYPES = (
 		# Translators: The label of a radio button to select the type of element
 		# in the browse mode Elements List dialog.
@@ -871,9 +873,12 @@ class ElementsListDialog(wx.Dialog):
 	lastSelectedElementType=0
 
 	def __init__(self, document):
+		super().__init__(
+			parent=gui.mainFrame,
+			# Translators: The title of the browse mode Elements List dialog.
+			title=_("Elements List")
+		)
 		self.document = document
-		# Translators: The title of the browse mode Elements List dialog.
-		super(ElementsListDialog, self).__init__(gui.mainFrame, wx.ID_ANY, _("Elements List"))
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		contentsSizer = wx.BoxSizer(wx.VERTICAL)
 
@@ -885,7 +890,11 @@ class ElementsListDialog(wx.Dialog):
 		contentsSizer.Add(child, flag=wx.EXPAND)
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
-		self.tree = wx.TreeCtrl(self, size=wx.Size(500, 600), style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE | wx.TR_EDIT_LABELS)
+		self.tree = wx.TreeCtrl(
+			self,
+			size=self.scaleSize((500, 300)),  # height is chosen to ensure the dialog will fit on an 800x600 screen
+			style=wx.TR_HAS_BUTTONS | wx.TR_HIDE_ROOT | wx.TR_LINES_AT_ROOT | wx.TR_SINGLE | wx.TR_EDIT_LABELS
+		)
 		self.tree.Bind(wx.EVT_SET_FOCUS, self.onTreeSetFocus)
 		self.tree.Bind(wx.EVT_CHAR, self.onTreeChar)
 		self.tree.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.onTreeLabelEditBegin)

--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -3,6 +3,7 @@
 #Copyright (C) 2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+from typing import Optional, Any, Callable
 
 
 def scaleSize(scaleFactor, size):
@@ -20,11 +21,29 @@ def getScaleFactor(windowHandle):
 	import windowUtils
 	return windowUtils.getWindowScalingFactor(windowHandle)
 
+
 class DpiScalingHelperMixin(object):
-	""" mixin to provide size scaling """
+	""" mixin to provide size scaling intended to be used with wx.Window (usually wx.Dialog)
+			Sub-classes are responsible for calling wx.Window init
+	"""
+
 	def __init__(self, windowHandle):
 		self._scaleFactor = getScaleFactor(windowHandle)
 
 	def scaleSize(self, size):
 		assert getattr(self, u"_scaleFactor", None)
+		return scaleSize(self._scaleFactor, size)
+
+
+class DpiScalingHelperMixinWithoutInit:
+	"""Same concept as DpiScalingHelperMixin, but ensures you do not have to explicitly call the init
+		of wx.Window or this mixin
+	"""
+	GetHandle: Callable[[], Any]  # Should be provided by wx.Window
+	_scaleFactor: Optional[float] = None
+
+	def scaleSize(self, size):
+		if self._scaleFactor is None:
+			windowHandle = self.GetHandle()
+			self._scaleFactor = getScaleFactor(windowHandle)
 		return scaleSize(self._scaleFactor, size)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10655

### Summary of the issue:
With a low screen resolution (800x600), the elements list cuts of some items.

### Description of how this pull request fixes the issue:
Reduce the size, and also scale using DPI level the tree view control in the elements list dialog.
While doing this I noticed how easy it is to make a mistake with the `DpiScalingHelperMixin`. I have introduced a new version that does not need to call `__init__`explicitly in the right order.

In the future, it would be nice to make this dialog resizable, and make this control fill the available space. For now though, this quick approach solves the problem.

### Testing performed:
Set screen to 800x600: logging out and back in before opening the elements list dialog.
Set screen to 1920x1080 at 100% dpi scaling: logging out and back in before opening the elements list dialog.
Set screen to 1920x1080 at 175% dpi scaling: logging out and back in before opening the elements list dialog

### Known issues with pull request:
I have moved a translation, however the string hasn't changed and won't require re-translation.

### Change log entry:
Probably not necessary, but if we wanted one:

Changes:
`- The elements list dialog has been resized to fit on low resolution screens. (#10655)`

