### PR TITLE
Temporarily disable the Chrome system tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -195,7 +195,7 @@ test_script:
 
      $robotArgs = '--argumentfile .\tests\system\robotArgs.robot'
      # useInstalledNVDA must come after args file to override the whichNVDA value
-     $useInstalledNVDA = '--variable whichNVDA:installed
+     $useInstalledNVDA = '--variable whichNVDA:installed'
 
      py -m robot $robotArgs $useInstalledNVDA $testSource
      Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -191,8 +191,13 @@ test_script:
  - ps: |
      $testOutput = (Resolve-Path .\testOutput\)
      $systemTestOutput = (Resolve-Path "$testOutput\system")
-     $testSource = "./tests/system"
-     py -m robot --loglevel DEBUG -d $systemTestOutput -x systemTests.xml -v whichNVDA:installed -P "$testSource/libraries" "$testSource"
+     $testSource = ".\tests\system\robot"
+
+     $robotArgs = '--argumentfile .\tests\system\robotArgs.robot'
+     # useInstalledNVDA must come after args file to override the whichNVDA value
+     $useInstalledNVDA = '--variable whichNVDA:installed
+
+     py -m robot $robotArgs $useInstalledNVDA $testSource
      Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
      Push-AppveyorArtifact "$testOutput\systemTestResult.zip"
      if($LastExitCode -ne 0) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -193,9 +193,9 @@ test_script:
      $systemTestOutput = (Resolve-Path "$testOutput\system")
      $testSource = ".\tests\system\robot"
 
-     $robotArgs = '--argumentfile .\tests\system\robotArgs.robot'
+     $robotArgs = '--argumentfile', '.\tests\system\robotArgs.robot'
      # useInstalledNVDA must come after args file to override the whichNVDA value
-     $useInstalledNVDA = '--variable whichNVDA:installed'
+     $useInstalledNVDA = '--variable', 'whichNVDA:installed'
 
      py -m robot $robotArgs $useInstalledNVDA $testSource
      Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"

--- a/readme.md
+++ b/readme.md
@@ -280,17 +280,12 @@ To be warned about linting errors faster, you may wish to integrate Flake8 other
 For more details, see `tests/lint/readme.md`
 
 ### System Tests
-You may also use scons to run the system tests, though this will still rely on having set up the dependencies (see `tests/system/readme.md`).
+You may also use `scons` to run the system tests,
+ though this will still require the dependencies to be set up.
+For more details (including filtering and exclusion of tests) see `tests/system/readme.md`.
 
 ```
 scons systemTests
-```
-
-To run only specific system tests, specify them using the `filter` variable on the command line.
-This filter accepts wildcard characters.
-
-```
-scons systemTests filter="Read welcome dialog"
 ```
 
 ## Contributing to NVDA

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -8,35 +8,69 @@ To install all required packages move to the root directory of this repo and exe
 
 ### Running the tests
 
+You can run the tests with `scons` or manually
+
+#### Scons (easier)
+`scons systemTests`
+
+To run only specific system tests,
+ specify them using the `filter` variable on the command line.
+This filter accepts wildcard characters.
+
+```
+scons systemTests filter="Read welcome dialog"
+```
+
+#### Manually (faster)
+
+SCons takes quite a long time to initialize and actually start running the tests,
+if you are running the tests repeatedly consider running them manually.
 These tests should be run from the windows command prompt (cmd.exe) from the root directory
  of your NVDA repository.
 
-
 ```
-python -m robot --loglevel DEBUG -d testOutput/system -x systemTests.xml -v whichNVDA:source -P ./tests/system/libraries ./tests/system/
+python -m robot --argumentfile ./tests/system/robotArgs.robot ./tests/system/robot
 ```
+Note that the path to the tests directory is required and must be the final argument.
 
-The `whichNVDA` argument allows the tests to be run against an installed copy
-of NVDA (first ensure it is compatible with the tests). Note valid values are:
-* "installed" - when running against the installed version of NVDA, you are likely to get errors in the log unless
-the tests are run from an administrator command prompt.
-* "source"
-
-To run a single test or filter tests, use the `--test` argument (wildcards accepted).
-Refer to the robot framework documentation for further details.
+To run a single test, add the `--test` argument (wildcards accepted).
 
 ```
 python -m robot --test "starts" ...
 ```
 
