### PR TITLE
Add support for Unigram

### DIFF
--- a/source/NVDAObjects/UIA/UWP_chat.py
+++ b/source/NVDAObjects/UIA/UWP_chat.py
@@ -1,0 +1,112 @@
+# NVDAObjects/UIA/UWP_chat.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 Bill Dengler
+
+import appModuleHandler
+import ui
+
+from abc import ABCMeta, abstractmethod
+from NVDAObjects.behaviors import Monitor
+from NVDAObjects.UIA import UIA
+from scriptHandler import script
+
+
+class UWPChatAppModule(appModuleHandler.AppModule, metaclass=ABCMeta):
+	"A base app module for UWP chat apps that present messages in a list view."
+	_lastMessage = None
+	_chat = None
+	POLLING_DELAY = 2
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if not isinstance(obj, UIA):
+			return
+		elif self._isMessagesListView(obj):
+			clsList.insert(0, MessagesListView)
+		elif self._isMessageTextBox(obj):
+			clsList.insert(0, MessageTextBox)
+
+	def event_NVDAObject_init(self, obj):
+		if isinstance(obj, UIA) and self._isMessagesListView(obj) and self.chat != obj:
+			self.chat = obj
+			obj.startMonitoring()
+
+	@script(gestures=[f"kb:control+NVDA+{i}" for i in range(10)])
+	def script_reviewRecentMessage(self, gesture):
+		try:
+			index = int(gesture.mainKeyName[-1])
+			if index == 0:
+				index = 10
+		except (AttributeError, ValueError):
+			return
+		try:
+			ui.message(self.getMessage(index))
+		except (AttributeError, IndexError):
+			# Translators: This is presented to inform the user that no instant message has been received.
+			ui.message(_("No message yet"))
+
+	def event_appModule_gainFocus(self):
+		if self.chat:
+			self.chat.startMonitoring()
+
+	def event_appModule_loseFocus(self):
+		if self.chat:
+			self.chat.stopMonitoring()
+
+	def _get_chat(self):
+		return self._chat
+
+	def _set_chat(self, obj):
+		if obj == self._chat:
+			return
+		if self._chat:
+			self._chat.stopMonitoring()
+		self._chat = obj
+
+	@abstractmethod
+	def _isMessagesListView(self, obj):
+		"Returns whether this object is the list view where new messages arrive."
+		raise NotImplementedError
+
+	@abstractmethod
+	def _isMessageTextBox(self, obj):
+		"Returns whether this object is the text entry field."
+		raise NotImplementedError
+
+	@abstractmethod
+	def getMessage(self, n):
+		"Returns the nth most recent message from the chat list."
+		raise NotImplementedError
+
+
+class MessagesListView(Monitor):
+	_lastMessage = None
+
+	def initOverlayClass(self):
+		self.POLLING_DELAY = self.appModule.POLLING_DELAY
+
+	def hasChanged(self):
+		if self._lastMessage is None:
+			self._lastMessage = self.appModule.getMessage(1)
+		return self.appModule.getMessage(1) != self._lastMessage
+
+	def reactToChange(self):
+		message = self.appModule.getMessage(1)
+		ui.message(message)
+		self._lastMessage = message
+
+	def _getMostRecentMessage(self):
+		try:
+			return self.getChild(self.childCount - 1).name
+		except IndexError:
+			return None
+
+
+class MessageTextBox(UIA):
+	def initOverlayClass(self):
+		if not self.appModule.chat:
+			for i in self.parent.children:
+				if isinstance(i, MessagesListView):
+					self.appModule.chat = i
+					i.startMonitoring()

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1356,13 +1356,25 @@ class UIA(Window):
 		try:
 			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
 		except COMError:
-			return super(UIA, self).children[index]
+			return super(UIA, self).getChild(index)
 		if not cachedChildren:
 			# GetCachedChildren returns null if there are no children.
-			raise IndexError
+			return None
 		e = cachedChildren.getElement(index)
 		windowHandle = self.windowHandle
 		return self.correctAPIForRelation(UIA(windowHandle=windowHandle, UIAElement=e))
+
+	def _get_childCount(self):
+		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
+		try:
+			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
+		except COMError:
+			return super().childCount
+		if not cachedChildren:
+			# GetCachedChildren returns null if there are no children.
+			return 0
+		return cachedChildren.length
 
 	def _get_rowNumber(self):
 		val=self._getUIACacheablePropertyValue(UIAHandler.UIA_GridItemRowPropertyId,True)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1350,6 +1350,20 @@ class UIA(Window):
 			children.append(self.correctAPIForRelation(UIA(windowHandle=windowHandle,UIAElement=e)))
 		return children
 
