### PR TITLE
Chrome: Don't announce 'list' on every line of ul, dl and ol tags in contenteditables

### DIFF
--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -75,7 +75,14 @@ class ToggleButton(ia2Web.Ia2Web):
 
 
 class PresentationalList(ia2Web.Ia2Web):
-	""" Ensures that lists like UL, DL and OL always have the readonly state."""
+	"""
+	Ensures that lists like UL, DL and OL always have the readonly state.
+	A work-around for issue #7562
+	allowing us to differentiate presentational lists from interactive lists
+	(such as of size greater 1 and ARIA list boxes).
+	In firefox, this is possible by the presence of a read-only state,
+	even in a content editable.
+	"""
 
 	def _get_states(self):
 		states = super().states

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -74,6 +74,15 @@ class ToggleButton(ia2Web.Ia2Web):
 		return states
 
 
+class PresentationalList(ia2Web.Ia2Web):
+	""" Ensures that lists like UL, DL and OL always have the readonly state."""
+
+	def _get_states(self):
+		states = super().states
+		states.add(controlTypes.STATE_READONLY)
+		return states
+
+
 def findExtraOverlayClasses(obj, clsList):
 	"""Determine the most appropriate class(es) for Chromium objects.
 	This works similarly to L{NVDAObjects.NVDAObject.findOverlayClasses} except that it never calls any other findOverlayClasses method.
@@ -82,5 +91,7 @@ def findExtraOverlayClasses(obj, clsList):
 		clsList.append(ComboboxListItem)
 	elif obj.role == controlTypes.ROLE_TOGGLEBUTTON:
 		clsList.append(ToggleButton)
+	elif obj.role == controlTypes.ROLE_LIST and obj.IA2Attributes.get('tag') in ('ul', 'dl', 'ol'):
+		clsList.append(PresentationalList)
 	ia2Web.findExtraOverlayClasses(obj, clsList,
 		documentClass=Document)

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -71,9 +71,9 @@ class ChromeLib:
 				<title>{ChromeLib._testCaseTitle}</title>
 			</head>
 			<body>
-				<button>{ChromeLib._beforeMarker}</button>
+				<p>{ChromeLib._beforeMarker}</p>
 				{testCase}
-				<button>{ChromeLib._afterMarker}</button>
+				<p>{ChromeLib._afterMarker}</p>
 			</body>
 		""")
 		with open(file=filePath, mode='w', encoding='UTF-8') as f:

--- a/tests/system/nvdaSettingsFiles/standard-doShowWelcomeDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-doShowWelcomeDialog.ini
@@ -12,3 +12,4 @@ schemaVersion = 2
 	enableScratchpadDir = True
 [virtualBuffers]
 	autoSayAllOnPageLoad = False
+	passThroughAudioIndication = False

--- a/tests/system/nvdaSettingsFiles/standard-dontShowWelcomeDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-dontShowWelcomeDialog.ini
@@ -12,3 +12,4 @@ schemaVersion = 2
 	enableScratchpadDir = True
 [virtualBuffers]
 	autoSayAllOnPageLoad = False
+	passThroughAudioIndication = False

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -15,7 +15,6 @@ from SystemTestSpy import (
 # Imported for type information
 from ChromeLib import ChromeLib as _ChromeLib
 from AssertsLib import AssertsLib as _AssertsLib
-import NvdaLib as _nvdaLib
 
 _builtIn: BuiltIn = BuiltIn()
 _chrome: _ChromeLib = _getLib("ChromeLib")
@@ -44,7 +43,6 @@ def checkbox_labelled_by_inner_element():
 
 def test_i7562():
 	""" List should not be announced on every line of a ul in a contenteditable """
-	spy = _nvdaLib.getSpyLib()
 	_chrome.prepareChrome(
 		r"""
 			<div contenteditable="true">

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -57,8 +57,17 @@ def test_i7562():
 			</div>
 		"""
 	)
-	# Tab into the contenteditable - focus mode will be enabled.
-	spy.emulateKeyPress("tab")
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+	# Tab into the contenteditable
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"section  multi line  editable  before"
+	)
 	# DownArow into the list. 'list' should be announced when entering.
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -41,6 +41,7 @@ def checkbox_labelled_by_inner_element():
 		"Simulate evil cat  check box  not checked"
 	)
 
+
 def test_i7562():
 	""" List should not be announced on every line of a ul in a contenteditable """
 	spy = _nvdaLib.getSpyLib()

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -26,3 +26,6 @@ default teardown
 checkbox labelled by inner element
 	[Documentation]	A checkbox labelled by an inner element should not read the label element twice.
 	checkbox_labelled_by_inner_element
+i7562
+	[Documentation]	List should not be announced on every line of a ul in a contenteditable
+	test_i7562

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,7 @@ What's New in NVDA
 - NVDA once again works correctly with edit fields when using the Fast Log Entry application. (#8996)
 - Report elapsed time in Foobar2000 if no total time is available (e.g. when playing a live stream). (#11337)
 - NVDA now honors the aria-roledescription attribute on elements in editable content in web pages. (#11607)
+- 'list' is no longer announced on every line of a list in Google Docs or other editable content in Google Chrome. (#7562)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #7562 

### Summary of the issue:
When arrowing up and down a ul, dl or ol list in Google Chrome, 'list' is announced on every line, and no announcement is made when leaving the list.
This can be reproduced when reading through a list in a Google Docs document in Chrome.
Or by the following test case in Chrome:
```
data:text/html,<div contenteditable="true"><p>start</p><ul><li>frogs</li><li>birds</li></ul><p>end</p></div>
```
This is because NVDA treats interactive and presentational lists differently. Interactive lists (such as `<select>` of size greater 1 and ARIA list boxes) it assumes only one line (value) is rendered, and thus it announces list on the line. But for presentational lists (`ul`, `dl` and `ol` tags), it announces list at the start, and out of list at the end.
NVDA normally detects presentation lists from interactive lists by the readonly state. Presentation lists have this, interactive lists don't. 

However, if a presentation list is within a `contenteditable`, Chrome seems to remove the readonly state. Note that Mozilla Firefox does not remove it and thus does not reproduce the issue.

There was a request for this to be fixed on the Chrome side, but as this is taking a long time and the change in NVDA is small, we should do it here also.


### Description of how this pull request fixes the issue:

Adds a new PresentationList NVDAObject class to Chrome IAccessibles for `ul`, `dl` and `OL` tags, and forces  the `readonly` state.

### Testing performed:
* Arrowed up and down a list in Google Docs in Chrome and confirmed that list is no longer announced on every line.
* Arrowed down past a `<select>` tag of size 2 in Chrome in browse mode and confirmed that  it is still announced as an interactive list.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
- 'list' is no longer announced on every line of a list in Google Docs in Chrome.