### PR TITLE
Foobar2000: implement a custom status bar routine to fix playback status commands

### DIFF
--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -46,6 +46,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	def _get_statusBar(self):
 		# #11082: retrieve status bar handle and resulting NVDA object from playlist window.
+		# If only default status bar routine is used to assign status bar object, it can result in recursion limit error.
 		try:
 			statusBarHwnd = windowUtils.findDescendantWindow(
 				api.getForegroundObject().windowHandle,

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -46,7 +46,8 @@ class AppModule(appModuleHandler.AppModule):
 
 	def _get_statusBar(self):
 		# #11082: retrieve status bar handle and resulting NVDA object from playlist window.
-		# If only default status bar routine is used to assign status bar object, it can result in recursion limit error.
+		# If only default status bar routine is used to assign status bar object,
+		# it can result in recursion limit error.
 		try:
 			statusBarHwnd = windowUtils.findDescendantWindow(
 				api.getForegroundObject().windowHandle,

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -45,7 +45,7 @@ def parseIntervalToTimestamp(interval):
 class AppModule(appModuleHandler.AppModule):
 
 	def _get_statusBar(self):
-		# #11080: retrieve status bar handle and resulting NVDA object from playlist window.
+		# #11082: retrieve status bar handle and resulting NVDA object from playlist window.
 		try:
 			statusBarHwnd = windowUtils.findDescendantWindow(
 				api.getForegroundObject().windowHandle,

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -1,13 +1,13 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2009-2020 NV Access Limited, Aleksey Sadovoy, James Teh, Joseph Lee, Tuukka Ojala
-# This file may be used under the terms of the GNU General Public License, version 2 or later.
-# For more details see: https://www.gnu.org/licenses/gpl-2.0.htmlimport appModuleHandler
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
+import appModuleHandler
 import calendar
 import collections
 import time
 import api
-import appModuleHandler
 from NVDAObjects.IAccessible import getNVDAObjectFromEvent
 import ui
 import windowUtils

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2009-2018 NV Access Limited, Aleksey Sadovoy, James Teh, Joseph Lee, Tuukka Ojala
+# Copyright (C) 2009-2020 NV Access Limited, Aleksey Sadovoy, James Teh, Joseph Lee, Tuukka Ojala
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.htmlimport appModuleHandler
 


### PR DESCRIPTION
Hi,

This is a follow-up to #9792:

### Link to issue number:
Fixes #11082 

### Summary of the issue:
In Foobar2000 with NVDA alpha.20080 and later (with custom status bar commit), NVDA says 'no track playing" when trying to obtain elpased time, total time, and remaining time for a playing track.

### Description of how this pull request fixes the issue:
Implemented a custom status bar fetcher for Foobar2000 that uses windowUtils.findDescendentWindow to retrieve the status bar for the foreground object.

### Testing performed:
Tested with Foobar2000 with latest alpha and with app module changes applied through this PR.

### Known issues with pull request:
None

### Change log entry:
None, as it is a follow-up to a change in alpha