+	def getChild(self, index):
+		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
+		try:
+			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
+		except COMError:
+			return super(UIA, self).children[index]
+		if not cachedChildren:
+			# GetCachedChildren returns null if there are no children.
+			raise IndexError
+		e = cachedChildren.getElement(index)
+		windowHandle = self.windowHandle
+		return self.correctAPIForRelation(UIA(windowHandle=windowHandle, UIAElement=e))
+
 	def _get_rowNumber(self):
 		val=self._getUIACacheablePropertyValue(UIAHandler.UIA_GridItemRowPropertyId,True)
 		if val!=UIAHandler.handler.reservedNotSupportedValue:

--- a/source/appModules/unigram.py
+++ b/source/appModules/unigram.py
@@ -1,0 +1,114 @@
+# appModules/unigram.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 Bill Dengler
+
+import appModuleHandler
+import time
+import threading
+import ui
+import UIAHandler
+
+from comtypes import COMError
+from NVDAObjects.UIA import UIA
+from scriptHandler import script
+
+
+class AppModule(appModuleHandler.AppModule):
+	_lastMessage = None
+	_chat = None
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if not isinstance(obj, UIA):
+			return
+		elif obj.UIAElement.CachedAutomationID == "Messages":
+			clsList.insert(0, MessagesListView)
+		elif obj.UIAElement.CachedAutomationID == "TextField":
+			clsList.insert(0, MessageTextBox)
+
+	def event_NVDAObject_init(self, obj):
+		if isinstance(obj, UIA) and obj.UIAElement.CachedAutomationID == "Messages" and self.chat != obj:
+			self.chat = obj
+			obj.startMonitoring()
+
+	@script(gestures=[f"kb:control+NVDA+{i}" for i in range(10)])
+	def script_reviewRecentMessage(self, gesture):
+		try:
+			index = int(gesture.mainKeyName[-1])
+			if index == 0:
+				index = 10
+		except (AttributeError, ValueError):
+			return
+		try:
+			ui.message(self.chat.getChild(self.chat._getChildCount() - index).name)
+		except (AttributeError, IndexError):
+			# Translators: This is presented to inform the user that no instant message has been received.
+			ui.message(_("No message yet"))
+
+	def event_appModule_gainFocus(self):
+		if self.chat:
+			self.chat.startMonitoring()
+
+	def event_appModule_loseFocus(self):
+		if self.chat:
+			self.chat.stopMonitoring()
+
+	def _get_chat(self):
+		return self._chat
+
+	def _set_chat(self, obj):
+		if obj == self._chat:
+			return
+		if self._chat:
+			self._chat.stopMonitoring()
+		self._chat = obj
+
+
+class MessagesListView(UIA):
+	_monitoring = False
+
+	def _getChildCount(self):
+		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
+		try:
+			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
+		except COMError:
+			return len(super().children)
+		if not cachedChildren:
+			# GetCachedChildren returns null if there are no children.
+			raise IndexError
+		return cachedChildren.length
+
+	def _monitor(self):
+		try:
+			lastMessage = self.getChild(self._getChildCount() - 1).name
+		except IndexError:
+			lastMessage = None
+		while self._monitoring:
+			try:
+				message = self.getChild(self._getChildCount() - 1).name
+			except IndexError:
+				message = None
+			if message != lastMessage:
+				ui.message(message)
+				lastMessage = message
+			time.sleep(2)
+
+	def startMonitoring(self):
+		if self._monitoring:
+			return
+		self._monitoring = True
+		threading.Thread(target=self._monitor).start()
+
+	def stopMonitoring(self):
+		self._monitoring = False
+
+
+class MessageTextBox(UIA):
+	def initOverlayClass(self):
+		if not self.appModule.chat:
+			for i in self.parent.children:
+				if isinstance(i, MessagesListView):
+					self.appModule.chat = i
+					i.startMonitoring()

--- a/source/appModules/unigram.py
+++ b/source/appModules/unigram.py
@@ -1,114 +1,18 @@
-# appModules/unigram.py
+# NVDAObjects/appModules/unigram.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2020 Bill Dengler
 
-import appModuleHandler
-import time
-import threading
-import ui
-import UIAHandler
-
-from comtypes import COMError
-from NVDAObjects.UIA import UIA
-from scriptHandler import script
+from NVDAObjects.UIA.UWP_chat import UWPChatAppModule
 
 
-class AppModule(appModuleHandler.AppModule):
-	_lastMessage = None
-	_chat = None
+class AppModule(UWPChatAppModule):
+	def _isMessagesListView(self, obj):
+		return obj.UIAElement.CachedAutomationID == "Messages"
 
-	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if not isinstance(obj, UIA):
-			return
-		elif obj.UIAElement.CachedAutomationID == "Messages":
-			clsList.insert(0, MessagesListView)
-		elif obj.UIAElement.CachedAutomationID == "TextField":
-			clsList.insert(0, MessageTextBox)
+	def _isMessageTextBox(self, obj):
+		return obj.UIAElement.CachedAutomationID == "TextField"
 
