### PR TITLE
Add significant optional debug logging for MSAA events

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -99,6 +99,57 @@ from comInterfaces.IAccessible2Lib import (
 	IA2_ROLE_FOOTER,
 	IA2_ROLE_MARK,
 )
+import config
+
+
+_winEventNameCache = {}
+
+
+def getWinEventName(eventID):
+	""" Looks up the name of an EVENT_* winEvent constant. """
+	global _winEventNameCache
+	if not _winEventNameCache:
+		_winEventNameCache = {y: x for x, y in vars(winUser).items() if x.startswith('EVENT_')}
+		_winEventNameCache.update({y: x for x, y in vars(IA2).items() if x.startswith('IA2_EVENT_')})
+	name = _winEventNameCache.get(eventID)
+	if not name:
+		name = "unknown event ({eventID})"
+	return name
+
+
+_objectIDNameCache = {}
+
+
+def getObjectIDName(objectID):
+	""" Looks up the name of an OBJID_* winEvent constant. """
+	global _objectIDNameCache
+	if not _objectIDNameCache:
+		_objectIDNameCache = {y: x for x, y in vars(winUser).items() if x.startswith('OBJID_')}
+	name = _objectIDNameCache.get(objectID)
+	if not name:
+		name = str(objectID)
+	return name
+
+
+def getWinEventLogInfo(window, objectID, childID, eventID=None):
+	"""
+	Formats the given winEvent parameters into a printable string.
+	window, objectID and childID are mandetory,
+	but eventID is optional.
+	"""
+	windowClassName = winUser.getClassName(window)
+	objectIDName = getObjectIDName(objectID)
+	if eventID is not None:
+		eventName = getWinEventName(eventID)
+		return f"{eventName} for window {window} ({windowClassName}), objectID {objectIDName} and childID {childID}"
+	else:
+		return f"window {window} ({windowClassName}), objectID {objectIDName} and childID {childID}"
+
+
+def isMSAADebugLoggingEnabled():
+	""" Whether the user has configured NVDA to log extra information about MSAA events. """
+	return config.conf["debugLog"]["MSAA"]
+
 
 from . import internalWinEventHandler
 # Imported for backwards compat
@@ -522,27 +573,45 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 	@returns: the NVDA event name and the NVDAObject the event is for
 	@rtype: tuple of string and L{NVDAObjects.IAccessible.IAccessible}
 	"""
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Creating NVDA event from winEvent: {getWinEventLogInfo(window, objectID, childID, eventID)}, "
+			f"use cache {useCache}"
+		)
 	NVDAEventName = winEventIDsToNVDAEventNames.get(eventID, None)
 	if not NVDAEventName:
+		log.debugWarning(f"No NVDA event name for {getWinEventName(eventID)}")
 		return None
+	if isMSAADebugLoggingEnabled():
+		log.debug(f"winEvent mapped to NVDA event: {NVDAEventName}")
 	# Ignore any events with invalid window handles
 	if not window or not winUser.isWindow(window):
+		if isMSAADebugLoggingEnabled():
+			log.debug("Dropping winEvent for invalid window")
 		return None
 	# Make sure this window does not have a ghost window if possible
 	if NVDAObjects.window.GhostWindowFromHungWindow and NVDAObjects.window.GhostWindowFromHungWindow(window):
+		if isMSAADebugLoggingEnabled():
+			log.debug("Dropping winEvent for ghosted hung window")
 		return None
 	# We do not support MSAA object proxied from native UIA
 	if UIAHandler.handler and UIAHandler.handler.isUIAWindow(window):
+		if isMSAADebugLoggingEnabled():
+			log.debug("Dropping winEvent for native UIA window")
 		return None
 	obj = None
 	if useCache:
 		# See if we already know an object by this win event info
 		obj = liveNVDAObjectTable.get((window, objectID, childID), None)
+		if isMSAADebugLoggingEnabled() and obj:
+			log.debug("Fetched existing NVDAObject for winEvent from liveNVDAObjectTable")
 	# If we don't yet have the object, then actually instanciate it.
 	if not obj:
 		obj = NVDAObjects.IAccessible.getNVDAObjectFromEvent(window, objectID, childID)
 	# At this point if we don't have an object then we can't do any more
 	if not obj:
+		if isMSAADebugLoggingEnabled():
+			log.debug("Could not instantiate an NVDAObject for winEvent")
 		return None
 	# SDM MSAA objects sometimes don't contain enough information to be useful Sometimes there is a real
 	# window that does, so try to get the SDMChild property on the NVDAObject, and if successull use that as
@@ -569,6 +638,10 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 	@returns: True if the event was processed, False otherwise.
 	@rtype: boolean
 	"""
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing generic winEvent: {getWinEventLogInfo(window, objectID, childID, eventID)}"
+		)
 	# Notify appModuleHandler of this new window
 	appModuleHandler.update(winUser.getWindowThreadProcessID(window)[0])
 	# Handle particular events for the special MSAA caret object just as if they were for the focus object
