### PR TITLE
UI Automation in Windows Console: Disable visible range bounding on 21H1 and later

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -18,57 +18,119 @@ from ..window import Window
 
 
 class consoleUIATextInfo(UIATextInfo):
+	def __ne__(self, other):
+		"""Support more accurate caret move detection."""
+		return not self == other
+
+	def _get_text(self):
+		# #10036: return a space if the text range is empty.
+		# Consoles don't actually store spaces, the character is merely left blank.
+		res = super(consoleUIATextInfo, self)._get_text()
+		if not res:
+			return ' '
+		else:
+			return res
+
+
+class consoleUIATextInfoPre21H1(consoleUIATextInfo):
+	"""Fixes expand/collapse on end inclusive UIA text ranges, uses rangeFromPoint
+	instead of broken GetVisibleRanges for bounding, and implements word
+	movement support."""
+
 	def __init__(self, obj, position, _rangeObj=None):
-		collapseToEnd = None
 		# We want to limit  textInfos to just the visible part of the console.
 		# Therefore we specifically handle POSITION_FIRST, POSITION_LAST and POSITION_ALL.
-		if not _rangeObj and position in (
-			textInfos.POSITION_FIRST,
-			textInfos.POSITION_LAST,
-			textInfos.POSITION_ALL
-		):
-			try:
-				_rangeObj, collapseToEnd = self._getBoundingRange(obj, position)
-			except (COMError, RuntimeError):
-				# We couldn't bound the console.
-				from logHandler import log
-				log.warning("Couldn't get bounding range for console", exc_info=True)
-				# Fall back to presenting the entire buffer.
-				_rangeObj, collapseToEnd = None, None
-		super(consoleUIATextInfo, self).__init__(obj, position, _rangeObj)
-		if collapseToEnd is not None:
-			self.collapse(end=collapseToEnd)
-
-	def _getBoundingRange(self, obj, position):
-		"""Returns the UIA text range to which the console should be bounded,
-		and whether the textInfo should be collapsed after instantiation."""
-		# microsoft/terminal#4495: In newer consoles,
-		# IUIAutomationTextRange::getVisibleRanges returns a reliable contiguous range.
-		_rangeObj = obj.UIATextPattern.GetVisibleRanges().GetElement(0)
-		collapseToEnd = None
-		if position == textInfos.POSITION_FIRST:
-			collapseToEnd = False
-		elif position == textInfos.POSITION_LAST:
+		# We could use IUIAutomationTextRange::getVisibleRanges, but it seems very broken in consoles
+		# once more than a few screens worth of content has been written to the console.
+		# Therefore we resort to using IUIAutomationTextPattern::rangeFromPoint
+		# for the top left, and bottom right of the console window.
+		if position is textInfos.POSITION_FIRST:
+			_rangeObj = self.__class__(obj, obj.location.topLeft)._rangeObj
+		elif position is textInfos.POSITION_LAST:
+			# Asking for the range at the bottom right of the window
+			# Seems to sometimes ignore the x coordinate.
+			# Therefore use the bottom left, then move   to the last character on that line.
+			tempInfo = self.__class__(obj, obj.location.bottomLeft)
+			tempInfo.expand(textInfos.UNIT_LINE)
 			# We must pull back the end by one character otherwise when we collapse to end,
 			# a console bug results in a textRange covering the entire console buffer!
 			# Strangely the *very* last character is a special blank point
 			# so we never seem to miss a real character.
-			_rangeObj.MoveEndpointByUnit(
-				UIAHandler.TextPatternRangeEndpoint_End,
-				UIAHandler.NVDAUnitsToUIAUnits['character'],
-				-1
-			)
-			collapseToEnd = True
-		return (_rangeObj, collapseToEnd)
+			UIATextInfo.move(tempInfo, textInfos.UNIT_CHARACTER, -1, endPoint="end")
+			tempInfo.setEndPoint(tempInfo, "startToEnd")
+			_rangeObj = tempInfo._rangeObj
+		elif position is textInfos.POSITION_ALL:
+			first = self.__class__(obj, textInfos.POSITION_FIRST)
+			last = self.__class__(obj, textInfos.POSITION_LAST)
+			first.setEndPoint(last, "endToEnd")
+			_rangeObj = first._rangeObj
+		super(consoleUIATextInfo, self).__init__(obj, position, _rangeObj)
 
 	def move(self, unit, direction, endPoint=None):
 		oldInfo = None
 		if self.basePosition != textInfos.POSITION_CARET:
-			# Ensure we haven't gone beyond the visible text.
+			# Insure we haven't gone beyond the visible text.
 			# UIA adds thousands of blank lines to the end of the console.
 			boundingInfo = self.obj.makeTextInfo(textInfos.POSITION_ALL)
 			oldInfo = self.copy()
