### PR TITLE
Fix of error preventing start when log unavailable

### DIFF
--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -51,6 +51,9 @@ class LogViewer(wx.Frame):
 		self.outputCtrl.SetFocus()
 
 	def refresh(self, evt=None):
+		# Ignore if log is not initialized
+		if(globalVars.appArgs.logFileName is None):
+			return
 		pos = self.outputCtrl.GetInsertionPoint()
 		# Append new text to the output control which has been written to the log file since the last refresh.
 		try:
@@ -103,6 +106,17 @@ def activate():
 		return
 	if not logViewer:
 		logViewer = LogViewer(gui.mainFrame)
+	# Check if log was properly initialized
+	if globalVars.appArgs.logFileName is None:
+		wx.CallAfter(
+			gui.messageBox,
+			# Translators: A message indicating that log cannot be loaded to LogViewer.
+			_("Log is unavailable"),
+			# Translators: The title of an error message dialog.
+			_("Error"),
+			wx.OK | wx.ICON_ERROR
+		)
+		return
 	logViewer.Raise()
 	# There is a MAXIMIZE style which can be used on the frame at construction, but it doesn't seem to work the first time it is shown,
 	# probably because it was in the background.

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2008-2018 NV Access Limited
+# Copyright (C) 2008-2020 NV Access Limited
 
 """Provides functionality to view the NVDA log.
 """

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -322,7 +322,14 @@ def initialize(shouldDoRemoteLogging=False):
 				os.rename(globalVars.appArgs.logFileName, oldLogFileName)
 			except (IOError, WindowsError):
 				pass # Probably log does not exist, don't care.
-			logHandler = FileHandler(globalVars.appArgs.logFileName, mode="w",encoding="utf-8")
+			try:
+				logHandler = FileHandler(globalVars.appArgs.logFileName, mode="w", encoding="utf-8")
+			except IOError:
+				# if log cannot be opened, we use NullHandler to avoid logging preserving logger behaviour
+				# and set log filename to None to inform logViewer about it
+				globalVars.appArgs.logFileName = None
+				logHandler = logging.NullHandler()
+				log.error("Faile to open log file, redirecting to standard output")
 			logLevel = globalVars.appArgs.logLevel
 			if globalVars.appArgs.debugLogging:
 				logLevel = Logger.DEBUG

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2019 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.
+# Copyright (C) 2007-2020 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 


### PR DESCRIPTION
### Issue:
Partial fix for #6330:
- Running out of space or changed permissions after NVDA is started is not handled.

### Summary of the issue:
Sometimes it occurs that NVDA is unable to create a log file.
This may be caused by no free disk space on the partition where %temp% folder is located, missing access privileges etc.
In such situations NVDA crashes.
It is undoubtedly not too preferred situation when logging is not working, but even worse problem is screenreader that does not start, not informing user about the cause.

### Description of how this pull request fixes the issue:
When log cannot be initialized (IOError), logging uses the NullHandler and continues loading.
Also, when user tries to open a Log Viewer, the proper error message is displayed.

### Testing performed:
All tests passed.
I simulated both situations when no disk space is available and user does not have write permissions to %temp% folder and NVDA is starting now.

### Known issues with pull request:
None yet.

### Change log entry:
Bug fixes
NVDA starts correctly when log file cannot be created