### PR TITLE
Add support for Dell Mobile Connect

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1,8 +1,9 @@
-#NVDAObjects/UIA/__init__.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2009-2019 NV Access Limited, Joseph Lee, Mohammad Suliman, Babbage B.V., Leonard de Ruijter
+# NVDAObjects/UIA/__init__.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2009-2020 NV Access Limited, Joseph Lee, Mohammad Suliman,
+# Babbage B.V., Leonard de Ruijter, Bill Dengler
 
 """Support for UI Automation (UIA) controls."""
 
@@ -1349,6 +1350,32 @@ class UIA(Window):
 			windowHandle=self.windowHandle
 			children.append(self.correctAPIForRelation(UIA(windowHandle=windowHandle,UIAElement=e)))
 		return children
+
+	def getChild(self, index):
+		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
+		try:
+			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
+		except COMError:
+			return super(UIA, self).getChild(index)
+		if not cachedChildren:
+			# GetCachedChildren returns null if there are no children.
+			return None
+		e = cachedChildren.getElement(index)
+		windowHandle = self.windowHandle
+		return self.correctAPIForRelation(UIA(windowHandle=windowHandle, UIAElement=e))
+
+	def _get_childCount(self):
+		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
+		try:
+			cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
+		except COMError:
+			return super().childCount
+		if not cachedChildren:
+			# GetCachedChildren returns null if there are no children.
+			return 0
+		return cachedChildren.length
 
 	def _get_rowNumber(self):
 		val=self._getUIACacheablePropertyValue(UIAHandler.UIA_GridItemRowPropertyId,True)

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -308,7 +308,14 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		# This override of _getTextLines takes advantage of the fact that
 		# the console text contains linefeeds for every line
 		# Thus a simple string splitlines is much faster than splitting by unit line.
-		ti = self.makeTextInfo(textInfos.POSITION_ALL)
+		try:
+			ti = self.makeTextInfo(textInfos.POSITION_ALL)
+		except (AttributeError, COMError):
+			# When the console exits, the updated lines are retrieved, but this
+			# fails since the window no longer exists.
+			from logHandler import log
+			log.debugWarning("Couldn't get text lines.", exc_info=True)
+			return []
 		text = ti.text or ""
 		return text.splitlines()
 

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -3,7 +3,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Joseph Lee, Bill Dengler
+# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Joseph Lee, Bill Dengler
 
 """Mix-in classes which provide common behaviour for particular types of controls across different APIs.
 Behaviors described in this mix-in include providing table navigation commands for certain table rows, terminal input and output support, announcing notifications and suggestion items and so on.
@@ -29,6 +29,7 @@ import api
 import ui
 import braille
 import nvwave
+from abc import ABCMeta, abstractmethod
 
 class ProgressBar(NVDAObject):
 
@@ -206,28 +207,20 @@ class EditableTextWithoutAutoSelectDetection(editableText.EditableTextWithoutAut
 
 	initOverlayClass = editableText.EditableTextWithoutAutoSelectDetection.initClass
 
-class LiveText(NVDAObject):
-	"""An object for which new text should be reported automatically.
-	These objects present text as a single chunk
-	and only fire an event indicating that some part of the text has changed; i.e. they don't provide the new text.
-	Monitoring must be explicitly started and stopped using the L{startMonitoring} and L{stopMonitoring} methods.
-	The object should notify of text changes using the textChange event.
-	"""
-	#: The time to wait before fetching text after a change event.
-	STABILIZE_DELAY = 0
-	# If the text is live, this is definitely content.
-	presentationType = NVDAObject.presType_content
 
-	announceNewLineText=False
+class Monitor(NVDAObject, metaclass=ABCMeta):
+	"""An object that reacts to particular changes. See LiveText for an example implementation."""
+	#: The time to wait before reacting to an event.
+	STABILIZE_DELAY = 0
+	#: The time to wait between checks for changes.
+	POLLING_DELAY = 0
 
 	def initOverlayClass(self):
-		self._event = threading.Event()
 		self._monitorThread = None
 		self._keepMonitoring = False
 
 	def startMonitoring(self):
-		"""Start monitoring for new text.
-		New text will be reported when it is detected.
+		"""Start monitoring for changes.
 		@note: If monitoring has already been started, this will have no effect.
 		@see: L{stopMonitoring}
 		"""
@@ -239,7 +232,6 @@ class LiveText(NVDAObject):
 		)
 		thread.daemon = True
 		self._keepMonitoring = True
-		self._event.clear()
 		thread.start()
 
 	def stopMonitoring(self):
@@ -250,14 +242,85 @@ class LiveText(NVDAObject):
 		if not self._monitorThread:
 			return
 		self._keepMonitoring = False
-		self._event.set()
 		self._monitorThread = None
