### PR TITLE
Don't include Out of date information for Skype in the user guide

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -933,13 +933,6 @@ Note: The above shortcuts work only with the default formatting string for fooba
 | Report notes for translators | control+shift+a | Reports any notes for translators. |
 %kc:endInclude
 
-++ Skype ++[Skype]
-%kc:beginInclude
-When in a conversation:
-|| Name | Key | Description |
-| Review message | NVDA+control+1-0 | Reports and moves the review cursor to a recent message, depending on the number pressed; e.g. NVDA+control+2 reads the second most recent message. |
-%kc:endInclude
-
 ++ Kindle for PC ++[Kindle]
 NVDA supports reading and navigating books in Amazon Kindle for PC.
 This functionality is only available in Kindle books designated with "Screen Reader: Supported" which you can check on the details page for the book.


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
@Qchristensen  noticed that NVDA key commands for Skype were still mentioned in the user guide, however this was only for Skype 7 which is no longer supported.
 
### Description of how this pull request fixes the issue:
Remove the section on Skype from the user guide.

### Testing performed:
Verified the Skype appmodule does not contain any key bindings.

### Known issues with pull request:
None.

### Change log entry:
None needed.