### PR TITLE
use SetSelection for wx.Choice in the advanced settings dialog

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2480,7 +2480,7 @@ class AdvancedPanelControls(wx.Panel):
 		self.UIAInMSWordCheckBox.SetValue(self.UIAInMSWordCheckBox.defaultValue)
 		self.ConsoleUIACheckBox.SetValue(self.ConsoleUIACheckBox.defaultValue == 'UIA')
 		self.winConsoleSpeakPasswordsCheckBox.SetValue(self.winConsoleSpeakPasswordsCheckBox.defaultValue)
-		self.cancelExpiredFocusSpeechCombo.SetValue(self.cancelExpiredFocusSpeechCombo.defaultValue)
+		self.cancelExpiredFocusSpeechCombo.SetSelection(self.cancelExpiredFocusSpeechCombo.defaultValue)
 		self.keyboardSupportInLegacyCheckBox.SetValue(self.keyboardSupportInLegacyCheckBox.defaultValue)
 		self.autoFocusFocusableElementsCheckBox.SetValue(self.autoFocusFocusableElementsCheckBox.defaultValue)
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)


### PR DESCRIPTION
### Link to issue number:
Fixes #11341 
Fixes #11342
### Summary of the issue:
When resetting advanced settings to default the error sound was heard. This was caused by the fact that the selection in wx.Choice used for enabling cancellation of speech for expired focus event was tried to be set with SetValue rather than with SetSelection. As the method responsible for resetting settings failed there settings which should be restored to default after that  weren't.
### Description of how this pull request fixes the issue:
SetSelection is used.
### Testing performed:
Tested that error sound is no longer played and that value of all advanced settings is restored to default.
### Known issues with pull request:
None
### Change log entry:
That depends if this is going to be merged to beta or not. If  not:
Bug fixes:
It is again possible to reset advanced settings to default.