### PR TITLE
Don't ever correct focus back to a UIA element that is not native or is from a window we have marked as bad UIA

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1046,7 +1046,6 @@ class UIA(Window):
 		Cached values of these properties will be available for the remainder of the current core cycle. After that, new values will be fetched.
 		@type initialUIACachedPropertyIDs: L{UIAHandler.IUIAutomationCacheRequest}
 		"""
-		self._initialStack = "\n".join(traceback.format_stack()[:-1])
 		if not UIAElement:
 			raise ValueError("needs a UIA element")
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -6,7 +6,6 @@
 
 """Support for UI Automation (UIA) controls."""
 
-import traceback
 from ctypes import byref
 from ctypes.wintypes import POINT, RECT
 from comtypes import COMError

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -35,6 +35,8 @@ What's New in NVDA
 - It is now possible to enter number 6 in computer braille from a braille keyboard on HIMS displays. (#11710)
 - Major performance improvements in Azure Data Studio. (#11533, #11715)
 - With "Attempt to Cancel speech for expired focus events" enabled the title of the NVDA Find dialog is announced again. (#11632)
+- NVDA should no longer freeze when waking the computer and focus lands in a Microsoft Edge document. (#11576)
+- It is no longer necessary to press tab or move focus after closing a context menu in MS Edge for browse mode to be functional again. (#11202)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #11202
Fixes #11536 
Partial fix for #11576 

### Summary of the issue:
NVDA can sometimes focus content in MS Edge / Chromium using UI automation, even though we have specifically disabled using UI Automation for Chrome in favor of IAccessible2.
This can happen either: 
* when waking the computer / unlocking, and focus straight away goes to within a document in Edge such as in #11576
* When focus goes back to document content in Edge after closing a context menu such as in #11202
* in Edge when a node in the document disappears and the web author does not first move focus somewhere else such as in #11536.
 
In all cases, the user may only notice that browseMode no longer works unless they tab or move focus once, but in the worse case, due to either bugs in Edge's UIA implementation or in NVDA's UIA rich text fetching code, NVDA may completely freeze. The freeze is partly why we disabled using UIA in Chromium in the first place.

In all cases, the following steps occur:
* The object (or Window) that had focus is destroyed, but NVDA still considers it the focused object as there has not been a new focus event yet.
* NVDA tries to locate the actual focus by asking the OS for the window with focus.
* This window apparently natively supports UI Automation. In this case it is a "Chrome_WidgetWin_1" window.
* In NVDAObjects.UIA.UIA.kwargsFromSuper: NVDA asks the OS for the UI Automation element with focus. In this case it gets back a link or other document content from Edge.
* NVDA however does not bother checking if this UIA element is a usable UIA element (I.e. it is not proxied, and we have not marked its window as being bad etc).

Like with similar code that asks the OS for an object at particular hittesting coordinates, it should ensure the UIA element it gets back is usable (UIAHandler.handler.isNativeUIAElement) and if it is not, it should return False, and thus Window NVDAObject will go on and try the focus according to MSAA.

### Description of how this pull request fixes the issue:
Add the needed check to NVDAObjects.UIA.UIA.kwargsFromSuper

### Testing performed:
* Logged into twitter.com in MS Edge 85 and focused a link. Put the computer to sleep and woke it up and unlocked the Windows session. Focus was restored to the link in Twitter, and it was confirmed that MSAA (not UIA) was used, by pressing NVDA+f1 and looking at the dev info.
* Logged into twitter.com with MS Edge 85 and focused a link in the document. Pressed the applications key to bring up the context menu. Pressed escape to close the context menu. Focus went back to the link, and it was confirmed that MSAA (not UIA) was used, by looking at the dev info with NVDA+f1.

### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* NVDA should no longer freeze when waking the computer and focus lands in a Microsoft Edge document. (#11576)
* It is no longer necessary to press tab or move focus after closing a context menu in MS Edge for browse mode to be functional again. (#11202)
