### PR TITLE
Replaced messages, items and dialog title relating to comments in excel to refer to notes, plus some userguide work

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1598,7 +1598,7 @@ class ExcelDropdown(Window):
 
 	@script(
 		gestures=("kb:downArrow", "kb:upArrow", "kb:leftArrow", "kb:rightArrow", "kb:home", "kb:end"),
-		canPropagate = True)
+		canPropagate=True)
 	def script_selectionChange(self,gesture):
 		gesture.send()
 		newFocus=self.selection or self
@@ -1607,7 +1607,7 @@ class ExcelDropdown(Window):
 
 	@script(
 		gestures=("kb:escape", "kb:enter", "kb:space"),
-		canPropagate = True)
+		canPropagate=True)
 	def script_closeDropdown(self,gesture):
 		gesture.send()
 		eventHandler.queueEvent("gainFocus",self.parent)
@@ -1741,7 +1741,7 @@ class ExcelFormControl(ExcelBase):
 
 	@script(
 		gestures=("kb:enter", "kb:space", "kb(desktop):numpadEnter"),
-		canPropagate = True)
+		canPropagate=True)
 	def script_doAction(self,gesture):
 		self.doAction()
 
@@ -1906,7 +1906,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 
 	@script(
 		gesture="kb:upArrow",
-		canPropagate = True)
+		canPropagate=True)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
@@ -1921,7 +1921,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 
 	@script(
 		gesture="kb:downArrow",
-		canPropagate = True)
+		canPropagate=True)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
@@ -1959,7 +1959,7 @@ class ExcelFormControlDropDown(ExcelFormControl):
 
 	@script(
 		gesture="kb:upArrow",
-		canPropagate = True)
+		canPropagate=True)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
@@ -1968,7 +1968,7 @@ class ExcelFormControlDropDown(ExcelFormControl):
 
 	@script(
 		gesture="kb:downArrow",
-		canPropagate = True)
+		canPropagate=True)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -509,49 +509,49 @@ class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 		eventHandler.executeEvent('gainFocus',obj)
 
 	@script(
-		gesture = ("kb:leftArrow")
+		gesture=("kb:leftArrow")
 	)
 	def script_moveLeft(self,gesture):
 		self.navigationHelper("left")
 
 	@script(
-		gesture = ("kb:rightArrow")
+		gesture=("kb:rightArrow")
 	)
 	def script_moveRight(self,gesture):
 		self.navigationHelper("right")
 
 	@script(
-		gesture = ("kb:upArrow")
+		gesture=("kb:upArrow")
 	)
 	def script_moveUp(self,gesture):
 		self.navigationHelper("up")
 
 	@script(
-		gesture = ("kb:downArrow")
+		gesture=("kb:downArrow")
 	)
 	def script_moveDown(self,gesture):
 		self.navigationHelper("down")
 
 	@script(
-		gesture = ("kb:control+upArrow")
+		gesture=("kb:control+upArrow")
 	)
 	def script_startOfColumn(self,gesture):
 		self.navigationHelper("startcol")
 
 	@script(
-		gesture = ("kb:control+leftArrow")
+		gesture=("kb:control+leftArrow")
 	)
 	def script_startOfRow(self,gesture):
 		self.navigationHelper("startrow")
 
 	@script(
-		gesture = ("kb:control+rightArrow")
+		gesture=("kb:control+rightArrow")
 	)
 	def script_endOfRow(self,gesture):
 		self.navigationHelper("endrow")
 
 	@script(
-		gesture = ("kb:control+downArrow")
+		gesture=("kb:control+downArrow")
 	)
 	def script_endOfColumn(self,gesture):
 		self.navigationHelper("endcol")

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -508,43 +508,35 @@ class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 		cellPosition.Activate()
 		eventHandler.executeEvent('gainFocus',obj)
 
-	@script(
-		gesture="kb:leftArrow")
+	@script(gesture="kb:leftArrow")
 	def script_moveLeft(self,gesture):
 		self.navigationHelper("left")
 
-	@script(
-		gesture="kb:rightArrow")
+	@script(gesture="kb:rightArrow")
 	def script_moveRight(self,gesture):
 		self.navigationHelper("right")
 
-	@script(
-		gesture="kb:upArrow")
+	@script(gesture="kb:upArrow")
 	def script_moveUp(self,gesture):
 		self.navigationHelper("up")
 
-	@script(
-		gesture="kb:downArrow")
+	@script(gesture="kb:downArrow")
 	def script_moveDown(self,gesture):
 		self.navigationHelper("down")
 
-	@script(
-		gesture="kb:control+upArrow")
+	@script(gesture="kb:control+upArrow")
 	def script_startOfColumn(self,gesture):
 		self.navigationHelper("startcol")
 
-	@script(
-		gesture="kb:control+leftArrow")
+	@script(gesture="kb:control+leftArrow")
 	def script_startOfRow(self,gesture):
 		self.navigationHelper("startrow")
 
-	@script(
-		gesture="kb:control+rightArrow")
+	@script(gesture="kb:control+rightArrow")
 	def script_endOfRow(self,gesture):
 		self.navigationHelper("endrow")
 
-	@script(
-		gesture="kb:control+downArrow")
+	@script(gesture="kb:control+downArrow")
 	def script_endOfColumn(self,gesture):
 		self.navigationHelper("endcol")
 
@@ -1215,8 +1207,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Sets the current cell as start of column header"),
-		gesture="kb:NVDA+shift+c"
-	)
+		gesture="kb:NVDA+shift+c")
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if not config.conf['documentFormatting']['reportTableHeaders']:
@@ -1605,9 +1596,7 @@ class ExcelDropdown(Window):
 		if eventHandler.lastQueuedFocusObject is newFocus: return
 		eventHandler.queueEvent("gainFocus",newFocus)
 
-	@script(
-		gestures=("kb:escape", "kb:enter", "kb:space"),
-		canPropagate=True)
+	@script(gestures=("kb:escape", "kb:enter", "kb:space"), canPropagate=True)
 	def script_closeDropdown(self,gesture):
 		gesture.send()
 		eventHandler.queueEvent("gainFocus",self.parent)
@@ -1739,9 +1728,7 @@ class ExcelFormControl(ExcelBase):
 			screenBottomRightY=int(Y + (bottomRightCellHeight/2+ bottomRightAddress.Top) * zoomRatio * py / pointsPerInch)
 			return (int(0.5*(screenTopLeftX+screenBottomRightX)), int(0.5*(screenTopLeftY+screenBottomRightY)))
 
-	@script(
-		gestures=("kb:enter", "kb:space", "kb(desktop):numpadEnter"),
-		canPropagate=True)
+	@script(gestures=("kb:enter", "kb:space", "kb(desktop):numpadEnter"), canPropagate=True)
 	def script_doAction(self,gesture):
 		self.doAction()
 
@@ -1904,9 +1891,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 		if self.listSize>0:
 			return self.getChildAtIndex(self.listSize-1)
 
-	@script(
-		gesture="kb:upArrow",
-		canPropagate=True)
+	@script(gesture="kb:upArrow", canPropagate=True)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
@@ -1919,9 +1904,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 			if child:
 				eventHandler.queueEvent("gainFocus",child)
 
-	@script(
-		gesture="kb:downArrow",
-		canPropagate=True)
+	@script(gesture="kb:downArrow", canPropagate=True)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
@@ -1957,18 +1940,14 @@ class ExcelFormControlDropDown(ExcelFormControl):
 		except:
 			self.selectedItemIndex=0
 
-	@script(
-		gesture="kb:upArrow",
-		canPropagate=True)
+	@script(gesture="kb:upArrow", canPropagate=True)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
 			self.excelOLEFormatObject.Selected[self.selectedItemIndex] = True
 			eventHandler.queueEvent("valueChange",self)
 
