### PR TITLE
Browse mode  with auto focus focusable elements disabled: Fix activation of non-focusable objects and activation after using the tab key.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -266,6 +266,9 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def _get_currentNVDAObject(self):
 		raise NotImplementedError
 
+	def _get_currentFocusableNVDAObject(self):
+		return self.makeTextInfo(textInfos.POSITION_CARET).focusableNVDAObjectAtStart
+
 	def event_treeInterceptor_gainFocus(self):
 		"""Triggered when this browse mode interceptor gains focus.
 		This event is only fired upon entering this treeInterceptor when it was not the current treeInterceptor before.
@@ -517,14 +520,18 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	script_activatePosition.__doc__ = _("Activates the current object in the document")
 
 	def _focusLastFocusableObject(self, activatePosition=False):
-		obj = self._lastFocusableObj
-		if not obj:
-			return
+		obj = self.currentFocusableNVDAObject
 		if obj!=self.rootNVDAObject and self._shouldSetFocusToObj(obj) and obj!= api.getFocusObject():
 			obj.setFocus()
-			speech.speakObject(obj,controlTypes.REASON_ONLYCACHE)
+			# We might be about to activate or pass through a key which will cause
+			# this object to change (e.g. checking a check box). However, we won't
+			# actually get the focus event until after the change has occurred.
+			# Therefore, we must cache properties for speech before the change occurs.
+			speech.speakObject(obj, controlTypes.REASON_ONLYCACHE)
+			self._objPendingFocusBeforeActivate = obj
 		if activatePosition:
-			self._activatePosition(obj=obj)
+			# Make sure we activate the object at the caret, which is not necessarily focusable.
+			self._activatePosition()
 
 	def script_passThrough(self,gesture):
 		if not config.conf["virtualBuffers"]["autoFocusFocusableElements"]:
@@ -1178,7 +1185,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		self._lastProgrammaticScrollTime = None
 		self.documentConstantIdentifier = self.documentConstantIdentifier
 		self._lastFocusObj = None
-		self._lastFocusableObj = None
+		self._objPendingFocusBeforeActivate = None
 		self._hadFirstGainFocus = False
 		self._enteringFromOutside = True
 		# We need to cache this because it will be unavailable once the document dies.
@@ -1281,7 +1288,6 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		if reason == controlTypes.REASON_FOCUS:
 			self._lastCaretMoveWasFocus = True
 			focusObj = api.getFocusObject()
-			self._lastFocusableObj = None
 			if focusObj==self.rootNVDAObject:
 				return
 		else:
@@ -1297,8 +1303,6 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			if followBrowseModeFocus:
 				if focusObj and not eventHandler.isPendingEvents("gainFocus") and focusObj!=self.rootNVDAObject and focusObj != api.getFocusObject() and self._shouldSetFocusToObj(focusObj):
 					focusObj.setFocus()
-			else:
-				self._lastFocusableObj = focusObj
 			obj.scrollIntoView()
 			if self.programmaticScrollMayFireEvent:
 				self._lastProgrammaticScrollTime = time.time()
@@ -1547,11 +1551,23 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 					# Note: this is usually called after the caret movement.
 					vision.handler.handleGainFocus(obj)
 				elif (
-					self._lastFocusableObj
-					and obj == self._lastFocusableObj
-					and obj is not self._lastFocusableObj
+					self._objPendingFocusBeforeActivate
+					and obj == self._objPendingFocusBeforeActivate
+					and obj is not self._objPendingFocusBeforeActivate
 				):
-					speech.speakObject(self._lastFocusableObj,controlTypes.REASON_CHANGE)
+					# With auto focus focusable elements disabled, when the user activates
+					# an element (e.g. by pressing enter) or presses a key which we pass
+					# through (e.g. control+enter), we call _focusLastFocusableObject.
+					# However, the activation/key press might cause a property change
+					# before we get the focus event, so NVDA's normal reporting of
+					# changes to the focus won't pick it up.
+					# The speech property cache on _objPendingFocusBeforeActivate reflects
+					# the properties before the activation/key, so use that to speak any
+					# changes.
+					speech.speakObject(
+						self._objPendingFocusBeforeActivate, controlTypes.REASON_CHANGE
+					)
+					self._objPendingFocusBeforeActivate = None
 			else:
 				self._replayFocusEnteredEvents()
 				return nextHandler()


### PR DESCRIPTION
### Link to issue number:
Fixes #8528. Fixes #9886.
Based on @leonardder's try build in https://github.com/nvaccess/nvda/pull/9511#issuecomment-495099828, commit 72316d5e, but with a fix for the over-chatting described in https://github.com/nvaccess/nvda/pull/9511#issuecomment-495146648.

### Summary of the issue:
In browse mode, with auto focus focusable elements disabled, it is not possible to activate non-focusable elements or activate an object after tabbing. Also, activating would sometimes cause NVDA to click in the wrong place, causing weirdness such as focusing the address bar or task bar.

### Description of how this pull request fixes the issue:
Previously, with auto focus focusable elements disabled, browse mode tracked the last focusable object and used this when activating at the caret. This meant that it wasn't possible to activate objects that weren't focusable. Furthermore, this wasn't updated correctly when using the tab key, which meant it wasn't possible to activate at the caret after tabbing.

To fix this:

1. Don't keep track of the last focusable object. Instead, _focusLastFocusableObject always uses the focusable ancestor of the caret.
2. If _focusLastFocusableObject is requested to activate, it does so using the object at the caret, not the focusable ancestor. This handles the case where the object at the caret isn't focusable.
3. _focusLastFocusableObject temporarily saves the object which is pending focus. This is because we might be about to activate or pass through a key which will cause this object to change (e.g. checing a check box). However, we won't actually get the focus event until after the change has occurred. The speech property cache on this saved object reflects the properties before the activation.
4. When the focus event arrives, event_gainFocus uses this saved pending focus object to report the change (if any) that occurred.

### Testing performed:
Test case:
`data:text/html,<button>a</button><button onClick="alert('b');">b</button><div onClick="alert('c');">c</div><input type="checkbox" aria-label="d"><div contenteditable><p>e</p></div>`

1. Tabbed to "b". Pressed enter and confirmed that a "b" dialog appeared. Dismissed the dialog.
2. Pressed down arrow to move to "c". Pressed enter. Confirmed that a "c" dialog appeared.
3. Pressed down arrow to move to "d". Pressed enter. Confirmed that NVDA said "checked".
4. Pressed down arrow to move to "e". Pressed enter to switch to focus mode. Pressed NVDA+tab. Confirmed that the "e" text box was focused.

### Known issues with pull request:
None known.

### Change log entry:

Bug fixes:
```
- In browse mode with Automatically set system focus to focusable elements disabled, it is now possible to activate elements that aren't focusable.
- In browse mode with Automatically set system focus to focusable elements disabled, it is now possible to activate elements reached by pressing the tab key. (#8528)
- In browse mode with Automatically set system focus to focusable elements disabled, activating certain elements no longer clicks in an incorrect location. (#9886)
```