### PR TITLE
Add a specific debug channel for frequent synthDriver log messages

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -246,6 +246,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	vision = boolean(default=false)
 	speech = boolean(default=false)
 	speechManager = boolean(default=false)
+	synthDriver = boolean(default=false)
 	nvwave = boolean(default=false)
 
 [uwpOcr]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2603,6 +2603,7 @@ class AdvancedPanelControls(wx.Panel):
 			"vision",
 			"speech",
 			"speechManager",
+			"synthDriver",
 			"nvwave",
 		]
 		# Translators: This is the label for a list in the

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -490,6 +490,10 @@ def handlePostConfigProfileSwitch(resetSpeechIfNeeded=True):
 	_curSynth.loadSettings(onlyChanged=True)
 
 
+def isDebugForSynthDriver():
+	return config.conf["debugLog"]["synthDriver"]
+
+
 #: Notifies when a synthesizer reaches an index during speech.
 #: Handlers are called with these keyword arguments:
 #: synth: The L{SynthDriver} which reached the index.


### PR DESCRIPTION
### Link to issue number:

Fixes #11574

### Summary of the issue:

When merging #11582 the nvwave debug log messages have been isolated in a specific 'nvwave' debug log category (in advanced settings panel).
However the frequent debug messages of OneCore driver are still logged at debug level and are really frequent, which makes debugging something else difficult.

### Description of how this pull request fixes the issue:

* As discussed in #11574, I have isolated the OneCore debug log messages in their own 'synthDriver' log category. 
* I have put the isDebugForSynthDriver function in the synthDriverHandler.py file so that it may be used by other synth drivers as well.
* For now, only OneCore has filtered debug messages. The only other synth that has debug messages is sapi5; however the message is not frequent at all (only at initialization), so I did not put it in the synthDriver log channel.

### Testing performed:

Used OneCore with the synthDriver log category enabled or disabled. And checked that the messages are logged or not respectively. The only message that I have not been able to check is "Cancelled, stopped pushing audio".

### Known issues with pull request:

None

### Change log entry:

Since #11582 did not specify a change log, I would not add it here either.


