### PR TITLE
Suppress duplicate Visual Studio tooltips

### DIFF
--- a/source/NVDAObjects/UIA/VisualStudio.py
+++ b/source/NVDAObjects/UIA/VisualStudio.py
@@ -58,7 +58,7 @@ class CompletionToolTip(ToolTip):
 	""" A tool tip for which duplicate open events can be fired.
 	"""
 
-	_lastToolTipOpenedInfo=(None,None) #: Keeps track of the last ToolTipOpened event (text, time)
+	_lastToolTipOpenedInfo = (None, None)  #: Keeps track of the last ToolTipOpened event (text, time)
 
 	def event_UIA_toolTipOpened(self):
 		oldText, oldTime = self._lastToolTipOpenedInfo

--- a/source/NVDAObjects/UIA/VisualStudio.py
+++ b/source/NVDAObjects/UIA/VisualStudio.py
@@ -59,7 +59,7 @@ class CompletionToolTip(ToolTip):
 	"""
 
 	_lastToolTipOpenedInfo = (None, None)  #: Keeps track of the last ToolTipOpened event (text, time)
-	_preventDuplicateToolTipSeconds = 0.2 #: The duplicate tooltip events will be dropped within this time window
+	_preventDuplicateToolTipSeconds = 0.2  #: The duplicate tooltip events will be dropped within this time window
 
 	def event_UIA_toolTipOpened(self):
 		oldText, oldTime = self._lastToolTipOpenedInfo

--- a/source/NVDAObjects/UIA/VisualStudio.py
+++ b/source/NVDAObjects/UIA/VisualStudio.py
@@ -58,8 +58,10 @@ class CompletionToolTip(ToolTip):
 	""" A tool tip for which duplicate open events can be fired.
 	"""
 
-	_lastToolTipOpenedInfo = (None, None)  #: Keeps track of the last ToolTipOpened event (text, time)
-	_preventDuplicateToolTipSeconds = 0.2  #: The duplicate tooltip events will be dropped within this time window
+	#: Keeps track of the last ToolTipOpened event (text, time)
+	_lastToolTipOpenedInfo = (None, None)
+	#: The duplicate tooltip events will be dropped within this time window
+	_preventDuplicateToolTipSeconds = 0.2
 
 	def event_UIA_toolTipOpened(self):
 		oldText, oldTime = self._lastToolTipOpenedInfo

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,6 +57,7 @@ What's New in NVDA
 - In Microsoft Teams builds with version numbers like 1.3.00.28xxx, NVDA no longer fails reading messages in chats or Teams channels due to an incorrectly focused menu. (#11821)
 - Text marked both as being a spelling and grammar error at the same time in Google Chrome will be appropriately announced as both a spelling and grammar error by NVDA. (#11787)
 - When using Outlook (French locale), the shortcut for 'Reply all' (control+shift+R) works again. (#11196)
+- In Visual Studio, IntelliSense tool tips that provide additional details about the currently selected IntelliSense item are now only reported once. (#11611)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Closes #11611 

### Summary of the issue:
In Visual Studio, the tooltip opened event is fired twice for IntelliSense popups.

### Description of how this pull request fixes the issue:
In an overlay class, ignore the event if it was fired less than 0.2 seconds ago and had the same name.

### Testing performed:
Tested that tool tips are only announced once.

### Known issues with pull request:
None
### Change log entry:
* Bug fixes
    + In Visual Studio, IntelliSense tool tips that provide additional details about the currently selected IntelliSense item are now only reported once. (#11611)