### PR TITLE
Python syntax: replace identity comparison (var is/is not literal) with equality comparison (var ==/!= literal)

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -226,12 +226,12 @@ class TextInfoQuickNavItem(QuickNavItem):
 			or "lambda property: getattr(self.obj, property, None)" for an L{NVDAObject}.
 		"""
 		content = self.textInfo.text.strip()
-		if self.itemType is "heading":
+		if self.itemType == "heading":
 			# Output: displayed text of the heading.
 			return content
 		labelParts = None
 		name = labelPropertyGetter("name")
-		if self.itemType is "landmark":
+		if self.itemType == "landmark":
 			landmark = aria.landmarkRoles.get(labelPropertyGetter("landmark"))
 			# Example output: main menu; navigation
 			labelParts = (name, landmark)
@@ -242,7 +242,7 @@ class TextInfoQuickNavItem(QuickNavItem):
 			unlabeled = _("Unlabeled")
 			realStates = labelPropertyGetter("states")
 			labeledStates = " ".join(controlTypes.processAndLabelStates(role, realStates, controlTypes.REASON_FOCUS))
-			if self.itemType is "formField":
+			if self.itemType == "formField":
 				if role in (controlTypes.ROLE_BUTTON,controlTypes.ROLE_DROPDOWNBUTTON,controlTypes.ROLE_TOGGLEBUTTON,controlTypes.ROLE_SPLITBUTTON,controlTypes.ROLE_MENUBUTTON,controlTypes.ROLE_DROPDOWNBUTTONGRID,controlTypes.ROLE_SPINBUTTON,controlTypes.ROLE_TREEVIEWBUTTON):
 					# Example output: Mute; toggle button; pressed
 					labelParts = (content or name or unlabeled, roleText, labeledStates)

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -58,7 +58,7 @@ def formatVersionForGUI(year, major, minor):
 		raise ValueError(
 			"Three values must be provided. Got year={}, major={}, minor={}".format(year, major, minor)
 		)
-	if minor is 0:
+	if minor == 0:
 		return "{y}.{M}".format(y=year, M=major)
 	return "{y}.{M}.{m}".format(y=year, M=major, m=minor)
 

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -114,7 +114,7 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 			states.discard(controlTypes.STATE_PRESSED)
 		attrs['role']=role
 		attrs['states']=states
-		if level is not "" and level is not None:
+		if level != "" and level is not None:
 			attrs['level']=level
 		if landmark:
 			attrs["landmark"]=landmark


### PR DESCRIPTION
Hi,

Although the issue noted below relates to Python 3.8, it is compatible with Python 3.7:

### Link to issue number:
Fixes #10966 

### Summary of the issue:
With Python 3.8 run with warnings to errors (-Werror) switch, identity comparison of the form is flagged as syntax errors:

* var is literal
* var is not literal

### Description of how this pull request fixes the issue:
Replace identity comparison with equality check:

* var == literal
* var != literal

### Testing performed:
Tested under:

* Flake8 checks.
* Running source code copy multiple times to verify changes do work, each time one change is made.

### Known issues with pull request:
None

### Change log entry:
None

### Testing procedure (for future reference):

1. Run source code copy of NVDA with -Werror switch (best to do so with Python 3.8).
2. If one didn't do so, install Flake8 (the easiest way to do so is running scons lint base=origin/master, which will download and install Flake8 and its dependencies via Pip).
3. Run Flake8 against the source directory with error codes related to what Python interpreter says (in this case, F632). To do so, go to drive/path/to/nvda/code, then run "flake8 --select {codeToLookFor} source" e.g. "flake8 --select F632 source".
4. Fix the issues Flake8 reports, one at a time.
5. Run NVDA from source with warnings converted to errors.
6. Run and fi another Flake8 error.
7. Repeat steps 5 and 6 until no issues remain.
8. Run NVDA from source multiple times to make sure there are no regressions.

Thanks.