### PR TITLE
Modern keyboard 2020: modernization and detection of state changes

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -220,6 +220,9 @@ class AppModule(appModuleHandler.AppModule):
 		nextHandler()
 
 	def event_stateChange(self, obj, nextHandler):
+		# Without clearing this, NVDA will not announce symbols after selecting a symbol group and
+		# tabbing through the modern keyboard interface.
+		self._symbolsGroupSelected = False
 		# Try detecting if modern keyboard elements are off-screen
 		# or the window itself is gone (parent's first child is nothing).
 		# But attempting to retrieve object location fails when emoji panel closes without selecting anything,

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -22,6 +22,8 @@ from NVDAObjects.UIA import UIA
 
 class AppModule(appModuleHandler.AppModule):
 
+	# Inform NVDA that modern keyboard interface is active.
+	_modernKeyboardInterfaceActive = False
 	# Cache the most recently selected item.
 	_recentlySelected = None
 
@@ -118,7 +120,7 @@ class AppModule(appModuleHandler.AppModule):
 				pass
 		# Emoji panel in build 17666 and later (unless this changes).
 		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
-			self._emojiPanelJustOpened = True
+			self._modernKeyboardInterfaceActive = True
 			# #10377: on some systems, there is something else besides grouping controls,
 			# so another child control must be used.
 			emojisList = inputPanel.children[-2]
@@ -141,9 +143,6 @@ class AppModule(appModuleHandler.AppModule):
 				clipboardHistory = clipboardHistory.next
 			eventHandler.executeEvent("UIA_elementSelected", clipboardHistory)
 		nextHandler()
-
-	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.
-	_emojiPanelJustOpened = False
 
 	def event_nameChange(self, obj, nextHandler):
 		# On some systems, touch keyboard keys keeps firing name change event.
@@ -173,11 +172,11 @@ class AppModule(appModuleHandler.AppModule):
 			except AttributeError:
 				return
 			if (
-				not self._emojiPanelJustOpened
+				not self._modernKeyboardInterfaceActive
 				or obj.UIAAutomationId != "TEMPLATE_PART_ExpressionGroupedFullView"
 			):
 				speech.cancelSpeech()
-			self._emojiPanelJustOpened = False
+			self._modernKeyboardInterfaceActive = False
 		# Don't forget to add "Microsoft Candidate UI" as something that should be suppressed.
 		if obj.UIAAutomationId not in (
 			"TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -97,9 +97,12 @@ class AppModule(appModuleHandler.AppModule):
 		# However this event is raised when the input panel closes.
 		inputPanel = obj.firstChild
 		if inputPanel is None:
+			self._modernKeyboardInterfaceActive = False
+			self._recentlySelected = None
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
 		inputPanelAutomationID = inputPanel.UIAAutomationId
+		self._modernKeyboardInterfaceActive = True
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
@@ -118,9 +121,8 @@ class AppModule(appModuleHandler.AppModule):
 			except AttributeError:
 				# Because this is dictation window.
 				pass
-		# Emoji panel in build 17666 and later (unless this changes).
+		# Emoji panel in Version 1809 (specifically, build 17666) and later.
 		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
-			self._modernKeyboardInterfaceActive = True
 			# #10377: on some systems, there is something else besides grouping controls,
 			# so another child control must be used.
 			emojisList = inputPanel.children[-2]

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,6 +1,5 @@
-# App module for Composable Shell (CShell) input panel
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017-2018 NV Access Limited, Joseph Lee
+#Copyright (C) 2017-2020 NV Access Limited, Joseph Lee
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -26,6 +26,8 @@ class AppModule(appModuleHandler.AppModule):
 	_modernKeyboardInterfaceActive = False
 	# Cache the most recently selected item.
 	_recentlySelected = None
+	# Set when an emoji/kaomoji/symbol group item is selected.
+	_symbolsGroupSelected = False
 	# Set when emoji/kaomoji/symbol search is in progress, used to prevent unpredictable state announcements.
 	_searchInProgress = False
 
@@ -37,9 +39,16 @@ class AppModule(appModuleHandler.AppModule):
 			self._modernKeyboardInterfaceActive = True
 		if winVersion.isWin10(version=1803) and not self._modernKeyboardInterfaceActive:
 			return
+		# If emoji/kaomoji/symbols group item gets selected,
+		# just tell NVDA to treat it as the new navigator object (for presentational purposes) and move on.
 		if obj.parent.UIAAutomationId == "TEMPLATE_PART_Groups_ListView":
 			if obj.positionInfo["indexInGroup"] == 1:
 				self._searchInProgress = True
+			else:
+				# Symbols group flag must be set if and only if emoji panel is active,
+				# because element selected event is fired when opening the panel after a while.
+				api.setNavigatorObject(obj)
+				self._symbolsGroupSelected = True
 			return
 		# #7273: in Version 1709 and 1803, first emoji from the newly selected category is not announced.
 		# Therefore, move the navigator object to that item if possible.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -183,3 +183,11 @@ class AppModule(appModuleHandler.AppModule):
 		):
 			ui.message(obj.name)
 		nextHandler()