-	@script(
-		gesture="kb:downArrow",
-		canPropagate=True)
+	@script(gesture="kb:downArrow", canPropagate=True)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
@@ -2018,22 +1997,18 @@ class ExcelFormControlScrollBar(ExcelFormControl):
 		self.excelControlFormatObject.value=newValue
 		eventHandler.queueEvent("valueChange",self)
 
-	@script(
-		gesture="kb:upArrow")
+	@script(gesture="kb:upArrow")
 	def script_moveUpSmall(self,gesture):
 		self.moveValue(True,False)
 
-	@script(
-		gesture="kb:downArrow")
+	@script(gesture="kb:downArrow")
 	def script_moveDownSmall(self,gesture):
 		self.moveValue(False,False)
 
-	@script(
-		gesture="kb:pageUp")
+	@script(gesture="kb:pageUp")
 	def script_moveUpLarge(self,gesture):
 		self.moveValue(True,True)
 
-	@script(
-		gesture="kb:pageDown")
+	@script(gesture="kb:pageDown")
 	def script_moveDownLarge(self,gesture):
 		self.moveValue(False,True)

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -509,50 +509,42 @@ class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 		eventHandler.executeEvent('gainFocus',obj)
 
 	@script(
-		gesture="kb:leftArrow"
-	)
+		gesture="kb:leftArrow")
 	def script_moveLeft(self,gesture):
 		self.navigationHelper("left")
 
 	@script(
-		gesture="kb:rightArrow"
-	)
+		gesture="kb:rightArrow")
 	def script_moveRight(self,gesture):
 		self.navigationHelper("right")
 
 	@script(
-		gesture="kb:upArrow"
-	)
+		gesture="kb:upArrow")
 	def script_moveUp(self,gesture):
 		self.navigationHelper("up")
 
 	@script(
-		gesture="kb:downArrow"
-	)
+		gesture="kb:downArrow")
 	def script_moveDown(self,gesture):
 		self.navigationHelper("down")
 
 	@script(
-		gesture="kb:control+upArrow"
-	)
+		gesture="kb:control+upArrow")
 	def script_startOfColumn(self,gesture):
 		self.navigationHelper("startcol")
 
 	@script(
-		gesture="kb:control+leftArrow"
-	)
+		gesture="kb:control+leftArrow")
 	def script_startOfRow(self,gesture):
 		self.navigationHelper("startrow")
 
 	@script(
-		gesture="kb:control+rightArrow"
-	)
+		gesture="kb:control+rightArrow")
 	def script_endOfRow(self,gesture):
 		self.navigationHelper("endrow")
 
 	@script(
-		gesture="kb:control+downArrow"
-	)
+		gesture="kb:control+downArrow")
 	def script_endOfColumn(self,gesture):
 		self.navigationHelper("endcol")
 
@@ -1197,8 +1189,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("opens a dropdown item at the current cell"),
-		gesture="kb:alt+downArrow"
-	)
+		gesture="kb:alt+downArrow")
 	def script_openDropdown(self,gesture):
 		gesture.send()
 		d=None
@@ -1251,8 +1242,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("sets the current cell as start of row header"),
-		gesture="kb:NVDA+shift+r"
-	)
+		gesture="kb:NVDA+shift+r")
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if not config.conf['documentFormatting']['reportTableHeaders']:
@@ -1437,8 +1427,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Reports the note on the current cell"),
-		gesture="kb:NVDA+alt+c"
-	)
+		gesture="kb:NVDA+alt+c")
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None
@@ -1451,11 +1440,11 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Opens the note editing dialog"),
-		gesture="kb:shift+f2"
-	)
+		gesture="kb:shift+f2")
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
-		d = wx.TextEntryDialog(gui.mainFrame, 
+		d = wx.TextEntryDialog(
+			gui.mainFrame,
 			# Translators: Dialog text for the note editing dialog
 			_("Editing note for cell {address}").format(address=self.cellCoordsText),
 			# Translators: Title for the note editing  dialog
@@ -1608,22 +1597,20 @@ class ExcelDropdown(Window):
 				return child
 
 	@script(
-		gestures=("kb:downArrow", "kb:upArrow", "kb:leftArrow", "kb:rightArrow", "kb:home", "kb:end")
-	)
+		gestures=("kb:downArrow", "kb:upArrow", "kb:leftArrow", "kb:rightArrow", "kb:home", "kb:end"),
+		canPropagate = True)
 	def script_selectionChange(self,gesture):
 		gesture.send()
 		newFocus=self.selection or self
 		if eventHandler.lastQueuedFocusObject is newFocus: return
 		eventHandler.queueEvent("gainFocus",newFocus)
-	script_selectionChange.canPropagate = True
 
 	@script(
-		gestures=("kb:escape", "kb:enter", "kb:space")
-	)
+		gestures=("kb:escape", "kb:enter", "kb:space"),
+		canPropagate = True)
 	def script_closeDropdown(self,gesture):
 		gesture.send()
 		eventHandler.queueEvent("gainFocus",self.parent)
-	script_closeDropdown.canPropagate = True
 
 	def event_gainFocus(self):
 		child=self.selection
@@ -1753,11 +1740,10 @@ class ExcelFormControl(ExcelBase):
 			return (int(0.5*(screenTopLeftX+screenBottomRightX)), int(0.5*(screenTopLeftY+screenBottomRightY)))
 
 	@script(
-		gestures=("kb:enter", "kb:space", "kb(desktop):numpadEnter")
-	)
+		gestures=("kb:enter", "kb:space", "kb(desktop):numpadEnter"),
+		canPropagate = True)
 	def script_doAction(self,gesture):
 		self.doAction()
-	script_doAction.canPropagate = True
 
 	def doAction(self):
 		(x,y)=self._getFormControlScreenCoordinates()
@@ -1919,8 +1905,8 @@ class ExcelFormControlListBox(ExcelFormControl):
 			return self.getChildAtIndex(self.listSize-1)
 
 	@script(
-		gesture="kb:upArrow"
-	)
+		gesture="kb:upArrow",
+		canPropagate = True)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
@@ -1932,11 +1918,10 @@ class ExcelFormControlListBox(ExcelFormControl):
 			child=self.getChildAtIndex(self.selectedItemIndex-1)
 			if child:
 				eventHandler.queueEvent("gainFocus",child)
-	script_moveUp.canPropagate = True
 
 	@script(
-		gesture="kb:downArrow"
-	)
+		gesture="kb:downArrow",
+		canPropagate = True)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
@@ -1948,7 +1933,6 @@ class ExcelFormControlListBox(ExcelFormControl):
 			child=self.getChildAtIndex(self.selectedItemIndex-1)
 			if child:
 				eventHandler.queueEvent("gainFocus",child)
-	script_moveDown.canPropagate = True
 
 	def doAction(self):
 		if self.isMultiSelectable:
@@ -1974,24 +1958,22 @@ class ExcelFormControlDropDown(ExcelFormControl):
 			self.selectedItemIndex=0
 
 	@script(
-		gesture="kb:upArrow"
-	)
+		gesture="kb:upArrow",
+		canPropagate = True)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
 			self.excelOLEFormatObject.Selected[self.selectedItemIndex] = True
 			eventHandler.queueEvent("valueChange",self)
-	script_moveUp.canPropagate = True
 
 	@script(
-		gesture="kb:downArrow"
-	)
+		gesture="kb:downArrow",
+		canPropagate = True)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
 			self.excelOLEFormatObject.Selected[self.selectedItemIndex] = True
 			eventHandler.queueEvent("valueChange",self)
-	script_moveDown.canPropagate = True
 
 	def _get_value(self):
 		if self.selectedItemIndex < self.listSize:
