### PR TITLE
Update brlapi to 0.8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * Adobe FlashAccessibility interface typelib
 * [MinHook](https://github.com/RaMMicHaeL/minhook), tagged version 1.2.2
-* brlapi Python bindings, version 0.7.0 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html/brltty/), version 4.2-2
+* brlapi Python bindings, version 0.8 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html), version 6.1
 * lilli.dll, version 2.1.0.0
 * [pySerial](https://pypi.python.org/pypi/pyserial), version 3.4
 * [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
With the migration to Python 3, we had to update our brlapi dependency to 0.7 to support the brltty braille display driver. However, there wasn't an upstream build of the brlapi python bindings, therefore we had to build them ourselves.

### Description of how this pull request fixes the issue:
Thanks to @davemielke, BRLTTY 6.1 bundles a brlapi binding built against Python 3.7 we could use directly from upstream. Note that it is still bundled inside our misc-deps repository.

### Testing performed:
Tested a try build with brlapi 0.8 against an installed build of brltty 6.1. I'm pretty sure however that this brlapi should still be able to work with older versions of brltty, may be @davemielke can give some info on that.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
    + Updated BrlApi to version 0.8 (BRLTTY 6.1). (#11065)