### PR TITLE
When NVDA config path is overwritten from the command line open actual config dir when using a keyboard command

### DIFF
--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -15,6 +15,7 @@ def openUserConfigurationDirectory():
 	"""Opens directory containing config files for the current user"""
 	import globalVars
 	try:
+		# configPath is guaranteed to be correct for NVDA, however it will not exist for NVDA_slave.
 		path = globalVars.appArgs.configPath
 	except AttributeError:
 		import config

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -11,14 +11,17 @@ import shellapi
 import winUser
 import os
 
-
 def openUserConfigurationDirectory():
 	"""Opens directory containing config files for the current user"""
-	import config
-	path = config.getUserDefaultConfigPath()
-	if not path:
-		raise ValueError("no user default config path")
-	config.initConfigPath(path)
+	import globalVars
+	try:
+		path = globalVars.appArgs.configPath
+	except AttributeError:
+		import config
+		path = config.getUserDefaultConfigPath()
+		if not path:
+			raise ValueError("no user default config path")
+		config.initConfigPath(path)
 	shellapi.ShellExecute(0, None, path, None, None, winUser.SW_SHOWNORMAL)
 
 


### PR DESCRIPTION
### Link to issue number:
Discussion in #10493 
### Summary of the issue:
If NVDA config path is overwritten from the command line and user tries to open configuration directory by pressing keyboard command wrong folder is opened,
### Description of how this pull request fixes the issue:
If possible globalVars.appArgs.configPath is used to retrieve actual config path falling back to config.getUserDefaultConfigPath() if not.
### Testing performed:
Ensured that when the  config path is specified on the command line and the script to open config path is executed proper folder opens.
### Known issues with pull request:
None known
### Change log entry:
None needed this is not in a release yet.