@@ -2037,25 +2019,21 @@ class ExcelFormControlScrollBar(ExcelFormControl):
 		eventHandler.queueEvent("valueChange",self)
 
 	@script(
-		gesture="kb:upArrow"
-	)
+		gesture="kb:upArrow")
 	def script_moveUpSmall(self,gesture):
 		self.moveValue(True,False)
 
 	@script(
-		gesture="kb:downArrow"
-	)
+		gesture="kb:downArrow")
 	def script_moveDownSmall(self,gesture):
 		self.moveValue(False,False)
 
 	@script(
-		gesture="kb:pageUp"
-	)
+		gesture="kb:pageUp")
 	def script_moveUpLarge(self,gesture):
 		self.moveValue(True,True)
 
 	@script(
-		gesture="kb:pageDown"
-	)
+		gesture="kb:pageDown")
 	def script_moveDownLarge(self,gesture):
 		self.moveValue(False,True)

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -509,49 +509,49 @@ class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 		eventHandler.executeEvent('gainFocus',obj)
 
 	@script(
-		gesture=("kb:leftArrow")
+		gesture="kb:leftArrow"
 	)
 	def script_moveLeft(self,gesture):
 		self.navigationHelper("left")
 
 	@script(
-		gesture=("kb:rightArrow")
+		gesture="kb:rightArrow"
 	)
 	def script_moveRight(self,gesture):
 		self.navigationHelper("right")
 
 	@script(
-		gesture=("kb:upArrow")
+		gesture="kb:upArrow"
 	)
 	def script_moveUp(self,gesture):
 		self.navigationHelper("up")
 
 	@script(
-		gesture=("kb:downArrow")
+		gesture="kb:downArrow"
 	)
 	def script_moveDown(self,gesture):
 		self.navigationHelper("down")
 
 	@script(
-		gesture=("kb:control+upArrow")
+		gesture="kb:control+upArrow"
 	)
 	def script_startOfColumn(self,gesture):
 		self.navigationHelper("startcol")
 
 	@script(
-		gesture=("kb:control+leftArrow")
+		gesture="kb:control+leftArrow"
 	)
 	def script_startOfRow(self,gesture):
 		self.navigationHelper("startrow")
 
 	@script(
-		gesture=("kb:control+rightArrow")
+		gesture="kb:control+rightArrow"
 	)
 	def script_endOfRow(self,gesture):
 		self.navigationHelper("endrow")
 
 	@script(
-		gesture=("kb:control+downArrow")
+		gesture="kb:control+downArrow"
 	)
 	def script_endOfColumn(self,gesture):
 		self.navigationHelper("endcol")
@@ -899,18 +899,55 @@ class ExcelWorksheet(ExcelBase):
 			states.add(controlTypes.STATE_PROTECTED)
 		return states
 
-	@script(
-		gestures=("kb:tab", "kb:shift+tab", "kb:enter", "kb:numpadEnter", "kb:shift+enter", "kb:shift+numpadEnter", 
-		"kb:upArrow", "kb:downArrow", "kb:leftArrow", "kb:rightArrow", "kb:control+upArrow", "kb:control+downArrow", 
-		"kb:control+leftArrow", "kb:control+rightArrow", "kb:home", "kb:end", "kb:control+home", "kb:control+end", 
-		"kb:shift+upArrow", "kb:shift+downArrow", "kb:shift+leftArrow", "kb:shift+rightArrow", 
-		"kb:shift+control+upArrow", "kb:shift+control+downArrow", "kb:shift+control+leftArrow", 
-		"kb:shift+control+rightArrow", "kb:shift+home", "kb:shift+end", "kb:shift+control+home", 
-		"kb:shift+control+end", "kb:shift+space", "kb:control+space", "kb:pageUp", "kb:pageDown", "kb:shift+pageUp", 
-		"kb:shift+pageDown", "kb:alt+pageUp", "kb:alt+pageDown", "kb:alt+shift+pageUp", "kb:alt+shift+pageDown", 
-		"kb:control+shift+8", "kb:control+pageUp", "kb:control+pageDown", "kb:control+a", "kb:control+v", 
-		"kb:shift+f11")
-	)
+	@scriptHandler.script(gestures=(
+		"kb:tab",
+		"kb:shift+tab",
+		"kb:enter",
+		"kb:numpadEnter",
+		"kb:shift+enter",
+		"kb:shift+numpadEnter",
+		"kb:upArrow",
+		"kb:downArrow",
+		"kb:leftArrow",
+		"kb:rightArrow",
+		"kb:control+upArrow",
+		"kb:control+downArrow",
+		"kb:control+leftArrow",
+		"kb:control+rightArrow",
+		"kb:home",
+		"kb:end",
+		"kb:control+home",
+		"kb:control+end",
+		"kb:shift+upArrow",
+		"kb:shift+downArrow",
+		"kb:shift+leftArrow",
+		"kb:shift+rightArrow",
+		"kb:shift+control+upArrow",
+		"kb:shift+control+downArrow",
+		"kb:shift+control+leftArrow",
+		"kb:shift+control+rightArrow",
+		"kb:shift+home",
+		"kb:shift+end",
+		"kb:shift+control+home",
+		"kb:shift+control+end",
+		"kb:shift+space",
+		"kb:control+space",
+		"kb:pageUp",
+		"kb:pageDown",
+		"kb:shift+pageUp",
+		"kb:shift+pageDown",
+		"kb:alt+pageUp",
+		"kb:alt+pageDown",
+		"kb:alt+shift+pageUp",
+		"kb:alt+shift+pageDown",
+		"kb:control+shift+8",
+		"kb:control+pageUp",
+		"kb:control+pageDown",
+		"kb:control+a",
+		"kb:control+v",
+		"kb:shift+f11",
+	), canPropagate=True)
+
 	def script_changeSelection(self,gesture):
 		oldSelection=api.getFocusObject()
 		gesture.send()
@@ -934,7 +971,6 @@ class ExcelWorksheet(ExcelBase):
 			if oldSelection.parent==newSelection.parent:
 				newSelection.parent=oldSelection.parent
 			eventHandler.executeEvent('gainFocus',newSelection)
-	script_changeSelection.canPropagate = True
 
 class ExcelCellTextInfo(NVDAObjectTextInfo):
 
@@ -1161,7 +1197,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("opens a dropdown item at the current cell"),
-		gesture=("kb:alt+downArrow")
+		gesture="kb:alt+downArrow"
 	)
 	def script_openDropdown(self,gesture):
 		gesture.send()
@@ -1188,7 +1224,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Sets the current cell as start of column header"),
-		gesture=("kb:NVDA+shift+c")
+		gesture="kb:NVDA+shift+c"
 	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -1215,7 +1251,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("sets the current cell as start of row header"),
-		gesture=("kb:NVDA+shift+r")
+		gesture="kb:NVDA+shift+r"
 	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -1401,7 +1437,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Reports the note on the current cell"),
-		gesture=("kb:NVDA+alt+c")
+		gesture="kb:NVDA+alt+c"
 	)
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
@@ -1415,7 +1451,7 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Opens the note editing dialog"),
-		gesture=("kb:shift+f2")
+		gesture="kb:shift+f2"
 	)
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
@@ -1883,7 +1919,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 			return self.getChildAtIndex(self.listSize-1)
 
 	@script(
-		gesture=("kb:upArrow")
+		gesture="kb:upArrow"
 	)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
@@ -1899,7 +1935,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 	script_moveUp.canPropagate = True
 
 	@script(
-		gesture=("kb:downArrow")
+		gesture="kb:downArrow"
 	)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
@@ -1938,7 +1974,7 @@ class ExcelFormControlDropDown(ExcelFormControl):
 			self.selectedItemIndex=0
 
 	@script(
-		gesture=("kb:upArrow")
+		gesture="kb:upArrow"
 	)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
