### PR TITLE
Adds Ukrainian computer braille table

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -400,7 +400,7 @@ addTable("te-in-g1.utb", _("Telugu grade 1"))
 addTable("tr.ctb", _("Turkish grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("uk.utb", _("Ukrainian"))
+addTable("uk.utb", _("Ukrainian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("uk-comp.utb", _("Ukrainian computer braille"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -403,6 +403,9 @@ addTable("tr.ctb", _("Turkish grade 1"))
 addTable("uk.utb", _("Ukrainian"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("uk-comp.utb", _("Ukrainian computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("uz-g1.utb", _("Uzbek grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.


### PR DESCRIPTION

### Link to issue number:
Follow-up https://github.com/nvaccess/nvda/pull/11268#issuecomment-646504128
See https://github.com/nvaccess/nvda/pull/11221#issuecomment-645368497

### Summary of the issue:
The Ukrainian computer braille table (that's part of liblouis 3.14) is missing in the GUI.

### Description of how this pull request fixes the issue:
* Adds an entry for "uk-comp.utb" in the GUI.
* To avoid confusion, renames a braille table in the GUI: “Ukrainian” -> {Ukrainian grade 1”

### Testing performed:
Tested from sources

### Known issues with pull request:
None

### Change log entry:
Entry already present.