### PR TITLE
Fix regressions from #10919

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -157,7 +157,17 @@ class UIATextInfo(textInfos.TextInfo):
 			if formatConfig["reportFontSize"]:
 				IDs.add(UIAHandler.UIA_FontSizeAttributeId)
 			if formatConfig["reportFontAttributes"]:
-				IDs.update({UIAHandler.UIA_FontWeightAttributeId,UIAHandler.UIA_IsItalicAttributeId,UIAHandler.UIA_UnderlineStyleAttributeId,UIAHandler.UIA_StrikethroughStyleAttributeId,UIAHandler.UIA_IsSuperscriptAttributeId,UIAHandler.UIA_IsSubscriptAttributeId,})
+				IDs.update({
+					UIAHandler.UIA_FontWeightAttributeId,
+					UIAHandler.UIA_IsItalicAttributeId,
+					UIAHandler.UIA_UnderlineStyleAttributeId,
+					UIAHandler.UIA_StrikethroughStyleAttributeId
+				})
+			if formatConfig["reportSuperscriptsAndSubscripts"]:
+				IDs.update({
+					UIAHandler.UIA_IsSuperscriptAttributeId,
+					UIAHandler.UIA_IsSubscriptAttributeId
+				})
 			if formatConfig["reportAlignment"]:
 				IDs.add(UIAHandler.UIA_HorizontalTextAlignmentAttributeId)
 			if formatConfig["reportColor"]:
