### PR TITLE
Speech generator refactor/say all handler: use flatten nested lists iterator from speech module rather than importing it directly

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -2,9 +2,9 @@
 # Copyright (C) 2006-2017 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
 import weakref
 import speech
-from speech import _flattenNestedSequences
 import synthDriverHandler
 from logHandler import log
 import config
@@ -169,7 +169,7 @@ class _TextReader(object):
 			reason=controlTypes.REASON_SAYALL,
 			useCache=state
 		)
-		seq = list(_flattenNestedSequences(speechGen))
+		seq = list(speech._flattenNestedSequences(speechGen))
 		seq.insert(0, cb)
 		# Speak the speech sequence.
 		spoke = speech.speakWithoutPauses(seq)


### PR DESCRIPTION

### Link to issue number:
Fixes #11052 

### Summary of the issue:
If things happen when NVDA isn't fully initialized (such as uninstalling add-ons), NVDA will throw errors such as attribute error (for the issue mentioned above, attribute error on speech dict handler). As this wqs seen after speech generator refactor, it was determined that say all handler was responsible for this change.

### Description of how this pull request fixes the issue:
In say all handler, rather than importing nested list flattener, juse call it fomr speech module.

### Testing performed:
See #11052 for a more thorough description:

* Tested with latest beta and alpha snapshots.
* Reverted beta branch from source code, and tested each file that were part of the reverted speech generator refactor commit to isolate them.
* Installed several add-ons with or without install tasks multiple times with all test configurations.
* Ran say all between tests to make sure things are working as advertised.

All these tests were conducted through a source code based portable copy and launcher (scons dist/launcher). Results indicate #11052 is resolved through this PR.

### Known issues with pull request:
None

### Change log entry:
None

### Additoinal context:
The only time nested list flattener was used in say all handler was when creating a list of iterators, thus it is safe to use speech module. An alternative would have been importing list flattener just before calling it, but since speech module includes this, there's no benefit for that alternative.

Thanks.