-	def event_NVDAObject_init(self, obj):
-		if isinstance(obj, UIA) and obj.UIAElement.CachedAutomationID == "Messages" and self.chat != obj:
-			self.chat = obj
-			obj.startMonitoring()
-
-	@script(gestures=[f"kb:control+NVDA+{i}" for i in range(10)])
-	def script_reviewRecentMessage(self, gesture):
-		try:
-			index = int(gesture.mainKeyName[-1])
-			if index == 0:
-				index = 10
-		except (AttributeError, ValueError):
-			return
-		try:
-			ui.message(self.chat.getChild(self.chat._getChildCount() - index).name)
-		except (AttributeError, IndexError):
-			# Translators: This is presented to inform the user that no instant message has been received.
-			ui.message(_("No message yet"))
-
-	def event_appModule_gainFocus(self):
-		if self.chat:
-			self.chat.startMonitoring()
-
-	def event_appModule_loseFocus(self):
-		if self.chat:
-			self.chat.stopMonitoring()
-
-	def _get_chat(self):
-		return self._chat
-
-	def _set_chat(self, obj):
-		if obj == self._chat:
-			return
-		if self._chat:
-			self._chat.stopMonitoring()
-		self._chat = obj
-
-
-class MessagesListView(UIA):
-	_monitoring = False
-
-	def _getChildCount(self):
-		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
-		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
-		try:
-			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
-		except COMError:
-			return len(super().children)
-		if not cachedChildren:
-			# GetCachedChildren returns null if there are no children.
-			raise IndexError
-		return cachedChildren.length
-
-	def _monitor(self):
-		try:
-			lastMessage = self.getChild(self._getChildCount() - 1).name
-		except IndexError:
-			lastMessage = None
-		while self._monitoring:
-			try:
-				message = self.getChild(self._getChildCount() - 1).name
-			except IndexError:
-				message = None
-			if message != lastMessage:
-				ui.message(message)
-				lastMessage = message
-			time.sleep(2)
-
-	def startMonitoring(self):
-		if self._monitoring:
-			return
-		self._monitoring = True
-		threading.Thread(target=self._monitor).start()
-
-	def stopMonitoring(self):
-		self._monitoring = False
-
-
-class MessageTextBox(UIA):
-	def initOverlayClass(self):
-		if not self.appModule.chat:
-			for i in self.parent.children:
-				if isinstance(i, MessagesListView):
-					self.appModule.chat = i
-					i.startMonitoring()
+	def getMessage(self, n):
+		return self.chat.getChild(self.chat.childCount - n).name

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1002,6 +1002,13 @@ The following built-in Windows Console keyboard shortcuts may be useful when [re
 | Scroll to end | control+end | Scrolls the console window to the end of the buffer. |
 %kc:endInclude
 
+++ Unigram ++[Unigram]
+%kc:beginInclude
+When in a conversation:
+|| Name | Key | Description |
+| Review message | NVDA+control+1-0 | Reports and moves the review cursor to a recent message, depending on the number pressed; e.g. NVDA+control+2 reads the second most recent message. |
+%kc:endInclude
+
 + Configuring NVDA +[ConfiguringNVDA]
 Most configuration can be performed using dialog boxes accessed through the Preferences sub-menu of the NVDA menu.
 Many of these settings can be found in the multi-page [NVDA Settings dialog #NVDASettings].


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
This PR adds support for the Unigram Telegram client. Incoming messages are automatically read when the app is in the foreground, and message history can be reviewed with control+NVDA+1 through 0 as with Skype 7 and Miranda.

### Description of how this pull request fixes the issue:
This PR:

* Adds a new `NVDAObjects.behaviors.Monitor` class for reacting to changes in objects, and refactors `NVDAObjects.behaviors.LiveText` in terms of it.
* Adds a new `NVDAObjects.UIA.UWP_chat.UWPChatAppModule`, a base app module for UWP chat apps like Unigram. This will ease #10900 as well.
* Adds a new app module for Unigram based on the base class.
* Adds optimized versions of `childCount` and `getChild` for UIA objects.

### Testing performed:
Tested the app module. Verified that automatic reading and the review message scripts are functional.

Tested CMD (with UIA enabled) and verified that `LiveText` is still functional.

### Known issues with pull request:
There may be a slight (about two second) delay before NVDA reads messages.

### Change log entry:

== New features ==
- Added support for Unigram. (#10904)

== Changes for developers ==
- Added a new `NVDAObjects.behaviors.Monitor` class that polls for particular changes in an object. See `NVDAObjects.behaviors.LiveText` for an example implementation. (#10904)