### PR TITLE
Don't filter out MSAA events for the currently focused object, even if the winEvent limit has been exceeded for that thread

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -126,8 +126,6 @@ import re
 
 from .orderedWinEventLimiter import MENU_EVENTIDS
 
-MAX_WINEVENTS = 500
-
 # Special Mozilla gecko MSAA constant additions
 NAVRELATION_LABEL_FOR = 0x1002
 NAVRELATION_LABELLED_BY = 0x1003
@@ -857,9 +855,14 @@ def pumpAll():  # noqa: C901
 	fakeFocusEvent = None
 	focus = eventHandler.lastQueuedFocusObject
 
+	alwaysAllowedObjects = []
+	# winEvents for the currently focused object are special,
+	# and should be never filtered out.
+	if isinstance(focus, NVDAObjects.IAccessible.IAccessible) and focus.event_objectID is not None:
+		alwaysAllowedObjects.append((focus.event_windowHandle, focus.event_objectID, focus.event_childID))
+
 	# Receive all the winEvents from the limiter for this cycle
-	winEvents = winEventLimiter.flushEvents()
-	winEvents = winEvents[0 - MAX_WINEVENTS:]
+	winEvents = winEventLimiter.flushEvents(alwaysAllowedObjects)
 
 	for winEvent in winEvents:
 		isEventOnCaret = winEvent[2] == winUser.OBJID_CARET

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -4,6 +4,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from typing import Tuple
 import struct
 import weakref
 # Kept for backwards compatibility
@@ -99,6 +100,12 @@ from comInterfaces.IAccessible2Lib import (
 	IA2_ROLE_FOOTER,
 	IA2_ROLE_MARK,
 )
+
+IAccessibleObjectIdentifierType = Tuple[
+	int,  # windowHandle
+	int,  # objectID
+	int,  # childID
+]
 
 from . import internalWinEventHandler
 # Imported for backwards compat

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -75,7 +75,7 @@ class OrderedWinEventLimiter(object):
 		self._genericEventCache[(eventID, window, objectID, childID, threadID)] = next(self._eventCounter)
 		return True
 
