### PR TITLE
Word 365: ignore UIA notification events seen after performing various editing functions

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -320,10 +320,12 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.
 	name=u""
 
-	def event_UIA_notification(self, **kwargs):
+	def event_UIA_notification(self, activityId=None, **kwargs):
 		# #10851: in recent Word 365 releases, UIA notification will cause NVDA to announce edit functions
 		# such as "delete back word" when Control+Backspace is pressed.
-		return
+		if activityId == "AccSN2":  # Delete activity ID
+			return
+		super(WordDocument, self).event_UIA_notification(**kwargs)
 
 	def script_reportCurrentComment(self,gesture):
 		caretInfo=self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -320,6 +320,11 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.
 	name=u""
 
+	def event_UIA_notification(self, **kwargs):
+		# #10851: in recent Word 365 releases, UIA notification will cause NVDA to announce edit functions
+		# such as "delete back word" when Control+Backspace is pressed.
+		return
+
 	def script_reportCurrentComment(self,gesture):
 		caretInfo=self.makeTextInfo(textInfos.POSITION_CARET)
 		caretInfo.expand(textInfos.UNIT_CHARACTER)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2016 NV Access Limited
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2016-2020 NV Access Limited, Joseph Lee
 
 from comtypes import COMError
 from collections import defaultdict


### PR DESCRIPTION
### Link to issue number:
 Fixes #10851 

### Summary of the issue:
In Word 365, word document UIA object fires UIA notification events after editing functions are performed. For example, NVDA will say "delete back word" when Control+Backspace is pressed.

### Description of how this pull request fixes the issue:
Added a "dummy" UIA notification event handler in NVDAObjects.UIA.wordDocument.WordDocument class that simply returns, thus making NVDA ignore UIA notification events.

### Testing performed:
Tested with Word 365, NVDA source code, and a somewhat limited fix in Windows 10 App Essentials add-on.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

In recent releases of Microsoft Word 365, NVDA will no longer announce "delete back word" when Control+Backspace is pressed while editing a document.