### PR TITLE
Synthesizer dialog: rename empty string in output device names to 'Microsoft Sound Mapper'

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -965,6 +965,10 @@ class SynthesizerSelectionDialog(SettingsDialog):
 		# headphones, etc.
 		deviceListLabelText = _("Audio output  &device:")
 		deviceNames=nvwave.getOutputDeviceNames()
+		# #11349: On Windows 10 20H1 and 20H2, Microsoft Sound Mapper returns an empty string.
+		if not deviceNames[0]:
+			# Translators: name for default (Microsoft Sound Mapper) audio output device.
+			deviceNames[0] = _("Microsoft Sound Mapper")
 		self.deviceList = settingsSizerHelper.addLabeledControl(deviceListLabelText, wx.Choice, choices=deviceNames)
 
 		try:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,6 +33,7 @@ What's New in NVDA
 - NVDA will announce Open With dialog content in Windows 10 May 2020 Update. (#11335)
 - A new experimental option in Advanced settings (Enable selective registration for UI Automation events and property changes) can provide major performance improvements in Microsoft Visual Studio and other UIAutomation based applications if enabled. (#11077, #11209)
 - For checkable list items, the selected state is no longer announced redundantly, and if applicable, the unselected state is announced instead. (#8554)
+- On Windows 10 May 2020 Update, NVDA now shows the Microsoft Sound Mapper when viewing output devices from synthesizer dialog. (#11349)
 
 
 == Changes For Developers ==


### PR DESCRIPTION

### Link to issue number:
Fixes #11349 

### Summary of the issue:
On Windows 10 Version 2004 (20H1) and 20H2, an empty string is returned when asking Windows for the friendly name of WAVE_MAPPER constant (-1). In older Windows releases, this is named 'Microsoft Sound Mapper'.

### Description of how this pull request fixes the issue:
If an empty string is returned, rename it to "Microsoft Sound Mapper" when listing output devices found in synthesizer dialog.

### Testing performed:
Tested by calling nvwave.GetOuputDeviceNames on thefollowing Windows 10 releases:

* Windows 10 earlier than 2004: first entry is "Microsoft Sound Mapper"
* Windows 10 Version 2004 and 20H2: first entry is an empty string
* Windows dev build 20161: first entry is "Microsoft Sound Mapper"

And making sure that for the second scenario, output device list found in synthesizer dialog says "Microsoft Sound Mapper". This was also confirmed on a virtual machine running build 20161 with Korean language pack installed - MS Sound Mapper entry is correctly translated.

### Known issues with pull request:
None

### Change log entry:
Bug fixes:

On Windows 10 May 2020 Update, NVDA will no longer show an empty device for Microsoft Sound Mapper when viewing output devices from synthesizer dialog. (#11349)

Or a more friendly entry if needed.

Thanks.