### PR TITLE
Add profile specific speech dictionaries

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -386,9 +386,11 @@ class ConfigManager(object):
 		init = currentRootSection is None
 		# Reset the cache.
 		self.rootSection = AggregatedSection(self, (), self.spec, self.profiles)
+		
 		if init:
 			# We're still initialising, so don't notify anyone about this change.
 			return
+		
 		if shouldNotify:
 			post_configProfileSwitch.notify(prevConf=currentRootSection.dict())
 
@@ -628,6 +630,11 @@ class ConfigManager(object):
 				if trigger._profile == delProfile:
 					del self._suspendedTriggers[trigger]
 
+	def getActiveProfile(self):
+		if globalVars.appArgs.secure:
+			return
+		return self.profiles[-1]
+	
 	def renameProfile(self, oldName, newName):
 		"""Rename a profile.
 		@param oldName: The current name of the profile.

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -630,9 +630,8 @@ class ConfigManager(object):
 				if trigger._profile == delProfile:
 					del self._suspendedTriggers[trigger]
 
-	# Returns the currently active profile
-	# If no custom profile is active (default profile is in use), returns None
-	def getActiveProfile(self):
+	# Returns the most recent currently active profile
+	def getMostRecentProfile(self):
 		return self.profiles[-1]
 	
 	def renameProfile(self, oldName, newName):

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -631,10 +631,8 @@ class ConfigManager(object):
 					del self._suspendedTriggers[trigger]
 
 	# Returns the currently active profile
-	# If no custom profile is active (default profile is in use) or custom profiles are not allowed, returns None
+	# If no custom profile is active (default profile is in use), returns None
 	def getActiveProfile(self):
-		if globalVars.appArgs.secure:  # custom profiles not allowed
-			return
 		return self.profiles[-1]
 	
 	def renameProfile(self, oldName, newName):

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -630,8 +630,10 @@ class ConfigManager(object):
 				if trigger._profile == delProfile:
 					del self._suspendedTriggers[trigger]
 
+	# Returns the currently active profile
+	# If no custom profile is active (default profile is in use) or custom profiles are not allowed, returns None
 	def getActiveProfile(self):
-		if globalVars.appArgs.secure:
+		if globalVars.appArgs.secure:  # custom profiles not allowed
 			return
 		return self.profiles[-1]
 	

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -203,14 +203,25 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onDefaultDictionaryCommand(self,evt):
+		# linting is complaining about from .settingsDialogs import * names
+		# too risky to change it all, so we will specify what we want on a method based aproach
+		from .settingsDialogs import DictionaryDialog
+		dic = speechDictHandler.getDictionary("default")
 		# Translators: Title for default speech dictionary dialog.
-		self._popupSettingsDialog(DictionaryDialog,_("Default dictionary"),speechDictHandler.dictionaries["default"])
+		self._popupSettingsDialog(DictionaryDialog, _("Default dictionary"), dic)
 
 	def onVoiceDictionaryCommand(self,evt):
+		# linting is complaining about from .settingsDialogs import * names
+		# too risky to change it all, so we will specify what we want on a method based aproach
+		from .settingsDialogs import DictionaryDialog
+		dic = speechDictHandler.getDictionary("voice")
 		# Translators: Title for voice dictionary for the current voice such as current eSpeak variant.
-		self._popupSettingsDialog(DictionaryDialog,_("Voice dictionary (%s)")%speechDictHandler.dictionaries["voice"].fileName,speechDictHandler.dictionaries["voice"])
+		self._popupSettingsDialog(DictionaryDialog, _("Voice dictionary (%s)") % dic.fileName, dic)
 
 	def onTemporaryDictionaryCommand(self,evt):
+		# linting is complaining about from .settingsDialogs import * names
+		# too risky to change it all, so we will specify what we want on a method based aproach
+		from .settingsDialogs import DictionaryDialog
 		# Translators: Title for temporary speech dictionary dialog (the voice dictionary that is active as long as NvDA is running).
 		self._popupSettingsDialog(DictionaryDialog,_("Temporary dictionary"),speechDictHandler.dictionaries["temp"])
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -32,6 +32,7 @@ import queueHandler
 import core
 from . import guiHelper
 from .settingsDialogs import *
+from .settingsDialogs import DictionaryDialog
 from .inputGestures import InputGesturesDialog
 import speechDictHandler
 import languageHandler
@@ -203,25 +204,18 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onDefaultDictionaryCommand(self,evt):
-		# linting is complaining about from .settingsDialogs import * names
-		# too risky to change it all, so we will specify what we want on a method based aproach
-		from .settingsDialogs import DictionaryDialog
 		dic = speechDictHandler.getDictionary("default")
 		# Translators: Title for default speech dictionary dialog.
 		self._popupSettingsDialog(DictionaryDialog, _("Default dictionary"), dic)
 
 	def onVoiceDictionaryCommand(self,evt):
-		# linting is complaining about from .settingsDialogs import * names
-		# too risky to change it all, so we will specify what we want on a method based aproach
-		from .settingsDialogs import DictionaryDialog
 		dic = speechDictHandler.getDictionary("voice")
-		# Translators: Title for voice dictionary for the current voice such as current eSpeak variant.
-		self._popupSettingsDialog(DictionaryDialog, _("Voice dictionary (%s)") % dic.fileName, dic)
+		self._popupSettingsDialog(DictionaryDialog, "{voiceDictionary} ({dictFileName})".format(
+			# Translators: Title for voice dictionary for the current voice such as current eSpeak variant.
+			voiceDictionary=_("Voice dictionary"),
+			dictFileName=dic.fileName), dic)
 
 	def onTemporaryDictionaryCommand(self,evt):
-		# linting is complaining about from .settingsDialogs import * names
-		# too risky to change it all, so we will specify what we want on a method based aproach
-		from .settingsDialogs import DictionaryDialog
 		# Translators: Title for temporary speech dictionary dialog (the voice dictionary that is active as long as NvDA is running).
 		self._popupSettingsDialog(DictionaryDialog,_("Temporary dictionary"),speechDictHandler.dictionaries["temp"])
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -24,7 +24,6 @@ import languageHandler
 import speech
 import gui
 import gui.contextHelp
-import os
 import globalVars
 from logHandler import log
 import nvwave
@@ -3061,9 +3060,11 @@ class DictionaryDialog(SettingsDialog):
 	def postInit(self):
 		self.dictList.SetFocus()
 
-	def hasEntry(self, pattern):
+	# Verifies whether a given pattern (text that should have a replacement)
+	# entry is already present on this dictionary
+	def hasPatternEntry(self, patternColText):
 		for row in range(self.dictList.GetItemCount()):
-			if self.dictList.GetItem(row, self.PATTERN_COL).GetText() == pattern:
+			if self.dictList.GetItem(row, self.PATTERN_COL).GetText() == patternColText:
 				return True
 		return False
 
@@ -3093,7 +3094,7 @@ class DictionaryDialog(SettingsDialog):
 		source.load(sourceFileName)
 		self.tempSpeechDict.syncFrom(source)
 		for entry in self.tempSpeechDict:
-			if not self.hasEntry(entry.pattern):
+			if not self.hasPatternEntry(entry.pattern):
 				self.dictList.Append((
 					entry.comment,
 					entry.pattern,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2988,7 +2988,7 @@ class DictionaryDialog(SettingsDialog):
 	PATTERN_COL = 1
 
 	def __init__(self,parent,title,speechDict):
-		self._profile = config.conf.getActiveProfile()
+		self._profile = config.conf.getMostRecentProfile()
 		self.title = self._makeTitle(title)
 		self.speechDict = speechDict
 		self.tempSpeechDict=speechDictHandler.SpeechDict()
@@ -4042,7 +4042,7 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 
 	def _doOnCategoryChange(self):
 		global NvdaSettingsDialogActiveConfigProfile
-		NvdaSettingsDialogActiveConfigProfile = config.conf.getActiveProfile().name
+		NvdaSettingsDialogActiveConfigProfile = config.conf.getMostRecentProfile().name
 		if not NvdaSettingsDialogActiveConfigProfile or isinstance(self.currentCategory, GeneralSettingsPanel):
 			# Translators: The profile name for normal configuration
 			NvdaSettingsDialogActiveConfigProfile = _("normal configuration")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3052,7 +3052,7 @@ class DictionaryDialog(SettingsDialog):
 			bHelper.addButton(
 				parent=self,
 				# Translators: The label for the import entries from default profile dictionary
-				label=_("&import entries from default profile dictionary")
+				label=_("&Import entries from default profile dictionary")
 			).Bind(wx.EVT_BUTTON, self.onImportEntriesClick)
 
 		sHelper.addItem(bHelper)

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -180,7 +180,7 @@ def getDictionary(type):
 	profile = config.conf.getActiveProfile()
 	if(type == "voice"):
 		return _getVoiceDictionary(profile)
-	# if we are om default profile or the specific dictionary profile is already loaded
+	# if we are on default profile or the specific dictionary profile is already loaded
 	if not profile.name or _hasDictionaryProfile(profile.name, f"{type}.dic"):
 		# we are with the correct dictionary loaded. Just return it.
 		log.debug(f"{type} dictionary, backed by {dictionaries[type].fileName} was requested")

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -41,6 +41,9 @@ class SpeechDictEntry:
 		self.caseSensitive=caseSensitive
 		self.type=type
 
+	def getPattern(self):
+		return self.pattern
+
 	def sub(self, text):
 		replacement=self.replacement
 		return self.compiled.sub(replacement, text)
@@ -49,6 +52,12 @@ class SpeechDict(list):
 
 	fileName = None
 
+	def create(self, fileName):
+		if os.path.exists(fileName):
+			raise f"can not create dictionary backed by file {fileName}"
+		self.fileName = fileName
+		log.debug("creating dictionary with file '%s'." % fileName)
+	
 	def load(self, fileName):
 		self.fileName=fileName
 		comment=""
@@ -84,6 +93,11 @@ class SpeechDict(list):
 		file.close()
 		return
 
+	def syncFrom(self, source):
+		for entry in source:
+			if not next((x for x in self if x.pattern == entry.pattern), None):
+				self.append(entry)
+	
 	def save(self,fileName=None):
 		if not fileName:
 			fileName=getattr(self,'fileName',None)
@@ -124,11 +138,91 @@ def initialize():
 		dictionaries[type]=SpeechDict()
 	dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
 	dictionaries["builtin"].load(os.path.join(globalVars.appDir, "builtin.dic"))
+	config.post_configProfileSwitch.register(_handlePostConfigProfileSwitch)
+
+
+def _handlePostConfigProfileSwitch(resetSpeechIfNeeded=True):
+	reloadDictionaries()
+
+
+def reloadDictionaries():
+	from synthDriverHandler import getSynth
+	synth = getSynth()
+	loadProfileDict()
+	loadVoiceDict(synth)
+	log.debug(f"loaded dictionaries for profile {config.conf.getActiveProfile().name or 'default'}")
+
+
+def _getVoiceDictionary(profile):
+	from synthDriverHandler import getSynth
+	synth = getSynth()
+	dictionaryFilename = _getVoiceDictionaryFileName(synth)
+	# if we are om default profile or the specific dictionary profile is already loaded
+	if not profile.name or _hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFilename):
+		# we are with the correct dictionary loaded. Just return it.
+		log.debug(f"Voice dictionary, backed by {dictionaries['voice'].fileName} was requested")
+		return dictionaries["voice"]
+	# we are on a user profile for which there is no dictionary created for the current voice.
+	# The current loaded dictionary is the default profile one.
+	# As we have beem called to get the profile dictionary for the current voice and it still does not exist,
+	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
+	# This is a task the caller should do when and if they wish
+	dic = SpeechDict()
+	dic.create(os.path.join(dictFormatUpgrade.getProfileVoiceDictsPath(), synth.name, dictionaryFilename))
+	log.debug(
+		f"voice dictionary was requested for profile {profile.name}, but the backing file does not exist."
+		f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
+	)
+	return dic
+
+
+def getDictionary(type):
+	profile = config.conf.getActiveProfile()
+	if(type == "voice"):
+		return _getVoiceDictionary(profile)
+	# if we are om default profile or the specific dictionary profile is already loaded
+	if not profile.name or _hasDictionaryProfile(profile.name, f"{type}.dic"):
+		# we are with the correct dictionary loaded. Just return it.
+		log.debug(f"{type} dictionary, backed by {dictionaries[type].fileName} was requested")
+		return dictionaries[type]
+	# we are on a user profile for which there is no dictionary created.
+	# The current loaded dictionary is the default profile one.
+	# As we have beem called to get the current profile dictionary and it still does not exist,
+	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
+	# This is a task the caller should do when and if they wish
+	dic = SpeechDict()
+	dic.create(os.path.join(speechDictsPath, profile.name, f"{type}.dic"))
+	log.debug(
+		f"{type} dictionary was requested for profile {profile.name}, but the backing file does not exist."
+		f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
+	)
+	return dic
+
+
+def loadProfileDict():
+	profile = config.conf.getActiveProfile()
+	if _hasDictionaryProfile(profile.name, "default.dic"):
+		_loadProfileDictionary(dictionaries["default"], profile.name, "default.dic")
+	else:
+		dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
+	dictionaries["builtin"].load("builtin.dic")
+
 
 def loadVoiceDict(synth):
 	"""Loads appropriate dictionary for the given synthesizer.
 It handles case when the synthesizer doesn't support voice setting.
 """
+	dictionaryFileName = _getVoiceDictionaryFileName(synth)
+	profile = config.conf.getActiveProfile()
+	if(_hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFileName)):
+		_loadProfileVoiceDictionary(dictionaries["voice"], synth.name, dictionaryFileName)
+	else:
+		voiceDictsPath = dictFormatUpgrade.voiceDictsPath
+		fileName = os.path.join(voiceDictsPath, synth.name, dictionaryFileName)
+		dictionaries["voice"].load(fileName)
+
+
+def _getVoiceDictionaryFileName(synth):
 	try:
 		dictFormatUpgrade.doAnyUpgrades(synth)
 	except:
@@ -139,6 +233,20 @@ It handles case when the synthesizer doesn't support voice setting.
 		baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
 	else:
 		baseName=r"{synth}.dic".format(synth=synth.name)
-	voiceDictsPath = dictFormatUpgrade.voiceDictsPath
-	fileName= os.path.join(voiceDictsPath, synth.name, baseName)
-	dictionaries["voice"].load(fileName)
+	return baseName
+
+
+def _hasDictionaryProfile(profileName, dictionaryName):
+	return os.path.exists(os.path.join(speechDictsPath, profileName or "", dictionaryName))
+
+
+def _hasVoiceDictionaryProfile(profileName, synthName, voiceName):
+	return os.path.exists(os.path.join(dictFormatUpgrade.getProfileVoiceDictsPath(), synthName, voiceName))
+
+
+def _loadProfileDictionary(target, profileName, dictionaryName):
+	target.load(os.path.join(speechDictsPath, profileName or "", dictionaryName))
+
+
+def _loadProfileVoiceDictionary(target, synthName, voiceName):
+	target.load(os.path.join(dictFormatUpgrade.getProfileVoiceDictsPath(), synthName, voiceName))

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -157,14 +157,14 @@ def _getVoiceDictionary(profile):
 	from synthDriverHandler import getSynth
 	synth = getSynth()
 	dictionaryFilename = _getVoiceDictionaryFileName(synth)
-	# if we are om default profile or the specific dictionary profile is already loaded
+	# if we are on default profile or the specific dictionary profile is already loaded
 	if not profile.name or _hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFilename):
 		# we are with the correct dictionary loaded. Just return it.
 		log.debug(f"Voice dictionary, backed by {dictionaries['voice'].fileName} was requested")
 		return dictionaries["voice"]
 	# we are on a user profile for which there is no dictionary created for the current voice.
 	# The current loaded dictionary is the default profile one.
-	# As we have beem called to get the profile dictionary for the current voice and it still does not exist,
+	# As we have been called to get the profile dictionary for the current voice and it still does not exist,
 	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
 	# This is a task the caller should do when and if they wish
 	dic = SpeechDict()
@@ -187,7 +187,7 @@ def getDictionary(type):
 		return dictionaries[type]
 	# we are on a user profile for which there is no dictionary created.
 	# The current loaded dictionary is the default profile one.
-	# As we have beem called to get the current profile dictionary and it still does not exist,
+	# As we have been called to get the current profile dictionary and it still does not exist,
 	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
 	# This is a task the caller should do when and if they wish
 	dic = SpeechDict()

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -54,7 +54,7 @@ class SpeechDict(list):
 
 	def create(self, fileName):
 		if os.path.exists(fileName):
-			raise f"can not create dictionary backed by file {fileName}"
+			raise FileExistsError(f"can not create dictionary backed by file {fileName}")
 		self.fileName = fileName
 		log.debug("creating dictionary with file '%s'." % fileName)
 	

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -150,7 +150,7 @@ def reloadDictionaries():
 	synth = getSynth()
 	loadProfileDict()
 	loadVoiceDict(synth)
-	log.debug(f"loaded dictionaries for profile {config.conf.getActiveProfile().name or 'default'}")
+	log.debug(f"loaded dictionaries for profile {config.conf.getMostRecentProfile().name or 'default'}")
 
 
 def _getVoiceDictionary(profile):
@@ -177,7 +177,7 @@ def _getVoiceDictionary(profile):
 
 
 def getDictionary(type):
-	profile = config.conf.getActiveProfile()
+	profile = config.conf.getMostRecentProfile()
 	if(type == "voice"):
 		return _getVoiceDictionary(profile)
 	# if we are on default profile or the specific dictionary profile is already loaded
@@ -200,7 +200,7 @@ def getDictionary(type):
 
 
 def loadProfileDict():
-	profile = config.conf.getActiveProfile()
+	profile = config.conf.getMostRecentProfile()
 	if _hasDictionaryProfile(profile.name, "default.dic"):
 		_loadProfileDictionary(dictionaries["default"], profile.name, "default.dic")
 	else:
@@ -213,7 +213,7 @@ def loadVoiceDict(synth):
 It handles case when the synthesizer doesn't support voice setting.
 """
 	dictionaryFileName = _getVoiceDictionaryFileName(synth)
