### PR TITLE
Respect the search reverse direction when pressing NVDA+shift+F3 first call

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -33,11 +33,12 @@ class FindDialog(wx.Dialog):
 	"""A dialog used to specify text to find in a cursor manager.
 	"""
 
-	def __init__(self, parent, cursorManager, text, caseSensitivity):
+	def __init__(self, parent, cursorManager, text, caseSensitivity, reverse=False):
 		# Translators: Title of a dialog to find text.
 		super(FindDialog, self).__init__(parent, wx.ID_ANY, _("Find"))
 		# Have a copy of the active cursor manager, as this is needed later for finding text.
 		self.activeCursorManager = cursorManager
+		self.reverse = reverse
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		# Translators: Dialog text for NvDA's find command.
@@ -61,7 +62,7 @@ class FindDialog(wx.Dialog):
 		caseSensitive = self.caseSensitiveCheckBox.GetValue()
 		# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
 		# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
-		core.callLater(100, self.activeCursorManager.doFindText, text, caseSensitive=caseSensitive)
+		core.callLater(100, self.activeCursorManager.doFindText, text, caseSensitive=caseSensitive, reverse=self.reverse)
 		self.Destroy()
 
 	def onCancel(self, evt):
@@ -164,11 +165,11 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 		CursorManager._lastFindText=text
 		CursorManager._lastCaseSensitivity=caseSensitive
 
-	def script_find(self,gesture):
+	def script_find(self,gesture, reverse=False):
 		# #8566: We need this to be a modal dialog, but it mustn't block this script.
 		def run():
 			gui.mainFrame.prePopup()
-			d = FindDialog(gui.mainFrame, self, self._lastFindText, self._lastCaseSensitivity)
+			d = FindDialog(gui.mainFrame, self, self._lastFindText, self._lastCaseSensitivity, reverse)
 			d.ShowModal()
 			gui.mainFrame.postPopup()
 		wx.CallAfter(run)
@@ -203,7 +204,7 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 	)
 	def script_findPrevious(self,gesture):
 		if not self._lastFindText:
-			self.script_find(gesture)
+			self.script_find(gesture, reverse=True)
 			return
 		self.doFindText(
 			self._lastFindText,

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -62,7 +62,13 @@ class FindDialog(wx.Dialog):
 		caseSensitive = self.caseSensitiveCheckBox.GetValue()
 		# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
 		# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
-		core.callLater(100, self.activeCursorManager.doFindText, text, caseSensitive=caseSensitive, reverse=self.reverse)
+		core.callLater(
+			100,
+			self.activeCursorManager.doFindText,
+			text,
+			caseSensitive=caseSensitive,
+			reverse=self.reverse
+		)
 		self.Destroy()
 
 	def onCancel(self, evt):
@@ -165,7 +171,7 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 		CursorManager._lastFindText=text
 		CursorManager._lastCaseSensitivity=caseSensitive
 
-	def script_find(self,gesture, reverse=False):
+	def script_find(self, gesture, reverse=False):
 		# #8566: We need this to be a modal dialog, but it mustn't block this script.
 		def run():
 			gui.mainFrame.prePopup()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -41,6 +41,7 @@ What's New in NVDA
 - It is no longer necessary to press tab or move focus after closing a context menu in MS Edge for browse mode to be functional again. (#11202)
 - NVDA no longer fails to read items in list views within a 64-bit application such as Tortoise SVN. (#8175)
 - ARIA treegrids are now exposed as normal tables in browse mode in both Firefox and Chrome. (#9715)
+- A reverse search can now be initiated with 'find previous' via NVDA+shift+F3 (#11770)
 
 
 == Changes for Developers ==


### PR DESCRIPTION

### Link to issue number:

Fixes #11770

### Summary of the issue:

When pressing NVDA+shift+F3 in browse mode for first time, the find dialog opens since nothing was searched before. However, the find dialog always considers that the term to find should be after the current cursor position.
In the case of NVDA+shift+F3 however, the user has clearly indicated that he wants to search backwards; this is not respected in this case.

### Description of how this pull request fixes the issue:

Add a boolean "reverse" parameter to the script_find and the FindDialog so that reverse searching can be honoured in this case.
This PR does the minimum to fix #11770.

Even if the FindDialog contains the information to know if search should be forward or backward (depending on how it was called), this information does not appear in the GUI and cannot be controlled/changed in the dialog.
This would be a new feature and may be the object of another PR if there is a need for it.

### Testing performed:

Tested these situations when nothing has been searched before:
* NVDA+ctrl+F (normal search)
* NVDA+F3 when there is something to find after current position
* NVDA+F3 when there is nothing to find after current position
* NVDA+shift+F3 when there is something to find after current position
* NVDA+shift+F3 when there is nothing to find after current position
Also tested these cases when something has been already searched before.

### Known issues with pull request:

None

### Change log entry:


Section: Bug fixes

The backward search direction is now respected when calling find previous script as first search action. (#11770)

Note: feel free to rephrase this change log entry; I did not find better.


