### PR TITLE
Don't fail build when symbols can't be uploaded

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -253,9 +253,15 @@ deploy_script:
        artifacts=$artifacts
       }
       ConvertTo-Json -InputObject $data -Compress | ssh nvaccess@exbi.nvaccess.org nvdaAppveyorHook
+
       # Upload symbols to Mozilla.
       py -m pip install --no-warn-script-location requests
-       py appveyor\mozillaSyms.py
+      py appveyor\mozillaSyms.py
+      if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        echo Unable to upload symbols to Mozilla
+        Add-AppveyorMessage "Unable to upload symbols to Mozilla"
+      }
      }
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -140,7 +140,7 @@ before_test:
       $installerProcess | wait-process -Timeout 180
       $errorCode=$installerProcess.ExitCode
      } catch {
-      echo NVDA installer process timed out
+      echo "NVDA installer process timed out"
       $errorCode=1
       Add-AppveyorMessage "Unable to install NVDA prior to tests."
      }
@@ -259,7 +259,7 @@ deploy_script:
       py appveyor\mozillaSyms.py
       if($LastExitCode -ne 0) {
         $errorCode=$LastExitCode
-        echo Unable to upload symbols to Mozilla
+        echo "Unable to upload symbols to Mozilla"
         Add-AppveyorMessage "Unable to upload symbols to Mozilla"
       }
      }

--- a/appveyor/mozillaSyms.py
+++ b/appveyor/mozillaSyms.py
@@ -89,7 +89,8 @@ def upload():
 			import time
 			time.sleep(15)
 		try:
-			r = requests.post(URL,
+			r = requests.post(
+				URL,
 				files={'symbols.zip': open(ZIP_FILE, 'rb')},
 				headers={'Auth-Token': os.getenv('mozillaSymsAuthToken')},
 				allow_redirects=False

--- a/appveyor/mozillaSyms.py
+++ b/appveyor/mozillaSyms.py
@@ -96,9 +96,9 @@ def upload():
 				allow_redirects=False
 			)
 			break  # success
-		except requests.ConnectionError as e:
-			print(f"Attempt {i + 1} failed.")
-			errors.append(str(e))
+		except Exception as e:
+			print(f"Attempt {i + 1} failed: {e!r}")
+			errors.append(repr(e))
 	else:  # no break in for loop
 		allErrors = "\n".join(
 			f"Attempt {index + 1} error: \n{e}"


### PR DESCRIPTION

The symbols are already saved as artefacts, if the upload to Mozilla
fails, it can be fixed manually.

Make the attempt more robust by trying multiple times with a short wait
in between.

### Summary of the issue:
Failing to upload symbols to Mozilla should not cause our build to fail.

Trying to create a release build keeps failing while trying to upload the debug symbols to the Mozilla server.
See: https://ci.appveyor.com/project/NVAccess/nvda/builds/34337309

The symbols are already saved as artifacts regardless of the builds success.
See: https://ci.appveyor.com/project/NVAccess/nvda/builds/34337309/artifacts

Error from build log:
```
py : Traceback (most recent call last):
At line:23 char:3
+   py appveyor\mozillaSyms.py
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Traceback (most recent call last)::String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "C:\Python37\lib\http\client.py", line 1354, in getresponse
    response.begin()
  File "C:\Python37\lib\http\client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "C:\Python37\lib\http\client.py", line 275, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\requests\adapters.py", line 449, in send
    timeout=timeout
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 727, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "C:\Python37\lib\site-packages\urllib3\util\retry.py", line 403, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "C:\Python37\lib\site-packages\urllib3\packages\six.py", line 734, in reraise
    raise value.with_traceback(tb)
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "C:\Python37\lib\http\client.py", line 1354, in getresponse
    response.begin()
  File "C:\Python37\lib\http\client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "C:\Python37\lib\http\client.py", line 275, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "appveyor\mozillaSyms.py", line 103, in <module>
    upload()
  File "appveyor\mozillaSyms.py", line 87, in upload
    allow_redirects=False
  File "C:\Python37\lib\site-packages\requests\api.py", line 119, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "C:\Python37\lib\site-packages\requests\api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "C:\Python37\lib\site-packages\requests\sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "C:\Python37\lib\site-packages\requests\sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "C:\Python37\lib\site-packages\requests\adapters.py", line 498, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
Command executed with exception:   File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "C:\Python37\lib\http\client.py", line 1354, in getresponse
    response.begin()
  File "C:\Python37\lib\http\client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "C:\Python37\lib\http\client.py", line 275, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\requests\adapters.py", line 449, in send
    timeout=timeout
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 727, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "C:\Python37\lib\site-packages\urllib3\util\retry.py", line 403, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "C:\Python37\lib\site-packages\urllib3\packages\six.py", line 734, in reraise
    raise value.with_traceback(tb)
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "C:\Python37\lib\site-packages\urllib3\connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "C:\Python37\lib\http\client.py", line 1354, in getresponse
    response.begin()
  File "C:\Python37\lib\http\client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "C:\Python37\lib\http\client.py", line 275, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "appveyor\mozillaSyms.py", line 103, in <module>
    upload()
  File "appveyor\mozillaSyms.py", line 87, in upload
    allow_redirects=False
  File "C:\Python37\lib\site-packages\requests\api.py", line 119, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "C:\Python37\lib\site-packages\requests\api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "C:\Python37\lib\site-packages\requests\sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "C:\Python37\lib\site-packages\requests\sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "C:\Python37\lib\site-packages\requests\adapters.py", line 498, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

### Description of how this pull request fixes the issue:
Try multiple times (7) to upload the symbols, with 15 seconds between attempts.
If all attempts fail, all errors should be printed to the log. A message should be added to the build messages, but the build should succeed.

### Testing performed:
PR build.
Release build.

