### PR TITLE
Avoid reporting systray tool-tips if their text equals the focused systray icon name (#6656)

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# appModules/explorer.py
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2019 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
 # This file is covered by the GNU General Public License.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#appModules/explorer.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited, Joseph Lee, Łukasz Golonka
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# appModules/explorer.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2019 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """App module for Windows Explorer (aka Windows shell and renamed to File Explorer in Windows 8).
 Provides workarounds for controls such as identifying Start button, notification area and others.
@@ -22,7 +22,10 @@ import mouseHandler
 from NVDAObjects.window import Window
 from NVDAObjects.IAccessible import IAccessible, List
 from NVDAObjects.UIA import UIA
+from NVDAObjects.behaviors import ToolTip
 from NVDAObjects.window.edit import RichEdit50, EditTextInfo
+import config
+
 
 # Suppress incorrect Win 10 Task switching window focus
 class MultitaskingViewFrameWindow(UIA):
@@ -74,16 +77,25 @@ class SysListView32EmittingDuplicateFocusEvents(IAccessible):
 class NotificationArea(IAccessible):
 	"""The Windows notification area, a.k.a. system tray.
 	"""
+	lastKnownLocation = None
 
 	def event_gainFocus(self):
+		NotificationArea.lastKnownLocation = self.location
 		if mouseHandler.lastMouseEventTime < time.time() - 0.2:
 			# This focus change was not caused by a mouse event.
-			# If the mouse is on another toolbar control, the notification area toolbar will rudely
+			# If the mouse is on another systray control, the notification area toolbar will rudely
 			# bounce the focus back to the object under the mouse after a brief pause.
 			# Moving the mouse to the focus object isn't a good solution because
 			# sometimes, the focus can't be moved away from the object under the mouse.
 			# Therefore, move the mouse out of the way.
-			winUser.setCursorPos(0, 0)
+			if self.location:
+				systrayLeft, systrayTop, systrayWidth, systrayHeight = self.location
+				mouseLeft, mouseTop = winUser.getCursorPos()
+				if (
+					systrayLeft <= mouseLeft <= systrayLeft + systrayWidth
+					and systrayTop <= mouseTop <= systrayTop + systrayHeight
+				):
+					winUser.setCursorPos(0, 0)
 
 		if self.role == controlTypes.ROLE_TOOLBAR:
 			# Sometimes, the toolbar itself receives the focus instead of the focused child.
@@ -101,6 +113,49 @@ class NotificationArea(IAccessible):
 		if eventHandler.isPendingEvents("gainFocus"):
 			return
 		super(NotificationArea, self).event_gainFocus()
+
+
+class ExplorerToolTip(ToolTip):
+
+	def shouldReport(self):
+		# Avoid reporting systray tool-tips if their text equals the focused systray icon name (#6656)
+
+		# Don't bother checking if reporting of tool-tips is disabled
+		if not config.conf["presentation"]["reportTooltips"]:
+			return False
+
+		focus = api.getFocusObject()
+
+		# Report if either
+		#  - the mouse has just moved
+		#  - the focus is not in the systray
+		#  - we do not know (yet) where the systray is located
+		if (
+			mouseHandler.lastMouseEventTime >= time.time() - 0.2
+			or not isinstance(focus, NotificationArea)
+			or NotificationArea.lastKnownLocation is None
+		):
+			return True
+
+		# Report if the mouse is indeed located in the systray
+		systrayLeft, systrayTop, systrayWidth, systrayHeight = NotificationArea.lastKnownLocation
+		mouseLeft, mouseTop = winUser.getCursorPos()
+		if (
+			systrayLeft <= mouseLeft <= systrayLeft + systrayWidth
+			and systrayTop <= mouseTop <= systrayTop + systrayHeight
+		):
+			return True
+
+		# Report is the next are different
+		if focus.name != self.name:
+			return True
+
+		# Do not report otherwise
+		return False
+
+	def event_show(self):
+		if self.shouldReport():
+			super().event_show()
 
 
 class GridTileElement(UIA):
@@ -217,7 +272,11 @@ class AppModule(appModuleHandler.AppModule):
 					toolbarParent = None
 				if toolbarParent and toolbarParent.windowClassName == "SysPager":
 					clsList.insert(0, NotificationArea)
-			return 
+			return
+
+		if obj.role == controlTypes.ROLE_TOOLTIP:
+			clsList.insert(0, ExplorerToolTip)
+			return
 
 		if windowClass == "Edit" and controlTypes.STATE_READONLY in obj.states:
 			clsList.insert(0, ReadOnlyEditBox)

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2019 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
+# Copyright (C) 2006-2020 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #6656 

### Summary of the issue:

When navigating the systray using the keyboard and tool-tips reporting is enabled, most systray icon names are double announced as their name is usually equal to the tool-tip text.

Additionally, to avoid focus jumps, NVDA moves the mouse cursor at the top left corner of the screen as soon as a systray control is gains focused as of keyboard navigation.

### Description of how this pull request fixes the issue:

In `appModules.explorer`:
Do not report if:
 - the focus is in the systray
 - and the mouse has not indeed recently been moved
 - and the mouse is located in the systray
 - and the name of the focused systray icon equals the tool-tip text.
Report as usual in any other case.

Additionally, do to reset the mouse cursor position to the top left screen corner upon navigating with the keyboard to the systray if the mouse wasn't their in the first place.

### Testing performed:

Ensured systray icons tool-tips are still always reported when actually hovered with the mouse.
Ensured other Explorer tool-tips are still reported, whether they appear due to mouse hovering or keyboard navigation.
Ensured the mouse cursor position is not reset upon systray keyboard navigation if the mouse is not over the systray.
Ensured the mouse cursor position is reset upon systray keyboard navigation if the mouse is over the systray and has not voluntarily been moved there.

### Known issues with pull request:

### Change log entry:

Section: Bug fixes
The tool-tips of the icons in the system tray are no longer reported upon keyboard navigation if their text is equal to the name of the icons, to avoid a double announce.