### PR TITLE
Add appModule for Visual Studio Code Insiders

### DIFF
--- a/source/appModules/code - insiders.py
+++ b/source/appModules/code - insiders.py
@@ -8,4 +8,6 @@ appModule for Visual Studio Code Insiders.
 Imports the appModule for Visual Studio Code.
 """
 
-from .code import AppModule
+# Normally these Flake8 errors shouldn't be ignored but here we are simply reusing existing ap module.
+
+from .code import *  # noqa: F401, F403

--- a/source/appModules/code - insiders.py
+++ b/source/appModules/code - insiders.py
@@ -1,0 +1,11 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 NV Access Limited, Babbage B.V., Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""
+appModule for Visual Studio Code Insiders.
+Imports the appModule for Visual Studio Code.
+"""
+
+from .code import AppModule


### PR DESCRIPTION
### Link to issue number:
Fixes #10853

### Summary of the issue:
Visual Studio Code Insiders is a special version of Code with bleeding edge features. The appModule for Code that disables browse mode by default doesn't work in the Insiders variant.

### Description of how this pull request fixes the issue:
Add an appModule for insiders that imports the regular appModule.

### Testing performed:
Tested that browse mode stays off by default in VS Code Insiders.

### Known issues with pull request:
This imports the code appModule from builtIN appModules. I wonder whether we should use `from appModules.code import AppModule` instead. Thoughts anyone?

### Change log entry:
* Changes
    + In Visual Studio Code Insiders, browse mode is now off by default as in Visual Studio Code stable.
