### PR TITLE
Fixes Excel selection reading for some synth/languages when the selected cells contain 3-digit number

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1487,7 +1487,14 @@ class ExcelSelection(ExcelBase):
 		firstCell=self.excelRangeObject.Item(1)
 		lastCell=self.excelRangeObject.Item(self.excelRangeObject.Count)
 		# Translators: This is presented in Excel to show the current selection, for example 'a1 c3 through a10 c10'
-		return _("{firstAddress} {firstContent} through {lastAddress} {lastContent}").format(firstAddress=self.getCellAddress(firstCell),firstContent=firstCell.Text,lastAddress=self.getCellAddress(lastCell),lastContent=lastCell.Text)
+		# Beware to keep two spaces between the address and the content. Otherwise some synthesizer
+		# may mix the address and the content when the cell contains a 3-digit number.
+		return _("{firstAddress}  {firstContent} through {lastAddress}  {lastContent}").format(
+			firstAddress=self.getCellAddress(firstCell),
+			firstContent=firstCell.Text,
+			lastAddress=self.getCellAddress(lastCell),
+			lastContent=lastCell.Text
+		)
 
 	def _get_parent(self):
 		worksheet=self.excelRangeObject.Worksheet


### PR DESCRIPTION
### Link to issue number:

Fixes #11363

### Summary of the issue:

When NVDA announces a selected range in Excel, some synth/languages mix the cell address and a 3-digit value to create a 4-digit value since the space is a thousand separator in these languages.

### Description of how this pull request fixes the issue:

* Insert two spaces instead of one between the cell address and its content in the announced message.
* Also modify the translator comment to warn the translators to keep these 2 spaces

Note: the only changes of this PR are the 2 x 2 space and the updated translator comment. The remaining changes are only due to linting.

I have chosen to fix this issue in core code and not only in translation repo so that:
* all translators will see the required formatting of this string as well as the explanation in the translator comment
* this allow to fix also the issue if a user uses NVDA in English (or not fully translated language) with a synthesizer language showing the issue such as eSpeak French or German.

### Testing performed:

Tested with eSpeak (French) and IBMTTS (French and Italian) that no number with thousands are not spoken in the example above.

### Known issues with pull request:

None.

### Change log entry:

Not needed in my opinion. This is a very minor issue.
