### PR TITLE
Gecko vbuf backend: Treat display: inline-flex as inline, not block.

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -573,7 +573,9 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 		isBlockElement=TRUE;
 	} else if((IA2AttribsMapIt=IA2AttribsMap.find(L"display"))!=IA2AttribsMap.end()) {
 		// If there is a display attribute, we can rely solely on this to determine whether this is a block element or not.
-		isBlockElement=(IA2AttribsMapIt->second!=L"inline"&&IA2AttribsMapIt->second!=L"inline-block");
+		isBlockElement = IA2AttribsMapIt->second != L"inline"
+			&& IA2AttribsMapIt->second != L"inline-block"
+			&& IA2AttribsMapIt->second != L"inline-flex";
 	} else if((IA2AttribsMapIt=IA2AttribsMap.find(L"formatting"))!=IA2AttribsMap.end()&&IA2AttribsMapIt->second==L"block") {
 		isBlockElement=TRUE;
 	} else if(role==ROLE_SYSTEM_TABLE||role==ROLE_SYSTEM_CELL||role==IA2_ROLE_SECTION||role==ROLE_SYSTEM_DOCUMENT||role==IA2_ROLE_INTERNAL_FRAME||role==IA2_ROLE_UNKNOWN||role==ROLE_SYSTEM_SEPARATOR) {


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
On the development version of [Riot web](https://about.riot.im/), links for mentions now appear on separate lines to the rest of the text with Firefox + NVDA browse mode. Previously, they appeared on the same line, which is the correct behaviour. Presumably, this change will graduate to the stable version at some point.

This occurs because Riot now uses display: inline-flex for these mention links.

### Description of how this pull request fixes the issue:
Make the Gecko vbuf backend check for "inline-flex" as well as the existing "inline" and "inline-block" checks.

### Testing performed:
With this test case:
`data:text/html,before <a style="display: inline-flex;" href="https://nvaccess.org/">inline-flex</a> after<div>block`

Verified that the text now appears like this in browse mode:

> before inline-flex after
> block

Before this PR, it appeared as:

> before
> inline-flex
> after
> block

Also verified that mention links appear on the same line as the rest of the text in Riot web develop.

### Known issues with pull request:
None.

### Change log entry:

Bug fixes:
`- In browse mode in Mozilla Firefox and Google Chrome, text no longer incorrectly appears on a separate line when web content uses CSS display: inline-flex.`