### PR TITLE
Fix-up of #11456: Fix for messages when context help is not available

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -80,7 +80,7 @@ def getDocFilePath(fileName, localized=True):
 				tryPath = os.path.join(tryDir, "%s.%s" % (fileName, tryExt))
 				if os.path.isfile(tryPath):
 					return tryPath
-
+		return None
 	else:
 		# Not localized.
 		if not hasattr(sys, "frozen") and fileName in ("copying.txt", "contributors.txt"):

--- a/source/gui/contextHelp.py
+++ b/source/gui/contextHelp.py
@@ -30,8 +30,8 @@ def showHelp(helpId: str):
 	recognized control.
 	"""
 	if not helpId:
-		# Translators: Message indicating no context sensitive help is available.
-		noHelpMessage = _("No context sensitive help is available here at this time.")
+		# Translators: Message indicating no context sensitive help is available for the control or dialog.
+		noHelpMessage = _("No help available here.")
 		queueHandler.queueFunction(queueHandler.eventQueue, ui.message, noHelpMessage)
 		return
 	helpFile = gui.getDocFilePath("userGuide.html")

--- a/source/gui/contextHelp.py
+++ b/source/gui/contextHelp.py
@@ -6,6 +6,7 @@
 import os
 import tempfile
 import typing
+import queueHandler
 
 import gui
 import ui
@@ -31,14 +32,16 @@ def showHelp(helpId: str):
 	if not helpId:
 		# Translators: Message indicating no context sensitive help is available.
 		noHelpMessage = _("No context sensitive help is available here at this time.")
-		ui.message(noHelpMessage)
+		queueHandler.queueFunction(queueHandler.eventQueue, ui.message, noHelpMessage)
+		return
 	helpFile = gui.getDocFilePath("userGuide.html")
-	if not os.path.exists(helpFile):
+	if helpFile is None:
 		# Translators: Message shown when trying to display context sensitive help,
 		# indicating that	the user guide could not be found.
 		noHelpMessage = _("No user guide found.")
 		log.debugWarning("No user guide found: possible cause - running from source without building user docs")
-		ui.message(noHelpMessage)
+		queueHandler.queueFunction(queueHandler.eventQueue, ui.message, noHelpMessage)
+		return
 	log.debug(f"Opening help: helpId = {helpId}, userGuidePath: {helpFile}")
 
 	nvdaTempDir = os.path.join(tempfile.gettempdir(), "nvda")


### PR DESCRIPTION
### Link to issue number:
Fixes #7757 (follow-up)
Fix-up of PR #11456: 

### Summary of the issue:

The code integrated with #11456 has defined two messages when no context help is available in the following cases:
1. The user guide cannot be found, e.g. because NVDA is running from source and the documentation has not yet been compiled.
2. The UI element on which context help is requested has no associated context sensitive help.
However, these messages cannot be heard.

#### Case 1
STR:
* Run NVDA from source; documentation should not have been compiled before
* Open General settings panel
* Press F1
The following error occurs:

> ```
> IO - inputCore.InputManager.executeGesture (13:53:44.662) - winInputHook (11948):
> Input: kb(desktop):f1
> IO - speech.speak (13:53:44.662) - MainThread (5156):
> Speaking ['No context sensitive help is available here at this time.']
> ERROR - unhandled exception (13:53:44.678) - MainThread (5156):
> Traceback (most recent call last):
>   File "gui\contextHelp.py", line 66, in <lambda>
>     lambda evt: _onEvtHelp(helpId, evt),
>   File "gui\contextHelp.py", line 74, in _onEvtHelp
>     showHelp(helpId)
>   File "gui\contextHelp.py", line 36, in showHelp
>     if not os.path.exists(helpFile):
>   File "C:\Users\Cyrille\AppData\Local\Programs\Python\Python37-32\lib\genericpath.py", line 19, in exists
>     os.stat(path)
> TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
> ```

#### Case 2
STR:
* Run NVDA from source with doc compiled (or probably from launcher, portable or installed version)
* Install an add-on having a setting panel, e.g. Instant Translate
* Open the add-on's setting panel
* Press F1
The following message should be spoken by NVDA:
> `"No context sensitive help is available here at this time."`
However it cannot be heard and the browser starts up with NVDA User Guide opened at the beginning of the document.
NVDA userguide is opened in the browser with the following address:
> `file:///C:/Users/Cyrille/Documents/DevP/GIT/nvda/user_docs/fr/userGuide.html#`

### Description of how this pull request fixes the issue:

* call `ui.message` in main thread since calling it from wx thread is not working
* when an error message is reported (ui.message calls), return immediately and do not open the browser since opening the browser cuts off the reported message.
* modified the condition to test if the help file could be found since gui.getDocFilePath returns None if no file has been found.
* gui.getDocFilePath: if it does not find any localized or not localized file, return None explicitely. It was already returning None in this case since no return instruction was called if the for loop did not find anything.

### Possible additional change

When pressing F1 in an add-on setting panel the following message is reported:
"No context sensitive help is available here at this time."
I suggest to change this message since:
* "context sensitive help" seems a developer term
* I do not understand why it is specified "at this time"
So I suggest to replace the message with:
"No help available here"
May I add it to this PR?

### Testing performed:

Tested successfully STR of cases 1 and 2: the messages can be heard correctly.
Also tested that user guide opens at the correct anchor when the doc is compiled in General setting panel language list.

### Known issues with pull request:

None

### Change log entry:

None: context help is not yet released.

Cc @feerrenrut; @ThomasStivers 