### PR TITLE
Added a specific log channel for nvwave debug message

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -244,6 +244,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	vision = boolean(default=false)
 	speech = boolean(default=false)
 	speechManager = boolean(default=false)
+	nvwave = boolean(default=false)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2456,6 +2456,7 @@ class AdvancedPanelControls(wx.Panel):
 			"vision",
 			"speech",
 			"speechManager",
+			"nvwave",
 		]
 		# Translators: This is the label for a list in the
 		#  Advanced settings panel

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -596,4 +596,3 @@ def _cleanup():
 	global fileWavePlayer, fileWavePlayerThread
 	fileWavePlayer = None
 	fileWavePlayerThread = None
-

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -119,6 +119,9 @@ for func in (
 	func.errcheck = _winmm_errcheck
 
 
+def _isDebug():
+	return config.conf["debugLog"]["nvwave"]
+
 class WavePlayer(garbageHandler.TrackedObject):
 	"""Synchronously play a stream of audio.
 	To use, construct an instance and feed it waveform audio using L{feed}.
@@ -230,10 +233,11 @@ class WavePlayer(garbageHandler.TrackedObject):
 	def _isPreferredDeviceOpen(self) -> bool:
 		if self._waveout is None:
 			return False
-		log.debug(
-			f"preferred device: {self._preferredDeviceName}"
-			f" current device name: {self._outputDeviceName} (id: {self._outputDeviceID})"
-		)
+		if _isDebug():
+			log.debug(
+				f"preferred device: {self._preferredDeviceName}"
+				f" current device name: {self._outputDeviceName} (id: {self._outputDeviceID})"
+			)
 		return self._outputDeviceName == self._preferredDeviceName
 
 	def _isPreferredDeviceAvailable(self) -> bool:
@@ -243,10 +247,12 @@ class WavePlayer(garbageHandler.TrackedObject):
 		"""
 		for ID, name in _getOutputDevices():
 			if name == self._preferredDeviceName:
-				log.debug("preferred Device is Available")
+				if _isDebug():
+					log.debug("preferred Device is Available")
 				return True
 
-		log.debug("preferred Device is not available")
+		if _isDebug():
+			log.debug("preferred Device is not available")
 		return False
 
 	def open(self):
@@ -257,11 +263,12 @@ class WavePlayer(garbageHandler.TrackedObject):
 		with self._waveout_lock:
 			if self._waveout:
 				return
-			log.debug(
-				f"Calling winmm.waveOutOpen."
-				f" outputDeviceName: {self._outputDeviceName}"
-				f" outputDeviceID: {self._outputDeviceID}"
-			)
+			if _isDebug():
+				log.debug(
+					f"Calling winmm.waveOutOpen."
+					f" outputDeviceName: {self._outputDeviceName}"
+					f" outputDeviceID: {self._outputDeviceID}"
+				)
 			wfx = WAVEFORMATEX()
 			wfx.wFormatTag = WAVE_FORMAT_PCM
 			wfx.nChannels = self.channels
@@ -281,13 +288,15 @@ class WavePlayer(garbageHandler.TrackedObject):
 						CALLBACK_EVENT
 					)
 			except WindowsError:
-				log.debug(
-					f"Error opening"
-					f" outputDeviceName: {self._outputDeviceName}"
-					f" with id: {self._outputDeviceID}"
-				)
+				if _isDebug():
+					log.debug(
+						f"Error opening"
+						f" outputDeviceName: {self._outputDeviceName}"
+						f" with id: {self._outputDeviceID}"
+					)
 				if self._outputDeviceID != WAVE_MAPPER:
-					log.debug(f"Falling back to WAVE_MAPPER")
+					if _isDebug():
+						log.debug(f"Falling back to WAVE_MAPPER")
 					self._setCurrentDevice(WAVE_MAPPER)
 					self.open()
 				else:
@@ -429,12 +438,14 @@ class WavePlayer(garbageHandler.TrackedObject):
 				if not self._waveout:
 					return
 				if self.closeWhenIdle:
-					log.debug("Closing due to idle.")
+					if _isDebug():
+						log.debug("Closing due to idle.")
 					self._close()  # Idle so no need to call stop.
 				else:
 					with self._global_waveout_lock:
 						if not self._isPreferredDeviceOpen() and self._isPreferredDeviceAvailable():
-							log.debug("Attempt re-open of preferred device.")
+							if _isDebug():
+								log.debug("Attempt re-open of preferred device.")
 							self._close()  # Idle so no need to call stop.
 							self._setCurrentDevice(self._preferredDeviceName)
 							self.open()
