### PR TITLE
Use locale.getpreferredencoding rather than locale.getlocale as latter can fail if Python doesn't know the locale

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -81,7 +81,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		if cp==SC_CP_UTF8:
 			return "utf-8"
 		else:
-			return textUtils.USERANSICODEPAGE
+			return textUtils.USER_ANSI_CODE_PAGE
 
 	def _getOffsetFromPoint(self,x,y):
 		x, y = winUser.ScreenToClient(self.obj.windowHandle, x, y)

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -16,7 +16,6 @@ import config
 from . import Window
 from .. import NVDAObjectTextInfo
 from ..behaviors import EditableTextWithAutoSelectDetection
-import locale
 import watchdog
 import eventHandler
 import locationHelper
@@ -82,7 +81,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		if cp==SC_CP_UTF8:
 			return "utf-8"
 		else:
-			return locale.getlocale()[1]
+			return textUtils.USERANSICODEPAGE
 
 	def _getOffsetFromPoint(self,x,y):
 		x, y = winUser.ScreenToClient(self.obj.windowHandle, x, y)

--- a/source/appModules/winamp.py
+++ b/source/appModules/winamp.py
@@ -116,7 +116,7 @@ class winampPlaylistEditor(winampMainWindow):
 			winKernel.virtualFreeEx(self.processHandle,internalInfo,0,winKernel.MEM_RELEASE)
 		# file title is fetched in the current locale encoding.
 		# We need to decode it to unicode first. 
-		encoding = textUtils.USERANSICODEPAGE
+		encoding = textUtils.USER_ANSI_CODE_PAGE
 		fileTitle=info.filetitle.decode(encoding,errors="replace")
 		return "%d.\t%s\t%s"%(curIndex+1,fileTitle,info.filelength)
 

--- a/source/appModules/winamp.py
+++ b/source/appModules/winamp.py
@@ -11,12 +11,12 @@ from scriptHandler import isScriptWaiting
 from NVDAObjects.IAccessible import IAccessible 
 import appModuleHandler
 import speech
-import locale
 import controlTypes
 import api
 import watchdog
 import braille
 import ui
+import textUtils
 
 # message used to sent many messages to winamp's main window. 
 # most all of the IPC_* messages involve sending the message in the form of:
@@ -116,7 +116,7 @@ class winampPlaylistEditor(winampMainWindow):
 			winKernel.virtualFreeEx(self.processHandle,internalInfo,0,winKernel.MEM_RELEASE)
 		# file title is fetched in the current locale encoding.
 		# We need to decode it to unicode first. 
-		encoding=locale.getlocale()[1]
+		encoding = textUtils.USERANSICODEPAGE
 		fileTitle=info.filetitle.decode(encoding,errors="replace")
 		return "%d.\t%s\t%s"%(curIndex+1,fileTitle,info.filelength)
 

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -17,7 +17,6 @@ import api
 import textUtils
 from dataclasses import dataclass
 from typing import Optional, Tuple
-import locale
 from logHandler import log
 
 @dataclass
@@ -282,7 +281,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		if self.encoding == textUtils.WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(text)
 			start, end = offsetConverter.wideToStrOffsets(start, end)
-		elif self.encoding not in (None, "utf_32_le", locale.getlocale()[1]):
+		elif self.encoding not in (None, "utf_32_le", textUtils.USERANSICODEPAGE):
 			raise NotImplementedError
 		return text[start:end]
 
@@ -346,7 +345,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return None
 
 	def _getCharacterOffsets(self, offset):
-		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
+		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", textUtils.USERANSICODEPAGE):
 			raise NotImplementedError
 		lineStart, lineEnd = self._getLineOffsets(offset)
 		lineText = self._getTextRange(lineStart, lineEnd)
@@ -363,7 +362,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return (offset, offset + 1)
 
 	def _getWordOffsets(self,offset):
-		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", locale.getlocale()[1]):
+		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", textUtils.USERANSICODEPAGE):
 			raise NotImplementedError
 		lineStart, lineEnd = self._getLineOffsets(offset)
 		lineText = self._getTextRange(lineStart,lineEnd)
@@ -397,7 +396,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			strStart=findStartOfLine(text, strOffset)
 			strEnd=findEndOfLine(text, strOffset)
 			return offsetConverter.strToWideOffsets(strStart, strEnd)
-		elif self.encoding not in (None, "utf_32_le", locale.getlocale()[1]):
+		elif self.encoding not in (None, "utf_32_le", textUtils.USERANSICODEPAGE):
 			raise NotImplementedError
 		start=findStartOfLine(text,offset)
 		end=findEndOfLine(text,offset)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -281,7 +281,11 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		if self.encoding == textUtils.WCHAR_ENCODING:
 			offsetConverter = textUtils.WideStringOffsetConverter(text)
 			start, end = offsetConverter.wideToStrOffsets(start, end)
