### PR TITLE
Reduce Python reference cycles especially when interacting with MS Word

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -185,6 +185,10 @@ class EditableTextWithAutoSelectDetection(EditableText):
 		super().event_gainFocus()
 		self.initAutoSelectDetection()
 
+	def event_loseFocus(self):
+		self.terminateAutoSelectDetection()
+		super().event_loseFocus()
+
 	def event_caret(self):
 		super(EditableText, self).event_caret()
 		if self is api.getFocusObject() and not eventHandler.isPendingEvents('gainFocus'):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -559,7 +559,7 @@ class ChartWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
 		return item.type==wdInlineShapeChart
 
 
-class LazyControlField(textInfos.ControlField):
+class LazyControlField_RowAndColumnHeaderText(textInfos.ControlField):
 
 	def __init__(self, ti):
 		self._ti = ti
@@ -822,8 +822,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 				field['name']=name
 				field['alwaysReportName']=True
 				field['role']=controlTypes.ROLE_FRAME
-		# Hack support for lazy fetching of row and column header text values
-		newField = LazyControlField(self)
+		newField = LazyControlField_RowAndColumnHeaderText(self)
 		newField.update(field)
 		return newField
 

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -8,7 +8,6 @@
 
 import ctypes
 import time
-import weakref
 from comtypes import COMError, GUID, BSTR
 import comtypes.client
 import comtypes.automation
@@ -559,29 +558,30 @@ class ChartWinWordCollectionQuicknavIterator(WinWordCollectionQuicknavIterator):
 	def filter(self,item):
 		return item.type==wdInlineShapeChart
 
-class LazyControlField(textInfos.ControlField): 
 
-	def __init__(self,ti):
+class LazyControlField(textInfos.ControlField):
+
+	def __init__(self, ti):
 		self._ti = ti
 		super().__init__()
 
-	def get(self,name,default=None):
-		if name=="table-rowheadertext":
+	def get(self, name, default=None):
+		if name == "table-rowheadertext":
 			try:
-				cell=self._ti._rangeObj.cells[1]
+				cell = self._ti._rangeObj.cells[1]
 			except IndexError:
 				log.debugWarning("no cells for table row, possibly on end of cell mark")
-				return super().get(name,default)
-			return self._ti.obj.fetchAssociatedHeaderCellText(cell,False)
-		elif name=="table-columnheadertext":
+				return super().get(name, default)
+			return self._ti.obj.fetchAssociatedHeaderCellText(cell, False)
+		elif name == "table-columnheadertext":
 			try:
-				cell=self._ti._rangeObj.cells[1]
+				cell = self._ti._rangeObj.cells[1]
 			except IndexError:
 				log.debugWarning("no cells for table row, possibly on end of cell mark")
-				return super().get(name,default)
-			return self._ti.obj.fetchAssociatedHeaderCellText(cell,True)
+				return super().get(name, default)
+			return self._ti.obj.fetchAssociatedHeaderCellText(cell, True)
 		else:
-			return super().get(name,default)
+			return super().get(name, default)
 
 class WordDocumentTextInfo(textInfos.TextInfo):
 

--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -58,13 +58,13 @@ class XMLTextParser(object):
 			cmdList.append(data)
 
 	def parse(self,XMLText):
-		parser=expat.ParserCreate('utf-8')
-		parser.StartElementHandler=self._startElementHandler
-		parser.EndElementHandler=self._EndElementHandler
-		parser.CharacterDataHandler=self._CharacterDataHandler
-		self._commandList=[]
+		parser = expat.ParserCreate('utf-8')
+		parser.StartElementHandler = self._startElementHandler
+		parser.EndElementHandler = self._EndElementHandler
+		parser.CharacterDataHandler = self._CharacterDataHandler
+		self._commandList = []
 		try:
 			parser.Parse(XMLText)
-		except:
-			log.error("XML: %s"%XMLText,exc_info=True)
+		except Exception:
+			log.error("XML: %s" % XMLText, exc_info=True)
 		return self._commandList

--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -11,13 +11,6 @@ from textUtils import WCHAR_ENCODING, isLowSurrogate
 
 class XMLTextParser(object): 
 
-	def __init__(self):
-		self.parser=expat.ParserCreate('utf-8')
-		self.parser.StartElementHandler=self._startElementHandler
-		self.parser.EndElementHandler=self._EndElementHandler
-		self.parser.CharacterDataHandler=self._CharacterDataHandler
-		self._commandList=[]
-
 	def _startElementHandler(self,tagName,attrs):
 		if tagName=='unich':
 			data=attrs.get('value',None)
@@ -65,8 +58,13 @@ class XMLTextParser(object):
 			cmdList.append(data)
 
 	def parse(self,XMLText):
+		parser=expat.ParserCreate('utf-8')
+		parser.StartElementHandler=self._startElementHandler
+		parser.EndElementHandler=self._EndElementHandler
+		parser.CharacterDataHandler=self._CharacterDataHandler
+		self._commandList=[]
 		try:
-			self.parser.Parse(XMLText)
+			parser.Parse(XMLText)
 		except:
 			log.error("XML: %s"%XMLText,exc_info=True)
 		return self._commandList

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -315,6 +315,8 @@ class EditableText(TextContainerObject,ScriptableObject):
 		"kb:control+backspace": "caret_backspaceWord",
 	}
 
