### PR TITLE
Revert PR #11586

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-#synthDrivers/sapi5.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import locale
 from collections import OrderedDict

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-# synthDrivers/sapi5.py
-# A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Aleksey Sadovoy
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+#synthDrivers/sapi5.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
 
 import locale
 from collections import OrderedDict
@@ -364,11 +364,6 @@ class SynthDriver(SynthDriver):
 		tagsChanged[0] = True
 		outputTags()
 
-		# Some SAPI5 synthesizers complete speech sequence just after the last text is said
-		# and ignore any indexes passed afterward.
-		# Therefore we add the pause of 1ms at the end of each sequence.
-		textList.append('<silence msec="1" />')
-		# Join textList to create xml document passed to synthesizer
 		text = "".join(textList)
 		flags = constants.SVSFIsXML | constants.SVSFlagsAsync
 		self.tts.Speak(text, flags)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -55,7 +55,6 @@ The existence of marked (highlighted) content can be reported in browsers, and t
 - NVDA will no longer freeze or exit when holding down control+shift+downArrow in Microsoft Word. (#9463)
 - The expanded / collapsed state of directories in the navigation treeview on drive.google.com is now always reported by NVDA. (#11520)
 - NVDA will auto detect the NLS eReader Humanware braille display via Bluetooth as its Bluetooth name is now "NLS eReader Humanware". (#11561)
-- Certain SAPI5 voices (such as Ivona) no longer skip speech. (#10901)
 - Major performance improvements in Visual Studio Code. (#11533)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.MD. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
PR #11586

### Summary of the issue:
PR #11586 introduced this change to address a long standing regression for Ivona synthesizers (since NVDA 2019.3). However, this then causes a regression in some other synthesizers, and this issue already has a more robust fix in alpha builds. 

### Description of how this pull request fixes the issue:
Revert this change, restoring behavior for CereProc voices 

### Testing performed:
None

### Known issues with pull request:
Ivona synths will lose some information as per #11586

### Change log entry:
None


