### PR TITLE
Update configobj to 5.1.0dev commit f9a265c4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit ca65812a
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
-* [ConfigObj](https://github.com/DiffSK/configobj), commit 5b5de48
+* [ConfigObj](https://github.com/DiffSK/configobj), commit f9a265c
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
 * [liblouis](http://www.liblouis.org/), version 3.13.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.0


### PR DESCRIPTION
### Link to issue number:
Fixes #10939 

### Summary of the issue:
Current version of configobj used by NVDA produces errors when run from source copy of NVDA with Python warnings set to "error".

### Description of how this pull request fixes the issue:
Recent configobj commits include:

* Official support for python 3.7
\* Resolve warnings with collections.abc imports

### Testing performed:
Tested with:

1. Loading and saving NvDA settings with or without new commits applied.
2. Migrating settings files between commits - master to the PR, PR to master.

### Known issues with pull request:
None so far

### Change log entry:
Changes for developers:

Updated configobj to 5.1.0dev commit f9a265c4. (#10939)

