### PR TITLE
Don't fail to speak single letters if speechViewer or speech logging is enabled

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -697,11 +697,11 @@ def speak(  # noqa: C901
 	@param priority: The speech priority.
 	"""
 	# speechSequence may be a generator.
-	#  As speechViewer needs to iterate over it 
+	#  As speechViewer needs to iterate over it
 	# before it is iterated over for actual speaking,
-	# Or similarly it may be iterated over for logging bad sequence types, 
+	# Or similarly it may be iterated over for logging bad sequence types,
 	# Flatten it into a list first.
-	if isinstance(speechSequence,collections.abc.Generator):
+	if isinstance(speechSequence, collections.abc.Generator):
 		speechSequence = [i for i in speechSequence]
 	types.logBadSequenceTypes(speechSequence)
 	if priority is None:

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -7,6 +7,7 @@
 """High-level functions to speak information.
 """ 
 
+import collections
 import itertools
 import weakref
 import unicodedata
@@ -695,6 +696,13 @@ def speak(  # noqa: C901
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
+	# speechSequence may be a generator.
+	#  As speechViewer needs to iterate over it 
+	# before it is iterated over for actual speaking,
+	# Or similarly it may be iterated over for logging bad sequence types, 
+	# Flatten it into a list first.
+	if isinstance(speechSequence,collections.abc.Generator):
+		speechSequence = [i for i in speechSequence]
 	types.logBadSequenceTypes(speechSequence)
 	if priority is None:
 		priority = Spri.NORMAL


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #10741 

### Summary of the issue:
NVDa fails to announce single letters when moving with the arrow keys and or reviewing by character, if either speechViewer is enabled, or the speech logging category is enabled in the Advanced settings panel.
The reason for this is that when speaking single letters, speech.speak is passed in a generator as the sequence, yet this generator tries to be iterated over up to 3 times (logging bad sequences, appending to speechViewer, and sending to the synth).

### Description of how this pull request fixes the issue:
If the given sequence is a generator, flatten it into a list first.

### Testing performed:
With neither speechViewer or speech logging enabled, speechViewer enabled but not speech logging,  speech logging but not speechViewer, and both speechViewer and speech logging, move through text in notepad with the left and right arrows, ensuring that each character is read aloud.

### Known issues with pull request:
None.

### Change log entry:
None needed -- Regression introduced after 2019.3.