### PR TITLE
queueHandler: use SimpleQueue rather than Queue

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -398,7 +398,13 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 def nvdaControllerInternal_typedCharacterNotify(threadID,ch):
 	focus=api.getFocusObject()
 	if focus.windowClassName!="ConsoleWindowClass":
-		eventHandler.queueEvent("typedCharacter",focus,ch=ch)
+		# Manually queue a call to executeEvent rather than using queueEvent,
+		# As Currently queueEvent uses a lock and there is a small chance it could deadlock
+		# If garbage collection within the lock caused a COM object from the same thread as the typed character to be released.
+		queueHandler.queueFunction(
+			queueHandler.eventQueue,
+			eventHandler.executeEvent, "typedCharacter", focus, ch=ch
+		)
 	return 0
 
 @WINFUNCTYPE(c_long, c_int, c_int)

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -400,7 +400,8 @@ def nvdaControllerInternal_typedCharacterNotify(threadID,ch):
 	if focus.windowClassName!="ConsoleWindowClass":
 		# Manually queue a call to executeEvent rather than using queueEvent,
 		# As Currently queueEvent uses a lock and there is a small chance it could deadlock
-		# If garbage collection within the lock caused a COM object from the same thread as the typed character to be released.
+		# If garbage collection within the lock
+		# caused a COM object from the same thread as the typed character to be released.
 		queueHandler.queueFunction(
 			queueHandler.eventQueue,
 			eventHandler.executeEvent, "typedCharacter", focus, ch=ch

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -16,7 +16,7 @@ import core
 # as SimpleQueue is very light-weight, does not use locks
 # and ensures that garbage collection won't unexpectedly happen in the middle of queuing something
 # Which may cause a deadlock.
-eventQueue=SimpleQueue()
+eventQueue = SimpleQueue()
 
 generators={}
 lastGeneratorObjID=0

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -5,14 +5,19 @@
 #See the file COPYING for more details.
 
 import types
-from queue import Queue
+from queue import SimpleQueue
 import globalVars
 from logHandler import log
 import watchdog
 import core
 
-eventQueue=Queue()
-eventQueue.__name__="eventQueue"
+# A queue for calls that should be made on NVDA's main thread
+# #11369: We use SimpleQueue rather than Queue here
+# as SimpleQueue is very light-weight, does not use locks
+# and ensures that garbage collection won't unexpectedly happen in the middle of queuing something
+# Which may cause a deadlock.
+eventQueue=SimpleQueue()
+
 generators={}
 lastGeneratorObjID=0
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #11369 

### Summary of the issue:
It is possible for both NVDA and an app (such as Microsoft Word) to both deadlock when typing characters.
The process is as follows:
1. The usertypes a character in the app.
2. NVDA's in-process code detects the typed character in the app's main thread and calls back into NVDA via rpc.
3. NVDA handles the incoming rpc call by queuing a typedCharacter event via eventHandler.queueEvent.
4. While NVDA is queuing the event function with Queue.put:
4.1. Python's garbage collector runs and or Python deletes objects that are no longer in scope.
4.2. One or more of these objects are comtypes COM objects marshalled from the app's main thread that sent the typed character notification.
4.3. Python calls Release on one of these COM objects which waits upon the app's main thread to release the object. Deadlock.

Even if this were addressed, a second deadlock is possible:
1. The usertypes a character in the app.
2. NVDA's in-process code detects the typed character in the app's main thread and calls back into NVDA via rpc.
3. NVDA handles the incoming rpc call by queuing a typedCharacter event via eventHandler.queueEvent.
4. queueEvent acquires a lock and increments counts for the event name etc so that eventHandler.isPendingEvents can tell there are events  if it were to be called.
4.1. During the lock, Python's garbage collector runs and or Python deletes objects that are no longer in scope.
4.2. One or more of these objects are comtypes COM objects marshalled from the app's main thread that sent the typed character notification.
4.3. Python calls Release on one of these COM objects which waits upon the app's main thread to release the object. Deadlock.

### Description of changes
* queueHandler now uses a queue.SimpleQueue rather than a queue.Queue. SimpleQueue does not use locking, is unbounded and has no task management. We never needed any of that functionality anyways.
* nvdaHelper.nvdaControlerInternal_typedCharacterNotify now manually queues a call to executeEvent rather than calling queueEvent.
Both of these changes ensure that no locks are entered during that particular incoming RPC call.

### Testing performed
Tried to make MS Word / NVDA freeze by typing very fast into a document for at least 30 seconds. No freeze was experienced.

### Known Issues
I don't believe there any drawbacks to these changes, though they may not address the issue as specifically as they could. The root of the problem still remains that 
1. It seems to be impossible to cancel an IUnknown::release COM call.
2. The Python garbage collector and or out-of-scope deletion can occur at any time in any thread, and for comtypes, this may not be even the thread the COM object was marshalled to.

### Changelog
Bug fixes:
- NVDA should no longer sometimes freeze when rapidly typing in Microsoft Word documents.