### PR TITLE
Update CLDR to version 36.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [ConfigObj](https://github.com/DiffSK/configobj), commit f9a265c
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
 * [liblouis](http://www.liblouis.org/), version 3.13.0
-* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.0
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.1
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * Adobe FlashAccessibility interface typelib


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:
Some emojis have been added since CLDR 36.0
For example, the black cat, person/man/woman giving milk to baby...

### Description of how this pull request fixes the issue:
CLDR submodule is updated to last master revision, which includes CLDR version 36.1 which add these emojis

### Testing performed:
With last NVDA Alpha, these emojis are not pronounced correctly and these are juste a part:
🐈‍⬛ (in french, I have "chat carré noir")
🐻‍❄ (in french "ours flocon")
With CLDR 36.1 these emojis are pronounced correctly.

### Known issues with pull request:

### Change log entry:

Section: Changes
- CLDR annotations have been updated to version 36.1
