### PR TITLE
When executing events other than focus, only take running tree interceptors into account

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -31,6 +31,8 @@ import globalPluginHandler
 import brailleInput
 import locationHelper
 import aria
+from typing import Optional
+
 
 class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
 	"""A default TextInfo which is used to enable text review of information about widgets that don't support text content.
@@ -365,26 +367,31 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	#: @type: bool
 	shouldCreateTreeInterceptor = True
 
-	def _get_treeInterceptor(self):
-		"""Retrieves the treeInterceptor associated with this object.
-		If a treeInterceptor has not been specifically set, the L{treeInterceptorHandler} is asked if it can find a treeInterceptor containing this object.
-		@return: the treeInterceptor
-		@rtype: L{treeInterceptorHandler.TreeInterceptor}
+	def _get_runningTreeInterceptor(self) -> Optional[treeInterceptorHandler.TreeInterceptor]:
+		"""Retrieves a running treeInterceptor associated with this object.
+		@return: the treeInterceptor or C{None} if a treeInterceptor has not been specifically set.
 		""" 
-		if hasattr(self,'_treeInterceptor'):
-			ti=self._treeInterceptor
-			if isinstance(ti,weakref.ref):
-				ti=ti()
+		if hasattr(self, '_treeInterceptor'):
+			ti = self._treeInterceptor
+			if isinstance(ti, weakref.ref):
+				ti = ti()
 			if ti and ti in treeInterceptorHandler.runningTable:
 				return ti
 			else:
 				self._treeInterceptor=None
 				return None
-		else:
-			ti=treeInterceptorHandler.getTreeInterceptor(self)
+
+	def _get_treeInterceptor(self) -> Optional[treeInterceptorHandler.TreeInterceptor]:
+		"""Retrieves the treeInterceptor associated with this object.
+		If a treeInterceptor has not been specifically set, the L{treeInterceptorHandler} is asked if it can find a treeInterceptor containing this object.
+		@return: the treeInterceptor
+		""" 
+		ti = self.runningTreeInterceptor
+		if not ti:
+			ti = treeInterceptorHandler.getTreeInterceptor(self)
 			if ti:
-				self._treeInterceptor=weakref.ref(ti)
-			return ti
+				self._treeInterceptor = weakref.ref(ti)
+		return ti
 
 	def _set_treeInterceptor(self,obj):
 		"""Specifically sets a treeInterceptor to be associated with this object.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -128,7 +128,7 @@ class _EventExecuter(garbageHandler.TrackedObject):
 				yield func, (obj, self.next)
 
 		# Tree interceptor level.
-		treeInterceptor = obj.treeInterceptor
+		treeInterceptor = obj.runningTreeInterceptor
 		if treeInterceptor:
 			func = getattr(treeInterceptor, funcName, None)
 			if func and (getattr(func,'ignoreIsReady',False) or treeInterceptor.isReady):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Fixes #11533 
Closes #11652 

### Summary of the issue:
When an event is fired, NVDA tries to fetch the tree interceptor for the object on which the event is fired. This includes a check whether the object belongs to every running tree interceptor. If an object in Chromium belongs to the same window but not to the same tree interceptor as another tree interceptor, this check can take some time, therefore causing major performance degradation. This happens in VS Code where the root node of the Electron application has a tree interceptor but most child nodes are part of an application.nodes are part of 

### Description of how this pull request fixes the issue:
1. Added a new object property: runningTreeInterceptor. This property only reveals the tree interceptor that is cached on the object, it does not call `treeInterceptorHandler.getTreeInterceptor`
2. When executing events, the new property is used. This ensures that we're no longer unnecessarily trying to get a tree interceptor when executing events.

### Testing performed:
Tested by several people that performance issues in VS Code are gone, see #11533.

### Known issues with pull request:
I think this needs to be tested more broadly. I can think of some possible regressions:

1. event_caret for objects in the BrowseModeDocumentTreeInterceptor are discarded when pass through is off. With this change, this no longer applies to objects that don't have a cached tree interceptor on them. However, we discard caret events for all but focus objects anyway, so I don't see how this could cause issues.
2. Something similar applies to event_focusEntered. The event might not come across the tree interceptor this way.

### Change log entry:
* Bug fixes
    + Major performance improvements in Visual Studio Code. (#11533)