### PR TITLE
Fix: NVDA remains silent when deleting characters while holding shift (#9132)

### DIFF
--- a/source/editableText.py
+++ b/source/editableText.py
@@ -305,10 +305,13 @@ class EditableText(TextContainerObject,ScriptableObject):
 		"kb:control+home": "caret_moveByLine",
 		"kb:control+end": "caret_moveByLine",
 		"kb:delete": "caret_deleteCharacter",
+		"kb:shift+delete": "caret_deleteCharacter",
 		"kb:numpadDelete": "caret_deleteCharacter",
+		"kb:shift+numpadDelete": "caret_deleteCharacter",
 		"kb:control+delete": "caret_deleteWord",
 		"kb:control+numpadDelete": "caret_deleteWord",
 		"kb:backspace": "caret_backspaceCharacter",
+		"kb:shift+backspace": "caret_backspaceCharacter",
 		"kb:control+backspace": "caret_backspaceWord",
 	}
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9132

### Summary of the issue:

In a text editor, when deleting a character with `backspace` or `delete`, NVDA remains silent if the `shift` key is held.

### Description of how this pull request fixes the issue:

Maps `shift+backspace` / `shift+delete` to the same scripts as `backspace` and `delete`, respectively.

### Testing performed:

Tested in Notepad, Word and Chrome.

### Known issues with pull request:

While support for `shift+backspace` seems quite common, `shift+delete` does not delete the character at the right of the caret in Word or Chrome. It does in Notepad or random Windows text fields, though.

### Change log entry:

This gesture being admittedly rarely used, I guess this does not deserve a change log entry.