### PR TITLE
App module for Winword to gather the code specific to MSWord

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1372,24 +1372,6 @@ class WordDocument(Window):
 		# Translators: a message when increasing or decreasing font size in Microsoft Word
 		ui.message(_("{size:g} point font").format(size=val))
 
-	def script_toggleChangeTracking(self, gesture):
-		if not self.WinwordDocumentObject:
-			# We cannot fetch the Word object model, so we therefore cannot report the status change.
-			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,
-			# or it's within Windows Defender Application Guard.
-			# In this case, just let the gesture through and don't report anything.
-			return gesture.send()
-		val = self._WaitForValueChangeForAction(
-			lambda: gesture.send(),
-			lambda: self.WinwordDocumentObject.TrackRevisions
-		)
-		if val:
-			# Translators: a message when toggling change tracking in Microsoft word
-			ui.message(_("Change tracking on"))
-		else:
-			# Translators: a message when toggling change tracking in Microsoft word
-			ui.message(_("Change tracking off"))
-
 	@script(gesture="kb:control+shift+8")
 	def script_toggleDisplayNonprintingCharacters(self, gesture):
 		if not self.WinwordWindowObject:
@@ -1514,7 +1496,6 @@ class WordDocument(Window):
 		"kb:control+1":"changeLineSpacing",
 		"kb:control+2":"changeLineSpacing",
 		"kb:control+5":"changeLineSpacing",