-		elif self.encoding not in (None, "utf_32_le", textUtils.USERANSICODEPAGE):
+		elif not (
+			self.encoding is None
+			or self.encoding == "utf_32_le"
+			or self.encoding == textUtils.USER_ANSI_CODE_PAGE
+		):
 			raise NotImplementedError
 		return text[start:end]
 
@@ -345,7 +349,12 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return None
 
 	def _getCharacterOffsets(self, offset):
-		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", textUtils.USERANSICODEPAGE):
+		if not (
+			self.encoding == textUtils.WCHAR_ENCODING
+			or self.encoding is None
+			or self.encoding == "utf_32_le"
+			or self.encoding == textUtils.USER_ANSI_CODE_PAGE
+		):
 			raise NotImplementedError
 		lineStart, lineEnd = self._getLineOffsets(offset)
 		lineText = self._getTextRange(lineStart, lineEnd)
@@ -362,7 +371,12 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		return (offset, offset + 1)
 
 	def _getWordOffsets(self,offset):
-		if self.encoding not in (textUtils.WCHAR_ENCODING, None, "utf_32_le", textUtils.USERANSICODEPAGE):
+		if not (
+			self.encoding == textUtils.WCHAR_ENCODING
+			or self.encoding is None
+			or self.encoding == "utf_32_le"
+			or self.encoding == textUtils.USER_ANSI_CODE_PAGE
+		):
 			raise NotImplementedError
 		lineStart, lineEnd = self._getLineOffsets(offset)
 		lineText = self._getTextRange(lineStart,lineEnd)
@@ -396,7 +410,11 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			strStart=findStartOfLine(text, strOffset)
 			strEnd=findEndOfLine(text, strOffset)
 			return offsetConverter.strToWideOffsets(strStart, strEnd)
-		elif self.encoding not in (None, "utf_32_le", textUtils.USERANSICODEPAGE):
+		elif not (
+			self.encoding is None
+			or self.encoding == "utf_32_le"
+			or self.encoding == textUtils.USER_ANSI_CODE_PAGE
+		):
 			raise NotImplementedError
 		start=findStartOfLine(text,offset)
 		end=findEndOfLine(text,offset)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-#textUtils.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2018-2019 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2018-2020 NV Access Limited, Babbage B.V., Łukasz Golonka
 
 """
 Classes and utilities to deal with offsets variable width encodings, particularly utf_16.
@@ -18,6 +17,8 @@ import locale
 from logHandler import log
 
 WCHAR_ENCODING = "utf_16_le"
+USERANSICODEPAGE = locale.getpreferredencoding()
+
 
 class WideStringOffsetConverter:
 	R"""
@@ -201,7 +202,7 @@ def getTextFromRawBytes(
 		if numChars > 1 and any(buf[numChars:]):
 			encoding = WCHAR_ENCODING
 		else:
-			encoding = locale.getlocale()[1]
+			encoding = USERANSICODEPAGE
 	else:
 		encoding = encodings.normalize_encoding(encoding).lower()
 	if encoding.startswith("utf_16"):

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,4 +1,3 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -17,7 +16,7 @@ import locale
 from logHandler import log
 
 WCHAR_ENCODING = "utf_16_le"
-USERANSICODEPAGE = locale.getpreferredencoding()
+USER_ANSI_CODE_PAGE = locale.getpreferredencoding()
 
 
 class WideStringOffsetConverter:
@@ -202,7 +201,7 @@ def getTextFromRawBytes(
 		if numChars > 1 and any(buf[numChars:]):
 			encoding = WCHAR_ENCODING
 		else:
-			encoding = USERANSICODEPAGE
+			encoding = USER_ANSI_CODE_PAGE
 	else:
 		encoding = encodings.normalize_encoding(encoding).lower()
 	if encoding.startswith("utf_16"):


### PR DESCRIPTION

### Link to issue number:
Fixes #11155

### Summary of the issue:
Whenever we needed to access the ANSI Windows code page we were using `locale.getlocale`. This was  problematic for two reasons:
1. `locale.getlocale`` returns the Python locale which we're changing when setting NVDA language so returned code page may not correspond to the user code page for example when someone's system is in Polish but NVDA in English.
2. More importantly Python, or rather the win32 function which Python invokes under the hood, cannot  determine what code page should be used for some locales e.g. Aragonese.

### Description of how this pull request fixes the issue:
In places where `locale.getlocale` was  formerly used I've switched to `locale.getpreferredencoding` as this method returns ANSI code page of the current Windows user.

### Testing performed:
Switched NVDA language to Aragonese, navigated in Notepad, run dialog and cmd - previously navigation was  not possible due to the fact that AN was not recognized as a valid  locale by Python.
### Known issues with pull request:
- I don't know why @leonardder have chosen to use `locale.getlocale` in #9545 so it is possible that it breaks something which I haven't considered.
- #11006 - I believe fixing inability to navigate in edit fields for some locales  which additionally is a regression from Py3 migration can be classified as important bug fix.
### Change log entry:

Bug fixes

It is once again possible to navigate in various controls when NVDA is set to Aragonese.