### PR TITLE
Update liblouis to 3.13.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
-* [liblouis](http://www.liblouis.org/), version 3.12.0
+* [liblouis](http://www.liblouis.org/), version 3.13.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -355,7 +355,7 @@ addTable("pu-in-g1.utb", _("Punjabi grade 1"))
 addTable("ro.ctb", _("Romanian"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru.ctb", _("Russian braille for computer code"))
+addTable("ru.ctb", _("Russian computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ru-ru-g1.utb", _("Russian grade 1"))


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Liblouis 3.13.0 has just been released.

### Description of how this pull request fixes the issue:
Update to liblouis 3.13.0, which apart from a new German braille table has no new or removed tables. The new tables haven't been added yet, as I"m not sure how they fit in the current list of tables. Any feedback would be appreciated.

### Testing performed:
T.b.d.

### Known issues with pull request:
None

### Change log entry:
* Changes
    + Updated liblouis braille translator to [3.13.0](https://github.com/liblouis/liblouis/releases/tag/v3.13.0)