### PR TITLE
Developer guide: document resumeSayAllMode keyword in script decorator parameters

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -468,6 +468,9 @@ The following keyword arguments can be used when applying the script decorator:
   This option defaults to False.
 - bypassInputHelp: A boolean indicating whether this script should run when input help is active.
   This option defaults to False.
+- resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
+  The constants for say all mode are prefixed with CURSOR_ and specified in the sayAllHandler modules.
+  If resumeSayAllMode is not specified, say all does not resume after this script.
 -
 
 Though the script decorator makes the script definition process a lot easier, there are more ways of binding gestures and setting script properties.


### PR DESCRIPTION
### Link to issue number:

Fixes #8616

### Summary of the issue:

In the paragraph ‘Defining script properties’, all the keyword arguments of script decorator were listed and explained except resumeSayAllMode.

### Description of how this pull request fixes the issue:

Add resumeSayAllMode to the list with adequate description.

### Testing performed:

Generated dev doc and checked it.

### Known issues with pull request:

None

### Change log entry:

Not needed.

