### PR TITLE
Ensure that all in-process log calls never block an app's threads

### DIFF
--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -162,6 +162,8 @@ DWORD WINAPI inprocMgrThreadFunc(LPVOID data) {
 		return 0;
 	}
 	nhAssert(dllHandle==tempHandle);
+	// Flush any log messages from other threads queued before the manager thread was started. 
+	log_flushQueue();
 	//Register for all winEvents in this process.
 	inprocWinEventHookID=SetWinEventHook(EVENT_MIN,EVENT_MAX,dllHandle,inproc_winEventCallback,GetCurrentProcessId(),0,WINEVENT_INCONTEXT);
 	if(inprocWinEventHookID==0) {
@@ -241,7 +243,7 @@ DWORD WINAPI inprocMgrThreadFunc(LPVOID data) {
 	UnhookWinEvent(inprocWinEventHookID);
 	inprocWinEventHookID=0;
 	// Flush any remaining log messages to NVDA
-	log_terminate();
+	log_flushQueue();
 	//Release and close the thread mutex
 	ReleaseMutex(threadMutex);
 	CloseHandle(threadMutex);

--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -240,6 +240,8 @@ DWORD WINAPI inprocMgrThreadFunc(LPVOID data) {
 	// Unregister inproc winEvent callback
 	UnhookWinEvent(inprocWinEventHookID);
 	inprocWinEventHookID=0;
+	// Flush any remaining log messages to NVDA
+	log_terminate();
 	//Release and close the thread mutex
 	ReleaseMutex(threadMutex);
 	CloseHandle(threadMutex);

--- a/nvdaHelper/remote/log.cpp
+++ b/nvdaHelper/remote/log.cpp
@@ -38,11 +38,10 @@ void log_flushQueue() {
 		std::lock_guard lock{logQueueLock};
 		tempQueue.swap(logQueue);
 	}
-	while(!tempQueue.empty()) {
-		auto& [level, msg] = tempQueue.front();
+	for(auto& [level, msg] : tempQueue) {
 		nvdaControllerInternal_logMessage(level, GetCurrentProcessId(), msg.c_str());
-		tempQueue.pop_front();
 	}
+
 }
 
 void __stdcall log_flushQueue_apcFunc(ULONG_PTR data) {
@@ -93,4 +92,3 @@ int NVDALogCrtReportHook(int reportType,const wchar_t *message,int *returnValue)
 	*returnValue=0;
 	return true;
 }
-

--- a/nvdaHelper/remote/log.cpp
+++ b/nvdaHelper/remote/log.cpp
@@ -31,6 +31,7 @@ void log_flushQueue() {
 		!inprocMgrThreadHandle
 		|| GetCurrentThreadId() != GetThreadId(inprocMgrThreadHandle)
 	) {
+		QueueUserAPC(log_flushQueue_apcFunc, inprocMgrThreadHandle, 0);
 		return;
 	}
 	std::deque<std::tuple<int, std::wstring>> tempQueue;

--- a/nvdaHelper/remote/log.cpp
+++ b/nvdaHelper/remote/log.cpp
@@ -47,7 +47,9 @@ void logMessage(int level, const wchar_t* msg) {
 		// So as to not block any app threads,
 		// The message is queued to NVDA's inproc manager thread to be logged from there.
 		logQueue.emplace_back(level, msg);
-		QueueUserAPC(log_flushQueue, inprocMgrThreadHandle, 1);
+		if(inprocMgrThreadHandle) {
+			QueueUserAPC(log_flushQueue, inprocMgrThreadHandle, 1);
+		}
 	} else {
 		// The message is being logged from NVDA's inproc manager thread.
 		// Log to NVDA via rpc directly.

--- a/nvdaHelper/remote/log.cpp
+++ b/nvdaHelper/remote/log.cpp
@@ -45,7 +45,7 @@ void logMessage(int level, const wchar_t* msg) {
 		// either the NVDA inproc manager thread is not yet running,
 		// Or this message is being logged from outside NVDA's inproc manager thread.
 		// So as to not block any app threads,
-		// The message is queued to NVDA's inproc manager thread to be logged from there.
+		// The message is queued for later fetching by  NVDA's inproc manager thread
 		logQueue.emplace_back(level, msg);
 		if(inprocMgrThreadHandle) {
 			QueueUserAPC(log_flushQueue, inprocMgrThreadHandle, 1);
@@ -53,8 +53,8 @@ void logMessage(int level, const wchar_t* msg) {
 	} else {
 		// The message is being logged from NVDA's inproc manager thread.
 		// Log to NVDA via rpc directly.
-	// But first flush any pending log messages from other threads to ensure they are kept in the right order
-	log_flushQueue(logQueue.size());
+		// But first flush any pending log messages from other threads to ensure they are kept in the right order
+		log_flushQueue(logQueue.size());
 		nvdaControllerInternal_logMessage(level,GetCurrentProcessId(),msg);
 	}
 }

--- a/nvdaHelper/remote/log.cpp
+++ b/nvdaHelper/remote/log.cpp
@@ -12,13 +12,54 @@ This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
+#include <string>
+#include <queue>
 #include <crtdbg.h>
 #include "nvdaControllerInternal.h"
+#include "nvdaHelperRemote.h"
 #include <common/log.h>
 
+std::deque<std::tuple<int, std::wstring>> logQueue;
+
+// Fetch a  maximum number of messages from the log queue
+// and send them onto NvDA via rpc.
+void __stdcall log_flushQueue(ULONG_PTR maxCount) {
+	while(!logQueue.empty()) {
+		if(maxCount < 1) break;
+		{
+			auto& [level, msg] = logQueue.front();
+			nvdaControllerInternal_logMessage(level, GetCurrentProcessId(), msg.c_str());
+		}
+		logQueue.pop_front();
+		--maxCount;
+	}
+}
+
 void logMessage(int level, const wchar_t* msg) {
-	if(level>LOGLEVEL_DEBUG) nvdaControllerInternal_logMessage(level,GetCurrentProcessId(),msg);
+	// Always log to any connected debugger 
 	OutputDebugString(msg);
+	if(
+		!inprocMgrThreadHandle
+		|| GetCurrentThreadId() != GetThreadId(inprocMgrThreadHandle)
+	) {
+		// either the NVDA inproc manager thread is not yet running,
+		// Or this message is being logged from outside NVDA's inproc manager thread.
+		// So as to not block any app threads,
+		// The message is queued to NVDA's inproc manager thread to be logged from there.
+		logQueue.emplace_back(level, msg);
+		QueueUserAPC(log_flushQueue, inprocMgrThreadHandle, 1);
+	} else {
+		// The message is being logged from NVDA's inproc manager thread.
+		// Log to NVDA via rpc directly.
+	// But first flush any pending log messages from other threads to ensure they are kept in the right order
+	log_flushQueue(logQueue.size());
+		nvdaControllerInternal_logMessage(level,GetCurrentProcessId(),msg);
+	}
+}
+
+void log_terminate() {
+	// Send any remaining messages in the queue to NVDA
+	log_flushQueue(logQueue.size());
 }
 
 int NVDALogCrtReportHook(int reportType,const wchar_t *message,int *returnValue) {

--- a/nvdaHelper/remote/nvdaHelperRemote.h
+++ b/nvdaHelper/remote/nvdaHelperRemote.h
@@ -71,6 +71,6 @@ extern HANDLE inprocMgrThreadHandle;
 
 // Flushes any remaining log messages to NVDA.
 // This should only be called from the NVDA inproc manager thread as it blocks while sending to NVDA.
-void log_terminate();
+void log_flushQueue();
 
 #endif

--- a/nvdaHelper/remote/nvdaHelperRemote.h
+++ b/nvdaHelper/remote/nvdaHelperRemote.h
@@ -69,4 +69,8 @@ bool unregisterWindowsHook(int hookType, HOOKPROC hookProc);
 // The handle for NVDA's inproc manager thread
 extern HANDLE inprocMgrThreadHandle;
 
+// Flushes any remaining log messages to NVDA.
+// This should only be called from the NVDA inproc manager thread as it blocks while sending to NVDA.
+void log_terminate();
+
 #endif

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,6 +39,7 @@ What's New in NVDA
 - In Internet Explorer, numbers are now announced correctly for ordered lists if the list does not start with 1. (#8438)
 - In Google chrome, NVDA will now report not checked for all checkable controls (not just check boxes) that are currently not checked. (#11377)
 - It is once again possible to navigate in various controls when NVDA's language is set to Aragonese. (#11384)
+- NVDA should no longer sometimes freeze in Microsoft Word when rapidly arrowing up and down or typing characters with Braille enabled. (#11431, #11425, #11414)
 
 
 == Changes For Developers ==


### PR DESCRIPTION
### Link to issue number:
Re #11369 , #11398 

### Summary of the issue:
While NVDA is running code within other processes (such as for visutlaBuffers, displayModels and other helper functions), it occasionally logs messages back to NvDA for debugging purposes. Log messages are sent to NvDA via rpc. But currently these rpc calls block while the log message is being sent to NVDA, which may mean that an app's main thread could block for a time or in the worst case deadlock with NvDA, if the Python garbage collector in NVDA happens to run within the incoming rpc call and happens to release a COM object for the thread the log call originated from.
 

### Description of how this pull request fixes the issue:
logMessage (in NVDAHelperRemote) will now do the following:
* First it will log the message via the Windows debugging API (so that it shows in a debugger if conected). Previously this was done after the log message was sent to NVDA.
* If NVDA's inproc manager thread is not yet running, or the current thread is not the inproc manager thread, then the log message is put in a queue for later retrieval in NVDA's inproc manager thread, and an APC function is queued to the inproc manager thread for later fetching and sending to NVDA.
* If the current thread is the inproc manager thread, then any previously queued log messages are fetched and sent to NVDA, then the current log message is sent to NVDA. We deliberately process any previously queued messages before sending the current message to ensure that log messages remain in the correct order.

Just before the inproc manager thread finally exits, we also process any queued log messages to catch any queued after the manager thread main loop completed.

### Testing performed:
Ran NVDA, interacting with Microsoft Word, Notepad and the Run dialog. 
Added some temporary log calls in various places in the in-process code, such as dllMain, and when handing typed characters in the app's main thread, to ensure that message ordering is correct, and that log calls were always happening from the manager thread.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
- NVDA should no longer sometimes freeze in Microsoft Word when rapidly arrowing up and down.