### PR TITLE
Fix handling of an empty name when creating or renaming a configuration profile (#11146)

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2020 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
-# Joseph Lee, Babbage B.V., Łukasz Golonka
+# Joseph Lee, Babbage B.V., Łukasz Golonka, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -585,6 +585,8 @@ class ConfigManager(object):
 		"""
 		if globalVars.appArgs.secure:
 			return
+		if not name:
+			raise ValueError("Missing name.")
 		fn = self._getProfileFn(name)
 		if os.path.isfile(fn):
 			raise ValueError("A profile with the same name already exists: %s" % name)
@@ -655,6 +657,8 @@ class ConfigManager(object):
 			return
 		if newName == oldName:
 			return
+		if not newName:
+			raise ValueError("Missing newName")
 		oldFn = self._getProfileFn(oldName)
 		newFn = self._getProfileFn(newName)
 		if not os.path.isfile(oldFn):

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -1,8 +1,7 @@
-#gui/configProfiles.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2013-2018 NV Access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2013-2018 NV Access Limited, Joseph Lee, Julien Cochuyt
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import wx
 import config
@@ -215,13 +214,30 @@ class ProfilesDialog(wx.Dialog):
 	def onRename(self, evt):
 		index = self.profileList.Selection
 		oldName = self.profileNames[index]
-		# Translators: The label of a field to enter a new name for a configuration profile.
-		with wx.TextEntryDialog(self, _("New name:"),
+		while True:
+			with wx.TextEntryDialog(
+				self,
+				# Translators: The label of a field to enter a new name for a configuration profile.
+				_("New name:"),
 				# Translators: The title of the dialog to rename a configuration profile.
-				_("Rename Profile"), value=oldName) as d:
-			if d.ShowModal() == wx.ID_CANCEL:
-				return
-			newName = api.filterFileName(d.Value)
+				caption=_("Rename Profile"),
+				value=oldName
+			) as d:
+				if d.ShowModal() == wx.ID_CANCEL:
+					return
+			newName = d.Value
+			if newName:
+				break
+			gui.messageBox(
+				# Translators: An error displayed when the user attempts to rename a configuration profile
+				# with an empty name.
+				_("A profile cannot have an empty name."),
+				# Translators: The title of an error message dialog.
+				caption=_("Error"),
+				style=wx.ICON_ERROR,
+				parent=self
+			)
+		newName = api.filterFileName(newName)
 		try:
 			config.conf.renameProfile(oldName, newName)
 		except ValueError:
@@ -412,9 +428,20 @@ class NewProfileDialog(wx.Dialog):
 		) == wx.NO:
 			return
 
-		name = api.filterFileName(self.profileName.Value)
+		name = self.profileName.Value
 		if not name:
+			gui.messageBox(
+				# Translators: An error displayed when the user attempts to create a configuration profile
+				# with an empty name.
+				_("You must choose a name for this profile."),
+				# Translators: The title of an error message dialog.
+				caption=_("Error"),
+				style=wx.ICON_ERROR,
+				parent=self
+			)
+			self.profileName.SetFocus()
 			return
+		name = api.filterFileName(name)
 		try:
 			config.conf.createProfile(name)
 		except ValueError:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #11146

### Summary of the issue:

When creating a new configuration profile with an empty name, the creation fails without notice.
When attempting to rename a configuration profile with an empty name, the configuration profile is deleted without notice.
This last behavior (renaming) is new in current master and is not exhibited by 2020.1 which instead incorrectly states that a profile with the same name already exists.

### Description of how this pull request fixes the issue:

When attempting to create a profile with an empty name, warn the user and focus back the name field.
When attempting to rename a profile with an empty name, warn the user and prompt again.


### Testing performed:

Creation and renaming of configuration profiles, with and without names.

### Known issues with pull request:

### Change log entry:

I guess this does not deserve a change log entry, as the biggest issue is only exhibited on latest master, not in 2020.1