### PR TITLE
Set Flake8 encoding to UTF-8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -173,7 +173,7 @@ test_script:
       git diff -U0 FETCH_HEAD...HEAD > $prDiff
       $flake8Config = "$lintSource\flake8.ini"
       $flake8Output = "$lintOutput\PR-Flake8.txt"
-      type "$prDiff" | py -m flake8 --diff --output-file="$flake8Output" --tee --config="$flake8Config"
+      type "$prDiff" | py -Xutf8 -m flake8 --diff --output-file="$flake8Output" --tee --config="$flake8Config"
       if($LastExitCode -ne 0) {
        $errorCode=$LastExitCode
        Add-AppveyorMessage "PR introduces Flake8 errors"

--- a/tests/lint/sconscript
+++ b/tests/lint/sconscript
@@ -47,7 +47,9 @@ lintTarget = externalEnv.Command(
 	"current.diff",
 	[[
 		'type', '$SOURCE', '|',  # provide diff to stdin
-		sys.executable, "-m", "flake8",
+		sys.executable,
+		"-Xutf8",  # UTF-8 mode (PEP 540, Python >= 3.7)
+		"-m", "flake8",
 		'--diff',  # accept a unified diff from stdin
 		'--output-file=$TARGET',  # output to a file to allow easier inspection
 		'--tee',  # also output to stdout, so results appear in scons output


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Follow-up of PR #11081

### Summary of the issue:

Flake8 encodes its output with the default encoding.
Without further instruction, Python chooses the default encoding of the system to do so.
When a line of source code contains both a linting error and a non-ASCII character, it currently leads to either the line being wrongly encoded, or worse the line being replaced by the stack trace of an UnicodeEncodeError.

For an example of this behavior, edit `source/globalCommands.py` and set the copyright year to 2020, then run `scons lint`.
Flake8 should complain about both the comment not starting with "# " and the line being too long.
If, like in my CP1252 Windows default encoding, the character "Ł" cannot be represented, you'll end up with the following output:
```
Traceback (most recent call last):
  File "C:\dev\Python37-32\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\dev\Python37-32\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\__main__.py", line 4, in <module>
    cli.main()
  File "C:\dev\venv\nvda\lib\site-packages\flake8\main\cli.py", line 18, in main
    app.run(argv)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\main\application.py", line 393, in run
    self._run(argv)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\main\application.py", line 382, in _run
    self.report()
  File "C:\dev\venv\nvda\lib\site-packages\flake8\main\application.py", line 373, in report
    self.report_errors()
  File "C:\dev\venv\nvda\lib\site-packages\flake8\main\application.py", line 334, in report_errors
    results = self.file_checker_manager.report()
  File "C:\dev\venv\nvda\lib\site-packages\flake8\checker.py", line 265, in report
    results_reported += self._handle_results(filename, results)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\checker.py", line 167, in _handle_results
    physical_line=physical_line,
  File "C:\dev\venv\nvda\lib\site-packages\flake8\style_guide.py", line 418, in handle_error
    code, filename, line_number, column_number, text, physical_line
  File "C:\dev\venv\nvda\lib\site-packages\flake8\style_guide.py", line 565, in handle_error
    self.formatter.handle(error)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\formatting\base.py", line 93, in handle
    self.write(line, source)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\formatting\base.py", line 203, in write
    self._write(source)
  File "C:\dev\venv\nvda\lib\site-packages\flake8\formatting\base.py", line 182, in _write
    self.output_fd.write(output + self.newline)
  File "C:\dev\Python37-32\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u0141' in position 176: character maps to <undefined>
```

By the way, all apologies to @lukaszgo1: it seems I might have misspelled your first name in the past as I did not notice earlier its first letter wasn't "L", but rather "Ł".

### Description of how this pull request fixes the issue:

Take advantage of the new UTF-8 Mode introduced by [PEP 540](https://www.python.org/dev/peps/pep-0540/) in Python 3.7: Add the `-Xutf8` command-line argument.

### Testing performed:

Linted the above described edit with and without the proposed change.

### Known issues with pull request:

### Change log entry:

I don't think this deserves a change log entry.