### PR TITLE
Fix-up of 670d16b4 (PR #9553): Typo in what's new

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,7 +40,7 @@ What's New in NVDA
 - The reporting of superscripts and subscripts is now controlled separately to the reporting of font attributes. (#10919)
 - Due to changes made in VS Code, NVDA no longer disables browse mode in Code by default. (#10888)
 - Removed "top" and "bottom" messages when moving the review cursor to the first or last line of the current navigator object. (#9551)
-- Removed "left" and "right" messages when moving the refiew cursor to the first or last character of the line for the current navigator object. (#9551)
+- Removed "left" and "right" messages when moving the review cursor to the first or last character of the line for the current navigator object. (#9551)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix-up of PR #9553

### Summary of the issue:

There is a small typo in *what's new* for PR #9553

### Description of how this pull request fixes the issue:

Replace "refiew" by "review"

### Testing performed:

None

### Known issues with pull request:

None

### Change log entry:

None