+	_autoSelectDetectionEnabled = False
+
 	def initAutoSelectDetection(self):
 		"""Initialise automatic detection of selection changes.
 		This should be called when the object gains focus.
@@ -325,10 +327,13 @@ class EditableText(TextContainerObject,ScriptableObject):
 			self._lastSelectionPos=None
 		self.isTextSelectionAnchoredAtStart=True
 		self.hasContentChangedSinceLastSelection=False
+		self._autoSelectDetectionEnabled = True
 
 	def detectPossibleSelectionChange(self):
 		"""Detects if the selection has been changed, and if so it speaks the change.
 		"""
+		if not self._autoSelectDetectionEnabled:
+			return
 		try:
 			newInfo=self.makeTextInfo(textInfos.POSITION_SELECTION)
 		except:
@@ -351,6 +356,13 @@ class EditableText(TextContainerObject,ScriptableObject):
 			self.isTextSelectionAnchoredAtStart=False
 		elif newInfo.compareEndPoints(oldInfo,"endToEnd")!=0:
 			self.isTextSelectionAnchoredAtStart=True
+
+	def terminateAutoSelectDetection(self):
+		""" Terminate automatic detection of selection changes.
+		This should be called when the object loses focus.
+		"""
+		self._lastSelectionPos = None
+		self._autoSelectDetectionEnabled = False
 
 class EditableTextWithoutAutoSelectDetection(EditableText):
 	"""In addition to L{EditableText}, provides scripts to report appropriately when the selection changes.


### PR DESCRIPTION
### Link to issue number:
#11369 
#11398 

### Summary of the issue:
Python reference counts all its objects, and automatically deletes them as soon as their reference count reaches 0. Most of the time this is as soon as the object goes out of scope. However, if there is a reference cycle, where by an object directly or indirectly references itself, the reference count will never reach 0. 
The Python garbage collection (gc) therefore periodically walks all tracked objects, and detects and breaks reference cycles once an object is deemed to be unreachable. However, this can happen in any thread, and sometimes a comtypes COM object might be deleted in the wrong thread.
Although reference cycles can never be completely avoided in Python (tracebacks can sometimes cause them) there are a few places in NvDA where we are creating them, where we don't really have to. These particular cycles are part of the cause for the freezes in MS Word as these cycles are cleaned up by the garbage collector sometimes in one of our incoming rpc threads.

### Description of how this pull request fixes the issue:
Refactor the code to address these particular cycles.

#### XMLFormatting.XMLTextParser
Previously, when initializing, this class creates an XMLParser object and stores it as a member on itself. But it also assigns some of its own instance methods to this parser object, thereby creating a reference cycle.
This in tern is holding around ControlField objects, which in tern are holding around some MS Word Range COM objects.
This code has now been refactored to not do anything at initialization time, and instead just hold the parser as a local variable in the parse method. So although we still assign self's instance methods to the parser, we don't store the parser on self.

#### WordDocumentTextInfo and lazy controlFields
When we normalize the ControlFields for Microsoft Word text content, we specifically make the row and column header values load lazily, as these are rather costly to compute, and not always required. We previously did this by creating a ControlField subclass which an overridden 'get' method. However, this subclass was defined inline inside WordDocumentextInfo's _normalizeControlField method, also making reference to self as a non-local variable. This somehow was causing a reference cycle on WordDocumentTextInfo... I don't fully understand this one, but it was hard to read and rather unnecessary anyway.
This code has been refactored out into its own class that is not inline, and takes the WordDocumentExtInfo instance as an argument, rather than referencing it as a non-local variable.
This fix, and the fix above, no longer leaves MS Word Range COM objects alive for the garbage collector to eventually find and destroy (possibly in the wrong thread).

#### EditableTextWithAutoSelectDetection
For certain editable controls that fire suitable caret events and such, we try and detect selection changes automatically. We do this by storing a TextInfo representing the initial selection on the object in the gainFocus event, and then keep checking and updating the TextInfo each time the caret moves. However, we never delete this TextInfo from the object, and for some TextInfos (such as CompoundDocument TextInfos) this creates reference cycles as the TextInfo may hold child NVDAObjects who may have cached their parent (the original object). 
Now, a terminateautoSelectDetection method has been added to EditableTextWithAutoSelectDetection which clears the TextInfo from the object. the loseFocus event now calls terminateAutoSelectDetection, matching the call to inititAutoSelectDetection in the gainFocus event.
 
### Testing performed:
* Instructed Python to save all unreachable objects in gc.garbage with ```gc.set_debug(gc.DEBUG_SAVEALL)```
* Interacted with Microsoft Word (sch as moving with up and down arrows, navigating a table)
* Forced Python to do a garbage collection run with ```gc.collect()```
* Looked through the contents of gc.garbage to verify that none of the above objects (WordDocumentTextInfo, XMLParser etc) appear in this list anymore.

Also, ensured that Microsoft word no longer froze after typing very quickly in a Word document for about 30 seconds or so, with Braille enabled.

### Known issues with pull request:
This by no means gets rid of all possible reference cycles caused by NVDA. But it does address the ones that played a part in the Microsoft Word freezes we have been seeing recently.
