### PR TITLE
Fix typos in what's new

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,13 +42,13 @@ What's New in NVDA
 
 
 == Changes For Developers ==
-- execElevated and hasUiAcces have moved from config module to systemUtils module. Usage via config module is deprecated. (#10493)
+- execElevated and hasUiAccess have moved from config module to systemUtils module. Usage via config module is deprecated. (#10493)
 - Updated configobj to 5.1.0dev commit f9a265c4. (#10939)
 - Automated testing of NVDA with Chrome and a HTML sample is now possible. (#10553)
 - IAccessibleHandler has been converted into a package, OrderedWinEventLimiter has been extracted to a module and unit tests added (#10934)
 - Updated BrlApi to version 0.8 (BRLTTY 6.1). (#11065)
 - Status bar retrieval may now be customized by an AppModule. (#2125, #4640)
-- NVDA no longer listens for IAccessible EVENT_OBJECT_REORDER.
+- NVDA no longer listens for IAccessible EVENT_OBJECT_REORDER. (#11076)
 
 
 = 2020.1 =


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
What's new was missing an issue number and "access" was spelled "acces".

### Description of how this pull request fixes the issue:
Update the changes file to correct the errors.

### Testing performed:
None.

### Known issues with pull request:
* #11006: not a code change.

### Change log entry:
None.
