### PR TITLE
Fix-up of PR #8393: Fix broken support for container AutoPropertyObject

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -21,7 +21,7 @@ class Getter(object):
 	def __get__(self,instance,owner):
 		if isinstance(self.fget, classmethod):
 			return self.fget.__get__(instance, owner)()
-		elif not instance:
+		elif instance is None:
 			return self
 		return self.fget(instance)
 
@@ -37,7 +37,7 @@ class CachingGetter(Getter):
 		if isinstance(self.fget, classmethod):
 			log.warning("Class properties do not support caching")
 			return self.fget.__get__(instance, owner)()
-		elif not instance:
+		elif instance is None:
 			return self
 		return instance._getPropertyViaCache(self.fget)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Fix-up of PR #8393

### Summary of the issue:

As of PR #8393, `baseObjects.Getter` and `CachingGetter` now include in their `__get__` method a boolean-coercion test on the `AutoPropertyObject` instance.
This test, namely `if not instance`, fails in its purpose if ever the `AutoPropertyObject` defines either a `__len__` or a `__bool__` method.

Long story short, it has been the cause of a regression in WebAccess, where we historically used the `AutoPropertyObject` facility on objects that are also containers.


### Description of how this pull request fixes the issue:

Change the boolean-coercion test into a test for nullity: `if instance is None`.

### Testing performed:

### Known issues with pull request:

### Change log entry:

I don't think this deserves a change log entry.