### PR TITLE
UI Automation in Windows Console: remove workaround at POSITION_LAST for 21H1

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -49,15 +49,6 @@ class consoleUIATextInfo(UIATextInfo):
 		if position == textInfos.POSITION_FIRST:
 			collapseToEnd = False
 		elif position == textInfos.POSITION_LAST:
-			# We must pull back the end by one character otherwise when we collapse to end,
-			# a console bug results in a textRange covering the entire console buffer!
-			# Strangely the *very* last character is a special blank point
-			# so we never seem to miss a real character.
-			_rangeObj.MoveEndpointByUnit(
-				UIAHandler.TextPatternRangeEndpoint_End,
-				UIAHandler.NVDAUnitsToUIAUnits['character'],
-				-1
-			)
 			collapseToEnd = True
 		return (_rangeObj, collapseToEnd)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.MD. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
microsoft/terminal#7771

### Summary of the issue:
From `winConsoleUIA.py`:

```python
# We must pull back the end by one character otherwise when we collapse to end,
# a console bug results in a textRange covering the entire console buffer!
# Strangely the *very* last character is a special blank point
# so we never seem to miss a real character.
```

This bug was fixed in microsoft/terminal#7792.

### Description of how this pull request fixes the issue:
Removes the workaround for 21H1, restoring correct behaviour in the 21H1 console. The pre-21H1 console is unaffected.

### Testing performed:
Tested in 21H1 console.

### Known issues with pull request:
Visible range bounding is non-functional until microsoft/terminal#7803 is fixed (PR in pipeline, CC @carlos-zamora). Marking as a draft until a PR fixing visible range bounding has been merged.

### Change log entry:
None needed.