### PR TITLE
Sort some lists of the UI according to locale translation

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -8,6 +8,7 @@
 import itertools
 import os
 from typing import Iterable, Union, Tuple, List, Optional
+from locale import strxfrm
 
 import driverHandler
 import pkgutil
@@ -363,7 +364,7 @@ def getDisplayList(excludeNegativeChecks=True) -> List[Tuple[str, str]]:
 				log.debugWarning("Braille display driver %s reports as unavailable, excluding" % name)
 		except:
 			log.error("", exc_info=True)
-	displayList.sort(key=lambda d : d[1].lower())
+	displayList.sort(key=lambda d: strxfrm(d[1]))
 	if lastDisplay:
 		displayList.append(lastDisplay)
 	return displayList

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -7,6 +7,7 @@
 """
 
 import collections
+from locale import strxfrm
 
 #: The directory in which liblouis braille tables are located.
 TABLES_DIR = r"louis\tables"
@@ -55,7 +56,7 @@ def listTables():
 	@return: A list of braille tables.
 	@rtype: list of L{BrailleTable}
 	"""
-	return sorted(_tables.values(), key=lambda table: table.displayName)
+	return sorted(_tables.values(), key=lambda table: strxfrm(table.displayName))
 
 #: Maps old table names to new table names for tables renamed in newer versions of liblouis.
 RENAMED_TABLES = {

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -6,6 +6,7 @@
 
 import os
 import weakref
+from locale import strxfrm
 
 import addonAPIVersion
 import wx
@@ -355,7 +356,7 @@ class AddonsDialog(wx.Dialog, DpiScalingHelperMixin):
 		self.addonsList.DeleteAllItems()
 		self.curAddons=[]
 		anyAddonIncompatible = False
-		for addon in addonHandler.getAvailableAddons():
+		for addon in sorted(addonHandler.getAvailableAddons(), key=lambda a: strxfrm(a.manifest['summary'])):
 			self.addonsList.Append((
 				addon.manifest['summary'],
 				self.getAddonStatus(addon),

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -59,6 +59,7 @@ import weakref
 import time
 import keyLabels
 from .dpiScalingHelper import DpiScalingHelperMixin
+from locale import strxfrm
 
 class SettingsDialog(wx.Dialog, DpiScalingHelperMixin, metaclass=guiHelper.SIPABCMeta):
 	"""A settings dialog.
@@ -4016,11 +4017,11 @@ class InputGesturesDialog(SettingsDialog):
 		)
 		# Flatten the gestures mappings for faster access by the VirtualTree
 		self.flattenedGestures: FlattenedGestureMappings = []
-		for category in sorted(gestures):
+		for category in sorted(gestures, key=strxfrm):
 			commands = gestures[category]
 			self.flattenedGestures.append((
 				category,
-				[(command, commands[command]) for command in sorted(commands)]
+				[(command, commands[command]) for command in sorted(commands, key=strxfrm)]
 			))
 		#: The L{GesturesTree} actually reads from this attribute
 		self.filteredGestures: FlattenedGestureMappings = self.flattenedGestures

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -10,6 +10,7 @@ import os
 import pkgutil
 import importlib
 from typing import Optional
+from locale import strxfrm
 
 import config
 import baseObject
@@ -404,7 +405,7 @@ def getSynthList():
 				log.debugWarning("Synthesizer '%s' doesn't pass the check, excluding from list" % name)
 		except:  # noqa: E722 # Legacy bare except
 			log.error("", exc_info=True)
-	synthList.sort(key=lambda s: s[1].lower())
+	synthList.sort(key=lambda s: strxfrm(s[1]))
 	if lastSynth:
 		synthList.append(lastSynth)
 	return synthList


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

After having merged #10355, I realize that some other lists in the UI are not sorted correctly according to locale.
Add-on list in add-on manager dialog is not sorted at all in French, since add-on (untranslated) name are used instead of add-on summary.

The following lists present sorting issues with letters with diacritic:
* Gesture categories and gesture description in a category in the tree in the input gesture dialog
"État du système" is sorted at the end of the tree; should be after "Entrée" instead.
* input and output table lists in the Braille setting panel
"Éthiopien intégral" is sorted at the end of the list; should be after "Espéranto grade 1" instead.

### Description of how this pull request fixes the issue:

Sort the following UI lists according to locale using locale.strxfrm key:
* Add-on list in add-on manager dialog
* Gesture categories and gesture description in a category in the tree in the input gesture dialog
* input and output table lists in the Braille setting panel
* synthesizer list in the synth selection dialog
* Braille display list in the Braille display selection dialog

Note that for add-on list, manifest['summary'] was used instead of name since this is the displayed information in the list.

### Testing performed:

Tested that all lists are sorted correctly. For synth list and Braille display list, I have created new names with diacriticized letters since the issue does not appear with the synth and braille display I have in these lists.

### Known issues with pull request:

None

### Change log entry:

Not needed.
