### PR TITLE
Excel - Element List dialog: Present the localized version of formulas (#9144)

### DIFF
--- a/nvdaHelper/remote/excel.cpp
+++ b/nvdaHelper/remote/excel.cpp
@@ -1,6 +1,6 @@
 /*
 This file is a part of the NVDA project.
-Copyright 2019 NV Access Limited.
+Copyright 2019-2020 NV Access Limited, Accessolutions, Julien Cochuyt
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -326,7 +326,7 @@ HRESULT getCellInfo(HWND hwnd, IDispatch* pDispatchRange, long cellInfoFlags, EX
 		}
 	}
 	if(cellInfoFlags&NVCELLINFOFLAG_FORMULA) {
-		res=_com_dispatch_raw_propget(pDispatchRange,XLDISPID_RANGE_FORMULA,VT_BSTR,&cellInfo->formula);
+		res = _com_dispatch_raw_propget(pDispatchRange, XLDISPID_RANGE_FORMULA_LOCAL, VT_BSTR, &cellInfo->formula);
 		if(FAILED(res)) {
 			LOG_DEBUGWARNING(L"range.formula failed with code "<<res);
 		}

--- a/nvdaHelper/remote/excel/Constants.h
+++ b/nvdaHelper/remote/excel/Constants.h
@@ -1,6 +1,6 @@
 /*
 This file is a part of the NVDA project.
-Copyright 2019 NV Access Limited.
+Copyright 2019-2020 NV Access Limited, Accessolutions, Julien Cochuyt
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -21,6 +21,7 @@ const long XLDISPID_WINDOW_APPLICATION=148;
 const long XLDISPID_APPLICATION_RANGE=197;
 const long XLDISPID_RANGE__NEWENUM=-4;
 const long XLDISPID_RANGE_FORMULA=261;
+const long XLDISPID_RANGE_FORMULA_LOCAL=263;
 const long XLDISPID_RANGE_ITEM=170;
 const long XLDISPID_RANGE_ROW=257;
 const long XLDISPID_RANGE_COLUMN=240;

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1,8 +1,7 @@
-#NVDAObjects/excel.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2016 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2020 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta, Accessolutions, Julien Cochuyt
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import abc
 import ctypes
@@ -317,7 +316,7 @@ class ExcelCommentQuickNavItem(ExcelRangeBasedQuickNavItem):
 class ExcelFormulaQuickNavItem(ExcelRangeBasedQuickNavItem):
 
 	def __init__( self , nodeType , document , formulaObject , formulaCollection ):
-		self.label = formulaObject.address(False,False,1,False) + " " + formulaObject.Formula
+		self.label = formulaObject.address(False, False, 1, False) + " " + formulaObject.FormulaLocal
 		super( ExcelFormulaQuickNavItem , self).__init__( nodeType , document , formulaObject , formulaCollection )
 
 class ExcelQuicknavIterator(object):


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #9144

### Summary of the issue:

In Microsoft Excel, the Elements List dialog presents formula in their English version, whatever the locale of the user.

### Description of how this pull request fixes the issue:

Present instead the localized version of the formula, as Excel itself presents it to the user.

### Testing performed:

From local source, opened the Elements List dialog in Excel 2016 with French locale on a worksheet containing formulas.

### Known issues with pull request:

To reduce the diff and limit the API impact for add-ons, I did not rename `ExcelCellInfo.formula` nor add a `formulaLocal` member. Instead, I simply filled the existing structure member with the appropriate value.
Please let me know if you feel this is less readable and prefer I proceed otherwise.

### Change log entry:

Section: Changes or Bug fixes, as you see fit.
In Microsoft Excel, the Elements List dialog now presents formulas in their localized form.