### PR TITLE
nvWave: Dont close audio device

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -105,7 +105,8 @@ class WavePlayer(garbageHandler.TrackedObject):
 	MIN_BUFFER_MS = 300
 	#: Flag used to signal that L{stop} has been called.
 	STOPPING = "stopping"
-	#: A lock to prevent WaveOut* functions from being called simultaneously, as this can cause problems even if they are for different HWAVEOUTs.
+	#: A lock to prevent WaveOut* functions from being called simultaneously,
+	# as this can cause problems even if they are for different HWAVEOUTs.
 	_global_waveout_lock = threading.RLock()
 	_audioDucker=None
 	#: Used to allow the device to temporarily be changed and return

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -8,6 +8,7 @@
 """
 
 import threading
+import typing
 from ctypes import *
 from ctypes.wintypes import *
 import time
@@ -108,25 +109,24 @@ class WavePlayer(garbageHandler.TrackedObject):
 	_global_waveout_lock = threading.RLock()
 	_audioDucker=None
 
-	def __init__(self, channels, samplesPerSec, bitsPerSample,
-			outputDevice=WAVE_MAPPER, closeWhenIdle=True, wantDucking=True,
-			buffered=False
+	def __init__(
+			self,
+			channels: int,
+			samplesPerSec: int,
+			bitsPerSample: int,
+			outputDevice: typing.Union[int, str] = WAVE_MAPPER,
+			closeWhenIdle: bool = False,
+			wantDucking: bool = True,
+			buffered: bool = False
 		):
 		"""Constructor.
 		@param channels: The number of channels of audio; e.g. 2 for stereo, 1 for mono.
-		@type channels: int
 		@param samplesPerSec: Samples per second (hz).
-		@type samplesPerSec: int
 		@param bitsPerSample: The number of bits per sample.
-		@type bitsPerSample: int
 		@param outputDevice: The device ID or name of the audio output device to use.
-		@type outputDevice: int or str
 		@param closeWhenIdle: If C{True}, close the output device when no audio is being played.
-		@type closeWhenIdle: bool
 		@param wantDucking: if true then background audio will be ducked on Windows 8 and higher
-		@type wantDucking: bool
 		@param buffered: Whether to buffer small chunks of audio to prevent audio glitches.
-		@type buffered: bool
 		@note: If C{outputDevice} is a name and no such device exists, the default device will be used.
 		@raise WindowsError: If there was an error opening the audio output device.
 		"""
@@ -396,7 +396,13 @@ def playWaveFile(fileName, asynchronous=True):
 	if f is None: raise RuntimeError("can not open file %s"%fileName)
 	if fileWavePlayer is not None:
 		fileWavePlayer.stop()
-	fileWavePlayer = WavePlayer(channels=f.getnchannels(), samplesPerSec=f.getframerate(),bitsPerSample=f.getsampwidth()*8, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
+	fileWavePlayer = WavePlayer(
+		channels=f.getnchannels(),
+		samplesPerSec=f.getframerate(),
+		bitsPerSample=f.getsampwidth()*8,
+		outputDevice=config.conf["speech"]["outputDevice"],
+		wantDucking=False
+	)
 	fileWavePlayer.feed(f.readframes(f.getnframes()))
 	if asynchronous:
 		if fileWavePlayerThread is not None:

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -282,7 +282,9 @@ class WavePlayer(garbageHandler.TrackedObject):
 						winmm.waveOutPrepareHeader(self._waveout, LPWAVEHDR(whdr), sizeof(WAVEHDR))
 						winmm.waveOutWrite(self._waveout, LPWAVEHDR(whdr), sizeof(WAVEHDR))
 				except WindowsError:
-					self.close()
+					log.info("Error during feed. Resetting the device.")
+					self._close()  # don't try to call stop on a "broken" device.
+					self._setCurrentDevice(self._preferredDeviceName)
 					self.open()
 					self.feed(data, onDone)
 					return

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -275,7 +275,6 @@ class WavePlayer(garbageHandler.TrackedObject):
 				try:
 					with self._global_waveout_lock:
 						winmm.waveOutPrepareHeader(self._waveout, LPWAVEHDR(whdr), sizeof(WAVEHDR))
-					with self._global_waveout_lock:
 						winmm.waveOutWrite(self._waveout, LPWAVEHDR(whdr), sizeof(WAVEHDR))
 				except WindowsError:
 					self.close()

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -9,8 +9,6 @@
 
 import threading
 import typing
-import ctypes
-from ctypes import wintypes
 from ctypes import *
 from ctypes.wintypes import *
 import time
@@ -209,18 +207,6 @@ class WavePlayer(garbageHandler.TrackedObject):
 			f"preferred device: {self._preferredDeviceName}"
 			f" current device name: {self._outputDeviceName} (id: {self._outputDeviceID})"
 		)
-		fetchedID = UINT(self._outputDeviceID)
-		winmm.waveOutGetID(self._waveout, byref(fetchedID))
-		fetchedID = ctypes.cast(byref(fetchedID), ctypes.POINTER(wintypes.INT)).contents.value
-		if fetchedID != self._outputDeviceID:
-			outdeviceName = outputDeviceIDToName(fetchedID)
-			log.debugWarning(
-				f"Fetched ID does not match current device."
-				f" fetched id: {fetchedID} name: {outdeviceName}"
-			)
-			self._outputDeviceID = fetchedID
-			self._outputDeviceName = outdeviceName
-			return False
 		return self._outputDeviceName == self._preferredDeviceName
 
 	def _isPreferredDeviceAvailable(self) -> bool:

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -122,6 +122,10 @@ for func in (
 class WavePlayer(garbageHandler.TrackedObject):
 	"""Synchronously play a stream of audio.
 	To use, construct an instance and feed it waveform audio using L{feed}.