+
+	def event_stateChange(self, obj, nextHandler):
+		# Attempting to retrieve object location fails when emoji panel closes without selecting anything,
+		# especially in Version 1903 and later.
+		if obj.location is None and winVersion.isWin10(version=1903):
+			self._modernKeyboardInterfaceActive = False
+			self._recentlySelected = None
+		nextHandler()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,11 +1,12 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2017-2020 NV Access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2017-2020 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """App module for Windows 10 Modern Keyboard aka new touch keyboard panel.
-The chief feature is allowing NVDA to announce selected emoji when using the keyboard to search for and select one.
-Other features include announcing candidates for misspellings if suggestions for hardware keyboard is selected, and managing cloud clipboard paste.
+The chief feature is announcing selected emoji when using the keyboard to search for and select one.
+Other features include announcing candidates for misspellings if suggestions for hardware keyboard is active,
+managing clipboard history, and dictation support.
 This is applicable on Windows 10 Fall Creators Update and later."""
 
 import appModuleHandler
@@ -17,34 +18,46 @@ import config
 import winVersion
 from NVDAObjects.UIA import UIA
 
+
 class AppModule(appModuleHandler.AppModule):
 
 	# Cache the most recently selected item.
 	_recentlySelected = None
 
 	def event_UIA_elementSelected(self, obj, nextHandler):
-		# #7273: When this is fired on categories, the first emoji from the new category is selected but not announced.
+		# #7273: in Version 1709 and 1803, first emoji from the newly selected category is not announced.
 		# Therefore, move the navigator object to that item if possible.
-		# However, in recent builds, name change event is also fired.
+		# In Version 1809 and later, name change event is also fired.
 		# For consistent experience, report the new category first by traversing through controls.
-		# #8189: do not announce candidates list itself (not items), as this is repeated each time candidate items are selected.
-		if obj.UIAElement.cachedAutomationID == "CandidateList": return
+		# #8189: do not announce candidates list itself (not items),
+		# as this is repeated each time candidate items are selected.
+		if obj.UIAElement.cachedAutomationID == "CandidateList":
+			return
 		speech.cancelSpeech()
-		# Sometimes, due to bad tree traversal or wrong item getting selected, something other than the selected item sees this event.
+		# Sometimes, due to bad tree traversal or wrong item getting selected,
+		# something other than the selected item sees this event.
 		# Sometimes clipboard candidates list gets selected, so ask NvDA to descend one more level.
 		if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList":
 			obj = obj.firstChild
-		# In build 18262, emoji panel may open to People group and skin tone modifier or the list housing them gets selected.
+		# In build 18262, emoji panel may open to People group and skin tone modifier
+		# or the list housing them gets selected.
 		elif obj.UIAElement.cachedAutomationID == "SkinTonePanelModifier_ListView":
 			obj = obj.next
 		elif obj.parent.UIAElement.cachedAutomationID == "SkinTonePanelModifier_ListView":
 			# But this will point to nothing if emoji search results are not people.
-			if obj.parent.next is not None: obj = obj.parent.next
-			else: obj = obj.parent.parent.firstChild
+			if obj.parent.next is not None:
+				obj = obj.parent.next
+			else:
+				obj = obj.parent.parent.firstChild
 		candidate = obj
-		if obj and obj.UIAElement.cachedClassName == "ListViewItem" and obj.parent and isinstance(obj.parent, UIA) and obj.parent.UIAElement.cachedAutomationID != "TEMPLATE_PART_ClipboardItemsList":
+		if (
+			obj and obj.UIAElement.cachedClassName == "ListViewItem"
+			and obj.parent and isinstance(obj.parent, UIA)
+			and obj.parent.UIAElement.cachedAutomationID != "TEMPLATE_PART_ClipboardItemsList"
+		):
 			# The difference between emoji panel and suggestions list is absence of categories/emoji separation.
-			# Turns out automation ID for the container is different, observed in build 17666 when opening clipboard copy history.
+			# Turns out automation ID for the container is different, observed in
+			# build 17666 when opening clipboard copy history.
 			candidate = obj.parent.previous
 			if candidate is not None:
 				# Emoji categories list.
@@ -61,14 +74,16 @@ class AppModule(appModuleHandler.AppModule):
 			# Cache selected item.
 			self._recentlySelected = obj.name
 		else:
-			# Translators: presented when there is no emoji when searching for one in Windows 10 Fall Creators Update and later.
+			# Translators: presented when there is no emoji when searching for one in
+			# Windows 10 Fall Creators Update and later.
 			ui.message(_("No emoji"))
 		nextHandler()
 
 	def event_UIA_window_windowOpen(self, obj, nextHandler):
 		# Make sure to announce most recently used emoji first in post-1709 builds.
 		# Fake the announcement by locating 'most recently used" category and calling selected event on this.
-		# However, in build 17666 and later, child count is the same for both emoji panel and hardware keyboard candidates list.
+		# However, in build 17666 and later,
+		# child count is the same for both emoji panel and hardware keyboard candidates list.
 		# Thankfully first child automation ID's are different for each modern input technology.
 		# However this event is raised when the input panel closes.
 		if obj.firstChild is None:
