### PR TITLE
Add a script to toggle the report of superscripts and subscripts

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -360,6 +360,22 @@ class GlobalCommands(ScriptableObject):
 	script_toggleReportFontAttributes.__doc__=_("Toggles on and off the reporting of font attributes")
 	script_toggleReportFontAttributes.category=SCRCAT_DOCUMENTFORMATTING
 
+	@script(
+		# Translators: Input help mode message for toggle report font attributes command.
+		description=_("Toggles on and off the reporting of superscripts and subscripts"),
+		category=SCRCAT_DOCUMENTFORMATTING,
+	)
+	def script_toggleReportSuperscriptsAndSubscripts(self,gesture):
+		if config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"]:
+			# Translators: The message announced when toggling the report superscripts and subscripts document formatting setting.
+			state = _("report superscripts and subscripts off")
+			config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = False
+		else:
+			# Translators: The message announced when toggling the report superscripts and subscripts document formatting setting.
+			state = _("report superscripts and subscripts on")
+			config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = True
+		ui.message(state)
+	
 	def script_toggleReportRevisions(self,gesture):
 		if config.conf["documentFormatting"]["reportRevisions"]:
 			# Translators: The message announced when toggling the report revisions document formatting setting.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -361,7 +361,7 @@ class GlobalCommands(ScriptableObject):
 	script_toggleReportFontAttributes.category=SCRCAT_DOCUMENTFORMATTING
 
 	@script(
-		# Translators: Input help mode message for toggle report font attributes command.
+		# Translators: Input help mode message for toggle superscripts and subscripts command.
 		description=_("Toggles on and off the reporting of superscripts and subscripts"),
 		category=SCRCAT_DOCUMENTFORMATTING,
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -365,13 +365,15 @@ class GlobalCommands(ScriptableObject):
 		description=_("Toggles on and off the reporting of superscripts and subscripts"),
 		category=SCRCAT_DOCUMENTFORMATTING,
 	)
-	def script_toggleReportSuperscriptsAndSubscripts(self,gesture):
+	def script_toggleReportSuperscriptsAndSubscripts(self, gesture):
 		if config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"]:
-			# Translators: The message announced when toggling the report superscripts and subscripts document formatting setting.
+			# Translators: The message announced when toggling the report superscripts and subscripts
+			# document formatting setting.
 			state = _("report superscripts and subscripts off")
 			config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = False
 		else:
-			# Translators: The message announced when toggling the report superscripts and subscripts document formatting setting.
+			# Translators: The message announced when toggling the report superscripts and subscripts
+			# document formatting setting.
 			state = _("report superscripts and subscripts on")
 			config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = True
 		ui.message(state)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -366,17 +366,18 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_DOCUMENTFORMATTING,
 	)
 	def script_toggleReportSuperscriptsAndSubscripts(self, gesture):
-		if config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"]:
-			# Translators: The message announced when toggling the report superscripts and subscripts
-			# document formatting setting.
-			state = _("report superscripts and subscripts off")
-			config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = False
-		else:
+		shouldReport: bool = not config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"]
+		config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] =  shouldReport
+		if shouldReport:
 			# Translators: The message announced when toggling the report superscripts and subscripts
 			# document formatting setting.
 			state = _("report superscripts and subscripts on")
-			config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = True
+		else:
+			# Translators: The message announced when toggling the report superscripts and subscripts
+			# document formatting setting.
+			state = _("report superscripts and subscripts off")
 		ui.message(state)
+
 	
 	def script_toggleReportRevisions(self,gesture):
 		if config.conf["documentFormatting"]["reportRevisions"]:
@@ -2873,4 +2874,3 @@ class ConfigProfileActivationCommands(ScriptableObject):
 #: The single instance for the configuration profile activation commands.
 #: @type: L{ConfigProfileActivationCommands}
 configProfileActivationCommands = ConfigProfileActivationCommands()
-

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -367,7 +367,7 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_toggleReportSuperscriptsAndSubscripts(self, gesture):
 		shouldReport: bool = not config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"]
-		config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] =  shouldReport
+		config.conf["documentFormatting"]["reportSuperscriptsAndSubscripts"] = shouldReport
 		if shouldReport:
 			# Translators: The message announced when toggling the report superscripts and subscripts
 			# document formatting setting.
@@ -377,7 +377,6 @@ class GlobalCommands(ScriptableObject):
 			# document formatting setting.
 			state = _("report superscripts and subscripts off")
 		ui.message(state)
-
 	
 	def script_toggleReportRevisions(self,gesture):
 		if config.conf["documentFormatting"]["reportRevisions"]:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

Almost all items of the "Document formatting" setting panel have an associated script to toggle the feature. Since #10919 has been merged, it would be useful to have a script to toggle superscripts and subscripts reporting. For example the feature would be activated when reading a mathematical document with squared variables. But it should be deactivated when reading a normal document containing abbreviations such as `1st`, `2nd`, etc.

### Description of how this pull request fixes the issue:

Add a script in global commands to toggle the reporting of superscripts and subscripts. This script has no default gesture assigned.

### Testing performed:

* Assigned a gesture to the script.
* Open [this page](https://developer.mozilla.org/fr/docs/Web/HTML/Element/sup
), and go to the demo output.
* Toggle the superscripts and subscripts reading with the gesture and checked that superscripts were reported consequently when reading the following line:
`a2 + b2 = c2`

Did not test with MS Word since there is a pending issue: #10979 
### Known issues with pull request:

This PR does not guarantee that all features of "Document formatting" setting panel has an associated script: cell border reporting is still missing. However there is already a PR for this (#10408)

### Change log entry:

Section: New features

`A script to toggle the report of subscripts and superscripts has been added.`

or just modify the change log entry for #10919 to add this PR's information.
