### PR TITLE
Add appModule for ESET antivirus gui.

### DIFF
--- a/source/appModules/egui.py
+++ b/source/appModules/egui.py
@@ -1,0 +1,16 @@
+#appModules/egui.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2020 Pavol Kecskemety <pavol.kecskemety@eset.sk>
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+import appModuleHandler
+
+class AppModule(appModuleHandler.AppModule):
+
+	def event_NVDAObject_init(self, obj):
+		obj.description = None
+		obj.shouldAllowIAccessibleFocusEvent=True
+
+		if obj.name == obj.value:
+			obj.value = None

--- a/source/appModules/egui.py
+++ b/source/appModules/egui.py
@@ -1,4 +1,3 @@
-#appModules/egui.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2020 Pavol Kecskemety <pavol.kecskemety@eset.sk>
 #This file is covered by the GNU General Public License.

--- a/source/appModules/egui.py
+++ b/source/appModules/egui.py
@@ -1,15 +1,17 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2020 Pavol Kecskemety <pavol.kecskemety@eset.sk>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 Pavol Kecskemety <pavol.kecskemety@eset.sk>
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
 
 import appModuleHandler
+
 
 class AppModule(appModuleHandler.AppModule):
 
 	def event_NVDAObject_init(self, obj):
 		obj.description = None
-		obj.shouldAllowIAccessibleFocusEvent=True
+		obj.shouldAllowIAccessibleFocusEvent = True
 
 		if obj.name == obj.value:
 			obj.value = None


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

### Summary of the issue:
When switching pages in ESET Egui, nothing is read. Popup notifications are not read. On the other hand, some items are read twice when focused.

### Description of how this pull request fixes the issue:
Rather simple appModule for egui:
- "obj.shouldAllowIAccessibleFocusEvent=True" fixes reading pages and notifications.
- Checks object name and value for duplicates.
- Object description is used for internal purposes, so there is no point reading it.

### Testing performed:
Tested if page content and notifications are read when they open.
General navigation of ESET Egui to see if anything broke.

### Known issues with pull request:

### Change log entry:
New features:
- Add appModule for ESET antivirus gui.

