### PR TITLE
Speech manager no longer sends synths utterances containing only param change and index commands. 

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -309,26 +309,35 @@ class SpeechManager(object):
 
 		def ensureEndUtterance(seq: SpeechSequence):
 			# We split at EndUtteranceCommands so the ends of utterances are easily found.
+			# This function ensures the given sequence ends with an EndUtterance command,
+			# Ensures that the sequence also includes an index command at the end,
+			# It places the complete sequence in outSeqs,
+			# It clears the given sequence list ready to build a new one,
+			# And clears the paramsToReplay list
+			# and refills it with any params that need to be repeated if a new sequence is going to be built.
 			if seq:
 				# There have been commands since the last split.
-				outSeqs.append(seq)
-				lastOutSeq = seq
+				lastOutSeq = paramsToReplay + seq
+				outSeqs.append(lastOutSeq)
+				paramsToReplay.clear()
+				seq.clear()
 				# Re-apply parameters that have been changed from their defaults.
-				seq = paramTracker.getChanged()
+				paramsToReplay.extend(paramTracker.getChanged())
 			else:
 				lastOutSeq = outSeqs[-1] if outSeqs else None
 			lastCommand = lastOutSeq[-1] if lastOutSeq else None
 			if not lastCommand or isinstance(lastCommand, (EndUtteranceCommand, ConfigProfileTriggerCommand)):
 				# It doesn't make sense to start with or repeat EndUtteranceCommands.
 				# We also don't want an EndUtteranceCommand immediately after a ConfigProfileTriggerCommand.
-				return seq
+				return
 			if not isinstance(lastCommand, IndexCommand):
 				# Add an index so we know when we've reached the end of this utterance.
 				reachedIndex = next(self._indexCounter)
 				lastOutSeq.append(IndexCommand(reachedIndex))
 			outSeqs.append([EndUtteranceCommand()])
-			return seq
 
+
+		paramsToReplay = []
 		outSeq = []
 		for command in inSeq:
 			if isinstance(command, BaseCallbackCommand):
@@ -337,8 +346,9 @@ class SpeechManager(object):
 				outSeq.append(IndexCommand(speechIndex))
 				self._indexesToCallbacks[speechIndex] = command
 				# We split at indexes so we easily know what has completed speaking.
-				outSeqs.append(outSeq)
-				outSeq = []
+				outSeqs.append(paramsToReplay + outSeq)
+				paramsToReplay.clear()
+				outSeq.clear()
 				continue
 			if isinstance(command, ConfigProfileTriggerCommand):
 				if not command.trigger.hasProfile:
@@ -350,7 +360,7 @@ class SpeechManager(object):
 				if not command.enter and command.trigger not in enteredTriggers:
 					log.debugWarning("Request to exit trigger which wasn't entered: %r" % command.trigger.spec)
 					continue
-				outSeq = ensureEndUtterance(outSeq)
+				ensureEndUtterance(outSeq)
 				outSeqs.append([command])
 				if command.enter:
 					enteredTriggers.append(command.trigger)
@@ -358,7 +368,7 @@ class SpeechManager(object):
 					enteredTriggers.remove(command.trigger)
 				continue
 			if isinstance(command, EndUtteranceCommand):
-				outSeq = ensureEndUtterance(outSeq)
+				ensureEndUtterance(outSeq)
 				continue
 			if isinstance(command, SynthParamCommand):
 				paramTracker.update(command)

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -336,7 +336,6 @@ class SpeechManager(object):
 				lastOutSeq.append(IndexCommand(reachedIndex))
 			outSeqs.append([EndUtteranceCommand()])
 
-
 		paramsToReplay = []
 		outSeq = []
 		for command in inSeq:

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -306,6 +306,7 @@ class SpeechManager(object):
 		paramTracker = ParamChangeTracker()
 		enteredTriggers = []
 		outSeqs = []
+		paramsToReplay = []
 
 		def ensureEndUtterance(seq: SpeechSequence):
 			# We split at EndUtteranceCommands so the ends of utterances are easily found.
@@ -336,7 +337,6 @@ class SpeechManager(object):
 				lastOutSeq.append(IndexCommand(reachedIndex))
 			outSeqs.append([EndUtteranceCommand()])
 
-		paramsToReplay = []
 		outSeq = []
 		for command in inSeq:
 			if isinstance(command, BaseCallbackCommand):

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -826,13 +826,13 @@ class InitialDevelopmentTests(unittest.TestCase):
 			"Testing testing ",
 			speech.PitchCommand(offset=100),
 			"1 2 3 4",
