### PR TITLE
Add missing addonHandler docstrings and linting for addonHandler module

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -32,17 +32,17 @@ from . import addonVersionCheck
 from .addonVersionCheck import isAddonCompatible
 
 MANIFEST_FILENAME = "manifest.ini"
-stateFilename="addonsState.pickle"
+stateFilename = "addonsState.pickle"
 BUNDLE_EXTENSION = "nvda-addon"
 BUNDLE_MIMETYPE = "application/x-nvda-addon"
 NVDA_ADDON_PROG_ID = "NVDA.Addon.1"
-ADDON_PENDINGINSTALL_SUFFIX=".pendingInstall"
-DELETEDIR_SUFFIX=".delete"
+ADDON_PENDINGINSTALL_SUFFIX = ".pendingInstall"
+DELETEDIR_SUFFIX = ".delete"
 
-state={}
+state = {}
 
 # Add-ons that are blocked from running because they are incompatible
-_blockedAddons=set()
+_blockedAddons = set()
 
 def loadState():
 	"""Reads the add-on state file (usually %appdata%\\nvda\\addonsState.pickle for an installed copy).
@@ -50,7 +50,7 @@ def loadState():
 	If there is no state file: creates an empty global state object.
 	"""
 	global state
-	statePath=os.path.join(globalVars.appArgs.configPath, stateFilename)
+	statePath = os.path.join(globalVars.appArgs.configPath, stateFilename)
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "rb") as f:
@@ -76,7 +76,7 @@ def saveState():
 	(usually %appdata%\\nvda\\addonsState.pickle for an installed copy).
 	Logs a warning on failure.
 	"""
-	statePath=os.path.join(globalVars.appArgs.configPath, stateFilename)
+	statePath = os.path.join(globalVars.appArgs.configPath, stateFilename)
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "wb") as f:
@@ -91,9 +91,9 @@ def getRunningAddons():
 
 def getIncompatibleAddons(
 		currentAPIVersion=addonAPIVersion.CURRENT,
-		backCompatToAPIVersion=addonAPIVersion.BACK_COMPAT_TO):
-	""" Returns a generator of the add-ons that are not compatible.
-	"""
+		backCompatToAPIVersion=addonAPIVersion.BACK_COMPAT_TO
+):
+	""" Returns a generator of the add-ons that are not compatible."""
 	return getAvailableAddons(
 		filterFunc=lambda addon: (
 			not addonVersionCheck.isAddonCompatible(
@@ -106,15 +106,15 @@ def getIncompatibleAddons(
 def completePendingAddonRemoves():
 	"""Removes any add-ons that could not be removed during the last run of NVDA"""
 	user_addons = os.path.abspath(os.path.join(globalVars.appArgs.configPath, "addons"))
-	pendingRemovesSet=state['pendingRemovesSet']
+	pendingRemovesSet = state['pendingRemovesSet']
 	for addonName in list(pendingRemovesSet):
-		addonPath=os.path.join(user_addons,addonName)
+		addonPath = os.path.join(user_addons, addonName)
 		if os.path.isdir(addonPath):
-			addon=Addon(addonPath)
+			addon = Addon(addonPath)
 			try:
 				addon.completeRemove()
 			except RuntimeError:
-				log.exception("Failed to remove %s add-on"%addonName)
+				log.exception("Failed to remove {0} add-on".format(addonName))
 				continue
 		pendingRemovesSet.discard(addonName)
 
@@ -123,24 +123,24 @@ def completePendingAddonInstalls():
 	the last NVDA shutdown. Intended to be called on NVDA (re)start.
 	"""
 	user_addons = os.path.abspath(os.path.join(globalVars.appArgs.configPath, "addons"))
-	pendingInstallsSet=state['pendingInstallsSet']
+	pendingInstallsSet = state['pendingInstallsSet']
 	for addonName in pendingInstallsSet:
-		newPath=os.path.join(user_addons, addonName)
-		oldPath=newPath+ADDON_PENDINGINSTALL_SUFFIX
+		newPath = os.path.join(user_addons, addonName)
+		oldPath = newPath+ADDON_PENDINGINSTALL_SUFFIX
 		try:
 			os.rename(oldPath, newPath)
 		except:
