### PR TITLE
Pitch: Changed range from 0-100 to 1-101 to avoid ZeroDivisionError

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -11,7 +11,7 @@ from configobj import ConfigObj
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config 
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 4
+latestSchemaVersion = 5
 
 #: The configuration specification string
 #: @type: String

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -15,6 +15,7 @@ that no information is lost, while updating the ConfigObj to meet the requiremen
 """
 
 from logHandler import log
+import configobj
 
 def upgradeConfigFrom_0_to_1(profile):
 	# Schema has been modified to set a new minimum blink rate
@@ -71,3 +72,18 @@ def upgradeConfigFrom_3_to_4(profile):
 	except KeyError:
 		# Setting does not exist, no need for upgrade of this setting
 		log.debug("reportFontAttributes not present, no action taken.")
+
+
+def upgradeConfigFrom_4_to_5(profile):
+	# Pitch setting range has been changed from 0-100 to 1-101.
+	# Pitch could be set to 0 earlier which resulted in a ZeroDivisionError
+	# when changing pitch with a multiplier.
+	try:
+		for item in profile["speech"]:
+			# synth specs are stored as config.Section objects while other specs are not.
+			if isinstance(profile["speech"][item], configobj.Section):
+				if profile["speech"][item].get("pitch") is not None:
+					# increment previously set value by 1
+					profile["speech"][item]["pitch"] = str(int(profile["speech"][item]["pitch"]) + 1)
+	except KeyError:
+		log.error("Speech attributes not present.")

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -79,7 +79,8 @@ class IndexCommand(SynthCommand):
 		@param index: the value of this index
 		@type index: integer
 		"""
-		if not isinstance(index, int): raise ValueError("index must be int, not %s" % type(index))
+		if not isinstance(index, int):
+			raise ValueError("index must be int, not %s" % type(index))
 		self.index = index
 
 	def __repr__(self):

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -104,7 +104,8 @@ class CharacterModeCommand(SynthParamCommand):
 		@param state: if true character mode is on, if false its turned off.
 		@type state: boolean
 		"""
-		if not isinstance(state, bool): raise ValueError("state must be boolean, not %s" % type(state))
+		if not isinstance(state, bool):
+			raise ValueError("state must be boolean, not %s" % type(state))
 		self.state = state
 		self.isDefault = not state
 

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -182,6 +182,11 @@ class SynthDriver(driverHandler.Driver):
 			"pitch",
 			# Translators: Label for a setting in voice settings dialog.
 			_("&Pitch"),
+			# Set minVal to 1 so it can never be zero and cause ZeroDivisionError.
+			minVal=1,
+			# If maxVal if set to 100 while minVal is 1, the value of 99 is lost due to scaling.
+			# setting maxVal to 101 solves this problem.
+			maxVal=101,
 			minStep=minStep,
 			availableInSettingsRing=True,
 			# Translators: Label for a setting in synth settings ring.


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/issues/10940

### Summary of the issue:
When the pitch is set to 0, a `ZeroDivisionError` occurs when trying to speak capital letters. This is because the `baseProsodyCommand.multiplier` property used to calculate the new value of pitch, to be used when speaking capital letters, relies on a division operation with the original pitch (`defaultVal`) in the denominator.

### Description of how this pull request fixes the issue:
The first solution I tried, was to use `baseProsodyCommand.offset` instead of the `baseProsodyCommand.multiplier` to perform all calculations but this was infeasible since the values for the prosody attribute Rate must be a relative non-negative-percentage value (refer [here](https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#number_values)) in the SSML. Using `baseProsodyCommand.offset` to calculate this value would replicate the logic in `baseProsodyCommand.multiplier` and thus result in the same error. Another issue with this solution is that a lot of other code was written to be used with the `baseProsodyCommand.multiplier`.

The second solution I tried, was to catch the `ZeroDivisionError` in `baseProsodyCommand.multiplier`  and raise it again to be handled by any code that calls it. Although the exception had to be handled a little differently for each case, the most common method was to set the multiplier to a fixed value (0 and multiplier values for other possible values of `baseProsodyCommand.defaultValue` or the pitch value stored in the config). The pitch value stored in the config is multiplied with `baseProsodyCommand.multiplier * 100` to calculate the new pitch to be used for speaking capital letters. Since the pitch value stored in the config is still 0 in this case, the result is 0 too and hence there is no pitch change.

The third solution was to change the range of pitch from 0-100 to 1-101, this way, a pitch value of 0 is avoided entirely. It was necessary to use a range of 1-101 and not 1-100 because it caused scaling issues and the value of 99 was omitted. This is apparent in speech settings GUI as the pitch slider announces all values except 99 when incrementing the slider by 1 from 0 to 100. An artefact of this solution is that the value for pitch stored in the config is 1 more than what the user sets in the speech settings GUI. For example, if the pitch is set to 0, the value stored in the config is 1 and if the pitch is set to 100, the value stored in the config is 101. Since pitch values of 0 are now invalid,
this change also required a profile upgrade step so the program won't crash for users who have pitch set to 0. 
This change of range was not applied for the other prosody attributes (Rate and Volume) since they do not cause errors when they are set to zero. However, as a precaution, a warning is logged for the two prosody settings if set to zero and created using non-default values of offset or multiplier.
Although not perfect, it was found that this solution had the least negative user impact and code change.

### Testing performed:

1. Set Pitch=0 CapPitchChange percentage=0
2. Open notepad and type lowercase and uppercase letters and check if pitch change could be heard
3. Repeat the previous steps with negative and positive values of CapPitchChange percentage (-100, -50, 50, 100)
4. Repeat the previous steps with different values of pitch (25, 50, 75,100)
5. Repeat the previous steps for the other prosody attributes: Rate and Volume 
6. Repeat the above test with different synth drivers: espeak, oneCore and sapi5

### Known issues with pull request:
None

### Change log entry:
not necessary

Section: New features, Changes, Bug fixes

