### PR TITLE
Remove rule for U+FFFC

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -181,7 +181,6 @@ _	line	most
 ‡	double dagger	some
 ‣	triangular bullet	none
 ✗	x-shaped bullet	none
-￼	object replacement character	none
 
 #Mathematical Operators U+2200 to U+220F
 ∀	for all	none

--- a/source/locale/fr/symbols.dic
+++ b/source/locale/fr/symbols.dic
@@ -192,7 +192,6 @@ _	souligné
 ⮚	pointe flèche droite	some
 🡺	flèche droite	some
 ✗	puce en x	some
-￼	caractère de remplacement d'objet	none
 
 #Opérateurs Mathématiques U+2200 to U+220F
 ∀	pour tout 

--- a/source/locale/sl/symbols.dic
+++ b/source/locale/sl/symbols.dic
@@ -171,7 +171,6 @@ _	podčrtaj
 ‡	dvojni križec
 ‣	trikotnik
 ✗	x kroglica
-￼	zamenjava predmeta
 
 #Mathematical Operators U+2200 to U+220F
 ∀	za vse


### PR DESCRIPTION
### Link to issue number:

https://github.com/nvaccess/nvda/issues/11177

### Summary of the issue:

Some spurious announcements of the replacement characters are done.

### Description of how this pull request fixes the issue:

It just removes the rule that was introduced that deals with the replacement character.

### Testing performed:

### Known issues with pull request:

### Change log entry:
