### PR TITLE
FIX FOR SAPI4 SYNTHESIZERS

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -1,6 +1,6 @@
 #synthDrivers/sapi4.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2020 NV Access Limited 
+# Copyright (C) 2006-2020 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -111,7 +111,8 @@ class SynthDriver(SynthDriver):
 		if charMode:
 			# Some synths stay in character mode if we don't explicitly disable it.
 			textList.append("\\RmS=0\\")
-		# Some SAPI4 synthesizers complete speech sequence just after the last text and ignore any indexes passed at the end
+		# Some SAPI4 synthesizers complete speech sequence just after the last text
+		# and ignore any indexes passed after it
 		# Therefore we add the pause of 1ms at the end
 		textList.append("\\PAU=1\\")
 		text="".join(textList)

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -111,8 +111,8 @@ class SynthDriver(SynthDriver):
 		if charMode:
 			# Some synths stay in character mode if we don't explicitly disable it.
 			textList.append("\\RmS=0\\")
-		#Some SAPI4 synthesizers complete speech sequence just after the last text and ignore any indexes passed at the end
-		#Therefore we add the pause of 1ms at the end
+		# Some SAPI4 synthesizers complete speech sequence just after the last text and ignore any indexes passed at the end
+		# Therefore we add the pause of 1ms at the end
 		textList.append("\\PAU=1\\")
 		text="".join(textList)
 		flags=TTSDATAFLAG_TAGGED

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -1,6 +1,6 @@
 #synthDrivers/sapi4.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited 
+#Copyright (C) 2006-2020 NV Access Limited 
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -111,6 +111,9 @@ class SynthDriver(SynthDriver):
 		if charMode:
 			# Some synths stay in character mode if we don't explicitly disable it.
 			textList.append("\\RmS=0\\")
+		#Some SAPI4 synthesizers complete speech sequence just after the last text and ignore any indexes passed at the end
+		#Therefore we add the pause of 1ms at the end
+		textList.append("\\PAU=1\\")
 		text="".join(textList)
 		flags=TTSDATAFLAG_TAGGED
 		self._ttsCentral.TextData(VOICECHARSET.CHARSET_TEXT, flags,TextSDATA(text),self._bufSinkPtr,ITTSBufNotifySink._iid_)


### PR DESCRIPTION
# Summary of the issue:
In NVDA 2019.3 some SAPI4 synthesizers like Syntalk don't work properly. as the final index is not get by Screenreader.
As a result, when focusing some lists or explorer windows, the highlighted element is not reported. Also spelling does not work.

### Description of how this pull request fixes the issue:
As the sequence is closed by some synthesizers just after reaching the last string in queue, we simply add 1ms break after all sequences sent to SAPI4 voice.

### Testing performed:
The last index in speech sequence is sent to NVDA again. When focusing the desktop or using tab to navigate across elements, all items are now reported properly.
This was ested both on Windows 10 and Windows 7 and confirmed by some users from Poland.

### Known issues with pull request:
None issues found.
The drawback is that spelling may prove to slow down a bit after implementing this solution.

### Change log entry:
Bug fixes
SAPI4 voices should now properly report once the speak is completed