-	profile = config.conf.getActiveProfile()
+	profile = config.conf.getMostRecentProfile()
 	if(_hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFileName)):
 		_loadProfileVoiceDictionary(dictionaries["voice"], synth.name, dictionaryFileName)
 	else:

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -34,9 +34,6 @@ def getProfileVoiceDictsPath():
 	return os.path.join(speechDictsPath, profile.name or "", r"voiceDicts.v1")
 
 
-def getProfileVoiceDictsBackupPath():
-	profile = conf.getActiveProfile()
-	return os.path.join(speechDictsPath, profile.name or "", r"voiceDictsBackup.v0")
 
 def doAnyUpgrades(synth):
 	""" Do any upgrades required for the synth passed in.

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -10,6 +10,7 @@
 import globalVars
 import os
 import api
+from config import conf
 import glob
 from logHandler import log
 from .speechDictVars import speechDictsPath
@@ -26,6 +27,16 @@ def createVoiceDictFileName(synthName, voiceName):
 			synth = synthName,
 			voice = api.filterFileName(voiceName)
 			)
+
+
+def getProfileVoiceDictsPath():
+	profile = conf.getActiveProfile()
+	return os.path.join(speechDictsPath, profile.name or "", r"voiceDicts.v1")
+
+
+def getProfileVoiceDictsBackupPath():
+	profile = conf.getActiveProfile()
+	return os.path.join(speechDictsPath, profile.name or "", r"voiceDictsBackup.v0")
 
 def doAnyUpgrades(synth):
 	""" Do any upgrades required for the synth passed in.

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -30,7 +30,7 @@ def createVoiceDictFileName(synthName, voiceName):
 
 
 def getProfileVoiceDictsPath():
