### PR TITLE
Fix reporting of "not checked" for check boxes with no other states in browse mode.

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -519,7 +519,7 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 	value = propertyValues.get("value")
 	if value and role not in controlTypes.silentValuesForRoles:
 		textList.append(value)
-	if states:
+	if states is not None:
 		textList.extend(
 			controlTypes.processAndLabelStates(role, states, controlTypes.REASON_FOCUS, states, None, positiveStateLabels, negativeStateLabels)
 		)

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1499,10 +1499,16 @@ def getPropertiesSpeech(  # noqa: C901
 		textList.append(roleText if roleText else controlTypes.roleLabels[role])
 	if value:
 		textList.append(value)
-	states=propertyValues.get('states',set())
+	states = propertyValues.get('states')
 	realStates=propertyValues.get('_states',states)
 	negativeStates=propertyValues.get('negativeStates',set())
-	if states or negativeStates:
+	# If the caller didn't want states, states will be None.
+	# However, empty states means the caller still wants states, but the object
+	# had no states; e.g. an unchecked check box with no other states.
+	if states is not None or negativeStates:
+		if states is None:
+			# processAndLabelStates won't accept None for states.
+			states = set()
 		labelStates = controlTypes.processAndLabelStates(role, realStates, reason, states, negativeStates)
 		textList.extend(labelStates)
 	# sometimes description key is present but value is None


### PR DESCRIPTION
### Link to issue number:
none. Fixes a regression introduced by #7279.

CC @leonardder.

### Summary of the issue:
STR:
1. Open this test case in Firefox:
    `data:text/html,<div role="checkbox">test`
2. Press down arrow to read the check box in browse mode.
    - Expected: NVDA should say "check box  not checked  test".
    - Actual: NVDA says just "check box  test".

### Description of how this pull request fixes the issue:
When determining whether the caller wants states, we must differentiate between None and the empty set. If the caller didn't want states, states will be None. However, empty states means the caller still wants states, but the object had no states; e.g. an unchecked check box with no other states. After #7279 but before this PR, we treated an empty set as if the caller didn't want states.

### Testing performed:
As above.

### Known issues with pull request:
None known.

### Change log entry:

Bug fixes:
`- In browse mode, NVDA now reports "not checked" for unchecked check boxes where it sometimes didn't previously.`