-		res = self._move(unit, direction, endPoint)
+		if unit == textInfos.UNIT_WORD and direction != 0:
+			# UIA doesn't implement word movement, so we need to do it manually.
+			# Relative to the current line, calculate our offset
+			# and the current word's offsets.
+			lineInfo = self.copy()
+			lineInfo.expand(textInfos.UNIT_LINE)
+			offset = self._getCurrentOffsetInThisLine(lineInfo)
+			start, end = self._getWordOffsetsInThisLine(offset, lineInfo)
+			if direction > 0:
+				# Moving in a forward direction, we can just jump to the
+				# end offset of the current word and we're done.
+				res = self.move(
+					textInfos.UNIT_CHARACTER,
+					end - offset,
+					endPoint=endPoint
+				)
+			else:
+				# Moving backwards
+				wordStartDistance = (offset - start) * -1
+				if wordStartDistance < 0:
+					# We are after the beginning of a word.
+					# So first move back to the start of the word.
+					self.move(
+						textInfos.UNIT_CHARACTER,
+						wordStartDistance,
+						endPoint=endPoint
+					)
+					offset += wordStartDistance
+				# Try to move one character back before the start of the word.
+				res = self.move(textInfos.UNIT_CHARACTER, -1, endPoint=endPoint)
+				if res == 0:
+					return 0
+				offset -= 1
+				# We are now positioned  within the previous word.
+				if offset < 0:
+					# We've moved on to the previous line.
+					# Recalculate the current offset based on the new line we are now on.
+					lineInfo = self.copy()
+					lineInfo.expand(textInfos.UNIT_LINE)
+					offset = self._getCurrentOffsetInThisLine(lineInfo)
+				# Finally using the new offset,
+				# Calculate the current word offsets and move to the start of
+				# this word if we are not already there.
+				start, end = self._getWordOffsetsInThisLine(offset, lineInfo)
+				wordStartDistance = (offset - start) * -1
+				if wordStartDistance < 0:
+					self.move(
+						textInfos.UNIT_CHARACTER,
+						wordStartDistance,
+						endPoint=endPoint
+					)
+		else:  # moving by a unit other than word
+			res = super(consoleUIATextInfo, self).move(unit, direction, endPoint)
+		if not endPoint:
+			# #10191: IUIAutomationTextRange::move in consoles does not correctly produce a collapsed range
+			# after moving.
+			# Therefore manually collapse.
+			self.collapse()
 		# Console textRanges have access to the entire console buffer.
 		# However, we want to limit ourselves to onscreen text.
 		# Therefore, if the textInfo was originally visible,
@@ -91,56 +153,6 @@ class consoleUIATextInfo(UIATextInfo):
 			except (COMError, RuntimeError):
 				pass
 		return res
