### PR TITLE
Disable labels with the controls they are associated with

### DIFF
--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -182,7 +182,9 @@ class BaseLabeledControl:
 		"""
 		self.label = wx.StaticText(parent, label=labelText)
 		if self.__class__ == BaseLabeledControl:
-			raise TypeError(f"BaseLabeledControl should be subclassed and should also inherit from {wxCtrlClass.__name__}.")
+			raise TypeError(
+				f"BaseLabeledControl should be subclassed and should also inherit from {wxCtrlClass.__name__}."
+			)
 		# Check that the final class also inherits from wxCtrlClass
 		if not isinstance(self, wxCtrlClass):
 			raise TypeError(f"{self.__class__.__name__} should be a subclass of {wxCtrlClass.__name__}.")
@@ -192,7 +194,7 @@ class BaseLabeledControl:
 	def Enable(self, state):
 		self.controlClass.Enable(self, state)
 		self.label.Enable(state)
-		
+
 	def Disable(self):
 		self.controlClass.Disable(self)
 		self.label.Disable()

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -154,6 +154,50 @@ def associateElements( firstElement, secondElement):
 
 	return sizer
 
+
+class BaseLabeledControl:
+	"""Base class used to create a labeled control subclass
+	A labeled control subclass allows to create a control with an associated label.
+	The associated label is enabled and disabled when the main control is enabled or disabled (respectively).
+	
+	Example usage:
+	
+	class LabeledChoice(BaseLabeledControl, wx.Choice):
+		pass
+	myChoice = LabeledChoice(
+		parent,
+		labelText='Choose an option',
+		wxCtrlClass=wx.Choice,
+		choices=['Option 1', 'Option 2', 'Option 3'],
+	)
+	"""
+
+	def __init__(self, parent, labelText, wxCtrlClass, **kwargs):
+		""" @param parent: An instance of the parent wx window. EG wx.Dialog
+			@param labelText: The text to associate with a wx control.
+			@type labelText: string
+			@param wxCtrlClass: The class to associate with the label, eg: wx.TextCtrl
+			@type wxCtrlClass: class
+			@param kwargs: The keyword arguments used to instantiate the wxCtrlClass
+		"""
+		self.label = wx.StaticText(parent, label=labelText)
+		if self.__class__ == BaseLabeledControl:
+			raise TypeError(f"BaseLabeledControl should be subclassed and should also inherit from {wxCtrlClass.__name__}.")
+		# Check that the final class also inherits from wxCtrlClass
+		if not isinstance(self, wxCtrlClass):
+			raise TypeError(f"{self.__class__.__name__} should be a subclass of {wxCtrlClass.__name__}.")
+		self.controlClass = wxCtrlClass
+		self.controlClass.__init__(self, parent, **kwargs)
+
+	def Enable(self, state):
+		self.controlClass.Enable(self, state)
+		self.label.Enable(state)
+		
+	def Disable(self):
+		self.controlClass.Disable(self)
+		self.label.Disable()
+
+
 class LabeledControlHelper(object):
 	""" Represents a Labeled Control. Provides a class to create and hold on to the objects and automatically associate
 	the two controls together.
@@ -168,9 +212,16 @@ class LabeledControlHelper(object):
 			@param kwargs: The keyword arguments used to instantiate the wxCtrlClass
 		"""
 		object.__init__(self)
-		self._label = wx.StaticText(parent, label=labelText)
-		self._ctrl = wxCtrlClass(parent, **kwargs)
-		self._sizer = associateElements(self._label, self._ctrl)
+		# Dynamically create a class inheriting from BaseLabeledControl and wxCtrlClass.
+		# This class acts as wxCtrlClass but overloads the Enable and Disable methods
+		# in order to also enable or disable self._label at the same time as the control.
+		LabeledControl = type(
+			f'Labeled{wxCtrlClass.__name__}',
+			(BaseLabeledControl, wxCtrlClass),
+			{},
+		)
+		self._ctrl = LabeledControl(parent, labelText=labelText, wxCtrlClass=wxCtrlClass, **kwargs)
+		self._sizer = associateElements(self._ctrl.label, self._ctrl)
 
 	@property
 	def control(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ What's New in NVDA
 - In Mozilla Firefox and Chromium based browsers, updates to ARIA live regions are now suppressed when reporting of dynamic content changes is disabled. (#9077)
 - NVDA will now report "Copied to clipboard" before the copied text. (#6757)
 - Presentation of graphical view table in disk management has been improved. (#10048)
+- Labels for controls are now disabled (greyed out) when the control is disabled. (#11809)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
### Link to issue number:

Fixes #11809

### Summary of the issue:

When some UI controls such as combo-box or edit field are disabled (greyed out), the associated label remains enabled. For low vision people this makes it harder to detect that the option has been disabled. Keeping the label enabled also lets the accelerator key active; thus pressing this acccelerator will make the focus jump to the next focusable control that is not disabled. This is an unexpected behaviour.

### Description of how this pull request fixes the issue:

guiHelper.LabeledControlHelper.control now returns an object whose class inherit both from BaseLabeledControl and the wxCtrlClass class that was passed to the constructor.
This object behaves the same way as the wxCtrlClass except for Enable and Disable methods.
The new BaseLabeledControl class contains the code to manage enabling and disabling the (main) control as well as the associated label. See the example in the BaseLabeledControl doc string for usage.
Thus any labeled controls that was created by guiHelper.LabeledControlHelper in the UI disables or enables its associated label along with itself.

### Testing performed:

In the Braille settings panel:
* Played with the "Show cursor" and "Blink" options and checked visually in the 3 options below that the labels were disabled and enabled along with the control they are associated with.
* For these 3 options, tried their access key and checked that the focus only moves if the option is enabled.

### Notes

I am not an expert in advanced concepts ofOOP Python object programming. Thus, any comment to refine my code is welcome. Especially:
* The check in the __init__ method of BaseLabeledControl may be an indication that I did not use the appropriate OOP tools. Maybe abstract classes? I am not used to them.
* Passing wxCtrlClass to the __init__ method of BaseLabeledControl seems a bit strange to me. Indeed, BaseLabeledControl should always be subclassed to a class that should also inherit from wxCtrlClass. Thus the information seems rendundant. Any other way to do?

Moreover the group name in the advanced setting panel are not greyed out with the rest of the panel. I do not know how to grey it out and, reading the Wx Python documentation, it seems this is an intended behaviour. So I did not dig further.

### Known issues with pull request:

None

### Change log entry:

Not needed.

Cc @feerenrut for review.

