### PR TITLE
Remove reference cycles in contentRecog objects

### DIFF
--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -14,11 +14,20 @@ They are implemented using the L{ContentRecognizer} class.
 """
 
 from collections import namedtuple
+import garbageHandler
+import cursorManager
 import textInfos.offsets
 from abc import ABCMeta, abstractmethod
 from locationHelper import RectLTWH
 
-class ContentRecognizer(object, metaclass=ABCMeta):
+
+class BaseContentRecogTextInfo(cursorManager._ReviewCursorManagerTextInfo):
+	"""
+	The TextInfo class that all TextInfos emitted by implementations of RecognitionResult must inherit from.
+	"""
+
+
+class ContentRecognizer(garbageHandler.TrackedObject, metaclass=ABCMeta):
 	"""Implementation of a content recognizer.
 	"""
 
@@ -143,7 +152,8 @@ class RecogImageInfo(object):
 		"""
 		return int(height / self.resizeFactor)
 
-class RecognitionResult(object, metaclass=ABCMeta):
+
+class RecognitionResult(garbageHandler.TrackedObject, metaclass=ABCMeta):
 	"""Provides access to the result of recognition by a recognizer.
 	The result is textual, but to facilitate navigation by word, line, etc.
 	and to allow for retrieval of screen coordinates within the text,
@@ -153,13 +163,12 @@ class RecognitionResult(object, metaclass=ABCMeta):
 	"""
 
 	@abstractmethod
-	def makeTextInfo(self, obj, position):
+	def makeTextInfo(self, obj, position) -> BaseContentRecogTextInfo:
 		"""Make a TextInfo within the recognition result text at the requested position.
 		@param obj: The object to return for the C{obj} property of the TextInfo.
 			The TextInfo itself doesn't use this, but NVDA requires it to set the review object, etc.
 		@param position: The requested position; one of the C{textInfos.POSITION_*} constants.
 		@return: The TextInfo at the requested position in the result.
-		@rtype: L{textInfos.TextInfo}
 		"""
 		raise NotImplementedError
 
@@ -230,7 +239,8 @@ class LinesWordsResult(RecognitionResult):
 	def makeTextInfo(self, obj, position):
 		return LwrTextInfo(obj, position, self)
 
-class LwrTextInfo(textInfos.offsets.OffsetsTextInfo):
+
+class LwrTextInfo(BaseContentRecogTextInfo, textInfos.offsets.OffsetsTextInfo):
 	"""TextInfo used by L{LinesWordsResult}.
 	This should only be instantiated by L{LinesWordsResult}.
 	"""
@@ -277,6 +287,7 @@ class LwrTextInfo(textInfos.offsets.OffsetsTextInfo):
 			word = nextWord
 		return RectLTWH(word.left, word.top, word.width, word.height)
 
+
 class SimpleTextResult(RecognitionResult):
 	"""A L{RecognitionResult} which presents a simple text string.
 	This should only be used if the recognizer only returns text
@@ -294,7 +305,8 @@ class SimpleTextResult(RecognitionResult):
 	def makeTextInfo(self, obj, position):
 		return SimpleResultTextInfo(obj, position, self)
 
-class SimpleResultTextInfo(textInfos.offsets.OffsetsTextInfo):
+
+class SimpleResultTextInfo(BaseContentRecogTextInfo, textInfos.offsets.OffsetsTextInfo):
 	"""TextInfo used by L{SimpleTextResult}.
 	This should only be instantiated by L{SimpleTextResult}.
 	"""

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -22,7 +22,8 @@ import eventHandler
 import textInfos
 from logHandler import log
 import queueHandler
-from . import RecogImageInfo
+from . import RecogImageInfo, BaseContentRecogTextInfo
+
 
 class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Window):
 	"""Fake NVDAObject used to present a recognition result in a cursor manager.
@@ -51,7 +52,12 @@ class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Wind
 			ti.collapse()
 		else:
 			ti = self.result.makeTextInfo(self, position)
-		return self._patchTextInfo(ti)
+		if not isinstance(ti, BaseContentRecogTextInfo):
+			log.warning(
+				f"Deprecation: {type(ti)} must inherit from {BaseContentRecogTextInfo} to avoid reference cycles."
+			)
+			ti = self._patchTextInfo(ti)
+		return ti
 
 	def _patchTextInfo(self, info):
 		# Patch TextInfos so that updateSelection/Caret updates our fake selection.

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -53,6 +53,8 @@ class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Wind
 		else:
 			ti = self.result.makeTextInfo(self, position)
 		if not isinstance(ti, BaseContentRecogTextInfo):
+			# Support of TextInfos that do not inherit from BaseContentRecogTextInfo is deprecated
+			# and will be removed in NVDA 2020.1.
 			log.warning(
 				f"Deprecation: {type(ti)} must inherit from {BaseContentRecogTextInfo} to avoid reference cycles."
 			)


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Follow up from pr #11499 

### Summary of the issue:
contentRecog.regogUI.RecogResultNVDAObject causes a reference cycle, and therefore warnings are logged about this when garbage collecting.
The RecogResultNVDAObject stores a TextInfo instance as _selection on itself. But, it also patches the TextInfo's updateCaret and updateSelection methods to use self._selection. It is the fact these lambdas reference self (the RecogResultNVDAObject and they are stored on the TextInfo instance, thus a reference cycle.

### Description of how this pull request fixes the issue:
Added a new contentRecog.BaseContentRecogTextInfo class which all TextInfos emitted by ContentRecogResult must inherit from. The built-in contentRecog TextInfos all do this now.
The BaseContentRecogTextInfo provides updatecaret and updateSelection implementations that use obj._selection. In fact, cursorManager._reviewCursorTextInfo was able to provide just this.
So for the built-in contentRecogs in NVDA, reference cycles have been addressed.

However, The RecogResultNVDAObject's makeTextInfo method now also logs a warning if it sees a TextInfo that does not correctly inherit from BaseContentRecogTextInfo, and still supports other TextInfos by continuing to patch causing the reference cycles.
 This should obviously be removed in 2021.1

### Testing performed:
Ran OCR (NvDA+r) on a File Explorer Window and arrowed up and down the text. Also arrowed to a particular file name and pressed enter, ensuring that that file was clicked.
Ensured that garbage collection errors/warnings related to contentRecog no longer appeared in the log.
 
### Known issues with pull request:
None.

### Change log entry:
None needed.