-There are several other options for choosing which tests to run (e.g. by suite, tag, etc).
-Consult `python -m robot --help` for more options.
+Other options exit for specifying tests to run (e.g. by suite, tag, etc).
+Consult `python -m robot --help`
 
 ### Getting the results
 
 The process is displayed in the command prompt, for more information consider the [Robot report and NVDA logs](#logs)
 `report.html`, `log.html`, and `output.xml` files.
 The logs from NVDA are saved to the `nvdaTestRunLogs` folder
+
+### Excluding tests
+
+Tests can be excluded by adding the tag `excluded_from_build` EG:
+
+```robot
+checkbox labelled by inner element
+	[Documentation]	A checkbox labelled by an inner element should not read the label element twice.
+	# Excluded due to intermittent failure.
+	[Tags]	excluded_from_build
+	checkbox_labelled_by_inner_element
+```
+
+When the tests are run, the option `--exclude excluded_from_build` is given to Robot.
+See [description of test args](#test-args)
+
+### Test args
+Common arguments (for both `scons` and AppVeyor) are kept in the `tests\system\robotArgs.robot` file.
+
+The `whichNVDA` argument allows the tests to be run against an installed copy
+of NVDA (first ensure it is compatible with the tests). Note valid values are:
+* "installed" - when running against the installed version of NVDA, you are likely to get errors in the log unless
+the tests are run from an administrator command prompt.
+* "source"
 
 ### Overview
 

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -4,7 +4,7 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 *** Settings ***
 Documentation	HTML test cases in Chrome
-Default Tags	NVDA	smoke test	browser	chrome
+Force Tags	NVDA	smoke test	browser	chrome
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py
@@ -18,4 +18,6 @@ Test Teardown	quit NVDA
 
 checkbox labelled by inner element
 	[Documentation]	A checkbox labelled by an inner element should not read the label element twice.
+	# Excluded due to intermittent failure: #11053
+	[Tags]	excluded_from_build
 	checkbox_labelled_by_inner_element

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -4,7 +4,7 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 *** Settings ***
 Documentation	Basic start and exit tests
-Default Tags	NVDA	smoke test
+Force Tags	NVDA	smoke test
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py

--- a/tests/system/robotArgs.robot
+++ b/tests/system/robotArgs.robot
@@ -1,0 +1,6 @@
+--loglevel DEBUG
+--outputdir testOutput\system
+--xunit systemTests.xml
+--pythonpath .\tests\system\libraries
+--exclude excluded_from_build
+--variable whichNVDA:source

--- a/tests/system/sconscript
+++ b/tests/system/sconscript
@@ -28,15 +28,12 @@ env = Environment(
 
 cmd = [
 	sys.executable, "-m", "robot",
-	"--loglevel", "DEBUG",
-	"-d", "testOutput/system",
-	"-x", "systemTests.xml",
-	"-P", "./tests/system/libraries",
-	"-v", "whichNVDA:source",
+	"--argumentfile", "./tests/system/robotArgs.robot",
 ]
 if tests:
 	# run specific tests
 	cmd += ['--test="{}"'.format(tests)]
-cmd.append("./tests/system")
+
+cmd.append("./tests/system/robot")  # must be the final argument
 target = env.Command(".", None, [cmd])
 Return('target')


### PR DESCRIPTION
### Link to issue number:
#11053

### Summary of the issue:
Chrome system tests are intermittently failing and need to be made more robust.

### Description of how this pull request fixes the issue:
Rather than revert, this PR temporarily disables them by setting the `excluded_from_build` tag on the test.

I almost forgot to update the appveyor args, so now appveyor and scons now use a common args file when running the system tests. This includes adjusting the path to the system tests remove the unnecessary 'system' prefix in test results.
`Force Tags` is now used in robot file settings, otherwise specifying tags on the test overrides the default.

### Testing performed:
- Ran system tests locally (using scons) with and without the `excluded_from_build` tag on the test
- Used the `filter` argument to select a single test, to ensure that still worked.
- The PR build will let us know if the appveyor file is correct.

### Change log entry:
None required.
