### PR TITLE
Restore the ability to report Emphasis formatting

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2139,6 +2139,7 @@ def getFormatFieldSpeech(  # noqa: C901
 				# Translators: Reported when text is no longer marked
 				else _("not marked"))
 			textList.append(text)
+	if formatConfig["reportEmphasis"]:
 		# strong text
 		strong=attrs.get("strong")
 		oldStrong=attrsCache.get("strong") if attrsCache is not None else None

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ What's New in NVDA
 - ARIA treegrids are now exposed as normal tables in browse mode in both Firefox and Chrome. (#9715)
 - A reverse search can now be initiated with 'find previous' via NVDA+shift+F3 (#11770)
 - An NVDA script is no longer treated as being repeated if an unrelated key press happens in between the two executions of the script. (#11388) 
+- Strong and emphasis tags in Internet Explorer can again be suppressed from being reported by returning off Report Emphasis in NVDA's Document Formatting settings. (#11808)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:

Fixes #11808
Closes #11640
Fix-up of #11436

### Summary of the issue:

When #11436 was merged, the check of formatConfig["reportEmphasis"] in getFormatFieldSpeech (speech\__init__.py) was dropped. Thus the Emphasis checkbox in doc formatting settings did not control anything more and reporting of emphasised and strong formatting were controlled by 'Marked' checkbox state.
This was clearly not the intent of this PR if you read the first point of "Known issues" paragraph in the initial description.

### Description of how this pull request fixes the issue:

Restored the dropped code line.

### Testing performed:

* Tested in IE that emphasis and strong are reported when Emphasis document formatting checkbox is checked.
* Tested in IE that marked is stilll reported when Marked document formatting checkbox is checked.
It was tested on [this document](https://github.com/nvaccess/nvda/files/5490739/ExEmphasisAndMarkedText.html.txt).

### Known issues with pull request:

Emphasis or strong, reported when respectively <em> or <strong> tags are encountered, are only reported in Internet Explorer. This seemed however to be already the case also before the regression, i.e. in NVDA 2020.2.

### Change log entry:

Section: Bug fixes

`Restored the ability to report Emphase formatting. (#11808, #11640)`

Cc @michaelDCurran to confirm this PR conforms to his initial intention.

