### PR TITLE
Fix typo in technical message

### DIFF
--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -342,7 +342,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			log.debugWarning(f"LVM_GETSUBITEMRECT failed for index {index} in list")
 			return None
 		# #8268: this might be a malformed rectangle
-		# (i.e. with a left coordinate that is greather than the right coordinate).
+		# (i.e. with a left coordinate that is greater than the right coordinate).
 		# This happens in Becky! Internet Mail,
 		# as well in applications that expose zero width columns.
 		left = localRect.left

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -208,8 +208,8 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 				# Get the last 16 bits of the line number
 				lineStart16=lineStart&0xFFFF
 				if lineStart16 > offset:
-					# There are cases where the last 16 bits of the line start are greather than the 16 bits offset.
-					# For example, this happens when the line start offset is 65534 (0xFFFE)
+					# There are cases where the last 16 bits of the line start are greater than the
+					# 16 bits offset. For example, this happens when the line start offset is 65534 (0xFFFE)
 					# and the offset we need ought to be 65537 (0x10001), which is a 17 bits number
 					# In that case, add 0x10000 to the offset, which will make the eventual formula return the correct offset,
 					# unless a line has more than 65535 characters, in which case we can't get a reliable offset.

--- a/source/locationHelper.py
+++ b/source/locationHelper.py
@@ -395,9 +395,9 @@ class RectLTRB(_RectMixin, namedtuple("RectLTRB",("left","top","right","bottom")
 
 	def __new__(cls, left, top, right, bottom):
 		if left>right:
-			raise ValueError("left=%d is greather than right=%d, which is not allowed"%(left,right))
+			raise ValueError("left=%d is greater than right=%d, which is not allowed" % (left, right))
 		if top>bottom:
-			raise ValueError("top=%d is greather than bottom=%d, which is not allowed"%(top,bottom))
+			raise ValueError("top=%d is greater than bottom=%d, which is not allowed" % (top, bottom))
 		return super(RectLTRB, cls).__new__(cls, left, top, right, bottom)
 
 	@property


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

None

### Summary of the issue:

I encountered what I believe is a small typo while adapting a buggy JAB app...

### Description of how this pull request fixes the issue:

Replace "greather" by "greater"

### Testing performed:

None, given how small the change is.

### Known issues with pull request:

### Change log entry:

N/A