### PR TITLE
Fix faulty read only state on UIA objects

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1331,7 +1331,9 @@ class UIA(Window):
 				document = self.UIATextPattern.documentRange
 				isReadOnly = document.GetAttributeValue(UIAHandler.UIA_IsReadOnlyAttributeId)
 			except COMError:
-				isReadOnly = UIAHandler.handler.reservedNotSupportedValue
+				isReadOnly = \UIAHandler.handler.reservedNotSupportedValue
+		if isReadOnly == UIAHandler.handler.reservedNotSupportedValue:
+			return False
 		return isReadOnly
 
 	def _get_presentationType(self):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1331,7 +1331,7 @@ class UIA(Window):
 				document = self.UIATextPattern.documentRange
 				isReadOnly = document.GetAttributeValue(UIAHandler.UIA_IsReadOnlyAttributeId)
 			except COMError:
-				isReadOnly = \UIAHandler.handler.reservedNotSupportedValue
+				isReadOnly = UIAHandler.handler.reservedNotSupportedValue
 		if isReadOnly == UIAHandler.handler.reservedNotSupportedValue:
 			return False
 		return isReadOnly


### PR DESCRIPTION
### Link to issue number:
Fixes regression caused by #10494 

### Summary of the issue:
In #10494, the detection of read only state for UIA objects was enhanced to support fetching the state from the text pattern. However, when the read only property isn't supported, for example on check boxes in the Windows 10 settings, the read only state is added erroneously because UIAHandler.handler.reservedNotSupportedValue evaluates to True

### Description of how this pull request fixes the issue:
in _getReadOnlyState, return False when isReadOnly == UIAHandler.handler.reservedNotSupportedValue

### Testing performed:
Ensured that the read only state is no longer added to objects such as in the windows 10 settings list view and checkboxes on the bluetooth devices tab.

### Known issues with pull request:
None

### Change log entry:
None needed, regression in current cycle.