### PR TITLE
Navigator object vaidation before recognition in contentRecog

### DIFF
--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -59,7 +59,7 @@ class ContentRecognizer(object, metaclass=ABCMeta):
 		"""
 		raise NotImplementedError
 
-	def validateNavigatorObject(self, nav):
+	def validateObject(self, nav):
 		"""Validation to be performed on the navigator object before content recognition
 		@param nav: The navigator object to be validated
 		@type nav: L{NVDAObjects.NVDAObject}

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -59,6 +59,16 @@ class ContentRecognizer(object, metaclass=ABCMeta):
 		"""
 		raise NotImplementedError
 
+	def validateNavigatorObject(self, nav):
+		"""Validation to be performed on the navigator object before content recognition
+		@param nav: The navigator object to be validated
+		@type nav: L{NVDAObjects.NVDAObject}
+		@return: C{True} or C{False}, depending on whether the navigator object is valid or not.
+			C{True} for no validation.
+		@rtype: bool
+		"""
+		return True
+
 class RecogImageInfo(object):
 	"""Encapsulates information about a recognized image and
 	provides functionality to convert coordinates.

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -126,7 +126,7 @@ def recognizeNavigatorObject(recognizer):
 		ui.message(_("Already in a content recognition result"))
 		return
 	nav = api.getNavigatorObject()
-	if not recognizer.validateNavigatorObject(nav):
+	if not recognizer.validateObject(nav):
 		return
 	# Translators: Reported when content recognition (e.g. OCR) is attempted,
 	# but the content is not visible.

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -126,6 +126,8 @@ def recognizeNavigatorObject(recognizer):
 		ui.message(_("Already in a content recognition result"))
 		return
 	nav = api.getNavigatorObject()
+	if not recognizer.validateNavigatorObject(nav):
+		return
 	# Translators: Reported when content recognition (e.g. OCR) is attempted,
 	# but the content is not visible.
 	notVisibleMsg = _("Content is not visible")


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/11380

### Summary of the issue:
`contentRecog.recogUI.recognizeNavigatorObject` currently has no mechanism for validating the navigator object before passing it to the recognizer for content recognition. This allows navigator objects that are known to produce bad or no results to be processed for content recognition and waste user time.

### Description of how this pull request fixes the issue:
This pull request adds a `validateNavigatorObject` to `contentRecog.ContentRecognizer` that can then be overridden by users to define validation code for their application and also define what to do when validation fails. This function is then called in `contentRecog.recogUI.recognizeNavigatorObject` to ensure that the currently focused navigator object is valid before it is passed to the `recognizer` for content recognition.

### Testing performed:
I overrode the `validateNavigatorObject` function when creating a class that derives from `contentRecog.ContentRecognizer` to ensure that the width and height of the navigator object are greater than a specific threshold. I then tested the code on navigator objects with dimensions both greater and lower than the specified threshold and got expected results. Which is, content recognition was performed for navigator objects that passed the validation test and not on navigator objects that failed the test.

### Known issues with pull request:
None