### PR TITLE
System test interference

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -39,6 +39,11 @@ class ChromeLib:
 	def _getTestCasePath(filename):
 		return _pJoin(ChromeLib._testFileStagingPath, filename)
 
+	def exit_chrome(self):
+		spy = _NvdaLib.getSpyLib()
+		spy.emulateKeyPress('control+w')
+		process.wait_for_process(self.chromeHandle, timeout="1 minute", on_timeout="continue")
+
 	def start_chrome(self, filePath):
 		builtIn.log(f"starting chrome: {filePath}")
 		self.chromeHandle = process.start_process(

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -114,6 +114,9 @@ class ChromeLib:
 		"""
 		spy = _NvdaLib.getSpyLib()
 		path = self._writeTestFile(testCase)
+
+		spy.wait_for_speech_to_finish()
+		nextSpeechIndex = spy.get_next_speech_index()
 		self.start_chrome(path)
 		# Ensure chrome started
 		# Different versions of chrome have variations in how the title is presented
@@ -124,8 +127,7 @@ class ChromeLib:
 		# If this continues to be unreliable we could use solenium or similar to start chrome and inform us when
 		# it is ready.
 		applicationTitle = f"{self._testCaseTitle}"
-		appTitleIndex = spy.wait_for_specific_speech(applicationTitle)
-		# Read all is configured, but just test interacting with the sample.
+		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=nextSpeechIndex)
 		spy.wait_for_speech_to_finish()
 
 		afterTitleSpeech = spy.get_speech_at_index_until_now(appTitleIndex)

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -269,7 +269,7 @@ class SystemTestSpyServer(globalPluginHandler.GlobalPlugin):
 			serve=False  # we want to start this serving on another thread so as not to block.
 		)
 		log.debug("Server address: {}".format(server.server_address))
-		server_thread = threading.Thread(target=server.serve)
+		server_thread = threading.Thread(target=server.serve, name="RF Test Spy Thread")
 		server_thread.start()
 
 	def terminate(self):

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -19,6 +19,7 @@ Test Teardown	default teardown
 default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
+	exit chrome
 	quit NVDA
 
 *** Test Cases ***


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.MD. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Intermittent system test failures such as: https://ci.appveyor.com/project/NVAccess/nvda/builds/35969586/tests

### Summary of the issue:
This seems to occur due to interference between tests. Chrome test cases are not closed when the test is complete, then when NVDA starts again for the next test it will read the foreground window (the previous test case in Chrome). The title of the window is used to determine if the test case has opened. This introduces a race condition between launching the new test case, and the next step after verifying the window is opened. 

### Description of how this pull request fixes the issue:

- Only consider speech that occurs after launching the test case while determining if Chrome has loaded the test case.
- Close Chrome after the test is complete. Just the tab is closed with <kbd>control+w</kbd>.

I noticed that when I used cmd in Windows Terminal to run the tests, I occasionally had NVDA freeze. I didn't notice it happen when I used only the console (conhost / cmd.exe). I spent some time to see if I could programmatically ensure that all windows were minimized before each test starts. With the expectation that the desktop would provide the benefit of a more consistent starting point for the tests. I found I could toggle "show desktop" but not query the current state easily. I used the following to toggle the state ([win32 shell toggleDesktop on msdn](https://docs.microsoft.com/en-us/windows/win32/shell/ishelldispatch4-toggledesktop)):

``` python
def show_desktop(self):
	import comtypes
	_shell = comtypes.client.CreateObject("shell.application", dynamic=True)
	_shell.ToggleDesktop()
```

### Testing performed:
Ran locally.
Result of the PR build

### Known issues with pull request:
None

### Change log entry:
None

