### PR TITLE
Fix several issues in speech manager

### DIFF
--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -233,7 +233,7 @@ def doPreGainFocus(obj,sleepMode=False):
 		# - lastQueuedFocusObject & obj.WAS_GAIN_FOCUS_OBJ_ATTR_NAME
 		#   - Set in stack: _trackFocusObject, eventHandler.queueEvent
 		#   - Which results in executeEvent being called, then doPreGainFocus
-		# - api.getFocusAncestors() via api.setFocusOject() called in doPreGainFocus
+		# - api.getFocusAncestors() via api.setFocusObject() called in doPreGainFocus
 		speech._manager.removeCancelledSpeechCommands()
 
 	if globalVars.focusDifferenceLevel<=1:

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -168,20 +168,20 @@ def _getFocusLossCancellableSpeechCommand(
 	)
 
 	def isSpeechStillValid():
-		from eventHandler import lastQueuedFocusObject
 		isLastFocusObj: bool = obj is lastQueuedFocusObject
 		stillValid = isLastFocusObj or not previouslyHadFocus
-
-		log._speechManagerDebug(
-			"checked if valid (isLast: %s, previouslyHad: %s): %s",
-			isLastFocusObj,
-			previouslyHadFocus,
-			obj.name
-		)
 		return stillValid
 
-	return _CancellableSpeechCommand(isSpeechStillValid)
+	if not speech.manager._shouldDoSpeechManagerLogging():
+		return _CancellableSpeechCommand(isSpeechStillValid)
 
+	def getDevInfo():
+		isLastFocusObj: bool = obj is lastQueuedFocusObject
+		return (
+			f"isLast: {isLastFocusObj},"
+			f" previouslyHad: {previouslyHadFocus}"
+		)
+	return _CancellableSpeechCommand(isSpeechStillValid, getDevInfo)
 
 def executeEvent(eventName, obj, **kwargs):
 	"""Executes an NVDA event.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -146,10 +146,12 @@ def _trackFocusObject(eventName, obj) -> None:
 	:param obj: the object to track if focused
 	"""
 	global lastQueuedFocusObject
+
 	if eventName == "gainFocus":
 		lastQueuedFocusObject = obj
