### PR TITLE
Upgrade to SCons 4.0.1

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -41,7 +41,7 @@ env = env.Clone()
 
 # Liblouis is build with Clang, as Microsoft Visual C++ is unable to build C99 code.
 clangDirs = glob.glob(os.path.join(
-    find_vc_pdir(env.get("MSVC_VERSION")),
+    find_vc_pdir(env, env.get("MSVC_VERSION")),
     r"Tools\Llvm\bin"
 ))
 if len(clangDirs) == 0:

--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -43,7 +43,7 @@ localWin10Lib = env.SharedLibrary(
 # Therefore  Search these versioned directories from newest to oldest  to collect all the files we need.
 msvc = env.get('MSVC_VERSION')
 vcRedistDirs = glob.glob(os.path.join(
-    find_vc_pdir(msvc),
+    find_vc_pdir(env, msvc),
     rf"Redist\MSVC\{msvc}*\x86\Microsoft.VC{msvc.replace('.', '')}.CRT"
 ))
 if len(vcRedistDirs)==0:

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ Additionally, the following build time dependencies are included in Git submodul
 * [Py2Exe](https://github.com/albertosottile/py2exe/), version 0.9.3.2 commit b372a8e
 * [Python Windows Extensions](https://sourceforge.net/projects/pywin32/ ), build 224, required by py2exe
 * [txt2tags](https://txt2tags.org/), version 2.5
-* [SCons](https://www.scons.org/), version 3.1.2
+* [SCons](https://www.scons.org/), version 4.0.1
 * [Nulsoft Install System](https://nsis.sourceforge.io/Main_Page/), version 2.51
 * [NSIS UAC plug-in](https://nsis.sourceforge.io/UAC_plug-in), version 0.2.4, ansi
 * xgettext and msgfmt from [GNU gettext](https://sourceforge.net/projects/cppcms/files/boost_locale/gettext_for_windows/)

--- a/scons.py
+++ b/scons.py
@@ -4,11 +4,13 @@
 import sys
 import os
 
-sconsPath = os.path.abspath(os.path.join(os.path.dirname(__file__), "include", "scons", "src", "engine"))
+sconsPath = os.path.abspath(os.path.join(os.path.dirname(__file__), "include", "scons"))
 
 if os.path.exists(sconsPath):
-	sys.path.append(sconsPath)
+	# sys.path[0] will always be the current dir, which should take precedence.
+	# Insert path to the SCons folder after that.
+	sys.path[1:1] = (sconsPath,)
 	import SCons.Script
-	SCons.Script.main()
+	SCons.Script.Main.main()
 else:
 	raise OSError("Path %s does not exist. Perhaps try running git submodule update --init" % sconsPath)


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
SCons 4.0.1 has been released. It is beneficial  for us to upgrade because it is compatible with Python 3.8, more importantly thought it once again allows to build with VS 2019 on Windows  versions older than Windows 10 (see https://github.com/SCons/scons/issues/3572 and [this threat on NVDA-addons mailing list](https://nvda-addons.groups.io/g/nvda-addons/topic/74637563#12616)
### Description of how this pull request fixes the issue:
The submodule is updated to the 4.0.1 release and some cosmetic changes are made to sconscripts to make them work with the new release of SCons.
### Testing performed:
Created a launcher with the new version confirmed that it works.
### Known issues with pull request:
None known creating a try branch from this before merging might be reasonable though.
### Change log entry:

Changes for developers:
Updated SCons to version 4.0.1