### PR TITLE
Remap F3 key for HIMS displays to avoi  conflicts with number 6 in computer braille tables

### DIFF
--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -639,7 +639,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				"br(hims):dot1+dot2+dot5+space",
 			),
 			"kb:f3": (
-				"br(hims):dot1+dot2+dot4+dot8",
+				"br(hims):dot1+dot4+dot8+space",
 			),
 			"kb:f4": (
 				"br(hims):dot7+f3",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,6 +16,7 @@ What's New in NVDA
 == Changes ==
 - Updated liblouis braille translator to version 3.15.0
 - When reading with say all in browse mode, the find next and find previous commands do not stop reading anymore if Allow skim reading option is enabled; say all rather resumes from after the next or previous found term. (#11563)
+- For HIMS braille displays F3 has been remapped to Space + dots 148. (#11710)
 
 
 == Bug Fixes ==
@@ -30,6 +31,7 @@ What's New in NVDA
 - NVDA no longer fails to announce a list item after typing a character in a list when speaking with the SAPI5 Ivona voices. (#11651)
 - It is again possible to use browse mode when reading emails in Windows 10 Mail 16005.13110 and later. (#11439)
 - When using the SAPI5 Ivona voices from harposoftware.com, NvDA is now able to save configuration, switch synthesizers, and no longer will stay silent after restarting. (#11650)
+- It is now possible to enter number 6 in computer braille from a braille keyboard on HIMS displays. (#11710)
 
 
 == Changes for Developers ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2627,7 +2627,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | escape key | dot1+dot5+space, f4, brailleedge:f1 |
 | delete key | dot1+dot3+dot5+space, dot1+dot4+dot5+space |
 | f1 key | dot1+dot2+dot5+space |
-| f3 key | dot1+dot2+dot4+dot8 |
+| f3 key | dot1+dot4+dot8+space |
 | f4 key | dot7+f3 |
 | windows+b key | dot1+dot2+f1 |
 | windows+d key | dot1+dot4+dot5+f1 |


### PR DESCRIPTION

### Link to issue number:
None, reported by users on one of the Polish mailing lists and subsequently confirmed by Polish distributor of HIMS displays.
### Summary of the issue:
Currently for HIMS braille displays F3 key is assigned to the  braille points 1248. For computer braille tables however (at least  for the Polish one) dots 1248 should enter number 6. For users it is impossible to write "6" from the braille keyboard in computer braille on HIMS displays.

### Description of how this pull request fixes the issue:
F3 key has been  remapped to Space+148. If we assume that Space+point 8 is responsible for invoking F keys this mapping is logical since dots 14 represents number 3.

### Testing performed:
TBD - I'll send the build to the distributor I don't have display to test.
### Known issues with pull request:
None known
### Change log entry:

Section: Bug fixes
It is now possible to enter number 6 in computer braille from a braille keyboard on HIMS displays.
Changes:

For HIMS braille displays F3 has been remapped to Space + dots  148