+
+	def _monitor(self):
+		while self._keepMonitoring:
+			if self.hasChanged():
+				# wait for the object to stabilise.
+				time.sleep(self.STABILIZE_DELAY)
+				if not self._keepMonitoring:
+					# Monitoring was stopped while waiting.
+					break
+				self.reactToChange()
+			time.sleep(self.POLLING_DELAY)
+
+	@abstractmethod
+	def hasChanged(self):
+		"Returns True if this object had a change for which we are monitoring."
+		raise NotImplementedError
+
+	@abstractmethod
+	def reactToChange(self):
+		"React to a change."
+		raise NotImplementedError
+
+
+class LiveText(Monitor):
+	"""An object for which new text should be reported automatically.
+	These objects present text as a single chunk
+	and only fire an event indicating that some part of the text has changed;
+	i.e. they don't provide the new text.
+	Monitoring must be explicitly started and stopped using the L{startMonitoring} and L{stopMonitoring} methods.
+	The object should notify of text changes using the textChange event.
+	"""
+	# If the text is live, this is definitely content.
+	presentationType = NVDAObject.presType_content
+	announceNewLineText = False
+	_oldLines = None
+
+	def initOverlayClass(self):
+		self._event = threading.Event()
+
+	def startMonitoring(self):
+		super().startMonitoring()
+		self._event.clear()
+
+	def stopMonitoring(self):
+		super().stopMonitoring()
+		self._event.set()
 
 	def event_textChange(self):
 		"""Fired when the text changes.
 		@note: It is safe to call this directly from threads other than the main thread.
 		"""
 		self._event.set()
+
+	def hasChanged(self):
+		if self._oldLines is None:
+			try:
+				self._oldLines = self._getTextLines()
+			except Exception:
+				log.exception("Error getting initial lines")
+				self._oldLines = []
+		self._event.wait()
+		return True
+
+	def reactToChange(self):
+		try:
+			newLines = self._getTextLines()
+			if config.conf["presentation"]["reportDynamicContentChanges"]:
+				outLines = self._calculateNewText(newLines)
+				if len(outLines) == 1 and len(outLines[0].strip()) == 1:
+					# This is only a single character,
+					# which probably means it is just a typed character,
+					# so ignore it.
+					del outLines[0]
+				if outLines:
+					queueHandler.queueFunction(queueHandler.eventQueue, self._reportnewLines, outLines)
+			self._oldLines = newLines
+		except Exception:
+			log.exception("Error getting lines or calculating new text")
 
 	def _getTextLines(self):
 		"""Retrieve the text of this object in lines.
@@ -269,7 +332,7 @@ class LiveText(NVDAObject):
 		"""
 		return list(self.makeTextInfo(textInfos.POSITION_ALL).getTextInChunks(textInfos.UNIT_LINE))
 
-	def _reportNewLines(self, lines):
+	def _reportnewLines(self, lines):
 		"""
 		Reports new lines of text using _reportNewText for each new line.
 		Subclasses may override this method to provide custom filtering of new text,
@@ -283,45 +346,11 @@ class LiveText(NVDAObject):
 		"""
 		speech.speakText(line)
 
-	def _monitor(self):
-		try:
-			oldLines = self._getTextLines()
-		except:
-			log.exception("Error getting initial lines")
-			oldLines = []
-
-		while self._keepMonitoring:
-			self._event.wait()
-			if not self._keepMonitoring:
-				break
-			if self.STABILIZE_DELAY > 0:
-				# wait for the text to stabilise.
-				time.sleep(self.STABILIZE_DELAY)
-				if not self._keepMonitoring:
-					# Monitoring was stopped while waiting for the text to stabilise.
-					break
-			self._event.clear()
-
-			try:
-				newLines = self._getTextLines()
-				if config.conf["presentation"]["reportDynamicContentChanges"]:
-					outLines = self._calculateNewText(newLines, oldLines)
-					if len(outLines) == 1 and len(outLines[0].strip()) == 1:
-						# This is only a single character,
-						# which probably means it is just a typed character,
-						# so ignore it.
-						del outLines[0]
-					if outLines:
-						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewLines, outLines)
-				oldLines = newLines
-			except:
-				log.exception("Error getting lines or calculating new text")
-
-	def _calculateNewText(self, newLines, oldLines):
+	def _calculateNewText(self, newLines):
 		outLines = []
 
 		prevLine = None
-		for line in difflib.ndiff(oldLines, newLines):
+		for line in difflib.ndiff(self._oldLines, newLines):
 			if line[0] == "?":
 				# We're never interested in these.
 				continue
@@ -366,8 +395,8 @@ class LiveText(NVDAObject):
 			if text and not text.isspace():
 				outLines.append(text)
 			prevLine = line
-
 		return outLines