-			log.error("Failed to complete add-on installation for %s" % addonName, exc_info=True)
+			log.error("Failed to complete add-on installation for {0}".format(addonName), exc_info=True)
 	pendingInstallsSet.clear()
 
 def removeFailedDeletions():
 	user_addons = os.path.abspath(os.path.join(globalVars.appArgs.configPath, "addons"))
 	for p in os.listdir(user_addons):
 		if p.endswith(DELETEDIR_SUFFIX):
-			path=os.path.join(user_addons,p)
-			shutil.rmtree(path,ignore_errors=True)
+			path = os.path.join(user_addons, p)
+			shutil.rmtree(path, ignore_errors=True)
 			if os.path.exists(path):
-				log.error("Failed to delete path %s, try removing manually"%path)
+				log.error("Failed to delete path {0}, try removing manually".format(path))
 
 _disabledAddons = set()
 def disableAddonsIfAny():
@@ -242,17 +242,19 @@ def getAvailableAddons(refresh=False, filterFunc=None):
 	return (addon for addon in _availableAddons.values() if not filterFunc or filterFunc(addon))
 
 def installAddonBundle(bundle):
-	"""Extracts an Addon bundle in to a unique subdirectory of the user addons directory, marking the addon as needing install completion on NVDA restart."""
-	addonPath = os.path.join(globalVars.appArgs.configPath, "addons",bundle.manifest['name']+ADDON_PENDINGINSTALL_SUFFIX)
+	"""Extracts an Addon bundle in to a unique subdirectory of the user addons directory,
+	marking the addon as needing install completion on NVDA restart.
+	"""
+	addonPath = os.path.join(globalVars.appArgs.configPath, "addons", bundle.manifest['name']+ADDON_PENDINGINSTALL_SUFFIX)
 	bundle.extract(addonPath)
-	addon=Addon(addonPath)
+	addon = Addon(addonPath)
 	# #2715: The add-on must be added to _availableAddons here so that
 	# translations can be used in installTasks module.
-	_availableAddons[addon.path]=addon
+	_availableAddons[addon.path] = addon
 	try:
 		addon.runInstallTask("onInstall")
 	except:
-		log.error("task 'onInstall' on addon '%s' failed"%addon.name,exc_info=True)
+		log.error("task 'onInstall' on add-on '{0}' failed".format(addon.name), exc_info=True)
 		del _availableAddons[addon.path]
 		addon.completeRemove(runUninstallTask=False)
 		raise AddonError("Installation failed")
@@ -332,7 +334,7 @@ class Addon(AddonBase):
 			state['pendingDisableSet'].discard(self.name)
 		saveState()
 
-	def completeRemove(self,runUninstallTask=True):
+	def completeRemove(self, runUninstallTask=True):
 		if runUninstallTask:
 			try:
 				# #2715: The add-on must be added to _availableAddons here so that
@@ -340,17 +342,17 @@ class Addon(AddonBase):
 				_availableAddons[self.path] = self
 				self.runInstallTask("onUninstall")
 			except:
-				log.error("task 'onUninstall' on addon '%s' failed"%self.name,exc_info=True)
+				log.error("task 'onUninstall' on addon '{0}' failed".format(self.name), exc_info=True)
 			finally:
 				del _availableAddons[self.path]
-		tempPath=tempfile.mktemp(suffix=DELETEDIR_SUFFIX,dir=os.path.dirname(self.path))
+		tempPath = tempfile.mktemp(suffix=DELETEDIR_SUFFIX, dir=os.path.dirname(self.path))
 		try:
-			os.rename(self.path,tempPath)
-		except (WindowsError,IOError):
+			os.rename(self.path, tempPath)
+		except (WindowsError, IOError):
 			raise RuntimeError("Cannot rename add-on path for deletion")
-		shutil.rmtree(tempPath,ignore_errors=True)
+		shutil.rmtree(tempPath, ignore_errors=True)
 		if os.path.exists(tempPath):
