### PR TITLE
Flake8: let lint fail early if F632 (identity versus equality comparison) is detected

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -58,7 +58,7 @@ def formatVersionForGUI(year, major, minor):
 		raise ValueError(
 			"Three values must be provided. Got year={}, major={}, minor={}".format(year, major, minor)
 		)
-	if minor == 0:
+	if minor is 0:
 		return "{y}.{M}".format(y=year, M=major)
 	return "{y}.{M}.{m}".format(y=year, M=major, m=minor)
 

--- a/tests/lint/flake8.ini
+++ b/tests/lint/flake8.ini
@@ -26,6 +26,9 @@ max-line-length = 110
 # Final bracket should match indentation of the start of the line of the opening bracket
 hang-closing = False
 
+select = 
+	F632,  # use ==/!= to compare str, bytes, and int literals
+
 ignore =
 	W191,  # indentation contains tabs
 	W503,  # line break before binary operator. We want W504(line break after binary operator)

--- a/tests/lint/flake8.ini
+++ b/tests/lint/flake8.ini
@@ -26,9 +26,6 @@ max-line-length = 110
 # Final bracket should match indentation of the start of the line of the opening bracket
 hang-closing = False
 
-select = 
-	F632,  # use ==/!= to compare str, bytes, and int literals
-
 ignore =
 	W191,  # indentation contains tabs
 	W503,  # line break before binary operator. We want W504(line break after binary operator)


### PR DESCRIPTION

### Link to issue number:
Follow-up to #10977 

### Summary of the issue:
As Python 3.8 raises syntax warning with identity comparison (is/is not) in places where equality (==/!=) should take place, try detecting this as a lint error.

### Description of how this pull request fixes the issue:
Add F632 under "select" directive.

### Testing performed:
To be done, as this is based on how AppVeyor interprets it.

### Known issues with pull request:
None

### Change log entry:
None needed.
