### PR TITLE
Fix: NVDA remains silent when deleting a word with `control+delete` (#3298, #11029)

### DIFF
--- a/source/editableText.py
+++ b/source/editableText.py
@@ -1,8 +1,7 @@
-#editableText.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Davy Kager
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2020 NV Access Limited, Davy Kager, Julien Cochuyt
 
 """Common support for editable text.
 @note: If you want editable text functionality for an NVDAObject,
@@ -267,7 +266,7 @@ class EditableText(TextContainerObject,ScriptableObject):
 	def script_caret_backspaceWord(self,gesture):
 		self._backspaceScriptHelper(textInfos.UNIT_WORD,gesture)
 
-	def script_caret_delete(self,gesture):
+	def _deleteScriptHelper(self, unit, gesture):
 		try:
 			info=self.makeTextInfo(textInfos.POSITION_CARET)
 		except:
@@ -279,8 +278,14 @@ class EditableText(TextContainerObject,ScriptableObject):
 		gesture.send()
 		# We'll try waiting for the caret to move, but we don't care if it doesn't.
 		caretMoved,newInfo=self._hasCaretMoved(bookmark,origWord=word)
-		self._caretScriptPostMovedHelper(textInfos.UNIT_CHARACTER,gesture,newInfo)
+		self._caretScriptPostMovedHelper(unit, gesture, newInfo)
 		braille.handler.handleCaretMove(self)
+
+	def script_caret_deleteCharacter(self, gesture):
+		self._deleteScriptHelper(textInfos.UNIT_CHARACTER, gesture)
+
+	def script_caret_deleteWord(self, gesture):
+		self._deleteScriptHelper(textInfos.UNIT_WORD, gesture)
 
 	__gestures = {
 		"kb:upArrow": "caret_moveByLine",
@@ -299,8 +304,10 @@ class EditableText(TextContainerObject,ScriptableObject):
 		"kb:end": "caret_moveByCharacter",
 		"kb:control+home": "caret_moveByLine",
 		"kb:control+end": "caret_moveByLine",
-		"kb:delete": "caret_delete",
-		"kb:numpadDelete": "caret_delete",
+		"kb:delete": "caret_deleteCharacter",
+		"kb:numpadDelete": "caret_deleteCharacter",
+		"kb:control+delete": "caret_deleteWord",
+		"kb:control+numpadDelete": "caret_deleteWord",
 		"kb:backspace": "caret_backspaceCharacter",
 		"kb:control+backspace": "caret_backspaceWord",
 	}


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #3298
Fixes #11029

### Summary of the issue:

As summarized by @bhavyashah in https://github.com/nvaccess/nvda/issues/3298#issuecomment-322667385:

> - Backspace erases the character at the left of the system caret and NVDA reports the erased character.
> - Delete erases the character at the right of the system caret and NVDA reports the character to the immediate right of the deleted character.
> - Ctrl+Backspace deletes the word at the left of the system caret and NVDA reports the erased word.
> - However, the bug is that when Ctrl+Delete is pressed, and it erases the word to the right of the system caret, NVDA remains silent. A user would ideally expect to hear the word present at the immediate right of the deleted word when Ctrl+Delete is pressed for consistency as well as functionality.

### Description of how this pull request fixes the issue:

NVDA now announces the word present at the immediate right of the deleted word when `control+delete` is pressed.

### Testing performed:

Deleted by characters and by words in various editors including Notepad, Microsoft Word and HTML forms with Google Chrome.

### Known issues with pull request:

As mentioned in various comments in both #3298 and #11029, some might have expected the deleted word should be announced, just like with `control+backspace`.
However, for consistency with `backspace` vs `delete`, I took here the path described by @bhavyashah in https://github.com/nvaccess/nvda/issues/3298#issuecomment-322667385:
Of course, you're welcome to criticize this decision.

Also, I did not lint the whole of the reused code and kept the legacy gesture binding pattern in order to reduce the diff and ease review. Please tell if you prefer otherwise.

### Change log entry:

Section: Bug fixes

When deleting a word with `control+delete`, NVDA no longer remains silent. It now announces the word present at the immediate right of the deleted word.