### PR TITLE
Make PR and bug templates more obvious

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 
 ---
 
-<!--
+<!-- Please read the text in this edit field before filling it in.
 Please thoroughly read NVDA's wiki article on how to fill in this template, including how to provide the required files.
 Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 
 ---
 
-<!--
+<!-- Please read the text in this edit field before filling it in.
 Please thoroughly read NVDA's wiki article on how to fill in this template, including how to provide the required files.
 Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-<!--
-Please fill in the following template, for an explanation of the sections see:
+<!-- Please read and fill in the following template, for an explanation of the sections see:
 https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
 -->
 


### PR DESCRIPTION
### Summary of the issue:
When landing on the edit field for the first time, often first time contributors do not notice that there is a template.

### Description of how this pull request fixes the issue:
For both the PR template and the issue templates to put a note about reading the template before filling it in. This not is now on the first line.