-			ExpectedIndex(1),
+			smi.create_ExpectedIndex(1),
 			# The preceeding index is expected,
 			# as the following profile trigger commands will cause the utterance to be split here.
 			ConfigProfileTriggerCommand(t1, True),
 			ConfigProfileTriggerCommand(t2, True),
 			"5 6 7 8",
-			ExpectedIndex(2),
+			smi.create_ExpectedIndex(2),
 			# The preceeding index is expected,
 			# as the following profile trigger commands will cause the utterance to be split here.
 			ConfigProfileTriggerCommand(t1, False),

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -1113,6 +1113,7 @@ class InitialDevelopmentTests_withCancellableSpeechEnabled(InitialDevelopmentTes
 		super().setUp()
 		config.conf['featureFlag']['cancelExpiredFocusSpeech'] = 1  # yes
 
+
 class Test_pr11651(unittest.TestCase):
 
 	def test_redundantSequenceAfterEndUtterance(self):

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -869,7 +869,7 @@ class InitialDevelopmentTests(unittest.TestCase):
 			smi.expect_synthSpeak(sequence=[
 				seq[1],  # PitchCommand
 				'9 10 11 12',
-				ExpectedIndex(expectedIndexCommandIndex=3)
+				smi.create_ExpectedIndex(expectedToBecomeIndex=3)
 			])
 			smi.expect_mockCall(t1.exit)
 
@@ -1134,6 +1134,12 @@ class Test_pr11651(unittest.TestCase):
 			# synth should receive the characterMode, the letter 'a' and an index command.
 			smi.expect_synthSpeak(sequence=seq[:-1])
 		with smi.expectation():
+			# Previously, this would result in synth.speak receiving
+			# a call with sequence:
+			# [CharacterModeCommand(True), IndexCommand(2)]
+			# This is a problem because it includes an index command but no speech.
+			# This is inefficient, and also some SAPI5 synths such as Ivona will not
+			# notify of this bookmark.
 			smi.indexReached(1)
 			smi.doneSpeaking()
 			smi.pumpAll()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ What's New in NVDA
 - NVDA now reads the correct line when the caret is placed at the end of a link on the end of a list item in Google Docs or other editable content on the web. (#11606)
 - On Windows 7, opening and closing the start menu from the desktop now sets focus correctly. (#10567)
 - When "attempt to cancel expired focus events" is enabled, the title of the tab is now announced again when switching tabs in Firefox. (#11397)
+- NVDA no longer fails to announce a list item after typing a character in a list when speaking with the SAPI5 Ivona voices. (#11651)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
An alternative to pr #11586 

### Link to issue number:
Fixes #11168

### Summary of the issue:
NvDA's speech manager  splits speech sequences on endUtterance commands, and ensures that each utterance ends in an index command. However, it was possible that this would result in a speech sequence being sent to the synth that only contained param change commands and a final lindex. This is not only a redundant sequence, but  some synths such as SAPI5 Ivona, could ignore the index completely, as the sequence did not actually contain any speech. And therefore, this would cause NVDA to not receive the final index callback and therefore not speak any further queued speech. For example in issue #11168 typing a letter in a list: NVDA would speak (spell) that character, but then fail to announce the newly highlighted list item.

### Description of how this pull request fixes the issue:
Improved the logic in _processSpeechSequence  and its ensureEndUtterance inner function, so that replaying of param change commands after the end of one utterance only occurs if there is actually more speech. And, therefore another index won't pointlessly be added after the param changes.
 
The test_4_profiles speech manager unit test had to be significantly rewritten though as this changed the numbering of indexes, as that test seemed to expect  the redundant param change and index commands (specifically between two configProfileSwitch commands with no actual speech).
 
### Testing performed:
Performed the stesps in issue #11168 while using an Australian SAPI5 Ivona demo voice from https://www.harposoftware.com/
Before the test NvDA would not say anything after speaking the typed character in the list. After, it also correctly spoke the list item as well.
 
### Known issues with pull request:
Although this directly addresses the problems with Ivona and therefore fixes issue #11168 , it does not fix issue #10901 which is somewhat worse and deals with much older software.

### Change log entry:
Bug fixes:
- NVDA no longer fails to announce a list item after typing a character in a list when speaking with the SAPI5 Ivona voices.

