### PR TITLE
Add additional files created during build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,11 +26,11 @@ dlldata.c
 user_docs/*/*.html
 extras/controllerClient/x86/nvdaController.h
 extras/controllerClient/x64
+extras/controllerClient/arm64
 source/_buildVersion.py
 user_docs/*/keyCommands.t2t
 output
 testOutput
-./developerGuide.html
 user_docs/build.t2tConf
 launcher/nvda_logo.wav
 uninstaller/UAC.nsh

--- a/devDocs/.gitignore
+++ b/devDocs/.gitignore
@@ -1,2 +1,3 @@
 _build/
 *.rst
+developerGuide.html


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:
When creating NVDA Controller Client the libraries created for ARM64 weren't ignored by Git. Also after compiling Developer guide the created HTML file was show as untracked.
### Description of how this pull request fixes the issue:
Gitignore was changed to ignore these files.
### Testing performed:
Launched scons devdocs and scons client - ensured that no untracked files are present.
### Known issues with pull request:
None known
### Change log entry:
None needed.