### PR TITLE
Added clarification that ctrl+enter activates the element containing formula in Math content

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -645,6 +645,9 @@ Please see the [MathPlayer documentation about navigation commands https://www.d
 
 When you wish to return to the document, simply press the escape key.
 
+Sometimes mathematical content might be displayed as a button or other type of element which, when activated, can display a dialog or more information related to the formula.
+To activate the button or the element containing the  formula, press ctrl+enter.
+
 + Braille +[Braille]
 If you own a braille display, NVDA can display information in braille.
 If your braille display has a Perkins-style keyboard, you can also enter contracted or uncontracted braille.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -646,7 +646,8 @@ Please see the [MathPlayer documentation about navigation commands https://www.d
 When you wish to return to the document, simply press the escape key.
 
 Sometimes mathematical content might be displayed as a button or other type of element which, when activated, can display a dialog or more information related to the formula.
-To activate the button or the element containing the  formula, press ctrl+enter.
+To activate the button or the element containing the formula, press ctrl+enter.
+
 
 + Braille +[Braille]
 If you own a braille display, NVDA can display information in braille.


### PR DESCRIPTION
### Link to issue number:
none
### Summary of the issue:
As discussed in #11215, when Math ML is a button containing formula but the button itself can be activated to display a separate dialog, enter or space is not working because this is already used by Math ML to enter the formula. So in this case to activate the element and to display the dialog, an user must press ctrl+enter instead.

### Description of how this pull request fixes the issue:
Documented this properly in chapter 7.1.

### Testing performed:
Tested in different browsers on the website provided in issue #11215 and also on other websites with Math ML in elements that ctrl+enter activates the elements.

### Known issues with pull request:
None

### Change log entry:
Not needed.