### PR TITLE
ensure NVDA speaks text being unselected in browse mode

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -145,7 +145,7 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 		info.expand(unit)
 		if not willSayAllResume(gesture): speech.speakTextInfo(info,unit=unit,reason=controlTypes.REASON_CARET)
 		if not oldInfo.isCollapsed:
-			speech.speakSelectionChange(oldInfo,selection)
+			speech.speakSelectionChange(oldInfo, selection)
 		self.selection = selection
 
 	def doFindText(self,text,reverse=False,caseSensitive=False):

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -145,7 +145,7 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 		info.expand(unit)
 		if not willSayAllResume(gesture): speech.speakTextInfo(info,unit=unit,reason=controlTypes.REASON_CARET)
 		if not oldInfo.isCollapsed:
-			speech.speakSelectionChange(oldInfo,self.selection)
+			speech.speakSelectionChange(oldInfo,selection)
 		self.selection = selection
 
 	def doFindText(self,text,reverse=False,caseSensitive=False):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10731 

### Summary of the issue:
Since the merging of pr #10389,  If text is selected in browse mode, then the an arrow key is pressed such that the selection is canceled and the caret is moved, NVDA no longer announces the text being unselected.
This is because although the original pr moved the speakSelectionChange call above the setting of self.selection, the speakSelectionChange call itself was passed self.selection as a parameter and after the move self.selection was no longer the new textInfo position, and therefore it could not get a correct delta of the new and old selections.

### Description of how this pull request fixes the issue:
In the speakSelectionchange call, change self.selection to selection.

### Testing performed:
Opened a page in Firefox. In browse mode, select a line with shift+downArrow. NVDA announced the line was selected. Then press downArrow (deselecting that line and moving to the next line). NVDA announced the new line and also announced the original line was unselected.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
NVDA will again announce text being unselected in browse mode if pressing an arrow key  while text is selected. (#10731).