### PR TITLE
Support aria roleDescription in contentEditables

### DIFF
--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -139,6 +139,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 			return None
 		field = textInfos.ControlField()
 		field["role"] = role
+		field['roleText'] = obj.roleText
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.STATE_EDITABLE)
 		states.discard(controlTypes.STATE_MULTILINE)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
 == Bug Fixes ==
 - NVDA once again works correctly with edit fields when using the Fast Log Entry application. (#8996)
 - Report elapsed time in Foobar2000 if no total time is available (e.g. when playing a live stream). (#11337)
+- NVDA now honors the aria-roledescription attribute on elements in editable content in web pages. (#11607)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
None

### Summary of the issue:
Web authors can override the way a screen reader announces the role for an element, by providing the aria-role-description attribute. 
This has been supported in NVDA's browse mode and NVDAObjects (via the roleText property) for some time, but was accidentally left out of compoundDocuments, and therefore contenteditables.
Editors such as Google Docs may want to expose more specific role descriptions on images (E.g. drawing).
 
Test case:
```
data:text/html,<div contenteditable="true"><p>Start <img aria-roledescription="drawing" alt="NV Access logo" src="https://www.nvaccess.org/images/logo.png" /> end</p></div>
``` 

### Description of how this pull request fixes the issue:
CompoundDocumentTextInfo._getControlFieldForObject: add the roleText property to the controlField.

### Testing performed:
In both Firefox and Chrome:
* Loaded the above html fragment.
* Switched to focus mode.
* Ensured that NVDA read the current line as "start drawing NV Access logo end". Previously it was "start graphic NV Access logo end".

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
- NVDA honors the aria-roledescription attribute on elements in editable content in web pages.