### PR TITLE
Detect Humanware Brailliant BI 40X and 20X via both USB and Bluetooth

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -465,6 +465,8 @@ addUsbDevices("brailliantB", KEY_HID, {
 	"VID_1C71&PID_CE01",  # NLS eReader 20 HID
 	"VID_1C71&PID_C006", # Brailliant BI 32, 40 and 80
 	"VID_1C71&PID_C022", # Brailliant BI 14
+	"VID_1C71&PID_C131",  # Brailliant BI 40X
+	"VID_1C71&PID_C141",  # Brailliant BI 20X
 	"VID_1C71&PID_C00A", # BrailleNote Touch
 	"VID_1C71&PID_C00E",  # BrailleNote Touch v2
 })
@@ -491,6 +493,8 @@ addBluetoothDevices(
 			"Humanware BrailleOne",
 			"NLS eReader",
 			"NLS eReader Humanware",
+			"Brailliant BI 40X",
+			"Brailliant BI 20X",
 		)
 	)
 )

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,6 +16,7 @@ What's New in NVDA
 - Added a command to toggle reporting of marked (highlighted) text; There is no default associated gesture. (#11807)
 - Added the --copy-portable-config command line parameter that allows you to automatically copy the provided configuration to the user account when silently installing NVDA. (#9676)
 - Braille routing is now supported with the Braille Viewer for mouse users, hover to route to a braille cell. (#11804)
+- NVDA will now automatically detect the Humanware Brailliant BI 40X and 20X devices via both USB and Bluetooth. (#11819)
 
 
 == Changes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2519,7 +2519,7 @@ Please see the display's documentation for descriptions of where these keys can 
 %kc:endInclude
 
 ++ HumanWare Brailliant BI/B Series / BrailleNote Touch  ++[HumanWareBrailliant]
-The Brailliant BI and B series of displays  from [HumanWare https://www.humanware.com/], including the BI 14, BI 32, BI 40 and B 80, are supported when connected via USB or bluetooth.
+The Brailliant BI and B series of displays  from [HumanWare https://www.humanware.com/], including the BI 14, BI 32, BI 20X, BI 40, BI 40X and B 80, are supported when connected via USB or bluetooth.
 If connecting via USB with the protocol set to HumanWare, you must first install the USB drivers provided by the manufacturer.
 USB drivers are not required if the protocol is set to OpenBraille.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None.

### Summary of the issue:
Humanware BI 40X and 20X devices should be automatically detected via USB and Bluetooth.

### Description of how this pull request fixes the issue:
Maps their respective USB IDs and Bluetooth names to our existing brailliantB driver.

### Testing performed:
None - we don't have access to the devices, but we are informed these are compatible with the other Brailliant BI devices.
 
### Known issues with pull request:
None.

### Change log entry:
New features:
- NVDA will automatically detect the Humanware BI 40X and 20X devices via both USB and Bluetooth.