### PR TITLE
Userguide work copied from #10867

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -363,10 +363,7 @@ Once you navigate to an object, you can review its content using the [text revie
 When [Focus Highlight #VisionFocusHighlight] is enabled, the location of the current navigator object is also exposed visually.
 By default, the navigator object moves along with the System focus, though this behavior can be toggled on and off.
 
-Note that by default, braille tries to follow automatically both the system focus and system caret as well as the NVDA navigator and the review cursor.
-If you want it to follow the focus and caret only, you need to configure braille to be tethered to focus.
-In this case, braille will not follow the NVDA navigator during object navigation or the review cursor during review.
-If you want braille to follow object navigation and text review instead, you need to configure braille to be tethered to review.
+Note that by default, braille tries to follow automatically both the system focus and the NVDA navigator. This can be configured in the [Braille Tether section #BrailleTether].
 
 To navigate by object, use the following commands:
 
@@ -394,10 +391,7 @@ When moving the review cursor, the System caret does not follow along, so you ca
 However, by default, when the System caret moves, the review cursor follows along.
 This can be toggled on and off.
 
-Note that by default, braille tries to follow automatically both the system focus and system caret as well as the NVDA navigator and the review cursor.
-If you want it to follow the focus and caret only, you need to configure braille to be tethered to focus.
-In this case, braille will not follow the NVDA navigator during object navigation or the review cursor during text review.
-If you want braille to follow only object navigation and text review instead, you need to configure braille to be tethered to review.
+Note that by default, braille tries to follow automatically both the system carret and the review cursor. This can be configured in the [Braille Tether section #BrailleTether].
 
 The following commands are available for reviewing text:
 %kc:beginInclude
@@ -1302,9 +1296,13 @@ This option allows NVDA messages to be displayed on the braille display indefini
 ==== Tether Braille ====[BrailleTether]
 Key: NVDA+control+t
 
-This option allows you to choose whether the braille display will follow the system focus, the navigator object / review cursor, or both.
+This option allows you to choose whether the braille display will follow the system focus / carret, the navigator object / review cursor, or both.
 When "automatically" is selected, NVDA will follow the system focus and caret by default.
 In this case, when the navigator object or the review cursor position is changed by means of explicit user interaction, NVDA will tether to review temporarily, until the focus or the caret changes.
+If you want it to follow the focus and caret only, you need to configure braille to be tethered to focus.
+In this case, braille will not follow the NVDA navigator during object navigation or the review cursor during review.
+If you want braille to follow object navigation and text review instead, you need to configure braille to be tethered to review.
+In this case, Braille  will not follow system focus and system carret.
 
 ==== Read by Paragraph ====[BrailleSettingsReadByParagraph]
 If enabled, braille will be displayed by paragraphs instead of lines.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -56,10 +56,14 @@ NVDA supports braille codes for many languages, including contracted, uncontract
 ++ License and Copyright ++[LicenseAndCopyright]
 NVDA is copyright NVDA_COPYRIGHT_YEARS NVDA contributors.
 
-NVDA is covered by the GNU General Public License (Version 2).
+NVDA is available under the GNU General Public License version 2, with two special exceptions.
+The exceptions are outlined in the license document under the sections "Non-GPL Components in Plugins and Drivers" and "Microsoft Distributable Code".
+NVDA also includes and uses components which are made available under different free and open source licenses.
 You are free to share or change this software in any way you like as long as it is accompanied by the license and you make all source code available to anyone who wants it.
 This applies to both original and modified copies of this software, plus any derivative works.
+
 For further details, you can [view the full license. https://www.gnu.org/licenses/old-licenses/gpl-2.0.html]
+For details regarding exceptions, access the license document from the NVDA menu under the "help" section.
 
 + System Requirements +[SystemRequirements]
 - Operating Systems: all 32-bit and 64-bit editions of Windows 7, Windows 8, Windows 8.1, Windows 10, and all Server Operating Systems starting from Windows Server 2008 R2.
@@ -391,7 +395,7 @@ However, by default, when the System caret moves, the review cursor follows alon
 This can be toggled on and off.
 
 Note that braille follows the [focus #SystemFocus] and [caret #SystemCaret] by default, rather than object navigation and text review.
-If you want it to follow object navigation and text review instead, you need to [configure braille to be tethered to #BrailleTether] review.
+If you want it to follow object navigation and text review instead, you need to [configure braille to be tethered to #BrailleTether] review or automatically to focus or review.
 
 The following commands are available for reviewing text:
 %kc:beginInclude
@@ -411,7 +415,7 @@ The following commands are available for reviewing text:
 | Move to end of line in review | shift+numpad3 | NVDA+end | none | Moves the review cursor to the end of the current line of text |
 | Say all with review | numpadPlus | NVDA+shift+a | 3-finger flick down (text mode) | Reads from the current position of the review cursor, moving it as it goes |
 | Select then Copy from review cursor | NVDA+f9 | NVDA+f9 | none | Starts the select then copy process from the current position of the review cursor. The actual action is not performed until you tell NVDA where the end of the text range is |
-| Select then Copy to review cursor | NVDA+f10 | NVDA+f10 | none | On the first press, text is selected from the position previously set start marker up to and including the review cursor's current position. After pressing this key a second time, the text will be copied to the Windows clipboard |
+| Select then Copy to review cursor | NVDA+f10 | NVDA+f10 | none | On the first press, text is selected from the position previously set as start marker up to and including the review cursor's current position. If the system carret can reach the text, it will be moved to the selected text. After pressing this key stroke a second time, the text will be copied to the Windows clipboard |
 | Move to marked start for copy in review | NVDA+shift+f9 | NVDA+shift+f9 | none | Moves the review cursor to the position previously set start marker for copy |
 | Report text formatting | NVDA+f | NVDA+f | none | Reports the formatting of the text where the review cursor is currently situated. Pressing twice shows the information in browse mode |
 | Report current symbol replacement | None | None | none | Speaks the symbol where the review cursor is positioned. Pressed twice, shows the symbol and the text used to speak it in browse mode. |
@@ -890,7 +894,12 @@ Selecting a form field and pressing enter or the Move to button moves to that fi
 %kc:beginInclude
 To report any comments for the currently focused cell, press NVDA+alt+c.
 %kc:endInclude
-All comments for the worksheet can also be listed in the NVDA Elements List.
+All comments for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.
+
+NVDA can also display a specific dialog for editing a certain comment.
+%kc:beginInclude
+To edit a certain comment, in a focused cell, press shift+f2.
+%kc:endInclude
 
 +++ Reading Protected Cells +++[ExcelReadingProtectedCells]
 If a workbook has been protected, it may not be possible to move focus to particular cells that have been locked for editing.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -896,10 +896,13 @@ To report any comments for the currently focused cell, press NVDA+alt+c.
 %kc:endInclude
 All comments for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.
 
-NVDA can also display a specific dialog for editing a certain comment.
+NVDA can also display a specific dialog for adding or editing a certain comment.
+NVDA overrwrites the native MS Excel comment editing region due to accessibility constraints, but the key stroke for displaying the dialog is inherited from MS Excel and therefore works also without NVDA running.
 %kc:beginInclude
-To edit a certain comment, in a focused cell, press shift+f2.
+To add or edit a certain comment, in a focused cell, press shift+f2.
 %kc:endInclude
+
+This key stroke does not appear and cannot be changed in NVDA's input gesture dialog.
 
 +++ Reading Protected Cells +++[ExcelReadingProtectedCells]
 If a workbook has been protected, it may not be possible to move focus to particular cells that have been locked for editing.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -363,10 +363,10 @@ Once you navigate to an object, you can review its content using the [text revie
 When [Focus Highlight #VisionFocusHighlight] is enabled, the location of the current navigator object is also exposed visually.
 By default, the navigator object moves along with the System focus, though this behavior can be toggled on and off.
 
-Note that braille follows both the [focus #SystemFocus] and [caret #SystemCaret] as well as object navigation and text review by default.
-If you want it to follow the focus and caret only, you need to [configure braille to be tethered to #BrailleTether] focus.
-In this case, braille will not follow object navigation and text review.
-If you want braille to follow object navigation and text review instead, you need to [configure braille to be tethered to #BrailleTether] review.
+Note that by default, braille tries to follow automatically both the system focus and system caret as well as the NVDA navigator and the review cursor.
+If you want it to follow the focus and caret only, you need to configure braille to be tethered to focus.
+In this case, braille will not follow the NVDA navigator during object navigation or the review cursor during review.
+If you want braille to follow object navigation and text review instead, you need to configure braille to be tethered to review.
 
 To navigate by object, use the following commands:
 
@@ -394,8 +394,10 @@ When moving the review cursor, the System caret does not follow along, so you ca
 However, by default, when the System caret moves, the review cursor follows along.
 This can be toggled on and off.
 
-Note that braille follows the [focus #SystemFocus] and [caret #SystemCaret] by default, rather than object navigation and text review.
-If you want it to follow object navigation and text review instead, you need to [configure braille to be tethered to #BrailleTether] review or automatically to focus or review.
+Note that by default, braille tries to follow automatically both the system focus and system caret as well as the NVDA navigator and the review cursor.
+If you want it to follow the focus and caret only, you need to configure braille to be tethered to focus.
+In this case, braille will not follow the NVDA navigator during object navigation or the review cursor during text review.
+If you want braille to follow only object navigation and text review instead, you need to configure braille to be tethered to review.
 
 The following commands are available for reviewing text:
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -906,7 +906,8 @@ To add or edit a certain comment, in a focused cell, press shift+f2.
 
 This key stroke does not appear and cannot be changed in NVDA's input gesture dialog.
 
-Note: it is possible to open the comment editing region in MS Excel also from the context menu of any cell of the work sheet. However, this will open the inaccessible comment editing region and not the NVDA specific comment editing dialog.
+Note: it is possible to open the comment editing region in MS Excel also from the context menu of any cell of the work sheet.
+However, this will open the inaccessible comment editing region and not the NVDA specific comment editing dialog.
 
 +++ Reading Protected Cells +++[ExcelReadingProtectedCells]
 If a workbook has been protected, it may not be possible to move focus to particular cells that have been locked for editing.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -904,6 +904,8 @@ To add or edit a certain comment, in a focused cell, press shift+f2.
 
 This key stroke does not appear and cannot be changed in NVDA's input gesture dialog.
 
+Note: it is possible to open the comment editing region in MS Excel also from the context menu of any cell of the work sheet. However, this will open the inaccessible comment editing region and not the NVDA specific comment editing dialog.
+
 +++ Reading Protected Cells +++[ExcelReadingProtectedCells]
 If a workbook has been protected, it may not be possible to move focus to particular cells that have been locked for editing.
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -363,7 +363,7 @@ Once you navigate to an object, you can review its content using the [text revie
 When [Focus Highlight #VisionFocusHighlight] is enabled, the location of the current navigator object is also exposed visually.
 By default, the navigator object moves along with the System focus, though this behavior can be toggled on and off.
 
-Note that by default, braille tries to follow automatically both the system focus and the NVDA navigator. This can be configured in the [Braille Tether section #BrailleTether].
+Note: Braille following Object Navigation can be configured via [Braille Tether #BrailleTether].
 
 To navigate by object, use the following commands:
 
@@ -391,7 +391,7 @@ When moving the review cursor, the System caret does not follow along, so you ca
 However, by default, when the System caret moves, the review cursor follows along.
 This can be toggled on and off.
 
-Note that by default, braille tries to follow automatically both the system carret and the review cursor. This can be configured in the [Braille Tether section #BrailleTether].
+Note: Braille following the review cursor can be configured via [Braille Tether #BrailleTether].
 
 The following commands are available for reviewing text:
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -8,7 +8,7 @@ NVDA NVDA_VERSION User Guide
 %%toc
 
 + Introduction +[Introduction]
-Welcome to NVDA!
+W elcome to NVDA!
 
 NonVisual Desktop Access (NVDA) is a free and open source screen reader for the Microsoft Windows operating system.
 Providing feedback via synthetic speech and Braille, it enables blind or vision impaired people to access computers running Windows for no more cost than a sighted person.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -8,7 +8,7 @@ NVDA NVDA_VERSION User Guide
 %%toc
 
 + Introduction +[Introduction]
-W elcome to NVDA!
+Welcome to NVDA!
 
 NonVisual Desktop Access (NVDA) is a free and open source screen reader for the Microsoft Windows operating system.
 Providing feedback via synthetic speech and Braille, it enables blind or vision impaired people to access computers running Windows for no more cost than a sighted person.


### PR DESCRIPTION
### Link to issue number:
fixes #7888

fixes #7394

fixes #6315

### Summary of the issue:
There are some descriptions missing in the user guide. specifically:
• In MS Excel a dialog for editing a comment can be displayed when pressing shift+f2. This dialog is NVDA specific and is not implemented by MS Excel.
• When copying from start marker up to and including the review cursor with NVDA+f10, the system carret is also moved to the end of the selection in case the text is reachable.
• The description of the exceptions in the license document section.

### Description of how this pull request fixes the issue:
Added the descriptions to the coresponding sections in the user guide.

### Testing performed:
• Tested that headings show up correctly and that the key stroke shift+f2 is shown correctly.
• Tested also the shift+f2 without NVDA running and noticed the different behavior (i.e. start NVDA (I) before and (II) after pressing shift+f2 in MS Excel).
• Tested also copying from start marker with NVDA+f10 in an edit field where text is reachable by the system carret and observed that the carret was moved.

### Known issues with pull request:
None

### Change log entry:
None
