### PR TITLE
Open With: treat Shell-Flyout as a good UIA window

### DIFF
--- a/source/appModules/openwith.py
+++ b/source/appModules/openwith.py
@@ -8,6 +8,7 @@ import appModuleHandler
 import controlTypes
 from NVDAObjects.UIA import UIA
 from NVDAObjects.behaviors import Dialog
+import winUser
 
 #win8hack: the nondefault items in the list of applications are not labeled
 class NonDefaultAppTile(UIA):
@@ -43,3 +44,9 @@ class AppModule(appModuleHandler.AppModule):
 			elif automationID=="ImmersiveOpenWithFlyout":
 				clsList.insert(0,ImmersiveOpenWithFlyout)
 
+	def isGoodUIAWindow(self, hwnd):
+		# #11335: Open With dialog isn't read in Windows 10 Version 2004 (May 2020 Update).
+		# Note that treating the below window as a UIA window will make NVDA no longer announce "pane".
+		if winUser.getClassName(hwnd) == "Shell_Flyout":
+			return True
+		return False

--- a/source/appModules/openwith.py
+++ b/source/appModules/openwith.py
@@ -1,8 +1,7 @@
-#appModules/openWith.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2011 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2011-2020 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 from comtypes import COMError
 import appModuleHandler

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -25,6 +25,7 @@ What's New in NVDA
 - In general settings panel, the language list is now sorted correctly. (#10348)
 - In the Input Gestures dialog, significantly improved performance while filtering. (#10307)(
 - You can now send Unicode characters beyond U+FFFF from a braille display. (#10796)
+- NVDA will announce Open With dialog content in Windows 10 May 2020 Update. (#11335)
 
 
 == Changes For Developers ==


### PR DESCRIPTION
### Link to issue number:
Closes #11335 

### Summary of the issue:
IN Windows 10 May 2020 Update, Open With dialog content is not announced on some systems.

### Description of how this pull request fixes the issue:
Treat Shell_Flyout window as a good UIA window as far as Open With dialog is concerned. Not only this resolves the mentioned issue, it will now let NVDA not announce "pane" when Open With opens. Also updated copyright header (the app module file was actually added in 2011 to provide a temporary workaround for Open With window in Windows 8 preview).

### Testing performed:
Tested via Windows 10 App Essentials add-on and via NVDA source code directly:

* Reading Open With window on all Windows releases since Windows 8.1: yes, reads dialog content.
* Reads Open With dialog in May 2020 Update: yes, reads dialog content.

### Known issues with pull request:
None

### Change log entry:
If one is to be provided:

Bug fixes: NVDA will announce Open With dialog content in Windows 10 May 2020 Update. (#11300 

### Additional considerations on app module content:
With the introduction of isGoodUIAWindow method in app modules, it might be tempting to go with this approach all the way - that is, remove overlay class chooser. Testing shows that it is okay to remove chooseNVDAObjectOverlayClasses for Open With app module for this particular case, but there might be times when overlay classes defined in this app module are needed. Therefore I propose revisiting the state of Open With app accessibility on Windows 8.1 and later before doing additional work on this app module after the pull request (perhaps deprecate this app module altogether).

Thanks.