-
-	def _move(self, unit, direction, endPoint=None):
-		"Perform a move without respect to bounding."
-		return super(consoleUIATextInfo, self).move(unit, direction, endPoint)
-
-	def __ne__(self, other):
-		"""Support more accurate caret move detection."""
-		return not self == other
-
-	def _get_text(self):
-		# #10036: return a space if the text range is empty.
-		# Consoles don't actually store spaces, the character is merely left blank.
-		res = super(consoleUIATextInfo, self)._get_text()
-		if not res:
-			return ' '
-		else:
-			return res
-
-
-class consoleUIATextInfoPre21H1(consoleUIATextInfo):
-	"""Fixes expand/collapse on end inclusive UIA text ranges, uses rangeFromPoint
-	instead of broken GetVisibleRanges for bounding, and implements word
-	movement support."""
-	def _getBoundingRange(self, obj, position):
-		# We could use IUIAutomationTextRange::getVisibleRanges, but it seems very broken in consoles
-		# once more than a few screens worth of content has been written to the console.
-		# Therefore we resort to using IUIAutomationTextPattern::rangeFromPoint
-		# for the top left, and bottom right of the console window.
-		_rangeObj = None
-		if position is textInfos.POSITION_FIRST:
-			_rangeObj = self.__class__(obj, obj.location.topLeft)._rangeObj
-		elif position is textInfos.POSITION_LAST:
-			# Asking for the range at the bottom right of the window
-			# Seems to sometimes ignore the x coordinate.
-			# Therefore use the bottom left, then move   to the last character on that line.
-			tempInfo = self.__class__(obj, obj.location.bottomLeft)
-			tempInfo.expand(textInfos.UNIT_LINE)
-			# We must pull back the end by one character otherwise when we collapse to end,
-			# a console bug results in a textRange covering the entire console buffer!
-			# Strangely the *very* last character is a special blank point
-			# so we never seem to miss a real character.
-			UIATextInfo.move(tempInfo, textInfos.UNIT_CHARACTER, -1, endPoint="end")
-			tempInfo.setEndPoint(tempInfo, "startToEnd")
-			_rangeObj = tempInfo._rangeObj
-		elif position is textInfos.POSITION_ALL:
-			first = self.__class__(obj, textInfos.POSITION_FIRST)
-			last = self.__class__(obj, textInfos.POSITION_LAST)
-			first.setEndPoint(last, "endToEnd")
-			_rangeObj = first._rangeObj
-		return (_rangeObj, None)
 
 	def collapse(self, end=False):
 		"""Works around a UIA bug on Windows 10 versions before 21H1.
@@ -210,69 +222,6 @@ class consoleUIATextInfoPre21H1(consoleUIATextInfo):
 				)
 		else:
 			return super(consoleUIATextInfo, self).expand(unit)
-
-	def _move(self, unit, direction, endPoint=None):
-		if unit == textInfos.UNIT_WORD and direction != 0:
-			# On Windows 10 versions before 21H1, UIA doesn't implement word
-			# movement, so we need to do it manually.
-			# Relative to the current line, calculate our offset
-			# and the current word's offsets.
-			lineInfo = self.copy()
-			lineInfo.expand(textInfos.UNIT_LINE)
-			offset = self._getCurrentOffsetInThisLine(lineInfo)
-			start, end = self._getWordOffsetsInThisLine(offset, lineInfo)
-			if direction > 0:
-				# Moving in a forward direction, we can just jump to the
-				# end offset of the current word and we're done.
-				res = self.move(
-					textInfos.UNIT_CHARACTER,
-					end - offset,
-					endPoint=endPoint
-				)
-			else:
-				# Moving backwards
-				wordStartDistance = (offset - start) * -1
-				if wordStartDistance < 0:
-					# We are after the beginning of a word.
-					# So first move back to the start of the word.
-					self.move(
-						textInfos.UNIT_CHARACTER,
-						wordStartDistance,
-						endPoint=endPoint
-					)
-					offset += wordStartDistance
-				# Try to move one character back before the start of the word.
-				res = self.move(textInfos.UNIT_CHARACTER, -1, endPoint=endPoint)
-				if res == 0:
-					return 0
-				offset -= 1
-				# We are now positioned  within the previous word.
-				if offset < 0:
-					# We've moved on to the previous line.
-					# Recalculate the current offset based on the new line we are now on.
-					lineInfo = self.copy()
-					lineInfo.expand(textInfos.UNIT_LINE)
-					offset = self._getCurrentOffsetInThisLine(lineInfo)
-				# Finally using the new offset,
-				# Calculate the current word offsets and move to the start of
-				# this word if we are not already there.
-				start, end = self._getWordOffsetsInThisLine(offset, lineInfo)
-				wordStartDistance = (offset - start) * -1
-				if wordStartDistance < 0:
-					self.move(
-						textInfos.UNIT_CHARACTER,
-						wordStartDistance,
-						endPoint=endPoint
-					)
-		else:  # moving by a unit other than word
-			res = super(consoleUIATextInfo, self).move(unit, direction,
-														endPoint)
-		if not endPoint:
-			# #10191: IUIAutomationTextRange::move in consoles does not correctly produce a collapsed range
-			# after moving.
-			# Therefore manually collapse.
-			self.collapse()
-		return res
 
 	def _getCurrentOffsetInThisLine(self, lineInfo):
 		"""


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Blocked by microsoft/terminal#6986.

### Summary of the issue:
It was mentioned in https://github.com/microsoft/terminal/issues/6453#issuecomment-674361602 that some new console text can actually appear below the visible range, making it completely inaccessible to NVDA.

### Description of how this pull request fixes the issue:
No longer bound the console's text info to the visible ranges on 21H1 and later. This will require upstream changes by Microsoft to maintain usability in the console after this PR.

### Testing performed:
* Adjusted `winConsoleUIA._getTextLines` to limit the number of lines in the diff and tested the case in microsoft/terminal#5481. Observed that the bug is no longer reproducible.
* Tested that pre-21H1 UIA consoles still work as expected (word navigation, bounding, going to the ends of the console).

### Known issues with pull request:
* There are thousands upon thousands of blank lines in the output, slowing down the diffing algorithm to the point that the console is unusable. Switching to DMP makes the console usable but with a noticeable brief lag.
* Moving the review cursor to the bottom of the console crashes it. I'll file an upstream bug.

### Change log entry:
Not user visible.