### PR TITLE
If reading a word and it contains only a symbol and white space, read symbol irrespective of symbol level (#5133)

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2,7 +2,8 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler
+# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
+# Julien Cochuyt
 
 """High-level functions to speak information.
 """ 
@@ -1281,7 +1282,7 @@ def getTextInfoSpeech(  # noqa: C901
 	if onlyInitialFields or (
 		isWordOrCharUnit
 		and len(textWithFields) > 0
-		and len(textWithFields[0]) == 1
+		and len(textWithFields[0].strip() if not textWithFields[0].isspace() else textWithFields[0]) == 1
 		and all(isControlEndFieldCommand(x) for x in itertools.islice(textWithFields, 1, None))
 	):
 		if not onlyCache:


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #5133

### Summary of the issue:

Currently, when navigation by word lands on a single symbol followed by white space, NVDA sometimes says nothing at all.

### Description of how this pull request fixes the issue:

Implemented the solution described by @jcsteh in https://github.com/nvaccess/nvda/issues/5133#issuecomment-320541113:
> In speech.py, in speakTextInfo around line 853, we check len(textWithFields[0])==1. This needs to be changed so that we strip white space from textWithFields[0] before checking the length. Note that we shouldn't strip if the text contains only white space, since that would cause, for example, single tab characters to be silenced when moving by word. 

### Testing performed:

### Known issues with pull request:

### Change log entry:

Section: Bug fixes

NVDA now always speaks when navigating by word and landing on any single symbol followed by white space, whatever the verbosity settings.