@@ -77,11 +92,20 @@ class AppModule(appModuleHandler.AppModule):
 		childAutomationID = obj.firstChild.UIAElement.cachedAutomationID
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
-		if winVersion.winVersion.build <= 17134 and childAutomationID in ("TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl", "TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"):
+		if (
+			winVersion.winVersion.build <= 17134
+			and childAutomationID in (
+				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
+				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
+			)
+		):
 			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
-		elif childAutomationID == "CandidateWindowControl" and config.conf["inputComposition"]["autoReportAllCandidates"]:
+		elif (
+			childAutomationID == "CandidateWindowControl"
+			and config.conf["inputComposition"]["autoReportAllCandidates"]
+		):
 			try:
 				self.event_UIA_elementSelected(obj.firstChild.firstChild.firstChild, nextHandler)
 			except AttributeError:
@@ -97,7 +121,8 @@ class AppModule(appModuleHandler.AppModule):
 				pass
 		# Clipboard history.
 		# Move to clipboard list so element selected event can pick it up.
-		# #9103: if clipboard is empty, a status message is displayed instead, and luckily it is located where clipboard data items can be found.
+		# #9103: if clipboard is empty, a status message is displayed instead,
+		# and luckily it is located where clipboard data items can be found.
 		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
 			self.event_UIA_elementSelected(obj.children[-2], nextHandler)
 		nextHandler()
@@ -108,24 +133,39 @@ class AppModule(appModuleHandler.AppModule):
 	def event_nameChange(self, obj, nextHandler):
 		# On some systems, touch keyboard keys keeps firing name change event.
 		# In build 17704, whenever skin tones are selected, name change is fired by emoji entries (GridViewItem).
-		if ((obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem"))
-		# Just ignore useless clipboard status.
-		# Also top emoji search result must be announced for better user experience.
-		or (obj.UIAElement.cachedAutomationID in ("TEMPLATE_PART_ClipboardItemsList", "TEMPLATE_PART_Search_TextBlock"))
-		# And no, emoji entries should not be announced here.
-		or (self._recentlySelected is not None and self._recentlySelected in obj.name)):
+		if (
+			obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem")
+			# Just ignore useless clipboard status.
+			# Also top emoji search result must be announced for better user experience.
+			or obj.UIAElement.cachedAutomationID in (
+				"TEMPLATE_PART_ClipboardItemsList", "TEMPLATE_PART_Search_TextBlock"
+			)
+			# And no, emoji entries should not be announced here.
+			or (self._recentlySelected is not None and self._recentlySelected in obj.name)
+		):
 			return
 		# The word "blank" is kept announced, so suppress this on build 17666 and later.
 		if winVersion.winVersion.build > 17134:
-			# In build 17672 and later, return immediatley when element selected event on clipboard item was fired just prior to this.
+			# In build 17672 and later, return immediatley
+			# when element selected event on clipboard item was fired just prior to this.
 			# In some cases, parent will be None, as seen when emoji panel is closed in build 18267.
 			try:
-				if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemIndex" or obj.parent.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList": return
+				if (
+					obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemIndex"
+					or obj.parent.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList"
+				):
+					return
 			except AttributeError:
 				return
-			if not self._emojiPanelJustOpened or obj.UIAElement.cachedAutomationID != "TEMPLATE_PART_ExpressionGroupedFullView": speech.cancelSpeech()
+			if (
+				not self._emojiPanelJustOpened
+				or obj.UIAElement.cachedAutomationID != "TEMPLATE_PART_ExpressionGroupedFullView"
+			):
+				speech.cancelSpeech()
 			self._emojiPanelJustOpened = False
 		# Don't forget to add "Microsoft Candidate UI" as something that should be suppressed.
-		if obj.UIAElement.cachedAutomationID not in ("TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"):
+		if obj.UIAElement.cachedAutomationID not in (
+			"TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"
+		):
 			ui.message(obj.name)
 		nextHandler()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -125,6 +125,7 @@ class AppModule(appModuleHandler.AppModule):
 		# #9104: different aspects of modern input panel are represented by automation iD's.
 		inputPanelAutomationID = inputPanel.UIAAutomationId
 		self._modernKeyboardInterfaceActive = True
+		self._symbolsGroupSelected = False
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
@@ -205,6 +206,8 @@ class AppModule(appModuleHandler.AppModule):
 			"TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"
 		):
 			ui.message(obj.name)
+		# Thankfully name change event is the last thing done when selecting items.
+		self._symbolsGroupSelected = False
 		# In Version 1809, name change event is fired just as emoji panel is being closed (entries are 0).
 		if not any(obj.location):
 			self._modernKeyboardInterfaceActive = False

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -121,20 +121,20 @@ class AppModule(appModuleHandler.AppModule):
 			self._recentlySelected = None
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
-		inputPanelAutomationID = inputPanel.UIAAutomationId
+		inputPanelAutomationId = inputPanel.UIAAutomationId
 		self._modernKeyboardInterfaceActive = True
 		self._symbolsGroupSelected = False
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
 			not winVersion.isWin10(version=1809)
