### PR TITLE
Added quick command reference for control+alt+n

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -273,6 +273,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 ++ Basic NVDA commands ++[BasicNVDACommands]
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
+| Starts or restarts NVDA | Control+alt+n | Control+alt+n | none | Starts or restarts NVDA from the Desktop, if this Windows shortcut is enabled during NVDA's installation process. This is a Windows specific shortcut and therefore it cannot be reassigned in the input gestures dialog. |
 | Stop speech | Control | control | 2-finger tap | Instantly stops speaking |
 | Pause Speech | shift | shift | none | Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer) |
 | NVDA Menu | NVDA+n | NVDA+n | 2-finger double-tap | Pops up the NVDA menu to allow you to access preferences, tools, help, etc. |


### PR DESCRIPTION
### Link to issue number:
fixes #10154 

### Summary of the issue:
The shortcut control+alt+n can be chosen during installation process to start or restart NVDA from the desktop. However, this keystroke is not included in quick command references.

### Description of how this pull request fixes the issue:
Added this shortcut to the quick command reference along with a proper description including that this command works only if it is enabled during NVDA's installation process.

### Testing performed:
Ran from source and checked that control+alt+n is shown in the command quick reference under basic NVDA commands.

### Known issues with pull request:
None

### Change log entry:
Not needed.
