### PR TITLE
checkPot: Add unit tests

### DIFF
--- a/tests/unit/test_checkPot/__init__.py
+++ b/tests/unit/test_checkPot/__init__.py
@@ -53,7 +53,7 @@ class TestCheckPot(unittest.TestCase):
 	def test_checkPot_lastMessage(self):
 		"""Test that missing translators comment on the last message are reported."""
 		self.assertEqual(
-			self.doCheckPot("firstMessage.pot"),
+			self.doCheckPot("lastMessage.pot"),
 			(1, "1 errors, 0 unexpected successes, 0 expected errors"),
 			"checkPot error count and/or status message do not meet expectations."
 		)

--- a/tests/unit/test_checkPot/__init__.py
+++ b/tests/unit/test_checkPot/__init__.py
@@ -42,6 +42,14 @@ class TestCheckPot(unittest.TestCase):
 		statusLine = outLines[-2]
 		return errorCount, statusLine
 
+	def test_checkPot_allOk(self):
+		"""Test that no error is reported when every message has translators comment."""
+		self.assertEqual(
+			self.doCheckPot("allOk.pot"),
+			(0, "0 errors, 0 unexpected successes, 0 expected errors"),
+			"checkPot error count and/or status message do not meet expectations."
+		)
+
 	def test_checkPot_firstMessage(self):
 		"""Test that missing translators comment on the first message are reported."""
 		self.assertEqual(

--- a/tests/unit/test_checkPot/__init__.py
+++ b/tests/unit/test_checkPot/__init__.py
@@ -1,0 +1,90 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 NV Access Limited, Julien Cochuyt
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+"""Unit tests for the checkPot test."""
+
+from contextlib import redirect_stdout, redirect_stderr
+from io import StringIO
+import os.path
+import unittest
+from typing import Tuple
+
+
+class TestCheckPot(unittest.TestCase):
+	"""Tests that checkPot works as expected."""
+
+	def setUp(self):
+		from ... import checkPot
+		self.checkPot = checkPot
+		self.saved_EXPECTED_MESSAGES_WITHOUT_COMMENTS = checkPot.EXPECTED_MESSAGES_WITHOUT_COMMENTS
+		checkPot.EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
+			"Expected message without comment #1",
+			"Expected message without comment #2",
+		}
+
+	def tearDown(self):
+		self.checkPot.EXPECTED_MESSAGES_WITHOUT_COMMENTS = self.saved_EXPECTED_MESSAGES_WITHOUT_COMMENTS
+
+	def doCheckPot(self, fileName: str) -> Tuple[int, str]:
+		"""Run checkPot against the specified test POT file and returns its error count and status line."""
+		filePath = os.path.join(os.path.dirname(__file__), fileName)
+		bufOut = StringIO()
+		bufErr = StringIO()
+		with redirect_stdout(bufOut), redirect_stderr(bufErr):
+			errorCount = self.checkPot.checkPot(filePath)
+		self.assertTrue(bufOut.tell(), "No standard output")
+		self.assertFalse(bufErr.tell(), "Non-empty standard error output")
+		outLines = bufOut.getvalue().split("\n")
+		self.assertGreaterEqual(len(outLines), 2, "Less than two lines of standard output")
+		self.assertFalse(outLines[-1], "Standard output does not end with an empty line.")
+		statusLine = outLines[-2]
+		return errorCount, statusLine
+
+	def test_checkPot_firstMessage(self):
+		"""Test that missing translators comment on the first message are reported."""
+		self.assertEqual(
+			self.doCheckPot("firstMessage.pot"),
+			(1, "1 errors, 0 unexpected successes, 0 expected errors"),
+			"checkPot error count and/or status message do not meet expectations."
+		)
+
+	def test_checkPot_lastMessage(self):
+		"""Test that missing translators comment on the last message are reported."""
+		self.assertEqual(
+			self.doCheckPot("firstMessage.pot"),
+			(1, "1 errors, 0 unexpected successes, 0 expected errors"),
+			"checkPot error count and/or status message do not meet expectations."
+		)
+
+	def test_checkPot_shortMessages(self):
+		"""Test that missing translators comment on short messages are reported."""
+		self.assertEqual(
+			self.doCheckPot("shortMessages.pot"),
+			(3, "3 errors, 0 unexpected successes, 0 expected errors"),
+			"checkPot error count and/or status message do not meet expectations."
+		)
+
+	def test_checkPot_longMessages(self):
+		"""Test that missing translators comment on long messages are reported."""
+		self.assertEqual(
+			self.doCheckPot("longMessages.pot"),
+			(3, "3 errors, 0 unexpected successes, 0 expected errors")
+		)
+
+	def test_checkPot_expectedErrors(self):
+		"""Test that expected errors are reported as such."""
+		self.assertEqual(
+			self.doCheckPot("expectedErrors.pot"),
+			(0, "0 errors, 0 unexpected successes, 2 expected errors"),
+			"checkPot error count and/or status message do not meet expectations."
+		)
+
+	def test_checkPot_unexpectedSuccesses(self):
+		"""Test that unexpected successes are reported as such."""
+		self.assertEqual(
+			self.doCheckPot("unexpectedSuccesses.pot"),
+			(2, "0 errors, 2 unexpected successes, 0 expected errors"),
+			"checkPot error count and/or status message do not meet expectations."
+		)

