### PR TITLE
Global commands/move to focus: add a space at the end of the first line of the command descripption/input help message

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -902,7 +902,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for move navigator object to current focus command.
-			"Sets the navigator object to the current focus,"
+			"Sets the navigator object to the current focus, "
 			"and the review cursor to the position of the caret inside it, if possible."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,


### PR DESCRIPTION
Hi,

Reported by a translator and subsequently confirmed:

### Link to issue number:
None

### Summary of the issue:
Input yelp message for move to focus command (NVDA+Numpad minus for desktop layout) does not have a space between "," and "and".

### Description of how this pull request fixes the issue:
Add a space at the end of the first line of move to focus command description text.

### Testing performed:
Tested with generating the pot file and translating it.

### Known issues with pull request:
None

### Change log entry:
None
