### PR TITLE
papenmeier braille driver fixes

### DIFF
--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -535,7 +535,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			self.id=brl_join_keys(brl_decode_key_names_repeat(driver))
 			return
 
-		if driver._baud != 1 and keys[0] == 'L':
+		if driver._baud != 1 and keys[0] == (b'L'):
 			assert isinstance(keys, bytes)
 			if (keys[3] - 48) >> 3:
 				scancode = keys[5] - 48 << 4 | keys[6] - 48


### PR DESCRIPTION
* fix braille input of Braillex Trio

* disable qwertz Keyboard support of Braillex Live 40 plus
  Maybe there is an issue in injectRawKeyboardInput since py3 conversion?

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.MD. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

### Summary of the issue:

### Description of how this pull request fixes the issue:

### Testing performed:

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

