### PR TITLE
Fix access to content of 64-bit syslistview32 controls

### DIFF
--- a/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.acf
+++ b/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.acf
@@ -20,6 +20,7 @@ interface NvdaInProcUtils {
 	[fault_status,comm_status] winword_getTextInRange();
 	[fault_status,comm_status] winword_moveByLine();
 	[fault_status,comm_status] sysListView32_getGroupInfo();
+	[fault_status,comm_status] sysListView32_getColumnContent();
 	[fault_status,comm_status] getActiveObject();
 	[fault_status,comm_status] dumpOnCrash();
 	[fault_status,comm_status] IA2Text_findContentDescendant();

--- a/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
+++ b/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2006-2018 NVDA contributers.
+Copyright 2006-2020 NV Access Limited, Leonard de Ruijter.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 cpp_quote("/*")
 cpp_quote("This file is a part of the NVDA project.")
 cpp_quote("URL: http://www.nvda-project.org/")
-cpp_quote("Copyright 2006-2010 NVDA contributers.")
+cpp_quote("Copyright 2006-2020 NV Access Limited, Leonard de Ruijter.
 cpp_quote("This program is free software: you can redistribute it and/or modify")
 cpp_quote("it under the terms of the GNU General Public License version 2.0, as published by")
 cpp_quote("the Free Software Foundation.")
@@ -65,6 +65,8 @@ interface NvdaInProcUtils {
 	error_status_t winword_moveByLine([in] const unsigned long windowHandle, [in] const int offset, [in] const int moveBack, [out] int* newOffset);
 
 	error_status_t sysListView32_getGroupInfo([in] const unsigned long windowHandle, [in] int groupIndex,  [out,string] BSTR* header, [out,string] BSTR* footer, [out] int* state);
+
+	error_status_t sysListView32_getColumnContent([in] const unsigned long windowHandle, [in] int item,  [in] int subItem, [out,string] BSTR* text);
 
 	error_status_t getActiveObject([in] handle_t bindingHandle, [in,string] const wchar_t* progid, [out] IUnknown** ppUnknown);
 

--- a/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
+++ b/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 cpp_quote("/*")
 cpp_quote("This file is a part of the NVDA project.")
 cpp_quote("URL: http://www.nvda-project.org/")
-cpp_quote("Copyright 2006-2020 NV Access Limited, Leonard de Ruijter.
+cpp_quote("Copyright 2006-2020 NV Access Limited, Leonard de Ruijter.")
 cpp_quote("This program is free software: you can redistribute it and/or modify")
 cpp_quote("it under the terms of the GNU General Public License version 2.0, as published by")
 cpp_quote("the Free Software Foundation.")

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -9,6 +9,7 @@ EXPORTS
 	nvdaInProcUtils_registerNVDAProcess
 	nvdaInProcUtils_unregisterNVDAProcess
 	nvdaInProcUtils_sysListView32_getGroupInfo
+	nvdaInProcUtils_sysListView32_getColumnContent
 	nvdaInProcUtils_dumpOnCrash
 	nvdaInProcUtils_IA2Text_findContentDescendant
 	nvdaInProcUtils_getActiveObject

--- a/nvdaHelper/remote/sysListView32.cpp
+++ b/nvdaHelper/remote/sysListView32.cpp
@@ -19,6 +19,12 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <common/log.h>
 #include "nvdaInProcUtils.h"
 
+// #7828: Windows headers define this as 260 characters.
+// However this is not long enough for modern Twitter clients that need at least 280 characters.
+// Therefore, round it up to the nearest power of 2.
+#undef CBEMAXSTRLEN
+#define CBEMAXSTRLEN 512
+
 error_status_t nvdaInProcUtils_sysListView32_getGroupInfo(handle_t bindingHandle, const unsigned long windowHandle, int groupIndex, BSTR* header, BSTR* footer, int* state) {
 	LVGROUP group={0};
 	group.cbSize=sizeof(group);
@@ -39,8 +45,8 @@ error_status_t nvdaInProcUtils_sysListView32_getColumnContent(handle_t bindingHa
 	lvItem.mask = LVIF_TEXT | LVIF_COLUMNS;
 	lvItem.iItem = item;
 	lvItem.iSubItem = subItem;
-	lvItem.cchTextMax = 512;
-	wchar_t textBuf[512];
+	lvItem.cchTextMax = CBEMAXSTRLEN;
+	wchar_t textBuf[CBEMAXSTRLEN];
 	lvItem.pszText= textBuf;
 	if (!SendMessage((HWND)UlongToHandle(windowHandle), LVM_GETITEM, (WPARAM)0, (LPARAM)&lvItem)) {
 		LOG_DEBUGWARNING(L"LVM_GETITEM failed");

--- a/nvdaHelper/remote/sysListView32.cpp
+++ b/nvdaHelper/remote/sysListView32.cpp
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2006-2010 NVDA contributers.
+Copyright 2006-2020 NV Access Limited, Leonard de Ruijter.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -31,5 +31,25 @@ error_status_t nvdaInProcUtils_sysListView32_getGroupInfo(handle_t bindingHandle
 	if(group.pszHeader) *header=SysAllocString(group.pszHeader);
 	if(group.pszFooter) *footer=SysAllocString(group.pszFooter);
 	*state=group.state;
+	return 0;
+}
+
+error_status_t nvdaInProcUtils_sysListView32_getColumnContent(handle_t bindingHandle, const unsigned long windowHandle, int item, int subItem, BSTR* text) {
+	LVITEM lvItem = {0};
+	lvItem.mask = LVIF_TEXT | LVIF_COLUMNS;
+	lvItem.iItem = item;
+	lvItem.iSubItem = subItem;
+	lvItem.cchTextMax = 512;
+	wchar_t textBuf[512];
+	lvItem.pszText= textBuf;
+	if (!SendMessage((HWND)UlongToHandle(windowHandle), LVM_GETITEM, (WPARAM)0, (LPARAM)&lvItem)) {
+		LOG_DEBUGWARNING(L"LVM_GETITEM failed");
+		return 1;
+	}
+	if(!lvItem.pszText) {
+		LOG_DEBUGWARNING(L"LVM_GETITEM didn't retrieve any text");
+		return 1;
+	}
+	*text = SysAllocString(lvItem.pszText);
 	return 0;
 }

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -357,7 +357,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return self._getColumnLocationRaw(self.parent._columnOrderArray[column - 1])
 
 	def _getColumnContentRaw(self, index):
-		item = self.IAccessibleChildID -1 
+		item = self.IAccessibleChildID - 1
 		subItem = index
 		text = AutoFreeBSTR()
 		if watchdog.cancellableExecute(
@@ -366,7 +366,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			self.windowHandle,
 			item,
 			subItem,
-			byref(text)
+			ctypes.byref(text)
 		) != 0:
 			return None
 		return text.value

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -1,9 +1,7 @@
-# -*- coding: UTF-8 -*-
-#NVDAObjects/IAccessible/sysListView32.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import time
 from ctypes import *
@@ -359,6 +357,21 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return self._getColumnLocationRaw(self.parent._columnOrderArray[column - 1])
 
 	def _getColumnContentRaw(self, index):
+		item = self.IAccessibleChildID -1 
+		subItem = index
+		text = AutoFreeBSTR()
+		if watchdog.cancellableExecute(
+			NVDAHelper.localLib.nvdaInProcUtils_sysListView32_getColumnContent,
+			self.appModule.helperLocalBindingHandle,
+			self.windowHandle,
+			item,
+			subItem,
+			byref(text)
+		) != 0:
+			return None
+		return text.value
+
+	def _getColumnContentRawOutProc(self, index):
 		buffer=None
 		processHandle=self.processHandle
 		internalItem=winKernel.virtualAllocEx(processHandle,None,sizeof(self.LVITEM),winKernel.MEM_COMMIT,winKernel.PAGE_READWRITE)
@@ -379,7 +392,10 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return buffer.value if buffer else None
 
 	def _getColumnContent(self, column):
-		return self._getColumnContentRaw(self.parent._columnOrderArray[column - 1])
+		index = self.parent._columnOrderArray[column - 1]
+		if not self.appModule.helperLocalBindingHandle:
+			return self._getColumnContentRawOutProc(index)
+		return self._getColumnContentRaw(index)
 
 	def _getColumnImageIDRaw(self, index):
 		processHandle=self.processHandle

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -38,6 +38,7 @@ What's New in NVDA
 - With "Attempt to Cancel speech for expired focus events" enabled the title of the NVDA Find dialog is announced again. (#11632)
 - NVDA should no longer freeze when waking the computer and focus lands in a Microsoft Edge document. (#11576)
 - It is no longer necessary to press tab or move focus after closing a context menu in MS Edge for browse mode to be functional again. (#11202)
+- NVDA no longer fails to read items in list views within a 64-bit application such as Tortoise SVN. (#8175)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Supersedes #8190
Fixes #8175

### Summary of the issue:
For some list view controls in 64-bit programs, most notably TortoiseSVN, NVDA is unable to output the list items.

### Description of how this pull request fixes the issue:
Adds an in process implementation to fetch column contents.

### Testing performed:
Tested that output works in 64-bit TortoiseSVN list views when commuting changes.

### Known issues with pull request:
See  in line code comment.

### Change log entry:
* Bug fixes
    - NVDA no longer fails to read items in list views within a 64-bit application such as Tortoise SVN. (#8175)