### PR TITLE
Fix up of 11738: Force UIA for BrokenCommctrl5Item controls, even though they don't support UIA natively

### DIFF
--- a/source/NVDAObjects/IAccessible/sysTreeView32.py
+++ b/source/NVDAObjects/IAccessible/sysTreeView32.py
@@ -1,8 +1,7 @@
-#NVDAObjects/IAccessible/sysTreeView32.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2007-2010 Michael Curran <mick@kulgan.net>, James Teh <jamie@jantrid.net>
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2007-2020 NV Access Limited
 
 from ctypes import *
 from ctypes.wintypes import *
@@ -222,10 +221,10 @@ class BrokenCommctrl5Item(IAccessible):
 			if parent and parent.hasFocus:
 				try:
 					kwargs = {}
-					UIA.kwargsFromSuper(kwargs, relation="focus")
+					UIA.kwargsFromSuper(kwargs, relation="focus", ignoreNonNativeElementsWithFocus=False)
 					self._uiaObj = UIA(**kwargs)
-				except:
-					log.debugWarning("Retrieving UIA focus failed", exc_info=True)
+				except Exception:
+					log.error("Retrieving UIA focus failed", exc_info=True)
 
 	def _get_role(self):
 		return self._uiaObj.role if self._uiaObj else controlTypes.ROLE_UNKNOWN

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1016,7 +1016,7 @@ class UIA(Window):
 				log.debugWarning("getFocusedElement failed", exc_info=True)
 				return False
 			# Ignore this object if it is non native.
-			if not UIAHandler.handler.isNativeUIAElement(UIAElement) and ignoreNonNativeElementsWithFocus:
+			if ignoreNonNativeElementsWithFocus and not UIAHandler.handler.isNativeUIAElement(UIAElement):
 				if UIAHandler._isDebug():
 					log.debug(
 						"kwargsFromSuper: ignoring non native element with focus"

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -993,7 +993,7 @@ class UIA(Window):
 						clsList.remove(x)
 
 	@classmethod
-	def kwargsFromSuper(cls,kwargs,relation=None):
+	def kwargsFromSuper(cls, kwargs, relation=None, ignoreNonNativeElementsWithFocus=True):
 		UIAElement=None
 		windowHandle=kwargs.get('windowHandle')
 		if isinstance(relation,tuple):
@@ -1016,7 +1016,7 @@ class UIA(Window):
 				log.debugWarning("getFocusedElement failed", exc_info=True)
 				return False
 			# Ignore this object if it is non native.
-			if not UIAHandler.handler.isNativeUIAElement(UIAElement):
+			if not UIAHandler.handler.isNativeUIAElement(UIAElement) and ignoreNonNativeElementsWithFocus:
 				if UIAHandler._isDebug():
 					log.debug(
 						"kwargsFromSuper: ignoring non native element with focus"


### PR DESCRIPTION

### Link to issue number:
Fixes #11797
### Summary of the issue:
In #11738 before using UIA for a particular control we added a check to ensure that the control in question supports UIA natively. This unfortunately broke access to tree view items used in Windows HTML help since for these controls we're using UIA explicitly even  though they're not native (MSAA is broken for them).

### Description of how this pull request fixes the issue:
I've added additional kwarg to `UIA.kwargsFromSuper` which allows to disable this check for a particular control and disabled it for `BrokenCommctrl5Item`. While at it I've also made error logged when we cannot get UIA element for these tree view items an error rather than debugWarning to make debugging such issues easier in the future.
### Testing performed:
Ensured that tree view items in HTML help are once again readable.
### Known issues with pull request:
None known
### Change log entry:
None needed - this bug is not in a release yet.