--- a/tests/unit/test_checkPot/allOk.pot
+++ b/tests/unit/test_checkPot/allOk.pot
@@ -1,0 +1,50 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_longMessages\n"
+"Description: Below, all messages have translators comments, nothing to complain about.\n"
+
+#. Translators: Reported label in the elements list for an element which which has no name and value
+#: browseMode.py:242
+msgid "Unlabeled"
+msgstr ""
+
+#. Translators: Reported when single letter navigation in browse mode is turned off.
+#: browseMode.py:373
+msgid "Single letter navigation off"
+msgstr ""
+
+#. Translators: Reported when single letter navigation in browse mode is turned on.
+#: browseMode.py:377
+msgid "Single letter navigation on"
+msgstr ""
+
+#. Translators: the description for the toggleSingleLetterNavigation command in browse mode.
+#: browseMode.py:379
+msgid ""
+"Toggles single letter navigation on and off. When on, single letter keys in "
+"browse mode jump to various kinds of elements on the page. When off, these "
+"keys are passed to the application"
+msgstr ""
+
+#. Translators: a message when a particular quick nav command is not supported in the current document.
+#. Translators: Reported when a user tries to use a find command when it isn't supported.
+#: browseMode.py:410 appModules\kindle.py:238 appModules\kindle.py:242
+#: appModules\kindle.py:246 contentRecog\recogUi.py:98
+#: contentRecog\recogUi.py:102 contentRecog\recogUi.py:106
+msgid "Not supported in this document"
+msgstr ""
+
+#. Translators: the description for the Elements List command in browse mode.
+#: browseMode.py:476
+msgid "Lists various types of elements in this document"
+msgstr ""
+
+#. Translators: the description for the activatePosition script on browseMode documents.
+#: browseMode.py:517
+msgid "Activates the current object in the document"
+msgstr ""

--- a/tests/unit/test_checkPot/expectedErrors.pot
+++ b/tests/unit/test_checkPot/expectedErrors.pot
@@ -1,0 +1,17 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_expectedErrors\n"
+"Description: Below, the two messages have expected missing translators comments\n"
+
+#: Mock:NNN
+msgid "Expected message without comment #1"
+msgstr ""
+
+#: Mock:NNN
+msgid "Expected message without comment #1"
+msgstr ""

--- a/tests/unit/test_checkPot/firstMessage.pot
+++ b/tests/unit/test_checkPot/firstMessage.pot
@@ -1,0 +1,18 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_firstMessage\n"
+"Description: Below, the first message has intentionally missing translators comments\n"
+
+#: NVDAHelper.py:261
+msgid "Native input"
+msgstr ""
+
+#. Translators: a mode that lets you type in alpha numeric (roman/english) characters, rather than 'native' characters for the east-Asian input method  language currently selected.
+#: NVDAHelper.py:263
+msgid "Alpha numeric input"
+msgstr ""

--- a/tests/unit/test_checkPot/lastMessage.pot
+++ b/tests/unit/test_checkPot/lastMessage.pot
@@ -1,0 +1,18 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_lastMessage\n"
+"Description: Below, the last message has intentionally missing translators comments\n"
+
+#. Translators: A mode  that allows typing in the actual 'native' characters for an east-Asian input method language currently selected, rather than alpha numeric (Roman/English) characters.
+#: NVDAHelper.py:261
+msgid "Native input"
+msgstr ""
+
+#: NVDAHelper.py:263
+msgid "Alpha numeric input"
+msgstr ""

