### PR TITLE
Restore chrome system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -87,13 +87,15 @@ class ChromeLib:
 		path = self._writeTestFile(testCase)
 		self.start_chrome(path)
 		# Ensure chrome started
+		# Different versions of chrome have variations in how the title is presented
+		# This may mean that there is a separator between document name and
+		# application name. E.G. "htmlTest   Google Chrome", "html – Google Chrome" or perhaps no applcation
+		# name at all.
+		# Rather than try to get this right, just wait for the doc title.
+		# If this continues to be unreliable we could use solenium or similar to start chrome and inform us when
+		# it is ready.
 		applicationTitle = f"{self._testCaseTitle}"
 		spy.wait_for_specific_speech(applicationTitle)
-		# Different versions of chrome have small variations in the separator between document name and
-		# application name. E.G. "htmlTest   Google Chrome", "html – Google Chrome"
-		# Rather than try to get the separator right, wait for the doc title, then wait for the 'Google Chrome'
-		# part. Note: this also works with "Chrome Canary"
-		spy.wait_for_specific_speech("Google Chrome")
 		# Read all is configured, but just test interacting with the sample.
 		spy.wait_for_speech_to_finish()
 

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -44,7 +44,11 @@ class ChromeLib:
 	def start_chrome(self, filePath):
 		builtIn.log(f"starting chrome: {filePath}")
 		self.chromeHandle = process.start_process(
-			f"start chrome \"{filePath}\"",
+			"start chrome"
+			" --force-renderer-accessibility"
+			" --suppress-message-center-popups"
+			" --disable-notifications"
+			f' "{filePath}"',
 			shell=True,
 			alias='chromeAlias',
 		)

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -104,21 +104,21 @@ class ChromeLib:
 			# Small changes in Chrome mean the number of tab presses to get into the document can vary.
 			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
 			actualSpeech = self.getSpeechAfterTab()
-			if actualSpeech == f"{ChromeLib._beforeMarker}  button":
+			if ChromeLib._beforeMarker in actualSpeech:
 				break
-			if actualSpeech == f"{ChromeLib._afterMarker}  button":
+			if ChromeLib._afterMarker in actualSpeech:
 				# somehow missed the start marker!
 				spy.dump_speech_to_log()
 				builtIn.fail(
 					"Unable to tab to 'before sample' marker, reached 'after sample' marker first."
-					f" Looking for '{ChromeLib._beforeMarker}  button'"
+					f" Looking for '{ChromeLib._beforeMarker}'"
 					" See NVDA log for full speech."
 				)
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(
 				"Unable to tab to 'before sample' marker."
-				f" Too many attempts looking for '{ChromeLib._beforeMarker}  button'"
+				f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
 				" See NVDA log for full speech."
 			)
 

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -108,19 +108,19 @@ class ChromeLib:
 				break
 			if actualSpeech == f"{ChromeLib._afterMarker}  button":
 				# somehow missed the start marker!
+				spy.dump_speech_to_log()
 				builtIn.fail(
 					"Unable to tab to 'before sample' marker, reached 'after sample' marker first."
 					f" Looking for '{ChromeLib._beforeMarker}  button'"
 					" See NVDA log for full speech."
 				)
-				spy.dump_speech_to_log()
 		else:  # Exceeded the number of tries
+			spy.dump_speech_to_log()
 			builtIn.fail(
 				"Unable to tab to 'before sample' marker."
 				f" Too many attempts looking for '{ChromeLib._beforeMarker}  button'"
 				" See NVDA log for full speech."
 			)
-			spy.dump_speech_to_log()
 
 	@staticmethod
 	def getSpeechAfterTab() -> str:

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -100,7 +100,7 @@ class ChromeLib:
 		# move to start marker
 		for i in range(10):  # set a limit on the number of tries.
 			# Small changes in Chrome mean the number of tab presses to get into the document can vary.
-			builtIn.sleep(0.5)  # ensure application has time to receive input
+			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
 			actualSpeech = self.getSpeechAfterTab()
 			if actualSpeech == f"{ChromeLib._beforeMarker}  button":
 				break

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -205,12 +205,18 @@ class NvdaLib:
 	def save_NVDA_log(self):
 		"""NVDA logs are saved to the ${OUTPUT DIR}/nvdaTestRunLogs/${SUITE NAME}-${TEST NAME}-nvda.log"""
 		builtIn.log("Saving NVDA log")
-		saveToPath = _pJoin(_locations.preservedLogsDir, self._createTestIdFileName("nvda.log"))
+		saveToPath = self.create_preserved_test_output_filename("nvda.log")
 		opSys.copy_file(
 			_locations.logPath,
 			saveToPath
 		)
 		builtIn.log(f"Log saved to: {saveToPath}", level='DEBUG')