-	setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, obj is lastQueuedFocusObject)
-
+		setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, True)
+	elif not hasattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME):
+		setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, False)
 
 def _getFocusLossCancellableSpeechCommand(
 		obj,
@@ -161,25 +163,32 @@ def _getFocusLossCancellableSpeechCommand(
 	if not isinstance(obj, NVDAObject):
 		log.warning("Unhandled object type. Expected all objects to be descendant from NVDAObject")
 		return None
-	previouslyHadFocus: bool = getattr(
-		obj,
-		WAS_GAIN_FOCUS_OBJ_ATTR_NAME,
-		False
-	)
+
+	def previouslyHadFocus():
+		return getattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, False)
+
+	def isLastFocusObj():
+		return obj is lastQueuedFocusObject
+
+	def isAncestorOfCurrentFocus():
+		return obj in api.getFocusAncestors()
 
 	def isSpeechStillValid():
-		isLastFocusObj: bool = obj is lastQueuedFocusObject
-		stillValid = isLastFocusObj or not previouslyHadFocus
+		stillValid = (
+			isLastFocusObj()
+			or not previouslyHadFocus()
+			or isAncestorOfCurrentFocus()
+		)
 		return stillValid
 
 	if not speech.manager._shouldDoSpeechManagerLogging():
 		return _CancellableSpeechCommand(isSpeechStillValid)
 
 	def getDevInfo():
-		isLastFocusObj: bool = obj is lastQueuedFocusObject
 		return (
-			f"isLast: {isLastFocusObj},"
-			f" previouslyHad: {previouslyHadFocus}"
+			f"isLast: {isLastFocusObj()}"
+			f", previouslyHad: {previouslyHadFocus()}"
+			f", isAncestorOfCurrentFocus: {isAncestorOfCurrentFocus()}"
 		)
 	return _CancellableSpeechCommand(isSpeechStillValid, getDevInfo)
 
@@ -197,14 +206,6 @@ def executeEvent(eventName, obj, **kwargs):
 		if isGainFocus and obj.focusRedirect:
 			obj=obj.focusRedirect
 		sleepMode=obj.sleepMode
-		if isGainFocus and speech.manager._shouldCancelExpiredFocusEvents():
-			log._speechManagerDebug("executeEvent: Removing cancelled speech commands.")
-			# ask speechManager to check if any of it's queued utterances should be cancelled
-			speech._manager.removeCancelledSpeechCommands()
-			# Don't skip objects without focus here. Even if an object no longer has focus, it needs to be processed
-			# to capture changes in document depth. For instance jumping into a list?
-			# This needs further investigation; when the next object gets focus, it should
-			# allow us to capture this information?
 		if isGainFocus and not doPreGainFocus(obj, sleepMode=sleepMode):
 			return
 		elif not sleepMode and eventName=="documentLoadComplete" and not doPreDocumentLoadComplete(obj):
@@ -219,6 +220,22 @@ def doPreGainFocus(obj,sleepMode=False):
 	oldFocus=api.getFocusObject()
 	oldTreeInterceptor=oldFocus.treeInterceptor if oldFocus else None
 	api.setFocusObject(obj)
+
+	if speech.manager._shouldCancelExpiredFocusEvents():
+		log._speechManagerDebug("executeEvent: Removing cancelled speech commands.")
+		# ask speechManager to check if any of it's queued utterances should be cancelled
+		# Note: Removing cancelled speech commands should happen after all dependencies for the isValid check
+		# have been updated:
+		# - lastQueuedFocusObject
+		# - obj.WAS_GAIN_FOCUS_OBJ_ATTR_NAME
+		# - api.getFocusAncestors()
+		# These are updated:
+		# - lastQueuedFocusObject & obj.WAS_GAIN_FOCUS_OBJ_ATTR_NAME
+		#   - Set in stack: _trackFocusObject, eventHandler.queueEvent
+		#   - Which results in executeEvent being called, then doPreGainFocus
+		# - api.getFocusAncestors() via api.setFocusOject() called in doPreGainFocus
+		speech._manager.removeCancelledSpeechCommands()
+
 	if globalVars.focusDifferenceLevel<=1:
 		newForeground=api.getDesktopObject().objectInForeground()
 		if not newForeground:

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -256,7 +256,7 @@ class SpeechManager(object):
 		interrupt = self._queueSpeechSequence(speechSequence, priority)
 		self._doRemoveCancelledSpeechCommands()
 		# If speech isn't already in progress, we need to push the first speech.
-		push = self._hasNoMoreSpeech() or not self._synthStillSpeaking()
+		push = self._hasNoMoreSpeech()
 		log._speechManagerDebug(
 			f"Will interrupt: {interrupt}"
 			f" Will push: {push}"
@@ -670,7 +670,11 @@ class SpeechManager(object):
 						log._speechManagerUnitTest("CallbackCommand End")
 					except Exception:
 						log.exception("Error running speech callback")
-		if endOfUtterance:
+		shouldPush = (
+			endOfUtterance
+			and not self._synthStillSpeaking()  # stops double speaking errors
+		)
+		if shouldPush:
 			if self._indexesSpeaking:
 				log._speechManagerDebug(
 					f"Indexes speaking: {self._indexesSpeaking!r},"

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -670,6 +670,7 @@ class SpeechManager(object):
 						log._speechManagerUnitTest("CallbackCommand End")
 					except Exception:
 						log.exception("Error running speech callback")
+		self._doRemoveCancelledSpeechCommands()
 		shouldPush = (
 			endOfUtterance
 			and not self._synthStillSpeaking()  # stops double speaking errors

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -256,7 +256,7 @@ class SpeechManager(object):
 		interrupt = self._queueSpeechSequence(speechSequence, priority)
 		self._doRemoveCancelledSpeechCommands()
 		# If speech isn't already in progress, we need to push the first speech.
-		push = self._hasNoMoreSpeech()
+		push = self._hasNoMoreSpeech() or not self._synthStillSpeaking()
 		log._speechManagerDebug(
 			f"Will interrupt: {interrupt}"
 			f" Will push: {push}"

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -22,6 +22,7 @@ SequenceItemT = Union[SpeechCommand, str]
 SpeechSequence = List[SequenceItemT]
 SpeechIterable = Iterable[SequenceItemT]
 
+_IndexT = int  # Type for indexes.
 
 def _isDebugForSpeech() -> bool:
 	"""Check if debug logging for speech is enabled."""

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -297,11 +297,9 @@ class CancellableSpeechTests(unittest.TestCase):
 
 		with smi.expectation():
 			smi.speak(["Stays valid", _CancellableSpeechCommand(lambda: True)])
-			# ToDo: Fix SpeechManager. Valid speech should be sent to synth
-			# 	Expected:
-			# smi.expect_synthSpeak(sequence=[
-			# 	"Stays valid", smi.create_ExpectedIndex(expectedToBecomeIndex=2)
-			# ])
+			smi.expect_synthSpeak(sequence=[
+				"Stays valid", smi.create_ExpectedIndex(expectedToBecomeIndex=2)
+			])
 
 
 class SayAllEmulatedTests(unittest.TestCase):

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -204,8 +204,7 @@ class CancellableSpeechTests(unittest.TestCase):
 			smi.indexReached(1)
 			smi.expect_indexReachedCallback(forIndex=1)
 			smi.pumpAll()
-			# Todo: Fix SpeechManager. Invalid speech should be cancelled
-			#  smi.expect_synthCancel()  # Expected here
+			smi.expect_synthCancel()
 
 	def test_invalidated_newSpeech(self):
 		"""New speech should cause a cancellation of speech that has become

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -1,0 +1,161 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 NV Access Limited
+
+"""Unit tests for speech/manger module
+"""
+import unittest
+import config
+from .speechManagerTestHarness import (
+	ExpectedIndex,
+	SpeechManagerInteractions,
+)
+
+
+class SayAllEmulatedTests(unittest.TestCase):
+	"""Tests for speechManager operations."""
+
+	def setUp(self):
+		import speechDictHandler
+		speechDictHandler.initialize()  # setting the synth depends on dictionary["voice"]
+		config.conf['featureFlag']['cancelExpiredFocusSpeech'] = 2  # no
+
+	def test_simpleSpeech(self):
+		smi = SpeechManagerInteractions(self)
+		with smi.expectation():
+			seqIndex = smi.speak(["hello ", "world", ExpectedIndex(1)])
+			smi.expect_synthSpeak(seqIndex)
+
+	def test_moreSpeechOnIndexReached(self):
+		smi = SpeechManagerInteractions(self)
+		with smi.expectation():
+			seqIndex1 = smi.speak(["hello ", "world", ExpectedIndex(1)])
+			seqIndex2 = smi.speak(["goodBye ", "earth", ExpectedIndex(2)])
+			smi.expect_synthSpeak(seqIndex1)
+
+		with smi.expectation():
+			smi.indexReached(1)
+			smi.pumpAll()
+			smi.expect_synthSpeak(seqIndex2)
+
+	def test_standardSayAll(self):
+		"""See #11144: Mimic behaviour that caused repeated speech during say-all - Full example.
+		"""
+		smi = SpeechManagerInteractions(self)
+		callBack = smi.create_CallBackCommand
+		expectIndex = smi.create_ExpectedIndex
+
+		# First sayAllHandler queues up a number of utterances.
+		with smi.expectation():
+			seqNum = smi.speak([
+				callBack(expectedToBecomeIndex=1),
+				'sequence 0  ',
+				callBack(expectedToBecomeIndex=2)
+			])
+			self.assertEqual(seqNum, 0)
+			# Speech manager is expected to get started immediately
+			smi.expect_synthSpeak(seqNum)
+
+		seqNum = smi.speak([
+			'sequence 1 before call back  ',
+			callBack(expectedToBecomeIndex=3),
+			'sequence 1 after call back  ',
+			callBack(expectedToBecomeIndex=4)
+		])
+		self.assertEqual(seqNum, 1)
+
+		# Synth has already reached the first index, callback shouldn't be called until
+		# pump all is called.
+		smi.indexReached(1)  # start of sequenceNumber 0
+
+		seqNum = smi.speak([
+			'sequence 2  ',
+			callBack(expectedToBecomeIndex=5)
+		])
+		self.assertEqual(seqNum, 2)
+
+		seqNum = smi.speak([
+			# for some reason say-all handler does not give this sequence callback commands
+			'sequence 3  ',
+			expectIndex(expectedToBecomeIndex=6)
+		])
+		self.assertEqual(seqNum, 3)
+
+		with smi.expectation():
+			smi.pumpAll()
+			# no side effect, sayAllHandler does not send more speech until the final callback index is hit.
+			smi.expect_indexReachedCallback(forIndex=1, sideEffect=None)
+
+		with smi.expectation():
+			smi.indexReached(2)  # end of sequenceNumber 0
+			smi.pumpAll()
+			smi.expect_indexReachedCallback(forIndex=2, sideEffect=None)
+			smi.expect_synthSpeak(1)  # new speech expected after reaching endOfUtterance
+
+		with smi.expectation():
+			smi.indexReached(3)  # in sequenceNumber 1
+			smi.pumpAll()
+			smi.expect_indexReachedCallback(forIndex=3, sideEffect=None)
+			# Don't expect new speech to be sent to the synth, index is not at the end of the utterance.
+
+		with smi.expectation():
+			smi.indexReached(4)  # in sequenceNumber 1
+			smi.pumpAll()
+			smi.expect_indexReachedCallback(forIndex=4, sideEffect=None)
+			smi.expect_synthSpeak(2)
+
+		with smi.expectation():
+			smi.indexReached(5)  # in sequenceNumber 2
+			# Only 1 pending speech sequence from say all, this results in new speech being sent during the
+			# callback which triggers the duplicate speech.
+			smi.pumpAllAndSendSpeechOnCallback(
+				expectCallbackForIndex=5,
+				expectedSendSequenceNumber=4,
+				seq=[
+					callBack(expectedToBecomeIndex=7),
+					'sequence 4  ', expectIndex(expectedToBecomeIndex=8)
+				]
+			)
+			# Todo: Fix SpeechManager. Should not be double speaking!
+			smi.expect_synthSpeak([3, 3])  # smi.expect_synthSpeak(1) expected here
+
+		smi.indexReached(6)  # in sequenceNumber 4, does not have a callback
+		with smi.expectation():
+			smi.pumpAll()  # No callback, so no handle index call
+			smi.expect_synthSpeak(4)
+
+	def test_speechNotRepeated(self):
+		"""Minimal test for #11144: Repeated speech during say-all.
+		Ensure that adding new speech during a callback does not result in double speaking.
+		"""
+		smi = SpeechManagerInteractions(self)
+		callBack = smi.create_CallBackCommand
+		expectIndex = smi.create_ExpectedIndex
+
+		with smi.expectation():
+			seq0 = smi.speak(['sequence 0  ', callBack(expectedToBecomeIndex=1)])
+			seq1 = smi.speak(['sequence 1  ', callBack(expectedToBecomeIndex=2)])
+			smi.expect_synthSpeak(seq0)
+
+		with smi.expectation():
+			smi.indexReached(1)  # in sequenceNumber 2
+			# Only 1 pending speech sequence from say all, this results in new speech being sent during the
+			# callback which triggers the duplicate speech.
+			smi.pumpAllAndSendSpeechOnCallback(
+				expectCallbackForIndex=1,
+				expectedSendSequenceNumber=2,
+				seq=[
+					callBack(expectedToBecomeIndex=3),
+					'sequence 2  ', expectIndex(expectedToBecomeIndex=4)
+				]
+			)
+			# Todo: Fix SpeechManager. Should not be double speaking!
+			smi.expect_synthSpeak([1, 1])  # smi.expect_synthSpeak(1) expected here
+
+
+class SayAllEmulatedTests_withCancellableSpeechEnabled(SayAllEmulatedTests):
+	"""Note, while cancellable speech is configurable test with and without it enabled."""
+	def setUp(self):
+		super().setUp()
+		config.conf['featureFlag']['cancelExpiredFocusSpeech'] = 1  # yes

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -7,10 +7,16 @@
 """
 import unittest
 import config
+import speech
 from .speechManagerTestHarness import (
 	ExpectedIndex,
 	SpeechManagerInteractions,
 )
+
+#: Enable logging used to aid in the development of unit
+# Hard coding this to True where it is defined makes creating new unit tests easier, since all interactions
+# can be tracked.
+speech.manager.IS_UNIT_TEST_LOG_ENABLED = True
 
 
 class SayAllEmulatedTests(unittest.TestCase):

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -3,7 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2020 NV Access Limited
 
-"""Unit tests for speech/manger module
+"""Unit tests for speech/manager module
 """
 import unittest
 import config

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -297,7 +297,11 @@ class CancellableSpeechTests(unittest.TestCase):
 
 		with smi.expectation():
 			smi.speak(["Stays valid", _CancellableSpeechCommand(lambda: True)])
-			smi.expect_synthSpeak(sequence=["Stays valid", smi.create_ExpectedIndex(expectedToBecomeIndex=2)])
+			# ToDo: Fix SpeechManager. Valid speech should be sent to synth
+			# 	Expected:
+			# smi.expect_synthSpeak(sequence=[
+			# 	"Stays valid", smi.create_ExpectedIndex(expectedToBecomeIndex=2)
+			# ])
 
 
 class SayAllEmulatedTests(unittest.TestCase):
@@ -404,8 +408,8 @@ class SayAllEmulatedTests(unittest.TestCase):
 					'sequence 4  ', expectIndex(expectedToBecomeIndex=8)
 				]
 			)
-			# Todo: Fix SpeechManager. Should not be double speaking!
-			smi.expect_synthSpeak([3, 3])  # smi.expect_synthSpeak(1) expected here
+			# Now ensure there is no double speaking!
+			smi.expect_synthSpeak(3)
 
 		smi.indexReached(6)  # in sequenceNumber 4, does not have a callback
 		with smi.expectation():
@@ -437,8 +441,8 @@ class SayAllEmulatedTests(unittest.TestCase):
 					'sequence 2  ', expectIndex(expectedToBecomeIndex=4)
 				]
 			)
-			# Todo: Fix SpeechManager. Should not be double speaking!
-			smi.expect_synthSpeak([1, 1])  # smi.expect_synthSpeak(1) expected here
+			# Now ensure there is no double speaking!
+			smi.expect_synthSpeak(seq1)
 
 
 class SayAllEmulatedTests_withCancellableSpeechEnabled(SayAllEmulatedTests):

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -1,0 +1,329 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 NV Access Limited
+
+"""A test harness for interacting with the SpeechManager class."""
+import typing
+import unittest
+from contextlib import contextmanager
+from typing import (
+	Callable,
+	Tuple,
+	Union,
+	Optional,
+	List,
+)
+from unittest import mock
+from unittest.mock import (
+	MagicMock,
+)
+
+from dataclasses import dataclass
+
+import queueHandler
+import speech.manager
+from speech import (
+	IndexCommand,
+	CallbackCommand,
+	SpeechSequence,
+)
+
+_IndexT = int
+_SentSequenceIndex = int
+
+
+@dataclass
+class ExpectedIndex:
+	expectedIndexCommandIndex: int
+
+	def __eq__(self, other):
+		if isinstance(other, IndexCommand):
+			return other.index == self.expectedIndexCommandIndex
+		elif isinstance(other, ExpectedIndex):
+			return other.expectedIndexCommandIndex == self.expectedIndexCommandIndex
+		return False
+
+
+class SpeechManagerInteractions:
+	""" Track expected state and interactions with the speechManager.
+	SpeechManager has the following functions that external code interacts with.
+	Inputs:
+	- SpeechManager.speak()
+	- SpeechManager.cancel()
+	- SpeechManager._onSynthIndexReached(): Normally via synthDriverHandler.synthIndexReached extensionPoint
+	- SpeechManager._onSynthDoneSpeaking(): Normally via synthDriverHandler.synthDoneSpeaking extensionPoint
+	- queueHandler.pumpAll(): handles all pending _onSynthIndexReached and _onSynthDoneSpeaking calls.
+	Outputs:
+	- synthDriverHandler.getSynth().speak(): Send speech to the synth.
+	- synthDriverHandler.getSynth().cancel(): Cancel current speech.
+	- CallbackCommand: Converted into index commands. When the index is reached (by the synth) the callback is
+			called after queueHandler.pumpAll is called.
+	"""
+	def __init__(self, testCase: unittest.TestCase):
+		"""
+		@param testCase: Used to run asserts
+		"""
+		self._testCase = testCase
+		import synthDriverHandler
+
+		#: speechManager needs to call to the synth
+		self.synthMock = MagicMock()
+		self.synthMock.speak.side_effect = self._sideEffect_synth_speak
+		self.synthMock.cancel.side_effect = self._sideEffect_synth_cancel
+
+		#: Used by CallbackCommands, called when their associated index is reached. Records the indexes.
+		self._indexReachedCallback = MagicMock()
+		self._indexReachedCallback.side_effect = self._sideEffect_callbackCommand
+
+		#: SequenceIndexes we are awaiting to be sent to the synth
+		self._awaitingSpeakCalls: List[_SentSequenceIndex] = []
+		#: Number of cancel calls we are waiting for
+		self._awaitingCancelCalls: int = 0
+		#: Index and Callbacks for callback commands
+		self._awaitingCallbackForIndex: List[Tuple[_IndexT, Optional[Callable[[], None]]]] = []
+
+		#: All sequence indexes already expected to be sent to the synth
+		self.expectedState_speak: List[_SentSequenceIndex] = []
+		#: Number of calls to cancel
+		self.expectedState_cancelCallCount: int = 0
+		#: Indexes that have been reached
+		self.expectedState_indexReached: List[_IndexT] = []
+
+		self._inExpectBlock = False
+
+		# Install the mock synth
+		synthDriverHandler._curSynth = self.synthMock
+		#: Sequences sent to the speechManager so far.
+		self._sentSequences = []
+
+		self._indexCommandIndexes = iter(range(1, 1000))
+		self._lastCommandIndex = 0
+		self._testDebug_IndexReached: List[int] = []
+
+		self.sManager = speech.manager.SpeechManager()
+
+	def _sideEffect_synth_speak(self, sequence):
+		if not self._inExpectBlock:  # an ExpectBlock will verify state on exit
+			self._testCase.assertTrue(self._awaitingSpeakCalls)
+			self._updateExpectedStateFromAwaiting_speak()
+			self._verifyCurrentState()
+
+	def _sideEffect_synth_cancel(self):
+		if not self._inExpectBlock:  # an ExpectBlock will verify state on exit
+			self._testCase.assertTrue(self._awaitingCancelCalls)
+			self._updateExpectedStateFromAwaiting_cancel()
+			self._verifyCurrentState()
+
+	def _sideEffect_callbackCommand(self, index):
+		"""Callback commands must be expected, so they can deliver new speech.
+		Asserts can not be run inside callback commands, the exceptions they raise on failure are caught by
+		speechManager.
+		"""
+		# pop used because there may be multiple callbacks for a given operation.
+		# We wish to verify the order of the callbacks.
+		expectedIndex, sideEffect = self._awaitingCallbackForIndex[-1]
+		if expectedIndex != index:
+			return
+		if sideEffect:
+			sideEffect()
+		self.expectedState_indexReached.append(expectedIndex)
+		self._awaitingCallbackForIndex.pop()
+
+	@contextmanager
+	def expectation(self):
+		"""Used to ensure that the next command results in an expected change."""
+		self._testCase.assertFalse(self._inExpectBlock, msg="This is likely a logic error in the test.")
+		self._inExpectBlock = True
+		self._verifyCurrentState()
+		yield
+		self.assertExpectedStateNowMet()
+		self._inExpectBlock = False
+
+	def assertExpectedStateNowMet(self):
+		self._updateExpectedStateFromAwaiting_speak()
+		self._updateExpectedStateFromAwaiting_cancel()
+		self._updateExpectedStateFromAwaiting_callbacks()
+		self._verifyCurrentState()
+
+	def _verifyCurrentState(self):
+		# Sequences sent to synth?
+		self._assertCurrentSpeechCallState()
+		self._assertIndexCallbackState()
+		self._assertCancelState()
+		pass
+
+	def speak(self, seq: SpeechSequence, priority=speech.Spri.NORMAL) -> _SentSequenceIndex:
+		nextSentSequenceNumber = len(self._sentSequences)
+		self._sentSequences.append(seq)
+		filteredSpeech = [
+			x for x in self._sentSequences[nextSentSequenceNumber]
+			if not isinstance(x, ExpectedIndex)  # don't send types used for behaviour tracking.
+		]
+		self.sManager.speak(filteredSpeech, priority)
+		return nextSentSequenceNumber
+
+	def cancel(self):
+		self.sManager.cancel()
+
+	def indexReached(self, index: _IndexT):
+		self._assertSpeechManagerKnowsAboutIndex(index)
+		self._testDebug_IndexReached.append(index)
+		self.sManager._onSynthIndexReached(self.synthMock, index)
+
+	def doneSpeaking(self):
+		self.sManager._onSynthDoneSpeaking(self.synthMock)
+
+	def pumpAll(self):
+		queueHandler.pumpAll()
+
+	def create_CallBackCommand(self, expectedToBecomeIndex):
+		self._assertStrictIndexOrder(expectedToBecomeIndex)
+		cb = CallbackCommand(
+			lambda i=expectedToBecomeIndex: self._indexReachedCallback(i),
+			name=f"indexCommandIndex: {expectedToBecomeIndex}"
+		)
+		cb.expectedIndexCommandIndex = expectedToBecomeIndex
+		return cb
+
+	def create_ExpectedIndex(self, expectedToBecomeIndex):
+		self._assertStrictIndexOrder(expectedToBecomeIndex)
+		return ExpectedIndex(expectedToBecomeIndex)
+
+	def expect_indexReachedCallback(
+			self,
+			forIndex: _IndexT,
+			sideEffect: Optional[Callable[[], None]] = None
+	):
+		if not self._inExpectBlock:
+			self._testCase.fail("Expectations should be set in a with expectation() block")
+		if not (self._lastCommandIndex >= forIndex > 0):
+			self._testCase.fail(
+				f"Test Case error. Index {forIndex} not sent to synth yet,"
+				f" ensure SpeechManagerInteractions.speak has already been called."
+			)
+		self._awaitingCallbackForIndex.append((forIndex, sideEffect))
+
+		if forIndex not in self._testDebug_IndexReached:
+			self._testCase.fail(
+				f"IndexReached not yet called for {forIndex}."
+				f" Check test for smi.indexReached({forIndex})"
+				f" IndexReach called for the following: {self._testDebug_IndexReached!r}"
+			)
+		self._assertSpeechManagerKnowsAboutIndex(forIndex)
+
+	def _assertSpeechManagerKnowsAboutIndex(self, index):
+		indexCommands = [
+			(seqNumber, speechItem)
+			for seqNumber, seq in enumerate(self._sentSequences)
+			for speechItem in seq
+			if isinstance(speechItem, (CallbackCommand, ExpectedIndex))
+			and speechItem.expectedIndexCommandIndex == index
+		]
+		if len(indexCommands) != 1:
+			self._testCase.fail(f"Index {index} is not one of the index commands sent to speech manager.")
+		seqNumber, speechItem = indexCommands[0]
+		if seqNumber not in self.expectedState_speak:  # ensure the index has been sent to the synth
+			self._testCase.fail(f"Index {index} not yet sent to the synth")
+
+	def expect_synthCancel(self):
+		if not self._inExpectBlock:
+			self._testCase.fail("Expectations should be set in a with expectation() block")
+		self._awaitingCancelCalls = 1 + self._awaitingCancelCalls
+
+	def expect_synthSpeak(self, sequenceNumbers: Union[int, typing.Iterable[int]]):
+		if isinstance(sequenceNumbers, int):
+			if not self._inExpectBlock:
+				self._testCase.fail("Expectations should be set in a with expectation() block")
+
+			self._testCase.assertLess(
+				sequenceNumbers,
+				len(self._sentSequences),
+				msg=f"Less than {sequenceNumbers} sequences have been sent to the synth (see calls to speak)"
+			)
+			self._awaitingSpeakCalls.append(sequenceNumbers)
+		else:
+			for i in sequenceNumbers:
+				if isinstance(i, int):
+					self.expect_synthSpeak(i)
+				else:
+					self._testCase.fail(
+						f"sequenceNumbers should be int or Iterable[int]. ArgType: {type(sequenceNumbers)}"
+					)
+
+	def _updateExpectedStateFromAwaiting_speak(self):
+		self.expectedState_speak.extend(self._awaitingSpeakCalls)
+		self._awaitingSpeakCalls.clear()
+
+	def _updateExpectedStateFromAwaiting_cancel(self):
+		self.expectedState_cancelCallCount = self.expectedState_cancelCallCount + self._awaitingCancelCalls
+		self._awaitingCancelCalls = 0
+
+	def _updateExpectedStateFromAwaiting_callbacks(self):
+		self.expectedState_indexReached.extend(
+			index for index, c in self._awaitingCallbackForIndex
+		)
+		self._awaitingCallbackForIndex.clear()
+
+	def _assertIndexCallbackState(self):
+		expectedCalls = [mock.call(i) for i in self.expectedState_indexReached]
+		self._indexReachedCallback.assert_has_calls(expectedCalls)
+
+	def _assertCancelState(self):
+		expectedCancelCallCount = self.expectedState_cancelCallCount
+		self._testCase.assertEqual(
+			expectedCancelCallCount,
+			self.synthMock.cancel.call_count,
+			msg=f"The number of calls to synth.cancel was not as expected. Expected {expectedCancelCallCount}"
+		)
+
+	def _assertCurrentSpeechCallState(self):
+		expectedSeqIndexes = self.expectedState_speak
+		mockSpeak = self.synthMock.speak
+		actualCallCount = mockSpeak.call_count
+		self._testCase.assertEqual(
+			len(expectedSeqIndexes),
+			actualCallCount,
+			msg=(
+				f"Number of sequences sent to synth not as expected."
+				f"\nExpected a total of {len(expectedSeqIndexes)}"
+				f"\nThe index(es) of the expected sequences: {expectedSeqIndexes}"
+				f"\nActual calls: {mockSpeak.call_args_list}"
+			)
+		)
+		# Build (total) expected call list
+		expectedCalls = []
+		for s in expectedSeqIndexes:
+			expectedSpeech = self._sentSequences[s]
+			expectedSpeech = [
+				x if not isinstance(x, CallbackCommand) else ExpectedIndex(x.expectedIndexCommandIndex)
+				for x in expectedSpeech
+			]
+			expectedCalls.append(mock.call(expectedSpeech))
+
+		if expectedCalls:
+			mockSpeak.assert_has_calls(expectedCalls)
+
+	def pumpAllAndSendSpeechOnCallback(
+			self,
+			expectCallbackForIndex: int,
+			expectedSendSequenceNumber: int,
+			seq,
+	):
+		"""Must be called in an 'expectation' block. """
+		def _lineReachedSideEffect():
+			actualSendSequenceNumber = self.speak(seq=seq)
+			self._testCase.assertEqual(expectedSendSequenceNumber, actualSendSequenceNumber)
+
+		self.expect_indexReachedCallback(expectCallbackForIndex, _lineReachedSideEffect)
+		self.pumpAll()
+		self._assertIndexCallbackState()
+
+	def _assertStrictIndexOrder(self, expectedToBecomeIndex):
+		indexCommandIndex = next(self._indexCommandIndexes)
+		self._lastCommandIndex = indexCommandIndex
+		self._testCase.assertEqual(
+			expectedToBecomeIndex,
+			indexCommandIndex,
+			msg=f"Did you forget to update the 'expectedToBecomeIndex' argument?"
+		)

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -51,6 +51,7 @@ class SpeechManagerInteractions:
 	Inputs:
 	- SpeechManager.speak()
 	- SpeechManager.cancel()
+	- SpeechManager.removeCancelledSpeechCommands: Normally via eventHandler.executeEvent
 	- SpeechManager._onSynthIndexReached(): Normally via synthDriverHandler.synthIndexReached extensionPoint
 	- SpeechManager._onSynthDoneSpeaking(): Normally via synthDriverHandler.synthDoneSpeaking extensionPoint
 	- queueHandler.pumpAll(): handles all pending _onSynthIndexReached and _onSynthDoneSpeaking calls.
@@ -165,6 +166,10 @@ class SpeechManagerInteractions:
 
 	def cancel(self):
 		self.sManager.cancel()
+
+	def removeCancelledSpeechCommands(self):
+		"""Call SpeechManager.removeCancelledSpeechCommands"""
+		self.sManager.removeCancelledSpeechCommands()
 
 	def indexReached(self, index: _IndexT):
 		self._assertSpeechManagerKnowsAboutIndex(index)

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -28,8 +28,8 @@ from speech import (
 	CallbackCommand,
 	SpeechSequence,
 )
+from speech.types import _IndexT
 
-_IndexT = int
 _SentSequenceIndex = int
 
 

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -314,7 +314,7 @@ class SpeechManagerInteractions:
 		return ExpectedProsody(expectedProsody)
 
 	def create_BeepCommand(self, hz, length, left=50, right=50, expectedToBecomeIndex=None):
-		"""BeepCommands get converted into IndexCommands by speechManger. The expectedToBecomeIndex argument
+		"""BeepCommands get converted into IndexCommands by speechManager. The expectedToBecomeIndex argument
 		allow us to track that.
 		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
 		indexed commands to help to prevent errors in the tests.
@@ -329,7 +329,7 @@ class SpeechManagerInteractions:
 		return b
 
 	def create_ConfigProfileTriggerCommand(self, trigger, enter=True, expectedToBecomeIndex=None):
-		"""ConfigProfileTriggerCommands get converted into IndexCommands by speechManger. The
+		"""ConfigProfileTriggerCommands get converted into IndexCommands by speechManager. The
 		expectedToBecomeIndex argument allows tracking that.
 		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
 		indexed commands to help to prevent errors in the tests.
@@ -344,7 +344,7 @@ class SpeechManagerInteractions:
 		return t
 
 	def create_WaveFileCommand(self, filename, expectedToBecomeIndex=None):
-		"""WaveFileCommands get converted into IndexCommands by speechManger. The expectedToBecomeIndex argument
+		"""WaveFileCommands get converted into IndexCommands by speechManager. The expectedToBecomeIndex argument
 		allows tracking that.
 		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
 		indexed commands to help to prevent errors in the tests.
@@ -359,7 +359,7 @@ class SpeechManagerInteractions:
 		return w
 
 	def create_EndUtteranceCommand(self, expectedToBecomeIndex=None):
-		"""EndUtteranceCommand get converted into IndexCommands by speechManger. The expectedToBecomeIndex argument
+		"""EndUtteranceCommand get converted into IndexCommands by speechManager. The expectedToBecomeIndex argument
 		allow tracking that.
 		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
 		indexed commands to help to prevent errors in the tests.

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2020 NV Access Limited
 
 """A test harness for interacting with the SpeechManager class."""
+
 import typing
 import unittest
 from contextlib import contextmanager
@@ -23,10 +24,13 @@ from dataclasses import dataclass
 
 import queueHandler
 import speech.manager
-from speech import (
+from speech.commands import (
 	IndexCommand,
 	CallbackCommand,
-	SpeechSequence,
+	BeepCommand,
+	WaveFileCommand,
+	EndUtteranceCommand,
+	ConfigProfileTriggerCommand,
 )
 from speech.types import _IndexT
 
@@ -35,6 +39,9 @@ _SentSequenceIndex = int
 
 @dataclass
 class ExpectedIndex:
+	"""To simplify building tests (de-duplication of test data) , ExpectedIndexes are not sent to the speech
+		manager, but represent indexes that is sent to the synth.
+	"""
 	expectedIndexCommandIndex: int
 
 	def __eq__(self, other):
@@ -45,9 +52,31 @@ class ExpectedIndex:
 		return False
 
 
+@dataclass
+class ExpectedProsody:
+	"""To simplify building (de-duplication of test data) tests, ExpectedProsody are not sent to the speech
+	manager,
+	but represent prosody
+	commands that are sent to the synth. This may be as a result of resuming a previous utterance.
+	"""
+	expectedProsody: Union[
+		speech.commands.PitchCommand,
+		speech.commands.RateCommand,
+		speech.commands.VolumeCommand
+	]
+
+	def __eq__(self, other):
+		if type(self.expectedProsody) != type(other):
+			return False
+		if isinstance(other, speech.commands.BaseProsodyCommand):
+			return repr(other) == repr(self.expectedProsody)
+		return False
+
+
 class SpeechManagerInteractions:
 	""" Track expected state and interactions with the speechManager.
-	SpeechManager has the following functions that external code interacts with.
+	SpeechManager has the following functions that external code interacts with. Currently only supports
+	setting / checking expectations within an expectation block. See L{SpeechManagerInteractions.expectation}
 	Inputs:
 	- SpeechManager.speak()
 	- SpeechManager.cancel()
@@ -60,7 +89,11 @@ class SpeechManagerInteractions:
 	- synthDriverHandler.getSynth().cancel(): Cancel current speech.
 	- CallbackCommand: Converted into index commands. When the index is reached (by the synth) the callback is
 			called after queueHandler.pumpAll is called.
+
+	The expectation method should be used as a context manager to assert the pre/post conditions on interactions
+	with the speech manager.
 	"""
+
 	def __init__(self, testCase: unittest.TestCase):
 		"""
 		@param testCase: Used to run asserts
@@ -83,6 +116,8 @@ class SpeechManagerInteractions:
 		self._awaitingCancelCalls: int = 0
 		#: Index and Callbacks for callback commands
 		self._awaitingCallbackForIndex: List[Tuple[_IndexT, Optional[Callable[[], None]]]] = []
+		#: Map of mocks to the number of times that we expect for them get called in this expect block.
+		self._awaitingMockCalls: typing.Dict[MagicMock, int] = {}
 
 		#: All sequence indexes already expected to be sent to the synth
 		self.expectedState_speak: List[_SentSequenceIndex] = []
@@ -91,12 +126,20 @@ class SpeechManagerInteractions:
 		#: Indexes that have been reached
 		self.expectedState_indexReached: List[_IndexT] = []
 
+		#: map mocks with the number of times we expect them to be called useful for extending this class
+		self._expectedMockCallCount: typing.Dict[MagicMock, int] = {}
+
+		self._unexpectedSideEffectFailureMessages = []
+
 		self._inExpectBlock = False
 
 		# Install the mock synth
 		synthDriverHandler._curSynth = self.synthMock
+		synthDriverHandler.getSynthInstance = mock.Mock(return_value=self.synthMock)
 		#: Sequences sent to the speechManager so far.
-		self._sentSequences = []
+		self._knownSequences = []
+		#: Map ExpectedIndexes (IndexCommand) to knownSequences index
+		self._speechManagerIndexes = {}
 
 		self._indexCommandIndexes = iter(range(1, 1000))
 		self._lastCommandIndex = 0
@@ -106,26 +149,42 @@ class SpeechManagerInteractions:
 
 	def _sideEffect_synth_speak(self, sequence):
 		if not self._inExpectBlock:  # an ExpectBlock will verify state on exit
-			self._testCase.assertTrue(self._awaitingSpeakCalls)
-			self._updateExpectedStateFromAwaiting_speak()
-			self._verifyCurrentState()
+			failureMessage = (
+				"Unexpected call to synth.speak. Calls should happen in an expect block."
+			)
+			# sometimes for code called by SpeechManager, exceptions caused by failed asserts are caught.
+			# record them so that at any subsequent _verifyCurrentState calls they can be reported.
+			self._unexpectedSideEffectFailureMessages.append(failureMessage)
+			self._testCase.fail(failureMessage)
 
 	def _sideEffect_synth_cancel(self):
 		if not self._inExpectBlock:  # an ExpectBlock will verify state on exit
-			self._testCase.assertTrue(self._awaitingCancelCalls)
-			self._updateExpectedStateFromAwaiting_cancel()
-			self._verifyCurrentState()
+			failureMessage = (
+				"Unexpected call to synth.cancel. Calls should happen in an expect block."
+			)
+			# sometimes for code called by SpeechManager, exceptions caused by failed asserts are caught.
+			# record them so that at any subsequent _verifyCurrentState calls they can be reported.
+			self._unexpectedSideEffectFailureMessages.append(failureMessage)
+			self._testCase.fail(failureMessage)
 
 	def _sideEffect_callbackCommand(self, index):
 		"""Callback commands must be expected, so they can deliver new speech.
 		Asserts can not be run inside callback commands, the exceptions they raise on failure are caught by
 		speechManager.
 		"""
+		if not self._inExpectBlock:  # an ExpectBlock will verify state on exit
+			failureMessage = "Unexpected call to callbackCommand. Calls should happen in an expect block."
+			# sometimes for code called by SpeechManager, exceptions caused by failed asserts are caught.
+			# record them so that at any subsequent _verifyCurrentState calls they can be reported.
+			self._unexpectedSideEffectFailureMessages.append(failureMessage)
+			self._testCase.fail(failureMessage)
 		# pop used because there may be multiple callbacks for a given operation.
 		# We wish to verify the order of the callbacks.
 		expectedIndex, sideEffect = self._awaitingCallbackForIndex[-1]
 		if expectedIndex != index:
-			return
+			failureMessage = "Unexpected index for callbackCommand. Calls should happen in an expect block."
+			self._unexpectedSideEffectFailureMessages.append(failureMessage)
+			return  # by returning early intentionally allow later asserts to fail
 		if sideEffect:
 			sideEffect()
 		self.expectedState_indexReached.append(expectedIndex)
@@ -133,7 +192,8 @@ class SpeechManagerInteractions:
 
 	@contextmanager
 	def expectation(self):
-		"""Used to ensure that the next command results in an expected change."""
+		"""Ensures the pre/post conditions are as expected when exercising the SpeechManager.
+		"""
 		self._testCase.assertFalse(self._inExpectBlock, msg="This is likely a logic error in the test.")
 		self._inExpectBlock = True
 		self._verifyCurrentState()
@@ -145,26 +205,61 @@ class SpeechManagerInteractions:
 		self._updateExpectedStateFromAwaiting_speak()
 		self._updateExpectedStateFromAwaiting_cancel()
 		self._updateExpectedStateFromAwaiting_callbacks()
+		self._updateExpectedStateFromAwaiting_mocks()
 		self._verifyCurrentState()
 
 	def _verifyCurrentState(self):
-		# Sequences sent to synth?
+		if self._unexpectedSideEffectFailureMessages:
+			self._testCase.fail(f"Unexpected calls: {self._unexpectedSideEffectFailureMessages!r}")
 		self._assertCurrentSpeechCallState()
 		self._assertIndexCallbackState()
 		self._assertCancelState()
+		self._assertMockCallsState()
 		pass
 
-	def speak(self, seq: SpeechSequence, priority=speech.Spri.NORMAL) -> _SentSequenceIndex:
-		nextSentSequenceNumber = len(self._sentSequences)
-		self._sentSequences.append(seq)
-		filteredSpeech = [
-			x for x in self._sentSequences[nextSentSequenceNumber]
-			if not isinstance(x, ExpectedIndex)  # don't send types used for behaviour tracking.
-		]
-		self.sManager.speak(filteredSpeech, priority)
-		return nextSentSequenceNumber
+	def _updateKnownSequences(self, seq) -> List[_SentSequenceIndex]:
+		"""Handle EndUtteranceCommands
+			Sequence gets split after the EndUtteranceCommand and two sequence numbers are returned.
+		"""
+		startOfUtteranceIndexes = set(
+			i + 1 for i, item in enumerate(seq)
+			if isinstance(item, speech.commands.EndUtteranceCommand)
+		)
+		startOfUtteranceIndexes.add(len(seq))  # ensure the last index is included
+		start = 0
+		seqNumbers = []
+		for nextStart in startOfUtteranceIndexes:
+			seqNumbers.append(len(self._knownSequences))
+			self._knownSequences.append(seq[start:nextStart])
+			start = nextStart
+		# Keep track of which sequence each "expectedIndex" belongs to.
+		# This allows us to verify that tests don't call "reached index" before the sequence it is part of
+		# has been sent to the synth. Essentially to prevent bugs in the tests.
+		for seqNumber in seqNumbers:
+			indexNumbers = [
+				speechItem.index
+				if not hasattr(speechItem, 'expectedIndexCommandIndex')
+				else speechItem.expectedIndexCommandIndex
+				for speechItem in self._knownSequences[seqNumber]
+				if hasattr(speechItem, 'expectedIndexCommandIndex')
+				or isinstance(speechItem, IndexCommand)
+			]
+			for index in indexNumbers:
+				self._speechManagerIndexes[index] = seqNumber
+		return seqNumbers
+
+	def speak(
+			self,
+			seq: List[Union[speech.types.SequenceItemT, ExpectedProsody, ExpectedIndex, EndUtteranceCommand]],
+			priority=speech.Spri.NORMAL
+	) -> Union[_SentSequenceIndex, List[_SentSequenceIndex]]:
+		"""Call SpeechManager.speak and track sequences used."""
+		sequenceNumbers = self._updateKnownSequences(seq)
+		self._filterAndSendSpeech(seq, priority)
+		return sequenceNumbers if len(sequenceNumbers) > 1 else sequenceNumbers[0]
 
 	def cancel(self):
+		"""Call SpeechManager.cancel"""
 		self.sManager.cancel()
 
 	def removeCancelledSpeechCommands(self):
@@ -172,17 +267,29 @@ class SpeechManagerInteractions:
 		self.sManager.removeCancelledSpeechCommands()
 
 	def indexReached(self, index: _IndexT):
+		"""Call SpeechManager.indexReached
+		@note SpeechManager requires a call to pumpAll for this to have any affect.
+		"""
 		self._assertSpeechManagerKnowsAboutIndex(index)
 		self._testDebug_IndexReached.append(index)
 		self.sManager._onSynthIndexReached(self.synthMock, index)
 
 	def doneSpeaking(self):
+		"""Call SpeechManager.doneSpeaking
+		@note SpeechManager requires a call to pumpAll for this to have any affect
+		"""
 		self.sManager._onSynthDoneSpeaking(self.synthMock)
 
 	def pumpAll(self):
+		"""Call queueHandler.pumpAll
+		@note This is required to process pending events (indexReached, doneSpeaking) for SpeechManager.
+		"""
 		queueHandler.pumpAll()
 
 	def create_CallBackCommand(self, expectedToBecomeIndex):
+		"""While a CallBackCommand could be created directly, this method augments it with the index number it
+		is expected to be represented by when sent to the synth. This reduces the duplication of the test data.
+		"""
 		self._assertStrictIndexOrder(expectedToBecomeIndex)
 		cb = CallbackCommand(
 			lambda i=expectedToBecomeIndex: self._indexReachedCallback(i),
@@ -192,14 +299,89 @@ class SpeechManagerInteractions:
 		return cb
 
 	def create_ExpectedIndex(self, expectedToBecomeIndex):
+		"""Creates a placeholder for an IndexCommand that should be created by SpeechManager.
+		ExpectedIndexes are not passed to the SpeechManager. They act as a placeholder to verify what is sent
+		to the synth. This is useful when you want to confirm that an index is created by speechManager
+		"""
 		self._assertStrictIndexOrder(expectedToBecomeIndex)
 		return ExpectedIndex(expectedToBecomeIndex)
+
+	def create_ExpectedProsodyCommand(self, expectedProsody):
+		"""ExpectedProsodyCommands are not passed to the speechManager. They act as a placeholder to verify
+		what is sent to the synth. This is useful when you want to confirm that speechManager recreates prosody
+		effectively.
+		"""
+		return ExpectedProsody(expectedProsody)
+
+	def create_BeepCommand(self, hz, length, left=50, right=50, expectedToBecomeIndex=None):
+		"""BeepCommands get converted into IndexCommands by speechManger. The expectedToBecomeIndex argument
+		allow us to track that.
+		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
+		indexed commands to help to prevent errors in the tests.
+		"""
+		self._testCase.assertIsNotNone(
+			expectedToBecomeIndex,
+			"Did you forget to provide the 'expectedToBecomeIndex' argument?"
+		)
+		self._assertStrictIndexOrder(expectedToBecomeIndex)
+		b = BeepCommand(hz, length, left, right)
+		b.expectedIndexCommandIndex = expectedToBecomeIndex
+		return b
+
+	def create_ConfigProfileTriggerCommand(self, trigger, enter=True, expectedToBecomeIndex=None):
+		"""ConfigProfileTriggerCommands get converted into IndexCommands by speechManger. The
+		expectedToBecomeIndex argument allows tracking that.
+		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
+		indexed commands to help to prevent errors in the tests.
+		"""
+		self._testCase.assertIsNotNone(
+			expectedToBecomeIndex,
+			"Did you forget to provide the 'expectedToBecomeIndex' argument?"
+		)
+		self._assertStrictIndexOrder(expectedToBecomeIndex)
+		t = ConfigProfileTriggerCommand(trigger, enter)
+		t.expectedIndexCommandIndex = expectedToBecomeIndex
+		return t
+
+	def create_WaveFileCommand(self, filename, expectedToBecomeIndex=None):
+		"""WaveFileCommands get converted into IndexCommands by speechManger. The expectedToBecomeIndex argument
+		allows tracking that.
+		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
+		indexed commands to help to prevent errors in the tests.
+		"""
+		self._testCase.assertIsNotNone(
+			expectedToBecomeIndex,
+			"Did you forget to provide the 'expectedToBecomeIndex' argument?"
+		)
+		self._assertStrictIndexOrder(expectedToBecomeIndex)
+		w = WaveFileCommand(filename)
+		w.expectedIndexCommandIndex = expectedToBecomeIndex
+		return w
+
+	def create_EndUtteranceCommand(self, expectedToBecomeIndex=None):
+		"""EndUtteranceCommand get converted into IndexCommands by speechManger. The expectedToBecomeIndex argument
+		allow tracking that.
+		@note: the expectedToBecomeIndex is tested to be ordered, contiguous, and unique with respect to other
+		indexed commands to help to prevent errors in the tests.
+		"""
+		self._testCase.assertIsNotNone(
+			expectedToBecomeIndex,
+			"Did you forget to provide the 'expectedToBecomeIndex' argument?"
+		)
+		self._assertStrictIndexOrder(expectedToBecomeIndex)
+		e = EndUtteranceCommand()
+		e.expectedIndexCommandIndex = expectedToBecomeIndex
+		return e
 
 	def expect_indexReachedCallback(
 			self,
 			forIndex: _IndexT,
 			sideEffect: Optional[Callable[[], None]] = None
 	):
+		"""Expect that upon exiting the expectation block, forIndex will have been reached.
+			If a side effect is required (such as speaking more text) this must be called before
+			triggering the index reached code, in this case consider using pumpAllAndSendSpeechOnCallback.
+		"""
 		if not self._inExpectBlock:
 			self._testCase.fail("Expectations should be set in a with expectation() block")
 		if not (self._lastCommandIndex >= forIndex > 0):
@@ -218,32 +400,51 @@ class SpeechManagerInteractions:
 		self._assertSpeechManagerKnowsAboutIndex(forIndex)
 
 	def _assertSpeechManagerKnowsAboutIndex(self, index):
-		indexCommands = [
-			(seqNumber, speechItem)
-			for seqNumber, seq in enumerate(self._sentSequences)
-			for speechItem in seq
-			if isinstance(speechItem, (CallbackCommand, ExpectedIndex))
-			and speechItem.expectedIndexCommandIndex == index
-		]
-		if len(indexCommands) != 1:
+		if index not in self._speechManagerIndexes.keys():
 			self._testCase.fail(f"Index {index} is not one of the index commands sent to speech manager.")
-		seqNumber, speechItem = indexCommands[0]
+		seqNumber = self._speechManagerIndexes[index]
 		if seqNumber not in self.expectedState_speak:  # ensure the index has been sent to the synth
-			self._testCase.fail(f"Index {index} not yet sent to the synth")
+			self._testCase.fail(f"Index {index} not yet sent to the synth. This indicates an error in the test.")
 
 	def expect_synthCancel(self):
 		if not self._inExpectBlock:
 			self._testCase.fail("Expectations should be set in a with expectation() block")
 		self._awaitingCancelCalls = 1 + self._awaitingCancelCalls
 
-	def expect_synthSpeak(self, sequenceNumbers: Union[int, typing.Iterable[int]]):
+	def addMockCallMonitoring(self, monitorMocks: typing.List[mock.Mock]):
+		""" Allows the call count state for other arbitrary mock objects to be tracked.
+		@param monitorMocks: Mock objects to track the number of calls to
+		"""
+		for m in monitorMocks:
+			self._expectedMockCallCount[m] = 0
+
+	def expect_mockCall(self, m: mock.Mock):
+		""" Expect another call to the given Mock. The total number of expected calls to this mock is incremented.
+		@param m: Mock object to expect another call on.
+		"""
+		if not self._inExpectBlock:
+			self._testCase.fail("Expectations should be set in a with expectation() block")
+		self._awaitingMockCalls[m] = 1 + self._awaitingMockCalls.get(m, 0)
+
+	def expect_synthSpeak(
+			self,
+			sequenceNumbers: Optional[Union[int, typing.Iterable[int]]] = None,
+			sequence: Optional[List[Union[speech.types.SequenceItemT, ExpectedProsody, ExpectedIndex]]] = None,
+	):
+		isSpeechSpecified = sequence is not None
+		areNumbersSpecified = sequenceNumbers is not None
+		if (isSpeechSpecified and areNumbersSpecified) or not (isSpeechSpecified or areNumbersSpecified):
+			raise ValueError("Exactly one argument should be provided.")
+		if isSpeechSpecified:
+			sequenceNumbers = self._updateKnownSequences(sequence)
+
 		if isinstance(sequenceNumbers, int):
 			if not self._inExpectBlock:
 				self._testCase.fail("Expectations should be set in a with expectation() block")
 
 			self._testCase.assertLess(
 				sequenceNumbers,
-				len(self._sentSequences),
+				len(self._knownSequences),
 				msg=f"Less than {sequenceNumbers} sequences have been sent to the synth (see calls to speak)"
 			)
 			self._awaitingSpeakCalls.append(sequenceNumbers)
@@ -264,6 +465,12 @@ class SpeechManagerInteractions:
 		self.expectedState_cancelCallCount = self.expectedState_cancelCallCount + self._awaitingCancelCalls
 		self._awaitingCancelCalls = 0
 
+	def _updateExpectedStateFromAwaiting_mocks(self):
+		for m, awaitCount in self._awaitingMockCalls.items():
+			e = self._expectedMockCallCount.get(m, 0)
+			self._expectedMockCallCount[m] = e + awaitCount
+		self._awaitingMockCalls.clear()
+
 	def _updateExpectedStateFromAwaiting_callbacks(self):
 		self.expectedState_indexReached.extend(
 			index for index, c in self._awaitingCallbackForIndex
@@ -272,6 +479,15 @@ class SpeechManagerInteractions:
 
 	def _assertIndexCallbackState(self):
 		expectedCalls = [mock.call(i) for i in self.expectedState_indexReached]
+		self._testCase.assertEqual(
+			len(expectedCalls),
+			self._indexReachedCallback.call_count,
+			msg=(
+				f"Number of CallbackCommand callbacks not as expected."
+				f"\nExpected: {expectedCalls}"
+				f"\nGot: {self._indexReachedCallback.call_args_list}"
+			)
+		)
 		self._indexReachedCallback.assert_has_calls(expectedCalls)
 
 	def _assertCancelState(self):
@@ -281,6 +497,14 @@ class SpeechManagerInteractions:
 			self.synthMock.cancel.call_count,
 			msg=f"The number of calls to synth.cancel was not as expected. Expected {expectedCancelCallCount}"
 		)
+
+	def _assertMockCallsState(self):
+		for m, e in self._expectedMockCallCount.items():
+			self._testCase.assertEqual(
+				e,
+				m.call_count,
+				msg=f"The number of calls to {m} was not as expected. Expected {e}"
+			)
 
 	def _assertCurrentSpeechCallState(self):
 		expectedSeqIndexes = self.expectedState_speak
@@ -297,11 +521,19 @@ class SpeechManagerInteractions:
 			)
 		)
 		# Build (total) expected call list
+		replaceWithExpectedIndexTypes = (
+			CallbackCommand,
+			BeepCommand,
+			WaveFileCommand,
+			EndUtteranceCommand,
+			ConfigProfileTriggerCommand,
+		)
 		expectedCalls = []
 		for s in expectedSeqIndexes:
-			expectedSpeech = self._sentSequences[s]
+			expectedSpeech = self._knownSequences[s]
 			expectedSpeech = [
-				x if not isinstance(x, CallbackCommand) else ExpectedIndex(x.expectedIndexCommandIndex)
+				x if not isinstance(x, replaceWithExpectedIndexTypes)
+				else ExpectedIndex(x.expectedIndexCommandIndex)
 				for x in expectedSpeech
 			]
 			expectedCalls.append(mock.call(expectedSpeech))
@@ -312,13 +544,17 @@ class SpeechManagerInteractions:
 	def pumpAllAndSendSpeechOnCallback(
 			self,
 			expectCallbackForIndex: int,
-			expectedSendSequenceNumber: int,
+			expectedSendSequenceNumber: Union[int, List[int]],
 			seq,
+			priority=speech.Spri.NORMAL
 	):
 		"""Must be called in an 'expectation' block. """
 		def _lineReachedSideEffect():
-			actualSendSequenceNumber = self.speak(seq=seq)
-			self._testCase.assertEqual(expectedSendSequenceNumber, actualSendSequenceNumber)
+			self._filterAndSendSpeech(seq, priority)
+
+		actualSequenceNumber = self._updateKnownSequences(seq)
+		actualSequenceNumber = actualSequenceNumber if len(actualSequenceNumber) > 1 else actualSequenceNumber[0]
+		self._testCase.assertEqual(expectedSendSequenceNumber, actualSequenceNumber)
 
 		self.expect_indexReachedCallback(expectCallbackForIndex, _lineReachedSideEffect)
 		self.pumpAll()
@@ -332,3 +568,10 @@ class SpeechManagerInteractions:
 			indexCommandIndex,
 			msg=f"Did you forget to update the 'expectedToBecomeIndex' argument?"
 		)
+
+	def _filterAndSendSpeech(self, seq, priority):
+		filteredSpeech = [
+			x for x in seq
+			if not isinstance(x, (ExpectedIndex, ExpectedProsody))  # don't send types used for behaviour tracking.
+		]
+		self.sManager.speak(filteredSpeech, priority)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
Please note, this is a large change, though most of the changes are unit tests. I have tried structure the commits in a logical order and keep changes separate. Please consider looking at the commits first to get an overview of the changes. The tests and extra debug logging is added first and the bugs are then fixed.

Note that this is blocking the 2020.2 release.

### Link to issue number:
fixes #11132 - Say-all repeats some lines
fixes #11144 - Attempt to cancel speech for expired focus events: dialog title discarded when finding text in browse mode

### Summary of the issue:
#### For #11132 - Say-all repeats some lines:
During say-all, after hitting an index, `speechManager._handleIndex` calls back to `sayallHandler` results in calling `speechManager.speak` and thus `_pushNextSpeech`, `speechManager._handleIndex` then goes on to call `_pushNextSpeech` itself.

#### For #11144 - Attempt to cancel speech for expired focus events: dialog title discarded when finding text in browse mode:
Titles were being dropped because they once had focus but when focus moves to the active control (automatically) they are considered previous focus and cancelled. In addition to this, removing cancelled speech was happening before all dependencies of the `isValid` callback were updated.

#### Wrapped indexes
During investigation I noticed that indexes were being compared naively, despite the fact that they are wrapped at a value of 10000. The indexes are not reset, it is feasible that this limit could be hit within a day and would cause some weird results.

### Description of how this pull request fixes the issue:
This PR adds a lot of unit tests:
- Tests modeling the errors during say all
- Tests exercising the how cancellable speech commands should affect the speech manager.
- Tests based on the initial development of the SpeechManager (see #7599), these were manual test cases.
- Tests for wrapped index comparisons

To support the unit tests, which could become hard to read and understand very quickly, a specific test harness was developed. There are a number of outputs to monitor, and it is useful to be able to assert the pre/post conditions for each step. To achieve this the test harness uses a context manager (see unit.test_speechManager.speechManagerTestHarness.SpeechManagerInteractions.expectation) which allows several post conditions to be added during the scope of a `with` block. These conditions are saved and used as the preconditions for the next `with` block.

### Testing performed:
- Unit tests
- Manual testing of say-all double speaking case (with and without cancellable speech)
- Manual testing of changing focus rapidly in focus mode (moving through email subjects with up and down arrow) in Gmail in Chrome 
- Manual testing of dialog title reporting with the run-dialog.

### Known issues with pull request:
None.

### Change log entry:
None

