### PR TITLE
Created a shortcut to the start menu folder for what's new

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -391,6 +391,15 @@ def _updateShortcuts(NVDAExe, installDir, shouldCreateDesktopShortcut, slaveExe,
 		prependSpecialFolder="AllUsersPrograms"
 	)
 
+	# Translators: A label for a shortcut in start menu to open NVDA what's new.
+	changesTranslated = _("What's new")
+	_createShortcutWithFallback(
+		path=os.path.join(docFolder, changesTranslated + ".lnk"),
+		fallbackPath=os.path.join(docFolder, "What's new.lnk"),
+		targetPath=getDocFilePath("changes.html", installDir),
+		prependSpecialFolder="AllUsersPrograms"
+	)
+
 
 def isDesktopShortcutInstalled():
 	wsh=_getWSH()


### PR DESCRIPTION
### Link to issue number:
fixes #9309

### Summary of the issue:
NVDA does not have a start menu shortcut for the what's new file.

### Description of how this pull request fixes the issue:
In installer.py, added a shortcut for what's new file in start menu for sake of completeness. This would now probably also open up the possibility to add a hotkey for opening the what's new file.


### Testing performed:
Created a launcher from source and installed the launcher and checked that the What's new file appeared in start menu. Checked that clicking on it opens the changes.html in the correct language.

### Known issues with pull request:
None

### Change log entry:
Probably not really needed.
