### PR TITLE
Ignore redundant winEvents proxied from UIA on EXCEL7 windows

### DIFF
--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -129,6 +129,18 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 			return
 
 		windowClassName = winUser.getClassName(window)
+		# Excel produces UI automation events
+		# Which are proxied by Windows into MSAA winEvents.
+		# However in certain builds of Excel 2016
+		# calling UIAHasServerSideProvider on the EXCEL7 window in responce to these events
+		# causes a freeze of several seconds.
+		# As we don't need these MSAA events for our Excel support, just ignore them early.
+		if windowClassName == "EXCEL7" and objectID > 0:
+			log.debug(
+				f"Dropping UIA proxied event for Excel7 window. "
+				f"WinEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
+			)
+			return
 		if windowClassName == "ConsoleWindowClass":
 			# #10113: we need to use winEvents to track the real thread for console windows.
 			consoleWindowsToThreadIDs[window] = threadID


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None

### Summary of the issue:
when the selection / focus moves between cells on an Excel sheet (EXCEL7 window), Excel's UI Automation implementation fires appropriate selection / focus events. Although there is separate work to support Excel in NvDA via UI automation, at the moment Excel is supported via its object model and MSAA. But, as Excel fires these UI Automation events, Windows proxies them to MSAA winEvents. Not only do we have no use for them as we handle selection / focus tracking in Excel cells entirely with the keyboard, these winEvents are broken in that trying to fetch an IAccessible object from them always fails, but more importantly, fetching, and checking if the winEvent should be dropped as it in deed did come from UIA causes a freeze of several seconds on some machines.

I am unable to reproduce the freeze myself, but can at least see the redundant events.

The user who reported this via email was running Windows 10.0.17763 and Office  365 MSO (16.0.11929.20966) 32-bit.

### Description of how this pull request fixes the issue:
Simply ignore all winEvents from EXCEL7 windows with an objectID greater than 0 as these are all proxied from UI Automation and we do not expect or need them.
We actually only expect a focus winEvent when the sheet gets focus, and anything else is not expected as historically Excel never fired any more winEvents than that. Thus all the winEvents now coming from its UI Automation implementation are redundant and cause a performance hit.

### Testing performed:
Tested Excel locally by moving selection / focus between cells with the arrow keys and made sure that NVDA still reported the cells.
Provided multiple try builds to the user to test, and they reported that the freezes disappeared for them.
 
### Known issues with pull request:
None.

### Change log entry:
Bug fixes:
* A freeze of several seconds experienced by a small amount of users when arrowing between cells in Excel should no longer occur. 