-			and inputPanelAutomationID in self._classicEmojiPanelAutomationIds
+			and inputPanelAutomationId in self._classicEmojiPanelAutomationIds
 		):
 			eventHandler.executeEvent("UIA_elementSelected", obj.lastChild.firstChild)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
 		elif (
-			inputPanelAutomationID == "CandidateWindowControl"
+			inputPanelAutomationId == "CandidateWindowControl"
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
@@ -143,7 +143,7 @@ class AppModule(appModuleHandler.AppModule):
 				# Because this is dictation window.
 				pass
 		# Emoji panel in Version 1809 (specifically, build 17666) and later.
-		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
+		elif inputPanelAutomationId == "TEMPLATE_PART_ExpressionGroupedFullView":
 			# #10377: on some systems, there is something else besides grouping controls,
 			# so another child control must be used.
 			emojisList = inputPanel.children[-2]
@@ -162,11 +162,11 @@ class AppModule(appModuleHandler.AppModule):
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead,
 		# and luckily it is located where clipboard data items can be found.
-		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
+		elif inputPanelAutomationId == "TEMPLATE_PART_ClipboardTitleBar":
 			# Under some cases, clipboard tip text isn't shown on screen,
 			# causing clipboard history title to be announced instead of most recently copied item.
 			clipboardHistory = obj.children[-2]
-			if clipboardHistory.UIAAutomationId == inputPanelAutomationID:
+			if clipboardHistory.UIAAutomationId == inputPanelAutomationId:
 				clipboardHistory = clipboardHistory.next
 			# Make sure to move to actual clipboard history item if available.
 			if clipboardHistory.firstChild is not None:

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -176,12 +176,15 @@ class AppModule(appModuleHandler.AppModule):
 				or obj.UIAAutomationId != "TEMPLATE_PART_ExpressionGroupedFullView"
 			):
 				speech.cancelSpeech()
-			self._modernKeyboardInterfaceActive = False
 		# Don't forget to add "Microsoft Candidate UI" as something that should be suppressed.
 		if obj.UIAAutomationId not in (
 			"TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"
 		):
 			ui.message(obj.name)
+		# In Version 1809, name change event is fired just as emoji panel is being closed (entries are 0).
+		if not any(obj.location):
+			self._modernKeyboardInterfaceActive = False
+			self._recentlySelected = None
 		nextHandler()
 
 	def event_stateChange(self, obj, nextHandler):

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -225,8 +225,10 @@ class AppModule(appModuleHandler.AppModule):
 		# But attempting to retrieve object location fails when emoji panel closes without selecting anything,
 		# especially in Version 1903 and later.
 		# Because of exceptions, check location first.
-		if ((obj.location is None and obj.parent.firstChild is None and winVersion.isWin10(version=1903))
-		or controlTypes.STATE_OFFSCREEN in obj.states):
+		if (
+			(obj.location is None and obj.parent.firstChild is None and winVersion.isWin10(version=1903))
+			or controlTypes.STATE_OFFSCREEN in obj.states
+		):
 			self._modernKeyboardInterfaceActive = False
 			self._recentlySelected = None
 		nextHandler()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -28,6 +28,10 @@ class AppModule(appModuleHandler.AppModule):
 	_recentlySelected = None
 
 	def event_UIA_elementSelected(self, obj, nextHandler):
+		# Wait until modern keyboard is fully displayed on screen.
+		# Not seen in Version 1709 as window open event is not fired.
+		if winVersion.isWin10(version=1803) and not self._modernKeyboardInterfaceActive:
+			return
 		# #7273: in Version 1709 and 1803, first emoji from the newly selected category is not announced.
 		# Therefore, move the navigator object to that item if possible.
 		# In Version 1809 and later, name change event is also fired.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -93,10 +93,11 @@ class AppModule(appModuleHandler.AppModule):
 		# child count is the same for both emoji panel and hardware keyboard candidates list.
 		# Thankfully first child automation ID's are different for each modern input technology.
 		# However this event is raised when the input panel closes.
-		if obj.firstChild is None:
+		inputPanel = obj.firstChild
+		if inputPanel is None:
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
-		inputPanelAutomationID = obj.firstChild.UIAElement.cachedAutomationID
+		inputPanelAutomationID = inputPanel.UIAElement.cachedAutomationID
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
@@ -111,7 +112,7 @@ class AppModule(appModuleHandler.AppModule):
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
-				eventHandler.executeEvent("UIA_elementSelected", obj.firstChild.firstChild.firstChild)
+				eventHandler.executeEvent("UIA_elementSelected", inputPanel.firstChild.firstChild)
 			except AttributeError:
 				# Because this is dictation window.
 				pass
@@ -119,7 +120,7 @@ class AppModule(appModuleHandler.AppModule):
 		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
 			try:
-				eventHandler.executeEvent("UIA_elementSelected", obj.firstChild.children[-2].firstChild.firstChild)
+				eventHandler.executeEvent("UIA_elementSelected", inputPanel.children[-2].firstChild.firstChild)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -94,7 +94,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
-			winVersion.winVersion.build <= 17134
+			not winVersion.isWin10(version=1809)
 			and childAutomationID in (
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
@@ -146,7 +146,7 @@ class AppModule(appModuleHandler.AppModule):
 		):
 			return
 		# The word "blank" is kept announced, so suppress this on build 17666 and later.
