### PR TITLE
Update the master of NVDA from master to main.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: "{branch}-{build}"
 
 branches:
  only:
-  - master
+  - main
   - beta
   - rc
   - /try-.*/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: "{branch}-{build}"
 
 branches:
  only:
+  - master
   - main
   - beta
   - rc


### PR DESCRIPTION
The current branch of Hello World [GitHub Guides](https://guides.github.com/activities/hello-world/#repository) has been transferred from master to main.


### Link to issue number:
#11452 
### Summary of the issue:
Update the master of NVDA from master to main.
### Description of how this pull request fixes the issue:
Use the latest official naming convention of github to update NVDA's master and branch
### Testing performed:
none
### Known issues with pull request:
none
### Change log entry:
changes
- Update the NVDA master to main. (#11452)
thanks