### PR TITLE
Revert live region changes to mshtml virtual buffer

### DIFF
--- a/nvdaHelper/vbufBackends/mshtml/node.cpp
+++ b/nvdaHelper/vbufBackends/mshtml/node.cpp
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2006-2020 NV Access Limited, Google LLC, Leonard de Ruijter
+Copyright 2006-2015 NVDA contributers.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -20,7 +20,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <mshtmdid.h>
 #include <common/log.h>
 #include "mshtml.h"
-#include <remote/nvdaControllerInternal.h>
+#include <remote/nvdaController.h>
 #include <common/xml.h>
 #include "node.h"
 
@@ -124,15 +124,7 @@ class CDispatchChangeSink : public IDispatch {
 		if(dispIdMember==DISPID_EVMETH_ONPROPERTYCHANGE||dispIdMember==DISPID_EVMETH_ONLOAD) {
 			this->storageNode->backend->invalidateSubtree(this->storageNode);
 			// Force the update to happen with no delay if we happen to be in a live region
-			if (
-				this->storageNode->ariaLiveNode
-				&& this->storageNode->ariaLiveNode != this->storageNode
-				&& !this->storageNode->ariaLiveIsBusy
-				&& (
-					this->storageNode->ariaLiveIsTextRelevant
-					|| this->storageNode->ariaLiveIsAdditionsRelevant
-				)
-			) {
+			if(this->storageNode->ariaLiveNode&&this->storageNode->ariaLiveNode!=this->storageNode&&!this->storageNode->ariaLiveIsBusy&&(this->storageNode->ariaLiveIsTextRelevant||this->storageNode->ariaLiveIsAdditionsRelevant)) {
 				this->storageNode->backend->forceUpdate();
 			}
 			return S_OK;
@@ -274,15 +266,7 @@ class CHTMLChangeSink : public IHTMLChangeSink {
 			this->storageNode->backend->invalidateSubtree(invalidNode);
 			MshtmlVBufStorage_controlFieldNode_t* invalidMshtmlNode=(MshtmlVBufStorage_controlFieldNode_t*)invalidNode;
 			// Force the update to happen with no delay if we happen to be in a live region
-			if (
-				invalidMshtmlNode->ariaLiveNode
-				&& invalidMshtmlNode->ariaLiveNode != invalidMshtmlNode
-				&& !invalidMshtmlNode->ariaLiveIsBusy
-				&& (
-					invalidMshtmlNode->ariaLiveIsTextRelevant
-					|| invalidMshtmlNode->ariaLiveIsAdditionsRelevant
-				)
-			) {
+			if(invalidMshtmlNode->ariaLiveNode&&invalidMshtmlNode->ariaLiveNode!=invalidMshtmlNode&&!invalidMshtmlNode->ariaLiveIsBusy&&(invalidMshtmlNode->ariaLiveIsTextRelevant||invalidMshtmlNode->ariaLiveIsAdditionsRelevant)) {
 				this->storageNode->backend->forceUpdate();
 			}
 		}
@@ -369,18 +353,11 @@ MshtmlVBufStorage_controlFieldNode_t::~MshtmlVBufStorage_controlFieldNode_t() {
 }
 
 void MshtmlVBufStorage_controlFieldNode_t::preProcessLiveRegion(const MshtmlVBufStorage_controlFieldNode_t* parent, const std::map<std::wstring,std::wstring>& attribsMap) {
-	auto i=attribsMap.find(L"HTMLAttrib::aria-live");
+	 auto i=attribsMap.find(L"HTMLAttrib::aria-live");
 	if(i!=attribsMap.end()&&!i->second.empty()) {
-		bool isAriaLiveEnabled = i->second == L"polite" || i->second == L"assertive";
-		this->ariaLiveNode = isAriaLiveEnabled ? this : nullptr;
-		this->ariaLivePoliteness = i->second;
+		this->ariaLiveNode=((i->second.compare(L"polite")==0)||(i->second.compare(L"assertive")==0))?this:NULL;
 	} else {
-		this->ariaLiveNode = parent? parent->ariaLiveNode : nullptr;
-		if (this->ariaLiveNode) {
-			this->ariaLivePoliteness = this->ariaLiveNode->ariaLivePoliteness;
-		} else {
-			this->ariaLivePoliteness = nullptr;
-		}
+		this->ariaLiveNode=parent?parent->ariaLiveNode:NULL;
 	}
 	i=attribsMap.find(L"HTMLAttrib::aria-relevant");
 	if(i!=attribsMap.end()&&!i->second.empty()) {
@@ -407,13 +384,13 @@ void MshtmlVBufStorage_controlFieldNode_t::preProcessLiveRegion(const MshtmlVBuf
 	} else {
 		this->ariaLiveAtomicNode=parent?parent->ariaLiveAtomicNode:NULL;
 	}
-	LOG_DEBUG(L"preProcessLiveRegion: ariaLiveNode "<<ariaLiveNode<<L", ariaLiveIsTextRelevant "<<ariaLiveIsTextRelevant<<L", ariaLiveIsAdditionsRelevant "<<ariaLiveIsAdditionsRelevant<<L", ariaLiveIsBusy "<<ariaLiveIsBusy<<L", ariaLiveAtomicNode "<<ariaLiveAtomicNode);
+	//LOG_INFO(L"preProcessLiveRegion: ariaLiveNode "<<ariaLiveNode<<L", ariaLiveIsTextRelevant "<<ariaLiveIsTextRelevant<<L", ariaLiveIsAdditionsRelevant "<<ariaLiveIsAdditionsRelevant<<L", ariaLiveIsBusy "<<ariaLiveIsBusy<<L", ariaLiveAtomicNode "<<ariaLiveAtomicNode);
 }
 
-void MshtmlVBufStorage_controlFieldNode_t::reportLiveText(wstring& text, wstring& politeness) {
+void MshtmlVBufStorage_controlFieldNode_t::reportLiveText(wstring& text) {
 	for(auto c: text) {
 		if(!iswspace(c)) {
-			nvdaControllerInternal_reportLiveRegion(text.c_str(), politeness.c_str());
+			nvdaController_speakText(text.c_str());
 			break;
 		}
 	}
@@ -422,7 +399,7 @@ void MshtmlVBufStorage_controlFieldNode_t::reportLiveText(wstring& text, wstring
 bool isNodeInLiveRegion(VBufStorage_fieldNode_t* node) {
 	if(!node) return false;
 	if(node->getFirstChild()) {
-		return ((MshtmlVBufStorage_controlFieldNode_t*)node)->ariaLiveNode != nullptr;
+		return ((MshtmlVBufStorage_controlFieldNode_t*)node)->ariaLiveNode!=NULL;
 	}
 	return true;
 }
@@ -430,15 +407,13 @@ bool isNodeInLiveRegion(VBufStorage_fieldNode_t* node) {
 void MshtmlVBufStorage_controlFieldNode_t::reportLiveAddition() {
 	wstring text; //=(this->ariaLiveAtomicNode==this)?L"atomic: ":L"additions: ";
 	this->getTextInRange(0,this->getLength(),text,false,isNodeInLiveRegion);
-	this->reportLiveText(text, this->ariaLivePoliteness);
+	this->reportLiveText(text);
 }
 
 void MshtmlVBufStorage_controlFieldNode_t::postProcessLiveRegion(VBufStorage_controlFieldNode_t* oldNode, set<VBufStorage_controlFieldNode_t*>& atomicNodes) {
-	LOG_DEBUG(L"postProcessLiveRegion: ariaLiveNode "<<ariaLiveNode<<L", ariaLiveIsTextRelevant "<<ariaLiveIsTextRelevant<<L", ariaLiveIsAdditionsRelevant "<<ariaLiveIsAdditionsRelevant<<L", ariaLiveIsBusy "<<ariaLiveIsBusy<<L", ariaLiveAtomicNode "<<ariaLiveAtomicNode);
-	if (!this->ariaLiveNode || this->ariaLiveIsBusy) {
-		return;
-	}
-	bool reportNode=!oldNode && this->ariaLiveIsAdditionsRelevant && this->ariaLiveNode != this;
+	//LOG_INFO(L"preProcessLiveRegion: ariaLiveNode "<<ariaLiveNode<<L", ariaLiveIsTextRelevant "<<ariaLiveIsTextRelevant<<L", ariaLiveIsAdditionsRelevant "<<ariaLiveIsAdditionsRelevant<<L", ariaLiveIsBusy "<<ariaLiveIsBusy<<L", ariaLiveAtomicNode "<<ariaLiveAtomicNode);
+	if(!this->ariaLiveNode||this->ariaLiveIsBusy) return;
+	bool reportNode=!oldNode&&this->ariaLiveIsAdditionsRelevant&&this->ariaLiveNode!=this;
 	wstring newChildrenText;
 	if(!reportNode&&oldNode&&ariaLiveIsTextRelevant) {
 		// Find the first new text child
@@ -494,7 +469,7 @@ void MshtmlVBufStorage_controlFieldNode_t::postProcessLiveRegion(VBufStorage_con
 	} else if(reportNode) {
 		this->reportLiveAddition();
 	} else if(!newChildrenText.empty()) {
-		this->reportLiveText(newChildrenText, this->ariaLivePoliteness);
+		this->reportLiveText(newChildrenText);
 	}
 }
 

--- a/nvdaHelper/vbufBackends/mshtml/node.h
+++ b/nvdaHelper/vbufBackends/mshtml/node.h
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2006-2020 NV Access Limited, Google LLC, Leonard de Ruijter
+Copyright 2006-2015 NVDA contributers.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -31,14 +31,13 @@ class MshtmlVBufStorage_controlFieldNode_t : public VBufStorage_controlFieldNode
 	IHTMLChangeSink* pHTMLChangeSink;
 	DWORD HTMLChangeSinkCookey;
 	std::wstring language;
-	MshtmlVBufStorage_controlFieldNode_t* ariaLiveNode;
-	std::wstring ariaLivePoliteness;
+	VBufStorage_controlFieldNode_t*  ariaLiveNode;
 	unsigned int formatState;
 	bool ariaLiveIsTextRelevant;
 	bool ariaLiveIsAdditionsRelevant;
 	bool ariaLiveIsBusy;
 	VBufStorage_controlFieldNode_t*  ariaLiveAtomicNode;
-	void reportLiveText(std::wstring& text, std::wstring& politeness);
+	void reportLiveText(std::wstring& text);
 	void reportLiveAddition();
 	void preProcessLiveRegion(const MshtmlVBufStorage_controlFieldNode_t* parent, const std::map<std::wstring,std::wstring>& attribsMap);
 	void postProcessLiveRegion(VBufStorage_controlFieldNode_t* oldNode, std::set<VBufStorage_controlFieldNode_t*>& atomicNodes);

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,7 +24,7 @@ What's New in NVDA
 - For HIMS braille displays F3 has been remapped to Space + dots 148. (#11710)
 - Improvements to the UX of the "braille message timeout" and "Show messages indefinitely" options. (#11602)
 - In web browsers and other applications that support browse mode, the Elements List dialog (NVDA+F7) can now be invoked when in focus mode. (#10453)
-- Updates to ARIA live regions are now suppressed when reporting of dynamic content changes is disabled. (#9077)
+- In Mozilla Firefox and Chromium based browsers, updates to ARIA live regions are now suppressed when reporting of dynamic content changes is disabled. (#9077)
 - NVDA will now report "Copied to clipboard" before the copied text. (#6757)
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #11834

### Summary of the issue:
Changes in #9079 caused crashes in the virtual buffer code when viewing a browsable message.

### Description of how this pull request fixes the issue:
Revert the MSHTML changes from #9079. This means that we're still using the new live region code in Firefox and Chrome. While this introduces an inconsistency, I think there are several justifications.

1. The mshtml vbuf is used less frequently than the Gecko vbuf
2. I'm intending to investigate the issue, though I'm not at all skilled to operate a debugger with NVDA. But at least, we now have an easy method to trigger the issue.

### Testing performed:
Tested that browseable messages no longer crash.

### Known issues with pull request:
None

### Change log entry:
In pr, as it modifies an existing entry.