### PR TITLE
UI Automation in Windows Console: remove optimized _getTextLines to fix autoread in 21H1 console

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -356,6 +356,14 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		# IUIAutomationTextRange::getVisibleRanges returns one visible range.
 		return self.UIATextPattern.GetVisibleRanges().length == 1
 
+	def _get_TextInfo(self):
+		"""Overriding _get_TextInfo and thus the TextInfo property
+		on NVDAObjects.UIA.UIA
+		consoleUIATextInfo bounds review to the visible text.
+		ConsoleUIATextInfoPre21H1 fixes expand/collapse and implements word
+		movement."""
+		return consoleUIATextInfo if self.is21H1Plus else consoleUIATextInfoPre21H1
+
 	def _getTextLines(self):
 		if self.is21H1Plus:
 			return super()._getTextLines()
@@ -365,14 +373,6 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		ti = self.makeTextInfo(textInfos.POSITION_ALL)
 		text = ti.text or ""
 		return text.splitlines()
-
-	def _get_TextInfo(self):
-		"""Overriding _get_TextInfo and thus the TextInfo property
-		on NVDAObjects.UIA.UIA
-		consoleUIATextInfo bounds review to the visible text.
-		ConsoleUIATextInfoPre21H1 fixes expand/collapse and implements word
-		movement."""
-		return consoleUIATextInfo if self.is21H1Plus else consoleUIATextInfoPre21H1
 
 
 def findExtraOverlayClasses(obj, clsList):

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -366,6 +366,9 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 
 	def _getTextLines(self):
 		if self.is21H1Plus:
+			# #11722: the 21H1 UIA console wraps across lines.
+			# When text wraps, NVDA starts reading from the beginning of the visible text for every new line of output.
+			# Use the superclass _getTextLines instead.
 			return super()._getTextLines()
 		# This override of _getTextLines takes advantage of the fact that
 		# the console text contains linefeeds for every line

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -356,6 +356,16 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		# IUIAutomationTextRange::getVisibleRanges returns one visible range.
 		return self.UIATextPattern.GetVisibleRanges().length == 1
 
+	def _getTextLines(self):
+		if self.is21H1Plus:
+			return super()._getTextLines()
+		# This override of _getTextLines takes advantage of the fact that
+		# the console text contains linefeeds for every line
+		# Thus a simple string splitlines is much faster than splitting by unit line.
+		ti = self.makeTextInfo(textInfos.POSITION_ALL)
+		text = ti.text or ""
+		return text.splitlines()
+
 	def _get_TextInfo(self):
 		"""Overriding _get_TextInfo and thus the TextInfo property
 		on NVDAObjects.UIA.UIA

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -49,10 +49,8 @@ class consoleUIATextInfo(UIATextInfo):
 		if position == textInfos.POSITION_FIRST:
 			collapseToEnd = False
 		elif position == textInfos.POSITION_LAST:
-			# We must pull back the end by one character otherwise when we collapse to end,
-			# a console bug results in a textRange covering the entire console buffer!
-			# Strangely the *very* last character is a special blank point
-			# so we never seem to miss a real character.
+			# The exclusive end hangs off the end of the visible ranges.
+			# Move back one character to remain within bounds.
 			_rangeObj.MoveEndpointByUnit(
 				UIAHandler.TextPatternRangeEndpoint_End,
 				UIAHandler.NVDAUnitsToUIAUnits['character'],
@@ -366,13 +364,6 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		movement."""
 		return consoleUIATextInfo if self.is21H1Plus else consoleUIATextInfoPre21H1
 
-	def _getTextLines(self):
-		# This override of _getTextLines takes advantage of the fact that
-		# the console text contains linefeeds for every line
-		# Thus a simple string splitlines is much faster than splitting by unit line.
-		ti = self.makeTextInfo(textInfos.POSITION_ALL)
-		text = ti.text or ""
-		return text.splitlines()
 
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.MD. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Fixes microsoft/terminal#5481. Blocking #10964.

### Summary of the issue:
In an old implementation of NVDA's UIA console support, we originally used the standard `_getTextLines` implementation, which called `getTextInChunks` to get each line from the console according to UIA. This was extremely slow to run over the entire buffer, so we switched to getting all text and calling `splitlines`, which was much faster.

In pre-21H1 UIA console, every line ended with a newline character. In 21H1 console, new text can wrap across lines, so every line doesn't necessarily end in a newline. This makes `splitlines` inadequate for 21H1: when text wraps, NVDA starts reading from the beginning of the visible text for every new line of output!

### Description of how this pull request fixes the issue:
This PR:

* Disables the `_getTextLines` override on the 21H1 UIA console. Pre-21H1 is entirely unaffected.
* Clarifies a comment in initialization at `POSITION_LAST` based on a conversation with @carlos-zamora.

### Testing performed:
Re-tested the case in microsoft/terminal#5481 and verified that it is no longer reproducible.

### Known issues with pull request:
None.

### Change log entry:
None needed.