### PR TITLE
Support for APH Mantis Q40, APH Chameleon, HumanWare BrailleOne, BrailleNote Touch v2, and NLS eReader

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -461,8 +461,8 @@ addBluetoothDevices("brailleNote", lambda m:
 addUsbDevices("brailliantB", KEY_HID, {
 	"VID_1C71&PID_C111",  # Mantis Q 40
 	"VID_1C71&PID_C101",  # Chameleon 20
-	"VID_1C71&PID_C121",  # Humanware BrailleOne 20 HID
-	"VID_1C71&PID_CE01",  # NLS eReader 20  HID
+	"VID_1C71&PID_C121",  # Humanware BrailleOne 20 HID
+	"VID_1C71&PID_CE01",  # NLS eReader 20 HID
 	"VID_1C71&PID_C006", # Brailliant BI 32, 40 and 80
 	"VID_1C71&PID_C022", # Brailliant BI 14
 	"VID_1C71&PID_C00A", # BrailleNote Touch

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -459,9 +459,14 @@ addBluetoothDevices("brailleNote", lambda m:
 
 # brailliantB
 addUsbDevices("brailliantB", KEY_HID, {
+	"VID_1C71&PID_C111", # Mantis Q 40
+	"VID_1C71&PID_C101", # Chameleon 20
+	"VID_1C71&PID_C121", # Humanware BrailleOne 20 HID
+	"VID_1C71&PID_CE01", # NLS eReader 20  HID
 	"VID_1C71&PID_C006", # Brailliant BI 32, 40 and 80
 	"VID_1C71&PID_C022", # Brailliant BI 14
 	"VID_1C71&PID_C00A", # BrailleNote Touch
+	"VID_1C71&PID_C00E", # BrailleNote Touch v2
 })
 addUsbDevices("brailliantB", KEY_SERIAL, {
 	"VID_1C71&PID_C005", # Brailliant BI 32, 40 and 80
@@ -474,7 +479,13 @@ addBluetoothDevices("brailliantB", lambda m: (
 		or "BrailleNote Touch" in m.id
 	)) or (m.type==KEY_HID
 		and m.deviceInfo.get("manufacturer") == "Humanware"
-		and m.deviceInfo.get("product") == "Brailliant HID"
+		and m.deviceInfo.get("product") in (
+			"Brailliant HID",
+			"APH Chameleon 20",
+			"APH Mantis Q40",
+			"Humanware BrailleOne",
+			"NLS eReader",
+		)
 ))
 
 # eurobraille

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -459,25 +459,30 @@ addBluetoothDevices("brailleNote", lambda m:
 
 # brailliantB
 addUsbDevices("brailliantB", KEY_HID, {
-	"VID_1C71&PID_C111", # Mantis Q 40
-	"VID_1C71&PID_C101", # Chameleon 20
-	"VID_1C71&PID_C121", # Humanware BrailleOne 20 HID
-	"VID_1C71&PID_CE01", # NLS eReader 20  HID
+	"VID_1C71&PID_C111",  # Mantis Q 40
+	"VID_1C71&PID_C101",  # Chameleon 20
+	"VID_1C71&PID_C121",  # Humanware BrailleOne 20 HID
+	"VID_1C71&PID_CE01",  # NLS eReader 20  HID
 	"VID_1C71&PID_C006", # Brailliant BI 32, 40 and 80
 	"VID_1C71&PID_C022", # Brailliant BI 14
 	"VID_1C71&PID_C00A", # BrailleNote Touch
-	"VID_1C71&PID_C00E", # BrailleNote Touch v2
+	"VID_1C71&PID_C00E",  # BrailleNote Touch v2
 })
 addUsbDevices("brailliantB", KEY_SERIAL, {
 	"VID_1C71&PID_C005", # Brailliant BI 32, 40 and 80
 	"VID_1C71&PID_C021", # Brailliant BI 14
 })
-addBluetoothDevices("brailliantB", lambda m: (
-	m.type==KEY_SERIAL
-		and (m.id.startswith("Brailliant B")
-		or m.id == "Brailliant 80"
-		or "BrailleNote Touch" in m.id
-	)) or (m.type==KEY_HID
+addBluetoothDevices(
+	"brailliantB", lambda m: (
+		m.type == KEY_SERIAL
+		and (
+			m.id.startswith("Brailliant B")
+			or m.id == "Brailliant 80"
+			or "BrailleNote Touch" in m.id
+		)
+	)
+	or (
+		m.type == KEY_HID
 		and m.deviceInfo.get("manufacturer") == "Humanware"
 		and m.deviceInfo.get("product") in (
 			"Brailliant HID",
@@ -486,7 +491,8 @@ addBluetoothDevices("brailliantB", lambda m: (
 			"Humanware BrailleOne",
 			"NLS eReader",
 		)
-))
+	)
+)
 
 # eurobraille
 addUsbDevices("eurobraille", KEY_HID, {

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2425,7 +2425,12 @@ The Brailliant BI and B series of displays  from [HumanWare https://www.humanwar
 If connecting via USB with the protocol set to HumanWare, you must first install the USB drivers provided by the manufacturer.
 USB drivers are not required if the protocol is set to OpenBraille.
 
-The BrailleNote Touch is also supported, and does not require any drivers to be installed.
+The following extra devices are also supported (and do not require any special drivers to be installed):
+- APH Mantis Q40
+- APH Chameleon 20
+- Humanware BrailleOne
+- NLS eReader
+
 
 Following are the key assignments for  the Brailliant BI/B and BrailleNote touch displays with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
HumanWare has recently announced several new devices, including APH Mantis Q40, APH Chameleon, HumanWare BrailleOne, BrailleNote Touch v2 and NLS eReader. All these devices are compatible with the Brailliant HID protocol.
NVDA should support these.

### Description of how this pull request fixes the issue:
Add mappings to the BrailliantB driver for these devices for both USB and bluetooth.

### Testing performed:
With both an APH Mantis and an APH Chameleon: Ensured that NVDA could find, connect to, and use these devices successfully when set to Automatic.

### Known issues with pull request:
Although based all on the same protocol, NV Access was unable to test the HumanWare BrailleOne, NLS eReader or BrailleNote Touch v2 due to no access to these devices.

### Change log entry:
What's new:
* Support for New braille displays: APH Chameleon 20, APH Mantis Q40, HumanWare BrailleOne, BrailleNote Touch v2, and NLS eReader.