### PR TITLE
Experimentially add a system test for APG checkbox

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -289,6 +289,7 @@ def test_ariaTreeGrid_browseMode():
 		])
 	)
 
+
 def test_ariaCheckbox_browseMode():
 	"""
 	Navigate to an unchecked checkbox in reading mode.

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -238,7 +238,7 @@ def test_ariaTreeGrid_browseMode():
 	testFile = os.path.join(ARIAExamplesDir, "treegrid", "treegrid-1.html")
 	_chrome.prepareChrome(
 		f"""
-			<iframe src="{testFile}" />
+			<iframe src="{testFile}"></iframe>
 		"""
 	)
 	# Jump to the first heading in the iframe.
@@ -287,4 +287,27 @@ def test_ariaTreeGrid_browseMode():
 			# Focus lands on row 2
 			"level 1  Treegrids are awesome Want to learn how to use them? aaron at thegoogle dot rocks  expanded",
 		])
+	)
+
+def test_ariaCheckbox_browseMode():
+	"""
+	Navigate to an unchecked checkbox in reading mode.
+	"""
+	testFile = os.path.join(ARIAExamplesDir, "checkbox", "checkbox-1", "checkbox-1.html")
+	_chrome.prepareChrome(
+		f"""
+			<iframe src="{testFile}"></iframe>
+		"""
+	)
+	# Jump to the first heading in the iframe.
+	actualSpeech = _chrome.getSpeechAfterKey("h")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  main landmark  Checkbox Example (Two State)  heading  level 1"
+	)
+	# Navigate to the checkbox.
+	actualSpeech = _chrome.getSpeechAfterKey("x")
+	_asserts.strings_match(
+		actualSpeech,
+		"Sandwich Condiments  grouping  list  with 4 items  Lettuce  check box  not checked"
 	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -40,3 +40,6 @@ ARIA treegrid
 	[Documentation]	Ensure that ARIA treegrids are accessible as a standard table in browse mode.
 	# Excluded due to regular failures.
 	test_ariaTreeGrid_browseMode
+ARIA checkbox
+	[Documentation]	Navigate to an unchecked checkbox in reading mode.
+	test_ariaCheckbox_browseMode

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -42,4 +42,5 @@ ARIA treegrid
 	test_ariaTreeGrid_browseMode
 ARIA checkbox
 	[Documentation]	Navigate to an unchecked checkbox in reading mode.
+	[Tags]	aria-at
 	test_ariaCheckbox_browseMode


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

### Summary of the issue:
This is an addition of a system test using the APG "checkbox" example, following the assertions from ARIA AT for the first test for this APG example: https://w3c.github.io/aria-at/tests/checkbox/index.html

The approach for this PR is the same as the existing APG test. However, to make it more scalable and maintainable, I'd like to explore other ways to run the ARIA AT tests. I can report a new issue to discuss this further.

### Description of how this pull request fixes the issue:

### Testing performed:
Ran `scons systemTests` locally.

### Known issues with pull request:

### Change log entry:

Section: New features, Changes, Bug fixes

