### PR TITLE
Update espeak to commit f2939490e19350fa7ea74ec56a39deab61038bc9

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ For reference, the following run time dependencies are included in Git submodule
 
 * [comtypes](https://github.com/enthought/comtypes), version 1.1.7
 * [wxPython](https://www.wxpython.org/), version 4.0.3
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit ca65812a
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit f2939490e 
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit f9a265c

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,6 +13,7 @@ What's New in NVDA
 == Changes ==
 - The Report formatting script (NVDA+f) has now been changed to report the formatting at the system caret rather than at the review cursor position. To report formatting at the review cursor position now use NVDA+shift+f. (#9505)
 - NVDA no longer automatically sets the system focus to focusable elements by default in browse mode, improving performance and stability. (#11190)
+- Updated eSpeak-NG to 1.51-dev, commit f2939490e
 
 
 == Bug Fixes ==


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:
eSpeak-ng has not been updated in a while, unfortunately it has been a while since there was a release.

### Description of how this pull request fixes the issue:
This PR updates eSpeak-ng to the latest in-development version.

### Testing performed:
Smoke tested that using NVDA with espeak works from a local build.

### Known issues with pull request:
Lack of testing, hopefully some time on alpha gives enough confidence in this.

### Change log entry:

Changes: `- Updated eSpeak-NG to 1.51-dev, commit f2939490e`