-		if winVersion.winVersion.build > 17134:
+		if winVersion.isWin10(version=1809):
 			# In build 17672 and later, return immediatley
 			# when element selected event on clipboard item was fired just prior to this.
 			# In some cases, parent will be None, as seen when emoji panel is closed in build 18267.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -16,6 +16,7 @@ import braille
 import ui
 import config
 import winVersion
+import eventHandler
 from NVDAObjects.UIA import UIA
 
 
@@ -99,7 +100,7 @@ class AppModule(appModuleHandler.AppModule):
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
 			)
 		):
-			self.event_UIA_elementSelected(obj.lastChild.firstChild, nextHandler)
+			eventHandler.executeEvent("UIA_elementSelected", obj.lastChild.firstChild)
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
 		elif (
@@ -107,7 +108,7 @@ class AppModule(appModuleHandler.AppModule):
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.firstChild.firstChild, nextHandler)
+				eventHandler.executeEvent("UIA_elementSelected", obj.firstChild.firstChild.firstChild)
 			except AttributeError:
 				# Because this is dictation window.
 				pass
@@ -115,7 +116,7 @@ class AppModule(appModuleHandler.AppModule):
 		elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
 			try:
-				self.event_UIA_elementSelected(obj.firstChild.children[-2].firstChild.firstChild, nextHandler)
+				eventHandler.executeEvent("UIA_elementSelected", obj.firstChild.children[-2].firstChild.firstChild)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
@@ -124,7 +125,7 @@ class AppModule(appModuleHandler.AppModule):
 		# #9103: if clipboard is empty, a status message is displayed instead,
 		# and luckily it is located where clipboard data items can be found.
 		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
-			self.event_UIA_elementSelected(obj.children[-2], nextHandler)
+			eventHandler.executeEvent("UIA_elementSelected", obj.children[-2])
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -56,7 +56,16 @@ class AppModule(appModuleHandler.AppModule):
 		# For consistent experience, report the new category first by traversing through controls.
 		# #8189: do not announce candidates list itself (not items),
 		# as this is repeated each time candidate items are selected.
-		if obj.UIAAutomationId == "CandidateList":
+		if (
+			obj.UIAAutomationId == "CandidateList"
+			# Also, when changing categories (emoji, kaomoji, symbols) in Version 1903 or later,
+			# category items are selected when in fact they have no useful label.
+			or obj.parent.UIAAutomationId == "TEMPLATE_PART_Sets_ListView"
+			# Suppress skin tone modifiers from being announced after an emoji group was selected.
+			or self._symbolsGroupSelected
+			# In Version 1709 and 1803, both categories and items raise element selected event when category changes.
+			or obj.name == self._recentlySelected and not winVersion.isWin10(version=1809)
+		):
 			return
 		speech.cancelSpeech()
 		# Sometimes, due to bad tree traversal or wrong item getting selected,

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -14,6 +14,7 @@ import api
 import speech
 import braille
 import ui
+import controlTypes
 import config
 import winVersion
 import eventHandler
@@ -225,9 +226,13 @@ class AppModule(appModuleHandler.AppModule):
 		nextHandler()
 
 	def event_stateChange(self, obj, nextHandler):
-		# Attempting to retrieve object location fails when emoji panel closes without selecting anything,
+		# Try detecting if modern keyboard elements are off-screen
+		# or the window itself is gone (parent's first child is nothing).
+		# But attempting to retrieve object location fails when emoji panel closes without selecting anything,
 		# especially in Version 1903 and later.
-		if obj.location is None and winVersion.isWin10(version=1903):
+		# Because of exceptions, check location first.
+		if ((obj.location is None and obj.parent.firstChild is None and winVersion.isWin10(version=1903))
+		or controlTypes.STATE_OFFSCREEN in obj.states):
 			self._modernKeyboardInterfaceActive = False
 			self._recentlySelected = None
 		nextHandler()

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -64,14 +64,9 @@ class AppModule(appModuleHandler.AppModule):
 		speech.cancelSpeech()
 		# Sometimes, due to bad tree traversal or wrong item getting selected,
 		# something other than the selected item sees this event.
-		# Sometimes clipboard candidates list gets selected, so ask NvDA to descend one more level.
-		if obj.UIAAutomationId == "TEMPLATE_PART_ClipboardItemsList":
-			obj = obj.firstChild
-		# In build 18262, emoji panel may open to People group and skin tone modifier
-		# or the list housing them gets selected.
-		elif obj.UIAAutomationId == "SkinTonePanelModifier_ListView":
-			obj = obj.next
-		elif obj.parent.UIAAutomationId == "SkinTonePanelModifier_ListView":
+		# In build 18262, emoji panel may open to People group and skin tone modifier gets selected.
+		# Skin tone modifiers are also selected when switching to People emoji group, and this should be suppressed.
+		if obj.parent.UIAAutomationId == "SkinTonePanelModifier_ListView":
 			# But this will point to nothing if emoji search results are not people.
 			if obj.parent.next is not None:
 				obj = obj.parent.next