-			log.error("Error removing addon directory %s, deferring until next NVDA restart"%self.path)
+			log.error("Error removing addon directory {}, deferring until next NVDA restart".format(self.path))
 		# clean up the addons state. If an addon with the same name is installed, it should not be automatically
 		# disabled / blocked.
 		log.debug("removing addon {} from _disabledAddons/_blockedAddons".format(self.name))
@@ -451,7 +453,7 @@ class Addon(AddonBase):
 		if not loader:
 			return None
 		# Create a qualified full name to avoid modules with the same name on sys.modules.
-		fullname = "addons.%s.%s" % (self.name, name)
+		fullname = "addons.{0}.{1}".format(self.name, name)
 		try:
 			return loader.load_module(fullname)
 		except ImportError:
@@ -468,15 +470,15 @@ class Addon(AddonBase):
 		localedir = os.path.join(self.path, "locale")
 		return gettext.translation(domain, localedir=localedir, languages=[languageHandler.getLanguage()], fallback=True)
 
-	def runInstallTask(self,taskName,*args,**kwargs):
+	def runInstallTask(self, taskName,*args,**kwargs):
 		"""
 		Executes the function having the given taskName with the given args and kwargs,
 		in the add-on's installTasks module if it exists.
 		"""
 		if not hasattr(self,'_installTasksModule'):
-			self._installTasksModule=self.loadModule('installTasks')
+			self._installTasksModule = self.loadModule('installTasks')
 		if self._installTasksModule:
-			func=getattr(self._installTasksModule,taskName,None)
+			func = getattr(self._installTasksModule, taskName, None)
 			if func:
 				func(*args,**kwargs)
 
@@ -577,7 +579,7 @@ class AddonBundle(AddonBase):
 		"""
 		self._path = bundlePath
 		# Read manifest:
-		translatedInput=None
+		translatedInput = None
 		with zipfile.ZipFile(self._path, 'r') as z:
 			for translationPath in _translatedManifestPaths(forBundle=True):
 				try:
@@ -620,7 +622,7 @@ class AddonBundle(AddonBase):
 		return self._manifest
 
 	def __repr__(self):
-		return "<AddonBundle at %s>" % self._path
+		return "<AddonBundle at {}>".format(self._path)
 
 def createAddonBundleFromPath(path, destDir=None):
 	""" Creates a bundle from a directory that contains a a addon manifest file."""
@@ -632,13 +634,13 @@ def createAddonBundleFromPath(path, destDir=None):
 		destDir = os.path.dirname(basedir)
 	manifest_path = os.path.join(basedir, MANIFEST_FILENAME)
 	if not os.path.isfile(manifest_path):
-		raise AddonError("Can't find %s manifest file." % manifest_path)
+		raise AddonError("Can't find {} manifest file.".format(manifest_path))
 	with open(manifest_path, 'rb') as f:
 		manifest = AddonManifest(f)
 	if manifest.errors is not None:
 		_report_manifest_errors(manifest)
 		raise AddonError("Manifest file has errors.")
-	bundleFilename = "%s-%s.%s" % (manifest['name'], manifest['version'], BUNDLE_EXTENSION)
+	bundleFilename = "{0}-{1}.{2}".format(manifest['name'], manifest['version'], BUNDLE_EXTENSION)
 	bundleDestination = os.path.join(destDir, bundleFilename)
 	with zipfile.ZipFile(bundleDestination, 'w') as z:
 		# FIXME: the include/exclude feature may or may not be useful. Also python files can be pre-compiled.
@@ -666,7 +668,7 @@ name = string()
 summary = string()
 
 # Long description with further information and instructions
-description = string(default=None)
+description = string(default = None)
 
 # Name of the author or entity that created the add-on
 author = string()
@@ -718,9 +720,9 @@ docFileName = string(default=None)
 		if translatedInput is not None:
 			self._translatedConfig = ConfigObj(translatedInput, encoding='utf-8', default_encoding='utf-8')
 			for k in ('summary','description'):
-				val=self._translatedConfig.get(k)
+				val = self._translatedConfig.get(k)
 				if val:
-					self[k]=val
+					self[k] = val
 
 	@property
 	def errors(self):

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -85,8 +85,7 @@ def saveState():
 		log.debugWarning("Error saving state", exc_info=True)
 
 def getRunningAddons():
-	""" Returns currently loaded add-ons.
-	"""
+	""" Returns currently loaded add-ons."""
 	return getAvailableAddons(filterFunc=lambda addon: addon.isRunning)
 
 def getIncompatibleAddons(
@@ -134,13 +133,16 @@ def completePendingAddonInstalls():
 	pendingInstallsSet.clear()
 
 def removeFailedDeletions():
+	"""For any removed add-on which has failed to be deleted for some reason:
+	try another method or log an error on failure.
+	"""
 	user_addons = os.path.abspath(os.path.join(globalVars.appArgs.configPath, "addons"))
 	for p in os.listdir(user_addons):
 		if p.endswith(DELETEDIR_SUFFIX):
 			path = os.path.join(user_addons, p)
 			shutil.rmtree(path, ignore_errors=True)
 			if os.path.exists(path):
-				log.error("Failed to delete path {0}, try removing manually".format(path))
+				log.error("Failed to delete path {}, try removing manually".format(path))
 
 _disabledAddons = set()
 def disableAddonsIfAny():

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 #addonHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee,
+# Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee,
 # Babbage B.V., Arnold Loubriat
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
@@ -724,7 +724,7 @@ docFileName = string(default=None)
 		"""
 		super(
 			AddonManifest, self
-		).__init__(
+			).__init__(
 			input, configspec=self.configspec,
 			encoding='utf-8', default_encoding='utf-8'
 		)

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -45,8 +45,12 @@ state={}
 _blockedAddons=set()
 
 def loadState():
