### PR TITLE
languageHandler.getAvailableLanguages: use globalVars.appDir rather than depending on the current directory 

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -14,6 +14,7 @@ import sys
 import ctypes
 import locale
 import gettext
+import globalVars
 
 #a few Windows locale constants
 LOCALE_SLANGUAGE=0x2
@@ -95,8 +96,13 @@ def getAvailableLanguages(presentational=False):
 	@rtype: list of tuples
 	"""
 	#Make a list of all the locales found in NVDA's locale dir
-	locales = [x for x in os.listdir('locale') if not x.startswith('.')]
-	locales = [x for x in locales if os.path.isfile('locale/%s/LC_MESSAGES/nvda.mo'%x)]
+	localesDir = os.path.join(globalVars.appDir, 'locale')
+	locales = [
+		x for x in os.listdir(localesDir) if (
+			not x.startswith('.')
+			and os.path.isfile(os.path.join(localesDir, x, 'lc_messages', 'nvda.mo'))
+		)
+	]
 	#Make sure that en (english) is in the list as it may not have any locale files, but is default
 	if 'en' not in locales:
 		locales.append('en')

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -98,10 +98,7 @@ def getAvailableLanguages(presentational=False):
 	#Make a list of all the locales found in NVDA's locale dir
 	localesDir = os.path.join(globalVars.appDir, 'locale')
 	locales = [
-		x for x in os.listdir(localesDir) if (
-			not x.startswith('.')
-			and os.path.isfile(os.path.join(localesDir, x, 'lc_messages', 'nvda.mo'))
-		)
+		x for x in os.listdir(localesDir) if os.path.isfile(os.path.join(localesDir, x, 'LC_MESSAGES', 'nvda.mo'))
 	]
 	#Make sure that en (english) is in the list as it may not have any locale files, but is default
 	if 'en' not in locales:


### PR DESCRIPTION
### Link to issue number:
Following on from pr #11650 

### Summary of the issue:
Pr #11650 aimed to remove all dependence on the current directory being set to NVDA's application directory.
However,  another place where we depend on the current directory has been identified:
languageHandler.getAvailableLanguages assumes the 'locale' directory is in the current directory. This should be changed to use globalVars.appDir.
If the current directory is changed to something else, such as when running SAPI5 voices from harposoftware, it is impossible to open the NVDA settings dialog set to the General settings panel as it cannot populate the languages dropdown list. And once this fails, it is then impossible to open Settings ever again until restarting NVDA, as it thinks that the settings dialog is still open.
 
### Description of how this pull request fixes the issue:
Changed languageHandler.getAvailableLanguages to use globalVars.appDir rather than the current directory when listing locales.

### Testing performed:
Ran NvDA with the Ivona voice from Harposoftware, and opened the NVDA settings dialog set to the General settings panel by pressing NvDA+control+g. The panel correctly opens and the language list is populated.
 
### Known issues with pull request:
None.

### Change log entry:
None needed.