+	Keeps device open until it is either not available, or WavePlayer is explicitly closed / deleted.
+	Will attempt to use the preferred device, if not will fallback to the WAVE_MAPPER device.
+	When not using the preferred device, when idle devices will be checked to see if the preferred
+	device has become available again. If so, it will be re-instated.
 	"""
 	#: Minimum length of buffer (in ms) before audio is played.
 	MIN_BUFFER_MS = 300

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -168,6 +168,9 @@ class WavePlayer(garbageHandler.TrackedObject):
 		with self._waveout_lock:
 			if self._waveout:
 				return
+			log.debug(
+				f"Calling winmm.waveOutOpen."
+			)
 			wfx = WAVEFORMATEX()
 			wfx.wFormatTag = WAVE_FORMAT_PCM
 			wfx.nChannels = self.channels
@@ -324,8 +327,12 @@ class WavePlayer(garbageHandler.TrackedObject):
 				self._close()
 
 	def _close(self):
+		log.debug("Calling winmm.waveOutClose")
 		with self._global_waveout_lock:
-			winmm.waveOutClose(self._waveout)
+			try:
+				winmm.waveOutClose(self._waveout)
+			except WindowsError:
+				log.debug("Error closing the device, it may have been removed.", exc_info=True)
 		self._waveout = None
 
 	def __del__(self):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -410,17 +410,11 @@ class WavePlayer(garbageHandler.TrackedObject):
 					self._close()  # Idle so no need to call stop.
 				else:
 					with self._global_waveout_lock:
-						start = time.perf_counter()
 						if not self._isPreferredDeviceOpen() and self._isPreferredDeviceAvailable():
-							end = time.perf_counter()
-							log.debug(f"preferred device check: {end-start} seconds")
 							log.debug("Attempt re-open of preferred device.")
 							self._close()  # Idle so no need to call stop.
 							self._setCurrentDevice(self._preferredDeviceName)
 							self.open()
-						else:
-							end = time.perf_counter()
-							log.debug(f"preferred device check: {end-start} seconds")
 			if self._audioDucker: self._audioDucker.disable()
 
 	def stop(self):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -339,7 +339,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 				self.open()
 				self._feedUnbuffered(data, onDone=onDone)
 			except Exception:
-				log.debugWarning("Unable to recover.")
+				log.debugWarning("Unable to send data to audio device on second attempt.", exc_info=True)
 				return False
 
 	def _feedUnbuffered(self, data, onDone=None):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -9,6 +9,24 @@
 
 import threading
 import typing
+from ctypes import (
+	windll,
+	POINTER,
+	Structure,
+	c_uint,
+	create_unicode_buffer,
+	sizeof,
+	byref,
+)
+from ctypes.wintypes import (
+	HANDLE,
+	WORD,
+	DWORD,
+	LPSTR,
+	WCHAR,
+	UINT,
+	LPUINT
+)
 from ctypes import *
 from ctypes.wintypes import *
 import time
@@ -447,6 +465,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 		winKernel.kernel32.CloseHandle(self._waveout_event)
 		self._waveout_event = None
 
+
 def _getOutputDevices():
 	"""Generator, returning device ID and device Name in device ID order.
 		@note: Depending on number of devices being fetched, this may take some time (~3ms)
@@ -459,6 +478,7 @@ def _getOutputDevices():
 		except WindowsError:
 			# It seems that in certain cases, Windows includes devices which cannot be accessed.
 			pass