+	"""Reads the add-on state file (usually %appdata%\\nvda\\addonsState.pickle for an installed copy).
+	Populates the global state object with data from the file.
+	If there is no state file: creates an empty global state object.
+	"""
 	global state
-	statePath=os.path.join(globalVars.appArgs.configPath,stateFilename)
+	statePath=os.path.join(globalVars.appArgs.configPath, stateFilename)
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "rb") as f:
@@ -60,15 +64,19 @@ def loadState():
 	except:
 		# Defaults.
 		state = {
-			"pendingRemovesSet":set(),
-			"pendingInstallsSet":set(),
-			"disabledAddons":set(),
-			"pendingEnableSet":set(),
-			"pendingDisableSet":set(),
+			"pendingRemovesSet": set(),
+			"pendingInstallsSet": set(),
+			"disabledAddons": set(),
+			"pendingEnableSet": set(),
+			"pendingDisableSet": set(),
 		}
 
 def saveState():
-	statePath=os.path.join(globalVars.appArgs.configPath,stateFilename)
+	"""Pickles the global state object, saving it to the add-on state file
+	(usually %appdata%\\nvda\\addonsState.pickle for an installed copy).
+	Logs a warning on failure.
+	"""
+	statePath=os.path.join(globalVars.appArgs.configPath, stateFilename)
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
 		with open(statePath, "wb") as f:
@@ -528,6 +536,10 @@ def getCodeAddon(obj=None, frameDist=1):
 	raise AddonError("Code does not belong to an addon")
 
 def initTranslation():
+	"""Initializes internationalization support for an add-on.
+	Must be called at the top of each Python module that is part of an add-on, to allow plugins in the
+add-on to access gettext message information via calls to _().
+	"""
 	addon = getCodeAddon(frameDist=2)
 	translations = addon.getTranslationsInstance()
 	# Point _ to the translation object in the globals namespace of the caller frame

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -199,7 +199,7 @@ def _getAvailableAddonsFromPath(path):
 		addon_path = os.path.join(path, p)
 		if os.path.isdir(addon_path) and addon_path not in ('.', '..'):
 			if not len(os.listdir(addon_path)):
