### PR TITLE
Add special character "ServiceMark" to source/locale/en/symbols.dic for legal 508 criteria

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -167,7 +167,7 @@ _	line	most
 ®	registered	some
 ™	Trademark	some
 ©	Copyright	some
-℠ Servicemark some
+℠	ServiceMark	some
 ±	Plus or Minus	some
 ×	times	some
 ÷	divide by	some

--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -167,7 +167,7 @@ _	line	most
 ®	registered	some
 ™	Trademark	some
 ©	Copyright	some
-℠Servicemark some
+℠ Servicemark some
 ±	Plus or Minus	some
 ×	times	some
 ÷	divide by	some

--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -167,6 +167,7 @@ _	line	most
 ®	registered	some
 ™	Trademark	some
 ©	Copyright	some
+℠ Servicemark some
 ±	Plus or Minus	some
 ×	times	some
 ÷	divide by	some

--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -167,7 +167,7 @@ _	line	most
 ®	registered	some
 ™	Trademark	some
 ©	Copyright	some
-℠ Servicemark some
+℠Servicemark some
 ±	Plus or Minus	some
 ×	times	some
 ÷	divide by	some


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
#11547
### Summary of the issue:
The service mark special character (℠) is not read by the NVDA screen reader on any punctuation setting.
### Description of how this pull request fixes the issue:
This pull request simply adds the character to the symbols.dic file inside of EN locale for special characters.
### Testing performed:
Unfortunately I am unable to test as my macbook did the broken monitor deal yesterday night. I tried building the source code to test and half of my screen flickered out! I am doing this PR on my wife's chrome book and I can't download anything on it or compile source code. I really hate to do this but if someone could test this fix for me I would really appreciate testing it for me as I have no idea when I will get my other computer repaired.
### Known issues with pull request:
n/a
### Change log entry:

Section: New features, Changes, Bug fixes

