### PR TITLE
NLS eReader is also known as NLS eReader Humanware

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -490,6 +490,7 @@ addBluetoothDevices(
 			"APH Mantis Q40",
 			"Humanware BrailleOne",
 			"NLS eReader",
+			"NLS eReader Humanware",
 		)
 	)
 )

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,6 +51,7 @@ What's New in NVDA
 - NVDA now keeps the audio device open improving performance on some sound cards (#5172, #10721)
 - NVDA will no longer freeze or exit when holding down control+shift+downArrow in Microsoft Word. (#9463)
 - The expanded / collapsed state of directories in the navigation treeview on drive.google.com is now always reported by NVDA. (#11520)
+- NVDA will auto detect the NLS eReader Humanware braille display via Bluetooth as its Bluethooth name is now "NLS eReader Humanware". (#11561)
 
 
 == Changes For Developers ==


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:
APH has informed me that the NLS eReader Bluetooth name has now been renamed to NLS eReader Humanware.

### Description of how this pull request fixes the issue:
Adds "NLS eReader Humanware" as another possible name to match on.

### Testing performed:
None. I don't have a device.

### Known issues with pull request:
None.

### Change log entry:
None.