@@ -585,3 +596,4 @@ def _cleanup():
 	global fileWavePlayer, fileWavePlayerThread
 	fileWavePlayer = None
 	fileWavePlayerThread = None
+

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -119,7 +119,7 @@ for func in (
 	func.errcheck = _winmm_errcheck
 
 
-def _isDebug():
+def _isDebugForNvWave():
 	return config.conf["debugLog"]["nvwave"]
 
 class WavePlayer(garbageHandler.TrackedObject):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -233,7 +233,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 	def _isPreferredDeviceOpen(self) -> bool:
 		if self._waveout is None:
 			return False
-		if _isDebug():
+		if _isDebugForNvWave():
 			log.debug(
 				f"preferred device: {self._preferredDeviceName}"
 				f" current device name: {self._outputDeviceName} (id: {self._outputDeviceID})"
@@ -247,11 +247,11 @@ class WavePlayer(garbageHandler.TrackedObject):
 		"""
 		for ID, name in _getOutputDevices():
 			if name == self._preferredDeviceName:
-				if _isDebug():
+				if _isDebugForNvWave():
 					log.debug("preferred Device is Available")
 				return True
 
-		if _isDebug():
+		if _isDebugForNvWave():
 			log.debug("preferred Device is not available")
 		return False
 
@@ -263,7 +263,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 		with self._waveout_lock:
 			if self._waveout:
 				return
-			if _isDebug():
+			if _isDebugForNvWave():
 				log.debug(
 					f"Calling winmm.waveOutOpen."
 					f" outputDeviceName: {self._outputDeviceName}"
@@ -288,14 +288,14 @@ class WavePlayer(garbageHandler.TrackedObject):
 						CALLBACK_EVENT
 					)
 			except WindowsError:
-				if _isDebug():
+				if _isDebugForNvWave():
 					log.debug(
 						f"Error opening"
 						f" outputDeviceName: {self._outputDeviceName}"
 						f" with id: {self._outputDeviceID}"
 					)
 				if self._outputDeviceID != WAVE_MAPPER:
-					if _isDebug():
+					if _isDebugForNvWave():
 						log.debug(f"Falling back to WAVE_MAPPER")
 					self._setCurrentDevice(WAVE_MAPPER)
 					self.open()
@@ -438,13 +438,13 @@ class WavePlayer(garbageHandler.TrackedObject):
 				if not self._waveout:
 					return
 				if self.closeWhenIdle:
-					if _isDebug():
+					if _isDebugForNvWave():
 						log.debug("Closing due to idle.")
 					self._close()  # Idle so no need to call stop.
 				else:
 					with self._global_waveout_lock:
 						if not self._isPreferredDeviceOpen() and self._isPreferredDeviceAvailable():
-							if _isDebug():
+							if _isDebugForNvWave():
 								log.debug("Attempt re-open of preferred device.")
 							self._close()  # Idle so no need to call stop.
 							self._setCurrentDevice(self._preferredDeviceName)


### PR DESCRIPTION
### Link to issue number:

Fixes #11574

### Summary of the issue:

After the merge of #11531, some extra debug messages have been added in the log. They are quite specific and make the log quite noisy while debugging something else.
Since they are used for a well specific purpose and to ease the debug tasks, it was suggested and approved in https://github.com/nvaccess/nvda/issues/11574#issuecomment-688757281 that they appear under a dedicated log flag.

### Description of how this pull request fixes the issue:

* Added a new "nvwave" item in the "Enabled logging categories" list of the "Advanced" setting panel. This allow to log nvwave utility messages only if this item is checked.
* This item is unchecked by default
* All the logger calls in the `nwave.py` have been put under "nvwave" log flag, unless the following ones:
  * `log.warning(f"Unable to open WAVE_MAPPER device, there may be no audio devices.")`
  * `log.warning("Error during feed. Resetting the device.")`
  * `log.debugWarning("Unable to send data to audio device on second attempt.", exc_info=True)`
  * `log.exception("Error calling onDone")`
* I have filtered the following log.debug call but I have a doubt on it:

>   ```
>   log.debug(
>   	f"Error opening"
>   	f" outputDeviceName: {self._outputDeviceName}"
>   	f" with id: {self._outputDeviceID}"
>   )```




### Testing performed:

* Set log level to debug
* Checked that some of the messages under this log channel are logged if "nvwave" log is enabled and that they are not logged if it is disabled.

### Known issues with pull request:

None.

### Change log entry:

No need to specify the corresponding issue (#11574) since this issue was only seen on alpha.
Is there a need to indicate this log channel in the `Changes for developers` section? Such other log channels are not specified in the change log.