### PR TITLE
sayAll skim reading no longer keeps announcing exiting initial control fields

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -145,9 +145,12 @@ class _TextReader(object):
 				self.finish()
 			return
 
+		# Copy the speakTextInfoState so that speak callbackCommand
+		# and its associated callback are using a copy isolated to this specific line. 
+		state=self.speakTextInfoState.copy()
 		# Call lineReached when we start speaking this line.
 		# lineReached will move the cursor and trigger reading of the next line.
-		def _onLineReached(obj=self.reader.obj, state=self.speakTextInfoState.copy()):
+		def _onLineReached(obj=self.reader.obj, state=state):
 			self.lineReached(obj, bookmark, state)
 
 		cb = speech.CallbackCommand(
@@ -155,13 +158,23 @@ class _TextReader(object):
 			name="say-all:lineReached"
 		)
 
-		spoke = speech.speakTextInfo(
+		# Generate the speech sequence for the reader textInfo
+		# and insert the lineReached callback at the very beginning of the sequence.
+		# _linePrefix on speakTextInfo cannot be used here
+		# As it would be inserted in the sequence after all initial control starts which is too late.
+		speechGen = speech.getTextInfoSpeech(
 			self.reader,
 			unit=textInfos.UNIT_READINGCHUNK,
 			reason=controlTypes.REASON_SAYALL,
-			_prefixSpeechCommand=cb,
-			useCache=self.speakTextInfoState
+			useCache=state
 		)
+		speechGen = speech.GeneratorWithReturn(speechGen)
+		seq = speech._flattenNestedSequences(speechGen)
+		seq.insert(0, cb)
+		# Speak the speech sequence.
+		spoke = speech.speakWithoutPauses(seq)
+		# Update the textInfo state ready for when speaking the next line.
+		self.speakTextInfoState = state.copy()
 
 		# Collapse to the end of this line, ready to read the next.
 		try:

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -146,10 +146,11 @@ class _TextReader(object):
 			return
 
 		# Copy the speakTextInfoState so that speak callbackCommand
-		# and its associated callback are using a copy isolated to this specific line. 
-		state=self.speakTextInfoState.copy()
+		# and its associated callback are using a copy isolated to this specific line.
+		state = self.speakTextInfoState.copy()
 		# Call lineReached when we start speaking this line.
 		# lineReached will move the cursor and trigger reading of the next line.
+
 		def _onLineReached(obj=self.reader.obj, state=state):
 			self.lineReached(obj, bookmark, state)
 

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1063,6 +1063,8 @@ def speakTextInfo(
 	)
 
 	if reason == controlTypes.REASON_SAYALL:
+		# Deprecation warning: In 2021.1 speakTextInfo will no longer  send speech through speakWithoutPauses
+		# if reason is sayAll, as sayAllhandler does this manually now.
 		return _speakWithoutPauses.speakWithoutPauses(speechSequences)
 
 	speechSequences = GeneratorWithReturn(speechSequences)

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1061,6 +1061,10 @@ def speakTextInfo(
 		onlyInitialFields,
 		suppressBlanks
 	)
+
+	if reason == controlTypes.REASON_SAYALL:
+		return _speakWithoutPauses.speakWithoutPauses(speechSequences)
+
 	speechSequences = GeneratorWithReturn(speechSequences)
 	for seq in speechSequences:
 		speak(seq, priority=priority)
@@ -1429,13 +1433,6 @@ def getTextInfoSpeech(  # noqa: C901
 
 	if reason == controlTypes.REASON_ONLYCACHE or not speechSequence:
 		return False
-
-	if reason == controlTypes.REASON_SAYALL:
-		withoutPauses = GeneratorWithReturn(
-			_speakWithoutPauses.getSpeechWithoutPauses(speechSequence)
-		)
-		yield from withoutPauses
-		return withoutPauses.returnValue
 
 	yield speechSequence
 	return True


### PR DESCRIPTION
### Link to issue number:
Fixes #10706 

### Summary of the issue:
When skim reading in sayAll starting from inside a list or other container, NVDA may keep announcing exiting the list when rapidly arrowing out and away from the container.
This is due to two reasons:
* in sayAllhandler's _nextLine method, the textInfo state was always a line behind when the _lineReached callback was executed, as the state was copied before the textInfo speech was actually generated and therefore the state was not updated for the new line.
* sayAllhandler's _nextLine method was placing the _lineReached callback after any initial control fields had been spoken, rather than right at the very beginning of the speech sequence, as it was using speakTextInfo's _linePrefix argument, which is not quite correct.

### Description of how this pull request fixes the issue:
* sayAllHandler's _nextLine method: ensure that the TextInfoState reflects the state of the correct line when the _lineReached callback is executed, by copying the state before that function is defined, and ensuring that  the new copy of the state is passed to the speech function that generates the speech.
* speech.getTextInfoSpeech no longer handles speakWithoutPauses for sayAll itself. This was confusing as getTextInfoSpeech was not predictable and did not always return the exact speech sequence for the given input. Now speakWithoutPauses is only handled in speakTextInfo. This then means that the sequence from getTextInfoSpeech can be safely mutated or appended/prepended to as needed. (such as adding a callback to the beginning for example).
* sayAllhandler's _nextLine method: use getTextInfoSpeech and speakWithoutPauses directly rather than speakTextInfo, inserting the _lineReached callback at the very start of the speech sequence output by getTextInfoSpeech.

### Testing performed:
Ran through the steps in #10706.  Ensured that the initial control fields were only announced the first time and did not continue to be repeated.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* Arrowing out and away from lists and tables in sayAll with skim reading enabled no longer continuously announces exiting the list or table. (#10706)