### PR TITLE
Revert "Allow display to turn off for power saving during say all"

### DIFF
--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -470,7 +470,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
 		if gesture.shouldPreventSystemIdle:
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
 			self._lastInputTime = time.time()

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -33,7 +33,7 @@ import globalVars
 import languageHandler
 import controlTypes
 import keyLabels
-import winKernel
+import systemUtils
 
 #: Script category for emulated keyboard keys.
 # Translators: The name of a category of NVDA commands.
@@ -470,7 +470,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
 		if gesture.shouldPreventSystemIdle:
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
+			systemUtils.preventSystemIdle()
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
 			self._lastInputTime = time.time()

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -63,7 +63,7 @@ class _ObjectsReader(garbageHandler.TrackedObject):
 		if self.prevObj:
 			# We just started speaking this object, so move the navigator to it.
 			api.setNavigatorObject(self.prevObj, isFocus=lastSayAllMode==CURSOR_CARET)
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
+			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
 		# Move onto the next object.
 		self.prevObj = obj = next(self.walker, None)
 		if not obj:
@@ -215,7 +215,7 @@ class _TextReader(garbageHandler.TrackedObject):
 			updater.updateCaret()
 		if self.cursor != CURSOR_CARET or config.conf["reviewCursor"]["followCaret"]:
 			api.setReviewPosition(updater, isCaret=self.cursor==CURSOR_CARET)
-		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
+		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
 		if self.numBufferedLines == 0:
 			# This was the last line spoken, so move on.
 			self.nextLine()

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -13,7 +13,7 @@ import controlTypes
 import api
 import textInfos
 import queueHandler
-import winKernel
+import systemUtils
 
 CURSOR_CARET = 0
 CURSOR_REVIEW = 1
@@ -63,7 +63,7 @@ class _ObjectsReader(garbageHandler.TrackedObject):
 		if self.prevObj:
 			# We just started speaking this object, so move the navigator to it.
 			api.setNavigatorObject(self.prevObj, isFocus=lastSayAllMode==CURSOR_CARET)
-			winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
+			systemUtils.preventSystemIdle()
 		# Move onto the next object.
 		self.prevObj = obj = next(self.walker, None)
 		if not obj:
@@ -215,7 +215,7 @@ class _TextReader(garbageHandler.TrackedObject):
 			updater.updateCaret()
 		if self.cursor != CURSOR_CARET or config.conf["reviewCursor"]["followCaret"]:
 			api.setReviewPosition(updater, isCaret=self.cursor==CURSOR_CARET)
-		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)
+		systemUtils.preventSystemIdle()
 		if self.numBufferedLines == 0:
 			# This was the last line spoken, so move on.
 			self.nextLine()

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2020 NV Access Limited, Łukasz Golonka, Leonard de Ruijter
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -72,3 +72,9 @@ def execElevated(path, params=None, wait=False, handleAlreadyElevated=False):
 			return winKernel.GetExitCodeProcess(sei.hProcess)
 		finally:
 			winKernel.closeHandle(sei.hProcess)
+
+
+def preventSystemIdle() -> int:
+	""" Helper function that prevents the system from going idle.
+	"""
+	return winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED | winKernel.ES_DISPLAY_REQUIRED)


### PR DESCRIPTION
### Issue
Reverts nvaccess/nvda#11118
Restores #10643

### Description of the issue
In #10643, I implemented support for the system not going to lock or sleep while in say all. #11118 changed this behavior, as some people found it problematic that the screen stays on during say all. However, after testing, it turns out that #11118 regressed in such a way that at least on my system with a group policy based lock timer, the system locks again during say all.

### Testing performed
Tried reading a long piece of text with say all in notepad. Without this reversion, the system locked whereas with it, it keeps reading.