### PR TITLE
Fix title cancellation

### DIFF
--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -153,6 +153,8 @@ def _trackFocusObject(eventName, obj) -> None:
 	if eventName == "gainFocus":
 		lastQueuedFocusObject = obj
 		setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, True)
+		if speech.manager._shouldDoSpeechManagerLogging():
+			log.debug(f"Changing last queued focus object: {obj!r}")
 	elif not hasattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME):
 		setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, False)
 

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -171,7 +171,8 @@ def _getFocusLossCancellableSpeechCommand(
 		return getattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, False)
 
 	def isLastFocusObj():
-		return obj is lastQueuedFocusObject
+		# Obj may have been created multiple times pointing to the same underlying object.
+		return obj is lastQueuedFocusObject or obj == lastQueuedFocusObject
 
 	def isAncestorOfCurrentFocus():
 		return obj in api.getFocusAncestors()

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -80,7 +80,13 @@ def _speechManagerUnitTest(msg, *args, **kwargs) -> None:
 		When
 	"""
 	if not IS_UNIT_TEST_LOG_ENABLED:
-		return _speechManagerDebug(msg, *args, **kwargs)
+		# Don't reuse _speechManagerDebug, it leads to incorrect function names in the log (all
+		# SpeechManager debug logging appears to come from _speechManagerUnitTest instead of the frame
+		# one stack higher. The codepath argument for _log could also be used to resolve this, but duplication
+		# simpler.
+		if log.isEnabledFor(log.DEBUG) and _shouldDoSpeechManagerLogging():
+			log._log(log.DEBUG, f"SpeechManager- " + msg, args, **kwargs)
+		return
 	log._log(log.INFO, f"SpeechManUnitTest- " + msg, args, **kwargs)
 
 # Install the custom log handlers.
@@ -420,7 +426,7 @@ class SpeechManager(object):
 				if isinstance(item, IndexCommand):
 					self._indexesSpeaking.append(item.index)
 			self._cancelledLastSpeechWithSynth = False
-			log._speechManagerUnitTest(f"Assert Synth Gets: {seq}")
+			log._speechManagerUnitTest(f"Synth Gets: {seq}")
 			getSynth().speak(seq)
 
 	def _getNextPriority(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,6 +22,7 @@ What's New in NVDA
 - NVDA now honors the aria-roledescription attribute on elements in editable content in web pages. (#11607)
 - 'list' is no longer announced on every line of a list in Google Docs or other editable content in Google Chrome. (#7562)
 - When arrowing by character or word from one list item to another in editable content on the web, entering the new list item is now announced. (#11569)
+- When "attempt to cancel expired focus events" is enabled, the title of the tab is now announced again when switching tabs in Firefox. (#11397)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #11397

### Summary of the issue:
When changing tabs in firefox, the title of the tab was no longer announced. 
This was a little confusing because the document seems to have focus, and thus it should still be announced.

### Description of how this pull request fixes the issue:
The reason this speech was being cancelled was that the focused object was not the same instance, despite pointing to the same underlying object (the document). This is due to the interceptor having a cache of this object and intercepting the event.

### Testing performed:
Steps in #11397

### Known issues with pull request:

### Change log entry:
Bug fixes:

- When "attempt to cancel expired focus events" is enabled, the title of the tab is now announced again when switching tabs in Firefox. (#11397)