@@ -1948,7 +1984,7 @@ class ExcelFormControlDropDown(ExcelFormControl):
 	script_moveUp.canPropagate = True
 
 	@script(
-		gesture=("kb:downArrow")
+		gesture="kb:downArrow"
 	)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
@@ -2001,25 +2037,25 @@ class ExcelFormControlScrollBar(ExcelFormControl):
 		eventHandler.queueEvent("valueChange",self)
 
 	@script(
-		gesture=("kb:upArrow")
+		gesture="kb:upArrow"
 	)
 	def script_moveUpSmall(self,gesture):
 		self.moveValue(True,False)
 
 	@script(
-		gesture=("kb:downArrow")
+		gesture="kb:downArrow"
 	)
 	def script_moveDownSmall(self,gesture):
 		self.moveValue(False,False)
 
 	@script(
-		gesture=("kb:pageUp")
+		gesture="kb:pageUp"
 	)
 	def script_moveUpLarge(self,gesture):
 		self.moveValue(True,True)
 
 	@script(
-		gesture=("kb:pageDown")
+		gesture="kb:pageDown"
 	)
 	def script_moveDownLarge(self,gesture):
 		self.moveValue(False,True)

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -33,6 +33,7 @@ import controlTypes
 from . import Window
 from .. import NVDAObjectTextInfo
 import scriptHandler
+from scriptHandler import script
 import browseMode
 import inputCore
 import ctypes
@@ -507,27 +508,51 @@ class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 		cellPosition.Activate()
 		eventHandler.executeEvent('gainFocus',obj)
 
+	@script(
+		gesture = ("kb:leftArrow")
+	)
 	def script_moveLeft(self,gesture):
 		self.navigationHelper("left")
 
+	@script(
+		gesture = ("kb:rightArrow")
+	)
 	def script_moveRight(self,gesture):
 		self.navigationHelper("right")
 
+	@script(
+		gesture = ("kb:upArrow")
+	)
 	def script_moveUp(self,gesture):
 		self.navigationHelper("up")
 
+	@script(
+		gesture = ("kb:downArrow")
+	)
 	def script_moveDown(self,gesture):
 		self.navigationHelper("down")
 
+	@script(
+		gesture = ("kb:control+upArrow")
+	)
 	def script_startOfColumn(self,gesture):
 		self.navigationHelper("startcol")
 
+	@script(
+		gesture = ("kb:control+leftArrow")
+	)
 	def script_startOfRow(self,gesture):
 		self.navigationHelper("startrow")
 
+	@script(
+		gesture = ("kb:control+rightArrow")
+	)
 	def script_endOfRow(self,gesture):
 		self.navigationHelper("endrow")
 
+	@script(
+		gesture = ("kb:control+downArrow")
+	)
 	def script_endOfColumn(self,gesture):
 		self.navigationHelper("endcol")
 
@@ -564,17 +589,6 @@ class ExcelBrowseModeTreeInterceptor(browseMode.BrowseModeTreeInterceptor):
 	# Translators: the description for the elements list command in Microsoft Excel.
 	script_elementsList.__doc__ = _("Lists various types of elements in this spreadsheet")
 	script_elementsList.ignoreTreeInterceptorPassThrough=True
-
-	__gestures = {
-		"kb:upArrow": "moveUp",
-		"kb:downArrow":"moveDown",
-		"kb:leftArrow":"moveLeft",
-		"kb:rightArrow":"moveRight",
-		"kb:control+upArrow":"startOfColumn",
-		"kb:control+downArrow":"endOfColumn",
-		"kb:control+leftArrow":"startOfRow",
-		"kb:control+rightArrow":"endOfRow",
-	}
 
 class ElementsListDialog(browseMode.ElementsListDialog):
 
@@ -885,54 +899,9 @@ class ExcelWorksheet(ExcelBase):
 			states.add(controlTypes.STATE_PROTECTED)
 		return states
 
-	@scriptHandler.script(gestures=(
-		"kb:tab",
-		"kb:shift+tab",
-		"kb:enter",
-		"kb:numpadEnter",
-		"kb:shift+enter",
-		"kb:shift+numpadEnter",
-		"kb:upArrow",
-		"kb:downArrow",
-		"kb:leftArrow",
-		"kb:rightArrow",
-		"kb:control+upArrow",
-		"kb:control+downArrow",
-		"kb:control+leftArrow",
-		"kb:control+rightArrow",
-		"kb:home",
-		"kb:end",
-		"kb:control+home",
-		"kb:control+end",
-		"kb:shift+upArrow",
-		"kb:shift+downArrow",
-		"kb:shift+leftArrow",
-		"kb:shift+rightArrow",
-		"kb:shift+control+upArrow",
-		"kb:shift+control+downArrow",
-		"kb:shift+control+leftArrow",
-		"kb:shift+control+rightArrow",
-		"kb:shift+home",
-		"kb:shift+end",
-		"kb:shift+control+home",
-		"kb:shift+control+end",
-		"kb:shift+space",
-		"kb:control+space",
-		"kb:pageUp",
-		"kb:pageDown",
-		"kb:shift+pageUp",
-		"kb:shift+pageDown",
-		"kb:alt+pageUp",
-		"kb:alt+pageDown",
-		"kb:alt+shift+pageUp",
-		"kb:alt+shift+pageDown",
-		"kb:control+shift+8",
-		"kb:control+pageUp",
-		"kb:control+pageDown",
-		"kb:control+a",
-		"kb:control+v",
-		"kb:shift+f11",
-	), canPropagate=True)
+	@script(
+		gestures = ("kb:tab", "kb:shift+tab", "kb:enter", "kb:numpadEnter", "kb:shift+enter", "kb:shift+numpadEnter", "kb:upArrow", "kb:downArrow", "kb:leftArrow", "kb:rightArrow", "kb:control+upArrow", "kb:control+downArrow", "kb:control+leftArrow", "kb:control+rightArrow", "kb:home", "kb:end", "kb:control+home", "kb:control+end", "kb:shift+upArrow", "kb:shift+downArrow", "kb:shift+leftArrow", "kb:shift+rightArrow", "kb:shift+control+upArrow", "kb:shift+control+downArrow", "kb:shift+control+leftArrow", "kb:shift+control+rightArrow", "kb:shift+home", "kb:shift+end", "kb:shift+control+home", "kb:shift+control+end", "kb:shift+space", "kb:control+space", "kb:pageUp", "kb:pageDown", "kb:shift+pageUp", "kb:shift+pageDown", "kb:alt+pageUp", "kb:alt+pageDown", "kb:alt+shift+pageUp", "kb:alt+shift+pageDown", "kb:control+shift+8", "kb:control+pageUp", "kb:control+pageDown", "kb:control+a", "kb:control+v", "kb:shift+f11")
+	)
 	def script_changeSelection(self,gesture):
 		oldSelection=api.getFocusObject()
 		gesture.send()
@@ -956,6 +925,7 @@ class ExcelWorksheet(ExcelBase):
 			if oldSelection.parent==newSelection.parent:
 				newSelection.parent=oldSelection.parent
 			eventHandler.executeEvent('gainFocus',newSelection)
+	script_changeSelection.canPropagate=True
 
 class ExcelCellTextInfo(NVDAObjectTextInfo):
 
@@ -1179,6 +1149,11 @@ class ExcelCell(ExcelBase):
 	def _get_rowHeaderText(self):
 		return self.parent.fetchAssociatedHeaderCellText(self,columnHeader=False)
 
+	@script(
+		# Translators: the description  for a script for Excel
+		description = _("opens a dropdown item at the current cell"),
+		gesture = ("kb:alt+downArrow")
+	)
 	def script_openDropdown(self,gesture):
 		gesture.send()
 		d=None
@@ -1201,6 +1176,11 @@ class ExcelCell(ExcelBase):
 		d.parent=self
 		eventHandler.queueEvent("gainFocus",d)
 
