### PR TITLE
Detect and log objects being cleaned up by the Python cyclic garbage collector, and remove several more reference cycles

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -148,6 +148,14 @@ class Editor(Ia2Web, DocumentWithTableNavigation):
 			# Treet this as the cell not existing.
 			raise LookupError
 
+	def event_loseFocus(self):
+		# MozillaCompoundTextInfo caches the deepest object with the caret.
+		# But this can create a reference cycle if not removed.
+		# As we no longer need it once this object loses focus, we can delete it here.
+		self._lastCaretObj = None
+		super().event_loseFocus()
+
+
 class EditorChunk(Ia2Web):
 	beTransparentToMouse = True
 

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -7,6 +7,7 @@
 """
 
 import weakref
+import garbageHandler
 from logHandler import log
 from abc import ABCMeta, abstractproperty
 
@@ -98,7 +99,8 @@ class AutoPropertyType(ABCMeta):
 			# The __abstractmethods__ set is frozen, therefore we ought to override it.
 			self.__abstractmethods__=(self.__abstractmethods__|newAbstractProps)-oldAbstractProps
 
-class AutoPropertyObject(object, metaclass=AutoPropertyType):
+
+class AutoPropertyObject(garbageHandler.TrackedObject, metaclass=AutoPropertyType):
 	"""A class that dynamically supports properties, by looking up _get_*, _set_*, and _del_* methods at runtime.
 	_get_x will make property x with a getter (you can get its value).
 	_set_x will make a property x with a setter (you can set its value).

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -51,6 +51,8 @@ finally:
 # It is safe to import any comtypes modules from here on down.
 
 from logHandler import log
+import garbageHandler  # noqa: E402
+
 
 from comtypes import COMError
 from comtypes.hresult import *
@@ -92,12 +94,14 @@ comtypes.client.dynamic._Dispatch.__call__=new__call__
 # Work around an issue with comtypes where __del__ seems to be called twice on COM pointers.
 # This causes Release() to be called more than it should, which is very nasty and will eventually cause us to access pointers which have been freed.
 from comtypes import _compointer_base
+
 _cpbDel = _compointer_base.__del__
 def newCpbDel(self):
 	if hasattr(self, "_deleted"):
 		# Don't allow this to be called more than once.
 		log.debugWarning("COM pointer %r already deleted" % self)
 		return
+	garbageHandler.notifyObjectDeletion(self)
 	_cpbDel(self)
 	self._deleted = True
 newCpbDel.__name__ = "__del__"

--- a/source/core.py
+++ b/source/core.py
@@ -37,6 +37,8 @@ import globalVars
 from logHandler import log
 import addonHandler
 import extensionPoints
+import garbageHandler  # noqa: E402
+
 
 # inform those who want to know that NVDA has finished starting up.
 postNvdaStartup = extensionPoints.Action()
@@ -424,6 +426,9 @@ def main():
 	else:
 		log.debugWarning("wx does not support language %s" % lang)
 
+	log.debug("Initializing garbageHandler")
+	garbageHandler.initialize()
+
 	import api
 	import winUser
 	import NVDAObjects.window
@@ -582,6 +587,7 @@ def main():
 	_terminate(braille)
 	_terminate(speech)
 	_terminate(addonHandler)
+	_terminate(garbageHandler)
 
 	if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:
 		try:

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -7,6 +7,7 @@
 import threading
 from typing import Optional
 
+import garbageHandler
 import queueHandler
 import api
 import speech
@@ -81,7 +82,8 @@ def isPendingEvents(eventName=None,obj=None):
 	elif eventName and obj:
 		return (eventName,obj) in _pendingEventCountsByNameAndObj
 
