### PR TITLE
Fix Powerpoint: reportSuperscriptAndSubscript error

### DIFF
--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -929,7 +929,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 			formatField['bold']=bool(font.bold)
 			formatField['italic']=bool(font.italic)
 			formatField['underline']=bool(font.underline)
-		if formatConfig['reportSuperscriptAndSubscript']:
+		if formatConfig['reportSuperscriptsAndSubscripts']:
 			if font.subscript:
 				formatField['text-position']='sub'
 			elif font.superscript:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #11094.

### Summary of the issue:
In the Powerpoint appModule, the incorrect config key was used. Looking up `reportSuperscriptAndSubscript` (instead of the correct `reportSuperscriptsAndSubscripts`) resulted in an error, making certain functions unusable.

Config option introduced in: "Separate the reporting of superscripts and subscripts from the report font attributes setting #10919"
Regression introduced with: https://github.com/nvaccess/nvda/pull/10932

### Description of how this pull request fixes the issue:
Uses the proper config key.

### Testing performed:
Checked that the singular version didn't appear anywhere else in NVDA's source tree.

### Known issues with pull request:
* #11006: this is a bugfix.

### Change log entry:
None.