-	def flushEvents(self, alwaysAllowedObjects):
+	def flushEvents(self, alwaysAllowedObjects=None):
 		"""Returns a list of winEvents that have been added.
 		Due to limiting, it will not necessarily be all the winEvents that were originally added.
 		They are definitely guaranteed to be in the correct order though.
@@ -90,7 +90,7 @@ class OrderedWinEventLimiter(object):
 		self._genericEventCache = {}
 		threadCounters = {}
 		for k, v in sorted(g.items(), key=lambda item: item[1], reverse=True):
-			if k[1:-1] not in alwaysAllowedObjects:
+			if not alwaysAllowedObjects or k[1:-1] not in alwaysAllowedObjects:
 				threadCount = threadCounters.get(k[-1], 0)
 				threadCounters[k[-1]] = threadCount + 1
 				if threadCount > MAX_WINEVENTS_PER_THREAD:

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -102,11 +102,11 @@ class OrderedWinEventLimiter(object):
 			threadCount = threadCounters.get(k[-1], 0)
 			threadCounters[k[-1]] = threadCount + 1
 			if isMSAADebugLoggingEnabled():
-				if threadCount == (MAX_WINEVENTS_PER_THREAD + 1):
+				if threadCount == MAX_WINEVENTS_PER_THREAD:
 					log.debug(f"winEvent limit for thread {k[-1]} hit for this core cycle")
 			# Find out if this event is for an object whos events are always allowed.
 			eventsForObjectAlwaysAllowed = alwaysAllowedObjects and k[1:-1] in alwaysAllowedObjects
-			if threadCount > MAX_WINEVENTS_PER_THREAD and not eventsForObjectAlwaysAllowed:
+			if threadCount >= MAX_WINEVENTS_PER_THREAD and not eventsForObjectAlwaysAllowed:
 				# Skip this event if too many events have already been emitted for this thread
 				# and this event is not for an object whos events are always allowed.
 				continue

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -90,9 +90,9 @@ class OrderedWinEventLimiter(object):
 		self._genericEventCache = {}
 		threadCounters = {}
 		for k, v in sorted(g.items(), key=lambda item: item[1], reverse=True):
+			threadCount = threadCounters.get(k[-1], 0)
+			threadCounters[k[-1]] = threadCount + 1
 			if not alwaysAllowedObjects or k[1:-1] not in alwaysAllowedObjects:
-				threadCount = threadCounters.get(k[-1], 0)
-				threadCounters[k[-1]] = threadCount + 1
 				if threadCount > MAX_WINEVENTS_PER_THREAD:
 					continue
 			heapq.heappush(self._eventHeap, (v,) + k)

--- a/tests/unit/test_orderedWinEventLimiter.py
+++ b/tests/unit/test_orderedWinEventLimiter.py
@@ -5,10 +5,21 @@
 
 """Unit tests for the orderedWinEventLimiter module.
 """
-
+import inspect
+import re
 import unittest
+from typing import List, Iterator, Callable
 import winUser
+from IAccessibleHandler import orderedWinEventLimiter
 from IAccessibleHandler.orderedWinEventLimiter import OrderedWinEventLimiter
+
+
+def softAssert(errorList: List[AssertionError], method: Callable, *args, **kwargs):
+	try:
+		method(*args, **kwargs)
+	except AssertionError as e:
+		errorList.append(e)
+
 
 specialCaseEvents = [
 	winUser.EVENT_SYSTEM_FOREGROUND,
@@ -22,7 +33,22 @@ specialCaseEvents = [
 ]
 
 
+def _getNonSpecialCaseEvents() -> Iterator[int]:
+	objectOrSystemEvent = re.compile("^EVENT_(OBJECT|SYSTEM)_")
+	for name, value in inspect.getmembers(winUser):
+		if value not in specialCaseEvents and objectOrSystemEvent.match(name):
+			yield value
+
+
+nonSpecialCaseEvents: List[int] = list(_getNonSpecialCaseEvents())
+
+
 class TestOrderedWinEventLimiter(unittest.TestCase):
+
+	def test_nonSpecialCaseEvents(self):
+		"""Test that the list of events without special cases matches expectations
+		"""
+		self.assertEqual(39, len(nonSpecialCaseEvents))
 
 	def test_maxFocusEvents(self):
 		limiter = OrderedWinEventLimiter(maxFocusItems=4)
@@ -150,6 +176,171 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 			(winUser.EVENT_OBJECT_HIDE, 2),
 		]
 		self.assertEqual(expectedEvents, actualEvents)
+
+	def test_alwaysAllowedObjects_specialCaseEvents(self):
+		# We have events from two unique objects:
+		# Window, objectID, childID
+		allowedSource = (1, 1, 1)
+
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+		for n in range(2000):  # send many events, to saturate all limits.
+			eventId = specialCaseEvents[n % len(specialCaseEvents)]
+			limiter.addEvent(eventId, *allowedSource, threadID=0)
+		events = limiter.flushEvents(alwaysAllowedObjects=[allowedSource, ])
+
+		expected = [
+			# Two Foreground events, because they are added to multiple queues.
+			# Added to both _focusEventCache and _genericEventCache
+			# See also test_limitEventsPerThread
+			(winUser.EVENT_SYSTEM_FOREGROUND, *allowedSource),
+			(winUser.EVENT_SYSTEM_FOREGROUND, *allowedSource),
+			(winUser.EVENT_OBJECT_FOCUS, *allowedSource),
+			(winUser.EVENT_OBJECT_HIDE, *allowedSource),  # latest out of show / hide is kept
+			(winUser.EVENT_SYSTEM_MENUPOPUPEND, *allowedSource),  # Only one menu event is allowed
+		]
+		self.assertEqual(expected, events)
+
+	def test_alwaysAllowedObjects_onlyLatestEventKept(self):
+		# We have events from two unique objects:
+		# Window, objectID, childID
+		allowedSource = (1, 1, 1)
+		otherSource = (2, 2, 2,)
+
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+		for n in range(50):  # send many value changed events
+			limiter.addEvent(winUser.EVENT_OBJECT_VALUECHANGE, *allowedSource, threadID=0)
+			limiter.addEvent(winUser.EVENT_OBJECT_VALUECHANGE, *otherSource, threadID=0)
+		events = limiter.flushEvents(alwaysAllowedObjects=[allowedSource, ])
+		# only the most recent event of each object is kept, all previous duplicates are discarded
+		self.assertEqual(2, len(events))
+
+	# todo: Fix assertion failures
+	@unittest.expectedFailure
+	def test_threadLimit_singleObject(self):
+		"""Test that only the latest events are kept when the thread limit is exceeded
+		"""
+		# We have events from two unique objects:
+		# Window, objectID, childID
+		source = (2, 2, 2,)
+
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+
+		for n in range(500):  # exceed the limit for a single thread
+			eventId = nonSpecialCaseEvents[n % len(nonSpecialCaseEvents)]
+			# same thread, different object. Use a second object to aid tracking.
+			limiter.addEvent(eventId, *source, threadID=0)
+
+		events = limiter.flushEvents()
+		errors = []
+		expectedEventCount = orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD
+		softAssert(errors, self.assertEqual, expectedEventCount, len(events))  # Fails with actual=11
+		self.assertListEqual([], errors)
+
+	# todo: Fix assertion failures
+	@unittest.expectedFailure
+	def test_threadLimit_noCanary(self):
+		"""Test that only the latest events are kept when the thread limit is exceeded
+		"""
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+
+		for n in range(500):  # exceed the limit for a single thread
+			eventId = nonSpecialCaseEvents[n % len(nonSpecialCaseEvents)]
+			# same thread, different object. Ensure there are no duplicates
+			# Window, objectID, childID
+			source = (2, 2, n,)
+			limiter.addEvent(eventId, *source, threadID=0)
+
+		events = limiter.flushEvents()
+
+		errors = []
+		expectedEventCount = orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD
+		softAssert(errors, self.assertEqual, expectedEventCount, len(events))  # Fails with 11 actual events
+		self.assertListEqual([], errors)
+
+	# todo: Fix assertion failures
+	@unittest.expectedFailure
+	def test_threadLimit_withCanaryAtStart(self):
+		"""Test that only the latest events are kept when the thread limit is exceeded
+		"""
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+
+		# Window, objectID, childID
+		canaryObject = (1, 1, 1)
+		eventStartCanary = (winUser.EVENT_OBJECT_VALUECHANGE, *canaryObject)
+		limiter.addEvent(*eventStartCanary, threadID=0)
+
+		for n in range(500):  # exceed the limit for a single thread
+			eventId = nonSpecialCaseEvents[n % len(nonSpecialCaseEvents)]
+			# same thread, different object. Ensure there are no duplicates
+			# Window, objectID, childID
+			source = (2, 2, n,)
+			limiter.addEvent(eventId, *source, threadID=0)
+
+		events = limiter.flushEvents()
+
+		errors = []
+		expectedEventCount = orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD
+		softAssert(errors, self.assertEqual, expectedEventCount, len(events))  # Fails with 11 actual events
+		softAssert(errors, self.assertNotIn, eventStartCanary, events)
+		self.assertListEqual([], errors)
+
+	# todo: Fix assertion failures
+	@unittest.expectedFailure
+	def test_threadLimit_canaryStartAndEnd(self):
+		"""Test that only the latest events are kept when the thread limit is exceeded
+		"""
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+
+		# Window, objectID, childID
+		canaryObject = (1, 1, 1)
+		eventStartCanary = (winUser.EVENT_OBJECT_VALUECHANGE, *canaryObject)
+		limiter.addEvent(*eventStartCanary, threadID=0)
+
+		for n in range(500):  # exceed the limit for a single thread
+			eventId = nonSpecialCaseEvents[n % len(nonSpecialCaseEvents)]
+			# same thread, different object. Ensure there are no duplicates
+			# Window, objectID, childID
+			source = (2, 2, n,)
+			limiter.addEvent(eventId, *source, threadID=0)
+
+		# Note event type must differ from start canary to ensure they are not duplicates
+		eventEndCanary = (winUser.EVENT_OBJECT_NAMECHANGE, *canaryObject)
+		limiter.addEvent(*eventEndCanary, threadID=0)
+
+		events = limiter.flushEvents()
+		errors = []
+		expectedEventCount = orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD
+		softAssert(errors, self.assertEqual, expectedEventCount, len(events))  # Fails with 11 actual events
+		softAssert(errors, self.assertIn, eventEndCanary, events)
+		softAssert(errors, self.assertNotIn, eventStartCanary, events)
+		self.assertListEqual([], errors)
+
+	def test_alwaysAllowedObjects(self):
+		"""Matches test_threadLimit_canaryStartAndEnd, but allows events from the first object
+		"""
+		limiter = OrderedWinEventLimiter(maxFocusItems=4)
+
+		# Window, objectID, childID
+		canaryObject = (1, 1, 1)
+		eventStartCanary = (winUser.EVENT_OBJECT_VALUECHANGE, *canaryObject)
+		limiter.addEvent(*eventStartCanary, threadID=0)
+
+		for n in range(orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD):  # exceed the limit for a single thread
+			eventId = nonSpecialCaseEvents[n % len(nonSpecialCaseEvents)]
+			# same thread, different object. Ensure there are no duplicates
+			# Window, objectID, childID
+			source = (2, 2, n,)
+			limiter.addEvent(eventId, *source, threadID=0)
+
+		eventEndCanary = (winUser.EVENT_OBJECT_NAMECHANGE, *canaryObject)
+		limiter.addEvent(*eventEndCanary, threadID=0)
+
+		events = limiter.flushEvents(alwaysAllowedObjects=[canaryObject, ])
+		# only the most recent event of each object is kept, all previous duplicates are discarded
+		self.assertEqual(12, len(events))
+		self.assertIn(eventStartCanary, events)
+		self.assertEqual(eventStartCanary, events[0])
+		self.assertIn(eventEndCanary, events)
 
 	def test_limitEventsPerThread(self):
 		limiter = OrderedWinEventLimiter(maxFocusItems=4)

--- a/tests/unit/test_orderedWinEventLimiter.py
+++ b/tests/unit/test_orderedWinEventLimiter.py
@@ -214,8 +214,6 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 		# only the most recent event of each object is kept, all previous duplicates are discarded
 		self.assertEqual(2, len(events))
 
-	# todo: Fix assertion failures
-	@unittest.expectedFailure
 	def test_threadLimit_singleObject(self):
 		"""Test that only the latest events are kept when the thread limit is exceeded
 		"""
@@ -233,11 +231,8 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 		events = limiter.flushEvents()
 		errors = []
 		expectedEventCount = orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD
-		softAssert(errors, self.assertEqual, expectedEventCount, len(events))  # Fails with actual=11
-		self.assertListEqual([], errors)
+		self.assertEqual(expectedEventCount, len(events))
 
-	# todo: Fix assertion failures
-	@unittest.expectedFailure
 	def test_threadLimit_noCanary(self):
 		"""Test that only the latest events are kept when the thread limit is exceeded
 		"""
@@ -257,8 +252,6 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 		softAssert(errors, self.assertEqual, expectedEventCount, len(events))  # Fails with 11 actual events
 		self.assertListEqual([], errors)
 
-	# todo: Fix assertion failures
-	@unittest.expectedFailure
 	def test_threadLimit_withCanaryAtStart(self):
 		"""Test that only the latest events are kept when the thread limit is exceeded
 		"""
@@ -284,8 +277,6 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 		softAssert(errors, self.assertNotIn, eventStartCanary, events)
 		self.assertListEqual([], errors)
 
-	# todo: Fix assertion failures
-	@unittest.expectedFailure
 	def test_threadLimit_canaryStartAndEnd(self):
 		"""Test that only the latest events are kept when the thread limit is exceeded
 		"""
@@ -337,7 +328,7 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 
 		events = limiter.flushEvents(alwaysAllowedObjects=[canaryObject, ])
 		# only the most recent event of each object is kept, all previous duplicates are discarded
-		self.assertEqual(12, len(events))
+		self.assertEqual(11, len(events))
 		self.assertIn(eventStartCanary, events)
 		self.assertEqual(eventStartCanary, events[0])
 		self.assertIn(eventEndCanary, events)
@@ -356,10 +347,10 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 			for e in events
 		]
 		# TODO: Note: repeated Id's (0 and 8) are EVENT_SYSTEM_FOREGROUND see test_maxFocusEvents
-		expectedIds = [26, 24, 19, 18, 16, 11, 10, 9, 8, 8, 4, 3, 2, 1, 0, 0]
+		expectedIds = [24, 19, 18, 16, 11, 10, 9, 8, 8, 4, 3, 2, 1, 0, 0]
 		self.assertEqual(expectedIds, windowIds)
-		# TODO:
-		#  Why isn't this equal to MAX_WINEVENTS_PER_THREAD=10
-		#  There are also 4 focus events.
-		#  But the total is 16 not 10+4=14?
-		self.assertEqual(len(windowIds), 16)
+		#  equal to MAX_WINEVENTS_PER_THREAD=10
+		# Plus 4 focus events,
+		# Plus the last menu event.
+		#  All totalling 15.
+		self.assertEqual(len(windowIds), 15)

--- a/tests/unit/test_orderedWinEventLimiter.py
+++ b/tests/unit/test_orderedWinEventLimiter.py
@@ -229,7 +229,6 @@ class TestOrderedWinEventLimiter(unittest.TestCase):
 			limiter.addEvent(eventId, *source, threadID=0)
 
 		events = limiter.flushEvents()
-		errors = []
 		expectedEventCount = orderedWinEventLimiter.MAX_WINEVENTS_PER_THREAD
 		self.assertEqual(expectedEventCount, len(events))
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,7 @@ What's New in NVDA
 - NVDA is no longer unable to read the features list in Internet Information Services (IIS) Manager. (#11468)
 - NVDA now keeps the audio device open improving performance on some sound cards (#5172, #10721)
 - NVDA will no longer freeze or exit when holding down control+shift+downArrow in Microsoft Word. (#9463)
+- The expanded / collapsed state of directories in the navigation treeview on drive.google.com is now always reported by NVDA. (#11520)
 
 
 == Changes For Developers ==
@@ -61,6 +62,7 @@ What's New in NVDA
  - The majority of NVDA's classes are tracked including NVDAObjects, appModules, GlobalPlugins, SynthDrivers, and TreeInterceptors.
  - A class that needs to be tracked should inherit from garbageHandler.TrackedObject.
 - Significant debug logging for MSAA events can be now enabled in NVDA's Advanced settings. (#11521)
+- MSAA winEvents for the currently focused object are no longer filtered out along with other events if the event count for a given thread is exceeded. (#11520)
 
 
 = 2020.2 =


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
If an app floods NVDA with a lot of MSAA events and therefore NVDA starts ignoring events due to the winEvent limit for that thread being exceeded, important MSAA events for the currently focused object may be ignored.
An example of this is on https://drive.google.com in Google Chrome:
Press gn to go to the navigation treeview.
When pressing right and left arrow to expand / collapse  particular directories in the tree, NVDA may fail to announce the expanded / collapsed state, if the directory contains a lot of subdirectories.
 Google Chrome seems to fire a great deal of locationChange, stateChange, show and hide events for the subdirectories. And because of this, the important stateChange event on the focused item is dropped by NVDA.

### Description of how this pull request fixes the issue:
* OrderedWinEventLimitor.flushEvents now takes a list of winEvent params, for which it should always allow events for, even if the winEvent limit for that thread has been exceeded.
* IAccessibleHandler.pumpAll now calls flushEvents giving it the winEvent params of the currently focused object (if it is an MSAA object), to ensure that all winEvents for the currently focused object are received.
* The hard limit of 500 winEvents per core pump in IAccessibleHandler has now been removed as the OrderedWinEventLimitor already limits to 10 events per thread, and even when allowing all events for the focused object, this will not be many more as we don't produce duplicates.
 
  
### Testing performed:
Expanded and collapsed a large directory in the drive.google.com navigation tree, ensuring that NVDA announced the expand / collapsed state, where as before this change it did not.

### Known issues with pull request:
None.

### Change log entry:

Bug fixes:
- The expanded / collapsed state of directories in the navigation treeview on drive.google.com is always reported by NVDA.