### PR TITLE
eventHandler: Drop hide events.

### DIFF
--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -244,6 +244,8 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 		return True
 	if eventName == "valueChange" and config.conf["presentation"]["progressBarUpdates"]["reportBackgroundProgressBars"]:
 		return True
+	if eventName == "hide":
+		return False
 	if eventName == "show":
 		# Only accept 'show' events for specific cases, as otherwise we get flooded.
 		return wClass in (


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
On twitter.com in Firefox, moving to tweets you haven't read yet by pressing j is pretty sluggish, taking upwards of 300 ms.

### Description of how this pull request fixes the issue:
Twitter fires quite a few hide events in this case. Aside from IAccessible caret support (which is handled within IAccessibleHandler), NVDA doesn't use hide events anywhere. Processing them is not only pointless, but it also degrades performance. So, drop them.

### Testing performed:
Refreshed Twitter, switched to focus mode and moved through tweets by pressing j. The timing is pretty variable, but before this PR, time since input shows > 300 ms most of the time. After this PR, time since input shows ~120 ms most of the time.

### Known issues with pull request:
None.

### Change log entry:
Probably not worth mentioning, since this is hardly blazing fast even with this PR.