+
 
 class Terminal(LiveText, EditableText):
 	"""An object which both accepts text input and outputs text which should be reported automatically.
@@ -465,16 +494,16 @@ class KeyboardHandlerBasedTypedCharSupport(Terminal):
 		speech.clearTypedWordBuffer()
 		gesture.send()
 
-	def _calculateNewText(self, newLines, oldLines):
+	def _calculateNewText(self, newLines):
 		hasNewLines = (
 			self._findNonBlankIndices(newLines)
-			!= self._findNonBlankIndices(oldLines)
+			!= self._findNonBlankIndices(self._oldLines)
 		)
 		if hasNewLines:
 			# Clear the typed word buffer for new text lines.
 			speech.clearTypedWordBuffer()
 			self._queuedChars = []
-		return super()._calculateNewText(newLines, oldLines)
+		return super()._calculateNewText(newLines)
 
 	def _dispatchQueue(self):
 		"""Sends queued typedCharacter events through to NVDA."""

--- a/source/appModules/dellmobileconnectclient.py
+++ b/source/appModules/dellmobileconnectclient.py
@@ -1,0 +1,11 @@
+# appModules/dellmobileconnectclient.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 Bill Dengler
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""The dellmobileconnectclient executable is used for some notifications.
+Import the main Dell Mobile Connect appModule to handle these cases."""
+
+# Normally these Flake8 errors shouldn't be ignored but here we are simply reusing existing ap module.
+from .dellmobileconnectuniversalclient import AppModule  # noqa: F401, F403

--- a/source/appModules/dellmobileconnectuniversalclient.py
+++ b/source/appModules/dellmobileconnectuniversalclient.py
@@ -92,7 +92,7 @@ class MessageTextBody(UIA):
 			self.appModule._lastMessage = self.notification
 			speech.speak(
 				(title, speech.EndUtteranceCommand(), content),
-				priority=speech.priorities.SpeechPriority.NEXT
+				priority=speech.priorities.SpeechPriority.NOW
 			)
 			braille.handler.message(f"{title}: {content}")
 

--- a/source/appModules/dellmobileconnectuniversalclient.py
+++ b/source/appModules/dellmobileconnectuniversalclient.py
@@ -99,6 +99,7 @@ class MessageTextBody(UIA):
 
 class MessagesListView(Monitor):
 	_lastMessage = None
+	POLLING_DELAY = 0.1
 
 	def _getMostRecentMessage(self):
 		try:

--- a/source/appModules/dellmobileconnectuniversalclient.py
+++ b/source/appModules/dellmobileconnectuniversalclient.py
@@ -1,0 +1,135 @@
+# appModules/dellmobileconnectuniversalclient.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 Bill Dengler
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+import api
+import appModuleHandler
+import braille
+import config
+import controlTypes
+import speech
+import textInfos
+import ui
+from NVDAObjects.behaviors import Monitor
+from NVDAObjects.UIA import UIA
+from scriptHandler import script
+
+
+class AppModule(appModuleHandler.AppModule):
+	_lastMessage = None
+	_chat = None
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if not isinstance(obj, UIA):
+			return
+		if obj.UIAElement.CachedAutomationID == "MessageTextBody":
+			clsList.insert(0, MessageTextBody)
+		elif obj.UIAElement.CachedAutomationID == "MessagesListView":
+			clsList.insert(0, MessagesListView)
+		elif isinstance(obj.parent, MessagesListView):
+			clsList.insert(0, MessagesListViewItem)
+		elif obj.UIAElement.CachedAutomationID == "MessageTextBox":
+			clsList.insert(0, MessageTextBox)
+
+	def event_NVDAObject_init(self, obj):
+		if isinstance(obj, UIA) and obj.UIAElement.CachedAutomationID == "MessagesListView" and self.chat != obj:
+			self.chat = obj
+			obj.startMonitoring()
+
+	@script(gestures=[f"kb:control+NVDA+{i}" for i in range(10)])
+	def script_reviewRecentMessage(self, gesture):
+		try:
+			index = int(gesture.mainKeyName[-1]) - 1
+		except (AttributeError, ValueError):
+			return
+		if index == -1:
+			index = 9
+		try:
+			message = self.chat.getChild(index)
+			api.setNavigatorObject(message, isFocus=True)
+			ui.message(message.name)
+		except (AttributeError, IndexError):
+			# Translators: This is presented to inform the user that no instant message has been received.
+			ui.message(_("No message yet"))
+
+	def event_appModule_gainFocus(self):
+		if self.chat:
+			self.chat.startMonitoring()
+
+	def event_appModule_loseFocus(self):
+		if self.chat:
+			self.chat.stopMonitoring()
+
+	def _get_chat(self):
+		return self._chat
+
+	def _set_chat(self, obj):
+		if obj == self._chat:
+			return
+		if self._chat:
+			self._chat.stopMonitoring()
+		self._chat = obj
+
+
+class MessageTextBody(UIA):
+	role = controlTypes.ROLE_UNKNOWN
+
+	def _get_notification(self):
+		title = ''
+		for i in self.parent.parent.children:
+			if isinstance(i, UIA) and i.UIAElement.CachedAutomationID in ("ContactName", "AppTitle"):
+				title = i.name
+		return (title, self.makeTextInfo(textInfos.POSITION_ALL).text)
+
+	def initOverlayClass(self):
+		# We only want to notify the user once a message window is created,
+		# and not everytime the message text gains focus (such as when tabbing
+		# in the notification window).
+		if self.notification != self.appModule._lastMessage and config.conf["presentation"]["reportHelpBalloons"]:
+			title, content = self.notification
+			self.appModule._lastMessage = self.notification
+			speech.speak(
+				(title, speech.EndUtteranceCommand(), content),
+				priority=speech.priorities.SpeechPriority.NEXT
+			)
+			braille.handler.message(f"{title}: {content}")
+
+
+class MessagesListView(Monitor):
+	_lastMessage = None
+
+	def _getMostRecentMessage(self):
+		try:
+			return self.getChild(0).name
+		except IndexError:
+			return None
+
+	def hasChanged(self):
+		if not self._lastMessage:
+			self._lastMessage = self._getMostRecentMessage()
+		message = self._getMostRecentMessage()
+		return message != self._lastMessage
+
+	def reactToChange(self):
+		message = self._getMostRecentMessage()
+		ui.message(message)
+		self._lastMessage = message
+
+
+class MessagesListViewItem(UIA):
+	def _get_name(self):
+		name = super().name
+		if name.startswith(",, "):
+			return name[3:]
+		return name
+
+
+class MessageTextBox(UIA):
+	def initOverlayClass(self):
+		if not self.appModule.chat:
+			for i in self.parent.children:
+				if isinstance(i, MessagesListView):
+					self.appModule.chat = i
+					i.startMonitoring()

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -933,7 +933,7 @@ Note: The above shortcuts work only with the default formatting string for fooba
 | Report notes for translators | control+shift+a | Reports any notes for translators. |
 %kc:endInclude
 
