### PR TITLE
User Guide: Provide link to Python Regular Expression HowTo in section 12.2.1. Speech dictionaries (#10958)

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1873,7 +1873,7 @@ This condition is met if the characters immediately before and after the word ar
 Thus, using the earlier example of replacing the word "bird" with "frog", if you were to make this a whole word replacement, it would not match "birds" or "bluebird".
 
 A regular expression is a pattern containing special symbols that allow you to match on more than one character at a time, or match on just numbers, or just letters, as a few examples.
-Regular expressions are not covered in this user guide, but there are many tutorials on the web which can provide you with more information.
+Regular expressions are not covered in this user guide. For an introductory tutorial, please refer to [https://docs.python.org/3.7/howto/regex.html].
 
 +++ Punctuation/symbol pronunciation +++[SymbolPronunciation]
 This dialog allows you to change the way punctuation and other symbols are pronounced, as well as the symbol level at which they are spoken.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1873,7 +1873,9 @@ This condition is met if the characters immediately before and after the word ar
 Thus, using the earlier example of replacing the word "bird" with "frog", if you were to make this a whole word replacement, it would not match "birds" or "bluebird".
 
 A regular expression is a pattern containing special symbols that allow you to match on more than one character at a time, or match on just numbers, or just letters, as a few examples.
-Regular expressions are not covered in this user guide. For an introductory tutorial, please refer to [https://docs.python.org/3.7/howto/regex.html].
+Regular expressions are not covered in this user guide.
+For an introductory tutorial, please refer to [https://docs.python.org/3.7/howto/regex.html].
+
 
 +++ Punctuation/symbol pronunciation +++[SymbolPronunciation]
 This dialog allows you to change the way punctuation and other symbols are pronounced, as well as the symbol level at which they are spoken.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10958

### Summary of the issue:

Section 12.2.1. Speech dictionaries of the User Guide notes the ability to use regular expressions in dictionary rules. It states:

> Regular expressions are not covered in this user guide, but there are many tutorials on the web which can provide you with more information.

This is true, however different Regex engines work slightly differently from each other.

### Description of how this pull request fixes the issue:

As proposed by @Qchristensen, link to the Regular Expression howto document for Python 3.7, which NVDA uses:

https://docs.python.org/3.7/howto/regex.html

### Testing performed:

Built the User Guide and ensured proper rendering.

### Known issues with pull request:

None.

### Change log entry:

I guess this does not deserve a change log entry.