### PR TITLE
Drop UIA property change events in 1Password to fix poor performance.

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -417,6 +417,14 @@ class UIAHandler(COMObject):
 			if _isDebug():
 				log.debug("HandlePropertyChangedEvent: event received while not fully initialized")
 			return
+		try:
+			processId = sender.CachedProcessID
+		except COMError:
+			pass
+		else:
+			appMod = appModuleHandler.getAppModuleFromProcessID(processId)
+			if not appMod.shouldProcessUIAPropertyChangedEvent(sender, propertyId):
+				return
 		NVDAEventName=UIAPropertyIdsToNVDAEventNames.get(propertyId,None)
 		if not NVDAEventName:
 			if _isDebug():

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -487,6 +487,18 @@ class AppModule(baseObject.ScriptableObject):
 		"""
 		return False
 
+	def shouldProcessUIAPropertyChangedEvent(self, sender, propertyId):
+		"""
+		Determines whether NVDA should process a UIA property changed event.
+		Returning False will cause the event to be dropped completely. This can be
+		used to work around UIA implementations which flood events and cause poor
+		performance.
+		Returning True means that the event will be processed, but it might still
+		be rejected later; e.g. because it isn't native UIA, because
+		shouldAcceptEvent returns False, etc.
+		"""
+		return True
+
 	def dumpOnCrash(self):
 		"""Request that this process writes a minidump when it crashes for debugging.
 		This should only be called if instructed by a developer.

--- a/source/appModules/1password.py
+++ b/source/appModules/1password.py
@@ -1,0 +1,22 @@
+# appModules/1password.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 James Teh
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+import appModuleHandler
+import UIAHandler
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def shouldProcessUIAPropertyChangedEvent(self, sender, propertyId):
+		if propertyId in (
+			UIAHandler.UIA_NamePropertyId,
+			UIAHandler.UIA_ItemStatusPropertyId,
+			UIAHandler.UIA_IsEnabledPropertyId
+		):
+			# #10508: 1Password floods property change events, resulting in very poor
+			# performance. Just drop them.
+			return False
+		return True


### PR DESCRIPTION
### Link to issue number:
Fixes #10508.

### Summary of the issue:
When moving between items in the list in 1Password, response is extremely sluggish, frequently taking over a second to report the newly selected item.

### Description of how this pull request fixes the issue:
1Password floods property change events whenever you move between items in the list. Because NVDA listens to all property changes and instantiates NVDAObjects in most cases, this causes severe sluggishness.

To work around this, drop all property change events from 1Password as early as possible. AppModule.shouldProcessUIAPropertyChangedEvent has been introduced to facilitate this.

### Testing performed:
Moved through items in the 1Password list with the down arrow key. Observed that response is much faster.

### Known issues with pull request:
This is somewhat of a hack. 1Password shouldn't be flooding these events. That said, Narrator and JAWS aren't impacted like NVDA is and there are certainly improvements that could be made to NVDA's UIA event handling. For now, this is the most effective solution without significant refactor/re-architecture of UIA event handling.

### Change log entry:

Bug fixes:
`- NVDA is no longer extremely sluggish when moving within the list of items in 1Password. (#10508)`