### PR TITLE
Use Intellisense menu items to provide instant Intellisense feedback in Visual Studio 2019

### DIFF
--- a/source/NVDAObjects/UIA/VisualStudio.py
+++ b/source/NVDAObjects/UIA/VisualStudio.py
@@ -36,8 +36,31 @@ class IntelliSenseList(UIA):
 	...
 
 
+class IntelliSenseLiveRegion(UIA):
+	"""
+	Visual Studio uses both Intellisense menu item objects and a live region
+	to communicate Intellisense selections.
+	NVDA uses the menu item approach and therefore the live region provides doubled information
+	and is disabled.
+	"""
+
+	_shouldAllowUIALiveRegionChangeEvent = False
+
+
+_INTELLISENSE_LIST_AUTOMATION_IDS = {
+	"listBoxCompletions",
+	"CompletionList"
+}
+
+
 def findExtraOverlayClasses(obj, clsList):
-	if obj.UIAElement.cachedAutomationId == "listBoxCompletions":
+	if obj.UIAAutomationId in _INTELLISENSE_LIST_AUTOMATION_IDS:
 		clsList.insert(0, IntelliSenseList)
 	elif isinstance(obj.parent, IntelliSenseList) and obj.UIAElement.cachedClassName == "IntellisenseMenuItem":
 		clsList.insert(0, IntelliSenseItem)
+	elif (
+		obj.UIAElement.cachedClassName == "LiveTextBlock"
+		and obj.previous
+		and isinstance(obj.previous.previous, IntelliSenseList)
+	):
+		clsList.insert(0, IntelliSenseLiveRegion)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,7 +7,7 @@ What's New in NVDA
 
 == New Features ==
 - Pressing F1 inside NVDA dialogs will now open the help file to most relevant section. (#7757)
-- Support for auto complete suggestions (IntelliSense) Microsoft SQL Server Management Studio and Visual Studio 2017. (#7504)
+- Support for auto complete suggestions (IntelliSense) in Microsoft SQL Server Management Studio plus Visual Studio 2017 and higher. (#7504)
 - Symbol pronunciation: Support for grouping in a complex symbol definition and support group references in a replacement rule making them simpler and more powerful. (#11107)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #8336 
Follow up of #11421 

### Summary of the issue:
intellisense in Visual Studio 2019 uses live regions to speak suggestions. However, the live region content is spoken after the selected line, making navigating suggestions a painful process, especially on long lines.

### Description of how this pull request fixes the issue:
This pr builds upon #11421, extending the UIA_elementSelected approach to .NET programming in Visual Studio 2019.

### Testing performed:
Tested in Visual Studio 2019 that intellisense items in C# read instantly, and that live region output for intellisense is suppressed. Confirmed that other live regions still work.

### Known issues with pull request:
There is a slight chance that we're suppressing too much live region output, though I"m pretty sure we are not as I tried to make sure we're only suppressing the output when there is a strict object relation ship with the intellisense list.

### Change log entry:
The SSMS and VS2017 entry can be updated to mention 2017 and newer

* Bug fixes
    + In Visual Studio 2017 and newer, IntelliSense suggestions are reported as soon as they are selected, rather than after speaking the current line. (#8336)
