### PR TITLE
Eliminate unwanted speech when opening Windows 7 start menu

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1869,6 +1869,13 @@ class MenuItem(IAccessible):
 class Taskbar(IAccessible):
 	name = _("Taskbar")
 
+	def event_gainFocus(self):
+		api.processPendingEvents(False)
+		# Sometimes before Windows 7 start menu opens taskbar gains focus for a moment producing annoying speech.
+		if eventHandler.isPendingEvents("gainFocus"):
+			return
+		super().event_gainFocus()
+
 class Button(IAccessible):
 
 	def _get_name(self):


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
One of the latest Windows 7 updates introduced a slight delay before start menu opens. This causes focus to land on the taskbar before being moved to the search field after Windows is pressed which for users translates to unwanted and not needed (taskbar is going to loose focus in a second anyway) speech.
### Description of how this pull request fixes the issue:
Focus events on the taskbar are ignored if there are other gainFocus events pending.
### Testing performed:
1. Ensured that "Taskbar" is no longer announced when start menu opens in situations in which it was before.
2. Ensured that when Taskbar gains focus and is not going to loose it immediately it is reported as it should be.
### Known issues with pull request:
None known
### Change log entry:
None needed