### PR TITLE
Remove references to lastIndex property on synth drivers

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -121,7 +121,6 @@ class SynthDriver(SynthDriver):
 
 	def cancel(self):
 		self._ttsCentral.AudioReset()
-		self.lastIndex=None
 
 	def pause(self,switch):
 		if switch:

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -198,13 +198,6 @@ class SynthDriver(SynthDriver):
 
 	def _get_voice(self):
 		return self.tts.voice.Id
- 
-	def _get_lastIndex(self):
-		bookmark=self.tts.status.LastBookmark
-		if bookmark!="" and bookmark is not None:
-			return int(bookmark)
-		else:
-			return None
 
 	def _percentToRate(self, percent):
 		return (percent - 50) // 5

--- a/source/synthDrivers/silence.py
+++ b/source/synthDrivers/silence.py
@@ -21,10 +21,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 	supportedSettings=[]
 
 	def speak(self, speechSequence):
-		self.lastIndex = None
-		for item in speechSequence:
-			if isinstance(item, speech.IndexCommand):
-				self.lastIndex = item.index
+		...
 
 	def cancel(self):
-		self.lastIndex = None
+		...


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The lastIndex property was removed from synth drivers during speech refactor. Yet, this proprty was still set/available on Sapi4, Sapi5 and silence synthesizers.

### Description of how this pull request fixes the issue:
Removed lastIndex implementations from these drivers.

### Testing performed:
T.b.d.

### Known issues with pull request:
None

### Change log entry:
None needed
