### PR TITLE
Fix `keyCommandsDoc` raises `UnboundLocalError` for a malformed `settingsSection` command

### DIFF
--- a/keyCommandsDoc.py
+++ b/keyCommandsDoc.py
@@ -180,6 +180,11 @@ class KeyCommandsMaker(object):
 			# Each of the remaining columns provides keystrokes for one layout.
 			# There's one less delimiter than there are columns, hence subtracting 1 instead of 2.
 			self._settingsNumLayouts = arg.strip("|").count("|") - 1
+			if self._settingsNumLayouts < 1:
+				raise KeyCommandsError(
+					f"{self._lineNum}, settingsSection command must specify the header row for a table"
+					" summarising the settings"
+				)
 		elif cmd == "setting":
 			self._handleSetting()
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Found while working on PR #11297

### Summary of the issue:

A malformed `settingsSection` command in `userGuide.t2t` can lead to the following misleading output:

```
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `source' is up to date.
Generating user_docs\en\keyCommands.t2t
scons: *** [user_docs\en\keyCommands.t2t] UnboundLocalError : local variable 'key' referenced before assignment
Traceback (most recent call last):
  File "C:\dev\workspace\nvda\include\scons\src\engine\SCons\Action.py", line 1209, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "C:\dev\workspace\nvda\SConstruct", line 80, in <lambda>
    lambda target,source,env: not keyCommandsDoc.KeyCommandsMaker(source[0].path,target[0].path).make(),
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 123, in make
    self._make()
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 137, in _make
    self._command(**m.groupdict())
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 184, in _command
    self._handleSetting()
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 263, in _handleSetting
    raise KeyCommandsError("%d, setting command: The keyboard shortcuts must be followed by a blank line. Multiple keys must be included in a table. Erroneous key: %s" % (self._lineNum, key))
UnboundLocalError: local variable 'key' referenced before assignment
scons: building terminated because of errors.
```

Explanation: The processing of the next `setting` command asserts there is at least one keyboard layout and thus misses to initialize the `key` variable if the previous `settingsSection` command did not define enough columns.

### Description of how this pull request fixes the issue:

Fail early when the malformed `settingsSection` command is processed, leading to this more informative output:

```
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `source' is up to date.
Generating user_docs\en\keyCommands.t2t
scons: *** [user_docs\en\keyCommands.t2t] KeyCommandsError : 1520, settingsSection command must specify the header row for a table summarising the settings
Traceback (most recent call last):
  File "C:\dev\workspace\nvda\include\scons\src\engine\SCons\Action.py", line 1209, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "C:\dev\workspace\nvda\SConstruct", line 80, in <lambda>
    lambda target,source,env: not keyCommandsDoc.KeyCommandsMaker(source[0].path,target[0].path).make(),
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 123, in make
    self._make()
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 137, in _make
    self._command(**m.groupdict())
  File "C:\dev\workspace\nvda\keyCommandsDoc.py", line 185, in _command
    f"{self._lineNum}, settingsSection command must specify the header row for a table"
keyCommandsDoc.KeyCommandsError: 1520, settingsSection command must specify the header row for a table summarising the settings
scons: building terminated because of errors.
```

### Testing performed:

Ran `scons source user_docs` with and without a malformed `settingsSection` command.
Ensured the produced `keyCommands.t2t` is not affected by this change when the input is valid.

### Known issues with pull request:

### Change log entry:

I guess this change does not deserve a change log entry.