### PR TITLE
Cleanup: Stop listening for IAccessible reorder events.

### DIFF
--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -51,7 +51,6 @@ winEventIDsToNVDAEventNames = {
 	winUser.EVENT_OBJECT_DESCRIPTIONCHANGE: "descriptionChange",
 	winUser.EVENT_OBJECT_LOCATIONCHANGE: "locationChange",
 	winUser.EVENT_OBJECT_NAMECHANGE: "nameChange",
-	winUser.EVENT_OBJECT_REORDER: "reorder",
 	winUser.EVENT_OBJECT_SELECTION: "selection",
 	winUser.EVENT_OBJECT_SELECTIONADD: "selectionAdd",
 	winUser.EVENT_OBJECT_SELECTIONREMOVE: "selectionRemove",
@@ -117,15 +116,14 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 		# and can't be used properly in conjunction with input composition support.
 		if windowClassName == "Microsoft.IME.UIManager.CandidateWindow.Host" and eventID in MENU_EVENTIDS:
 			return
-		# At the moment we can't handle show, hide or reorder events on Mozilla Firefox Location bar,
-		# as there are just too many of them Ignore show, hide and reorder on MozillaDropShadowWindowClass
+		# At the moment we can't handle show or hide events on Mozilla Firefox Location bar,
+		# as there are just too many of them. Ignore show and hide on MozillaDropShadowWindowClass
 		# windows.
 		if (
 			windowClassName.startswith('Mozilla')
 			and eventID in (
 				winUser.EVENT_OBJECT_SHOW,
-				winUser.EVENT_OBJECT_HIDE,
-				winUser.EVENT_OBJECT_REORDER
+				winUser.EVENT_OBJECT_HIDE
 			) and childID < 0
 		):
 			# Mozilla Gecko can sometimes fire win events on a catch-all window which isn't really the real window

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -254,9 +254,6 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 			"mscandui21.candidate", "mscandui40.candidate", "MSCandUIWindow_Candidate", # IMM candidates
 			"TTrayAlert", # 5405: Skype
 		)
-	if eventName == "reorder":
-		# Prevent another flood risk.
-		return wClass == "TTrayAlert" # #4841: Skype
 	if eventName == "alert" and winUser.getClassName(winUser.getAncestor(windowHandle, winUser.GA_PARENT)) == "ToastChildWindowClass":
 		# Toast notifications.
 		return True


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
The only place we used reorder events in the NVDA process was Skype classic, which is dead now and which NVDA already dropped support for. I doubt this is having much of a real impact, since shouldAcceptEvent dropped them anyway, but it doesn't make sense to listen (and waste CPU cycles) for something we don't use.

### Description of how this pull request fixes the issue:
Remove reorder from the win event map and remove code for reorder in shouldAcceptEvent.

### Testing performed:
Not really much to test for, but browsed the web a bit just to be sure.

### Known issues with pull request:
There might be add-ons which used requestEvent to listen for reorder. However, this is very unlikely. I grepped through all of the add-ons which have repositories on the NV Access server (which should be most of the add-ons on the official site) and didn't find event_reorder in any of them.

### Change log entry:
Changes for developers:
`- NVDA no longer listens for IAccessible EVENT_OBJECT_REORDER.`