-		"kb:control+shift+e": "toggleChangeTracking",
 		"kb:control+pageUp": "caret_moveByLine",
 		"kb:control+pageDown": "caret_moveByLine",
 	}

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -1,0 +1,43 @@
+# appModules/winword.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 NV Access Limited.
+
+""" App module for Microsoft Word.
+Word and Outlook share a lot of code and components. This app module gathers the code that is relevant for
+Microsoft Word only.
+"""
+
+import appModuleHandler
+from scriptHandler import script
+import ui
+from NVDAObjects.IAccessible.winword import WordDocument
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if WordDocument in clsList:
+			clsList.insert(0, WinwordWordDocument)
+
+
+class WinwordWordDocument(WordDocument):
+
+	@script(gesture="kb:control+shift+e")
+	def script_toggleChangeTracking(self, gesture):
+		if not self.WinwordDocumentObject:
+			# We cannot fetch the Word object model, so we therefore cannot report the status change.
+			# The object model may be unavailable because it's within Windows Defender Application Guard.
+			# In this case, just let the gesture through and don't report anything.
+			return gesture.send()
+		val = self._WaitForValueChangeForAction(
+			lambda: gesture.send(),
+			lambda: self.WinwordDocumentObject.TrackRevisions
+		)
+		if val:
+			# Translators: a message when toggling change tracking in Microsoft word
+			ui.message(_("Change tracking on"))
+		else:
+			# Translators: a message when toggling change tracking in Microsoft word
+			ui.message(_("Change tracking off"))

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -1,8 +1,7 @@
-# appModules/winword.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2020 NV Access Limited.
+# Copyright (C) 2019-2020 NV Access Limited, Cyrille Bougot
 
 """ App module for Microsoft Word.
 Word and Outlook share a lot of code and components. This app module gathers the code that is relevant for

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,12 +56,14 @@ What's New in NVDA
 - A freeze of several seconds experienced by a small amount of users when arrowing between cells in Excel should no longer occur. (#11818)
 - In Microsoft Teams builds with version numbers like 1.3.00.28xxx, NVDA no longer fails reading messages in chats or Teams channels due to an incorrectly focused menu. (#11821)
 - Text marked both as being a spelling and grammar error at the same time in Google Chrome will be appropriately announced as both a spelling and grammar error by NVDA. (#11787)
+- When using Outlook (French locale), the shortcut for 'Reply all' (control+shift+R) works again. (#11196)
 
 
 == Changes for Developers ==
 - System tests can now send keys using spy.emulateKeyPress, which takes a key identifier that conforms to NVDA's own key names, and by default also blocks until the action is executed. (#11581)
 - NVDA no longer requires the current directory to be the NVDA application directory in order to function. (#6491)
 - The aria live politeness setting for live regions can now be found on NVDA Objects using the liveRegionPoliteness property. (#11596)
+- It is now possible to define separate gestures for Outlook and Word document. (#11196)
 
 
 = 2020.3 =


### PR DESCRIPTION
### Link to issue number:

Fixes #11196 (with adapted translation for the `gestures.ini` file)

### Summary of the issue:

The NVDAObjects\window\winword.WordDocument class gathers some scripts that apply to word documents either in MS Word than in MS Outlook.
For Outlook, there is a specific app module defining among others a WordDocument subclass embedding the code specific to Outlook that does not apply to word.
However a subclass of NVDAObjects\window\winword.WordDocument applying to MS Word document only (i.e. not to Outlook one) is missing to embed code that applies to Word but not to Outlook. I have found two cases where it is missing.

#### Case 1: script toggleChangeTracking

Since change tracking is a Word only feature, the toggleChangeTracking script should not be called in Outlook. When using French MS Office and NVDA, we have control+shift+R being the shortcut for change tracking toggle in MS Word, but control+shift+R is the shortcut for "Reply all" in Outlook. This may cause unexpected errors (see #11196  for details).

Sometimes also one can hear a part of change tracking state reporting when pressing control+shift+R (reply all); this is however interrupted by new focused message window.

#### Case 2: script toggleAlignment

Toggle paragraph alignment commands exist both in Word and Outlook. However in French version they do not have exactly the same shortcuts (Office 2016):

| Command | Word | Outlook |
| --- | --- | --- |
| Align left | control+shift+G | control+L |
| Align right | control+shift+D | control+R or control+shift+G |

In present version however, NVDA does not allow to assign separate shortcuts for Word or Outlook.

### Description of how this pull request fixes the issue:

* Created a specific app module for MS Word.
* The code common to MS Word and other applications (such as MS Outlook) should not be stored in this module but in shared files such as NVDAObjects/window/winword.py and similar.
* For now this appModule contains only the toggleChangeTracking script since this feature is available in Word only.

When `gestures.ini` is translated accordingly, this will solve the case 1.

Regarding case 2, NVDA's French `gestures.ini` file may modified to associate scripts only where applicable (Word, Outlook or Word+Outlook), provided that all versions of Office have the same shortcuts. If this is not the case, the modifications may still be done at user level in the personal `gestures.ini`file. I will investigate this point with other French translators and users.

### Testing performed:

Just for test purpose, I have modified the French gesture.ini as follows:
```
diff --git a/source/locale/fr/gestures.ini b/source/locale/fr/gestures.ini
index 200ad026e..d8c78a736 100644
--- a/source/locale/fr/gestures.ini
+++ b/source/locale/fr/gestures.ini
@@ -9,11 +9,14 @@
 	toggleRightMouseButton = kb(laptop):nvda+control+*
 
 [NVDAObjects.window.winword.WordDocument]
-	None = kb:control+b, kb:control+[, kb:control+], "kb:control+shift+,", kb:control+shift+., kb:control+l, kb:control+r, kb:control+shift+e, kb:control+1, kb:control+alt+2
+	None = kb:control+b, kb:control+[, kb:control+], "kb:control+shift+,", kb:control+shift+., kb:control+shift+e, kb:control+1, kb:control+alt+2
 	increaseDecreaseFontSize = kb:control+shift+<, kb:control+<, kb:control+alt+<, kb:control+alt+shift+<
 	toggleBold = kb:control+g, kb:control+shift+b
-	toggleAlignment = kb:control+shift+g, kb:control+shift+d
+	toggleAlignment = kb:control+shift+d
+[appModules.winword.WinwordWordDocument]
+	None = kb:control+l, kb:control+r
 	toggleChangeTracking = kb:control+shift+r
+	toggleAlignment = kb:control+shift+g, 
 [NVDAObjects.window.excel.ExcelWorksheet]
 	changeSelection= kb:control+*
``` 	

Or download the modified French `gestures.ini` file
[gestures.ini.txt](https://github.com/nvaccess/nvda/files/5513449/gestures.ini.txt).

The changes in the modified `gestures.ini`file are the following:
* Created a new section `[appModules.winword.WinwordWordDocument]`.
* Moved the changeTracking script remapping in this section
* Unmapped kb:control+l and kb:control+r in this section rather than in `[NVDAObjects.window.winword.WordDocument]`
* Moved `toggleAlignment` mapping to `kb:control+shift+g` in this section rather than in `[NVDAObjects.window.winword.WordDocument]`

With this file, I have checked that:
* control+shift+R calls toggleChangeTracking script only in MS Word and not in Outlook: the change tracking status is not reported anymore in Outlook.
* All the scripts in the table of Case 2 description are now reporting paragraph alignment.

### Known issues with pull request:

* French `gesture.ini` need to be modified accordingly; I will take care of it
* Maybe some other language translators will need to make some equivalent changes. I will send a message to translation mailing list when alpha is merged to beta for new translation.
* There may be some NVDA add-on for Word, at least in French community there is [Word Access Enhancement](https://github.com/paulber19/wordAccessEnhancementNVDAAddon) from @paulber19. Author(s) of these add-ons will need to take into account that word has noww a built-in app module.

### Change log entry:

Bug fixes:
`In Outlook French version, the shortcut for 'Reply all' (control+shift+R) should be working again. (#11196)`

Changes for developers:
`It is now possible to define separate gestures for Outlook and Word document. (#11196)`
