### PR TITLE
Automatically set system focus to focusable elements: properly set focus when automatic focus mode is triggered

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,8 +1,7 @@
-#browseMode.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2018 NV Access Limited, Babbage B.V.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2020 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import itertools
 import collections
@@ -1323,18 +1322,24 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			if not obj:
 				log.debugWarning("Invalid NVDAObjectAtStart")
 				return
-			followBrowseModeFocus= config.conf["virtualBuffers"]["autoFocusFocusableElements"]
 			if obj==self.rootNVDAObject:
 				return
-			if followBrowseModeFocus:
-				if focusObj and not eventHandler.isPendingEvents("gainFocus") and focusObj!=self.rootNVDAObject and focusObj != api.getFocusObject() and self._shouldSetFocusToObj(focusObj):
-					focusObj.setFocus()
 			obj.scrollIntoView()
 			if self.programmaticScrollMayFireEvent:
 				self._lastProgrammaticScrollTime = time.time()
-		self.passThrough=self.shouldPassThrough(focusObj,reason=reason)
-		# Queue the reporting of pass through mode so that it will be spoken after the actual content.
-		queueHandler.queueFunction(queueHandler.eventQueue, reportPassThrough, self)
+		if focusObj:
+			self.passThrough = self.shouldPassThrough(focusObj, reason=reason)
+			if (
+				not eventHandler.isPendingEvents("gainFocus")
+				and focusObj != self.rootNVDAObject
+				and focusObj != api.getFocusObject()
+				and self._shouldSetFocusToObj(focusObj)
+			):
+				followBrowseModeFocus = config.conf["virtualBuffers"]["autoFocusFocusableElements"]
+				if followBrowseModeFocus or self.passThrough:
+					focusObj.setFocus()
+			# Queue the reporting of pass through mode so that it will be spoken after the actual content.
+			queueHandler.queueFunction(queueHandler.eventQueue, reportPassThrough, self)
 
 	def _shouldSetFocusToObj(self, obj):
 		"""Determine whether an object should receive focus.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,7 @@ The existence of marked (highlighted) content can be reported in browsers, and t
 - New emulated system keyboard keys can be added from NVDA's Input gestures dialog. (#6060)
   - To do this, press the add button after you selected the Emulated system keyboard keys category.
 - Handy Tech Active Braille with joystick is now supported. (#11655)
+- "Automatic focus mode for caret movement" setting is now compatible with disabling "Automatically set focus to focusable elements". (#11663)
 
 
 == Changes ==


### PR DESCRIPTION
Many thanks to @lukaszgo1 for assisting in tracking this down!

This is opened against beta, since it fixes a regression introduced during 2020.3 development cycle

### Link to issue number:
Fixes #11663
Replaces #11665

### Summary of the issue:
With focus focusable elements disabled and Automatic focus mode for caret movements enabled when switching to focus mode as a result of caret movement focus was not moved to the control with caret. This made it impossible to, for example type text to the edit fields or properly interact with combo boxes.

### Description of how this pull request fixes the issue:
Automatic focus mode is triggered when calling _set_selection on the browse mode document tree interceptor. The logic in this method has been changed to set focus to the object, either when Automatically set system focus to focusable elements is on or when we are going to pass through.

### Testing performed:
Tested the steps to reproduce from #11663.

### Known issues with pull request:
None

### Change log entry:
Note, though this fixes a regression in 2020.3 beta, the auto set focus to focusable elements option was there before 2020.3.

* Bug fixes
    + When automatically set focus to focusable elements is disabled, NVDA once again sets focus to the focused object when focus mode is activated due to a focus change or caret movement. (#11663)