### PR TITLE
Add missing progress bar settings

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -92,9 +92,9 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 		reportBackgroundProgressBars = boolean(default=false)
 		#output modes are beep, speak, both, or off
 		progressBarOutputMode = string(default="beep")
-		speechPercentageInterval = integer(default=10)
-		beepPercentageInterval = integer(default=1)
-		beepMinHZ = integer(default=110)
+		speechPercentageInterval = integer(default=10,min=1,max=20)
+		beepPercentageInterval = integer(default=1,min=1,max=20)
+		beepMinHZ = integer(default=110,min=55,max=220)
 
 [mouse]
 	enableMouseTracking = boolean(default=True) #must be true for any of the other settings to work

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1791,6 +1791,61 @@ class ObjectPresentationPanel(SettingsPanel):
 				break
 		else:
 			log.debugWarning("Could not set progress list to current report progress bar updates setting")
+		self.progressList.Bind(wx.EVT_CHOICE, self.onProgressBarOutputModeChange)
+
+		# Translators: The label for a setting in presentation settings to change speech percentage interval
+		SpeechIntrLabelText = _("Progress bar &speech percentage Interval")
+		minSpeechIntr = int(config.conf.getConfigValidation(
+			("presentation", "progressBarUpdates", "speechPercentageInterval")
+		).kwargs["min"])
+		maxSpeechIntr = int(config.conf.getConfigValidation(
+			("presentation", "progressBarUpdates", "speechPercentageInterval")
+		).kwargs["max"])
+		self.SpeechIntrEdit = sHelper.addLabeledControl(
+			SpeechIntrLabelText,
+			nvdaControls.SelectOnFocusSpinCtrl,
+			min=minSpeechIntr,
+			max=maxSpeechIntr,
+			initial=config.conf["presentation"]["progressBarUpdates"]["speechPercentageInterval"]
+		)
+		if self.progressList.GetSelection() == 0 or self.progressList.GetSelection() == 2:
+			self.SpeechIntrEdit.Disable()
+
+		# Translators: The label for a setting in presentation settings to change beep percentage interval
+		BeepIntrLabelText = _("Progress bar b&eep percentage Interval")
+		minBeepIntr = int(config.conf.getConfigValidation(
+			("presentation", "progressBarUpdates", "beepPercentageInterval")
+		).kwargs["min"])
+		maxBeepIntr = int(config.conf.getConfigValidation(
+			("presentation", "progressBarUpdates", "beepPercentageInterval")
+		).kwargs["max"])
+		self.BeepIntrEdit = sHelper.addLabeledControl(
+			BeepIntrLabelText,
+			nvdaControls.SelectOnFocusSpinCtrl,
+			min=minBeepIntr,
+			max=maxBeepIntr,
+			initial=config.conf["presentation"]["progressBarUpdates"]["beepPercentageInterval"]
+		)
+		if self.progressList.GetSelection() == 0 or self.progressList.GetSelection() == 1:
+			self.BeepIntrEdit.Disable()
+
+		# Translators: The label for a setting in presentation settings to change minimum beep frequency
+		beepMinHZLabelText = _("Progress bar minimum beep &frequency (Hz)")
+		minBeepHZ = int(config.conf.getConfigValidation(
+			("presentation", "progressBarUpdates", "beepMinHZ")
+		).kwargs["min"])
+		maxBeepHZ = int(config.conf.getConfigValidation(
+			("presentation", "progressBarUpdates", "beepMinHZ")
+		).kwargs["max"])
+		self.beepMinHZEdit = sHelper.addLabeledControl(
+			beepMinHZLabelText,
+			nvdaControls.SelectOnFocusSpinCtrl,
+			min=minBeepHZ,
+			max=maxBeepHZ,
+			initial=config.conf["presentation"]["progressBarUpdates"]["beepMinHZ"]
+		)
+		if self.progressList.GetSelection() == 0 or self.progressList.GetSelection() == 1:
+			self.beepMinHZEdit.Disable()
 
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings panel.
@@ -1810,6 +1865,11 @@ class ObjectPresentationPanel(SettingsPanel):
 		self.autoSuggestionSoundsCheckBox=sHelper.addItem(wx.CheckBox(self,label=autoSuggestionsLabelText))
 		self.autoSuggestionSoundsCheckBox.SetValue(config.conf["presentation"]["reportAutoSuggestionsWithSound"])
 
