### PR TITLE
Remove the readme.md prompt for Unable to build with Python 3.7.6.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,6 @@ The NVDA source depends on several other packages to run correctly.
 The following dependencies need to be installed on your system:
 
 * [Python](https://www.python.org/), version 3.7, 32 bit
-	* Don't use `3.7.6` it causes an error while building, for now use `3.7.5` see #10696.
 * Microsoft Visual Studio 2019 Community, Version 16.3 or later:
 	* Download from https://visualstudio.microsoft.com/vs/
 	* When installing Visual Studio, you need to enable the following:


### PR DESCRIPTION
* Because the issue has been resolved in python3.7.7

### Link to issue number:
#10696 
### Summary of the issue:
* Because the issue has been resolved in python3.7.7

### Description of how this pull request fixes the issue:
* Remove the readme.md prompt for Unable to build with Python 3.7.6
### Testing performed:
Already used local environment: visual studio 2019 + python3.7.7 for build test
### Known issues with pull request:
none
### Change log entry:
none
thanks