### PR TITLE
Report virtual desktop switches in Windows 10

### DIFF
--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -84,9 +84,6 @@ An NVDAObject for a window
 	def getPossibleAPIClasses(cls,kwargs,relation=None):
 		windowHandle=kwargs['windowHandle']
 		windowClassName=winUser.getClassName(windowHandle)
-		#The desktop window should stay as a window
-		if windowClassName=="#32769":
-			return
 		#If this window has a ghost window its too dangerous to try any higher APIs 
 		if GhostWindowFromHungWindow and GhostWindowFromHungWindow(windowHandle):
 			return

--- a/source/core.py
+++ b/source/core.py
@@ -426,8 +426,12 @@ def main():
 
 	import api
 	import winUser
-	import NVDAObjects.window
-	desktopObject=NVDAObjects.window.Window(windowHandle=winUser.getDesktopWindow())
+	import NVDAObjects.IAccessible
+	desktopObject = NVDAObjects.IAccessible.getNVDAObjectFromEvent(
+		winUser.getDesktopWindow(),
+		winUser.OBJID_CLIENT,
+		winUser.CHILDID_SELF
+	)
 	api.setDesktopObject(desktopObject)
 	api.setFocusObject(desktopObject)
 	api.setNavigatorObject(desktopObject)


### PR DESCRIPTION
### Link to issue number:
Fixes #5641.

### Summary of the issue:
In Windows 10, it is possible to have different virtual desktops, so as to switch between large groups of applications.
To switch between desktops, press control+windows+left/rightArrow.
NVDA however does not report when the desktop changes.

### Description of how this pull request fixes the issue:
Based on reverted #8259.

Desktop switches can only be reported on Windows 10 May 2019 and above.
Previous Windows 10 builds could experience delays and incorrect desktop names.

Implementation details:

1. Added a Desktop IAccessible NVDAObject which is now used instead of the Desktop Window NVDAObject.
	This is used for api.getDesktopObject().
	It is also used to retrieve the name and to catch nameChange events (see below).
	Querying of the name via IAccessible is disabled altogether before Windows 10 may 2019, in which case it is hard-coded like it was before this PR.
2. Added eventHandler.handlePossibleDesktopNameChange function.
	This function checks to see if the Desktop's name has changed since the last time it was called.
	If so, then it reports the new desktop name.
	It fetches the desktop name using the Desktop IAccessible object.
3. eventHandler.doPreGainFocus now calls handlePossibleDesktopNameChange, but only after any possible foreground event, so as to ensure that speech is not interrupted.
	In short this means that the desktop name will be announced before the new focus and its ancestry, but after speech is canceled due to a foreground change.
4. handlePossibleDesktopNameChange is also called for nameChange events on the Desktop IAccessible object.
	However, NVDA delays the execution of handlePossibleDesktopNameChange in this case by 250 ms, to ensure that it executes after any other possible focus changes.
	Of course if a focus change did detect the desktop name change, then the delayed call from the name change event will simply do nothing.
	The reason for the call in the name change event is to handle the situations where the desktop changes but there is no focus event, such as when focused on the taskbar.

Changes from #8259:

1. Don't allow the name property on the Desktop object to retrieve the name via IAccessible on earlier versions of Windows, since this could be triggered outside of handlePossibleDesktopNameChange, potentially causing problems.
2. Use the Desktop IAccessible NVDAObject for api.getDesktopObject(). In #8259, a WindowRoot IAccessible NVDAObject was being used instead. This requires us to use getNVDAObjectFromEvent when setting the desktop object so we can specify OBJID_CLIENT.
3. handlePossibleDesktopNameChange fetches the name via IAccessible instead of UIA. I think these are both the same, but we already have a Desktop IAccessible, so we may as well use it.

### Testing performed:
Ran NVDA on Windows 10. Switched between multiple virtual desktops. Confirmed that the new desktop name was reported. This test was done both with focus in an application, and on the taskbar.

Also confirmed that if a desktop is renamed, the user specified name is reported instead of "Desktop 1", etc.

### Known issues with pull request:
I don't have older builds of Windows 10 to test with. I believe this should address the issues that caused #8259 to be reverted, but I can't be certain.

### Change log entry:

New features:
`- The name of the current virtual desktop on windows 10 is now reported when switching virtual desktops. (#5641)`