+
 
 def getOutputDeviceNames():
 	"""Obtain the names of all audio output devices on the system.
@@ -518,7 +538,7 @@ def playWaveFile(fileName, asynchronous=True):
 	fileWavePlayer = WavePlayer(
 		channels=f.getnchannels(),
 		samplesPerSec=f.getframerate(),
-		bitsPerSample=f.getsampwidth()*8,
+		bitsPerSample=f.getsampwidth() * 8,
 		outputDevice=config.conf["speech"]["outputDevice"],
 		wantDucking=False
 	)

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -332,7 +332,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 			self._feedUnbuffered(data, onDone=onDone)
 			return True
 		except WindowsError:
-			log.info("Error during feed. Resetting the device.")
+			log.warning("Error during feed. Resetting the device.")
 			try:
 				self._close()  # don't try to call stop on a "broken" device.
 				self._setCurrentDevice(self._preferredDeviceName)

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -243,15 +243,20 @@ class WavePlayer(garbageHandler.TrackedObject):
 			self._waveout = waveout.value
 			self._prev_whdr = None
 
-	def feed(self, data, onDone=None):
+	def feed(
+			self,
+			data: bytes,
+			onDone: typing.Optional[typing.Callable] = None
+	) -> None:
 		"""Feed a chunk of audio data to be played.
 		This is normally synchronous.
-		However, synchronisation occurs on the previous chunk, rather than the current chunk; i.e. calling this while no audio is playing will begin playing the chunk but return immediately.
-		This allows for uninterrupted playback as long as a new chunk is fed before the previous chunk has finished playing.
+		However, synchronisation occurs on the previous chunk, rather than the current chunk;
+		i.e. calling this while no audio is playing will begin playing the chunk
+		but return immediately.
+		This allows for uninterrupted playback as long as a new chunk is fed before
+		the previous chunk has finished playing.
 		@param data: Waveform audio in the format specified when this instance was constructed.
-		@type data: str
 		@param onDone: Function to call when this chunk has finished playing.
