### PR TITLE
Don't attempt to format a tuple with "%s"

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -330,7 +330,7 @@ class MSHTMLTextInfo(textInfos.TextInfo):
 			else:
 				raise TypeError("Bookmark was for %s type, not for %s type"%(position.infoClass.__name__,self.__class__.__name__))
 		else:
-			raise NotImplementedError("position: %s"%position)
+			raise NotImplementedError("position: %s" % (position,))
 
 	def expand(self,unit):
 		if unit==textInfos.UNIT_PARAGRAPH:


### PR DESCRIPTION
This fixes #10736, errors in mousemove events over some MSHTML elements
(such as buttons).

<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

fixes #10736

### Summary of the issue:

mouse move over buttons doesn't read the button text in Internet Explorer 8 MSHTML, fails with a logged TypeError exception.

### Description of how this pull request fixes the issue:

In order to keep the `%` operator from trying to format each element of the Point namedtuple, wrap the position in a one element tuple. This way the right exception gets thrown and caught. I went into more detail in https://github.com/nvaccess/nvda/issues/10736#issuecomment-618760090

### Testing performed:

I confirmed that this allowed the button to be read in the embedded MSHTML instance in the Firefox stub installer. [Build 1 here](https://bugzilla.mozilla.org/show_bug.cgi?id=1596812#c21) can be used to demonstrate the issue, though it has other problems: the Re-install button does not read out when moused over unless this fix is made.

### Known issues with pull request:

There are possibly other similar issues, but I didn't go looking for them.

### Change log entry:

*Bug fixes*
Fix mouse tracking for some MSHTML elements