### PR TITLE
Stronger guarantee regarding Generators in speech

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -2,9 +2,9 @@
 # Copyright (C) 2006-2017 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
-
 import weakref
 import speech
+from speech import _flattenNestedSequences
 import synthDriverHandler
 from logHandler import log
 import config
@@ -169,8 +169,7 @@ class _TextReader(object):
 			reason=controlTypes.REASON_SAYALL,
 			useCache=state
 		)
-		speechGen = speech.GeneratorWithReturn(speechGen)
-		seq = speech._flattenNestedSequences(speechGen)
+		seq = list(_flattenNestedSequences(speechGen))
 		seq.insert(0, cb)
 		# Speak the speech sequence.
 		spoke = speech.speakWithoutPauses(seq)

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -7,7 +7,6 @@
 """High-level functions to speak information.
 """ 
 
-import collections
 import itertools
 import weakref
 import unicodedata
@@ -52,9 +51,23 @@ from .commands import (  # noqa: F401
 	ConfigProfileTriggerCommand,
 )
 
-from . import types
-from .types import SpeechSequence, SequenceItemT
-from typing import Optional, Dict, List, Any, Generator, Union, Callable, Iterator, Tuple
+from .types import (
+	SpeechSequence,
+	SequenceItemT,
+	logBadSequenceTypes,
+	GeneratorWithReturn,
+	_flattenNestedSequences
+)
+from typing import (
+	Optional,
+	Dict,
+	List,
+	Any,
+	Generator,
+	Union,
+	Callable,
+	Tuple,
+)
 from logHandler import log
 import config
 import aria
@@ -204,7 +217,12 @@ def speakSpelling(
 		useCharacterDescriptions: bool = False,
 		priority: Optional[Spri] = None
 ) -> None:
-	seq = list(getSpellingSpeech(text, locale=locale, useCharacterDescriptions=useCharacterDescriptions))
+	# This could be a very large list. In future we could convert this into chunks.
+	seq = list(getSpellingSpeech(
+		text,
+		locale=locale,
+		useCharacterDescriptions=useCharacterDescriptions
+	))
 	speak(seq, priority=priority)
 
 