-				log.error("Error loading Addon from path: %s", addon_path)
+				log.error("Error loading add-on from path: %s", addon_path)
 			else:
 				log.debug("Loading add-on from %s", addon_path)
 				try:
@@ -219,7 +219,7 @@ def _getAvailableAddonsFromPath(path):
 						_blockedAddons.add(a.name)
 					yield a
 				except:
-					log.error("Error loading Addon from path: %s", addon_path, exc_info=True)
+					log.error("Error loading add-on from path: %s", addon_path, exc_info=True)
 				
 _availableAddons = collections.OrderedDict()
 def getAvailableAddons(refresh=False, filterFunc=None):
@@ -384,7 +384,7 @@ class Addon(AddonBase):
 		converted_path = self._getPathForInclusionInPackage(package)
 		package.__path__.insert(0, converted_path)
 		self._extendedPackages.add(package)
-		log.debug("Addon %s added to %s package path", self.manifest['name'], package.__name__)
+		log.debug("Add-on %s added to %s package path", self.manifest['name'], package.__name__)
 
 	def enable(self, shouldEnable):
 		"""Sets this add-on to be disabled or enabled when NVDA restarts."""

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -335,6 +335,7 @@ class Addon(AddonBase):
 		saveState()
 
 	def completeRemove(self, runUninstallTask=True):
+		"""Removes an add-on that has been fully installed, or that is pending install."""
 		if runUninstallTask:
 			try:
 				# #2715: The add-on must be added to _availableAddons here so that

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -119,15 +119,18 @@ def completePendingAddonRemoves():
 		pendingRemovesSet.discard(addonName)
 
 def completePendingAddonInstalls():
+	"""Finish installing any partially installed installable add-ons that didn't finish before
+	the last NVDA shutdown. Intended to be called on NVDA (re)start.
+	"""
 	user_addons = os.path.abspath(os.path.join(globalVars.appArgs.configPath, "addons"))
 	pendingInstallsSet=state['pendingInstallsSet']
 	for addonName in pendingInstallsSet:
-		newPath=os.path.join(user_addons,addonName)
+		newPath=os.path.join(user_addons, addonName)
 		oldPath=newPath+ADDON_PENDINGINSTALL_SUFFIX
 		try:
-			os.rename(oldPath,newPath)
+			os.rename(oldPath, newPath)
 		except:
-			log.error("Failed to complete addon installation for %s"%addonName,exc_info=True)
+			log.error("Failed to complete add-on installation for %s" % addonName, exc_info=True)
 	pendingInstallsSet.clear()
 
 def removeFailedDeletions():

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -104,7 +104,7 @@ def getIncompatibleAddons(
 	))
 
 def completePendingAddonRemoves():
-	"""Removes any add-ons that could not be removed on the last run of NVDA"""
+	"""Removes any add-ons that could not be removed during the last run of NVDA"""
 	user_addons = os.path.abspath(os.path.join(globalVars.appArgs.configPath, "addons"))
 	pendingRemovesSet=state['pendingRemovesSet']
 	for addonName in list(pendingRemovesSet):

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -146,8 +146,7 @@ def removeFailedDeletions():
 
 _disabledAddons = set()
 def disableAddonsIfAny():
-	"""
-	Disables add-ons if told to do so by the user from add-ons manager.
+	"""Disables add-ons if told to do so by the user from add-ons manager.
 	This is usually executed before refreshing the list of available add-ons.
 	"""
 	global _disabledAddons
@@ -172,7 +171,6 @@ def initialize():
 	getAvailableAddons(refresh=True)
 	saveState()
 
-
 def terminate():
 	""" Terminates the add-ons subsystem. """
 	pass
@@ -190,7 +188,7 @@ def _getDefaultAddonPaths():
 
 def _getAvailableAddonsFromPath(path):
 	""" Gets available add-ons from path.
-	An addon is only considered available if the manifest file is loaded with no errors.
+	An add-on is only considered available if the manifest file is loaded with no errors.
 	@param path: path from where to find addon directories.
 	@type path: string
 	@rtype generator of Addon instances