@@ -155,7 +150,11 @@ class AppModule(appModuleHandler.AppModule):
 			if emojisList.UIAAutomationId != "TEMPLATE_PART_Items_GridView":
 				emojisList = emojisList.previous
 			try:
-				eventHandler.executeEvent("UIA_elementSelected", emojisList.firstChild.firstChild)
+				# Avoid announcing skin tone modifiers if possible.
+				emojiItem = emojisList.firstChild.firstChild
+				if emojiItem.UIAAutomationId == "SkinTonePanelModifier_ListView":
+					emojiItem = emojiItem.next
+				eventHandler.executeEvent("UIA_elementSelected", emojiItem)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
@@ -169,6 +168,9 @@ class AppModule(appModuleHandler.AppModule):
 			clipboardHistory = obj.children[-2]
 			if clipboardHistory.UIAAutomationId == inputPanelAutomationID:
 				clipboardHistory = clipboardHistory.next
+			# Make sure to move to actual clipboard history item if available.
+			if clipboardHistory.firstChild is not None:
+				clipboardHistory = clipboardHistory.firstChild
 			eventHandler.executeEvent("UIA_elementSelected", clipboardHistory)
 		nextHandler()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -80,6 +80,12 @@ class AppModule(appModuleHandler.AppModule):
 			ui.message(_("No emoji"))
 		nextHandler()
 
+	# Emoji panel for build 16299 and 17134.
+	_classicEmojiPanelAutomationID = (
+		"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
+		"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
+	)
+
 	def event_UIA_window_windowOpen(self, obj, nextHandler):
 		# Make sure to announce most recently used emoji first in post-1709 builds.
 		# Fake the announcement by locating 'most recently used" category and calling selected event on this.
@@ -95,10 +101,7 @@ class AppModule(appModuleHandler.AppModule):
 		# This event is properly raised in build 17134.
 		if (
 			not winVersion.isWin10(version=1809)
-			and inputPanelAutomationID in (
-				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
-				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
-			)
+			and inputPanelAutomationID in self._classicEmojiPanelAutomationID
 		):
 			eventHandler.executeEvent("UIA_elementSelected", obj.lastChild.firstChild)
 		# Handle hardware keyboard suggestions.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -119,8 +119,13 @@ class AppModule(appModuleHandler.AppModule):
 		# Emoji panel in build 17666 and later (unless this changes).
 		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
+			# #10377: on some systems, there is something else besides grouping controls,
+			# so another child control must be used.
+			emojisList = inputPanel.children[-2]
+			if emojisList.UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
+				emojisList = emojisList.previous
 			try:
-				eventHandler.executeEvent("UIA_elementSelected", inputPanel.children[-2].firstChild.firstChild)
+				eventHandler.executeEvent("UIA_elementSelected", emojisList.firstChild.firstChild)
 			except AttributeError:
 				# In build 18272's emoji panel, emoji list becomes empty in some situations.
 				pass
@@ -129,7 +134,12 @@ class AppModule(appModuleHandler.AppModule):
 		# #9103: if clipboard is empty, a status message is displayed instead,
 		# and luckily it is located where clipboard data items can be found.
 		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
-			eventHandler.executeEvent("UIA_elementSelected", obj.children[-2])
+			# Under some cases, clipboard tip text isn't shown on screen,
+			# causing clipboard history title to be announced instead of most recently copied item.
+			clipboardHistory = obj.children[-2]
+			if clipboardHistory.UIAElement.cachedAutomationID == inputPanelAutomationID:
+				clipboardHistory = clipboardHistory.next
+			eventHandler.executeEvent("UIA_elementSelected", clipboardHistory)
 		nextHandler()
 
 	# Argh, name change event is fired right after emoji panel opens in build 17666 and later.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -90,12 +90,12 @@ class AppModule(appModuleHandler.AppModule):
 		if obj.firstChild is None:
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
-		childAutomationID = obj.firstChild.UIAElement.cachedAutomationID
+		inputPanelAutomationID = obj.firstChild.UIAElement.cachedAutomationID
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
 			not winVersion.isWin10(version=1809)
