### PR TITLE
Userdocs: clarify whole word radio for speech dictionaries

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1851,7 +1851,7 @@ The Add rule dialog also contains a checkbox to say whether or not you want the 
 NVDA ignores case by default).
 
 Finally, a set of radio buttons allows you to tell NVDA whether your pattern should match anywhere, should only match if it is a complete word or should be treated as a "Regular expression".
-Setting the pattern to match as a whole word means that the replacement will only be made if the pattern does not occur as part of a larger word; i.e. a character other than an alphanumeric character or an underscore (or no character at all) comes both immediately before and after the pattern.
+Setting the pattern to match as a whole word means that the replacement will only be made if the pattern does not occur as part of a larger word. This condition is met if the characters immediately before and after the word are anything other than a letter, a number, or an underscore, or if there are no characters at all.
 Thus, using the earlier example of replacing the word "bird" with "frog", if you were to make this a whole word replacement, it would not match "birds" or "bluebird".
 
 A regular expression is a pattern containing special symbols that allow you to match on more than one character at a time, or match on just numbers, or just letters, as a few examples.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1851,7 +1851,8 @@ The Add rule dialog also contains a checkbox to say whether or not you want the 
 NVDA ignores case by default).
 
 Finally, a set of radio buttons allows you to tell NVDA whether your pattern should match anywhere, should only match if it is a complete word or should be treated as a "Regular expression".
-Setting the pattern to match as a whole word means that the replacement will only be made if the pattern does not occur as part of a larger word. This condition is met if the characters immediately before and after the word are anything other than a letter, a number, or an underscore, or if there are no characters at all.
+Setting the pattern to match as a whole word means that the replacement will only be made if the pattern does not occur as part of a larger word.
+This condition is met if the characters immediately before and after the word are anything other than a letter, a number, or an underscore, or if there are no characters at all.
 Thus, using the earlier example of replacing the word "bird" with "frog", if you were to make this a whole word replacement, it would not match "birds" or "bluebird".
 
 A regular expression is a pattern containing special symbols that allow you to match on more than one character at a time, or match on just numbers, or just letters, as a few examples.


### PR DESCRIPTION
### Link to issue number: 
fixes #10959

### Summary of the issue: 
User doc entry for whole word radio button was unclear.

### Description of how this pull request fixes the issue: 
Replaces current user doc entry with the suggestion made [here](https://github.com/nvaccess/nvda/issues/10959#issue-596224560).

### Testing performed:

### Known issues with pull request:

### Change log entry:

Section: not necessary

