### PR TITLE
Active Braille now supports joystick.

### DIFF
--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -394,7 +394,7 @@ class EasyBraille(OldProtocolMixin, Model):
 	genericName = name = "Easy Braille"
 
 
-class ActiveBraille(TimeSyncFirmnessMixin, AtcMixin, TripleActionKeysMixin, Model):
+class ActiveBraille(TimeSyncFirmnessMixin, AtcMixin, JoystickMixin, TripleActionKeysMixin, Model):
 	deviceId = MODEL_ACTIVE_BRAILLE
 	numCells = 40
 	genericName = name = 'Active Braille'

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,6 +16,7 @@ The existence of marked (highlighted) content can be reported in browsers, and t
  - This can be toggled on and off by a new NVDA Document Formatting option for Highlighting.
 - New emulated system keyboard keys can be added from NVDA's Input gestures dialog. (#6060)
   - To do this, press the add button after you selected the Emulated system keyboard keys category.
+- Handy Tech Active Braille with joystick is now supported. (#11655)
 
 
 == Changes ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:
Does not apply.
### Summary of the issue:
Future Handy Tech Active Braille devices will support the joystick introduced in Actilino. This pr modifies the Help Tech Braille driver accordingly.
### Description of how this pull request fixes the issue:
ActiveBraille inherits from JoystickMixin.
### Testing performed:
Tested with prototype firmware.
### Known issues with pull request:
None.
### Change log entry:

Changes:
Handy Tech Active Braille with joystick is now supported.