### PR TITLE
Chrome system tests - off by one error

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -121,7 +121,7 @@ class ChromeLib:
 		path = self._writeTestFile(testCase)
 
 		spy.wait_for_speech_to_finish()
-		nextSpeechIndex = spy.get_next_speech_index()
+		lastSpeechIndex = spy.get_last_speech_index()
 		self.start_chrome(path)
 		# Ensure chrome started
 		# Different versions of chrome have variations in how the title is presented
@@ -132,7 +132,7 @@ class ChromeLib:
 		# If this continues to be unreliable we could use solenium or similar to start chrome and inform us when
 		# it is ready.
 		applicationTitle = f"{self._testCaseTitle}"
-		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=nextSpeechIndex)
+		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
 		spy.wait_for_speech_to_finish()
 
 		afterTitleSpeech = spy.get_speech_at_index_until_now(appTitleIndex)


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:
The system tests occasionally fail due to an off by one error when finding the application title.

### Description of how this pull request fixes the issue:
Rather than pass the index of the next speech to be generated, and expecting the speech for the title of the application to be after that, pass the index of the last speech. The title speech could be the very next utterance.

### Testing performed:
- Ran the test 50 times locally without failure.
- PR build should pass

### Known issues with pull request:
None

### Change log entry:
None

