### PR TITLE
Fix missing translator comment warning for split translatable strings

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1375,8 +1375,8 @@ class GlobalCommands(ScriptableObject):
 
 	def script_review_sayAll(self,gesture):
 		sayAllHandler.readText(sayAllHandler.CURSOR_REVIEW)
-	# Translators: Input help mode message for say all in review cursor command.
 	script_review_sayAll.__doc__ = _(
+		# Translators: Input help mode message for say all in review cursor command.
 		"Reads from the review cursor up to the end of the current text,"
 		" moving the review cursor as it goes"
 	)
@@ -2052,9 +2052,9 @@ class GlobalCommands(ScriptableObject):
 	script_review_markStartForCopy.category=SCRCAT_TEXTREVIEW
 
 	@script(
-		# Translators: Input help mode message for move review cursor to marked start position for a
-		# select or copy command
 		description=_(
+			# Translators: Input help mode message for move review cursor to marked start position for a
+			# select or copy command
 			"Move the review cursor to the position marked as the start of text to be selected or copied"
 		),
 		category=SCRCAT_TEXTREVIEW,
@@ -2465,8 +2465,8 @@ class GlobalCommands(ScriptableObject):
 		ui.message(state)
 
 	@script(
-		# Translators: Describes a command.
 		description=_(
+			# Translators: Describes a command.
 			"Toggles the state of the screen curtain, "
 			"enable to make the screen black or disable to show the contents of the screen. "
 			"Pressed once, screen curtain is enabled until you restart NVDA. "

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -417,14 +417,33 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		self.Bind(wx.EVT_MENU, frame.onNVDASettingsCommand, item)
 		subMenu_speechDicts = wx.Menu()
 		if not globalVars.appArgs.secure:
-			# Translators: The label for the menu item to open Default speech dictionary dialog.
-			item = subMenu_speechDicts.Append(wx.ID_ANY,_("&Default dictionary..."),_("A dialog where you can set default dictionary by adding dictionary entries to the list"))
+			item = subMenu_speechDicts.Append(
+				wx.ID_ANY,
+				# Translators: The label for the menu item to open Default speech dictionary dialog.
+				_("&Default dictionary..."),
+				# Translators: The help text for the menu item to open Default speech dictionary dialog.
+				_("A dialog where you can set default dictionary by adding dictionary entries to the list")
+			)
 			self.Bind(wx.EVT_MENU, frame.onDefaultDictionaryCommand, item)
-			# Translators: The label for the menu item to open Voice specific speech dictionary dialog.
-			item = subMenu_speechDicts.Append(wx.ID_ANY,_("&Voice dictionary..."),_("A dialog where you can set voice-specific dictionary by adding dictionary entries to the list"))
+			item = subMenu_speechDicts.Append(
+				wx.ID_ANY,
+				# Translators: The label for the menu item to open Voice specific speech dictionary dialog.
+				_("&Voice dictionary..."),
+				_(
+					# Translators: The help text for the menu item
+					# to open Voice specific speech dictionary dialog.
+					"A dialog where you can set voice-specific dictionary by adding"
+					" dictionary entries to the list"
+				)
+			)
 			self.Bind(wx.EVT_MENU, frame.onVoiceDictionaryCommand, item)
-		# Translators: The label for the menu item to open Temporary speech dictionary dialog.
-		item = subMenu_speechDicts.Append(wx.ID_ANY,_("&Temporary dictionary..."),_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box"))
+		item = subMenu_speechDicts.Append(
+			wx.ID_ANY,
+			# Translators: The label for the menu item to open Temporary speech dictionary dialog.
+			_("&Temporary dictionary..."),
+			# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
+			_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
+		)
 		self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
 		# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
 		menu_preferences.AppendSubMenu(subMenu_speechDicts,_("Speech &dictionaries"))
@@ -655,9 +674,10 @@ class WelcomeDialog(wx.Dialog):
 	This dialog is displayed the first time NVDA is started with a new configuration.
 	"""
 
-	# Translators: The main message for the Welcome dialog when the user starts NVDA for the first time.
 	WELCOME_MESSAGE_DETAIL = _(
-		"Most commands for controlling NVDA require you to hold down the NVDA key while pressing other keys.\n"
+		# Translators: The main message for the Welcome dialog when the user starts NVDA for the first time.
+		"Most commands for controlling NVDA require you to hold down"
+		" the NVDA key while pressing other keys.\n"
 		"By default, the numpad Insert and main Insert keys may both be used as the NVDA key.\n"
 		"You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 		"Press NVDA+n at any time to activate the NVDA menu.\n"

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -22,8 +22,9 @@ from . import nvdaControls
 from .dpiScalingHelper import DpiScalingHelperMixin
 
 def promptUserForRestart():
-	# Translators: A message asking the user if they wish to restart NVDA as addons have been added, enabled/disabled or removed.
 	restartMessage = _(
+		# Translators: A message asking the user if they wish to restart NVDA
+		# as addons have been added, enabled/disabled or removed.
 		"Changes were made to add-ons. "
 		"You must restart NVDA for these changes to take effect. "
 		"Would you like to restart now?"
@@ -108,8 +109,8 @@ class ErrorAddonInstallDialog(nvdaControls.MessageDialog):
 
 def _showAddonInfo(addon):
 	manifest = addon.manifest
-	# Translators: message shown in the Addon Information dialog.
 	message=[_(
+		# Translators: message shown in the Addon Information dialog.
 		"{summary} ({name})\n"
 		"Version: {version}\n"
 		"Author: {author}\n"
@@ -171,8 +172,8 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		firstTextSizer = wx.BoxSizer(wx.VERTICAL)
 		listAndButtonsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=wx.BoxSizer(wx.HORIZONTAL))
 		if globalVars.appArgs.disableAddons:
-			# Translators: A message in the add-ons manager shown when add-ons are globally disabled.
 			label = _(
+				# Translators: A message in the add-ons manager shown when add-ons are globally disabled.
 				"NVDA was started with all add-ons disabled. "
 				"You may modify the enabled / disabled state, and install or uninstall add-ons. "
 				"Changes will not take effect until after NVDA is restarted."
@@ -511,15 +512,17 @@ def installAddon(parentWindow, addonPath):
 		# add-on with this one.
 		messageBoxTitle = _("Add-on Installation")
 
-		# Translators: A message asking if the user wishes to update an add-on with the same version
-		# currently installed according to the version number.
 		overwriteExistingAddonInstallationMessage = _(
-			"You are about to install version {newVersion} of {summary}, which appears to be already installed. "
+			# Translators: A message asking if the user wishes to update an add-on with the same version
+			# currently installed according to the version number.
+			"You are about to install version {newVersion} of {summary},"
+			" which appears to be already installed. "
 			"Would you still like to update?"
 		).format(summary=summary, newVersion=newVersion)
 
-		# Translators: A message asking if the user wishes to update a previously installed add-on with this one.
 		updateAddonInstallationMessage = _(
+			# Translators: A message asking if the user wishes to update a previously installed
+			# add-on with this one.
 			"A version of this add-on is already installed. "
 			"Would you like to update {summary} version {curVersion} to version {newVersion}?"
 		).format(summary=summary, curVersion=curVersion, newVersion=newVersion)
@@ -590,9 +593,9 @@ def handleRemoteAddonInstall(addonPath):
 
 
 def _showAddonRequiresNVDAUpdateDialog(parent, bundle):
-	# Translators: The message displayed when installing an add-on package is prohibited, because it requires
-	# a later version of NVDA than is currently installed.
 	incompatibleMessage = _(
+		# Translators: The message displayed when installing an add-on package is prohibited,
+		# because it requires a later version of NVDA than is currently installed.
 		"Installation of {summary} {version} has been blocked. The minimum NVDA version required for "
 		"this add-on is {minimumNVDAVersion}, your current NVDA version is {NVDAVersion}"
 	).format(
@@ -611,8 +614,9 @@ def _showAddonRequiresNVDAUpdateDialog(parent, bundle):
 
 
 def _showAddonTooOldDialog(parent, bundle):
-	# Translators: A message informing the user that this addon can not be installed because it is not compatible.
 	confirmInstallMessage = _(
+		# Translators: A message informing the user that this addon can not be installed
+		# because it is not compatible.
 		"Installation of {summary} {version} has been blocked."
 		" An updated version of this add-on is required,"
 		" the minimum add-on API supported by this version of NVDA is {backCompatToAPIVersion}"
@@ -629,8 +633,8 @@ def _showAddonTooOldDialog(parent, bundle):
 	).ShowModal()
 
 def _showConfirmAddonInstallDialog(parent, bundle):
-	# Translators: A message asking the user if they really wish to install an addon.
 	confirmInstallMessage = _(
+		# Translators: A message asking the user if they really wish to install an addon.
 		"Are you sure you want to install this add-on?\n"
 		"Only install add-ons from trusted sources.\n"
 		"Addon: {summary} {version}"
@@ -694,8 +698,8 @@ class IncompatibleAddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		settingsSizer=wx.BoxSizer(wx.VERTICAL)
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		maxControlWidth = 550
-		# Translators: The title of the Incompatible Addons Dialog
 		introText = _(
+			# Translators: The title of the Incompatible Addons Dialog
 			"The following add-ons are incompatible with NVDA version {}."
 			" These add-ons can not be enabled."
 			" Please contact the add-on author for further assistance."

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -128,8 +128,9 @@ class InstallerDialog(wx.Dialog, DpiScalingHelperMixin):
 				# Translators: a message in the installer telling the user NVDA is now located in a different place.
 				msg+=" "+_("The installation path for NVDA has changed. it will now  be installed in {path}").format(path=installer.defaultInstallPath)
 		if shouldAskAboutAddons:
-			# Translators: A message in the installer to let the user know that some addons are not compatible.
 			msg+=_(
+				# Translators: A message in the installer to let the user know that
+				# some addons are not compatible.
 				"\n\n"
 				"However, your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
 				"These add-ons will be disabled after installation. If you rely on these add-ons, "
@@ -236,11 +237,13 @@ class InstallingOverNewerVersionDialog(wx.Dialog, DpiScalingHelperMixin):
 		contentSizer = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		text = wx.StaticText(
 			self,
-			# Translators: A warning presented when the user attempts to downgrade NVDA
-			# to an older version.
 			label=_(
-				"You are attempting to install an earlier version of NVDA than the version currently installed. "
-				"If you really wish to revert to an earlier version, you should first cancel this installation "
+				# Translators: A warning presented when the user attempts to downgrade NVDA
+				# to an older version.
+				"You are attempting to install an earlier version of NVDA "
+				"than the version currently installed. "
+				"If you really wish to revert to an earlier version, "
+				"you should first cancel this installation "
 				"and completely uninstall NVDA before installing the earlier version."
 			))
 		text.Wrap(self.scaleSize(600))

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -768,9 +768,9 @@ class GeneralSettingsPanel(SettingsPanel):
 	def onCopySettings(self,evt):
 		addonsDirPath = os.path.join(globalVars.appArgs.configPath, 'addons')
 		if os.path.isdir(addonsDirPath) and 0 < len(os.listdir(addonsDirPath)):
-			# Translators: A message to warn the user when attempting to copy current
-			# settings to system settings.
 			message = _(
+				# Translators: A message to warn the user when attempting to copy current
+				# settings to system settings.
 				"Add-ons were detected in your user settings directory. "
 				"Copying these to the system profile could be a security risk. "
 				"Do you still wish to copy your settings?"
@@ -1409,10 +1409,10 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		)
 		self.trustVoiceLanguageCheckbox.SetValue(config.conf["speech"]["trustVoiceLanguage"])
 
-		# Translators: This is the label for a checkbox in the
-		# voice settings panel (if checked, data from the unicode CLDR will be used
-		# to speak emoji descriptions).
 		includeCLDRText = _(
+			# Translators: This is the label for a checkbox in the
+			# voice settings panel (if checked, data from the unicode CLDR will be used
+			# to speak emoji descriptions).
 			"Include Unicode Consortium data (including emoji) when processing characters and symbols"
 		)
 		self.includeCLDRCheckbox = settingsSizerHelper.addItem(
@@ -2469,8 +2469,8 @@ class AdvancedPanel(SettingsPanel):
 	# Advanced settings panel
 	warningHeader = _("Warning!")
 
-	# Translators: This is a label appearing on the Advanced settings panel.
 	warningExplanation = _(
+		# Translators: This is a label appearing on the Advanced settings panel.
 		"The following settings are for advanced users. "
 		"Changing them may cause NVDA to function incorrectly. "
 		"Please only change these if you know what you are doing or "
@@ -2498,8 +2498,8 @@ class AdvancedPanel(SettingsPanel):
 		self.windowText = warningGroup.addItem(wx.StaticText(warningBox, label=self.warningExplanation))
 		self.windowText.Wrap(self.scaleSize(544))
 
-		# Translators: This is the label for a checkbox in the Advanced settings panel.
 		enableAdvancedControlslabel = _(
+			# Translators: This is the label for a checkbox in the Advanced settings panel.
 			"I understand that changing these settings may cause NVDA to function incorrectly."
 		)
 		self.enableControlsCheckBox = warningGroup.addItem(
@@ -3170,9 +3170,9 @@ def showTerminationErrorForProviders(
 		)
 	else:
 		providerNames = ", ".join(provider.displayName for provider in providers)
-		# Translators: This message is presented when
-		# NVDA is unable to terminate multiple vision enhancement providers.
 		message = _(
+			# Translators: This message is presented when
+			# NVDA is unable to terminate multiple vision enhancement providers.
 			"Could not gracefully terminate the following vision enhancement providers:\n"
 			"{providerNames}"
 		).format(providerNames=providerNames)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -344,8 +344,9 @@ class UpdateResultDialog(wx.Dialog, DpiScalingHelperMixin):
 				backCompatToAPIVersion=self.backCompatTo
 			))
 			if showAddonCompat:
-				# Translators: A message indicating that some add-ons will be disabled unless reviewed before installation.
 				message = message + _(
+					# Translators: A message indicating that some add-ons will be disabled
+					# unless reviewed before installation.
 					"\n\n"
 					"However, your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
 					"These add-ons will be disabled after installation. If you rely on these add-ons, "
@@ -460,8 +461,9 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 			backCompatToAPIVersion=self.backCompatTo
 		))
 		if showAddonCompat:
-			# Translators: A message indicating that some add-ons will be disabled unless reviewed before installation.
 			message = message + _(
+				# Translators: A message indicating that some add-ons will be disabled
+				# unless reviewed before installation.
 				"\n"
 				"However, your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
 				"These add-ons will be disabled after installation. If you rely on these add-ons, "
@@ -698,8 +700,8 @@ class UpdateDownloader(object):
 		))
 
 class DonateRequestDialog(wx.Dialog):
-	# Translators: The message requesting donations from users.
 	MESSAGE = _(
+		# Translators: The message requesting donations from users.
 		"We need your help in order to continue to improve NVDA.\n"
 		"This project relies primarily on donations and grants. By donating, you are helping to fund full time development.\n"
 		"If even $10 is donated for every download, we will be able to cover all of the ongoing costs of the project.\n"

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -19,7 +19,9 @@ url = "https://www.nvaccess.org/"
 copyrightYears = "2006-2020"
 copyright = _("Copyright (C) {years} NVDA Contributors").format(
 	years=copyrightYears)
-aboutMessage = _(u"""{longName} ({name})
+aboutMessage = _(
+	# Translators: "About NVDA" dialog box message
+	u"""{longName} ({name})
 Version: {version}
 URL: {url}
 {copyright}
@@ -29,4 +31,5 @@ For further details, you can view the license from the Help menu.
 It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 {name} is developed by NV Access, a non-profit organisation committed to helping and promoting free and open source solutions for blind and vision impaired people.
-If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu.""").format(**globals())
+If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu."""  # noqa: E501 line too long
+).format(**globals())

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -1,8 +1,7 @@
-#tests/checkPot.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2017-2019 NV Access Limited
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2017-2020 NV Access Limited, James Teh, Ethan Holliger, Dinesh Kaushal, Leonard de Ruijter, Joseph Lee, Reef Turner, Julien Cochuyt  # noqa: E501 line too long
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """Check a translation template (pot) for strings without translator comments.
 """
@@ -98,6 +97,24 @@ EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
 	'Primary footer',
 	'Primary header',
 	'Text frame',
+	# core.py:87
+	r'Your gesture map file contains errors.\n"More details about the errors can be found in the log file."',
+	# NVDAObjects\IAccessible\winword.py:229
+	'Pressing once will set this cell as the first column header for any cells '
+	'"lower and to the right of it within this table. Pressing twice will forget '
+	'"the current column header for this cell."',
+	# NVDAObjects\IAccessible\winword.py:257
+	'Pressing once will set this cell as the first row header for any cells lower '
+	'"and to the right of it within this table. Pressing twice will forget the '
+	'"current row header for this cell."',
+	# NVDAObjects\window\excel.py:1222
+	'Pressing once will set this cell as the first column header for any cells '
+	'"lower and to the right of it within this region. Pressing twice will forget '
+	'"the current column header for this cell."',
+	# NVDAObjects\window\excel.py:1244
+	'Pressing once will set this cell as the first row header for any cells lower '
+	'"and to the right of it within this region. Pressing twice will forget the '
+	'"current row header for this cell."',
 }
 
 def checkPot(fileName):
@@ -112,6 +129,7 @@ def checkPot(fileName):
 	expectedErrors = 0
 	unexpectedSuccesses = 0
 	with open(fileName, "rt") as pot:
+		passedHeader = False
 		for line in pot:
 			line = line.rstrip()
 			if not line:
@@ -120,8 +138,9 @@ def checkPot(fileName):
 				sourceLines = []
 				context = ""
 				continue
-			if line == 'msgid ""':
+			if line == 'msgid ""' and not passedHeader:
 				# Header.
+				passedHeader = True
 				continue
 			if line.startswith("#. Translators: "):
 				# This is a comment for translators.

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -139,7 +139,9 @@ def checkPot(fileName):
 				context = ""
 				continue
 			if line == 'msgid ""' and not passedHeader:
-				# Header.
+				# The first msgid in POT files is expected to be empty, and considered part of the header.
+				# Once it has been passed, any subsequent empty msgid marks the start of a long msgid split
+				# accross multiple lines.
 				passedHeader = True
 				continue
 			if line.startswith("#. Translators: "):
@@ -161,8 +163,13 @@ def checkPot(fileName):
 				# This is the untranslated message.
 				# Get the message.
 				if line == 'msgid ""':
-					# Multi-line msgid.
+					# Long msgid, split across multiple lines.
 					# Subsequent lines are just quoted strings which should be concatenated.
+					# Example:
+					# 	msgid ""
+					# 	"Toggles single letter navigation on and off. When on, single letter keys in "
+					# 	"browse mode jump to various kinds of elements on the page. When off, these "
+					# 	"keys are passed to the application"
 					msgid = ""
 					for line in pot:
 						if line.startswith("msgstr "):
@@ -170,7 +177,7 @@ def checkPot(fileName):
 							break
 						msgid += getStringFromLine(line)
 				else:
-					# Single line msgid.
+					# Short msgid, presented on a single line.
 					# Example: msgid "Secure Desktop"
 					msgid = getStringFromLine(line)
 				if context:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix-up of PR #7492
Found thanks to PR #10941
Fixes #11071
Follow-up of PR #11092

### Summary of the issue:

When `xgettext` extracts lengthy translatable strings, it starts its entry in the POT file with
```
msgid ""
```
`checkPot` misinterpret this as the header line and thus triggers no error for missing translators comment for this message.

### Description of how this pull request fixes the issue:

 - Ensured `checkPot` does not mistake a lengthy `msgid` with the POT file header
 - Added 5 additional known messages without translators comment with reference to their location in the source
 - Added 1 missing translators comment
 - Linted 25 existing translators comment so that they now properly land in the POT file

### Testing performed:

Ran `scons checkPot` with its sole fix.
Result: 31 errors
Addressed the 31 errors as detailed above.
Ran `scons checkPot` again.
Result: 0 errors
Manually checked in the POT file some of the previously reported errors and ensured their translators comment has indeed been copied.
Finally, ran `scons tests`, built a local launcher and checked in the GUI that some of the 31 incriminated messages were still translated as expected.

### Known issues with pull request:

### Change log entry:

I don't think this deserves a change log entry.