### PR TITLE
Use collections.deque instead of list for EnhancedTermTypedCharSupport objects

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -29,6 +29,7 @@ import api
 import ui
 import braille
 import nvwave
+from collections import deque
 
 class ProgressBar(NVDAObject):
 
@@ -406,7 +407,7 @@ class EnhancedTermTypedCharSupport(Terminal):
 	_supportsTextChange = True
 	#: A queue of typed characters, to be dispatched on C{textChange}.
 	#: This queue allows NVDA to suppress typed passwords when needed.
-	_queuedChars = []
+	_queuedChars = deque()
 	#: Whether the last typed character is a tab.
 	#: If so, we should temporarily disable filtering as completions may
 	#: be short.
@@ -422,7 +423,7 @@ class EnhancedTermTypedCharSupport(Terminal):
 			return
 		# Clear the typed word buffer for new text lines.
 		speech.clearTypedWordBuffer()
-		self._queuedChars = []
+		self._queuedChars.clear()
 		super()._reportNewLines(lines)
 
 	def event_typedCharacter(self, ch):
@@ -462,7 +463,7 @@ class EnhancedTermTypedCharSupport(Terminal):
 		Since these gestures clear the current word/line, we should flush the
 		queue to avoid erroneously reporting these chars.
 		"""
-		self._queuedChars = []
+		self._queuedChars.clear()
 		speech.clearTypedWordBuffer()
 		gesture.send()
 
@@ -470,7 +471,7 @@ class EnhancedTermTypedCharSupport(Terminal):
 	def _dispatchQueue(self):
 		"""Sends queued typedCharacter events through to NVDA."""
 		while self._queuedChars:
-			ch = self._queuedChars.pop(0)
+			ch = self._queuedChars.popleft()
 			super().event_typedCharacter(ch)
 
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Closes #11418.

### Summary of the issue:
Currently, `enhancedTermTypedCharSupport` objects use a `list` (array) to queue typed character events. Per the Python docs, `list`s are not optimized for pushing and popping at the ends.

### Description of how this pull request fixes the issue:
Switch to a `deque` (linked list). While performance improvement may only be theoretical, I think the implementation is clearer this way.

### Testing performed:
Tested that no perceptible loss of performance is observed in Windows Console.

### Known issues with pull request:
None.

### Change log entry:
Probably not user visible.