### PR TITLE
Touch interaction: Add a global command to toggle support (Follow-up of #10557)

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2412,7 +2412,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Describes a command.
 		description=_("Toggles the support of touch interaction"),
 		category=SCRCAT_TOUCH,
-		gesture="kb:NVDA+alt+t",
+		gesture="kb:NVDA+control+alt+t",
 	)
 	def script_toggleTouchSupport(self, gesture):
 		enabled = not bool(config.conf["touch"]["enabled"])

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2410,7 +2410,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes a command.
-		description=_("Toggles on and off the support of touch interaction"),
+		description=_("Toggles the support of touch interaction"),
 		category=SCRCAT_TOUCH,
 		gesture="kb:NVDA+alt+t",
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2412,7 +2412,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Describes a command.
 		description=_("Toggles on and off the support of touch interaction"),
 		category=SCRCAT_TOUCH,
-		gesture="kb:NVDA+shift+t",
+		gesture="kb:NVDA+alt+t",
 	)
 	def script_toggleTouchSupport(self, gesture):
 		enabled = not bool(config.conf["touch"]["enabled"])

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2408,6 +2408,29 @@ class GlobalCommands(ScriptableObject):
 	script_navigatorObject_previousInFlow.__doc__=_("Moves to the previous object in a flattened view of the object navigation hierarchy")
 	script_navigatorObject_previousInFlow.category=SCRCAT_OBJECTNAVIGATION
 
+	@script(
+		# Translators: Describes a command.
+		description=_("Toggles on and off the support of touch interaction"),
+		category=SCRCAT_TOUCH,
+		gesture="kb:NVDA+shift+t",
+	)
+	def script_toggleTouchSupport(self, gesture):
+		enabled = not bool(config.conf["touch"]["enabled"])
+		try:
+			touchHandler.setTouchSupport(enabled)
+		except NotImplementedError:
+			# Translators: Presented when attempting to toggle touch interaction support
+			ui.message(_("Touch interaction not supported"))
+			return
+		# Set configuration upon success
+		config.conf["touch"]["enabled"] = enabled
+		if enabled:
+			# Translators: Presented when support of touch interaction has been enabled
+			ui.message(_("Touch interaction enabled"))
+		else:
+			# Translators: Presented when support of touch interaction has been disabled
+			ui.message(_("Touch interaction disabled"))
+
 	def script_touch_changeMode(self,gesture):
 		mode=touchHandler.handler._curTouchMode
 		index=touchHandler.availableTouchModes.index(mode)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -206,7 +206,7 @@ If you are running NVDA on a device with a touchscreen and running Windows 8 or 
 While NVDA is running, unless touch interaction support is disabled, all touch input will go directly to NVDA. 
 Therefore, actions that can be performed normally without NVDA will not work.
 %kc:beginInclude
-To toggle touch interaction support, press NVDA+alt+t.
+To toggle touch interaction support, press NVDA+control+alt+t.
 %kc:endInclude
 You can also enable or disable [touch interaction support #TouchSupportEnable] from the Touch Interaction category of the NVDA settings.
 
@@ -1529,7 +1529,7 @@ This category contains the following options:
 This checkbox enables NVDA's touch interaction support.
 If enabled, you can use your fingers to navigate and interact with items on screen using a touchscreen device.
 If disabled, touchscreen support will be disabled as though NVDA is not running.
-This setting can also be toggled using NVDA+alt+t. 
+This setting can also be toggled using NVDA+control+alt+t. 
 
 ==== Touch typing mode ====[TouchTypingMode]
 This checkbox allows you to specify the method you wish to use when entering text using the touch keyboard.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -205,7 +205,10 @@ If your laptop cannot do this or does not allow you to turn Num Lock off, you ma
 If you are running NVDA on a device with a touchscreen and running Windows 8 or higher, you can also control NVDA directly via touch commands.
 While NVDA is running, unless touch interaction support is disabled, all touch input will go directly to NVDA. 
 Therefore, actions that can be performed normally without NVDA will not work.
-You can change this by enabling or disabling [touch interaction support # TouchSupportEnable] from touch interaction category of the NVDA settings.
+%kc:beginInclude
+To toggle touch interaction support on and off, press NVDA+alt+t.
+%kc:endInclude
+You can also enable or disable [touch interaction support #TouchSupportEnable] from the Touch Interaction category of the NVDA settings.
 
 +++ Exploring the Screen +++[ExploringTheScreen]
 The most basic action you can perform with the touch screen is to announce the control or text at any point on the screen.
@@ -215,6 +218,8 @@ You can also keep your finger on the screen and move it around to read other con
 +++ Touch Gestures +++[TouchGestures]
 When NVDA commands are described later in this user guide, they may list a touch gesture which can be used to activate that command with the touchscreen.
 Following are some instructions on how to perform the various touch gestures.
+
+
 
 ==== Taps ====
 Tap the screen quickly with one or more fingers.
@@ -1524,6 +1529,7 @@ This category contains the following options:
 This checkbox enables NVDA's touch interaction support.
 If enabled, you can use your fingers to navigate and interact with items on screen using a touchscreen device.
 If disabled, touchscreen support will be disabled as though NVDA is not running.
+This setting can also be toggled on and off using NVDA+alt+t. 
 
 ==== Touch typing mode ====[TouchTypingMode]
 This checkbox allows you to specify the method you wish to use when entering text using the touch keyboard.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -206,7 +206,7 @@ If you are running NVDA on a device with a touchscreen and running Windows 8 or 
 While NVDA is running, unless touch interaction support is disabled, all touch input will go directly to NVDA. 
 Therefore, actions that can be performed normally without NVDA will not work.
 %kc:beginInclude
-To toggle touch interaction support on and off, press NVDA+alt+t.
+To toggle touch interaction support, press NVDA+alt+t.
 %kc:endInclude
 You can also enable or disable [touch interaction support #TouchSupportEnable] from the Touch Interaction category of the NVDA settings.
 
@@ -1529,7 +1529,7 @@ This category contains the following options:
 This checkbox enables NVDA's touch interaction support.
 If enabled, you can use your fingers to navigate and interact with items on screen using a touchscreen device.
 If disabled, touchscreen support will be disabled as though NVDA is not running.
-This setting can also be toggled on and off using NVDA+alt+t. 
+This setting can also be toggled using NVDA+alt+t. 
 
 ==== Touch typing mode ====[TouchTypingMode]
 This checkbox allows you to specify the method you wish to use when entering text using the touch keyboard.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Follow-up of PR #10557

### Summary of the issue:

Support of touch interaction can now be disabled thanks to PR #10557.
https://github.com/nvaccess/nvda/pull/10557#issuecomment-622944182 proposed the addition of a dedicated gesture to toggle this setting.

### Description of how this pull request fixes the issue:

Add a global command, bound to `kb:NVDA+shift+t` to toggle touch interaction.

### Testing performed:

### Known issues with pull request:

As mentioned in https://github.com/nvaccess/nvda/pull/10557#issuecomment-622990734, toggling on the touch interaction support can only be achieved through keyboard or braille gestures.

### Change log entry:

I guess the change log entry for PR #10557 could be augmented to include the new gesture if it is approved before the release.