### PR TITLE
Change wording of nvda at sign in

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -158,7 +158,7 @@ class InstallerDialog(wx.Dialog, DpiScalingHelperMixin):
 		)))
 
 		# Translators: The label of a checkbox option in the Install NVDA dialog.
-		startOnLogonText = _("Start NVDA during sign-in")
+		startOnLogonText = _("Use NVDA during sign-in")
 		self.startOnLogonCheckbox = optionsSizer.addItem(wx.CheckBox(self, label=startOnLogonText))
 		if globalVars.appArgs.enableStartOnLogon is not None:
 			self.startOnLogonCheckbox.Value = globalVars.appArgs.enableStartOnLogon

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -724,7 +724,7 @@ class GeneralSettingsPanel(SettingsPanel):
 			# allow NVDA to come up in Windows login screen (useful if user
 			# needs to enter passwords or if multiple user accounts are present
 			# to allow user to choose the correct account).
-			label=_("Start NVDA during sign-in (requires administrator privileges)")
+			label=_("Use NVDA during sign-in (requires administrator privileges)")
 		)
 		self.startOnLogonScreenCheckBox.SetValue(config.getStartOnLogonScreen())
 		if globalVars.appArgs.secure or not config.canStartOnSecureScreens():

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -118,7 +118,7 @@ Before you're able to press the Continue button you will have to use the checkbo
 There will also be a button present to review the add-ons that will be disabled.
 Refer to the [incompatible add-ons dialog section #incompatibleAddonsManager] for more help on this button.
 
-+++ Start NVDA during sign-in +++[StartAtWindowsLogon]
++++ Use NVDA during sign-in +++[StartAtWindowsLogon]
 This option allows you to choose whether or not NVDA should automatically start while at the Windows sign-in screen, before you have entered a password.
 This also includes User Account Control and other secure screens.
 This option is enabled by default for fresh installations.
@@ -129,7 +129,7 @@ If created, this shortcut will also be assigned a  shortcut key of control+alt+n
 
 +++ Copy Portable Configuration to Current User Account +++[CopyPortableConfigurationToCurrentUserAccount]
 This option allows you to choose whether or not NVDA should copy the user configuration from the currently running NVDA into the configuration for the currently logged on  user, for the installed copy of NVDA. 
-This will not  copy the configuration for   any other users  of this system nor to the system configuration for use during Windows sign-in and other secure screens.
+This will not copy the configuration for any other users of this system nor to the system configuration for use during Windows sign-in and other secure screens.
 This option is only available when installing from a portable copy, not when installing directly from the downloaded Launcher package.
 
 ++ Creating a Portable Copy ++[CreatingAPortableCopy]
@@ -1075,7 +1075,7 @@ The available logging levels are:
 If this option is enabled, NVDA will start automatically as soon as you sign into Windows.
 This option is only available for installed copies of NVDA.
 
-==== Start NVDA during sign-in (requires administrator privileges) ====[GeneralSettingsStartOnLogOnScreen]
+==== Use NVDA during sign-in (requires administrator privileges) ====[GeneralSettingsStartOnLogOnScreen]
 If you sign into Windows by providing a user name and password, then enabling this option will make NVDA start automatically at the sign-in screen when Windows starts.
 This option is only available for installed copies of NVDA.
 
@@ -3079,14 +3079,14 @@ Following are the command line options for NVDA:
 | -l LOGLEVEL | --log-level=LOGLEVEL | The lowest level of message logged (debug 10, input/output 12, debug warning 15, info 20, warning 30, error 40, critical 50, disabled 100), default is warning |
 | -c CONFIGPATH | --config-path=CONFIGPATH | The path where all settings for NVDA are stored |
 | -m | --minimal | No sounds, no interface, no start message, etc. |
-| -s | --secure | Secure mode: disables Python console, profile features such as creation, deletion, renaming profiles etc., update check, some checkboxes in the welcome dialog and in general settings category (e.g. start NVDA after sign-in, save configuration after exit etc.), as well as logviewer and logging features (used often in secure screens). Note also that this command will disable the possibility to save settings in system config and the gesture map will not be saved on the disk. |
+| -s | --secure | Secure mode: disables Python console, profile features such as creation, deletion, renaming profiles etc., update check, some checkboxes in the welcome dialog and in general settings category (e.g. Use NVDA during sign-in, save configuration after exit etc.), as well as logviewer and logging features (used often in secure screens). Note also that this command will disable the possibility to save settings in system config and the gesture map will not be saved on the disk. |
 | None | --disable-addons | Add-ons will have no effect |
 | None | --debug-logging | Enable debug level logging just for this run. This setting will override any other log level ( ""--loglevel"", -l) argument given, including no logging option. |
 | None | --no-logging | Disable logging altogether while using NVDA. This setting can be overridden if a log level ( ""--loglevel"", -l) is specified from command line or if debug logging is turned on. |
 | None | --no-sr-flag  | Don't change the global system screen reader flag |
 | None | --install | Installs NVDA (starting the newly installed copy) |
 | None | --install-silent | Silently installs NVDA (does not start the newly installed copy) |
-| None | --enable-start-on-logon=True|False | When installing, enable NVDA's [start during Windows sign-in #StartAtWindowsLogon] |
+| None | --enable-start-on-logon=True|False | When installing, enable NVDA's [Use NVDA during Windows sign-in #StartAtWindowsLogon] |
 | None | --create-portable | Creates a portable copy of NVDA (starting the newly created copy). Requires --portable-path to be specified |
 | None | --create-portable-silent | Creates a portable copy of NVDA (does not start the newly installed copy). Requires --portable-path to be specified |
 | None | --portable-path=PORTABLEPATH | The path where a portable copy will be created |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1072,11 +1072,11 @@ The available logging levels are:
 
 
 ==== Start NVDA after I sign in ====[GeneralSettingsStartAfterLogOn]
-If this option is enabled, NVDA will start automatically as soon as you sign into Windows.
+If this option is enabled, NVDA will start automatically as soon as you sign in to Windows.
 This option is only available for installed copies of NVDA.
 
 ==== Use NVDA during sign-in (requires administrator privileges) ====[GeneralSettingsStartOnLogOnScreen]
-If you sign into Windows by providing a user name and password, then enabling this option will make NVDA start automatically at the sign-in screen when Windows starts.
+If you sign in to Windows by providing a user name and password, then enabling this option will make NVDA start automatically at the sign-in screen when Windows starts.
 This option is only available for installed copies of NVDA.
 
 ==== Use currently saved settings during sign-in and on secure screens (requires administrator privileges) ====[GeneralSettingsCopySettings]


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Follow on from #10941

### Summary of the issue:
The label "Start NVDA during sign-in" can be confusing. For those unfamiliar, "sign-in" may be understood as the process after the user has entered their password. 

### Description of how this pull request fixes the issue:
To help clarify, this PR changes the label to "Use NVDA during sign-in". This is slightly less wordy than "Use NVDA on the sign-in screen". However, I think it conveys that NVDA is active while the user is interacting with the sign-in screen rather than after.

I have also changed "sign into Windows" since we use "sign-in" and the phrase "sign in", "sign into" seems like an unnecessary variation. This matches advice similar advice around "log in" https://english.stackexchange.com/questions/5302/log-in-to-or-log-into-or-login-to

### Testing performed:
None (Automatic tests only)

### Known issues with pull request:
None

### Change log entry:
None