+	def onProgressBarOutputModeChange(self, evt):
+		self.SpeechIntrEdit.Enable(evt.GetSelection() == 1 or evt.GetSelection() == 3)
+		self.BeepIntrEdit.Enable(evt.GetSelection() == 2 or evt.GetSelection() == 3)
+		self.beepMinHZEdit.Enable(evt.GetSelection() == 2 or evt.GetSelection() == 3)
+
 	def onSave(self):
 		config.conf["presentation"]["reportTooltips"]=self.tooltipCheckBox.IsChecked()
 		config.conf["presentation"]["reportHelpBalloons"]=self.balloonCheckBox.IsChecked()
@@ -1818,6 +1878,9 @@ class ObjectPresentationPanel(SettingsPanel):
 		config.conf["presentation"]["guessObjectPositionInformationWhenUnavailable"]=self.guessPositionInfoCheckBox.IsChecked()
 		config.conf["presentation"]["reportObjectDescriptions"]=self.descriptionCheckBox.IsChecked()
 		config.conf["presentation"]["progressBarUpdates"]["progressBarOutputMode"]=self.progressLabels[self.progressList.GetSelection()][0]
+		config.conf["presentation"]["progressBarUpdates"]["speechPercentageInterval"] = self.SpeechIntrEdit.Value
+		config.conf["presentation"]["progressBarUpdates"]["beepPercentageInterval"] = self.BeepIntrEdit.Value
+		config.conf["presentation"]["progressBarUpdates"]["beepMinHZ"] = self.beepMinHZEdit.Value
 		config.conf["presentation"]["progressBarUpdates"]["reportBackgroundProgressBars"]=self.reportBackgroundProgressBarsCheckBox.IsChecked()
 		config.conf["presentation"]["reportDynamicContentChanges"]=self.dynamicContentCheckBox.IsChecked()
 		config.conf["presentation"]["reportAutoSuggestionsWithSound"]=self.autoSuggestionSoundsCheckBox.IsChecked()

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1576,6 +1576,16 @@ It has the following options:
 - Beep and speak: This option tells NVDA to both beep and speak when a progress bar updates.
 -
 
+==== Progress bar speech percentage Interval ====[ObjectPresentationReportProgressBarSpeechPercentageInterval]
+This setting allows you to set after which percentage change the new progress bar state will be read by the synthesizer.
+
+==== Progress bar Beep percentage Interval ====[ObjectPresentationReportProgressBarBeepPercentageInterval]
+This setting allows you to set after which percentage change the new progress bar state will be indicated by the beep sound.
+
+==== Progress bar minimum beep frequency (HZ) ====[ObjectPresentationReportProgressBarMinimumBeepFrequency (HZ)]
+Here you can set what will be the initial frequency (in Hz), which will be used for the audio presentation of the progress bars.
+The default value of 110Hz corresponds to the sound A in the great octave.
+
 ==== Report background progress bars ====[ObjectPresentationReportBackgroundProgressBars]
 This is an option that, when checked, tells NVDA to keep reporting a progress bar, even if it is not physically in the foreground.
 If you minimize or switch away from a window that contains a progress bar, NVDA will keep track of it, allowing you to do other things while NVDA tracks the progress bar.


### PR DESCRIPTION
### Link to issue number:
#9206 
(Partially)

### Summary of the issue:
Three options associated with progress bars:
* speechPercentageInterval
* beepPercentageInterval
* beepMinHZ

were available, but configurable only manually.

### Description of how this pull request fixes the issue:
The respective options were added to Object Presentation Settings.

### Testing performed:
All tests passed.
All three configurations work properly.

### Known issues with pull request:
None yet.
My only doubt is whether the minBeepHZ setting should not be moved to the advanced settings.

### Change log entry:
Changes
In Object Presentation Settings one can set progress bar update intervals and beep frequency.