### PR TITLE
`brailleInput.handler.sendChars`: allow sending Unicode characters beyond U+FFFF

### DIFF
--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -21,6 +21,7 @@ import keyboardHandler
 import api
 from baseObject import AutoPropertyObject
 import keyLabels
+import struct
 
 
 """Framework for handling braille input from the user.
@@ -391,6 +392,9 @@ class BrailleInputHandler(AutoPropertyObject):
 		@param chars: The characters to send to the system.
 		"""
 		inputs = []
+		chars = ''.join(
+			ch if ord(ch) <= 0xffff else ''.join(
+				chr(x) for x in struct.unpack(">2H", ch.encode("utf-16be"))) for ch in chars)
 		for ch in chars:
 			for direction in (0,winUser.KEYEVENTF_KEYUP): 
 				input = winUser.Input()


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
We currently don't properly send an Unicode characters beyond U+FFFF from the braille input.

```
>>> brailleInput.handler.sendChars("😆")
>>> 
```

### Description of how this pull request fixes the issue:
Break UTF-32 characters into its UTF-16 surrogate pair and send them using SendInput.

### Testing performed:
Tested the previous test with a try build.
Also I addded this patch to Braille Extender add-on since awhile. The add-on allows send any Unicode character via [HUC](https://danielmayr.at/huc/en.html)/hexadecimal/decimal/octal/binary value of the character. Tested with several Unicode characters beyond U+FFFF.


### Known issues with pull request:
None

### Change log entry:
Section: bug fixes
> `- You can now send Unicode characters beyond U+FFFF from a braille display. (#10796)`