### PR TITLE
Fix-up of PR #8818: Remove unused imports

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1339,8 +1339,6 @@ class GlobalCommands(ScriptableObject):
 			parent=parent.parent
 		if parent:
 			parent.treeInterceptor.rootNVDAObject.setFocus()
-			import eventHandler
-			import wx
 			# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
 			# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
 			core.callLater(50,eventHandler.executeEvent,"gainFocus",parent.treeInterceptor.rootNVDAObject)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Fix-up of PR #8818

### Summary of the issue:

PR #8818 changed calls to `wx.CallLater` into calls to `core.callLater`.
An unused late import of `wx` has been left away.

### Description of how this pull request fixes the issue:

Removed the unused late import of `wx`.
While at it, also removed an unused late import of `eventHandler` the line above: `eventHandler` is already imported globally at the start of this module.

### Testing performed:

### Known issues with pull request:

### Change log entry:

I don't think this deserves a change log entry.