### PR TITLE
Fix shortcut creation installer

### DIFF
--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -82,7 +82,7 @@ file /R "${NVDADistDir}\"
 ${GetParameters} $0
 Banner::destroy
 exec:
-execWait "$PLUGINSDIR\app\nvda_noUIAccess.exe $0 -r --launcher" $1
+execWait "$PLUGINSDIR\app\nvda_noUIAccess.exe $0 -r --launcher --debug-logging" $1
 ;If exit code is 3 then execute again (restart)
 intcmp $1 3 exec +1
 SectionEnd

--- a/source/installer.py
+++ b/source/installer.py
@@ -283,7 +283,15 @@ uninstallerRegInfo={
 	"URLInfoAbout":versionInfo.url,
 }
 
-def registerInstallation(installDir,startMenuFolder,shouldCreateDesktopShortcut,startOnLogonScreen,configInLocalAppData=False):
+
+def registerInstallation(
+		installDir,
+		startMenuFolder,
+		shouldCreateDesktopShortcut,
+		startOnLogonScreen,
+		hotkeyCode,
+		configInLocalAppData=False
+):
 	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NVDA",0,winreg.KEY_WRITE) as k:
 		for name,value in uninstallerRegInfo.items(): 
 			winreg.SetValueEx(k,name,None,winreg.REG_SZ,value.format(installDir=installDir))
@@ -517,7 +525,8 @@ def tryCopyFile(sourceFilePath,destFilePath):
 			errorCode=GetLastError()
 			raise OSError("Unable to copy file %s to %s, error %d"%(sourceFilePath,destFilePath,errorCode))
 
-def install(shouldCreateDesktopShortcut=True,shouldRunAtLogon=True):
+
+def install(shouldCreateDesktopShortcut=True, shouldRunAtLogon=True, hotkeyCode=0):
 	prevInstallPath=getInstallPath(noDefault=True)
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, config.NVDA_REGKEY)
@@ -548,7 +557,14 @@ def install(shouldCreateDesktopShortcut=True,shouldRunAtLogon=True):
 			break
 	else:
 		raise RuntimeError("No available executable to use as nvda.exe")
-	registerInstallation(installDir,startMenuFolder,shouldCreateDesktopShortcut,shouldRunAtLogon,configInLocalAppData)
+	registerInstallation(
+		installDir,
+		startMenuFolder,
+		shouldCreateDesktopShortcut,
+		shouldRunAtLogon,
+		hotkeyCode,
+		configInLocalAppData
+	)
 	removeOldLibFiles(installDir,rebootOK=True)
 	COMRegistrationFixes.fixCOMRegistrations()
 

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -114,7 +114,7 @@ def main():
 
 if __name__ == "__main__":
 	logHandler.initialize(True)
-	logHandler.log.setLevel(0)
+	logHandler.log.setLevel(10)
 	import languageHandler
 	languageHandler.setLanguage("Windows")
 	main()

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -44,7 +44,11 @@ def main():
 
 	try:
 		if action=="install":
-			installer.install(bool(int(args[0])),bool(int(args[1])))
+			installer.install(
+				shouldCreateDesktopShortcut=bool(int(args[0])),
+				shouldRunAtLogon=bool(int(args[1])),
+				hotkeyCode=int(args[2])
+			)
 		elif action=="unregisterInstall":
 			import installer
 			installer.unregisterInstallation()


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
fixes #5166
fixes #6326

### Summary of the issue:
We currently allow translators to modify/translate the hotkey used to start NVDA, however hotkeys for windows shortcuts have several limitations and it is easy to get this wrong. Additionally, users may not be happy (or unable to use) the hotkey selected by the translator.

### Description of how this pull request fixes the issue:
This PR is a (currently a proof of concept) to allow setting the hotkey from the installer GUI.

Documentation for the win32 shell link object:
https://docs.microsoft.com/en-gb/windows/win32/shell/shelllinkobject-object

Documentation for the LNK file format (windows shortcuts), particularly relevant is the section on hotkeys:
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-shllink/16cb4ca1-9339-4d0c-a68d-bf1d6cc0f943?redirectedfrom=MSDN

### Testing performed:
Set the hot key to ctrl+alt+m, also set the hotkey with international keyboard.
This will require further testing by international users before merging.

### Known issues with pull request:
- There are some obvious (minor) usability concerns with the current implementation
- The hotkey is not loaded from the shortcut file, so it's initial state is to disable the hotkey. This should be improved to initialize the hotkey control from the shortcut file, or use the default (`ctrl+alt+n`) if the shortcut file does not exist.

### Change log entry:

Section: New features, Changes, Bug fixes

