### PR TITLE
Possible fix for suppression of single lines containing less than three characters in EnhancedTermTypedCharSupport objects

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -413,7 +413,7 @@ class EnhancedTermTypedCharSupport(Terminal):
 		if (
 			len(lines) == 1
 			and not self._hasTab
-			and len(lines[0].strip()) < max(len(speech.curWordChars) + 1, 3)
+			and len(lines[0].strip()) <= max(len(speech.curWordChars), len(self._queuedChars))
 		):
 			return
 		# Clear the typed word buffer for new text lines.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #10988.

### Summary of the issue:
In Windows Console and other `EnhancedTermTypedCharSupport` objects, single new lines containing less than three characters are not read.

### Description of how this pull request fixes the issue:
Adjusts the typed character filtering logic in `_reportNewLines` to limit the minimum line length to the max of the number of currently queued characters and the number of characters in the current word.

### Testing performed:
Checked that the test case in #10988 is now reported. Tested that most extraneous characters are suppressed when typing quickly.

### Known issues with pull request:
When typing very quickly, there is a greater chance that some characters may be echoed twice (if speak typed characters is on) or spoken when not desired (if off). We may need to find another approach to filter duplicate characters.

### Change log entry:
=== Bug fixes ===
- In Windows Console and other terminal programs, single new lines containing two characters or fewer are now automatically reported. (#10988)