### PR TITLE
Fix for last script count when an unbound gesture is executed between two identical bound gestures

### DIFF
--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -493,11 +493,6 @@ class InputManager(baseObject.AutoPropertyObject):
 
 		gesture.reportExtra()
 		
-		# Clear memorized last script to avoid getLastScriptRepeatCount detect a repeat
-		# in case an unbound gesture is executed between two identical bound gestures.
-		if not script:
-			scriptHandler.clearLastScript()
-		
 		# #2953: if an intercepted command Script (script that sends a gesture) is queued
 		# then queue all following gestures (that don't have a script) with a fake script so that they remain in order.
 		if not script and scriptHandler._numIncompleteInterceptedCommandScripts:
@@ -507,8 +502,11 @@ class InputManager(baseObject.AutoPropertyObject):
 		if script:
 			scriptHandler.queueScript(script, gesture)
 			return
-
-		raise NoInputGestureAction
+		else:
+			# Clear memorized last script to avoid getLastScriptRepeatCount detect a repeat
+			# in case an unbound gesture is executed between two identical bound gestures.
+			queueHandler.queueFunction(queueHandler.eventQueue, scriptHandler.clearLastScript)
+			raise NoInputGestureAction
 
 	def _get_isInputHelpActive(self):
 		"""Whether input help is enabled, wherein the function of each key pressed by the user is reported but not executed.

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -493,8 +493,8 @@ class InputManager(baseObject.AutoPropertyObject):
 
 		gesture.reportExtra()
 		
-		# Clear memorized last script to avoid getLastScriptRepeatCount return multiple press
-		# when an unbound gesture is executed between 2 bound gestures.
+		# Clear memorized last script to avoid getLastScriptRepeatCount detect a repeat
+		# in case an unbound gesture is executed between two identical bound gestures.
 		if not script:
 			scriptHandler.clearLastScript()
 		

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -492,7 +492,12 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.speakMessage, gesture.displayName)
 
 		gesture.reportExtra()
-
+		
+		# Clear memorized last script to avoid getLastScriptRepeatCount return multiple press
+		# when an unbound gesture is executed between 2 bound gestures.
+		if not script:
+			scriptHandler.clearLastScript()
+		
 		# #2953: if an intercepted command Script (script that sends a gesture) is queued
 		# then queue all following gestures (that don't have a script) with a fake script so that they remain in order.
 		if not script and scriptHandler._numIncompleteInterceptedCommandScripts:

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -226,7 +226,13 @@ def getLastScriptRepeatCount():
 
 
 def clearLastScript():
-	global _lastScriptRef, _lastScriptCount
+	"""Clears the variables that keeps track of the execution of duplicate scripts with in a certain amount of
+	time, so that next script execution will always be detected as a first execution of this script.
+	This function should only be called from the main thread.
+	"""
+
+	global _lastScriptTime, _lastScriptRef, _lastScriptCount
+	_lastScriptTime = 0
 	_lastScriptRef = None
 	_lastScriptCount = 0
 

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -224,10 +224,12 @@ def getLastScriptRepeatCount():
 	else:
 		return _lastScriptCount
 
+
 def clearLastScript():
 	global _lastScriptRef, _lastScriptCount
 	_lastScriptRef = None
 	_lastScriptCount = 0
+
 
 def isScriptWaiting():
 	return bool(_numScriptsQueued)

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -224,6 +224,11 @@ def getLastScriptRepeatCount():
 	else:
 		return _lastScriptCount
 
+def clearLastScript():
+	global _lastScriptRef, _lastScriptCount
+	_lastScriptRef = None
+	_lastScriptCount = 0
+
 def isScriptWaiting():
 	return bool(_numScriptsQueued)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,6 +42,7 @@ What's New in NVDA
 - NVDA no longer fails to read items in list views within a 64-bit application such as Tortoise SVN. (#8175)
 - ARIA treegrids are now exposed as normal tables in browse mode in both Firefox and Chrome. (#9715)
 - A reverse search can now be initiated with 'find previous' via NVDA+shift+F3 (#11770)
+- An NVDA script is no longer treated as being repeated if an unrelated key press happens in between the two executions of the script. (#11388) 
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:

Fixes #11388

### Summary of the issue:

scriptHandler.getLastScriptRepeatCount is used to detect double/triple press.
However, in the case described in #11388, the user presses 3 keystrokes quickly:
* NVDA+UpArrow
* F3
* NVDA+UpArrow
The first and the third are bound to a script but not the second.
Since the second keystroke is not bound to a script, NVDA does not detect it and thus consider that the 2 keystrokes of NVDA+UpArrow is a double key press.

### Description of how this pull request fixes the issue:

When a gesture that is not bound to a script is executed, clear the last script ref and count so that the subsequent script is not detected as a repeat.

### Testing performed:

* Tested the STR of #11388
* Tested normal double press (NVDA+T)
* Tested input help mode

### Known issues with pull request:

None

### Notes for reviewer

I would especially like to have the following points confirmed:
* where is the best place in executeGesture to call clearLastScript?
* which variables should be cleared in clearLastScript? Maybe I should also add _lastScriptTime? Or any other private variable located at the beginning of scriptHandler.py (after imports)

### Change log entry:

Section: Bug fixes

NVDA no longer detects repeated script gesture inappropriately when executing quickly some sequences of gestures. (#11388)

