### PR TITLE
Don't block an app's main thread when sending typed characters to NVDA

### DIFF
--- a/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
+++ b/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
@@ -47,10 +47,9 @@ interface NvdaControllerInternal {
 
 /**
  * Notifies NVDA that a character has been typed in this thread.
- * @param threadID the thread the layout change occured in
  * @param ch the character typed.
  */
-	error_status_t __stdcall typedCharacterNotify([in] const long threadID, [in] const wchar_t ch);
+	error_status_t __stdcall typedCharacterNotify([in] const wchar_t ch);
 
 /**
  * Notifies NVDA that text in the given rectangle (in screen coordinates), in the given window, has changed.

--- a/nvdaHelper/local/nvdaControllerInternal.c
+++ b/nvdaHelper/local/nvdaControllerInternal.c
@@ -24,9 +24,9 @@ error_status_t __stdcall nvdaControllerInternal_inputLangChangeNotify(const long
 	return _nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString);
 }
 
-error_status_t(__stdcall *_nvdaControllerInternal_typedCharacterNotify)(const long, const wchar_t); 
-error_status_t __stdcall nvdaControllerInternal_typedCharacterNotify(const long threadID, const wchar_t ch) {
-	return _nvdaControllerInternal_typedCharacterNotify(threadID,ch);
+error_status_t(__stdcall *_nvdaControllerInternal_typedCharacterNotify)(const wchar_t); 
+error_status_t __stdcall nvdaControllerInternal_typedCharacterNotify(const wchar_t ch) {
+	return _nvdaControllerInternal_typedCharacterNotify(ch);
 }
 
 

--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -193,14 +193,23 @@ DWORD WINAPI inprocMgrThreadFunc(LPVOID data) {
 	// Even though we only registered for in-context winEvents, we may still receive some out-of-context events; e.g. console events.
 	// Therefore, we must have a message loop.
 	// Otherwise, any out-of-context events will cause major lag which increases over time.
-	do {
-		// Consume and handle all pending messages.
-		MSG msg;
-		while(PeekMessage(&msg,NULL,0,0,PM_REMOVE)) {
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
+	while(true) {
+		DWORD res=MsgWaitForMultipleObjectsEx(1,&nvdaUnregisteredEvent,INFINITE,QS_ALLINPUT,MWMO_ALERTABLE);
+		if(res==(WAIT_OBJECT_0+1)) {
+			// Consume and handle all pending messages.
+			MSG msg;
+			while(PeekMessage(&msg,NULL,0,0,PM_REMOVE)) {
+				TranslateMessage(&msg);
+				DispatchMessage(&msg);
+			}
+			continue;
+		} else if(res==WAIT_IO_COMPLETION) {
+			// Woke for an queued APC function. Keep going.
+			continue;
 		}
-	} while(MsgWaitForMultipleObjects(1,&nvdaUnregisteredEvent,FALSE,INFINITE,QS_ALLINPUT)==WAIT_OBJECT_0+1);
+		// anything else (the registrationEvent was set, there was an error) means we need to stop.
+		break;
+	}
 	nhAssert(inprocMgrThreadHandle);
 	inprocThreadsLock.acquire();
 	CloseHandle(inprocMgrThreadHandle);

--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -194,8 +194,10 @@ DWORD WINAPI inprocMgrThreadFunc(LPVOID data) {
 	// Therefore, we must have a message loop.
 	// Otherwise, any out-of-context events will cause major lag which increases over time.
 	while(true) {
-		DWORD res=MsgWaitForMultipleObjectsEx(1,&nvdaUnregisteredEvent,INFINITE,QS_ALLINPUT,MWMO_ALERTABLE);
-		if(res==(WAIT_OBJECT_0+1)) {
+		const long handleCount=1;
+		const long WAIT_PENDING_MESSAGES=WAIT_OBJECT_0+handleCount;
+		DWORD res=MsgWaitForMultipleObjectsEx(handleCount,&nvdaUnregisteredEvent,INFINITE,QS_ALLINPUT,MWMO_ALERTABLE);
+		if(res==(WAIT_PENDING_MESSAGES)) {
 			// Consume and handle all pending messages.
 			MSG msg;
 			while(PeekMessage(&msg,NULL,0,0,PM_REMOVE)) {

--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -206,7 +206,7 @@ DWORD WINAPI inprocMgrThreadFunc(LPVOID data) {
 			}
 			continue;
 		} else if(res==WAIT_IO_COMPLETION) {
-			// Woke for an queued APC function. Keep going.
+			// Woke for a queued APC function. Keep going.
 			continue;
 		}
 		// anything else (the registrationEvent was set, there was an error) means we need to stop.

--- a/nvdaHelper/remote/nvdaHelperRemote.h
+++ b/nvdaHelper/remote/nvdaHelperRemote.h
@@ -66,4 +66,7 @@ bool registerWindowsHook(int hookType, HOOKPROC hookProc);
  */
 bool unregisterWindowsHook(int hookType, HOOKPROC hookProc);
 
+// The handle for NVDA's inproc manager thread
+extern HANDLE inprocMgrThreadHandle;
+
 #endif

--- a/nvdaHelper/remote/typedCharacter.cpp
+++ b/nvdaHelper/remote/typedCharacter.cpp
@@ -32,7 +32,8 @@ LRESULT CALLBACK typedCharacter_getMessageHook(int code, WPARAM wParam, LPARAM l
 		typedCharacter_window=pmsg->hwnd;
 		lastCharacter=0;
 	} else if((typedCharacter_window!=0)&&(pmsg->message==WM_CHAR)&&(pmsg->hwnd==typedCharacter_window)&&(pmsg->wParam!=lastCharacter)) { 
-		// Instruct NVDA's inproc manager thread to report the typed chracter to NVDA via rpc.
+		// Instruct NVDA's inproc manager thread to report the typed character to NVDA via rpc.
+
 		// If we were to call the rpc function directly, it might cause a deadlock
 		// if NvDA were to interact with this app's main thread while the rpc function was in progress.
 		QueueUserAPC(typedCharacter_apcFunc, inprocMgrThreadHandle, static_cast<ULONG_PTR>(pmsg->wParam));

--- a/nvdaHelper/remote/typedCharacter.cpp
+++ b/nvdaHelper/remote/typedCharacter.cpp
@@ -21,6 +21,10 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 HWND typedCharacter_window=NULL;
 
+void __stdcall typedCharacter_apcFunc(ULONG_PTR data) {
+	nvdaControllerInternal_typedCharacterNotify(GetCurrentThreadId(),static_cast<wchar_t>(data));
+}
+
 LRESULT CALLBACK typedCharacter_getMessageHook(int code, WPARAM wParam, LPARAM lParam) {
 	static WPARAM lastCharacter=0;
 	MSG* pmsg=(MSG*)lParam;
@@ -28,7 +32,10 @@ LRESULT CALLBACK typedCharacter_getMessageHook(int code, WPARAM wParam, LPARAM l
 		typedCharacter_window=pmsg->hwnd;
 		lastCharacter=0;
 	} else if((typedCharacter_window!=0)&&(pmsg->message==WM_CHAR)&&(pmsg->hwnd==typedCharacter_window)&&(pmsg->wParam!=lastCharacter)) { 
-		nvdaControllerInternal_typedCharacterNotify(GetCurrentThreadId(),static_cast<wchar_t>(pmsg->wParam));
+		// Instruct NVDA's inproc manager thread to report the typed chracter to NVDA via rpc.
+		// If we were to call the rpc function directly, it might cause a deadlock
+		// if NvDA were to interact with this app's main thread while the rpc function was in progress.
+		QueueUserAPC(typedCharacter_apcFunc, inprocMgrThreadHandle, static_cast<ULONG_PTR>(pmsg->wParam));
 		lastCharacter=pmsg->wParam;
 	}
 	return 0;

--- a/nvdaHelper/remote/typedCharacter.cpp
+++ b/nvdaHelper/remote/typedCharacter.cpp
@@ -22,7 +22,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 HWND typedCharacter_window=NULL;
 
 void __stdcall typedCharacter_apcFunc(ULONG_PTR data) {
-	nvdaControllerInternal_typedCharacterNotify(GetCurrentThreadId(),static_cast<wchar_t>(data));
+	nvdaControllerInternal_typedCharacterNotify(static_cast<wchar_t>(data));
 }
 
 LRESULT CALLBACK typedCharacter_getMessageHook(int code, WPARAM wParam, LPARAM lParam) {

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -13,6 +13,11 @@ import winKernel
 import config
 
 from ctypes import *
+from ctyps import (
+	WINFUNCTYPE,
+	c_long,
+	c_wchar,
+)
 from ctypes.wintypes import *
 from comtypes import BSTR
 import winUser
@@ -393,6 +398,7 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 	lastLayoutString=layoutString
 	queueHandler.queueFunction(queueHandler.eventQueue,ui.message,msg)
 	return 0
+
 
 @WINFUNCTYPE(c_long, c_wchar)
 def nvdaControllerInternal_typedCharacterNotify(ch):

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -13,7 +13,7 @@ import winKernel
 import config
 
 from ctypes import *
-from ctyps import (
+from ctypes import (
 	WINFUNCTYPE,
 	c_long,
 	c_wchar,

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -394,8 +394,8 @@ def nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString):
 	queueHandler.queueFunction(queueHandler.eventQueue,ui.message,msg)
 	return 0
 
-@WINFUNCTYPE(c_long,c_long,c_wchar)
-def nvdaControllerInternal_typedCharacterNotify(threadID,ch):
+@WINFUNCTYPE(c_long, c_wchar)
+def nvdaControllerInternal_typedCharacterNotify(ch):
 	focus=api.getFocusObject()
 	if focus.windowClassName!="ConsoleWindowClass":
 		eventHandler.queueEvent("typedCharacter", focus, ch=ch)


### PR DESCRIPTION
### Link to issue number:
Re #11369 , #11398  

### Summary of the issue:
Currently, the main way that NVDA reports characters being typed is by detecting them in-process by watching for WM_CHAR window messages, and then sending the characters to NVDA via an RPC call.
However, the rpc call to NvDA is made directly from the app's main thread where the message was detected, and therefore blocks that thread until the rpc call is fully executed.
This can cause a deadlock between multiple threads in NVDA, bit more importantly a deadlock between NVDA and the app in question, if a cross-process COM object for the app happens to be released by Python's garbage collector within the incoming RPC call to NVDA, as this COM object's Release method will try and execute via the Windows message loop on the app's main thread, which is currently blocked by the rpc call.
  
### Description of how this pull request fixes the issue:
Rather than making the RPC call directly, queue it to NVDA's in-process manager thread using APC (Asynchronous Procedure Calls) , and execute it there, no longer blocking the app's main thread.
 
### Testing performed:
* Ran NVDA with speak typed characters turned on. Ensured that typed characters could be heard in various  situations such as in Microsoft Word, Notepad, and the Run dialog.
* Placed temporarily logging in the in-process code, to verify that the rpc call was in deed being made from the manager thread.

### Known issues with pull request:
Not an issue, but just a note for future: In Windows 10 1607 and higher, we are able to detect typed characters within NVDA itself, rather than having to rely on in-process code at all. We should consider disabling the typed character support in-process completely on these more recent versions of Windows 10. However, right now it is more important to address the issue at its source, where it affects all Operating System versions.

### Change log entry:
Bug fixes:
- NVDA should no longer freeze in Microsoft word when rapidly typing characters.