### PR TITLE
Fix system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -80,6 +80,33 @@ class ChromeLib:
 			f.write(fileContents)
 		return filePath
 
+	def _wasStartMarkerSpoken(self, speech: str):
+		if not "document" in speech:
+			return False
+		documentIndex = speech.index("document")
+		marker = ChromeLib._beforeMarker
+		return marker in speech and documentIndex < speech.index(marker)
+
+	def _moveToStartMarker(self, spy):
+		""" Press F6 until the start marker is spoken
+		@param spy:
+		@type spy: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
+		@return: None
+		"""
+		for i in range(10):  # set a limit on the number of tries.
+			# Small changes in Chrome mean the number of tab presses to get into the document can vary.
+			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
+			actualSpeech = self.getSpeechAfterKey('f6')
+			if self._wasStartMarkerSpoken(actualSpeech):
+				break
+		else:  # Exceeded the number of tries
+			spy.dump_speech_to_log()
+			builtIn.fail(
+				"Unable to tab to 'before sample' marker."
+				f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
+				" See NVDA log for full speech."
+			)
+
 	def prepareChrome(self, testCase: str) -> None:
 		"""
 		Starts Chrome opening a file containing the HTML sample
@@ -97,24 +124,14 @@ class ChromeLib:
 		# If this continues to be unreliable we could use solenium or similar to start chrome and inform us when
 		# it is ready.
 		applicationTitle = f"{self._testCaseTitle}"
-		spy.wait_for_specific_speech(applicationTitle)
+		appTitleIndex = spy.wait_for_specific_speech(applicationTitle)
 		# Read all is configured, but just test interacting with the sample.
 		spy.wait_for_speech_to_finish()
 
-		# move to start marker
-		for i in range(10):  # set a limit on the number of tries.
-			# Small changes in Chrome mean the number of tab presses to get into the document can vary.
-			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
-			actualSpeech = self.getSpeechAfterKey('f6')
-			if ChromeLib._beforeMarker in actualSpeech:
-				break
-		else:  # Exceeded the number of tries
-			spy.dump_speech_to_log()
-			builtIn.fail(
-				"Unable to tab to 'before sample' marker."
-				f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
-				" See NVDA log for full speech."
-			)
+		afterTitleSpeech = spy.get_speech_at_index_until_now(appTitleIndex)
+		if not self._wasStartMarkerSpoken(afterTitleSpeech):
+			self._moveToStartMarker(spy)
+
 
 	@staticmethod
 	def getSpeechAfterKey(key) -> str:

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -81,7 +81,7 @@ class ChromeLib:
 		return filePath
 
 	def _wasStartMarkerSpoken(self, speech: str):
-		if not "document" in speech:
+		if "document" not in speech:
 			return False
 		documentIndex = speech.index("document")
 		marker = ChromeLib._beforeMarker

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -125,7 +125,7 @@ class ChromeLib:
 		spy.wait_for_speech_to_finish()
 		nextSpeechIndex = spy.get_next_speech_index()
 		spy.emulateKeyPress(key)
-		spy.wait_for_speech_to_finish()
+		spy.wait_for_speech_to_finish(speechStartedIndex=nextSpeechIndex)
 		speech = spy.get_speech_at_index_until_now(nextSpeechIndex)
 		return speech
 

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -114,9 +114,11 @@ class NVDASpyLib:
 					return index
 			return -1
 
-	def _hasSpeechFinished(self):
+	def _hasSpeechFinished(self, speechStartedIndex: Optional[int] = None):
 		with self._speechLock:
-			return self.SPEECH_HAS_FINISHED_SECONDS < _timer() - self._lastSpeechTime_requiresLock
+			started = speechStartedIndex is None or speechStartedIndex < self.get_next_speech_index()
+			finished = self.SPEECH_HAS_FINISHED_SECONDS < _timer() - self._lastSpeechTime_requiresLock
+			return started and finished
 
 	def _devInfoToLog(self):
 		import api
@@ -202,9 +204,13 @@ class NVDASpyLib:
 			)
 		return speechIndex
 
-	def wait_for_speech_to_finish(self, maxWaitSeconds=5.0):
+	def wait_for_speech_to_finish(
+			self,
+			maxWaitSeconds=5.0,
+			speechStartedIndex: Optional[int] = None
+	):
 		_blockUntilConditionMet(
-			getValue=self._hasSpeechFinished,
+			getValue=lambda: self._hasSpeechFinished(speechStartedIndex=speechStartedIndex),
 			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),
 			errorMessage="Speech did not finish before timeout"
 		)

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -39,6 +39,11 @@ To run a single test, add the `--test` argument (wildcards accepted).
 python -m robot --test "starts" ...
 ```
 
+To run all tests with a particular tag use `-i`:
+```
+python -m robot -i "chrome" ...
+```
+
 Other options exit for specifying tests to run (e.g. by suite, tag, etc).
 Consult `python -m robot --help`
 

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -38,5 +38,4 @@ pr11606
 ARIA treegrid
 	[Documentation]	Ensure that ARIA treegrids are accessible as a standard table in browse mode.
 	# Excluded due to regular failures.
-	[Tags]	excluded_from_build
 	test_ariaTreeGrid_browseMode


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.MD. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Following https://github.com/nvaccess/nvda/pull/11765
and many other recent system test failures.

### Summary of the issue:
Several system tests were failing intermittently. 

It looked like the focus was initially in the document, then NVDA presses 'F6' then 'h' very rapidly, then the address bar is announced. Based on the following log:

```
DEBUG - virtualBuffers.VirtualBuffer._loadBuffer (15:39:08.077) - NVDAObjects.IAccessible.chromium.VirtualBuffer.loadBuffer (2804):
Buffer load took 0.000 sec, 23 chars
IO - speech.speak (15:39:08.139) - MainThread (4028):
Speaking [LangChangeCommand ('en'), 'NVDA Browser Test Case', 'document']
IO - speech.speak (15:39:08.139) - MainThread (4028):
Speaking [LangChangeCommand ('en'), 'Before Test Case Marker']
IO - inputCore.InputManager.executeGesture (15:39:08.139) - Thread-1 (4376):
Input: kb(desktop):f6
DEBUG - speech.manager.SpeechManager._handleIndex (15:39:08.155) - MainThread (4028):
Unknown index 5, speech probably cancelled from main thread.
IO - inputCore.InputManager.executeGesture (15:39:08.671) - Thread-1 (4376):
Input: kb(desktop):h
IO - speech.speak (15:39:08.921) - MainThread (4028):
Speaking [LangChangeCommand ('en'), 'Address and search bar', 'edit', 'has auto complete', 'Ctrl+L', 'selected file:///C:/Users/appveyor/AppData/Local/Temp/1/tmpf_1ge_8k/test.html']
IO - speech.speak (15:39:08.985) - MainThread (4028):
Speaking [LangChangeCommand ('en'), 'frame', 'main landmark', 'Treegrid Email Inbox Example', 'heading', 'level 1']
```

Looking at [this build failure](https://ci.appveyor.com/project/NVAccess/nvda/builds/35828669/artifacts)
- Note it seems to take a few rounds of pressing F6 to find the start marker, this will make more sense in a moment.
- It looks like `wait_for_speech_to_finish`, is not waiting long enough. By interleaving the logs from Robot and NVDA (based on timestamp), you can see that `get_speech_at_index_until_now` is called before speech is produced. See interleaved log below (Robot log lines are prefixed with 'robot' for clarity)
- The reason this happens is that it has already been more than 0.5 seconds since the last speech but the new speech has not yet started (to restart the timer). The test should wait for speech to start, before it waits for it to stop. 

```
IO - speech.speak (12:16:58.266) - MainThread (2824):
Speaking [LangChangeCommand ('en'), 'Before Test Case Marker']    
robot 14:16:58.859 INFO emulateKeyPress ('tab',)
IO - inputCore.InputManager.executeGesture (12:16:58.862) - Thread-1 (3696):
Input: kb(desktop):tab  
robot 14:16:59.021 INFO wait_for_speech_to_finish
robot 14:16:59.028 INFO get_speech_at_index_until_now (12,)
robot 14:16:59.034 DEBUG Argument types are:<type 'unicode'><type 'unicode'>
robot 14:16:59.034 INFO repr of actual vs expected (ignore_case=False):''vs'Simulate evil cat check box not checked'
DEBUG - speech.getControlFieldSpeech (12:16:59.060) - MainThread (2824):
Skipping name sequence: control field is labelled by content
IO - speech.speak (12:16:59.061) - MainThread (2824):
Speaking [LangChangeCommand ('en'), 'Simulate evil cat', 'check box', 'not checked']
WARNING - stdout (12:16:59.233) - Thread-1 (3696):
Robot Framework remote server at 127.0.0.1:8270 stopped.
```

I also noticed that a mistake was made when using `threading.Lock()`, which creates a lock instance that can be used as a context manager. The Python docs are a little confusing here, more examples would help.

I ran this a number of times locally and found that sometimes the URL gets focus and other times the document does, this is strange but quite possibly outside of our control. However, even when the document received the initial focus, we used `F6` to cycle through until the document is focused again.

### Description of how this pull request fixes the issue:
- Use a single `RLock` object to protect the speech cache. Note that the speech cache is only updated by NVDA threads, and the read access (via various Robot Library commands) will all be from the Robot Remote Server thread.
- Added an argument to be able to specify the speech index that should be considered speech starting. Then the pattern can become: "get next index", "complete action which triggers speech", "wait for speech to finish after the index"
- When the document has focus, continue on with the test.
- Re-enabled the the aria treegrid test.

### Testing performed:
- Ran tests locally.
- PR tests should pass.

### Known issues with pull request:
None

### Change log entry:
None

