### PR TITLE
Fix pop error on empty list

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -307,7 +307,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		while fields[-1] is not None:
 			# The end hasn't yet been reached, which means it isn't a descendant of obj.
 			# Therefore, continue from where obj was embedded.
-			if withFields:
+			if withFields and controlStack:
 				field = controlStack.pop()
 				if field:
 					# This object had a control field.


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
fixes #10619 
### Summary of the issue:
An error is raised from braille code often. The impact of this has not been noticed, however it probably causes some later code to be skipped.

### Description of how this pull request fixes the issue:
It is hard to judge the exact intent of the original code, however, given that `field` is checked to
be truthy it was probably expected to be `None` if the list is empty. Given this, it seems like this whole block can be skipped.


### Testing performed:
None - We don't have a repro case for this issue. I propose we merge it into alpha and see if it causes worse problems! I suspect not, bombing out of this code with an exception that causes the rest of the cursor move code to be skipped seems worse.

### Known issues with pull request:
None

### Change log entry:
None