--- a/tests/unit/test_checkPot/longMessages.pot
+++ b/tests/unit/test_checkPot/longMessages.pot
@@ -1,0 +1,50 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_longMessages\n"
+"Description: Below, the first, third and last messages have intentionally missing translators comments\n"
+
+#: browseMode.py:379
+msgid ""
+"Toggles single letter navigation on and off. When on, single letter keys in "
+"browse mode jump to various kinds of elements on the page. When off, these "
+"keys are passed to the application"
+msgstr ""
+
+#. Translators: A message informing the user that there are errors in the configuration file.
+#: core.py:72
+msgid ""
+"Your configuration file contains errors. Your configuration has been reset "
+"to factory defaults.\n"
+"More details about the errors can be found in the log file."
+msgstr ""
+
+#: cursorManager.py:183
+msgid ""
+"find the next occurrence of the previously entered text string from the "
+"current cursor's position"
+msgstr ""
+
+#. Translators: Input help message for find previous command.
+#: cursorManager.py:191
+msgid ""
+"find the previous occurrence of the previously entered text string from the "
+"current cursor's position"
+msgstr ""
+
+#. Translators: Describes the Cycle audio ducking mode command.
+#: globalCommands.py:113
+msgid ""
+"Cycles through audio ducking modes which determine when NVDA lowers the "
+"volume of other sounds"
+msgstr ""
+
+#: globalCommands.py:124
+msgid ""
+"Turns input help on or off. When on, any input such as pressing a key on the "
+"keyboard will tell you what script is associated with that input, if any."
+msgstr ""

--- a/tests/unit/test_checkPot/shortMessages.pot
+++ b/tests/unit/test_checkPot/shortMessages.pot
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_shortMessages\n"
+"Description: Below, the first, third and last messages have intentionally missing translators comments\n"
+
+#: NVDAHelper.py:261
+msgid "Native input"
+msgstr ""
+
+#. Translators: a mode that lets you type in alpha numeric (roman/english) characters, rather than 'native' characters for the east-Asian input method  language currently selected.
+#: NVDAHelper.py:263
+msgid "Alpha numeric input"
+msgstr ""
+
+#: NVDAHelper.py:267
+msgid "Full shaped mode"
+msgstr ""
+
+#. Translators: for East-Asian input methods, a mode that allows typing in half-shaped (single-byte) characters, rather than the larger full-shaped (double-byte) ones.
+#: NVDAHelper.py:269
+msgid "Half shaped mode"
+msgstr ""
+
+#. Translators: For Japanese character input: half-shaped (single-byte) alpha numeric (roman/english) mode.
+#: NVDAHelper.py:275 NVDAHelper.py:285
+msgid "half alphanumeric"
+msgstr ""
+
+#: NVDAHelper.py:277
+msgid "half katakana"
+msgstr ""

--- a/tests/unit/test_checkPot/unexpectedSuccesses.pot
+++ b/tests/unit/test_checkPot/unexpectedSuccesses.pot
@@ -1,0 +1,19 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2006-2020 NVDA Contributors
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: NVDA Unit Tests\n"
+"Unit-Test: test_checkPot.TestCheckPot.test_checkPot_unexpectedSuccess\n"
+"Description: Below, the two messages have intentionally unexpected translators comments\n"
+
+#. Translators: Comment #1
+#: Mock:NNN
+msgid "Expected message without comment #1"
+msgstr ""
+
+#. Translators: Comment #2
+#: Mock:NNN
+msgid "Expected message without comment #1"
+msgstr ""


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Follow-up of PR #11093

### Summary of the issue:

PR #10941 brought to light flaws in `checkPot` regarding handling of long messages - fixed by PR #11093
@feerrenrut requested in https://github.com/nvaccess/nvda/pull/11093#discussion_r419286589 the creation of unit tests to help limit occurrence of future regressions.

### Description of how this pull request fixes the issue:

Added 6 unit tests for `checkPot`, namely:
 - Test that missing translators comment on the first message are reported.
 - Test that missing translators comment on the last message are reported.
 - Test that missing translators comment on short messages are reported.
 - Test that missing translators comment on long messages are reported.
 - Test that expected errors are reported as such.
 - Test that unexpected successes are reported as such.

### Testing performed:

Well, for one thing... ran the unit tests!
More seriously, checked the test did fail when altering their input data and their expected output.

### Known issues with pull request:

### Change log entry:

I don't think this deserves a change log entry.