### PR TITLE
Modify SConscript to make it possible to build with different version of Scons than the one bundled in the repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,8 @@ The NVDA source depends on several other packages to run correctly.
 The following dependencies need to be installed on your system:
 
 * [Python](https://www.python.org/), version 3.7, 32 bit
-	* Don't use `3.7.6` it causes an error while building, for now use `3.7.5` see #10696.
+	* Use latest minor version if possible.
+	* Don't use `3.7.6` it causes an error while building, see #10696.
 * Microsoft Visual Studio 2019 Community, Version 16.3 or later:
 	* Download from https://visualstudio.microsoft.com/vs/
 	* When installing Visual Studio, you need to enable the following:

--- a/scons.py
+++ b/scons.py
@@ -3,22 +3,12 @@
 
 import sys
 import os
-import platform
-# Variables for storing required version of Python, and the version which is used to run this script.
-requiredPythonMajor ="3"
-requiredPythonMinor = "7"
-requiredPythonArchitecture = "32bit"
-installedPythonMajor = str(sys.version_info.major)
-installedPythonMinor = str(sys.version_info.minor)
-installedPythonArchitecture = platform.architecture()[0]
-# Ensure, that we are running with required version of Python, otherwise inform the user and exit.
-if installedPythonArchitecture != requiredPythonArchitecture or installedPythonMajor != requiredPythonMajor or installedPythonMinor != requiredPythonMinor:
-	print("This script is started with Python %s.%s %s, however to build NVDA you have to use Python %s.%s %s." %(installedPythonMajor, installedPythonMinor, installedPythonArchitecture, requiredPythonMajor, requiredPythonMinor, requiredPythonArchitecture))
-	print("Please install the needed version of Python and launch SCons again, or if you have mulltiple versions of Python installed start this script with required version explicitly.")
-	sys.exit(1)
-sys.path.append(os.path.abspath(
-	os.path.join(__file__, "..", "source")))
-import sourceEnv
-del sys.path[-1]
-import SCons.Script
-SCons.Script.main()
+
+sconsPath = os.path.abspath(os.path.join(os.path.dirname(__file__), "include", "scons", "src", "engine"))
+
+if os.path.exists(sconsPath):
+	sys.path.append(sconsPath)
+	import SCons.Script
+	SCons.Script.main()
+else:
+	raise OSError("Path %s does not exist. Perhaps try running git submodule update --init" % sconsPath)

--- a/sconstruct
+++ b/sconstruct
@@ -1,22 +1,61 @@
 ###
-#This file is a part of the NVDA project.
-#URL: https://www.nvaccess.org/
-#Copyright 2010-2019 NV Access Limited, Babbage B.V.
-#This program is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License version 2.0, as published by
-#the Free Software Foundation.
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#This license can be found at:
-#http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# This file is a part of the NVDA project.
+# URL: https://www.nvaccess.org/
+# Copyright 2010-2020 NV Access Limited, Babbage B.V.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2.0, as published by
+# the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# This license can be found at:
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 ###
 
 import sys
 import os
+import platform
+
+# Variables for storing required version of Python, and the version which is used to run this script.
+requiredPythonMajor ="3"
+requiredPythonMinor = "7"
+requiredPythonArchitecture = "32bit"
+installedPythonMajor = str(sys.version_info.major)
+installedPythonMinor = str(sys.version_info.minor)
+installedPythonArchitecture = platform.architecture()[0]
+# Ensure that we are running with required version of Python, otherwise inform the user and exit.
+if (
+	installedPythonArchitecture != requiredPythonArchitecture
+	or installedPythonMajor != requiredPythonMajor
+	or installedPythonMinor != requiredPythonMinor
+):
+	print(
+		"This script is started with Python %s.%s %s, however to build NVDA you have to use Python %s.%s %s."
+		%(
+			installedPythonMajor,
+			installedPythonMinor,
+			installedPythonArchitecture,
+			requiredPythonMajor,
+			requiredPythonMinor,
+			requiredPythonArchitecture
+		)
+	)
+	print(
+		("Please install the needed version of Python and launch SCons again, or if you have multiple "
+		"versions of Python installed start this script with required version explicitly.")
+	)
+	sys.exit(1)
+if sys.version_info.micro == 6:
+	# #10696: Building with Python 3.7.6 fails. Innform user and exit.
+	print("Building with Python 3.7.6 is not possible.")
+	print("Please use more  recent version of Python 3.")
+	sys.exit(2)
+sourceEnvPath = os.path.abspath(os.path.join(Dir('.').srcnode().path, "source"))
+sys.path.append(sourceEnvPath)
+import sourceEnv
+sys.path.remove(sourceEnvPath)
 import time
 from glob import glob
-import sourceEnv
 from py2exe.dllfinder import pydll
 import importlib.util
 import winreg

--- a/sconstruct
+++ b/sconstruct
@@ -29,27 +29,24 @@ if (
 	or installedPythonMajor != requiredPythonMajor
 	or installedPythonMinor != requiredPythonMinor
 ):
-	print(
-		"This script is started with Python %s.%s %s, however to build NVDA you have to use Python %s.%s %s."
-		%(
-			installedPythonMajor,
-			installedPythonMinor,
-			installedPythonArchitecture,
-			requiredPythonMajor,
-			requiredPythonMinor,
-			requiredPythonArchitecture
-		)
-	)
-	print(
-		("Please install the needed version of Python and launch SCons again, or if you have multiple "
+	unsupportedPythonMsg = (
+		("This script is started with Python %s.%s %s, however to build NVDA you have to use Python %s.%s %s.\n"
+		"Please install the needed version of Python and launch SCons again, or if you have multiple "
 		"versions of Python installed start this script with required version explicitly.")
 	)
-	sys.exit(1)
+	raise RuntimeError(unsupportedPythonMsg %(
+		installedPythonMajor,
+		installedPythonMinor,
+		installedPythonArchitecture,
+		requiredPythonMajor,
+		requiredPythonMinor,
+		requiredPythonArchitecture
+	)
+	)
 if sys.version_info.micro == 6:
 	# #10696: Building with Python 3.7.6 fails. Innform user and exit.
-	print("Building with Python 3.7.6 is not possible.")
-	print("Please use more  recent version of Python 3.")
-	sys.exit(2)
+	Py376FailMsg = "Building with Python 3.7.6 is not possible.\nPlease use more  recent version of Python 3."
+	raise RuntimeError(Py376FailMsg)
 sourceEnvPath = os.path.abspath(os.path.join(Dir('.').srcnode().path, "source"))
 sys.path.append(sourceEnvPath)
 import sourceEnv

--- a/source/sourceEnv.py
+++ b/source/sourceEnv.py
@@ -1,8 +1,7 @@
-#sourceEnv.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2013-2018 NV Access Limited, Leonard de Ruijter
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2013-2020 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Set up the Python environment when running from source.
 """
@@ -14,7 +13,6 @@ import os
 TOP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # Directories containing Python modules included in git submodules.
 PYTHON_DIRS = (
-	os.path.join(TOP_DIR, "include", "scons", "src", "engine"),
 	os.path.join(TOP_DIR, "include", "pyserial"),
 	os.path.join(TOP_DIR, "include", "comtypes"),
 	os.path.join(TOP_DIR, "include", "configobj", "src"),


### PR DESCRIPTION
### Link to issue number:
Closes #10876
supersedes #10870
### Summary of the issue:
If for any reason the version of Scons included in NVDA repository is not working on a particular configuration developer suffering from this issue has to request NVDA team to update Scons which takes time and is being done only when never version brings a important improvements for the project. It would be easier if NVDA's build Sconscript could  be invoked with the Scons installed in the Python distribution.
Its currently not possible as our Sconscript cannot be started directly -  scons.py has to set PYTHONPATH in a particular way to make it working.
### Description of how this pull request fixes the issue:
The imports during Scons execution has been reorganized. Now scons.py imports only Scons, and other directories containing Python packages required during build are imported by the sconscript. Also check ensuring that build is being run with the correct Python version has been moved to the Sconscript. While at it I've also added additional check to ensure that someone is not building with Python 3.7.6 (see #10696, and [this commend from pr 10870](https://github.com/nvaccess/nvda/pull/10870#issuecomment-598092551)).
### Testing performed:
- Tested launcher creation when invoked with the Scons from the repository.
- On a machine on which currently included Scons fails also tested building with the Scons installed in Python by moving to the top dir of the repo and executing c:\Python37\Scripts\scons.bat. Ensured that build is successful.

### Known issues with pull request:
I haven't updated readme yet - I don't thing we should encourage usage of non-default version of Scons, and if someone asks on a bug tracker or on NVDA-Devel we can always explain how to use more recent Scons.

### Change log entry:
None needed