### PR TITLE
Watchdog: List stacks for all Python threads when trying to recover from freeze

### DIFF
--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -109,8 +109,8 @@ def _watcher():
 		if _isAlive():
 			continue
 		if log.isEnabledFor(log.DEBUGWARNING):
-			log.debugWarning("Trying to recover from freeze, core stack:\n%s"%
-				"".join(traceback.format_stack(sys._current_frames()[core.mainThreadId])))
+			stacks = getFormattedStacksForAllThreads()
+			log.debugWarning(f"Trying to recover from freeze. Listing stacks for Python threads:\n{stacks}")
 		lastTime=time.time()
 		isAttemptingRecovery = True
 		# Cancel calls until the core is alive.


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
NVDA's watchdog tries to recover from freezes, and when doing so logs the main thread's stack. However, the freeze may be caused also by what is going on in another thread. We should log stacks for all Python threads when trying to recover. 

### Description of how this pull request fixes the issue:
Log stacks for all Python threads when watchdog is trying to recover from a possible freeze.
Note that we already started logging all threads when the core was completely frozen. This pr extends this to recovery attempts also.

### Testing performed:
Caused NVDA to temporarily freeze and try recovery by opening the Python console, typing ```time.sleep(5)```, pressing enter and alt tabbing away quickly. 
Confirmed that the the log showed the message about trying to recover from freeze, and that it listed all Python threads.

### Known issues with pull request:
None.

### Change log entry:
None.