### PR TITLE
Removed double entry for Role_Alert from ControlTypes

### DIFF
--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -119,7 +119,6 @@ ROLE_WHITESPACE=110
 ROLE_TREEVIEWBUTTON=111
 ROLE_IPADDRESS=112
 ROLE_DESKTOPICON=113
-ROLE_ALERT=114
 ROLE_INTERNALFRAME=115
 ROLE_DESKTOPPANE=116
 ROLE_OPTIONPANE=117
@@ -435,8 +434,6 @@ roleLabels: Dict[int, str] = {
 	ROLE_IPADDRESS:_("IP address"),
 	# Translators: Identifies a desktop icon (the icons on the desktop such as computer and various shortcuts for programs).
 	ROLE_DESKTOPICON:_("desktop icon"),
-	# Translators: Identifies an alert message such as file download alert in Internet explorer 9 and above.
-	ROLE_ALERT:_("alert"),
 	# Translators: Identifies an internal frame. This is usually a frame on a web page; i.e. a web page embedded within a web page.
 	ROLE_INTERNALFRAME:_("frame"),
 	# Translators: Identifies desktop pane (the desktop window).


### PR DESCRIPTION
### Link to issue number:
closes #7247

### Summary of the issue:
The Role_Alert appears twice in ControlTypes.

### Description of how this pull request fixes the issue:
Removed the first instance and also the corresponding entry in the dict.

### Testing performed:
Tested that alerts are still reported properly.

### Known issues with pull request:
none

### Change log entry:
not needed