### PR TITLE
Revert change to typedCharacterNotify using executeEvent directly rather than queueEvent

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -398,7 +398,7 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 def nvdaControllerInternal_typedCharacterNotify(threadID,ch):
 	focus=api.getFocusObject()
 	if focus.windowClassName!="ConsoleWindowClass":
-		eventHandler.queueEvent("typedCharacter",focus,ch=ch)
+		eventHandler.queueEvent("typedCharacter", focus, ch=ch)
 	return 0
 
 @WINFUNCTYPE(c_long, c_int, c_int)

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -398,14 +398,7 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 def nvdaControllerInternal_typedCharacterNotify(threadID,ch):
 	focus=api.getFocusObject()
 	if focus.windowClassName!="ConsoleWindowClass":
-		# Manually queue a call to executeEvent rather than using queueEvent,
-		# As Currently queueEvent uses a lock and there is a small chance it could deadlock
-		# If garbage collection within the lock
-		# caused a COM object from the same thread as the typed character to be released.
-		queueHandler.queueFunction(
-			queueHandler.eventQueue,
-			eventHandler.executeEvent, "typedCharacter", focus, ch=ch
-		)
+		eventHandler.queueEvent("typedCharacter",focus,ch=ch)
 	return 0
 
 @WINFUNCTYPE(c_long, c_int, c_int)

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -5,14 +5,13 @@
 #See the file COPYING for more details.
 
 import types
-from queue import Queue
+from queue import SimpleQueue
 import globalVars
 from logHandler import log
 import watchdog
 import core
 
-eventQueue=Queue()
-eventQueue.__name__="eventQueue"
+eventQueue = SimpleQueue()
 generators={}
 lastGeneratorObjID=0
 

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -11,7 +11,13 @@ from logHandler import log
 import watchdog
 import core
 
+# A queue for calls that should be made on NVDA's main thread
+# #11369: We use SimpleQueue rather than Queue here
+# as SimpleQueue is very light-weight, does not use locks
+# and ensures that garbage collection won't unexpectedly happen in the middle of queuing something
+# Which may cause a deadlock.
 eventQueue = SimpleQueue()
+
 generators={}
 lastGeneratorObjID=0
 

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -5,19 +5,14 @@
 #See the file COPYING for more details.
 
 import types
-from queue import SimpleQueue
+from queue import Queue
 import globalVars
 from logHandler import log
 import watchdog
 import core
 
-# A queue for calls that should be made on NVDA's main thread
-# #11369: We use SimpleQueue rather than Queue here
-# as SimpleQueue is very light-weight, does not use locks
-# and ensures that garbage collection won't unexpectedly happen in the middle of queuing something
-# Which may cause a deadlock.
-eventQueue = SimpleQueue()
-
+eventQueue=Queue()
+eventQueue.__name__="eventQueue"
 generators={}
 lastGeneratorObjID=0
 


### PR DESCRIPTION
Reverts part of nvaccess/nvda#11373
As there was some disagreement or concern over typedCharacterNotify using executeEvent directly, this particular change has been reverted. Now just leaving the change in queueHandler from Queue to SimpleQueue, as people seem to agree on that one. 