### PR TITLE
Report default colors for MS Word with UIA enabled

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -3,7 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2009-2020 NV Access Limited, Joseph Lee, Mohammad Suliman,
-# Babbage B.V., Leonard de Ruijter, Bill Dengler
+# Babbage B.V., Leonard de Ruijter, Bill Dengler, Jakub Lukowicz
 
 """Support for UI Automation (UIA) controls."""
 
@@ -242,9 +242,15 @@ class UIATextInfo(textInfos.TextInfo):
 			val=fetcher.getValue(UIAHandler.UIA_BackgroundColorAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if isinstance(val,int):
 				formatField['background-color']=colors.RGB.fromCOLORREF(val)
+			else:
+				# Translators: a message for reporting a default background color
+				formatField['background-color'] = "default"
 			val=fetcher.getValue(UIAHandler.UIA_ForegroundColorAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if isinstance(val,int):
 				formatField['color']=colors.RGB.fromCOLORREF(val)
+			else:
+				# Translators: a message for reporting a default  foreground color
+				formatField['color'] = "default"
 		if formatConfig['reportLineSpacing']:
 			val=fetcher.getValue(UIAHandler.UIA_LineSpacingAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if val!=UIAHandler.handler.reservedNotSupportedValue:


### PR DESCRIPTION
# Link to issue number:
closes #9182
### Summary of the issue:
Currently, with UIA support enabled, a default color of text isn't reported in word documents. 
For fetching information about color two attributes are used - UIA_BackgroundColorAttribute and UIA_ForegroundColorAttribute. According to the documentation these should return zero as default value. For non default they return a 32-bit value which is then converted to a human understandable color. However for default color they return something like <POINTER(IUnknown) ptr=0x6b196c98 at 1790580>, which can't be converted to anything useful. The link to a list of all UIA text range attributes is below
https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-textattribute-ids
### Description of how this pull request fixes the issue:
I added an else statement to the conditions which fetches foreground and background color, so if the attrib value is not an integer value it is hard-coded as default. Because of that I also added a message for translators.
### Testing performed:
In Word document with UIA support enabled I wrote few lines, changed color for some and navigate through the whole document. The formatting info changes so the user knows which lines have default color.
### Known issues with pull request:
Ideally the actual color should be retrieved however I'm afraid it's not possible with these attributes. I also confirmed that Narator doesn't read that so I doubt anything can be done here. Also in Object Model the actual color isn't retrieved either.
### Change log entry:
Section: Bug fixes
In Word documents with UIA support enabled, a default color is reported.