### PR TITLE
gecko_ia2 vbuf backend: Don't unnecessarily calculate labelledByContent (and thus unnecessarily fetch labelledBy).

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -901,10 +901,6 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 		}
 	}
 
-	//If the name isn't being rendered as the content, then add the name as a field attribute.
-	if (!nameIsContent && name)
-		parentNode->addAttribute(L"name", name);
-
 	if(nameIsContent) {
 		// We may render an accessible name for this node if it has been explicitly set or it has no useful content. 
 		parentNode->alwaysRerenderDescendants=true;
@@ -1149,17 +1145,22 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 		}
 	}
 
-	auto labelId = getLabelIDCached();
-	if (labelId) {
-		auto labelControlFieldNode = buffer->getControlFieldNodeWithIdentifier(docHandle, labelId.value());
-		if (labelControlFieldNode) {
-			bool isDescendant = buffer->isDescendantNode(parentNode, labelControlFieldNode);
-			if (isDescendant) {
-				parentNode->addAttribute(L"labelledByContent", L"true");
+	//If the name isn't being rendered as the content, then add the name as a field attribute.
+	if (!nameIsContent && name) {
+		parentNode->addAttribute(L"name", name);
+		if (nameIsExplicit) {
+			auto labelId = getLabelIDCached();
+			if (labelId) {
+				auto labelControlFieldNode = buffer->getControlFieldNodeWithIdentifier(docHandle, labelId.value());
+				if (labelControlFieldNode) {
+					bool isDescendant = buffer->isDescendantNode(parentNode, labelControlFieldNode);
+					if (isDescendant) {
+						parentNode->addAttribute(L"labelledByContent", L"true");
+					}
+				}
 			}
 		}
 	}
-
 
 	// Clean up.
 	if(name)

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1148,6 +1148,9 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 	//If the name isn't being rendered as the content, then add the name as a field attribute.
 	if (!nameIsContent && name) {
 		parentNode->addAttribute(L"name", name);
+		// Determine whether this node is labelled by its content. We only need to do
+		// this if the node has a name and the name is explicit, since this is what
+		// browsers expose in this case.
 		if (nameIsExplicit) {
 			auto labelId = getLabelIDCached();
 			if (labelId) {


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In #10552, we started querying the labelledBy relation in the gecko_ia2 vbuf backend for all objects. In a large document (e.g. a 10000 row table, which does happen on GitHub, etc.), this can result in thousands of unnecessary calls, increasing page load times by several seconds.

### Description of how this pull request fixes the issue:
The labelledByContent ControlField attribute is only used when the name attribute is set and the name is an explicit name.
Previously, this was always calculated, which required the labelledBy relation to be fetched even if we weren't going to use this.
Instead, only calculate labelledByContent if we're going to use it.

This involves moving the code which calculates the name attribute further down in the function, since we can only calculate labelledByContent *after* descendants have been added to the buffer. However, no other code in the function depends on us setting the name attribute on the node, so this doesn't change the rendering.

### Testing performed:
As per #10552:

> Simplified test case:
> 
> ```
> data:text/html,<button>begin</button><div tabindex="0" role="checkbox" aria-labelledby="inner-label"><div style="display:inline" id="inner-label">Simulate evil cat</div></div>
> ```

### Known issues with pull request:
None.