### PR TITLE
Fix backspace issue with QLineEdit + Password echo mode with Qt 5.9

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -261,7 +261,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			start,end,text = self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_CHAR)
 		except COMError:
 			return super(IA2TextTextInfo,self)._getCharacterOffsets(offset)
-		if textUtils.isHighSurrogate(text) or textUtils.isLowSurrogate(text):
+		if text and (textUtils.isHighSurrogate(text) or textUtils.isLowSurrogate(text)):
 			# #8953: Some IA2 implementations, including Gecko and Chromium,
 			# erroneously report one offset for surrogates.
 			return super(IA2TextTextInfo,self)._getCharacterOffsets(offset)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -227,8 +227,6 @@ HIGH_SURROGATE_LAST = u"\uDBFF"
 
 def isHighSurrogate(ch: str) -> bool:
 	"""Returns if the given character is a high surrogate UTF-16 character."""
-	if ch is None:
-		return False
 	return HIGH_SURROGATE_FIRST <= ch <= HIGH_SURROGATE_LAST
 
 LOW_SURROGATE_FIRST = u"\uDC00"
@@ -236,6 +234,4 @@ LOW_SURROGATE_LAST = u"\uDFFF"
 
 def isLowSurrogate(ch: str) -> bool:
 	"""Returns if the given character is a low surrogate UTF-16 character."""
-	if ch is None:
-		return False
 	return LOW_SURROGATE_FIRST <= ch <= LOW_SURROGATE_LAST

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -227,6 +227,8 @@ HIGH_SURROGATE_LAST = u"\uDBFF"
 
 def isHighSurrogate(ch: str) -> bool:
 	"""Returns if the given character is a high surrogate UTF-16 character."""
+	if ch is None:
+		return False
 	return HIGH_SURROGATE_FIRST <= ch <= HIGH_SURROGATE_LAST
 
 LOW_SURROGATE_FIRST = u"\uDC00"
@@ -234,4 +236,6 @@ LOW_SURROGATE_LAST = u"\uDFFF"
 
 def isLowSurrogate(ch: str) -> bool:
 	"""Returns if the given character is a low surrogate UTF-16 character."""
+	if ch is None:
+		return False
 	return LOW_SURROGATE_FIRST <= ch <= LOW_SURROGATE_LAST


### PR DESCRIPTION
### Link to issue number:
NA

### Summary of the issue:
The issue is specific to the applications built with Qt 5.9. The password field doesn't accept backspace key.

### Description of how this pull request fixes the issue:
In Qt application, by setting echoMode Password to QLineEdit, we can have a password edit box.
When the user hits backspace key, NVDA reaches here:
https://github.com/nvaccess/nvda/blob/release-2019.3/source/NVDAObjects/IAccessible/__init__.py#L261
And it hits this Qt code:
https://github.com/qt/qtbase/blob/5.9/src/widgets/accessible/simplewidgets.cpp#L848-L849
So, ```start``` and ```end``` are -1 and ```text``` is None.
That raises an error here:
https://github.com/nvaccess/nvda/blob/release-2019.3/source/NVDAObjects/IAccessible/__init__.py#L264


### Testing performed:
1. Create a Qt widget base application with Qt 5.9.
2. Place a QLineEdit and set echoMode Password.
3. Build application and enter characters in the password edit box.
4. Press backspace key.

Without the fix, nothing gets deleted.
With the fix, the characters get deleted normally.


### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

