### PR TITLE
Fix qflushQueue trying to log an exception with queue name

### DIFF
--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -54,7 +54,7 @@ def flushQueue(queue):
 			try:
 				func(*args,**kwargs)
 			except:
-				log.exception("Error in func %s from %s"%(func.__name__,queue.__name__))
+				log.exception(f"Error in func {func.__qualname__}")
 
 def isPendingItems(queue):
 	if not queue.empty():


### PR DESCRIPTION
### Link to issue number:
Introduced in #11373 

### Summary of the issue:
#11373 no longer sets the __name__ attribute on the new SimpleQueue as it is not allowed. However, when an exception was raised by a queued function in flushQueue, that tried to log the name of the queue.

### Description of how this pull request fixes the issue:
No longer log the name of the queue. Instead, log the function's __qualname__ to give more context about what function caused an error.

### Testing performed:
Queued a function to the queue that required a parameter without providing it to the function call.

### Known issues with pull request:
This still fails when throwing a partial at it, as a partial neither has __name__ nor __qualname__ set, so in the past, it already did so. I think we should somehow come up with a generic method to get the name of a callback.

### Change log entry:
None