@@ -196,6 +206,7 @@ class UIATextInfo(textInfos.TextInfo):
 			val=fetcher.getValue(UIAHandler.UIA_StrikethroughStyleAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if val!=UIAHandler.handler.reservedNotSupportedValue:
 				formatField['strikethrough']=bool(val)
+		if formatConfig["reportSuperscriptsAndSubscripts"]:
 			textPosition=None
 			val=fetcher.getValue(UIAHandler.UIA_IsSuperscriptAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if val!=UIAHandler.handler.reservedNotSupportedValue and val:

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -264,6 +264,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 			formatField["italic"]=bool(charFormat.dwEffects&CFE_ITALIC)
 			formatField["underline"]=bool(charFormat.dwEffects&CFE_UNDERLINE)
 			formatField["strikethrough"]=bool(charFormat.dwEffects&CFE_STRIKEOUT)
+		if formatConfig["reportSuperscriptsAndSubscripts"]:
 			if charFormat.dwEffects&CFE_SUBSCRIPT:
 				formatField["text-position"]="sub"
 			elif charFormat.dwEffects&CFE_SUPERSCRIPT:

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -929,6 +929,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 			formatField['bold']=bool(font.bold)
 			formatField['italic']=bool(font.italic)
 			formatField['underline']=bool(font.underline)
+		if formatConfig['reportSuperscriptAndSubscript']:
 			if font.subscript:
 				formatField['text-position']='sub'
 			elif font.superscript:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1371,6 +1371,8 @@ class GlobalCommands(ScriptableObject):
 	script_sayAll.category=SCRCAT_SYSTEMCARET
 
 	def _reportFormattingHelper(self, info, browseable=False):
+		# Report all formatting-related changes regardless of user settings
+		# when explicitly requested.
 		formatConfig = {
 			"detectFormatAfterCursor": False,
 			"reportFontName": True,

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1373,35 +1373,32 @@ class GlobalCommands(ScriptableObject):
 	def _reportFormattingHelper(self, info, browseable=False):
 		# Report all formatting-related changes regardless of user settings
 		# when explicitly requested.
-		formatConfig = {
-			"detectFormatAfterCursor": False,
-			"reportFontName": True,
-			"reportFontSize": True,
-			"reportFontAttributes": True,
-			"reportSuperscriptsAndSubscripts": True,
-			"reportColor": True,
-			"reportRevisions": False,
-			"reportEmphasis": False,
-			"reportStyle": True,
-			"reportAlignment": True,
-			"reportSpellingErrors": True,
-			"reportPage": False,
-			"reportLineNumber": False,
-			"reportLineIndentation": True,
-			"reportLineIndentationWithTones": False,
-			"reportParagraphIndentation": True,
-			"reportLineSpacing": True,
-			"reportTables": False,
-			"reportLinks": False,
-			"reportHeadings": False,
-			"reportLists": False,
-			"reportBlockQuotes": False,
-			"reportComments": False,
-			"reportBorderStyle": True,
-			"reportBorderColor": True,
-		}
-		textList=[]
+		# These are the options we want reported when reporting formatting manually.
+		# for full list of options that may be reported see the "documentFormatting" section of L{config.configSpec}
+		reportFormattingOptions = (
+			"reportFontName",
+			"reportFontSize",
+			"reportFontAttributes",
+			"reportSuperscriptsAndSubscripts",
+			"reportColor",
+			"reportStyle",
+			"reportAlignment",
+			"reportSpellingErrors",
+			"reportLineIndentation",
+			"reportParagraphIndentation",
+			"reportLineSpacing",
+			"reportBorderStyle",
+			"reportBorderColor",
+		)
 
+		# Create a dictionary to replace the config section that would normally be 
+		# passed to getFormatFieldsSpeech / getFormatFieldsBraille
+		formatConfig  = dict()
+		from config import conf
+		for i in conf["documentFormatting"]:
+			formatConfig [i] = i in reportFormattingOptions
+
+		textList=[]
 		# First, fetch indentation.
 		line=info.copy()
 		line.expand(textInfos.UNIT_LINE)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1391,14 +1391,14 @@ class GlobalCommands(ScriptableObject):
 			"reportBorderColor",
 		)
 
-		# Create a dictionary to replace the config section that would normally be 
+		# Create a dictionary to replace the config section that would normally be
 		# passed to getFormatFieldsSpeech / getFormatFieldsBraille
-		formatConfig  = dict()
+		formatConfig = dict()
 		from config import conf
 		for i in conf["documentFormatting"]:
-			formatConfig [i] = i in reportFormattingOptions
+			formatConfig[i] = i in reportFormattingOptions
 
-		textList=[]
+		textList = []
 		# First, fetch indentation.
 		line=info.copy()
 		line.expand(textInfos.UNIT_LINE)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1371,14 +1371,32 @@ class GlobalCommands(ScriptableObject):
 	script_sayAll.category=SCRCAT_SYSTEMCARET
 
 	def _reportFormattingHelper(self, info, browseable=False):
-		formatConfig={
-			"detectFormatAfterCursor":False,
-			"reportFontName":True,"reportFontSize":True,"reportFontAttributes":True,"reportColor":True,"reportRevisions":False,"reportEmphasis":False,
-			"reportStyle":True,"reportAlignment":True,"reportSpellingErrors":True,
-			"reportPage":False,"reportLineNumber":False,"reportLineIndentation":True,"reportLineIndentationWithTones":False,"reportParagraphIndentation":True,"reportLineSpacing":True,"reportTables":False,
-			"reportLinks":False,"reportHeadings":False,"reportLists":False,
-			"reportBlockQuotes":False,"reportComments":False,
-			"reportBorderStyle":True,"reportBorderColor":True,
+		formatConfig = {
+			"detectFormatAfterCursor": False,
+			"reportFontName": True,
+			"reportFontSize": True,
+			"reportFontAttributes": True,
+			"reportSuperscriptsAndSubscripts": True,
+			"reportColor": True,
+			"reportRevisions": False,
+			"reportEmphasis": False,
+			"reportStyle": True,
+			"reportAlignment": True,
+			"reportSpellingErrors": True,
+			"reportPage": False,
+			"reportLineNumber": False,
+			"reportLineIndentation": True,
+			"reportLineIndentationWithTones": False,
+			"reportParagraphIndentation": True,
+			"reportLineSpacing": True,
+			"reportTables": False,
+			"reportLinks": False,
+			"reportHeadings": False,
+			"reportLists": False,
+			"reportBlockQuotes": False,
+			"reportComments": False,
+			"reportBorderStyle": True,
+			"reportBorderColor": True,
 		}
 		textList=[]
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10931.

### Summary of the issue:
* The report formatting script (NVDA+f) is not functional.
* Some superscript/subscript reporting was not separated.

### Description of how this pull request fixes the issue:
* Adds a `reportSuperscriptsAndSubscripts` key to the `formatConfig` in `_reportFormattingHelper`.
* Separates superscript/subscript fetching in more situations (PowerPoint, UIA).

### Testing performed:
Tested that NVDA+f is now functional.

### Known issues with pull request:
None.

### Change log entry:
None.
