### PR TITLE
add VSInstaller Import file

### DIFF
--- a/extras/.vsconfig
+++ b/extras/.vsconfig
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset",
+    "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang",
+    "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,16 @@ The following dependencies need to be installed on your system:
 			* MSVC v142 - VS 2019 C++ ARM64 build tools
 			* C++ ATL for v142 build tools (ARM64)
 
+### Note
+
+When you show the NVDA\extras\.vsconfig file in the source folder of NVDA to Visual Studio Istaller by following the steps of:
+1. Visual Studio Installer
+2. More
+3. Import configuration
+4. browse
+
+VSInstaller will automatically check the components.  
+You can then click on the Review details -> Modify or install button.
 
 ### Git Submodules
 Most of the dependencies are contained in Git submodules.


### PR DESCRIPTION
### Link to issue number:

https://github.com/nvaccess/nvda/issues/10811

### Summary of the issue:

Installing NVDA's Visual Studio components is relatively time consuming.
It was discussed that the import file option can be used in Issue.


### Description of how this pull request fixes the issue:

A section explaining the import file option has been added to Readme.

Import file has been added to the extras folder.

### Testing performed:

yes.

VSInstaller correctly checked the components.

### Known issues with pull request:

None

### Change log entry:

Section: Changes