@@ -454,10 +472,6 @@ def speakObject(
 		speak(sequence, priority=priority)
 
 
-def _flattenNestedSequences(nestedSequences: Iterator[SpeechSequence]) -> Iterator[SequenceItemT]:
-	return [i for seq in nestedSequences for i in seq]
-
-
 # C901 'getObjectSpeech' is too complex
 # Note: when working on getObjectSpeech, look for opportunities to simplify
 # and move logic out into smaller helper functions.
@@ -696,14 +710,7 @@ def speak(  # noqa: C901
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
-	# speechSequence may be a generator.
-	#  As speechViewer needs to iterate over it
-	# before it is iterated over for actual speaking,
-	# Or similarly it may be iterated over for logging bad sequence types,
-	# Flatten it into a list first.
-	if isinstance(speechSequence, collections.abc.Generator):
-		speechSequence = [i for i in speechSequence]
-	types.logBadSequenceTypes(speechSequence)
+	logBadSequenceTypes(speechSequence)
 	if priority is None:
 		priority = Spri.NORMAL
 	if not speechSequence: #Pointless - nothing to speak 
@@ -1034,20 +1041,6 @@ def _extendSpeechSequence_addMathForTextInfo(
 		return
 
 
-class GeneratorWithReturn:
-	"""Helper class, used with generator functions to access the 'return' value after there are no more values
-	to iterate over.
-	"""
-	def __init__(self, gen, defaultReturnValue=None):
-		self.gen = gen
-		self.returnValue = defaultReturnValue
-		self.iterationFinished = False
-
-	def __iter__(self):
-		self.returnValue = yield from self.gen
-		self.iterationFinished = True
-
-
 def speakTextInfo(
 		info: textInfos.TextInfo,
 		useCache: Union[bool, SpeakTextInfoState] = True,
@@ -1059,7 +1052,7 @@ def speakTextInfo(
 		suppressBlanks: bool = False,
 		priority: Optional[Spri] = None
 ) -> bool:
-	speechSequences = getTextInfoSpeech(
+	speechGen = getTextInfoSpeech(
 		info,
 		useCache,
 		formatConfig,
@@ -1071,14 +1064,17 @@ def speakTextInfo(
 	)
 
 	if reason == controlTypes.REASON_SAYALL:
-		# Deprecation warning: In 2021.1 speakTextInfo will no longer  send speech through speakWithoutPauses
-		# if reason is sayAll, as sayAllhandler does this manually now.
-		return _speakWithoutPauses.speakWithoutPauses(speechSequences)
+		log.error(
+			"Deprecation warning: In 2021.1 speakTextInfo will no longer  send speech through "
+			"speakWithoutPauses if reason is sayAll, as sayAllhandler does this manually now."
+		)
+		flatSpeechGen = list(_flattenNestedSequences(speechGen))
+		return _speakWithoutPauses.speakWithoutPauses(flatSpeechGen)
 
-	speechSequences = GeneratorWithReturn(speechSequences)
-	for seq in speechSequences:
+	speechGen = GeneratorWithReturn(speechGen)
+	for seq in speechGen:
 		speak(seq, priority=priority)
-	return speechSequences.returnValue
+	return speechGen.returnValue
 
 
 # C901 'getTextInfoSpeech' is too complex
@@ -1280,10 +1276,12 @@ def getTextInfoSpeech(  # noqa: C901
 			if onlyInitialFields or any(isinstance(x, str) for x in speechSequence):
 				yield speechSequence
 			if not onlyInitialFields:
-				yield getSpellingSpeech(
+				spellingSequence = list(getSpellingSpeech(
 					textWithFields[0],
 					locale=language
-				)
+				))
+				logBadSequenceTypes(spellingSequence)
+				yield spellingSequence
 		if useCache:
 			speakTextInfoState.controlFieldStackCache=newControlFieldStack
 			speakTextInfoState.formatFieldAttributesCache=formatFieldAttributesCache
@@ -2442,6 +2440,8 @@ class SpeechWithoutPauses:
 		L{GeneratorWithReturn} to retain the return value. A generator is used because the previous
 		implementation had several calls to speech, this approach replicates that.
 		"""
+		if speechSequence is not None:
+			logBadSequenceTypes(speechSequence)
 		# Break on all explicit break commands
 		if detectBreaks and speechSequence:
 			speech = GeneratorWithReturn(self._detectBreaksAndGetSpeech(speechSequence))

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -7,7 +7,12 @@
 """Types used by speech package.
 Kept here so they can be re-used without having to worry about circular imports.
 """
-from typing import Union, List
+from collections.abc import Sequence
+from typing import (
+	Union,
+	List,
+	Iterable, Any, Optional, Generator,
+)
 
 import config
 from logHandler import log
@@ -15,6 +20,7 @@ from .commands import SpeechCommand
 
 SequenceItemT = Union[SpeechCommand, str]
 SpeechSequence = List[SequenceItemT]
+SpeechIterable = Iterable[SequenceItemT]
 
 
 def _isDebugForSpeech() -> bool:
@@ -22,7 +28,31 @@ def _isDebugForSpeech() -> bool:
 	return config.conf["debugLog"]["speech"]
 
 
-def logBadSequenceTypes(sequence: SpeechSequence, raiseExceptionOnError=False) -> bool:
+class GeneratorWithReturn(Iterable):
+	"""Helper class, used with generator functions to access the 'return' value after there are no more values
+	to iterate over.
+	"""
+	def __init__(self, gen: Iterable, defaultReturnValue=None):
+		self.gen = gen
+		self.returnValue = defaultReturnValue
+		self.iterationFinished = False
+
+	def __iter__(self):
+		self.returnValue = yield from self.gen
+		self.iterationFinished = True
+
+
+def _flattenNestedSequences(
+		nestedSequences: Union[Iterable[SpeechSequence], GeneratorWithReturn]
+) -> Generator[SequenceItemT, Any, Optional[bool]]:
+	"""Turns [[a,b,c],[d,e]] into [a,b,c,d,e]"""
+	yield from (i for seq in nestedSequences for i in seq)
+	if isinstance(nestedSequences, GeneratorWithReturn):
+		return nestedSequences.returnValue
+	return None
+
+
+def logBadSequenceTypes(sequence: SpeechIterable, raiseExceptionOnError=False) -> bool:
 	"""
 		Check if the provided sequence is valid, otherwise log an error (only if speech is
 		checked in the "log categories" setting of the advanced settings panel.
@@ -33,9 +63,22 @@ def logBadSequenceTypes(sequence: SpeechSequence, raiseExceptionOnError=False) -
 	"""
 	if not _isDebugForSpeech():
 		return True
+
+	# Check the type of the container
+	if not isinstance(sequence, Sequence):
+		log.error(
+			f"Unexpected Sequence Type: {type(sequence)!r} supplied,"
+			f" a {SpeechSequence!r} is required.",
+			stack_info=True
+		)
+		if raiseExceptionOnError:
+			raise ValueError("Unexpected type in speech sequence")
+		return False
+
+	# Check each items type
 	for value in sequence:
 		if not isinstance(value, (SpeechCommand, str)):
-			log.error(f"unexpectedType: {value!r}", stack_info=True)
+			log.error(f"Unexpected Item Type: {value!r}", stack_info=True)
 			if raiseExceptionOnError:
 				raise ValueError("Unexpected type in speech sequence")
 			return False


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
From comment on https://github.com/nvaccess/nvda/pull/10879#issuecomment-605286360

### Summary of the issue:
The concern was that by suggesting that speech.speak may now accept a generator, the addon API had changed, potentially breaking addons.
PRs #10878 and #10879 addressed some issues with Speech.speak being passed a Generator.

### Description of how this pull request fixes the issue:
Confirms that speech.speak does not accept a generator. Checked all locations that return generators for speech sequences ('getSpellingSpeech` and `getTextInfoSpeech`) and the functions that call them to ensure that speak isn't called with the generator.

I added more typing information to functions to help narrow this down. Notably, `_flattenNestedSequences` was implicitly creating a list. This has been fixed to return a generator which was the original intention, all usages have been checked to ensure they now explicitly convert to a list.

An issue was found in the "say all" branch of `speakTextInfo`, this has been resolved and the deprecation has been made more explicit.

Logging of generator types has been added in several places, enabled via the advanced settings panel 'speech' debug logging category.

### Testing performed:
Manual testing of speak spelling and say-all.

### Known issues with pull request:
None

### Change log entry:
None

