### PR TITLE
Don't activate Say All profile if there is nothing to read

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -109,7 +109,7 @@ class _TextReader(object):
 	def __init__(self, cursor):
 		self.cursor = cursor
 		self.trigger = SayAllProfileTrigger()
-		self.trigger.enter()
+		self.reader = None
 		# Start at the cursor.
 		if cursor == CURSOR_CARET:
 			try:
@@ -118,6 +118,8 @@ class _TextReader(object):
 				raise NotImplementedError("Unable to make TextInfo: " + str(e))
 		else:
 			self.reader = api.getReviewPosition()
+		# #10899: SayAll profile can't be activated earlier because they may not be anything to read
+		self.trigger.enter()
 		self.speakTextInfoState = speech.SpeakTextInfoState(self.reader.obj)
 		self.numBufferedLines = 0
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,6 +43,7 @@ What's New in NVDA
 - It is once again possible to navigate in various controls when NVDA's language is set to Aragonese. (#11384)
 - NVDA should no longer sometimes freeze in Microsoft Word when rapidly arrowing up and down or typing characters with Braille enabled. (#11431, #11425, #11414)
 - NVDA no longer appends nonexistent trailing space when copying the current navigator object to the clipboard. (#11438)
+- NVDA no longer activates the Say All profile if there is nothing to read. (#10899, #9947)
 
 
 == Changes For Developers ==


### PR DESCRIPTION

### Link to issue number:
Fixes #10899
Fixes #9947 completely


### Summary of the issue:
In Python 3 versions of NVDA when user attempted to perform Say All in non text and had separate profile for Say All the profile was activated without possibility of disabling unless NVDA is restarted. Also Say All in non text raised an error. (#10723 attempted to fix  this but the fix was not complete).
### Description of how this pull request fixes the issue:
The say all trigger is only entered if there is something to read. Normally the destructor is responsible for disabling this trigger when reading ends but due to #9947 this was not happening.
### Testing performed:
1. On desktop pressed NVDA + Down arrow ensured that there is no error sound.
2. With profile for Say all ensured that NVDA does not switch into it when there is not text to read and that it switches to it when performing say all in text.
### Known issues with pull request:
- #11006 - This fixes a regression from Python 3 migration.
### Change log entry:

Section: Bug fixes

NVDA no longer activates Say All profile if there is nothing to read.