@@ -225,7 +223,7 @@ def _getAvailableAddonsFromPath(path):
 				
 _availableAddons = collections.OrderedDict()
 def getAvailableAddons(refresh=False, filterFunc=None):
-	""" Gets all available addons on the system.
+	""" Gets all available add-ons on the system.
 	@param refresh: Whether or not to query the file system for available add-ons.
 	@type refresh: bool
 	@param filterFunc: A function that allows filtering of add-ons.
@@ -244,7 +242,7 @@ def getAvailableAddons(refresh=False, filterFunc=None):
 	return (addon for addon in _availableAddons.values() if not filterFunc or filterFunc(addon))
 
 def installAddonBundle(bundle):
-	"""Extracts an Addon bundle in to a unique subdirectory of the user addons directory,
+	"""Extracts an Add-on bundle in to a unique subdirectory of the user addons directory,
 	marking the addon as needing install completion on NVDA restart.
 	"""
 	addonPath = os.path.join(globalVars.appArgs.configPath, "addons", bundle.manifest['name']+ADDON_PENDINGINSTALL_SUFFIX)
@@ -292,7 +290,7 @@ class Addon(AddonBase):
 	""" Represents an Add-on available on the file system."""
 	def __init__(self, path):
 		""" Constructs an L{Addon} from.
-		@param path: the base directory for the addon data.
+		@param path: the base directory for the add-on data.
 		@type path: string
 		"""
 		self.path = os.path.abspath(path)
@@ -313,16 +311,16 @@ class Addon(AddonBase):
 
 	@property
 	def isPendingInstall(self):
-		"""True if this addon has not yet been fully installed."""
+		"""True if this add-on has not yet been fully installed."""
 		return self.path.endswith(ADDON_PENDINGINSTALL_SUFFIX)
 
 	@property
 	def isPendingRemove(self):
-		"""True if this addon is marked for removal."""
+		"""True if this add-on is marked for removal."""
 		return not self.isPendingInstall and self.name in state['pendingRemovesSet']
 
 	def requestRemove(self):
-		"""Markes this addon for removal on NVDA restart."""
+		"""Markes this add-on for removal on NVDA restart."""
 		if self.isPendingInstall:
 			self.completeRemove()
 			state['pendingInstallsSet'].discard(self.name)
@@ -473,8 +471,7 @@ class Addon(AddonBase):
 		return gettext.translation(domain, localedir=localedir, languages=[languageHandler.getLanguage()], fallback=True)
 
 	def runInstallTask(self, taskName,*args,**kwargs):
-		"""
-		Executes the function having the given taskName with the given args and kwargs,
+		"""Executes the function having the given taskName with the given args and kwargs,
 		in the add-on's installTasks module if it exists.
 		"""
 		if not hasattr(self,'_installTasksModule'):
@@ -516,10 +513,11 @@ class Addon(AddonBase):
 		return None
 
 def getCodeAddon(obj=None, frameDist=1):
-	""" Returns the L{Addon} where C{obj} is defined. If obj is None the caller code frame is assumed to allow simple retrieval of "current calling addon".
+	""" Returns the L{Addon} where C{obj} is defined.
+	If obj is None the caller code frame is assumed to allow simple retrieval of "current calling addon".
 	@param obj: python object or None for default behaviour.
 	@param frameDist: how many frames is the caller code. Only change this for functions in this module.
-	@return: L{Addon} instance or None if no code does not belong to a add-on package.
+	@return: L{Addon} instance or None if no code does not belong to an add-on package.
 	@rtype: C{Addon}
 	"""
 	global _availableAddons
@@ -574,7 +572,8 @@ def _translatedManifestPaths(lang=None, forBundle=False):
 class AddonBundle(AddonBase):
 	""" Represents the contents of an NVDA addon suitable for distribution.
 	The bundle is compressed using the zip file format. Manifest information
