### PR TITLE
Fix a rare infinite loop in IAccessibleHandler.findGroupboxObject.

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -973,7 +973,12 @@ def findGroupboxObject(obj):
 				and (top + height) <= (groupTop + groupHeight)
 			):
 				return groupObj
-		prevWindow = winUser.getPreviousWindow(prevWindow)
+		tempWindow = winUser.getPreviousWindow(prevWindow)
+		if tempWindow == prevWindow:
+			# In rare cases (e.g. HWND 65554 "Message"), getPreviousWindow can return
+			# the window passed to it, causing an infinite loop.
+			break
+		prevWindow = tempWindow
 
 
 # C901 'getRecursiveTextFromIAccessibleTextObject'


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
When you open the context menu for 1Password in the system notification area, NVDA freezes.

### Description of how this pull request fixes the issue:
This occurs because:

1. 1Password sets focus to a window which is a child of HWND 65554, widow class "Message". I assume this is some sort of special system message-only window, but I can't find any details.
2. NVDA walks the focus ancestry, which involves calling IAccessibleHandler.findGroupboxObject on ancestors.
3. IAccessibleHandler.findGroupboxObject is thus called for this "Message" window.
4. IAccessibleHandler.findGroupboxObject loops through previous windows, but when you call getPreviousWindow for this window, it returns itself!
5. And thus an infinite loop ensues.

To work around this, IAccessibleHandler.findGroupboxObject now ensures that the returned previous window is not the same as the window on which it was called.

### Testing performed:
Opened the context menu for 1Password in the system notification area. Confirmed that the menu gets focus as expected and that NVDA doesn't freeze.

### Known issues with pull request:
None.

### Change log entry:

Bug fixes:
`- NVDA no longer freezes when you open the context menu for 1Password in the system notification area.`