### PR TITLE
Fix updateCheck._updateWindowsRootCertificates() for Python 3.

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -823,8 +823,10 @@ def _updateWindowsRootCertificates():
 	crypt = ctypes.windll.crypt32
 	# Get the server certificate.
 	sslCont = ssl._create_unverified_context()
-	u = urllib.request.urlopen("https://www.nvaccess.org/nvdaUpdateCheck", context=sslCont)
-	cert = u.fp._sock.getpeercert(True)
+	# We must specify versionType so the server doesn't return a 404 error and
+	# thus cause an exception.
+	u = urllib.request.urlopen(CHECK_URL + "?versionType=stable", context=sslCont)
+	cert = u.fp.raw._sock.getpeercert(True)
 	u.close()
 	# Convert to a form usable by Windows.
 	certCont = crypt.CertCreateCertificateContext(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ What's New in NVDA
 - NVDA error sounds are no longer heard when accessing DevExpress text controls. (#10918)
 - The tool-tips of the icons in the system tray are no longer reported upon keyboard navigation if their text is equal to the name of the icons, to avoid a double announcing. (#6656)
 - In browse mode with 'Automatically set system focus to focusable elements' disabled, switching to focus mode with NVDA+space now focuses the element under the caret. (#11206)
+- It is once again possible to check for NVDA updates on certain systems; e.g. clean Windows installs. (#11253)
 
 
 == Changes For Developers ==


### PR DESCRIPTION
### Link to issue number:
Related to #4803.

### Summary of the issue:
`updateCheck._updateWindowsRootCertificates` is broken in Python 3. This will mean that a system which doesn't have the root SSL certificate used by nvaccess.org (e.g. a clean Windows install) won't be able to check for updates.

### Description of how this pull request fixes the issue:
This was missed in the migration to Python 3.
There are two problems that needed to be addressed here:

1. We use https://www.nvaccess.org/nvdaUpdateCheck as the URL to get the certificate. However, that returns a 404. In Python 2, urllib didn't raise an exception for errors. In Python 3, it does. So, this was raising an exception and preventing us from getting any further.
    To fix this, pass versionType=stable as the query string, which will stop the server from throwing 404.
2. When getting the peer certificate, we need the raw SSL socket. In Python 3, the way to get that raw socket has changed slightly, so this code had to be adjusted accordingly.

### Testing performed:
I don't have a clean system to test this on, but I confirmed that I don't get any exceptions when I do this in the NVDA Python console:

```
import updateCheck
updateCheck._updateWindowsRootCertificates()
```

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
`- It is once again possible to check for NVDA updates on certain systems; e.g. clean Windows installs.`