-	is available without the need for extraction."""
+	is available without the need for extraction.
+	"""
 	def __init__(self, bundlePath):
 		""" Constructs an L{AddonBundle} from a filename.
 		@param bundlePath: The path for the bundle file.
@@ -627,7 +626,7 @@ class AddonBundle(AddonBase):
 		return "<AddonBundle at {}>".format(self._path)
 
 def createAddonBundleFromPath(path, destDir=None):
-	""" Creates a bundle from a directory that contains a a addon manifest file."""
+	""" Creates a bundle from a directory that contains an add-on manifest file."""
 	basedir = os.path.abspath(path)
 	# If  caller did not provide a destination directory name
 	# Put the bundle at the same level as the add-on's top-level directory,

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -125,7 +125,7 @@ def completePendingAddonInstalls():
 	pendingInstallsSet = state['pendingInstallsSet']
 	for addonName in pendingInstallsSet:
 		newPath = os.path.join(user_addons, addonName)
-		oldPath = newPath+ADDON_PENDINGINSTALL_SUFFIX
+		oldPath = newPath + ADDON_PENDINGINSTALL_SUFFIX
 		try:
 			os.rename(oldPath, newPath)
 		except:
@@ -245,7 +245,11 @@ def installAddonBundle(bundle):
 	"""Extracts an Add-on bundle in to a unique subdirectory of the user addons directory,
 	marking the addon as needing install completion on NVDA restart.
 	"""
-	addonPath = os.path.join(globalVars.appArgs.configPath, "addons", bundle.manifest['name']+ADDON_PENDINGINSTALL_SUFFIX)
+	addonPath = os.path.join(
+		globalVars.appArgs.configPath,
+		"addons",
+		bundle.manifest['name'] + ADDON_PENDINGINSTALL_SUFFIX
+	)
 	bundle.extract(addonPath)
 	addon = Addon(addonPath)
 	# #2715: The add-on must be added to _availableAddons here so that
@@ -471,7 +475,7 @@ class Addon(AddonBase):
 		localedir = os.path.join(self.path, "locale")
 		return gettext.translation(domain, localedir=localedir, languages=[languageHandler.getLanguage()], fallback=True)
 
-	def runInstallTask(self, taskName,*args,**kwargs):
+	def runInstallTask(self, taskName, *args, **kwargs):
 		"""Executes the function having the given taskName with the given args and kwargs,
 		in the add-on's installTasks module if it exists.
 		"""
@@ -480,7 +484,7 @@ class Addon(AddonBase):
 		if self._installTasksModule:
 			func = getattr(self._installTasksModule, taskName, None)
 			if func:
-				func(*args,**kwargs)
+				func(*args, **kwargs)
 
 	def getDocFilePath(self, fileName=None):
 		"""Get the path to a documentation file for this add-on.

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: UTF-8 -*-
 #addonHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V., Arnold Loubriat
+#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee,
+# Babbage B.V., Arnold Loubriat
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -270,7 +271,8 @@ class AddonError(Exception):
 	""" Represents an exception coming from the addon subsystem. """
 
 class AddonBase(object):
-	"""The base class for functionality that is available both for add-on bundles and add-ons on the file system.
+	"""The base class for functionality that is available both for add-on bundles, and
+	for add-ons on the file system.
 	Subclasses should at least implement L{manifest}.
 	"""
 
@@ -423,7 +425,12 @@ class Addon(AddonBase):
 
 	@property
 	def isRunning(self):
-		return not (globalVars.appArgs.disableAddons or self.isPendingInstall or self.isDisabled or self.isBlocked)
+		return not (
+			globalVars.appArgs.disableAddons
+			or self.isPendingInstall
+			or self.isDisabled
+			or self.isBlocked
+		)
 
 	@property
 	def isDisabled(self):
@@ -473,7 +480,11 @@ class Addon(AddonBase):
 		@returns: the gettext translation class.
 		"""
 		localedir = os.path.join(self.path, "locale")
-		return gettext.translation(domain, localedir=localedir, languages=[languageHandler.getLanguage()], fallback=True)
+		return gettext.translation(
+			domain, localedir=localedir,
+			languages=[languageHandler.getLanguage()],
+			fallback=True
+		)
 
 	def runInstallTask(self, taskName, *args, **kwargs):
 		"""Executes the function having the given taskName with the given args and kwargs,
@@ -711,7 +722,12 @@ docFileName = string(default=None)
 		@param translatedInput: translated manifest input
 		@type translatedInput: file-like object
 		"""
