### PR TITLE
Settings/object presentation: fix accelerator for 'guess object position information' checkbox

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1776,7 +1776,7 @@ class ObjectPresentationPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings panel.
-		guessPositionInfoText = _("&Guess object &position information when unavailable")
+		guessPositionInfoText = _("&Guess object position information when unavailable")
 		self.guessPositionInfoCheckBox=sHelper.addItem(wx.CheckBox(self,label=guessPositionInfoText))
 		self.guessPositionInfoCheckBox.SetValue(config.conf["presentation"]["guessObjectPositionInformationWhenUnavailable"])
 


### PR DESCRIPTION

### Link to issue number:
Follow-up to #7726 

### Summary of the issue:
In object presentation panel, 'guess object position information' displays an ampersand, causing accelerator issue.

### Description of how this pull request fixes the issue:
Removed old accelerator 9seocnd ampersand) in favor of the new accelerator.

### Testing performed:
Tested on source code copy to make sure new accelerator moves focus to the mentioned checkbox.

### Known issues with pull request:
None

### Change log entry:
None