+
+	def create_preserved_test_output_filename(self, fileName):
+		"""EG for nvda.log path will become:
+			${OUTPUT DIR}/nvdaTestRunLogs/${SUITE NAME}-${TEST NAME}-nvda.log
+		"""
+		return _pJoin(_locations.preservedLogsDir, self._createTestIdFileName(fileName))
 
 	def quit_NVDA(self):
 		builtIn.log("Stopping nvdaSpy server: {}".format(self._spyServerURI))

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -9,7 +9,7 @@ package. This enables sharing utility methods between the global plugin and othe
 """
 
 from time import sleep as _sleep
-from time import clock as _timer
+from time import perf_counter as _timer
 from typing import Any, Callable, Optional, Tuple
 
 

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -135,13 +135,16 @@ class NVDASpyLib:
 			log.info("No developer info for navigator object")
 
 	def dump_speech_to_log(self):
+		log.debug("dump_speech_to_log.")
 		with threading.Lock():
 			try:
 				self._devInfoToLog()
 			except Exception:
 				log.error("Unable to log dev info")
-
-			log.debug(f"All speech:\n{repr(self._nvdaSpeech_requiresLock)}")
+			try:
+				log.debug(f"All speech:\n{repr(self._nvdaSpeech_requiresLock)}")
+			except Exception:
+				log.error("Unable to log speech")
 
 	def _minTimeout(self, timeout: float) -> float:
 		"""Helper to get the minimum value, the timeout passed in, or self._maxKeywordDuration"""

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -15,7 +15,7 @@ import globalPluginHandler
 import threading
 from .blockUntilConditionMet import _blockUntilConditionMet
 from logHandler import log
-from time import clock as _timer
+from time import perf_counter as _timer
 
 import sys
 import os

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -126,8 +126,21 @@ class NVDASpyLib:
 		with threading.Lock():
 			return self.SPEECH_HAS_FINISHED_SECONDS < _timer() - self._lastSpeechTime_requiresLock
 
+	def _devInfoToLog(self):
+		import api
+		obj = api.getNavigatorObject()
+		if hasattr(obj, "devInfo"):
+			log.info("Developer info for navigator object:\n%s" % "\n".join(obj.devInfo))
+		else:
+			log.info("No developer info for navigator object")
+
 	def dump_speech_to_log(self):
 		with threading.Lock():
+			try:
+				self._devInfoToLog()
+			except Exception:
+				log.error("Unable to log dev info")
+
 			log.debug(f"All speech:\n{repr(self._nvdaSpeech_requiresLock)}")
 
 	def _minTimeout(self, timeout: float) -> float:

--- a/tests/system/requirements.txt
+++ b/tests/system/requirements.txt
@@ -7,3 +7,4 @@ pyautogui==0.9.43
 nose
 robotframework
 robotremoteserver
+robotframework-screencaplibrary

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -10,9 +10,16 @@ Force Tags	NVDA	smoke test	browser	chrome
 Library	NvdaLib.py
 # for test cases
 Library	chromeTests.py
+Library	ScreenCapLibrary
 
 Test Setup	start NVDA	standard-dontShowWelcomeDialog.ini
-Test Teardown	quit NVDA
+Test Teardown	default teardown
+
+*** Keywords ***
+default teardown
+	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
+	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
+	quit NVDA
 
 *** Test Cases ***
 

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -25,6 +25,4 @@ default teardown
 
 checkbox labelled by inner element
 	[Documentation]	A checkbox labelled by an inner element should not read the label element twice.
-	# Excluded due to intermittent failure: #11053
-	[Tags]	excluded_from_build
 	checkbox_labelled_by_inner_element

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -9,10 +9,16 @@ Force Tags	NVDA	smoke test
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py
 Library	startupShutdownNVDA.py
+Library	ScreenCapLibrary
 
 Test Setup	start NVDA	standard-dontShowWelcomeDialog.ini
-Test Teardown	quit NVDA
+Test Teardown	default teardown
 
+*** Keywords ***
+default teardown
+	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
+	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
+	quit NVDA
 
 *** Test Cases ***
 Starts

--- a/tests/system/sconscript
+++ b/tests/system/sconscript
@@ -18,13 +18,17 @@ Import("env")
 import os
 
 tests = env.get("filter")
-env = Environment(
-	ENV={
-		'PATH': os.environ['PATH'],
-		'TEMP': os.environ['TEMP'],
-		'TMP': os.environ['TMP'],
-	})
-
+# This should probably be limited just to the environment vars needed for NVDA to run.
+# EG: testRunnerEnv = Environment(
+# 	ENV={
+# 		'PATH': os.environ['PATH'],
+# 		'TEMP': os.environ['TEMP'],
+# 		'TMP': os.environ['TMP'],
+# 	})
+# On CI, tests are run directly (using CI env), not via SCons. See appveyor.yml.
+# Running tests via SCons is included for developer convenience. Since it is likely that the
+# developers environment is appropriate for running NVDA, we will just inherit it.
+testRunnerEnv = Environment(ENV=os.environ)  # noqa: F821 Flake8 does not recognise scons patterns.
 
 cmd = [
 	sys.executable, "-m", "robot",
@@ -35,5 +39,5 @@ if tests:
 	cmd += ['--test="{}"'.format(tests)]
 
 cmd.append("./tests/system/robot")  # must be the final argument
-target = env.Command(".", None, [cmd])
+target = testRunnerEnv.Command(".", None, [cmd])
 Return('target')


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#11053

### Summary of the issue:
Chrome system test was failing intermittently. It was difficult to determine why the chrome tests failed. several improvements have been made to make it easier in the future.

In addition the order "button" is now spoken before the "before sample" button. This is not important for this test, the intent is to place focus immediately before the sample to be tested.

### Description of how this pull request fixes the issue:
The system tests wait for the chrome window title in order to know that chrome has started, however, the title of the chrome window seems to vary. This PR removes the check for the chrome part of the title, only looking for the title of the document opened.

Removed the requirement for "button" to be spoken when finding the marker.

Chrome is started explicitly with accessibility support, toasts and notifications turned off to reduce fragility.

Removed deprecated `time import clock`

A screenshot is saved after a failing test, this should us to spot any rogue notification / error / application that may interfere. 

### Testing performed:
Ran locally with scons, and directly.
CI build / test.

### Known issues with pull request:
None

### Change log entry:
None


