### PR TITLE
Fix order of what's new sections

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,16 @@ What's New in NVDA
 - Updated liblouis braille translator to version 3.12 (#10161)
 
 
+== Bug Fixes ==
+- Fixed not announcing Unicode minus symbol (U+2212) (#10633)
+- When installing add-on from add-ons manager names of files and folders in the browse window are no longer reported twice. (#10620, #2395)
+- In Firefox, when loading Mastodon with the advanced web interface enabled, all timelines now render correctly in browse mode. (#10776)
+- In browse mode, NVDA now reports "not checked" for unchecked check boxes where it sometimes didn't previously. (#10781)
+- ARIA switch controls no longer report confusing information such as "not pressed checked" or "pressed checked". (#9187)
+- SAPI4 voices should no longer refuse to speak certain text. (#10792)
+- NVDA can again read and interact with math equations in Microsoft Word. (#10803)
+
+
 == Changes for Developers ==
 - Developer documentation is now build using sphinx. (#9840)
 - Several speech functions have been split into two. (#10593)
@@ -33,16 +43,6 @@ What's New in NVDA
   - Module level 'REASON_*' constants are deprecated.
 - Compiling NVDA dependencies now requires Visual Studio 2019 (16.2 or newer). (#10169)
 - Updated SCons to version 3.1.1. (#10169)
-
-
-== Bug Fixes ==
-- Fixed not announcing Unicode minus symbol (U+2212) (#10633)
-- When installing add-on from add-ons manager names of files and folders in the browse window are no longer reported twice. (#10620, #2395)
-- In Firefox, when loading Mastodon with the advanced web interface enabled, all timelines now render correctly in browse mode. (#10776)
-- In browse mode, NVDA now reports "not checked" for unchecked check boxes where it sometimes didn't previously. (#10781)
-- ARIA switch controls no longer report confusing information such as "not pressed checked" or "pressed checked". (#9187)
-- SAPI4 voices should no longer refuse to speak certain text. (#10792)
-- NVDA can again read and interact with math equations in Microsoft Word. (#10803)
 
 
 = 2019.3 =


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
The "changes for developers" section appears before "bug fixes" in what's new, inconsistent with previous NVDA versions.

### Description of how this pull request fixes the issue:
Move "bug fixes" to its correct location.

### Testing performed:
None needed.

### Known issues with pull request:
None.

### Change log entry:
None.
