### PR TITLE
Don't use sibling text as the description of groupings in IA2 web browsers.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -15,7 +15,7 @@ import controlTypes
 from logHandler import log
 from documentBase import DocumentWithTableNavigation
 from NVDAObjects.behaviors import Dialog, WebDialog 
-from . import IAccessible
+from . import IAccessible, Groupbox
 from .ia2TextMozilla import MozillaCompoundTextInfo
 import aria
 import api
@@ -219,6 +219,13 @@ def findExtraOverlayClasses(obj, clsList, baseClass=Ia2Web, documentClass=None):
 		clsList.append(Math)
 	elif xmlRoles[0] == "switch":
 		clsList.append(Switch)
+	elif iaRole == oleacc.ROLE_SYSTEM_GROUPING:
+		try:
+			# The Groupbox class uses sibling text as the description. This is
+			# inappropriate for IA2 web browsers.
+			clsList.remove(Groupbox)
+		except ValueError:
+			pass
 
 	if iaRole==oleacc.ROLE_SYSTEM_APPLICATION:
 		clsList.append(Application)


### PR DESCRIPTION
### Link to issue number:
Blocks #11120.

### Summary of the issue:
NVDA uses the sibling text of a grouping in Firefox or Chrome as the description for the grouping. While this is appropriate for Win32 group boxes, it is inappropriate for IA2 web browsers. Specifically, in Firefox with NODE_CHILD_OF removed (see #11120), it causes "grouping </" to be reported whenever you enter a nested tree item in the Dev Tools main inspector.

The reason this doesn't occur with NODE_CHILD_OF is that Firefox skips grouping ancestors with NODE_CHILD_OF.

### Description of how this pull request fixes the issue:
In ia2Web.findExtraOverlayClasses, Groupbox is removed if present.

### Testing performed:
Test case:
`data:text/html,<button>before</button><fieldset><input></fieldset>After<br>`
Tabbed to the input.
Before PR: "grouping  after,  edit has autocomplete"
After PR: just "edit has autocomplete"

### Known issues with pull request:
None.

### Change log entry:
I doubt anyone has seen this in the wild, and given how obscure this is, I'm not sure it's worth having a What's New entry for it. The reason for this PR is #11120, but the problem wouldn't be noticeable until that PR is merged.