### PR TITLE
GUI: Do not scale the default size of -1 (#10216)

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3706,7 +3706,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.filterEdit = sHelper.addLabeledControl(
 			labelText = filterText,
 			wxCtrlClass=wx.TextCtrl,
-			size=self.scaleSize((310, -1)),
+			size=(self.scaleSize(310), -1),
 		)
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)
 
@@ -3758,7 +3758,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.replacementEdit = changeSymbolHelper.addLabeledControl(
 			labelText=replacementText,
 			wxCtrlClass=wx.TextCtrl,
-			size=self.scaleSize((300, -1)),
+			size=(self.scaleSize(300), -1),
 		)
 		self.replacementEdit.Bind(wx.EVT_TEXT, skipEventAndCall(self.onSymbolEdited))
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

Fixes #10216

### Summary of the issue:

On the Symbol Pronunciation dialog, depending on the display scaling settings, the Filter edit field and the Replacement edit field might be functional but not visible.

### Description of how this pull request fixes the issue:

Do not attempt to scale the default size of -1.
That is, replace `self.scaleSize((300, 1))` by `(self.scaleSize(300), -1)`

### Testing performed:

Ensured that both fields are visible with varying display scaling settings.

### Known issues with pull request:

### Change log entry:

I don't think this deserves a change log entry.