### PR TITLE
Discard duplicated value for a Windows Explorer list items when accessed via IAccessible

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1956,7 +1956,7 @@ class IENotificationBar(Dialog,IAccessible):
 
 
 class UIItem(IAccessible):
-	"""List items in Windows Explorer repeate the name as the value"""
+	"""List items in Windows Explorer repeat the name as the value"""
 
 	def _get_value(self):
 		return ""

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1954,6 +1954,14 @@ class IENotificationBar(Dialog,IAccessible):
 				speech.speakObject(child,reason=controlTypes.REASON_FOCUS)
 			child=child.simpleNext
 
+
+class UIItem(IAccessible):
+	"""List items in Windows Explorer repeate the name as the value"""
+
+	def _get_value(self):
+		return ""
+
+
 ###class mappings
 
 _staticMap={
@@ -1979,6 +1987,7 @@ _staticMap={
 	("SysListView32",oleacc.ROLE_SYSTEM_LIST):"sysListView32.List",
 	("SysListView32",oleacc.ROLE_SYSTEM_GROUPING):"sysListView32.List",
 	("SysListView32",oleacc.ROLE_SYSTEM_LISTITEM):"sysListView32.ListItem",
+	("DirectUIHWND", oleacc.ROLE_SYSTEM_LISTITEM): "UIItem",
 	("SysListView32",oleacc.ROLE_SYSTEM_MENUITEM):"sysListView32.ListItemWithoutColumnSupport",
 	("SysTreeView32",oleacc.ROLE_SYSTEM_OUTLINE):"sysTreeView32.TreeView",
 	("SysTreeView32",oleacc.ROLE_SYSTEM_OUTLINEITEM):"sysTreeView32.TreeViewItem",


### PR DESCRIPTION
### Link to issue number:
Fixes #10620 fixes #2395
### Summary of the issue:
Windows Explorer list items repeat name as the value. By default we are accessing it via UIA, and in this case the value was discarded. There are situations, such as NVDA's own open windows where UIA cannot be used (it causes freezes) and in these cases repetitions were annoying.
### Description of how this pull request fixes the issue:
Similar to what has been done for UIA value of these items is discarded when accessed via IAccessible
### Testing performed:
Tested that when navigating in the list view in open window from add-on manager value of list items is not announced. Tested the same in Windows Explorer with UIA disabled.
### Known issues with pull request:
None known
### Change log entry:

Section: Bug fixes
When installing add-on from add-ons manager names of files and folders in the browse window are no longer reported twice.