-		@type onDone: callable
 		@raise WindowsError: If there was an error playing the audio.
 		"""
 		if not self._minBufferSize:

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -470,6 +470,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 		self.close()
 		winKernel.kernel32.CloseHandle(self._waveout_event)
 		self._waveout_event = None
+		super().__del__()
 
 
 def _getOutputDevices():

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -340,9 +340,13 @@ def initialize(indexCallback=None):
 	)
 	if sampleRate <= 0:
 		raise OSError(f"espeak_Initialize failed with code {sampleRate}. Given Espeak data path of {eSpeakPath}")
-	player = nvwave.WavePlayer(channels=1, samplesPerSec=sampleRate, bitsPerSample=16,
+	player = nvwave.WavePlayer(
+		channels=1,
+		samplesPerSec=sampleRate,
+		bitsPerSample=16,
 		outputDevice=config.conf["speech"]["outputDevice"],
-		buffered=True)
+		buffered=True
+	)
 	onIndexReached = indexCallback
 	espeakDLL.espeak_SetSynthCallback(callback)
 	bgQueue = queue.Queue()

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -180,9 +180,12 @@ class SynthDriver(SynthDriver):
 			self._player.idle()
 		bytesPerSample = wav.getsampwidth()
 		self._bytesPerSec = samplesPerSec * bytesPerSample
-		self._player = nvwave.WavePlayer(channels=wav.getnchannels(),
-			samplesPerSec=samplesPerSec, bitsPerSample=bytesPerSample * 8,
-			outputDevice=config.conf["speech"]["outputDevice"])
+		self._player = nvwave.WavePlayer(
+			channels=wav.getnchannels(),
+			samplesPerSec=samplesPerSec,
+			bitsPerSample=bytesPerSample * 8,
+			outputDevice=config.conf["speech"]["outputDevice"]
+		)
 
 	def terminate(self):
 		super(SynthDriver, self).terminate()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -48,6 +48,7 @@ What's New in NVDA
 - NVDA no longer appends nonexistent trailing space when copying the current navigator object to the clipboard. (#11438)
 - NVDA no longer activates the Say All profile if there is nothing to read. (#10899, #9947)
 - NVDA is no longer unable to read the features list in Internet Information Services (IIS) Manager. (#11468)
+- NVDA now keeps the audio device open improving performance on some sound cards (#5172, #10721)
 - NVDA will no longer freeze or exit when holding down control+shift+downArrow in Microsoft Word. (#9463)
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -48,8 +48,6 @@ What's New in NVDA
 - NVDA no longer appends nonexistent trailing space when copying the current navigator object to the clipboard. (#11438)
 - NVDA no longer activates the Say All profile if there is nothing to read. (#10899, #9947)
 - NVDA is no longer unable to read the features list in Internet Information Services (IIS) Manager. (#11468)
-- The start or end of speech / sound is no longer truncated. (#5172, #10721)
-  - NVDA now holds the audio device open for a short time after speech utterances, improving performance on some sound cards.
 - NVDA will no longer freeze or exit when holding down control+shift+downArrow in Microsoft Word. (#9463)
 
 


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
Intends to replace:
- PR #11024 nvwave: Don't close the audio device unless there hasn't been any audio played for 10 seconds. 
- PR #11505 nvwave: Fix occasional exception related to close timer. 

### Link to issue number:
Fixes #11482
Fixes #11490
Fixes #5172
Fixes #10721

### Summary of the issue:
Original issues previously fixed by PR #11024 :
- As described in #5172, some audio drivers/hardware take a long time to open the device and/or truncate the start/end of the audio.
- As described in #10721 (comment), calling WaveOutOpen in the OneCore synth callback mysteriously blocks (and thus lags) for ~100 ms. Because we close the audio device on idle, we can trigger this problem. Although #11023 mostly fixes this, it's impossible (or at least very difficult) to resolve this completely from within the OneCore driver.
- Aside from all of this, closing and opening the audio device for rapid short utterances (e.g. rapid movement with the cursor keys or typing) doesn't seem particularly optimal. It's difficult to measure this, but I'd say mitigating this is likely to make audio performance faster/smoother.

Subsequently, occasional exceptions from nvwave, particularly when switching synthesisers.
- When using Microsoft Sound Mapper, NVDA should use the Windows default device.
- Devices becoming invalid, nvWave should fall back to Microsoft Sound Mapper
- When the configured device becomes available again, NVDA should switch back to using it.

### Description of how this pull request fixes the issue:
Don't close the device at all.

- Closing and opening the audio device was originally introduced to support Remote Desktop audio, this is now better served by other solutions. 
- Performance is improved by keeping it open, using a timeout means that the lag is more rare, but will still occur.

As per the discussion:
https://github.com/nvaccess/nvda/pull/11505#issuecomment-674879807

To fix issues with current / preferred device:
- nvWave now saves the preferred device when it is constructed.
- If using a device fails, it is considered unavailable, nvWave attempts to fall back to "Microsoft Sound Mapper".
- From my testing, using "Microsoft Sound Mapper" correctly handled changing the default device (Win 10 2004). It would be helpful if others could confirm, especially on different OS versions.
- During `_idleUnbuffered`
  - The current device is checked to see if it matches the preferred device.
  - The available devices are polled to see if the preferred device is available, if so it switches.

### Testing performed:

- Set NVDA audio device: Microsoft Sound Mapper
  - Set default device via system tray: laptop speakers
  - Set default device via system tray: bt headphones
  - Turn off bt headphones
  - Turn on bt headphones
- Set NVDA audio device: bt headphones
  - Turn off bt headphones
  - Turn on bt headphones

Logged performance of checking for preferred device.
- Check if nvWave is already using the preferred device is fast.
  - [Tested code (which has since been simplified even further)](https://github.com/nvaccess/nvda/commit/78c48fd3121f08d9f768572b54626d7fb10bb837#diff-ea1b000a4d25ba3adfccce3616353820R215)
  - Average on my machine: 0.2 ms
- Check if the preferred device is available again can be slow.
  - This has to enumerate and fetch the name for each device. If there are many devices this could be exacerbated. 
  - Average on my machine: 3ms
  - This may be fine as it is, since it only is hit during `_idleUnbuffered` and when not using the preferred device.
  - It would be possible to check this in a non-blocking way, but I'm not convinced it is worth the complication.
  - If attempting to test this specific case, you must configure NVDA to use a device that you then remove. Eg configure it to use bluetooth headphones, then turn the headphones off.

### Known issues with pull request:
None

### Change log entry:

Section: Bug fixes

Remove change log entry:
```
- The start or end of speech / sound is no longer truncated. (#5172, #10721)
  - NVDA now holds the audio device open for a short time after speech utterances, improving performance on some sound cards.
```

Replace it with:
```
- NVDA now keeps the audio device open improving performance on some sound cards (#5172, #10721)
```
I'm uncomfortable saying that sound is no longer truncated, this still seems to affect certain devices (EG my bluetooth headphones when no other sound is playing). I think this issue should be looked at separately. 
