### PR TITLE
Fix reporting of ARIA role="switch" in Firefox and Chrome.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -179,6 +179,19 @@ class Math(Ia2Web):
 				"Not supported in this browser or ISimpleDOM COM proxy not registered.", exc_info=True)
 			raise LookupError
 
+
+class Switch(Ia2Web):
+	# role="switch" gets mapped to IA2_ROLE_TOGGLE_BUTTON, but it uses the
+	# checked state instead of pressed. The simplest way to deal with this
+	# identity crisis is to map it to a check box.
+	role = controlTypes.ROLE_CHECKBOX
+
+	def _get_states(self):
+		states = super().states
+		states.discard(controlTypes.STATE_PRESSED)
+		return states
+
+
 def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 	"""Determine the most appropriate class if this is an IA2 web object.
 	This should be called after finding any classes for the specific web implementation.
@@ -204,6 +217,8 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 		clsList.append(Dialog)
 	elif iaRole == oleacc.ROLE_SYSTEM_EQUATION:
 		clsList.append(Math)
+	elif xmlRoles[0] == "switch":
+		clsList.append(Switch)
 
 	if iaRole==oleacc.ROLE_SYSTEM_APPLICATION:
 		clsList.append(Application)

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -103,6 +103,12 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 			role = controlTypes.ROLE_FIGURE
 		elif role in (controlTypes.ROLE_LANDMARK, controlTypes.ROLE_SECTION) and xmlRoles[0] == "region":
 			role = controlTypes.ROLE_REGION
+		elif xmlRoles[0] == "switch":
+			# role="switch" gets mapped to IA2_ROLE_TOGGLE_BUTTON, but it uses the
+			# checked state instead of pressed. The simplest way to deal with this
+			# identity crisis is to map it to a check box.
+			role = controlTypes.ROLE_CHECKBOX
+			states.discard(controlTypes.STATE_PRESSED)
 		attrs['role']=role
 		attrs['states']=states
 		if level is not "" and level is not None:
@@ -278,7 +284,10 @@ class Gecko_ia2(VirtualBuffer):
 		elif nodeType=="comboBox":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_COMBOBOX]}
 		elif nodeType=="checkBox":
-			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_CHECKBUTTON]}
+			attrs = [
+				{"IAccessible::role": [oleacc.ROLE_SYSTEM_CHECKBUTTON]},
+				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("switch")]},
+			]
 		elif nodeType=="graphic":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_GRAPHIC]}
 		elif nodeType=="blockQuote":


### PR DESCRIPTION
### Link to issue number:
Fixes #9187.

CC @MarcoZehe.

### Summary of the issue:
The spec maps role="switch" to IA2_ROLE_TOGGLE_BUTTON. However, it also says that aria-checked should be used for switch, not aria-pressed, and aria-checked is mapped to the checked state.
Firefox does exactly as specified, resulting in NVDA reporting weirdness like "toggle button  not pressed  checked".
Chrome exposes both checked and pressed, resulting in NVDA reporting weirdness like "toggle button  checked  pressed".

### Description of how this pull request fixes the issue:
Since the spec says that a switch is "a type of checkbox", resolve this mess by mapping switch to check box and killing the pressed state.

### Testing performed:
`data:text/html,<div role="switch">test`
In both Firefox and Chrome, confirmed that NVDA reports "check box  not checked  test" in browse mode and "test  check box  not checked" with object navigation. Note that this won't report "not checked" without #10781.

`data:text/html,<div role="switch" aria-checked="true">test`
In both Firefox and Chrome, confirmed that NVDA reports "check box  checked  test" in browse mode and "test  check box  checked" with object navigation.

Also confirmed that "x" quick navigation reaches switches and that they appear in Elements List.

### Known issues with pull request:
There's some controversy around whether this should be mapped to toggle button (pressed/not pressed) or check box (checked/not checked). The spec says that a switch is "a type of checkbox", so I went with that, but the spec is hardly clear given that it maps to toggle button. One other argument in favour of this is that associating it with check box quick nav distinguishes it from purely actionable "buttons".

There's also some discussion of getting this fixed in the spec/browsers; e.g. having browsers map it to role checkbox. See https://github.com/w3c/aria-practices/issues/1327

### Change log entry:

Bug fixes:
`- ARIA switch controls no longer report confusing information such as "not pressed checked" or "pressed checked". (#9187)`