### PR TITLE
Try f6 and no auto say all for chrome system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -107,17 +107,9 @@ class ChromeLib:
 		for i in range(10):  # set a limit on the number of tries.
 			# Small changes in Chrome mean the number of tab presses to get into the document can vary.
 			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
-			actualSpeech = self.getSpeechAfterTab()
+			actualSpeech = self.getSpeechAfterKey('F6')
 			if ChromeLib._beforeMarker in actualSpeech:
 				break
-			if ChromeLib._afterMarker in actualSpeech:
-				# somehow missed the start marker!
-				spy.dump_speech_to_log()
-				builtIn.fail(
-					"Unable to tab to 'before sample' marker, reached 'after sample' marker first."
-					f" Looking for '{ChromeLib._beforeMarker}'"
-					" See NVDA log for full speech."
-				)
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(
@@ -127,14 +119,21 @@ class ChromeLib:
 			)
 
 	@staticmethod
-	def getSpeechAfterTab() -> str:
-		"""Press tab, and get speech until it stops.
-		@return: The speech after tab.
+	def getSpeechAfterKey(key) -> str:
+		"""Ensure speech has stopped, press key, and get speech until it stops.
+		@return: The speech after key press.
 		"""
 		spy = _NvdaLib.getSpyLib()
 		spy.wait_for_speech_to_finish()
 		nextSpeechIndex = spy.get_next_speech_index()
-		keyInputLib.send('\t')
+		keyInputLib.send(key)
 		spy.wait_for_speech_to_finish()
 		speech = spy.get_speech_at_index_until_now(nextSpeechIndex)
 		return speech
+
+	@staticmethod
+	def getSpeechAfterTab() -> str:
+		"""Ensure speech has stopped, press tab, and get speech until it stops.
+		@return: The speech after tab.
+		"""
+		return ChromeLib.getSpeechAfterKey('\t')

--- a/tests/system/nvdaSettingsFiles/standard-doShowWelcomeDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-doShowWelcomeDialog.ini
@@ -10,3 +10,5 @@ schemaVersion = 2
 	synth = speechSpySynthDriver
 [development]
 	enableScratchpadDir = True
+[virtualBuffers]
+	autoSayAllOnPageLoad = False

--- a/tests/system/nvdaSettingsFiles/standard-dontShowWelcomeDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-dontShowWelcomeDialog.ini
@@ -10,3 +10,5 @@ schemaVersion = 2
 	synth = speechSpySynthDriver
 [development]
 	enableScratchpadDir = True
+[virtualBuffers]
+	autoSayAllOnPageLoad = False


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#11339 

### Summary of the issue:
Chrome tests are failing intermittently. Some logs look like a freeze, others seem to be related to not finding the start marker for the test content. Say-all on page load is certainly making it harder to debug.

### Description of how this pull request fixes the issue:
This PR will disable say-all on page load, and use F6 to navigate to the document content.

### Testing performed:
Ran tests locally, tests pass. 
PR build / automated tests.

### Known issues with pull request:

### Change log entry:
None

