### PR TITLE
Fixed a t2t formatting issue in User guide

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1575,6 +1575,7 @@ Many Windows and controls show a small message (or tooltip) when you move the mo
 This checkbox, when checked, tells NVDA to report help balloons and toast notifications as they appear.
 - Help Balloons are like tooltips, but are usually larger in size, and are associated with system events such as a network cable being unplugged, or perhaps to alert you about Windows security issues.
 - Toast notifications have been introduced in Windows 10 and appear in the notification centre in the system tray, informing about several events (i.e. if an update has been downloaded, a new e-mail arrived in your inbox, etc.).
+-
 
 ==== Report Object Shortcut Keys ====[ObjectPresentationShortcutKeys]
 When this checkbox is checked, NVDA will include the shortcut key that is associated with a certain object or control when it is reported.


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:
Search for "====" in the generated html file of user guide. You will find them instead of title.

### Description of how this pull request fixes the issue:
The list above these titles is not closed correctly.
In t2t, an empty item (hyphen alone on its line) is required to close the list.
So that's what I have added.

### Testing performed:
Tested only on the French version on assembla for now, since I do not have the whole framework with Visual studio on this computer. I will check that Appveyor generates the User Guide without "====".

### Known issues with pull request:
I have made it against beta... But it's a bit late for translators since translation freeze is next Wednesday. If this PR is accepted, Ii may send a message to translation list to inform of this minimal modification to do.

### Change log entry:
Not required.