### PR TITLE
Update eSpeak-ng to commit aafd2e72

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ For reference, the following run time dependencies are included in Git submodule
 
 * [comtypes](https://github.com/enthought/comtypes), version 1.1.7
 * [wxPython](https://www.wxpython.org/), version 4.0.3
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit f2939490e 
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 1fb68ffffea4 
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit 21bbb176
 * [ConfigObj](https://github.com/DiffSK/configobj), commit f9a265c

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,7 +15,7 @@ What's New in NVDA
 - The Report formatting script (NVDA+f) has now been changed to report the formatting at the system caret rather than at the review cursor position. To report formatting at the review cursor position now use NVDA+shift+f. (#9505)
 - NVDA no longer automatically sets the system focus to focusable elements by default in browse mode, improving performance and stability. (#11190)
 - CLDR updated from version 36.1 to version 37. (#11303)
-- Updated eSpeak-NG to 1.51-dev, commit f2939490e
+- Updated eSpeak-NG to 1.51-dev, commit 1fb68ffffea4
 - You can now utilize table navigation in list boxes with checkable list items when the particular list has multiple columns. (#8857)
 - In the Add-ons manager, when prompted to confirm removal of an add-on, "No" is now the default. (#10015)
 - In Microsoft Excel, the Elements List dialog now presents formulas in their localized form. (#9144)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes: #11254

### Summary of the issue:
Broken pronunciation of Hawai'i with espeak in English

### Description of how this pull request fixes the issue:
Update espeak-ng to include fix in commit https://github.com/espeak-ng/espeak-ng/commit/1fb68ffffea45bb1c182fdc27a4a436c69b937e5

### Testing performed:
Built and run locally with espeak synth
Tested reading the text on #11254

### Known issues with pull request:
None known

### Change log entry:

Section: Changes 

Modify `- Updated eSpeak-NG to 1.51-dev, commit f2939490e` to be `- Updated eSpeak-NG to 1.51-dev, commit 1fb68ffffea4`
