### PR TITLE
Ensure that espeak does not exit NVDA's process on initialization error

### DIFF
--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -83,7 +83,7 @@ EE_OK=0
 #EE_BUFFER_FULL=1
 #EE_NOT_FOUND=2
 
-#eSpeak initialization flags
+# eSpeak initialization flags
 espeakINITIALIZE_DONT_EXIT = 0x8000
 
 class espeak_EVENT_id(Union):
@@ -332,8 +332,8 @@ def initialize(indexCallback=None):
 	espeakDLL.espeak_GetCurrentVoice.restype=POINTER(espeak_VOICE)
 	espeakDLL.espeak_SetVoiceByName.argtypes=(c_char_p,)
 	eSpeakPath=os.path.abspath("synthDrivers")
-	sampleRate=espeakDLL.espeak_Initialize(
-		AUDIO_OUTPUT_SYNCHRONOUS,300,
+	sampleRate = espeakDLL.espeak_Initialize(
+		AUDIO_OUTPUT_SYNCHRONOUS, 300,
 		os.fsencode(eSpeakPath),
 		# #10607: ensure espeak does not exit NVDA's process on errors such as the espeak path being invalid.
 		espeakINITIALIZE_DONT_EXIT

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -339,7 +339,7 @@ def initialize(indexCallback=None):
 		espeakINITIALIZE_DONT_EXIT
 	)
 	if sampleRate <= 0:
-		raise OSError(f"espeak_Initialize failed with code {sampleRate}. Given Espeak data path of {eSpeakPath}") 
+		raise OSError(f"espeak_Initialize failed with code {sampleRate}. Given Espeak data path of {eSpeakPath}")
 	player = nvwave.WavePlayer(channels=1, samplesPerSec=sampleRate, bitsPerSample=16,
 		outputDevice=config.conf["speech"]["outputDevice"],
 		buffered=True)

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -83,6 +83,9 @@ EE_OK=0
 #EE_BUFFER_FULL=1
 #EE_NOT_FOUND=2
 
+#eSpeak initialization flags
+espeakINITIALIZE_DONT_EXIT = 0x8000
+
 class espeak_EVENT_id(Union):
 	_fields_=[
 		('number',c_int),
@@ -329,9 +332,13 @@ def initialize(indexCallback=None):
 	espeakDLL.espeak_GetCurrentVoice.restype=POINTER(espeak_VOICE)
 	espeakDLL.espeak_SetVoiceByName.argtypes=(c_char_p,)
 	eSpeakPath=os.path.abspath("synthDrivers")
-	sampleRate=espeakDLL.espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS,300,
-		os.fsencode(eSpeakPath),0)
-	if sampleRate<0:
+	sampleRate=espeakDLL.espeak_Initialize(
+		AUDIO_OUTPUT_SYNCHRONOUS,300,
+		os.fsencode(eSpeakPath),
+		# #10607: ensure espeak does not exit NVDA's process on errors such as the espeak path being invalid.
+		espeakINITIALIZE_DONT_EXIT
+	)
+	if sampleRate <= 0:
 		raise OSError("espeak_Initialize %d"%sampleRate)
 	player = nvwave.WavePlayer(channels=1, samplesPerSec=sampleRate, bitsPerSample=16,
 		outputDevice=config.conf["speech"]["outputDevice"],

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -339,7 +339,7 @@ def initialize(indexCallback=None):
 		espeakINITIALIZE_DONT_EXIT
 	)
 	if sampleRate <= 0:
-		raise OSError("espeak_Initialize %d"%sampleRate)
+		raise OSError(f"espeak_Initialize failed with code {sampleRate}. Given Espeak data path of {eSpeakPath}") 
 	player = nvwave.WavePlayer(channels=1, samplesPerSec=sampleRate, bitsPerSample=16,
 		outputDevice=config.conf["speech"]["outputDevice"],
 		buffered=True)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10607 

### Summary of the issue:
By default, if eSpeak encounters an error on initialization such as the path to its data being invalid, it will call exit(), killing the entire NVDA process.
This specifically happens when NVDA is located in a path that contains non-ascii characters.

### Description of how this pull request fixes the issue:
Ensure that espeak does not exit NVDA's process by passing the espeakINITIALIZE_DONT_EXIT flag to espeak_initialize.

### Testing performed:
Ran NVDA from a path containing non-ascii characters. Ensured that NVDA with default config fell back to silence when espeak failed to initialize. Similarly, when NVDA was configured to use the oneCore synth, ensured that trying to choose espeak from the Synthesizer dialog showed an error dialog and stayed using oneCore.
 
### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
NVDA no longer exits if there is an error initializing eSpeak. (#10607)