### PR TITLE
languageHandler: Remove outdated zh Chinese IE8N entries

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -224,7 +224,7 @@ windowsPrimaryLCIDsToLocaleNames={
 	1:'ar',
 	2:'bg',
 	3:'ca',
-	4:'zh',
+	4:'zh_CN',
 	5:'cs',
 	6:'da',
 	7:'de',


### PR DESCRIPTION

### Link to issue number:
try:
#9524 
### Summary of the issue:
Modify the entry (4zh), dimension (zh_CN)

### Description of how this pull request fixes the issue:
Remove outdated zh Chinese IE8N entries
### Testing performed:
Compiled and tested using the local environment
### Known issues with pull request:
Remove outdated zh Chinese IE8N entries
### Change log entry:
none
Section: Bug fixes 

thanks