@@ -577,15 +650,21 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 		winUser.EVENT_OBJECT_LOCATIONCHANGE,
 		winUser.EVENT_OBJECT_SHOW
 	):
+		if isMSAADebugLoggingEnabled():
+			log.debug("handling winEvent as caret event on focus")
 		NVDAEvent = ("caret", focus)
 	else:
 		NVDAEvent = winEventToNVDAEvent(eventID, window, objectID, childID)
 		if not NVDAEvent:
 			return False
 	if NVDAEvent[0] == "nameChange" and objectID == winUser.OBJID_CURSOR:
+		if isMSAADebugLoggingEnabled():
+			log.debug("Handling winEvent as mouse shape change")
 		mouseHandler.updateMouseShape(NVDAEvent[1].name)
 		return
 	if NVDAEvent[1] == focus:
+		if isMSAADebugLoggingEnabled():
+			log.debug("Directing winEvent to focus object")
 		NVDAEvent = (NVDAEvent[0], focus)
 	eventHandler.queueEvent(*NVDAEvent)
 	return True
@@ -605,6 +684,11 @@ def processFocusWinEvent(window, objectID, childID, force=False):
 	@returns: True if the focus is valid and was handled, False otherwise.
 	@rtype: boolean
 	"""
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing focus winEvent: {getWinEventLogInfo(window, objectID, childID)}, "
+			f"force {force}"
+		)
 	windowClassName = winUser.getClassName(window)
 	# Generally, we must ignore focus on child windows of SDM windows as we only want the SDM MSAA events.
 	# However, we don't want to ignore focus if the child ID isn't 0,
@@ -693,6 +777,10 @@ class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
 
 
 def processDesktopSwitchWinEvent(window, objectID, childID):
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing desktopSwitch winEvent: {getWinEventLogInfo(window, objectID, childID)}"
+		)
 	hDesk = windll.user32.OpenInputDesktop(0, False, 0)
 	if hDesk != 0:
 		windll.user32.CloseDesktop(hDesk)
@@ -724,6 +812,10 @@ def processForegroundWinEvent(window, objectID, childID):
 	@returns: True if the foreground was processed, False otherwise.
 	@rtype: boolean
 	"""
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing foreground winEvent: {getWinEventLogInfo(window, objectID, childID)}"
+		)
 	# Ignore foreground events on windows that aren't the current foreground window
 	if window != winUser.getForegroundWindow():
 		return False
@@ -758,6 +850,10 @@ def processForegroundWinEvent(window, objectID, childID):
 
 
 def processShowWinEvent(window, objectID, childID):
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing show winEvent: {getWinEventLogInfo(window, objectID, childID)}"
+		)
 	# eventHandler.shouldAcceptEvent only accepts show events for a few specific cases.
 	# Narrow this further to only accept events for clients or custom objects.
 	if objectID == winUser.OBJID_CLIENT or objectID > 0:
@@ -771,6 +867,10 @@ def processDestroyWinEvent(window, objectID, childID):
 	This removes the object associated with the event parameters from L{liveNVDAObjectTable} if
 	such an object exists.
 	"""
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing destroy winEvent: {getWinEventLogInfo(window, objectID, childID)}"
+		)
 	try:
 		del liveNVDAObjectTable[(window, objectID, childID)]
 	except KeyError:
@@ -796,6 +896,11 @@ def processMenuStartWinEvent(eventID, window, objectID, childID, validFocus):
 	"""Process a menuStart win event.
 	@postcondition: Focus will be directed to the menu if appropriate.
 	"""
+	if isMSAADebugLoggingEnabled():
+		log.debug(
+			f"Processing menuStart winEvent: {getWinEventLogInfo(window, objectID, childID)}, "
+			f"validFocus {validFocus}"
+		)
 	if validFocus:
 		lastFocus = eventHandler.lastQueuedFocusObject
 		if (

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -611,7 +611,7 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 	# At this point if we don't have an object then we can't do any more
 	if not obj:
 		if isMSAADebugLoggingEnabled():
-			log.debug("Could not instantiate an NVDAObject for winEvent")
+			log.debug(f"Could not instantiate an NVDAObject for winEvent: {getWinEventLogInfo(window, objectID, childID, eventID)}")
 		return None
 	# SDM MSAA objects sometimes don't contain enough information to be useful Sometimes there is a real
 	# window that does, so try to get the SDMChild property on the NVDAObject, and if successull use that as

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -604,7 +604,7 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 		# See if we already know an object by this win event info
 		obj = liveNVDAObjectTable.get((window, objectID, childID), None)
 		if isMSAADebugLoggingEnabled() and obj:
-			log.debug("Fetched existing NVDAObject for winEvent from liveNVDAObjectTable")
+			log.debug(f"Fetched existing NVDAObject for winEvent from liveNVDAObjectTable: {getWinEventLogInfo(window, objectID, childID)}")
 	# If we don't yet have the object, then actually instanciate it.
 	if not obj:
 		obj = NVDAObjects.IAccessible.getNVDAObjectFromEvent(window, objectID, childID)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -646,7 +646,7 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 			obj = SDMChild
 	if isMSAADebugLoggingEnabled():
 		log.debug(
-			f"Successfully created NvDA event {NVDAEventName} for {obj} "
+			f"Successfully created NVDA event {NVDAEventName} for {obj} "
 			f"from winEvent {getWinEventLogInfo(window, objectID, childID, eventID)}"
 		)
 	return (NVDAEventName, obj)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -134,7 +134,7 @@ def getObjectIDName(objectID):
 def getWinEventLogInfo(window, objectID, childID, eventID=None):
 	"""
 	Formats the given winEvent parameters into a printable string.
