### PR TITLE
nvwave: make idle close delay configurable

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -47,6 +47,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 # Audio settings
 [audio]
 	audioDuckingMode = integer(default=0)
+	idleCloseDelay = integer(default=10000,min=0,max=86400000)
 
 # Braille settings
 [braille]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2417,6 +2417,27 @@ class AdvancedPanelControls(wx.Panel):
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
+		label = _("Audio")
+		audioGroup = guiHelper.BoxSizerHelper(
+			parent=self,
+			sizer=wx.StaticBoxSizer(parent=self, label=label, orient=wx.VERTICAL)
+		)
+		sHelper.addItem(audioGroup)
+
+		# Translators: This is the label for a numeric control in the
+		#  Advanced settings panel.
+		label = _("Idle close delay (in ms)")
+		self.idleCloseDelaySpinControl = audioGroup.addLabeledControl(
+			label,
+			nvdaControls.SelectOnFocusSpinCtrl,
+			min=0,
+			max=86400000,
+			initial=config.conf["audio"]["idleCloseDelay"]
+		)
+		self.idleCloseDelaySpinControl.defaultValue = self._getDefaultValue(["audio", "idleCloseDelay"])
+
+		# Translators: This is the label for a group of advanced options in the
+		#  Advanced settings panel
 		label = _("Editable Text")
 		editableTextGroup = guiHelper.BoxSizerHelper(
 			self,
@@ -2495,6 +2516,7 @@ class AdvancedPanelControls(wx.Panel):
 			and self.winConsoleSpeakPasswordsCheckBox.IsChecked() == self.winConsoleSpeakPasswordsCheckBox.defaultValue
 			and self.cancelExpiredFocusSpeechCombo.GetSelection() == self.cancelExpiredFocusSpeechCombo.defaultValue
 			and self.keyboardSupportInLegacyCheckBox.IsChecked() == self.keyboardSupportInLegacyCheckBox.defaultValue
+			and self.idleCloseDelaySpinControl.GetValue() == self.idleCloseDelaySpinControl.defaultValue
 			and self.caretMoveTimeoutSpinControl.GetValue() == self.caretMoveTimeoutSpinControl.defaultValue
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and True  # reduce noise in diff when the list is extended.
@@ -2508,6 +2530,7 @@ class AdvancedPanelControls(wx.Panel):
 		self.winConsoleSpeakPasswordsCheckBox.SetValue(self.winConsoleSpeakPasswordsCheckBox.defaultValue)
 		self.cancelExpiredFocusSpeechCombo.SetSelection(self.cancelExpiredFocusSpeechCombo.defaultValue)
 		self.keyboardSupportInLegacyCheckBox.SetValue(self.keyboardSupportInLegacyCheckBox.defaultValue)
+		self.idleCloseDelaySpinControl.SetValue(self.idleCloseDelaySpinControl.defaultValue)
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self._defaultsRestored = True
@@ -2524,6 +2547,7 @@ class AdvancedPanelControls(wx.Panel):
 		config.conf["terminals"]["speakPasswords"] = self.winConsoleSpeakPasswordsCheckBox.IsChecked()
 		config.conf["featureFlag"]["cancelExpiredFocusSpeech"] = self.cancelExpiredFocusSpeechCombo.GetSelection()
 		config.conf["terminals"]["keyboardSupportInLegacy"]=self.keyboardSupportInLegacyCheckBox.IsChecked()
+		config.conf["audio"]["idleCloseDelay"] = self.idleCloseDelaySpinControl.GetValue()
 		config.conf["editableText"]["caretMoveTimeoutMs"]=self.caretMoveTimeoutSpinControl.GetValue()
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1848,7 +1848,14 @@ This option enables behaviour which attempts to cancel speech for expired focus 
 In particular moving quickly through messages in Gmail with Chrome can cause NVDA to speak outdated information.
 This functionality is experimental as of NVDA 2020.2.
 
-==== Caret move timeout (in MS) ====[AdvancedSettingsCaretMoveTimeout]
+==== Idle close delay (in MS) ====[AdvancedSettingsIdleCloseDelay]
+Some audio drivers, notably for newer Realtek sound cards, take a long time to open the audio device causing the start or end of speech to be truncated.
+By default, NVDA keeps the device open for 10,000 ms (10 seconds) after a speech utterence to improve performance on these systems.
+However, it may be desirable to increase this timeout, to possibly further improve performance at the cost of battery power.
+It might also be desirable in some cases to decrease this timeout for power savings on systems without this issue.
+Setting the delay to 0 causes NVDA to close the device immediately after each utterence, matching the behaviour of version 2020.2 and earlier.
+
+==== Caret movement timeout (in MS) ====[AdvancedSettingsCaretMoveTimeout]
 This option allows you to configure the number of milliseconds NVDA will wait for the caret (insertion point) to move in editable text controls.
 If you find that NVDA seems to be incorrectly tracking the caret E.g. it seems to be always one character behind or is repeating lines, then you may wish to try increasing this value.
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
https://github.com/nvaccess/nvda/pull/11024#issuecomment-625802805

### Summary of the issue:
In #11024, some users asked for the ability to increase the default timeout of 10 seconds for holding open the audio device. This could improve performance on systems with newer Realtek audio chipsets at the cost of some battery power. Others asked to decrease or disable the delay, as their systems do not exhibit this issue and there is concern that holding open the audio device in this way might use more power.

### Description of how this pull request fixes the issue:
Adds a new advanced setting for configuring the idle close delay, and replaces the `IDLE_CLOSE_DELAY` constant in `nvwave` with references to this new setting.

### Testing performed:
Added a beep in `nvwave._close` and observed that it played according to user-configured values of the `idleCloseDelay` setting.

### Known issues with pull request:
None.

### Change log entry:
Add a second sub-point to the #11024 entry:
  - This timeout is 10 seconds by default, but it is configurable in advanced settings.