### PR TITLE
Fix superscripts and subscripts reporting for MS Word (legacy).

### DIFF
--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -626,7 +626,7 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 			if((formatConfig&formatConfig_reportColor)&&(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_COLOR,VT_I4,&iVal)==S_OK)) {
 				formatAttribsStream<<L"color=\""<<iVal<<L"\" ";
 			}
-			if(formatConfig&formatConfig_reportFontAttributes) {if(formatConfig&formatConfig_reportFontAttributes) {
+			if(formatConfig&formatConfig_reportFontAttributes) {
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_BOLD,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"bold=\"1\" ";
 				}

--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -51,8 +51,9 @@ constexpr int formatConfig_reportRevisions = 0x8000;
 constexpr int formatConfig_reportParagraphIndentation = 0x10000;
 constexpr int formatConfig_includeLayoutTables = 0x20000;
 constexpr int formatConfig_reportLineSpacing = 0x40000;
+constexpr int formatConfig_reportSuperscriptsAndSubscripts = 0x80000;
 
-constexpr int formatConfig_fontFlags =(formatConfig_reportFontName|formatConfig_reportFontSize|formatConfig_reportFontAttributes|formatConfig_reportColor);
+constexpr int formatConfig_fontFlags =(formatConfig_reportFontName|formatConfig_reportFontSize|formatConfig_reportFontAttributes|formatConfig_reportColor|formatConfig_reportSuperscriptsAndSubscripts);
 constexpr int formatConfig_initialFormatFlags =(formatConfig_reportPage|formatConfig_reportLineNumber|formatConfig_reportTables|formatConfig_reportHeadings|formatConfig_includeLayoutTables);
 
 constexpr wchar_t PAGE_BREAK_VALUE = L'\x0c';
@@ -625,7 +626,7 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 			if((formatConfig&formatConfig_reportColor)&&(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_COLOR,VT_I4,&iVal)==S_OK)) {
 				formatAttribsStream<<L"color=\""<<iVal<<L"\" ";
 			}
-			if(formatConfig&formatConfig_reportFontAttributes) {
+			if(formatConfig&formatConfig_reportFontAttributes) {if(formatConfig&formatConfig_reportFontAttributes) {
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_BOLD,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"bold=\"1\" ";
 				}
@@ -635,11 +636,6 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_UNDERLINE,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"underline=\"1\" ";
 				}
-				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_SUPERSCRIPT,VT_I4,&iVal)==S_OK&&iVal) {
-					formatAttribsStream<<L"text-position=\"super\" ";
-				} else if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_SUBSCRIPT,VT_I4,&iVal)==S_OK&&iVal) {
-					formatAttribsStream<<L"text-position=\"sub\" ";
-				}
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_STRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"strikethrough=\"1\" ";
 				} else if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_DOUBLESTRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
@@ -648,6 +644,13 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_HIDDEN,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"hidden=\"1\" ";
 				}			
+			}
+			if(formatConfig&formatConfig_reportSuperscriptsAndSubscripts) {
+			    if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_SUPERSCRIPT,VT_I4,&iVal)==S_OK&&iVal) {
+					formatAttribsStream<<L"text-position=\"super\" ";
+				} else if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_SUBSCRIPT,VT_I4,&iVal)==S_OK&&iVal) {
+					formatAttribsStream<<L"text-position=\"sub\" ";
+				}
 			}
 		}
 	}

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -327,6 +327,7 @@ formatConfigFlagsMap={
 	"reportRevisions":0x8000,
 	"reportParagraphIndentation":0x10000,
 	"reportLineSpacing":0x40000,
+	"reportSuperscriptsAndSubscripts":0x80000,
 }
 formatConfigFlag_includeLayoutTables=0x20000
 

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -327,7 +327,7 @@ formatConfigFlagsMap={
 	"reportRevisions":0x8000,
 	"reportParagraphIndentation":0x10000,
 	"reportLineSpacing":0x40000,
-	"reportSuperscriptsAndSubscripts":0x80000,
+	"reportSuperscriptsAndSubscripts": 0x80000,
 }
 formatConfigFlag_includeLayoutTables=0x20000
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:

With #10919, superscript and subscript are now reported separately from other attributes. However in MS Word legacy (no UIA), this works only if "Font attributes" is also checked in "Document formatting" setting panel. Checking only "Subscript and superscript" does not work in MS Word legacy support (no UIA).

### Description of how this pull request fixes the issue:

This PR separates completely subscript and superscript handling with respect to attributes handling in winword.cpp

### Testing performed:
Not yet. I have issue with my build environment on my machine. I will try an another machine when I have access to it or test with the build from appVeyor.
I leave this PR as draft in the meantime.

~Planned~ Now Completed tests on Word (legacy mode) ([as per comment](https://github.com/nvaccess/nvda/pull/10979#issuecomment-612210458) ):
* Type a text such as a1^2 + a2^2 = a^2 containing subscripts and superscripts.
* Format the "+" and "=" in bold
* Try the 4 possible following configurations and read the text character by character:
  * attributes off, subscripts/supberscripts off (normal)
  * attributes off, subscripts/supberscripts on
  * attributes on, subscripts/supberscripts off
  * attributes on, subscripts/supberscripts on
Check that bold and subscripts/superscripts announcements are honored when requested.

### Known issues with pull request:

None

### Change log entry:

None since #10919 is not yet in a stable release.

