### PR TITLE
Fix-up of PR #11582: filter an extra call to log.debug in nvwave channel

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -484,7 +484,8 @@ class WavePlayer(garbageHandler.TrackedObject):
 				self._close()
 
 	def _close(self):
-		log.debug("Calling winmm.waveOutClose")
+		if _isDebugForNvWave():
+			log.debug("Calling winmm.waveOutClose")
 		with self._global_waveout_lock:
 			if not self._waveout:
 				return


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

None
Fix-up of #11582.

### Summary of the issue:

When #11582 was implemented, I have forgotten to filter a call to log.debug under nvwave channel in nvwave.py. Thus the following message appears regularly in the log even if nvwave debug logging option is not enabled in Advanced settings panel.

> ```
> DEBUG - nvwave.WavePlayer._close (14:33:34.617) - MainThread (3920):
> Calling winmm.waveOutClose
> ```

### Description of how this pull request fixes the issue:

Filter this call to log.debug as for other already filtered calls.

So now, in nwave.py, all calls to log.debug are filtered under the nvwave debug log category except the following one:

> `log.debug("Error closing the device, it may have been removed.", exc_info=True)`

As written in #11582, I have left this one outside of nvwave debug filter since it was an error and thus seemed more important to me. Let me know however if my reasoning is not correct since I do not know when this error can occur.

Moreover, the calls to log.debugWarning and log.warning are not filtered since they are not at debug level.

### Testing performed:

Changed synthesizer and checked that this message has disappeared.

### Known issues with pull request:

None.

### Change log entry:

N/A

