### PR TITLE
Fix-up of #10307: Don't use bare except

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4101,7 +4101,7 @@ class InputGesturesDialog(SettingsDialog):
 		def run():
 			try:
 				self._filter(token, filter)
-			except:  # noqa: E722
+			except Exception:
 				log.exception()
 		
 		threading.Thread(
@@ -4277,7 +4277,7 @@ class InputGesturesDialog(SettingsDialog):
 		inputCore.manager.userGestureMap.clear()
 		try:
 			inputCore.manager.userGestureMap.save()
-		except:  # noqa: E722
+		except Exception:
 			log.debugWarning("", exc_info=True)
 			# Translators: An error displayed when saving user defined input gestures fails.
 			gui.messageBox(


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fix-up of #10307

### Summary of the issue:

While having a look at helping to resolve merge conflicts for #7784, I've had to re-read this old code of mine, recently merged into master.
I've back then used twice a bare except neutralized with `noqa: E722`.
If @leonardder had a chance to review this code, he would have wisely pointed out this is bad practice and requested for a change.
I know there are 271 other occurrences of bare except in the source code of NVDA vs. only 34 of `except Exception`, but please allow me to help move in the good direction rather than perpetuate errors - especially as the `noqa` constructs might lead new readers to erroneously assume this construct has recently been validated.

### Description of how this pull request fixes the issue:

Remove two occurrences, introduced by myself, of:
```
except:  # noqa: E722
```
by the correct form:
```
except Exception:
```

### Testing performed:

### Known issues with pull request:

### Change log entry:

N/A