-	window, objectID and childID are mandetory,
+	window, objectID and childID are mandatory,
 	but eventID is optional.
 	"""
 	windowClassName = winUser.getClassName(window)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -604,14 +604,20 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 		# See if we already know an object by this win event info
 		obj = liveNVDAObjectTable.get((window, objectID, childID), None)
 		if isMSAADebugLoggingEnabled() and obj:
-			log.debug(f"Fetched existing NVDAObject for winEvent from liveNVDAObjectTable: {getWinEventLogInfo(window, objectID, childID)}")
+			log.debug(
+				"Fetched existing NVDAObject for winEvent from liveNVDAObjectTable: "
+				f"{getWinEventLogInfo(window, objectID, childID)}"
+			)
 	# If we don't yet have the object, then actually instanciate it.
 	if not obj:
 		obj = NVDAObjects.IAccessible.getNVDAObjectFromEvent(window, objectID, childID)
 	# At this point if we don't have an object then we can't do any more
 	if not obj:
 		if isMSAADebugLoggingEnabled():
-			log.debug(f"Could not instantiate an NVDAObject for winEvent: {getWinEventLogInfo(window, objectID, childID, eventID)}")
+			log.debug(
+				"Could not instantiate an NVDAObject for winEvent: "
+				f"{getWinEventLogInfo(window, objectID, childID, eventID)}"
+			)
 		return None
 	# SDM MSAA objects sometimes don't contain enough information to be useful Sometimes there is a real
 	# window that does, so try to get the SDMChild property on the NVDAObject, and if successull use that as

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -597,7 +597,7 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 	# We do not support MSAA object proxied from native UIA
 	if UIAHandler.handler and UIAHandler.handler.isUIAWindow(window):
 		if isMSAADebugLoggingEnabled():
-			log.debug("Dropping winEvent for native UIA window")
+			log.debug(f"Dropping winEvent for native UIA window {window} ({winUser.getClassName(window)})")
 		return None
 	obj = None
 	if useCache:

--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -79,9 +79,19 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 	try:
 		# Ignore all object IDs from alert onwards (sound, nativeom etc) as we don't support them
 		if objectID <= winUser.OBJID_ALERT:
+			if isMSAADebugLoggingEnabled():
+				log.debug(
+					f"objectID not supported. "
+					f"Dropping winEvent {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 			return
 		# Ignore all locationChange events except ones for the caret
 		if eventID == winUser.EVENT_OBJECT_LOCATIONCHANGE and objectID != winUser.OBJID_CARET:
+			if isMSAADebugLoggingEnabled():
+				log.debug(
+					f"locationChange for something other than the caret. "
+					f"Dropping winEvent {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 			return
 		if eventID == winUser.EVENT_OBJECT_DESTROY:
 			_processDestroyWinEvent(window, objectID, childID)
@@ -90,7 +100,10 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 		if (objectID == 0) and (childID == 0):
 			objectID = winUser.OBJID_CLIENT
 			if isMSAADebugLoggingEnabled():
-				log.debug(f"Changing OBJID_WINDOW to OBJID_CLIENT for winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}")
+				log.debug(
+					f"Changing OBJID_WINDOW to OBJID_CLIENT "
+					f"for winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 		# Ignore events with invalid window handles
 		isWindow = winUser.isWindow(window) if window else 0
 		if window == 0 or (
@@ -102,11 +115,17 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 			)
 		):
 			if isMSAADebugLoggingEnabled():
-				log.debug(f"Changing NULL or invalid window to desktop window for winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}")
+				log.debug(
+					f"Changing NULL or invalid window to desktop window "
+					f"for winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 			window = winUser.getDesktopWindow()
 		elif not isWindow:
 			if isMSAADebugLoggingEnabled():
-				log.debug(f"Invalid window. Dropping winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}")
+				log.debug(
+					f"Invalid window. "
+					f"Dropping winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 			return
 
 		windowClassName = winUser.getClassName(window)
@@ -118,13 +137,19 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 		# and can't be used properly in conjunction with input composition support.
 		if windowClassName == "Microsoft.IME.UIManager.CandidateWindow.Host" and eventID in MENU_EVENTIDS:
 			if isMSAADebugLoggingEnabled():
-				log.debug(f"Dropping menu event for IME window. WinEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}")
+				log.debug(
+					f"Dropping menu event for IME window. "
+					f"WinEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 			return
 		if eventID == winUser.EVENT_SYSTEM_FOREGROUND:
 			# We never want to see foreground events for the Program Manager or Shell (task bar)
 			if windowClassName in ("Progman", "Shell_TrayWnd"):
 				if isMSAADebugLoggingEnabled():
-					log.debug(f"Progman or shell_trayWnd window. Dropping winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}")
+					log.debug(
+						f"Progman or shell_trayWnd window. "
+						f"Dropping winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+					)
 				return
 			# #3831: Event handling can be deferred if Windows takes a while to change the foreground window.
 			# See pumpAll for details.
@@ -132,7 +157,10 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 			_deferUntilForegroundWindow = window
 			_foregroundDefers = 0
 			if isMSAADebugLoggingEnabled():
-				log.debug(f"Recording foreground defer for WinEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}")
+				log.debug(
+					f"Recording foreground defer "
+					f"for WinEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+				)
 		if windowClassName == "MSNHiddenWindowClass":
 			# HACK: Events get fired by this window in Windows Live Messenger 2009 when it starts. If we send a
 			# WM_NULL to this window at this point (which happens in accessibleObjectFromEvent), Messenger will

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -107,11 +107,11 @@ class OrderedWinEventLimiter(object):
 		self._eventHeap = []
 		r = []
 		for count in range(len(e)):
-			event = heapq.heappop(e)[1:-1]
+			event = heapq.heappop(e)[1:]
 			if isMSAADebugLoggingEnabled():
-				eventID, window, objectID, childID = event
+				eventID, window, objectID, childID, threadID = event
 				log.debug(
-					f"Emitting winEvent {getWinEventLogInfo(window, objectID, childID, eventID)}"
+					f"Emitting winEvent {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
 				)
-			r.append(event)
+			r.append(event[:-1])
 		return r

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -235,6 +235,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 [debugLog]
 	hwIo = boolean(default=false)
+	MSAA = boolean(default=false)
 	UIA = boolean(default=false)
 	audioDucking = boolean(default=false)
 	gui = boolean(default=false)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2447,6 +2447,7 @@ class AdvancedPanelControls(wx.Panel):
 
 		self.logCategories=[
 			"hwIo",
+			"MSAA",
 			"UIA",
 			"audioDucking",
 			"gui",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -61,6 +61,7 @@ What's New in NVDA
 - NVDA-specific objects that are found by Python's cyclic garbage collector are now logged when being deleted by the collector to aide in removing reference cycles from NVDA. (#11499)
  - The majority of NVDA's classes are tracked including NVDAObjects, appModules, GlobalPlugins, SynthDrivers, and TreeInterceptors.
  - A class that needs to be tracked should inherit from garbageHandler.TrackedObject.
+- Significant debug logging for MSAA events can be now enabled in NVDA's Advanced settings. (#11521)
 
 
 = 2020.2 =


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None.

### Summary of the issue:
There is not much logging for the receiving and processing of MSAA `winEvents` in NVDA. It is currently hard to debug issues around missing MSAA events and or creating IAccessible objects from events.

### Description of how this pull request fixes the issue:
Ads a significant amount of debug and debugWarning messages to the log in the `winEvent` hook, the limiter, and the various `process*WinEvent` functions. **This logging must be turned on  with the MSAA debug log checkbox in NVDA's advanced settings.**
When `winEvent` params are logged, the `eventID` and `objectID` constant names are resolved, as well as the window class name for the window handle.

### Testing performed:
Ran NVDA with and without this logging turned on.

### Known issues with pull request:
None.

### Change log entry:
Changes for developers:
- Significant debug logging for MSAA events can be now enabled in NVDA's Advanced settings.