### PR TITLE
Update liblouis to 3.14.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit f9a265c
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
-* [liblouis](http://www.liblouis.org/), version 3.13.0
+* [liblouis](http://www.liblouis.org/), version 3.14.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 36.1
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -235,6 +235,12 @@ addTable("grc-international-en.utb", _("Greek international braille"))
 addTable("he.ctb", _("Hebrew 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("he-IL.utb", _("Israeli grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("he-IL-comp8.utb", _("Israeli 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("hi-in-g1.utb", _("Hindi grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -293,6 +299,9 @@ addTable("ml-in-g1.utb", _("Malayalam grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("mn-in-g1.utb", _("Manipuri grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("ms-my-g2.ctb", _("Malay grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("mn-MN-g1.utb", _("Mongolian grade 1"))
@@ -392,6 +401,9 @@ addTable("tr.ctb", _("Turkish grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("uk.utb", _("Ukrainian"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("uz-g1.utb", _("Uzbek grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("unicode-braille.utb", _("Unicode braille"), output=False)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,7 +19,7 @@ What's New in NVDA
 
 
 == Changes ==
-- Updated liblouis braille translator to [3.13.0 https://github.com/liblouis/liblouis/releases/tag/v3.13.0] (from 3.12.0). (#10832)
+- Updated liblouis braille translator to [3.14.0 https://github.com/liblouis/liblouis/releases/tag/v3.14.0] (from 3.12.0). (#10832, #11221)
 - The reporting of superscripts and subscripts is now controlled separately to the reporting of font attributes. (#10919)
 - Due to changes made in VS Code, NVDA no longer disables browse mode in Code by default. (#10888)
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
[Liblouis 3.14.0 has just been released](https://github.com/liblouis/liblouis/tree/v3.14.0).

### Description of how this pull request fixes the issue:
1. Updates the liblouis submodule.
2. Changes the readme.
3. Adds the following tables: Uzbek grade 1, Israeli grade 1, Israeli 8 dot computer braille and Malay grade 2.

### Testing performed:
Tested from source.

### Known issues with pull request:
None

### Change log entry:
* Changes
  - Updated liblouis braille translator to [3.14.0](https://github.com/liblouis/liblouis/releases/tag/v3.14.0) (from 3.13.0).