-	profile = conf.getActiveProfile()
+	profile = conf.getMostRecentProfile()
 	return os.path.join(speechDictsPath, profile.name or "", r"voiceDicts.v1")
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1924,6 +1924,38 @@ A regular expression is a pattern containing special symbols that allow you to m
 Regular expressions are not covered in this user guide.
 For an introductory tutorial, please refer to [https://docs.python.org/3.7/howto/regex.html].
 
+++++ Profiles and dictionaries ++++
+
+Dictionaries are bound to profiles.
+
+This means that you can have different dictionaries for different profiles if desired.
+
+In general, the following rules apply:
+
+- If dictionaries (default or voice specific) exist for the current profile, they are used.
+- If they don't exist, the dictionaries for default profile are used. This is consistent to the way NVDA behaves, in the sense that when a new profile is created, the settings not specified on that profile are taken from the default one.
+- The dictionary dialog, when opened, always shows on its title what profile that dictionary relates to.
+- The active profile will determine which dictionary is opened for editing when the default or voice dictionary menus are activated.
+- If a given dictionary does not exist on an active profile and the dictionary dialog is opened, a new dictionary for that profile will be created. It will show no entries, as it is new. However, it won't be saved until you close that dialog clicking on "ok". If you click on "cancel", the new dictionary is not saved.
+- Whenever a profile changes, the specific dictionaries (default and voice) become active immediately. If these dictionaries do not exist, the default profile one's are used.
+- Builtin and temp dictionaries aren't affected, they are not dependent on profiles, the latter because it is temporary, the former because it is built in.
+-
+
+++++ Syncing dictionaries ++++
+
+Because dictionaries are bound to profiles, entries added to the default profile dictionary won't be immediately reflected on profiles for which you decided to create specific dictionaries.
+
+Although this is usually what you want, sometimes it makes sense to have some entries which were first added to the dictionary for the default profile also reflected on dictionaries for other profiles.
+
+To help in these cases, a new button, called "import entries from default dictionary profile", is created in the dictionary dialog.
+
+This button appears only when a profile specific dictionary is being edited. On activation, it behaves the following way:
+
+- The entries from default dictionary (or voice specific dictionary) from the default profile are read.
+- Entries that are not found on the dictionary being edited are added to it.
+- If an entry from the default (or voice) dictionary is found on the dictionary being edited, it does not overwrite the current entry.
+- The import does not save the new entries on disc. It just adds imported entries in the entries list in the dictionary dialog. Focus is placed on the list so that you have the oportunity to review the new list of entries, as if you have typed them by hand.
+
 +++ Punctuation/symbol pronunciation +++[SymbolPronunciation]
 This dialog allows you to change the way punctuation and other symbols are pronounced, as well as the symbol level at which they are spoken.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number: #3656 

### Summary of the issue:

NVDA dictionaries are powerful, offering great features such as regular expression processing. However, there is currently no way of applying dictionary processing conditionally.
The way NVDA applies other conditional settings, such as document formatting and others, is through the use of profiles.
Profiles are groups of settings that can, together, be applied conditionally to the screen reader.
However, right until this pull request, dictionary processing wasn't taking in consideration the active profile.

### Description of how this pull request fixes the issue:
This pull request implements profile context when processing and creating / editing dictionaries. For a description in terms of behavior, see https://github.com/nvaccess/nvda/issues/3656#issuecomment-613374615

Bellow is a summary of implementation changes:

#### Config.ConfigManager
 - Created an accessor method called getMostRecentProfile, offering a better way than conf.profiles[-1] to access active most recent profile information

#### gui.MainFrame
- changed onDefaultDictionaryCommand and onVoiceDictionaryCommand methods to reference default and voice dictionaries from a method on speechDictHandler instead of directly, cinse now there can be specific profile dictionaries

#### gui.SettingsDialogs.DictionaryDialog
 - Created some internal helper methods
 - Added button for importing default dictionary entries, if we are editing specific profile dictionaries
- created hasPatternEntry method that decides if a given entry is already listed on screen.
 - Added code on onOk method to make sure a new created profile specific dictionary is activated as soon as it is created
 - added onImportEntriesClick to handle activation of import entries from default dictionary button

#### speechDictHandler module
 - registred for being notified on profile change
 - Created handler for reacting to profile chananges notification
 - created function to reload dictionaries. This will analyse current state (e.e are we under a specific or default profile) and load dictionaries into the system appropriately
- Created functions getDictionary and _getVoiceDictionary that return on call the correct dictionary object, considering profiles.
 - Created loadProfileDict that will load the correct dictionary on NVDA, considering profiles.
- Changed the loadVoiceDict function to consider profiles when loading voice dictionary
- Created other helper functions

#### speechDictHandler.SpeechDict class
 - added accessor getPattern
 - added create method, which creates and returns an empty dictionary object with its backing file configured
 - added syncFrom method, which takes another SpeechDict object and import its entries to itself, as long as they don't overwrite current ones

#### dictFormatUpgrade module
 - added function getProfileVoiceDictsPath which correctly resolve voice specific dictionary path

#### Dictionary files

This PR Creates specific dictionary for profiles on %appdata%\nvda\speechDicts, where the dictionaries are currently saved. Default dictionary (for default profile) is placed on the root folder, as usual. The voice dictionaries for the default profile reside on voiceDicts.v1 subdirectory.

The profile specific dictionaries are placed in subdirectories with the profile name, inside the speechDicts directory.
The default.dict dictionary for each profile is placed on the profile root directory, while voice dictionaries are placed inside the voiceDicts.v1 for each profile.

Migrations are made for default dictionaries only, following the procedure as before. New dictionaries are placed on profile subfolders, as stated avobe.

##### Why dictionaries are saved on speechDicts folder instead of on profiles folder

This decision was taken because, although a "profiles" folder already exists, profiles aren't created within subfolders. Instead, they are single files scattered at the same folder.

Ideally, each profile should deserve its own subdirectory where the configuration itself plus additional files could live, but taking this step now would envolve a migration tool and discussion with the community, which would be too much for this functionality.

So, by now, dictionary files will reside on speechDicts subfolder and be separated by profiles, and if and when the profiles folder get under discussion we can write a migration tool.


### Testing performed:
1. on default profile, access settings / dictionaries / default.
2. The title bar shows standard dictionary - normal configuration.
3. buttons exibited are add, remove, edit, ok and cancel.
4. Add an entry, for example changing word to word1 and click ok to close the dictionary.
5. Open notepad.
6. Type word and perform a read line. You should hear word1.
7. Activate any profile.
8. Perform a readline. You should hear word1.
9. Still with that profile activated, access settings / dictionaries / default.
10. The title bar shows standard dictionary - [ your profile name]
11. buttons exibited are add, remove, edit, import entries from the default dictionary, ok and cancel.
12. The dictionary is empty, as it is new. Hit cancel and back to the notepad.
13. Make a perform line, you should hear word1.
14. access settings / dictionaries / default.
15. The title bar shows default dictionary - [ your profile name].
16. buttons exibited are add, remove, edit, import entries from the default dictionary, ok and cancel.
17. Add an entry, for example changing word to word2 and click ok to close the dictionary.
18. Back to notepad and make a read line. You should hear word2.
19. Change profile to normal configuration and make a readline on notepad. You should hear word1.
20. Change to the profile you are using for testing.
21. access settings / dictionaries / default.
22. The title bar shows standard dictionary - [ your profile name].
23. buttons exibited are add, remove, edit, import entries from the default dictionary, ok and cancel.
24. Remove the word entry and click ok.
25. on notepad, make a read line. You will hear word, because now the specific dictionary has been created and its empty.
26. Change profile to normal configuration and make a readline on notepad. You should hear word1.
27. Change to the profile you are using for testing.
28. access settings / dictionaries / default.
29. The title bar shows standard dictionary - [ your profile name].
30. buttons exibited are add, remove, edit, import entries from the default dictionary, ok and cancel.
31. The list of entires is empty.
32. Activate the import entries from the default dictionary button.
33. You are focused in the entries list and can see all entries from your default dictionary added, including the one you created for word, replacing it by word1. Hit cancel.
34. Back to notepad, make a readline. You should hear word because the dictionary is still empty.
35. access settings / dictionaries / default.
36. The title bar shows standard dictionary - [ your profile name].
37. buttons exibited are add, remove, edit, import entries from the default dictionary, ok and cancel.
38. The list of entires is empty.
39. Activate the import entries from the default dictionary button.
40. You are focused in the entries list and can see all entries from your default dictionary added, including the one you created for word, replacing it by word1. Hit ok.
41. Back to notepad, perform a readline. You should hear word1, because you have imported entries from the default dictionary into the profile dictionary.
42. access settings / dictionaries / default.
43. The title bar shows standard dictionary - [ your profile name].
44. buttons exibited are add, remove, edit, import entries from the default dictionary, ok and cancel.
45. Remove all entries from the dictionary.
46. Add a new entry replacing word by word3.
47. Activate the import entries from the default dictionary button.
48. You are focused in the entries list and can see all entries from your default dictionary added. However, the entry for the word term is replacing by word3, not by word1, because on import the entry from default dictionary didn't overwrite the entry already on this dictionary.
49. Hit ok. Back to notepad, a read line should speech word3.

All tests above can be performed with voice specific dictionaries. The behaviour will be the same.



### Known issues with pull request:
None at this time
### Change log entry:

Section: New features, Changes, Bug fixes