-++ Skype ++[Skype]
+++ Dell Mobile Connect ++[DellMobileConnect]
 %kc:beginInclude
 When in a conversation:
 || Name | Key | Description |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -939,7 +939,7 @@ For NVDA to be able to report the text of pop-up notifications, the "hide conten
 %kc:beginInclude
 When in a conversation:
 || Name | Key | Description |
-| Review message | NVDA+control+1-0 | Reports and moves the review cursor to a recent message, depending on the number pressed; e.g. NVDA+control+2 reads the second most recent message. |
+| Review message | NVDA+control+1–0 | Reports and moves the review cursor to a recent message, depending on the number pressed; e.g. NVDA+control+2 reads the second most recent message. |
 %kc:endInclude
 
 ++ Kindle for PC ++[Kindle]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -934,6 +934,8 @@ Note: The above shortcuts work only with the default formatting string for fooba
 %kc:endInclude
 
 ++ Dell Mobile Connect ++[DellMobileConnect]
+For NVDA to be able to report the text of pop-up notifications, the "hide contents of notifications" option should be disabled on the notification tab of the application's settings.
+
 %kc:beginInclude
 When in a conversation:
 || Name | Key | Description |


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10900.

### Summary of the issue:
This PR adds support for Dell Mobile Connect, an iMessage client officially for Dell systems and unofficially for other OEMs. Incoming messages are automatically read when the app is in the foreground, and message history can be reviewed with control+NVDA+1 through 0 as with Skype 7 and Miranda.

### Description of how this pull request fixes the issue:
This PR:

* Adds a new `NVDAObjects.behaviors.Monitor` class for reacting to changes in objects, and refactors `NVDAObjects.behaviors.LiveText` in terms of it.
* Adds a new app module for Dell Mobile Connect which implements automatic readout, notifications, and reading message history with NVDA gestures.
* Adds optimized versions of `childCount` and `getChild` for UIA objects.
* Removes outdated Skype 7 commands from the user guide.

### Testing performed:
Tested the app module. Verified that automatic reading and the review message scripts are functional.

Tested Windows Console (UIA and legacy) and PuTTY. Verified that `LiveText` is still functional.

### Known issues with pull request:
* For the text of pop-up notifications to be reported, the "hide content of notifications" option needs to be disabled in application settings.
* If the application window is open in the background and a pop-up notification arrives, NVDA does not always report it. Notifications are reported if the application is minimized to the system tray.

### Change log entry:

== New features ==
- Added support for Dell Mobile Connect. (#10900)

== Changes for developers ==
- Added a new `NVDAObjects.behaviors.Monitor` class that polls for particular changes in an object. See `NVDAObjects.behaviors.LiveText` for an example implementation. (#10910)