### PR TITLE
Winamp: NVDA will once again announce shuffle and repeat status

### DIFF
--- a/source/appModules/winamp.py
+++ b/source/appModules/winamp.py
@@ -1,8 +1,7 @@
-#appModules/winamp.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2012 NVDA Contributors
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2020 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 from ctypes import *
 from ctypes.wintypes import *

--- a/source/appModules/winamp.py
+++ b/source/appModules/winamp.py
@@ -56,7 +56,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	def event_NVDAObject_init(self,obj):
 		global hwndWinamp
-		hwndWinamp=windll.user32.FindWindowA("Winamp v1.x",None)
+		hwndWinamp = winUser.FindWindow("Winamp v1.x", None)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		windowClass = obj.windowClassName


### PR DESCRIPTION
### Link to issue number:
Fixes #10945 

### Summary of the issue:
NVDA does not announce shuffle and repeat status.

### Description of how this pull request fixes the issue:
Calls winUser.FindWindow, which eventually calls user32.dll::FindWindowW, as Python 3 wants to work with Unicode strings by default.

### Testing performed:
Tested with Winamp 5.66 and 5.8:

1. From main window, press S to toggle shuffle and R to toggle repeat.
2. Verified the status of these flags by opening Winamp options menu.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

In Winamp, NVDA will once again announce toggle status of shuffle and repeat. (#10945)

