### PR TITLE
Allow again _FakeTableCell to have no location defined

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -583,7 +583,7 @@ class RowWithFakeNavigation(NVDAObject):
 			return
 		else:
 			new = cur.next
-		while new and new.hasIrrelevantLocation:
+		while new and new.location and new.location.width == 0:
 			new = new.next
 		self._moveToColumn(new)
 	script_moveToNextColumn.canPropagate = True
@@ -598,7 +598,7 @@ class RowWithFakeNavigation(NVDAObject):
 			new = self
 		else:
 			new = cur.previous
-			while new and new.hasIrrelevantLocation:
+			while new and new.location and new.location.width == 0:
 				new = new.previous
 		self._moveToColumn(new)
 	script_moveToPreviousColumn.canPropagate = True
@@ -642,7 +642,8 @@ class RowWithFakeNavigation(NVDAObject):
 class RowWithoutCellObjects(NVDAObject):
 	"""An abstract class which creates cell objects for table rows which don't natively expose them.
 	Subclasses must override L{_getColumnContent} and can optionally override L{_getColumnHeader}
-	to retrieve information about individual columns.
+	to retrieve information about individual columns and L{_getColumnLocation} to support mouse or
+	magnification tracking or highlighting.
 	The parent (table) must support the L{columnCount} property.
 	"""
 
@@ -735,7 +736,7 @@ class _FakeTableCell(NVDAObject):
 
 	def _get_states(self):
 		states = self.parent.states.copy()
-		if not self.location or self.location.width == 0:
+		if self.location and self.location.width == 0:
 			states.add(controlTypes.STATE_INVISIBLE)
 		return states
 


### PR DESCRIPTION

### Link to issue number:
Fixes #10864

### Summary of the issue:
In NVDA 2019.2.1 it was possible to define behaviors.RowWithoutCellObjects without defining column location. In NVDA 2019.3.1, the code documentation still states that RowWithoutCellObjects._getColumnLocation  method is optional, but not implementing it breaks fake table navigation.

### Description of how this pull request fixes the issue:
Restore fake table navigation when RowWithoutCellObjects._getColumnLocation is not implemented (overridden)

### Alternative
An alternative could have been to document _get_columnLocation as required instead of optional. However, since RowWithoutCellObjects and inherits from NVDAObject which can have location set to None, it seemed important to me that _get_columnLocation remain optional, even if I do not know any case where this method is not implemented.

### Testing performed:
* Tested with [Outlook Extended 1.4](https://github.com/CyrilleB79/outlookExtended/releases/download/V1.4/outlookExtended-1.4.nvda-addon) that column navigation works in Outlook's address book results. No navigation object highlighter shows up during fake cell navigation since these fake cells don't have a defined location.
* Checked in task manager "Details" processus list that table navigation still works.
* In the same list, reduced a column width to 0 and checked that this column was skipped as expected
* In the same list with this 0-width column, activated nav obj highlighter and went from one fake cell to another with object navigation (not in simple mode). Checked that the 0-width fake cell still shows up the highlighter rectangle (narrow vertical) when selecting it by object navigation.

### Known issues with pull request:
None

### Change log entry:

Section: Changes for developers or bugfixes

`Allow again behaviors._FakeTableCell to have no location defined (#10864)`


