### PR TITLE
Watchdog: log all stacks (not just the main thread) when the core is …

### DIFF
--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -47,6 +47,23 @@ _suspended = False
 _watcherThread=None
 _cancelCallEvent = None
 
+
+def getFormattedStacksForAllThreads():
+	"""
+	Generates a string containing a call stack for every Python thread in this process, suitable for logging.
+	"""
+	# First collect the names of all threads that have actually been started by Python itself.
+	threadNamesByID = {x.ident: x.name for x in threading.enumerate()}
+	stacks = []
+	# If a Python function is entered by a thread that was not started by Python itself,
+	# It will have a frame, but won't be tracked by Python's threading module and therefore will have no name.
+	for ident, frame in sys._current_frames().items():
+		stack = "".join(traceback.format_stack(frame))
+		name = threadNamesByID.get(ident, "Unknown")
+		stacks.append(f"Python stack for thread {ident} ({name}):\n{stack}")
+	return "\n".join(stacks)
+
+
 def alive():
 	"""Inform the watchdog that the core is alive.
 	"""
@@ -103,8 +120,11 @@ def _watcher():
 			curTime=time.time()
 			if curTime-lastTime>FROZEN_WARNING_TIMEOUT:
 				lastTime=curTime
-				log.warning("Core frozen in stack:\n%s"%
-					"".join(traceback.format_stack(sys._current_frames()[core.mainThreadId])))
+				# Core is completely frozen.
+				# Collect formatted stacks for all Python threads.
+				log.error("Core frozen in stack!")
+				stacks = getFormattedStacksForAllThreads()
+				log.info(f"Listing stacks for Python threads:\n{stacks}")
 			_recoverAttempt()
 			time.sleep(RECOVER_ATTEMPT_INTERVAL)
 			if _isAlive():
@@ -174,9 +194,8 @@ def _crashHandler(exceptionInfo):
 		log.critical("NVDA crashed! Minidump written to %s" % dumpPath)
 
 	# Log Python stacks for every thread.
-	for logThread, logFrame in sys._current_frames().items():
-		log.info("Python stack for thread %d" % logThread,
-			stack_info=traceback.extract_stack(logFrame))
+	stacks = getFormattedStacksForAllThreads()
+	log.info(f"Listing stacks for Python threads:\n{stacks}")
 
 	log.info("Restarting due to crash")
 	core.restart()

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -58,6 +58,7 @@ def getFormattedStacksForAllThreads():
 	# If a Python function is entered by a thread that was not started by Python itself,
 	# It will have a frame, but won't be tracked by Python's threading module and therefore will have no name.
 	for ident, frame in sys._current_frames().items():
+		# The strings in the formatted stack all end with \n, so no join separator is necessary.
 		stack = "".join(traceback.format_stack(frame))
 		name = threadNamesByID.get(ident, "Unknown")
 		stacks.append(f"Python stack for thread {ident} ({name}):\n{stack}")


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
When NVDA detects its core has frozen, it only logs the stack for the main thread (core). However, the reason the core has frozen may be due to a deadlock with another of NVDA's threads (such as a thread handling an incoming RPC call.
  
### Description of how this pull request fixes the issue:
NVDA now logs the stack for all threads in NVDA that have a Python frame. The name of the thread is also included, if the thread was started by Python itself.
This functionality is all in its own new function: watchdog.getFormattedStacksForAllThreads(), which is called and its result is logged when the core is frozen.
The log call has also now been changed from level warning to level error, and all stacks are included in the one log call.
 
### Testing performed:
* Manually ran watchdog.getformattedStacksForAllThreads() from the Python console, and verified that all stacks were listed.
*  Caused NVDA to freeze when typing in MS Word (#11369) and verified that all stacks were logged.

### Known issues with pull request:
None.

### Change log entry:
None needed.