### PR TITLE
Foobar2000: restore track playback status by renaming status bar attribute

### DIFF
--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -40,16 +40,16 @@ def parseIntervalToTimestamp(interval):
 	return calendar.timegm(time.strptime(interval.strip(), format))
 
 class AppModule(appModuleHandler.AppModule):
-	statusBar=None
+	_statusBar=None
 
 	def event_gainFocus(self, obj, nextHandler):
-		if not self.statusBar: self.statusBar=api.getStatusBar()
+		if not self._statusBar: self._statusBar=api.getStatusBar()
 		nextHandler()
 
 	def getElapsedAndTotal(self):
 		empty = statusBarTimes(None, None)
-		if not self.statusBar: return empty
-		statusBarContents = self.statusBar.firstChild.name
+		if not self._statusBar: return empty
+		statusBarContents = self._statusBar.firstChild.name
 		try:
 			playingTimes = statusBarContents.split("|")[4].split("/")
 			return statusBarTimes(playingTimes[0], playingTimes[1])

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -1,14 +1,13 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2009-2018 NV Access Limited, Aleksey Sadovoy, James Teh, Joseph Lee, Tuukka Ojala
-# This file may be used under the terms of the GNU General Public License, version 2 or later.
-# For more details see: https://www.gnu.org/licenses/gpl-2.0.htmlimport appModuleHandler
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
 
+import appModuleHandler
 import calendar
 import collections
 import time
-
 import api
-import appModuleHandler
 import ui
 
 # A named tuple for holding the elapsed and total playing times from Foobar2000's status bar

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2009-2018 NV Access Limited, Aleksey Sadovoy, James Teh, Joseph Lee, Tuukka Ojala
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import appModuleHandler
 import calendar
@@ -40,15 +40,17 @@ def parseIntervalToTimestamp(interval):
 	return calendar.timegm(time.strptime(interval.strip(), format))
 
 class AppModule(appModuleHandler.AppModule):
-	_statusBar=None
+	_statusBar = None
 
 	def event_gainFocus(self, obj, nextHandler):
-		if not self._statusBar: self._statusBar=api.getStatusBar()
+		if not self._statusBar:
+			self._statusBar = api.getStatusBar()
 		nextHandler()
 
 	def getElapsedAndTotal(self):
 		empty = statusBarTimes(None, None)
-		if not self._statusBar: return empty
+		if not self._statusBar:
+			return empty
 		statusBarContents = self._statusBar.firstChild.name
 		try:
 			playingTimes = statusBarContents.split("|")[4].split("/")


### PR DESCRIPTION

### Link to issue number:
Another attempt at fixing #11082

### Summary of the issue:
Since introduction of _get_statusBar method for app modules, track playback announcement in Foobar2000 broke.

### Description of how this pull request fixes the issue:
Rename statusBar to _statusBar.

### Testing performed:
Tested with Foobar2000 with the modified app module.

### Known issues with pull request:
None

### Change log entry:
None
