### PR TITLE
Allow display to turn off for power saving during say all

### DIFF
--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -444,7 +444,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
 		if gesture.shouldPreventSystemIdle:
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
 			self._lastInputTime = time.time()

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -61,7 +61,7 @@ class _ObjectsReader(object):
 		if self.prevObj:
 			# We just started speaking this object, so move the navigator to it.
 			api.setNavigatorObject(self.prevObj, isFocus=lastSayAllMode==CURSOR_CARET)
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
 		# Move onto the next object.
 		self.prevObj = obj = next(self.walker, None)
 		if not obj:
@@ -206,7 +206,7 @@ class _TextReader(object):
 			updater.updateCaret()
 		if self.cursor != CURSOR_CARET or config.conf["reviewCursor"]["followCaret"]:
 			api.setReviewPosition(updater, isCaret=self.cursor==CURSOR_CARET)
-		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
+		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
 		if self.numBufferedLines == 0:
 			# This was the last line spoken, so move on.
 			self.nextLine()


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/pull/10643#issuecomment-623010211

### Summary of the issue:
When in say all, the screen is forced to stay on even when there are no screen updates. For non-visual use, this seems unnecessary. 
Some users may wish to have their screen turn off for power saving reasons. 

### Description of how this pull request fixes the issue:
No longer provide the `winKernel.ES_DISPLAY_REQUIRED` flag to `SetThreadExecutionState`

### Testing performed:
Tested that say all still continues for the original use case in #10643 

### Known issues with pull request:
If the screen really updates, such as due to cursor movement, this may not make any difference. Therefore difference is only expected when:

* Say all in browse mode with long paragraphs
* Braille display gestures when reading with the review cursor.

### Change log entry:
* Changes
    + Braille display gestures and say all will still prevent the system from going idle, but no longer prevent the screen from disabling. (#10643)