### PR TITLE
Allow providing absolute path to the certificate file when executing  scons

### DIFF
--- a/appx/sconscript
+++ b/appx/sconscript
@@ -14,6 +14,7 @@
 
 import subprocess
 import versionInfo
+import os
 
 Import([
 	'env',
@@ -26,11 +27,15 @@ def getCertPublisher(env):
 	If no signing certificate is provided, then the given publisher is used as is.
 	If a signing certificate is given, then the publisher is extracted from the certificate.
 	"""
-	certFile=env.get('certFile')
-	if not certFile:
+	certFilePath = env.get('certFile')
+	if not certFilePath:
 		return env['publisher']
 	certPassword=env.get('certPassword','')
-	cmd=['certutil','-dump','-p',certPassword,File('#'+certFile).abspath.replace('/','\\')]
+	if not os.path.isabs(certFilePath):
+		# If path is not absolute it is assumed that it is being given relative to the top dir of the repo
+		repoTopDir = Dir('#').abspath
+		certFilePath = os.path.abspath(os.path.normpath(os.path.join(repoTopDir, certFilePath)))
+	cmd=['certutil', '-dump', '-p', certPassword, certFilePath]
 	lines=subprocess.run(cmd,check=True,capture_output=True,text=True).stdout.splitlines()
 	linePrefix='Subject: '
 	for line in lines:


### PR DESCRIPTION

### Link to issue number:
None, discovered when working on #10493
### Summary of the issue:
When wanting to self-sign NVDA launcher it is not possible to provide absolute path to the certificate file. This is not documented, error given by certutil when this is done is quite cryptic but more importantly storing certificate inside the repo increases chances of committing it mistakenly to the public.
### Description of how this pull request fixes the issue:
Sconscript used to sign appx version of NVDAno longer assumes that the given path starts at the top dir of the repo. If the  path is absolute it is used as is, if not it is  being joined with the top directory of the repo.
### Testing performed:
With the following layout:
- file called selfsigned.pfx stored at d:\
- NVDA repository stored at d:\my_repos_nvda
- The file from point 1 stored at d:\my_repos\nvda\appveyor\selfsigned.pfx


tried the following scons invocations from the top dir of the repo:
- `scons launcher appx certFile=d:\selfsigned.pfx`
- `scons launcher appx certFile=appveyor\selfsigned.pfx`
- `scons launcher appx certFile=..\..\selfsigned.pfx`

In all cases signing process succeeded

### Known issues with pull request:
- It would be good to create a try branch from this one before merge just to make sure that signed .appx packages  can still be created on AppVeyor. I don't have such permission @michaelDCurran @feerrenrut  @josephsl  could one of you help here?
- The process of retrieving publisher from the certificate parses output of certutil dump  to find the needed info. This unfortunately fails on non-english versions of Windows (the certutil output is localized). I don't think this should be fixed as part of this pr.
### Change log entry:
Either  none or:
Changes for developers:
- It is now possible to provide absolute path to the certificate file when signing an NVDA executable.