### PR TITLE
Microsoft Sound Mapper: 'translate' Microsoft Sound Mapper entry if not translated by Windows

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -960,7 +960,7 @@ class SynthesizerSelectionDialog(SettingsDialog):
 		deviceListLabelText = _("Audio output  &device:")
 		deviceNames=nvwave.getOutputDeviceNames()
 		# #11349: On Windows 10 20H1 and 20H2, Microsoft Sound Mapper returns an empty string.
-		if not deviceNames[0]:
+		if deviceNames[0] in ("", "Microsoft Sound Mapper"):
 			# Translators: name for default (Microsoft Sound Mapper) audio output device.
 			deviceNames[0] = _("Microsoft Sound Mapper")
 		self.deviceList = settingsSizerHelper.addLabeledControl(deviceListLabelText, wx.Choice, choices=deviceNames)


### PR DESCRIPTION
### Link to issue number:
Closes #11616 
Fixes #11349 
Tweaks #11353

### Summary of the issue:
Microsoft Sound Mapper is once again printed when asking for audio device names but is not translated in some languages (technically a regression from Microsoft).

### Description of how this pull request fixes the issue:
Temporary workaround: "translate" Microsoft Sound Mapper if it wasn't.

### Testing performed:
Tested via source copy under Windows 10 Version 2004 build 19041.508 (and corresponding 20H2 build).

### Known issues with pull request:
None

### Change log entry:
None

Thanks.