+	@script(
+		# Translators: the description  for a script for Excel
+		description = _("Sets the current cell as start of column header"),
+		gesture = ("kb:NVDA+shift+c")
+	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if not config.conf['documentFormatting']['reportTableHeaders']:
@@ -1223,6 +1203,11 @@ class ExcelCell(ExcelBase):
 				ui.message(_("Cannot find {address}    in column headers").format(address=self.cellCoordsText))
 	script_setColumnHeader.__doc__=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this region. Pressing twice will forget the current column header for this cell.")
 
+	@script(
+		# Translators: the description  for a script for Excel
+		description = _("sets the current cell as start of row header"),
+		gesture = ("kb:NVDA+shift+r")
+	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if not config.conf['documentFormatting']['reportTableHeaders']:
@@ -1404,6 +1389,11 @@ class ExcelCell(ExcelBase):
 
 	# In Office 2016, 365 and newer, comments are now called notes.
 	# Thus, messages dialog title and so on should refer to notes.
+	@script(
+		# Translators: the description  for a script for Excel
+		description = _("Reports the note on the current cell"),
+		gesture = ("kb:NVDA+alt+c")
+	)
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None
@@ -1412,9 +1402,12 @@ class ExcelCell(ExcelBase):
 		else:
 			# Translators: A message in Excel when there is no note
 			ui.message(_("Not on a note"))
-	# Translators: the description  for a script for Excel
-	script_reportComment.__doc__ = _("Reports the note on the current cell")
 
+	@script(
+		# Translators: the description  for a script for Excel
+		description = _("Opens the note editing dialog"),
+		gesture = ("kb:shift+f2")
+	)
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		d = wx.TextEntryDialog(gui.mainFrame, 
@@ -1451,14 +1444,6 @@ class ExcelCell(ExcelBase):
 			)
 			speech.speak(sequence)
 		super(ExcelCell,self).reportFocus()
-
-	__gestures = {
-		"kb:NVDA+shift+c": "setColumnHeader",
-		"kb:NVDA+shift+r": "setRowHeader",
-		"kb:shift+f2":"editComment",
-		"kb:alt+downArrow":"openDropdown",
-		"kb:NVDA+alt+c": "reportComment",
-	}
 
 class ExcelSelection(ExcelBase):
 
@@ -1577,6 +1562,9 @@ class ExcelDropdown(Window):
 			if controlTypes.STATE_SELECTED in child.states:
 				return child
 
+	@script(
+		gestures = ("kb:downArrow", "kb:upArrow", "kb:leftArrow", "kb:rightArrow", "kb:home", "kb:end")
+	)
 	def script_selectionChange(self,gesture):
 		gesture.send()
 		newFocus=self.selection or self
@@ -1584,22 +1572,13 @@ class ExcelDropdown(Window):
 		eventHandler.queueEvent("gainFocus",newFocus)
 	script_selectionChange.canPropagate=True
 
+	@script(
+		gestures = ("kb:escape", "kb:enter", "kb:space")
+	)
 	def script_closeDropdown(self,gesture):
 		gesture.send()
 		eventHandler.queueEvent("gainFocus",self.parent)
 	script_closeDropdown.canPropagate=True
-
-	__gestures={
-		"kb:downArrow":"selectionChange",
-		"kb:upArrow":"selectionChange",
-		"kb:leftArrow":"selectionChange",
-		"kb:rightArrow":"selectionChange",
-		"kb:home":"selectionChange",
-		"kb:end":"selectionChange",
-		"kb:escape":"closeDropdown",
-		"kb:enter":"closeDropdown",
-		"kb:space":"closeDropdown",
-	}
 
 	def event_gainFocus(self):
 		child=self.selection
@@ -1728,6 +1707,9 @@ class ExcelFormControl(ExcelBase):
 			screenBottomRightY=int(Y + (bottomRightCellHeight/2+ bottomRightAddress.Top) * zoomRatio * py / pointsPerInch)
 			return (int(0.5*(screenTopLeftX+screenBottomRightX)), int(0.5*(screenTopLeftY+screenBottomRightY)))
 
+	@script(
+		gestures = ("kb:enter", "kb:space", "kb(desktop):numpadEnter")
+	)
 	def script_doAction(self,gesture):
 		self.doAction()
 	script_doAction.canPropagate=True
@@ -1740,12 +1722,6 @@ class ExcelFormControl(ExcelBase):
 		mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP,0,0)
 		self.invalidateCache()
 		wx.CallLater(100,eventHandler.executeEvent,"stateChange",self)
-
-	__gestures= {
-				"kb:enter":"doAction",
-				"kb:space":"doAction",
-				"kb(desktop):numpadEnter":"doAction",
-				}
 
 class ExcelFormControlQuickNavItem(ExcelQuickNavItem):
 
@@ -1897,6 +1873,9 @@ class ExcelFormControlListBox(ExcelFormControl):
 		if self.listSize>0:
 			return self.getChildAtIndex(self.listSize-1)
 
+	@script(
+		gesture = ("kb:upArrow")
+	)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
@@ -1910,6 +1889,9 @@ class ExcelFormControlListBox(ExcelFormControl):
 				eventHandler.queueEvent("gainFocus",child)
 	script_moveUp.canPropagate=True
 
+	@script(
+		gesture = ("kb:downArrow")
+	)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
@@ -1933,11 +1915,6 @@ class ExcelFormControlListBox(ExcelFormControl):
 			child=self.getChildAtIndex(self.selectedItemIndex-1)
 			eventHandler.queueEvent("gainFocus",child)
 
-	__gestures= {
-		"kb:upArrow": "moveUp",
-		"kb:downArrow":"moveDown",
-	}
-
 class ExcelFormControlDropDown(ExcelFormControl):
 
 	def __init__(self,windowHandle=None,parent=None,excelFormControlObject=None):
@@ -1951,6 +1928,9 @@ class ExcelFormControlDropDown(ExcelFormControl):
 		except:
 			self.selectedItemIndex=0
 
+	@script(
+		gesture = ("kb:upArrow")
+	)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
@@ -1958,6 +1938,9 @@ class ExcelFormControlDropDown(ExcelFormControl):
 			eventHandler.queueEvent("valueChange",self)
 	script_moveUp.canPropagate=True
 
+	@script(
+		gesture = ("kb:downArrow")
+	)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
@@ -1968,11 +1951,6 @@ class ExcelFormControlDropDown(ExcelFormControl):
 	def _get_value(self):
 		if self.selectedItemIndex < self.listSize:
 			return str(self.excelOLEFormatObject.List(self.selectedItemIndex))
-
-	__gestures= {
-		"kb:upArrow": "moveUp",
-		"kb:downArrow":"moveDown",
-	}
 
 class ExcelFormControlScrollBar(ExcelFormControl):
 
@@ -2013,21 +1991,26 @@ class ExcelFormControlScrollBar(ExcelFormControl):
 		self.excelControlFormatObject.value=newValue
 		eventHandler.queueEvent("valueChange",self)
 
+	@script(
+		gesture = ("kb:upArrow")
+	)
 	def script_moveUpSmall(self,gesture):
 		self.moveValue(True,False)
 
+	@script(
+		gesture = ("kb:downArrow")
+	)
 	def script_moveDownSmall(self,gesture):
 		self.moveValue(False,False)
 
+	@script(
+		gesture = ("kb:pageUp")
+	)
 	def script_moveUpLarge(self,gesture):
 		self.moveValue(True,True)
 
+	@script(
+		gesture = ("kb:pageDown")
+	)
 	def script_moveDownLarge(self,gesture):
 		self.moveValue(False,True)
-
-	__gestures={
-		"kb:upArrow":"moveUpSmall",
-		"kb:downArrow":"moveDownSmall",
-		"kb:pageUp":"moveUpLarge",
-		"kb:pageDown":"moveDownLarge",
-	}

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -900,7 +900,16 @@ class ExcelWorksheet(ExcelBase):
 		return states
 
 	@script(
-		gestures = ("kb:tab", "kb:shift+tab", "kb:enter", "kb:numpadEnter", "kb:shift+enter", "kb:shift+numpadEnter", "kb:upArrow", "kb:downArrow", "kb:leftArrow", "kb:rightArrow", "kb:control+upArrow", "kb:control+downArrow", "kb:control+leftArrow", "kb:control+rightArrow", "kb:home", "kb:end", "kb:control+home", "kb:control+end", "kb:shift+upArrow", "kb:shift+downArrow", "kb:shift+leftArrow", "kb:shift+rightArrow", "kb:shift+control+upArrow", "kb:shift+control+downArrow", "kb:shift+control+leftArrow", "kb:shift+control+rightArrow", "kb:shift+home", "kb:shift+end", "kb:shift+control+home", "kb:shift+control+end", "kb:shift+space", "kb:control+space", "kb:pageUp", "kb:pageDown", "kb:shift+pageUp", "kb:shift+pageDown", "kb:alt+pageUp", "kb:alt+pageDown", "kb:alt+shift+pageUp", "kb:alt+shift+pageDown", "kb:control+shift+8", "kb:control+pageUp", "kb:control+pageDown", "kb:control+a", "kb:control+v", "kb:shift+f11")
+		gestures=("kb:tab", "kb:shift+tab", "kb:enter", "kb:numpadEnter", "kb:shift+enter", "kb:shift+numpadEnter", 
+		"kb:upArrow", "kb:downArrow", "kb:leftArrow", "kb:rightArrow", "kb:control+upArrow", "kb:control+downArrow", 
+		"kb:control+leftArrow", "kb:control+rightArrow", "kb:home", "kb:end", "kb:control+home", "kb:control+end", 
+		"kb:shift+upArrow", "kb:shift+downArrow", "kb:shift+leftArrow", "kb:shift+rightArrow", 
+		"kb:shift+control+upArrow", "kb:shift+control+downArrow", "kb:shift+control+leftArrow", 
+		"kb:shift+control+rightArrow", "kb:shift+home", "kb:shift+end", "kb:shift+control+home", 
+		"kb:shift+control+end", "kb:shift+space", "kb:control+space", "kb:pageUp", "kb:pageDown", "kb:shift+pageUp", 
+		"kb:shift+pageDown", "kb:alt+pageUp", "kb:alt+pageDown", "kb:alt+shift+pageUp", "kb:alt+shift+pageDown", 
+		"kb:control+shift+8", "kb:control+pageUp", "kb:control+pageDown", "kb:control+a", "kb:control+v", 
+		"kb:shift+f11")
 	)
 	def script_changeSelection(self,gesture):
 		oldSelection=api.getFocusObject()
@@ -925,7 +934,7 @@ class ExcelWorksheet(ExcelBase):
 			if oldSelection.parent==newSelection.parent:
 				newSelection.parent=oldSelection.parent
 			eventHandler.executeEvent('gainFocus',newSelection)
-	script_changeSelection.canPropagate=True
+	script_changeSelection.canPropagate = True
 
 class ExcelCellTextInfo(NVDAObjectTextInfo):
 
@@ -1151,8 +1160,8 @@ class ExcelCell(ExcelBase):
 
 	@script(
 		# Translators: the description  for a script for Excel
-		description = _("opens a dropdown item at the current cell"),
-		gesture = ("kb:alt+downArrow")
+		description=_("opens a dropdown item at the current cell"),
+		gesture=("kb:alt+downArrow")
 	)
 	def script_openDropdown(self,gesture):
 		gesture.send()
@@ -1178,8 +1187,8 @@ class ExcelCell(ExcelBase):
 
 	@script(
 		# Translators: the description  for a script for Excel
-		description = _("Sets the current cell as start of column header"),
-		gesture = ("kb:NVDA+shift+c")
+		description=_("Sets the current cell as start of column header"),
+		gesture=("kb:NVDA+shift+c")
 	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -1205,8 +1214,8 @@ class ExcelCell(ExcelBase):
 
 	@script(
 		# Translators: the description  for a script for Excel
-		description = _("sets the current cell as start of row header"),
-		gesture = ("kb:NVDA+shift+r")
+		description=_("sets the current cell as start of row header"),
+		gesture=("kb:NVDA+shift+r")
 	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -1391,8 +1400,8 @@ class ExcelCell(ExcelBase):
 	# Thus, messages dialog title and so on should refer to notes.
 	@script(
 		# Translators: the description  for a script for Excel
-		description = _("Reports the note on the current cell"),
-		gesture = ("kb:NVDA+alt+c")
+		description=_("Reports the note on the current cell"),
+		gesture=("kb:NVDA+alt+c")
 	)
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
@@ -1405,8 +1414,8 @@ class ExcelCell(ExcelBase):
 
 	@script(
 		# Translators: the description  for a script for Excel
-		description = _("Opens the note editing dialog"),
-		gesture = ("kb:shift+f2")
+		description=_("Opens the note editing dialog"),
+		gesture=("kb:shift+f2")
 	)
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
@@ -1563,22 +1572,22 @@ class ExcelDropdown(Window):
 				return child
 
 	@script(
-		gestures = ("kb:downArrow", "kb:upArrow", "kb:leftArrow", "kb:rightArrow", "kb:home", "kb:end")
+		gestures=("kb:downArrow", "kb:upArrow", "kb:leftArrow", "kb:rightArrow", "kb:home", "kb:end")
 	)
 	def script_selectionChange(self,gesture):
 		gesture.send()
 		newFocus=self.selection or self
 		if eventHandler.lastQueuedFocusObject is newFocus: return
 		eventHandler.queueEvent("gainFocus",newFocus)
-	script_selectionChange.canPropagate=True
+	script_selectionChange.canPropagate = True
 
 	@script(
-		gestures = ("kb:escape", "kb:enter", "kb:space")
+		gestures=("kb:escape", "kb:enter", "kb:space")
 	)
 	def script_closeDropdown(self,gesture):
 		gesture.send()
 		eventHandler.queueEvent("gainFocus",self.parent)
-	script_closeDropdown.canPropagate=True
+	script_closeDropdown.canPropagate = True
 
 	def event_gainFocus(self):
 		child=self.selection
@@ -1708,11 +1717,11 @@ class ExcelFormControl(ExcelBase):
 			return (int(0.5*(screenTopLeftX+screenBottomRightX)), int(0.5*(screenTopLeftY+screenBottomRightY)))
 
 	@script(
-		gestures = ("kb:enter", "kb:space", "kb(desktop):numpadEnter")
+		gestures=("kb:enter", "kb:space", "kb(desktop):numpadEnter")
 	)
 	def script_doAction(self,gesture):
 		self.doAction()
-	script_doAction.canPropagate=True
+	script_doAction.canPropagate = True
 
 	def doAction(self):
 		(x,y)=self._getFormControlScreenCoordinates()
@@ -1874,7 +1883,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 			return self.getChildAtIndex(self.listSize-1)
 
 	@script(
-		gesture = ("kb:upArrow")
+		gesture=("kb:upArrow")
 	)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
@@ -1887,10 +1896,10 @@ class ExcelFormControlListBox(ExcelFormControl):
 			child=self.getChildAtIndex(self.selectedItemIndex-1)
 			if child:
 				eventHandler.queueEvent("gainFocus",child)
-	script_moveUp.canPropagate=True
+	script_moveUp.canPropagate = True
 
 	@script(
-		gesture = ("kb:downArrow")
+		gesture=("kb:downArrow")
 	)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
@@ -1903,7 +1912,7 @@ class ExcelFormControlListBox(ExcelFormControl):
 			child=self.getChildAtIndex(self.selectedItemIndex-1)
 			if child:
 				eventHandler.queueEvent("gainFocus",child)
-	script_moveDown.canPropagate=True
+	script_moveDown.canPropagate = True
 
 	def doAction(self):
 		if self.isMultiSelectable:
@@ -1929,24 +1938,24 @@ class ExcelFormControlDropDown(ExcelFormControl):
 			self.selectedItemIndex=0
 
 	@script(
-		gesture = ("kb:upArrow")
+		gesture=("kb:upArrow")
 	)
 	def script_moveUp(self, gesture):
 		if self.selectedItemIndex > 1:
 			self.selectedItemIndex= self.selectedItemIndex - 1
 			self.excelOLEFormatObject.Selected[self.selectedItemIndex] = True
 			eventHandler.queueEvent("valueChange",self)
-	script_moveUp.canPropagate=True
+	script_moveUp.canPropagate = True
 
 	@script(
-		gesture = ("kb:downArrow")
+		gesture=("kb:downArrow")
 	)
 	def script_moveDown(self, gesture):
 		if self.selectedItemIndex < self.listSize:
 			self.selectedItemIndex= self.selectedItemIndex + 1
 			self.excelOLEFormatObject.Selected[self.selectedItemIndex] = True
 			eventHandler.queueEvent("valueChange",self)
-	script_moveDown.canPropagate=True
+	script_moveDown.canPropagate = True
 
 	def _get_value(self):
 		if self.selectedItemIndex < self.listSize:
@@ -1992,25 +2001,25 @@ class ExcelFormControlScrollBar(ExcelFormControl):
 		eventHandler.queueEvent("valueChange",self)
 
 	@script(
-		gesture = ("kb:upArrow")
+		gesture=("kb:upArrow")
 	)
 	def script_moveUpSmall(self,gesture):
 		self.moveValue(True,False)
 
 	@script(
-		gesture = ("kb:downArrow")
+		gesture=("kb:downArrow")
 	)
 	def script_moveDownSmall(self,gesture):
 		self.moveValue(False,False)
 
 	@script(
-		gesture = ("kb:pageUp")
+		gesture=("kb:pageUp")
 	)
 	def script_moveUpLarge(self,gesture):
 		self.moveValue(True,True)
 
 	@script(
-		gesture = ("kb:pageDown")
+		gesture=("kb:pageDown")
 	)
 	def script_moveDownLarge(self,gesture):
 		self.moveValue(False,True)

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -322,7 +322,8 @@ class ExcelFormulaQuickNavItem(ExcelRangeBasedQuickNavItem):
 
 class ExcelQuicknavIterator(object):
 	"""
-	Allows iterating over an MS excel collection (e.g. notes, Formulas or charts) emitting L{QuickNavItem} objects.
+	Allows iterating over an MS excel collection
+	(e.g. notes, Formulas or charts) emitting L{QuickNavItem} objects.
 	"""
 
 	def __init__(self, itemType , document , direction , includeCurrent):
@@ -338,7 +339,8 @@ class ExcelQuicknavIterator(object):
 
 	def collectionFromWorksheet(self,worksheetObject):
 		"""
-		Fetches a Microsoft Excel collection object from a Microsoft excel worksheet object. E.g. charts, notes, or formula.
+		Fetches a Microsoft Excel collection object from a Microsoft excel worksheet object.
+		E.g. charts, notes, or formula.
 		@param worksheetObject: a Microsoft excel worksheet object.
 		@return: a Microsoft excel collection object.
 		"""
@@ -1400,7 +1402,8 @@ class ExcelCell(ExcelBase):
 		level=max(self.excelCellInfo.outlineLevel-1,0) or None
 		return {'level':level}
 
-	# In Office 2016, 365 and newer, comments are now called notes. Thus, messages dialog title and so on should refer to notes.
+	# In Office 2016, 365 and newer, comments are now called notes.
+	# Thus, messages dialog title and so on should refer to notes.
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None
@@ -1410,14 +1413,14 @@ class ExcelCell(ExcelBase):
 			# Translators: A message in Excel when there is no note
 			ui.message(_("Not on a note"))
 	# Translators: the description  for a script for Excel
-	script_reportComment.__doc__=_("Reports the note on the current cell")
+	script_reportComment.__doc__ = _("Reports the note on the current cell")
 
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		d = wx.TextEntryDialog(gui.mainFrame, 
-			# Translators: Dialog text for 
+			# Translators: Dialog text for the note editing dialog
 			_("Editing note for cell {address}").format(address=self.cellCoordsText),
-			# Translators: Title of a dialog edit an Excel note 
+			# Translators: Title for the note editing  dialog
 			_("Note"),
 			value=commentObj.text() if commentObj else u"",
 			style=wx.TE_MULTILINE|wx.OK|wx.CANCEL)
@@ -1454,7 +1457,7 @@ class ExcelCell(ExcelBase):
 		"kb:NVDA+shift+r": "setRowHeader",
 		"kb:shift+f2":"editComment",
 		"kb:alt+downArrow":"openDropdown",
-		"kb:NVDA+alt+n":"reportComment",
+		"kb:NVDA+alt+c": "reportComment",
 	}
 
 class ExcelSelection(ExcelBase):

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -322,7 +322,7 @@ class ExcelFormulaQuickNavItem(ExcelRangeBasedQuickNavItem):
 
 class ExcelQuicknavIterator(object):
 	"""
-	Allows iterating over an MS excel collection (e.g. Comments, Formulas or charts) emitting L{QuickNavItem} objects.
+	Allows iterating over an MS excel collection (e.g. notes, Formulas or charts) emitting L{QuickNavItem} objects.
 	"""
 
 	def __init__(self, itemType , document , direction , includeCurrent):
@@ -338,7 +338,7 @@ class ExcelQuicknavIterator(object):
 
 	def collectionFromWorksheet(self,worksheetObject):
 		"""
-		Fetches a Microsoft Excel collection object from a Microsoft excel worksheet object. E.g. charts, comments, or formula.
+		Fetches a Microsoft Excel collection object from a Microsoft excel worksheet object. E.g. charts, notes, or formula.
 		@param worksheetObject: a Microsoft excel worksheet object.
 		@return: a Microsoft excel collection object.
 		"""
@@ -582,7 +582,7 @@ class ElementsListDialog(browseMode.ElementsListDialog):
 		("chart", _("&Charts")),
 		# Translators: The label of a radio button to select the type of element
 		# in the browse mode Elements List dialog.
-		("comment", _("C&omments")),
+		("comment", _("N&otes")),
 		# Translators: The label of a radio button to select the type of element
 		# in the browse mode Elements List dialog.
 		("formula", _("Fo&rmulas")),
@@ -1400,24 +1400,25 @@ class ExcelCell(ExcelBase):
 		level=max(self.excelCellInfo.outlineLevel-1,0) or None
 		return {'level':level}
 
+	# In Office 2016, 365 and newer, comments are now called notes. Thus, messages dialog title and so on should refer to notes.
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None
 		if text:
 			ui.message(text)
 		else:
-			# Translators: A message in Excel when there is no comment
-			ui.message(_("Not on a comment"))
+			# Translators: A message in Excel when there is no note
+			ui.message(_("Not on a note"))
 	# Translators: the description  for a script for Excel
-	script_reportComment.__doc__=_("Reports the comment on the current cell")
+	script_reportComment.__doc__=_("Reports the note on the current cell")
 
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		d = wx.TextEntryDialog(gui.mainFrame, 
 			# Translators: Dialog text for 
-			_("Editing comment for cell {address}").format(address=self.cellCoordsText),
-			# Translators: Title of a dialog edit an Excel comment 
-			_("Comment"),
+			_("Editing note for cell {address}").format(address=self.cellCoordsText),
+			# Translators: Title of a dialog edit an Excel note 
+			_("Note"),
 			value=commentObj.text() if commentObj else u"",
 			style=wx.TE_MULTILINE|wx.OK|wx.CANCEL)
 		def callback(result):
@@ -1453,7 +1454,7 @@ class ExcelCell(ExcelBase):
 		"kb:NVDA+shift+r": "setRowHeader",
 		"kb:shift+f2":"editComment",
 		"kb:alt+downArrow":"openDropdown",
-		"kb:NVDA+alt+c":"reportComment",
+		"kb:NVDA+alt+n":"reportComment",
 	}
 
 class ExcelSelection(ExcelBase):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2011,7 +2011,7 @@ class DocumentFormattingPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
-		commentsText = _("Co&mments")
+		commentsText = _("No&tes and comments")
 		self.commentsCheckBox=docInfoGroup.addItem(wx.CheckBox(self,label=commentsText))
 		self.commentsCheckBox.SetValue(config.conf["documentFormatting"]["reportComments"])
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
 - You can now utilize table navigation in list boxes with checkable list items when the particular list has multiple columns. (#8857)
 - In the Add-ons manager, when prompted to confirm removal of an add-on, "No" is now the default. (#10015)
 - In Microsoft Excel, the Elements List dialog now presents formulas in their localized form. (#9144)
+- NVDA now reports the correct terminology for notes in MS Excel. (#11311)
 
 
 == Bug Fixes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -891,10 +891,10 @@ For each form field, the Elements List shows the alternative text of the field a
 Selecting a form field and pressing enter or the Move to button moves to that field in browse mode.
 -
 
-+++ Reporting Notes +++[ExcelReportingNotes]
++++ Reporting Notes +++[ExcelReportingComments]
 %kc:beginInclude
+To report any notes for the currently focused cell, press NVDA+alt+c.
 In Microsoft 2016, 365 and newer, the classic comments in Microsoft Excel have been renamed to "notes".
-To report any notes for the currently focused cell, press NVDA+alt+n.
 %kc:endInclude
 All notes for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -69,9 +69,7 @@ For details regarding exceptions, access the license document from the NVDA menu
 - Operating Systems: all 32-bit and 64-bit editions of Windows 7, Windows 8, Windows 8.1, Windows 10, and all Server Operating Systems starting from Windows Server 2008 R2.
  - For Windows 7, NVDA requires Service Pack 1 or higher.
  - For Windows Server 2008 R2, NVDA requires Service Pack 1 or higher.
-- Memory: 256 mb or more of RAM
-- Processor speed: 1.0 ghz or above
-- About 90 MB of storage space.
+- at least 150 MB of storage space.
 -
 
 + Getting and Setting Up NVDA +[GettingAndSettingUpNVDA]
@@ -893,22 +891,28 @@ For each form field, the Elements List shows the alternative text of the field a
 Selecting a form field and pressing enter or the Move to button moves to that field in browse mode.
 -
 
-+++ Reporting Comments +++[ExcelReportingComments]
++++ Reporting Notes +++[ExcelReportingNotes]
 %kc:beginInclude
-To report any comments for the currently focused cell, press NVDA+alt+c.
+In Microsoft 2016, 365 and newer, the classic comments in Microsoft Excel have been renamed to "notes".
+To report any notes for the currently focused cell, press NVDA+alt+n.
 %kc:endInclude
-All comments for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.
+All notes for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.
 
-NVDA can also display a specific dialog for adding or editing a certain comment.
-NVDA overrides the native MS Excel comment editing region due to accessibility constraints, but the key stroke for displaying the dialog is inherited from MS Excel and therefore works also without NVDA running.
+NVDA can also display a specific dialog for adding or editing a certain note.
+NVDA overrides the native MS Excel notes editing region due to accessibility constraints, but the key stroke for displaying the dialog is inherited from MS Excel and therefore works also without NVDA running.
 %kc:beginInclude
-To add or edit a certain comment, in a focused cell, press shift+f2.
+To add or edit a certain note, in a focused cell, press shift+f2.
 %kc:endInclude
 
 This key stroke does not appear and cannot be changed in NVDA's input gesture dialog.
 
-Note: it is possible to open the comment editing region in MS Excel also from the context menu of any cell of the work sheet.
-However, this will open the inaccessible comment editing region and not the NVDA specific comment editing dialog.
+Note: it is possible to open the note editing region in MS Excel also from the context menu of any cell of the work sheet.
+However, this will open the inaccessible note editing region and not the NVDA specific note editing dialog.
+
+In Microsoft Office 2016, 365 and newer, a new style comment dialog has been added.
+This dialog is accessible and provides more features such as replying to comments, etc.
+It can also be opened from the context menu of a certain cell.
+The comments added to the cells via the new style comment dialog are not related to "notes".
 
 +++ Reading Protected Cells +++[ExcelReadingProtectedCells]
 If a workbook has been protected, it may not be possible to move focus to particular cells that have been locked for editing.
@@ -1294,6 +1298,7 @@ The selection indicator is not affected by this option, it is always dots 7 and 
 ==== Message Timeout (sec) ====[BrailleSettingsMessageTimeout]
 This option is a numerical field that controls how long NVDA messages are displayed on the braille display.
 Specifying 0 disables displaying of these messages completely.
+The NVDA message is imediately dismissed when pressing a routing key on the braille display, but appears again when pressing a coresponding key which triggers the message.
 
 ==== Show Messages Indefinitely ====[BrailleSettingsNoMessageTimeout]
 This option allows NVDA messages to be displayed on the braille display indefinitely.


### PR DESCRIPTION
### Link to issue number:
fixes #10923 
fixes #4864 
Addresses discussions in #11153.

### Summary of the issue:
Outdated system requirements and missing note for braille timeout.
The main issue addressed here however, is the new controltype in MS Excel since version 2016, which introduces new style comments, allowing for replying to comments and creating conversations on a specific cell or cell range. Thus, the comments as they were called in previous MS Office versions are now called "notes". The new style comment editing dialog is different from the notes editing dialog. The notes editing dialog is the former comments editing dialog, which remains also inaccessible in MS Office 2016, 365 and newer.

### Description of how this pull request fixes the issue:
1. Updated system requirements and added a small note to braille timeout (very small change thus I included it in this PR)
2. Changed all messages in MS Excel, as well as coresponding dialog title for the NVDA specific comment editing dialog (shift+f2) and the item label in elements list, now refering to notes instead of comments. Changed also the key stroke in MS Excel to report notes from nvda+alt+c to nvda+alt+n.

### Testing performed:
Tested in MS Excel:
* That in elements list, the item is called notes instead of comments
* That pressing nvda+alt+n reports the note added via the notes editing dialog and the NVDA specific notes editing dialog (shift+f2)
* Checked that the NVDA specific note editing dialog (shift+f2) is refering to notes and not to comments.
Tested in Microsoft Word and Powerpoint:
* That NVDA+alt+c still reports the comments as before.

### Known issues with pull request:
* When focusing a cell with notes, NVDA still reports "has comment" while it should now report "has note". This is because the controltype for controls which contain a comment is the same controltype used in MS Word and Powerpoint, thus it is defined in controltypes as one type with the label "has comment".
* The comment controltype in Excel should be separated from the controltype in MS Word and Powerpoint, changing its label to "has note"
* A new controltype for MS Excel should have the label "has comment" which should report the cells with new style comments. For that new controltype, the key stroke nvda+alt+c should be assigned, to be consistent with MS Word.

### Other notes
* In MS Word, the new style comments and the notes are not splited, so they are the same. This means we must adjust how NVDA treats this in Excel only.
* The downgrade is that people using Excel 2013 or older will still get notes reported although in those versions of MS Excel they are still called comments.

### Change log entry:

Section: Changes,
* NVDA now reports the correct terminology for notes in MS Excel