### PR TITLE
Set `xgettext` encoding to UTF-8 (#11080)

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -1,16 +1,7 @@
-###
-# This file is a part of the NVDA project.
-# URL: https://www.nvaccess.org/
-# Copyright 2010-2020 NV Access Limited, Babbage B.V.
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2.0, as published by
-# the Free Software Foundation.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# This license can be found at:
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
-###
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2010-2020 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee, Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt  # noqa: E501
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import sys
 import os
@@ -425,6 +416,7 @@ def makePot(target, source, env):
 			"--foreign-user",
 			"--add-comments=Translators:",
 			"--keyword=pgettext:1c,2",
+			"--from-code", "utf-8",
 			# Needed because xgettext doesn't recognise the .pyw extension.
 			"--language=python",
 		] + [os.path.relpath(str(f), str(sourceDir)) for f in source]


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #11080

### Summary of the issue:

Current xgettext integration does not allow to follow copyright headers guidelines as xgettext complains about non-ASCII characters found in author names.

### Description of how this pull request fixes the issue:

Setting UTF-8 as the source files encoding upon invoking xgettext from Scons.

### Testing performed:

Building POT.

### Known issues with pull request:

The proposed change automatically considers all source files as encoded in UTF-8, which is the standard in Python 3.
If we still were using Python 2, I would have instead advocated for the use of an encoding declaration header line in each incriminated source file, such as:
```
# -*- coding: utf-8 -*-
```

### Change log entry:

I do not think this deserves a change log entry.
