### PR TITLE
Fix line too long translation string and comment

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -733,11 +733,14 @@ class GeneralSettingsPanel(SettingsPanel):
 
 		self.copySettingsButton = wx.Button(
 			self,
-			# Translators: The label for a button in general settings to copy
-			# current user settings to system settings (to allow current
-			# settings to be used in secure screens such as User Account
-			# Control (UAC) dialog).
-			label=_("Use currently saved settings during sign-in and on secure screens (requires administrator privileges)")  # noqa: E501 line too long
+			label=_(
+				# Translators: The label for a button in general settings to copy
+				# current user settings to system settings (to allow current
+				# settings to be used in secure screens such as User Account
+				# Control (UAC) dialog).
+				"Use currently saved settings during sign-in and on secure screens"
+				" (requires administrator privileges)"
+			)
 		)
 		self.copySettingsButton.Bind(wx.EVT_BUTTON,self.onCopySettings)
 		if globalVars.appArgs.secure or not config.canStartOnSecureScreens():


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix-up of PR #10941

### Summary of the issue:

Finding the appropriate code style for a lengthy translatable string along with its required translators comment might not be obvious, even for some of our most seasoned contributors.
This problem has led to discussion about various attempts in PR #10941 and the raise of issue #11071.
PR #10941 finally resigned by disabling line length checks on a line of the patch.

### Description of how this pull request fixes the issue:

As pointed out in https://github.com/nvaccess/nvda/issues/11071#issuecomment-622685234 a styling that complies both with line length and translators comment could finally be found.
The [Contributing wiki page](https://github.com/nvaccess/nvda/wiki/Contributing) has then be updated accordingly.

While the disabling of line length check is of course not a bug, I guess it can be considered a misleading example for anyone that would not have read either this ticket or [gettext manual](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html#Operation-mode)

### Testing performed:

Successfuly ran `scons lint`, `scons pot` and `scons checkPot`
Ensured the translators comment landed in the `.pot` file as expected.

### Known issues with pull request:

### Change log entry:

None,