-class _EventExecuter(object):
+
+class _EventExecuter(garbageHandler.TrackedObject):
 	"""Facilitates execution of a chain of event functions.
 	L{gen} generates the event functions and positional arguments.
 	L{next} calls the next function in the chain.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -96,7 +96,8 @@ class _EventExecuter(garbageHandler.TrackedObject):
 			self.next()
 		except StopIteration:
 			pass
-		del self._gen
+		finally:
+			del self._gen
 
 	def next(self):
 		func, args = next(self._gen)

--- a/source/garbageHandler.py
+++ b/source/garbageHandler.py
@@ -1,3 +1,10 @@
+# -*- coding: UTF-8 -*-
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+
 import gc
 import threading
 from logHandler import log

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -64,7 +64,15 @@ def getCodePath(f):
 	className=""
 	#Code borrowed from http://mail.python.org/pipermail/python-list/2000-January/020141.html
 	if f.f_code.co_argcount:
-		arg0=f.f_locals[f.f_code.co_varnames[0]]
+		f_locals = f.f_locals
+		arg0 = f_locals[f.f_code.co_varnames[0]]
+		if f.f_code.co_flags & inspect.CO_NEWLOCALS:
+			# Fetching of Frame.f_locals causes a function frames's locals to be cached on the frame for ever.
+			# If an Exception is currently stored as a local variable on that frame,
+			# A reference cycle will be created, holding the frame and all its variables.
+			# Therefore clear f_locals manually.
+			f_locals.clear()
+		del f_locals
 		# #6122: Check if this function is a member of its first argument's class (and specifically which base class if any) 
 		# Rather than an instance member of its first argument.
 		# This stops infinite recursions if fetching data descriptors,

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -13,6 +13,7 @@ from ctypes.wintypes import *
 import time
 import atexit
 import wx
+import garbageHandler
 import winKernel
 import wave
 import config
@@ -95,7 +96,8 @@ for func in (
 ):
 	func.errcheck = _winmm_errcheck
 
-class WavePlayer(object):
+
+class WavePlayer(garbageHandler.TrackedObject):
 	"""Synchronously play a stream of audio.
 	To use, construct an instance and feed it waveform audio using L{feed}.
 	"""

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -4,6 +4,7 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import weakref
+import garbageHandler
 import speech
 import synthDriverHandler
 from logHandler import log
@@ -40,7 +41,8 @@ def readObjects(obj):
 	_activeSayAll = weakref.ref(reader)
 	reader.next()
 
-class _ObjectsReader(object):
+
+class _ObjectsReader(garbageHandler.TrackedObject):
 
 	def __init__(self, root):
 		self.walker = self.walk(root)
@@ -84,7 +86,8 @@ def readText(cursor):
 	_activeSayAll = weakref.ref(reader)
 	reader.nextLine()
 
-class _TextReader(object):
+
+class _TextReader(garbageHandler.TrackedObject):
 	"""Manages continuous reading of text.
 	This is intended for internal use only.
 

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -7,6 +7,7 @@
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.
 """
+import garbageHandler
 import globalVars
 import config
 if globalVars.appArgs.secure:
@@ -215,7 +216,8 @@ def _executeUpdate(destPath):
 		executeParams,
 		None, winUser.SW_SHOWNORMAL)
 
-class UpdateChecker(object):
+
+class UpdateChecker(garbageHandler.TrackedObject):
 	"""Check for an updated version of NVDA, presenting appropriate user interface.
 	The check is performed in the background.
 	This class is for manual update checks.
@@ -550,7 +552,8 @@ class UpdateAskInstallDialog(wx.Dialog, DpiScalingHelperMixin):
 		saveState()
 		self.EndModal(wx.ID_CLOSE)
 
