### PR TITLE
Browse mode with focus focusable elements disabled: Before switching to focus mode set focus to the lastFocusableObject

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1333,6 +1333,12 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			if self.programmaticScrollMayFireEvent:
 				self._lastProgrammaticScrollTime = time.time()
 		self.passThrough=self.shouldPassThrough(focusObj,reason=reason)
+		if self.passThrough and not config.conf["virtualBuffers"]["autoFocusFocusableElements"]:
+			# #11654, #11663: If we are going to switch to focus mode and focus is not following browse mode cursor
+			# We need to synchronize it to the last focusable control,
+			# Otherwise it is impossible to, for example, write in the edit field
+			#  on which browse mode caret is located.
+			self._focusLastFocusableObject()
 		# Queue the reporting of pass through mode so that it will be spoken after the actual content.
 		queueHandler.queueFunction(queueHandler.eventQueue, reportPassThrough, self)
 


### PR DESCRIPTION
This is opened against beta, since it fixes regression introduced during 2020.3 development cycle
### Link to issue number:


Fixes #11663
Fixes #11654

### Summary of the issue:
With focus focusable elements disabled and Automatic focus mode for caret movements enabled when switching to focus mode as a result of caret movement focus was not moved to the control with caret. This made it impossible to, for example type text to the edit fields or properly interact with comboboxes.
### Description of how this pull request fixes the issue:
Before we are going to switch to focus mode focus is set to the last focusable object.
### Testing performed:
Tested STR's from both issues referenced above - confirmed they are no longer reproducible.
### Known issues with pull request:
None known
### Change log entry:

Section: Bug fixes

When automatic focus mode for caret movement is enabled focus is once again moved to the control which requires focus mode.