-		super(AddonManifest, self).__init__(input, configspec=self.configspec, encoding='utf-8', default_encoding='utf-8')
+		super(
+			AddonManifest, self
+		).__init__(
+			input, configspec=self.configspec,
+			encoding='utf-8', default_encoding='utf-8'
+		)
 		self._errors = None
 		val = Validator({"apiVersion":validate_apiVersionString})
 		result = self.validate(val, copy=True, preserve_errors=True)

--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -26,8 +26,8 @@ def isAddonCompatible(
 		currentAPIVersion=addonAPIVersion.CURRENT,
 		backwardsCompatToVersion=addonAPIVersion.BACK_COMPAT_TO
 ):
-	"""Tests if the addon is compatible.
-	The compatibility is defined by having the required features in NVDA, and by having been tested / built against
-	an API version that is still supported by this version of NVDA.
+	"""Tests if the addon is compatible.  The compatibility is defined by having the required features in
+NVDA, and by having been tested / built against an API version that is still supported
+by this version of NVDA.
 	"""
 	return hasAddonGotRequiredSupport(addon, currentAPIVersion) and isAddonTested(addon, backwardsCompatToVersion)

--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -7,7 +7,9 @@
 import addonAPIVersion
 
 def hasAddonGotRequiredSupport(addon, currentAPIVersion=addonAPIVersion.CURRENT):
-	"""True if NVDA provides the add-on with an API version high enough to meet the add-on's minimum requirements."""
+	"""True if NVDA provides the add-on with an API version high enough
+	to meet the add-on's minimum requirements.
+	"""
 	minVersion = addon.minimumNVDAVersion
 	return minVersion <= currentAPIVersion
 

--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -7,8 +7,7 @@
 import addonAPIVersion
 
 def hasAddonGotRequiredSupport(addon, currentAPIVersion=addonAPIVersion.CURRENT):
-	"""True if NVDA provides the add-on with an API version high enough to meet the add-on's minimum requirements
-	"""
+	"""True if NVDA provides the add-on with an API version high enough to meet the add-on's minimum requirements."""
 	minVersion = addon.minimumNVDAVersion
 	return minVersion <= currentAPIVersion
 


### PR DESCRIPTION

### Link to issue number:

Fixes #11579 

### Summary of the issue:

initTranslation and several other functions in addonHandler, were without docstrings.
While working on those, I noticed a bunch of stylistic errors, grammar oddities, and some slight code improvements that could be done.

### Description of how this pull request fixes the issue:

* Added docstrings for:
    + initTranslation()
    + loadState()
    + saveState()
    + completePendingAddonInstalls()
    + removeFailedDeletions()
    + completeRemove()
* Corrected "addon" to "add-on" in several user visible strings and docstrings.
* Lots of linting of old code.
* Format and grammar corrections to several docstrings.
* Replaced % substitutions with calls to format() for several user and log messages, exceptions, and some assignments.

### Testing performed:

None yet.

### Known issues with pull request:

1.  Regarding percent substitutions (%s) mentioned above: I didn't alter percent-based substitutions, when the substituting was not handled locally, such as:
    ```
    log.debug("Addon %s added to %s package path", self.manifest['name'], package.__name__)
    ```
    It would be easy enough to convert that into a locally formatted string to log.debug, but I would prefer some feedback before doing so, since I don't actually know why it's being done like this.  instead of by normal percent based substitution. Converted, it would be:
    ```
    log.debug("Add-on {0} added to {1} package path".format(self.manifest['name'], package.__name__))
    ```
2.  Didn't try to write missing comment strings for private functions and methods, although someone should.
3.  Didn't document property accessors, although some are already (inconsistent).

### Change log entry:

Section: New features, Changes, Bug fixes

*Changes for developers*
Increased documentation of functions in addonHandler.