-class UpdateDownloader(object):
+
+class UpdateDownloader(garbageHandler.TrackedObject):
 	"""Download and start installation of an updated version of NVDA, presenting appropriate user interface.
 	To use, call L{start} on an instance.
 	"""

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -58,6 +58,9 @@ What's New in NVDA
 - Additional properties were added to app modules, including path for the executable (appPath), is a Windows Store app (isWindowsStoreApp), and machine architecture for the app (appArchitecture). (#7894)
 - It is now possible to create app modules for apps hosted inside wwahost.exe on Windows 8 and later. (#4569)
 - A fragment of the log can now be delimited and then copied to clipboard using NVDA+control+shift+F1. (#9280)
+- NVDA-specific objects that are found by Python's cyclic garbage collector are now logged when being deleted by the collector to aide in removing reference cycles from NVDA. (#11499)
+ - The majority of NVDA's classes are tracked including NVDAObjects, appModules, GlobalPlugins, SynthDrivers, and TreeInterceptors.
+ - A class that needs to be tracked should inherit from garbageHandler.TrackedObject.
 
 
 = 2020.2 =


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:
The lifetime of objects in Python are managed by reference counting. When an object's reference count hits 0, it is deleted straight away. However, if an object directly or indirectly holds a reference to itself, then the reference count will never reach 0 and therefore the object would not normally be cleaned up. Python therefore has a Garbage Collector (gc) which periodically searches through all objects that can hold references, and forcefully deletes any object found to be unreachable. As this check is periodic, and can happen in any thread, objects that participate in reference cycles may get deleted at strange or unpredictable times. This is especially problematic for comtypes COM objects as when they destruct, they call their IUnknown::Release method, which may block or cause other issues as it may be called from the wrong thread.

We try not to cause reference cycles in NVDA, but they easily can happen by accident.

It would be good if we were able to detect reference cycles, or at very least, when an object is being deleted by the garbage collector, and clearly log this.

In future we may also wish to take complete control of garbage collection and perform it at predictable times in our main thread, but for now at least knowing when it is already going wrong would be a big step forward in debugging.
 
### Description of how this pull request fixes the issue:
This pr adds a new garbageHandler module to NVDA which hooks into the Python garbage collector, such that it knows when a garbage collection run starts and stops. It provides a module-level function (notifyObjectDeletion) which an object can call from its ```__del__``` method. If this function detects that the caller is currently inside a garbage collection run (one is in progress and it is in the same thread) then a warning is logged stating that this object is being deleted by the Garbage collector. 
Further to this, the very first time a deleted object is logged in this garbage collection run, an error is logged to clearly notify us that the garbage collector has found one or more important objects in this run. this error message also contains the full stack at this point, so that we can clearly see exactly where the garbage collector run happened, before anything bad happens (such as a freeze).
Of course the long-term goal is to not see any errors/warnings at all, as we will have removed all reference cycles.

the ```__del__``` method on comtypes COM objects has been patched to call this function, thus we now can see in the log as soon as a COM object is about to be released due to the garbage collector.
So if for instance a COM object happened to be released by the garbage collector which caused a freeze, we now have very clear logging to understand what happened.

garbageHandler also provides a new TrackedObject class, which also provides a ```__del__``` that does this. And now all major NVDA classes inherit from TrackedObject. Thus we now can see in the log when one of these objects is deleted due to the garbage collector. Object's that inherit from TrackedObject include nvwave.WavePlayer, the sayAll reader classes, eventHandler._eventExecutor, and baseObject.AutoPropertyObject (which therefore provides it for appModules, synthDrivers, globalPlugins, NVDAObjects, treeInterceptors etc).
Note that before Python 3.4 we could not have done this, as it used to be the case that any object with a ```__del__``` would not be cleaned up by the garbage collector.
 
Thanks to this functionality, several more reference cycles were identified, and also addressed in further commits on this pr.

They include:
* NVDAObjects.IAccessible.ia2Web.Editor was holding one of its descendants as _lastCaretObj (cached by MozillaCompoundTextInfo).  As NVDAObjects usually cache their parents, this created a reference cycle. As we don't need _lastCaretObj once the Editor NVDAObject loses focus, it is now removed in event_loseFocus.
* eventHandler._eventExecutor holds its 'gen' generator object on itself, so that its 'next' method can be called by various event levels. This reference was correctly cleaned up after the event was executed, but if there was an exception, this did not occur, and therefore the _event Executor was in a reference cycle until the garbage collector could later forcefully delete it. This may have also held around many execution frames containing local variables. Now, the reference is correctly removed in the 'finally' clause so that it always occurs even if there is an exception.
* Our logHandler module had a bug (or is it Python's bug) where if a message was logged from within an 'except' clause where the Exception was exposed as a variable in the clause (E.g. ```except Exception as e```), a reference cycle would be created on the frame holding that variable, thus all the frames (and local variables in each) to do with that exception were held until the garbage collector could forcefully delete them. This bug would have been new to Python 3, as Python 3 holds the traceback and frames on the Exception object. Python 2 does not do this. The bug was specifically in logHandler.getCodePath, where when fetching the given frame's local variables, they were being cached on the frame. It seems that a function Frame's f_locals member creates a new locals dictionary and caches it on itself each time this member is accessed. Therefore, we now clear this dictionary once we have fetched what we need.

### Testing performed:
Ran NVDA for extended periods performing daily tasks. Running with just the first commit, causes a lot of errors to be logged about deleting unreachable objects. After the rest of the commits, I am so far not seeing any errors at all. Though there very well may be more -- but the whole point of this pr is to keep detecting them and fixing them.

### Known issues with pull request:
None.

### Change log entry:
tbd.
