### PR TITLE
Work around VS Code specific performance issues

### DIFF
--- a/source/appModules/code - insiders.py
+++ b/source/appModules/code - insiders.py
@@ -1,0 +1,10 @@
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2020 NV Access Limited, Leonard de Ruijter
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+""" App module for Visual Studio Code Insiders.
+This app module simply inherrits from the app module for the stable version of Code.
+"""
+
+from .code import *

--- a/source/appModules/code - insiders.py
+++ b/source/appModules/code - insiders.py
@@ -1,10 +1,11 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2020 NV Access Limited, Leonard de Ruijter
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """ App module for Visual Studio Code Insiders.
 This app module simply inherrits from the app module for the stable version of Code.
 """
 
-from .code import *
+# Ignoring Flake8 imported but unused error since appModuleHandler yet uses the import.
+from .code import AppModule  # noqa: F401

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2020 NV Access Limited, Leonard de Ruijter
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """ App module for Visual Studio Code.
 """

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -1,0 +1,26 @@
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2020 NV Access Limited, Leonard de Ruijter
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+
+""" App module for Visual Studio Code.
+"""
+
+import appModuleHandler
+from NVDAObjects.IAccessible.chromium import Document
+from NVDAObjects import NVDAObject
+
+
+class VSCodeDocument(Document):
+	"""The only content in the root document node of Visual Studio code is the application object.
+	Creating a tree interceptor on this object causes a major slow down of Code.
+	Therefore, forcefully block tree interceptor creation.
+	"""
+	_get_treeInterceptorClass = NVDAObject._get_treeInterceptorClass
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if Document in clsList and obj.IA2Attributes.get("tag") == "#document":
+			clsList.insert(0, VSCodeDocument)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ The existence of marked (highlighted) content can be reported in browsers, and t
 - The expanded / collapsed state of directories in the navigation treeview on drive.google.com is now always reported by NVDA. (#11520)
 - NVDA will auto detect the NLS eReader Humanware braille display via Bluetooth as its Bluetooth name is now "NLS eReader Humanware". (#11561)
 - Certain SAPI5 voices (such as Ivona) no longer skip speech. (#10901)
+- Major performance improvements in Visual Studio Code. (#11533)
 
 
 == Changes For Developers ==


### PR DESCRIPTION
Note, I filed this against beta as I feel that this issue has impact for many developers and therefore deserves urgency. Furthermore, the impact outside code is zero.

### Link to issue number:
Fixes #11533 
Replaces #11653 

### Summary of the issue:
Visual Studio Code can be very sluggish. The reason is that the root of the Electron application has a tree interceptor that only contains an application, and therefore is basically doing nothing. However, when NVDA receives an event inside Visual Studio Code, it tries to find the tree interceptor assigned to the event's object. It also queries the unused tree interceptor, which is very costly.

### Description of how this pull request fixes the issue:
Reintroduced appmodules as suggested by https://github.com/nvaccess/nvda/pull/11653#issuecomment-696467362 .

### Testing performed:
Tested that performance increased significantly in both code and code insiders.

### Known issues with pull request:
1. When you enable browse mode in the VS Code application using NVDA+space and then disable it, performance degrades a little. This is solved by alt+tab out and back in.
2. Not general fix, as such #11652 remains. This is a VS Code specific workaround. Ideally, the mentioned issue should be investigated further, but this issue has too much impact for end users to be left alone for a better fix.

### Change log entry:
* Bug fixes
    + Major performance improvements in Visual Studio Code. (#11533)
