### PR TITLE
Revert "Synthesizer dialog: ensure 'Microsoft Sound Mapper' is named

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -959,10 +959,6 @@ class SynthesizerSelectionDialog(SettingsDialog):
 		# headphones, etc.
 		deviceListLabelText = _("Audio output  &device:")
 		deviceNames=nvwave.getOutputDeviceNames()
-		# #11349: On Windows 10 20H1 and 20H2, Microsoft Sound Mapper returns an empty string.
-		if not deviceNames[0]:
-			# Translators: name for default (Microsoft Sound Mapper) audio output device.
-			deviceNames[0] = _("Microsoft Sound Mapper")
 		self.deviceList = settingsSizerHelper.addLabeledControl(deviceListLabelText, wx.Choice, choices=deviceNames)
 
 		try:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,7 +42,6 @@ The existence of marked (highlighted) content can be reported in browsers, and t
 - NVDA will announce Open With dialog content in Windows 10 May 2020 Update. (#11335)
 - A new experimental option in Advanced settings (Enable selective registration for UI Automation events and property changes) can provide major performance improvements in Microsoft Visual Studio and other UIAutomation based applications if enabled. (#11077, #11209)
 - For checkable list items, the selected state is no longer announced redundantly, and if applicable, the unselected state is announced instead. (#8554)
-- On Windows 10 May 2020 Update, NVDA now shows the Microsoft Sound Mapper when viewing output devices from synthesizer dialog. (#11349)
 - In Internet Explorer, numbers are now announced correctly for ordered lists if the list does not start with 1. (#8438)
 - In Google chrome, NVDA will now report not checked for all checkable controls (not just check boxes) that are currently not checked. (#11377)
 - It is once again possible to navigate in various controls when NVDA's language is set to Aragonese. (#11384)


### PR DESCRIPTION
### Link to issue number:
Reverts #11353 
Original issue: #11349 

### Summary of the issue:
In earlier releases of Windows 10 Version 2004 (May 2020 Update), Microsoft Sound Mapper was not named (empty string). IN a summer cumulative update for 2004 (and 20H2), this problem is gone.

### Description of how this pull request fixes the issue:
Reverts PR #11353 via beta branch.

### Testing performed:
Tested via source and from Python Console (in 2020.2 and 2020.3 beta) to make sure Microsoft Sound Mapper is listed (tested on both 2004 and 20H2).

### Known issues with pull request:
None

### Change log entry:
None (#11349 entry removed as part of this PR).

Thanks.