### PR TITLE
Script to toggle marked (highlighted) text reporting.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -406,6 +406,24 @@ class GlobalCommands(ScriptableObject):
 	# Translators: Input help mode message for toggle report emphasis command.
 	script_toggleReportEmphasis.__doc__=_("Toggles on and off the reporting of emphasis")
 	script_toggleReportEmphasis.category=SCRCAT_DOCUMENTFORMATTING
+	
+	@script(
+		# Translators: Input help mode message for toggle report marked (highlighted) content command.
+		description=_("Toggles on and off the reporting of marked (highlighted) text"),
+		category=SCRCAT_DOCUMENTFORMATTING,
+	)
+	def script_toggleReportHighlightedText(self, gesture):
+		shouldReport: bool = not config.conf["documentFormatting"]["reportHighlight"]
+		config.conf["documentFormatting"]["reportHighlight"] = shouldReport
+		if shouldReport:
+			# Translators: The message announced when toggling the report marked (highlighted text)
+			# document formatting setting.
+			state = _("report marked (highlighted) text on")
+		else:
+			# Translators: The message announced when toggling the report marked (highlighted text)
+			# document formatting setting.
+			state = _("report marked (highlighted) text off")
+		ui.message(state)	
 
 	def script_toggleReportColor(self,gesture):
 		if config.conf["documentFormatting"]["reportColor"]:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -423,7 +423,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: The message announced when toggling the report marked (highlighted text)
 			# document formatting setting.
 			state = _("report marked (highlighted) text off")
-		ui.message(state)	
+		ui.message(state)
 
 	def script_toggleReportColor(self,gesture):
 		if config.conf["documentFormatting"]["reportColor"]:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -409,20 +409,18 @@ class GlobalCommands(ScriptableObject):
 	
 	@script(
 		# Translators: Input help mode message for toggle report marked (highlighted) content command.
-		description=_("Toggles on and off the reporting of marked (highlighted) text"),
+		description=_("Toggles on and off the reporting of marked text"),
 		category=SCRCAT_DOCUMENTFORMATTING,
 	)
 	def script_toggleReportHighlightedText(self, gesture):
 		shouldReport: bool = not config.conf["documentFormatting"]["reportHighlight"]
 		config.conf["documentFormatting"]["reportHighlight"] = shouldReport
 		if shouldReport:
-			# Translators: The message announced when toggling the report marked (highlighted text)
-			# document formatting setting.
-			state = _("report marked (highlighted) text on")
+			# Translators: The message announced when toggling the report marked document formatting setting.
+			state = _("report marked on")
 		else:
-			# Translators: The message announced when toggling the report marked (highlighted text)
-			# document formatting setting.
-			state = _("report marked (highlighted) text off")
+			# Translators: The message announced when toggling the report marked document formatting setting.
+			state = _("report marked off")
 		ui.message(state)
 
 	def script_toggleReportColor(self,gesture):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2123,7 +2123,7 @@ class DocumentFormattingPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
-		highlightText = _("Marked (highlighted text)")
+		highlightText = _("Mar&ked (highlighted text)")
 		self.highlightCheckBox = fontGroup.addItem(
 			wx.CheckBox(self, label=highlightText)
 		)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,6 +13,7 @@ What's New in NVDA
   - Specifically grouping errors are now detected.
 - Added support for the new chinese Traditional Quick and Pinyin Input methods in Windows 10. (#11562)
 - Tab headers are now considered form fields with quick navigation f key. (#10432)
+- Added a command to toggle reporting of marked (highlighted) text; There is no default associated gesture. (#11807)
 
 
 == Changes ==


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

In #11436, the 'Marked (highlighted) text' option has been added to Document formatting settings panel. 
Almost all document formatting settings option have a corresponding script. However in the case of marked text, there is no way to toggle this option quickly:
* there is no associated script to toggle this option
* there is even no accelerator key in the document formatting settings panel

When adding an option to document formatting settings, it seems important to me to have the corresponding toggle script since formatting reporting is only useful in some cases.

### Description of how this pull request fixes the issue:

1. Added the script to toggle this option in globalCommands.py. I have taken example on script_toggleReportSuperscriptsAndSubscripts since this script was recently added and reviewed in #10985. This script is unassigned by default.
2. Added an accelerator key to 'Marked (highlighted) text' in the Document formatting settings panel. The letter K was choosen. It is also associated to 'clickable' checkbox. However, the Document formatting panel has many options and almost all letter of the alphabet are already defined as accelerator. It is still better than no accelerator at all.

### Testing performed:

1. Assigned the script, used it and checked opening the doc formatting settings panel the checkbox corresponding to this option.
2. pressed alt+k in the doc formatting settings panel and checked that the focus moved to 'Marked text' checkbox.

### Known issues with pull request:

None

### Change log entry:

Section: New feature

`Added a command to toggle reporting of marked (highlighted) text; no default associated gesture.`