-			and childAutomationID in (
+			and inputPanelAutomationID in (
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
 				"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
 			)
@@ -104,7 +104,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Handle hardware keyboard suggestions.
 		# Treat it the same as CJK composition list - don't announce this if candidate announcement setting is off.
 		elif (
-			childAutomationID == "CandidateWindowControl"
+			inputPanelAutomationID == "CandidateWindowControl"
 			and config.conf["inputComposition"]["autoReportAllCandidates"]
 		):
 			try:
@@ -113,7 +113,7 @@ class AppModule(appModuleHandler.AppModule):
 				# Because this is dictation window.
 				pass
 		# Emoji panel in build 17666 and later (unless this changes).
-		elif childAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
+		elif inputPanelAutomationID == "TEMPLATE_PART_ExpressionGroupedFullView":
 			self._emojiPanelJustOpened = True
 			try:
 				eventHandler.executeEvent("UIA_elementSelected", obj.firstChild.children[-2].firstChild.firstChild)
@@ -124,7 +124,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Move to clipboard list so element selected event can pick it up.
 		# #9103: if clipboard is empty, a status message is displayed instead,
 		# and luckily it is located where clipboard data items can be found.
-		elif childAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
+		elif inputPanelAutomationID == "TEMPLATE_PART_ClipboardTitleBar":
 			eventHandler.executeEvent("UIA_elementSelected", obj.children[-2])
 		nextHandler()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -103,7 +103,7 @@ class AppModule(appModuleHandler.AppModule):
 		nextHandler()
 
 	# Emoji panel for build 16299 and 17134.
-	_classicEmojiPanelAutomationID = (
+	_classicEmojiPanelAutomationIds = (
 		"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarItemControl",
 		"TEMPLATE_PART_ExpressiveInputFullViewFuntionBarCloseButton"
 	)
@@ -128,7 +128,7 @@ class AppModule(appModuleHandler.AppModule):
 		# This event is properly raised in build 17134.
 		if (
 			not winVersion.isWin10(version=1809)
-			and inputPanelAutomationID in self._classicEmojiPanelAutomationID
+			and inputPanelAutomationID in self._classicEmojiPanelAutomationIds
 		):
 			eventHandler.executeEvent("UIA_elementSelected", obj.lastChild.firstChild)
 		# Handle hardware keyboard suggestions.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -32,19 +32,19 @@ class AppModule(appModuleHandler.AppModule):
 		# For consistent experience, report the new category first by traversing through controls.
 		# #8189: do not announce candidates list itself (not items),
 		# as this is repeated each time candidate items are selected.
-		if obj.UIAElement.cachedAutomationID == "CandidateList":
+		if obj.UIAAutomationId == "CandidateList":
 			return
 		speech.cancelSpeech()
 		# Sometimes, due to bad tree traversal or wrong item getting selected,
 		# something other than the selected item sees this event.
 		# Sometimes clipboard candidates list gets selected, so ask NvDA to descend one more level.
-		if obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList":
+		if obj.UIAAutomationId == "TEMPLATE_PART_ClipboardItemsList":
 			obj = obj.firstChild
 		# In build 18262, emoji panel may open to People group and skin tone modifier
 		# or the list housing them gets selected.
-		elif obj.UIAElement.cachedAutomationID == "SkinTonePanelModifier_ListView":
+		elif obj.UIAAutomationId == "SkinTonePanelModifier_ListView":
 			obj = obj.next
-		elif obj.parent.UIAElement.cachedAutomationID == "SkinTonePanelModifier_ListView":
+		elif obj.parent.UIAAutomationId == "SkinTonePanelModifier_ListView":
 			# But this will point to nothing if emoji search results are not people.
 			if obj.parent.next is not None:
 				obj = obj.parent.next
@@ -54,7 +54,7 @@ class AppModule(appModuleHandler.AppModule):
 		if (
 			obj and obj.UIAElement.cachedClassName == "ListViewItem"
 			and obj.parent and isinstance(obj.parent, UIA)
-			and obj.parent.UIAElement.cachedAutomationID != "TEMPLATE_PART_ClipboardItemsList"
+			and obj.parent.UIAAutomationId != "TEMPLATE_PART_ClipboardItemsList"
 		):
 			# The difference between emoji panel and suggestions list is absence of categories/emoji separation.
 			# Turns out automation ID for the container is different, observed in
@@ -97,7 +97,7 @@ class AppModule(appModuleHandler.AppModule):
 		if inputPanel is None:
 			return
 		# #9104: different aspects of modern input panel are represented by automation iD's.
-		inputPanelAutomationID = inputPanel.UIAElement.cachedAutomationID
+		inputPanelAutomationID = inputPanel.UIAAutomationId
 		# Emoji panel for build 16299 and 17134.
 		# This event is properly raised in build 17134.
 		if (
@@ -122,7 +122,7 @@ class AppModule(appModuleHandler.AppModule):
 			# #10377: on some systems, there is something else besides grouping controls,
 			# so another child control must be used.
 			emojisList = inputPanel.children[-2]
-			if emojisList.UIAElement.cachedAutomationID != "TEMPLATE_PART_Items_GridView":
+			if emojisList.UIAAutomationId != "TEMPLATE_PART_Items_GridView":
 				emojisList = emojisList.previous
 			try:
 				eventHandler.executeEvent("UIA_elementSelected", emojisList.firstChild.firstChild)
@@ -137,7 +137,7 @@ class AppModule(appModuleHandler.AppModule):
 			# Under some cases, clipboard tip text isn't shown on screen,
 			# causing clipboard history title to be announced instead of most recently copied item.
 			clipboardHistory = obj.children[-2]
-			if clipboardHistory.UIAElement.cachedAutomationID == inputPanelAutomationID:
+			if clipboardHistory.UIAAutomationId == inputPanelAutomationID:
 				clipboardHistory = clipboardHistory.next
 			eventHandler.executeEvent("UIA_elementSelected", clipboardHistory)
 		nextHandler()
@@ -152,7 +152,7 @@ class AppModule(appModuleHandler.AppModule):
 			obj.UIAElement.cachedClassName in ("CRootKey", "GridViewItem")
 			# Just ignore useless clipboard status.
 			# Also top emoji search result must be announced for better user experience.
-			or obj.UIAElement.cachedAutomationID in (
+			or obj.UIAAutomationId in (
 				"TEMPLATE_PART_ClipboardItemsList", "TEMPLATE_PART_Search_TextBlock"
 			)
 			# And no, emoji entries should not be announced here.
@@ -166,20 +166,20 @@ class AppModule(appModuleHandler.AppModule):
 			# In some cases, parent will be None, as seen when emoji panel is closed in build 18267.
 			try:
 				if (
-					obj.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemIndex"
-					or obj.parent.UIAElement.cachedAutomationID == "TEMPLATE_PART_ClipboardItemsList"
+					obj.UIAAutomationId == "TEMPLATE_PART_ClipboardItemIndex"
+					or obj.parent.UIAAutomationId == "TEMPLATE_PART_ClipboardItemsList"
 				):
 					return
 			except AttributeError:
 				return
 			if (
 				not self._emojiPanelJustOpened
-				or obj.UIAElement.cachedAutomationID != "TEMPLATE_PART_ExpressionGroupedFullView"
+				or obj.UIAAutomationId != "TEMPLATE_PART_ExpressionGroupedFullView"
 			):
 				speech.cancelSpeech()
 			self._emojiPanelJustOpened = False
 		# Don't forget to add "Microsoft Candidate UI" as something that should be suppressed.
-		if obj.UIAElement.cachedAutomationID not in (
+		if obj.UIAAutomationId not in (
 			"TEMPLATE_PART_ExpressionFullViewItemsGrid", "TEMPLATE_PART_ClipboardItemIndex", "CandidateWindowControl"
 		):
 			ui.message(obj.name)


### PR DESCRIPTION
Hi,

Although changes in here are extensive, it can be summed up as modernization and adding state change event handling, including lessons learned in the last several years.

### Link to issue number:
Closes #11454 
Another attempt at #10377
Succeeds #10378 

### Summary of the issue:
Consider the following scenarios:

1. In Version 1809 and later, user opens emoji panel, then selects People emoji group. Navigator object will jump to the first people emoji when it should stay on emoji group item.
2. On some systems, when opening emoji panel and/or clipboard history, wrong item is announced.

These were traced to UIA tree traversal and event handling issues, ultimately stemming from changes to modern input facility (emoji panel, hardware keyboard input suggestions, clipboard history, dictation, CJK IME candidate announcements in recent feature updates) over the last three years. Adding to the complication is #11445, as the work in there now allows more events to be tracked and handled such as state change event seen when modern input interface is closed (elements are off-screen).

### Description of how this pull request fixes the issue:
Updates modern input facility support to account for happenings in 2020:

1. General Flake8 based lint and use of winVersion.isWin10 function throughout the app module.
2. NVDA will perform a better job at locating the correct emoji and clipboard history item when input panel opens. Consequently, element selected event no longer carries workarounds for these.
3. Renamed the private "emoji panel just opened" flag to "modern keyboard interface active" to better convey what it is supposed to do, along with keeping it alive as long as possible.
4. When an emoji group is selected, navigator object will no longer ujump to odd places, most noticeable if skin tone modifier is selected. This also allows element selected event to return early if emoji group is selected (controlled by a new private flag).
5. added state change event handler to clear modern keyboard interface flag if the element is off-screen or object reports no location. The latter condition is also used as part of name change to clear flags when name change object has no location (location tuple items are zero).

### Testing performed:
Tested via Windows 10 App Essentials:

1. Opening and closing emoji panel (Windows)Period) multiple times in quick succession.
2. While emoji panel is active, pressing Windows+V to open clipboard history.
3. While clipboard history is active, pressing Windows+Period to open emoji panel.
4. Search for emojis.
5. Selecting different symbol categories (emoji/kaomoji/symbol in Version 1903 and later).
6. Tracking UIA events to make sure modern keyboard interface flag is cleared according to the conditions noted above.
7. Hardware keyboard input suggestions are announced.
8. With selective UIA event registration off, making sure dictation result is announced when dictation is active (Windows+H).

### Known issues with pull request:
This PR does not solve:

1. Announcing clipboard history management menu (#10597) as it requires fooling NVDA into thinking that modern input elements are focusable, thereby letting gain focus event to be handled.
2. Announcing CJK IME candidates in recent feature updates (#10093) although it is a trivial change and is being tested via Windows 10 App Essentials add-on.

### Change log entry:
Same as #10378) unless the following is considered useful for users:

Bug fixes:
In Windows 10 October 2018 Update and later, NVDA will no longer set navigator object to off-screen or first emoji item for a group when an emoji group such as People is selected.

### Future work:
In name change event handler, conditions required to proceed with name change event is becoming unmanageable inside the handler method body itself. To reduce review workload, I plan to separate this out of name change event handler into a new private app module method in a future pull request. Along with this, the early return conditions for name change event will be expanded to cover things such as IME candidates, clipboard history repetitions and such (doing it here means name change event handler will be long, making it harder to review this PR).

Thanks.