### PR TITLE
Fix up of PR 9843: Once again report when copying text in browse mode in MS Word.

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-# NVDAObjects/window/winword.py
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2020 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V.
 # This file is covered by the GNU General Public License.
@@ -613,8 +611,10 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		textList.append(_("{distance} from top edge of page").format(distance=distance))
 		return ", ".join(textList)
 
-	def copyToClipboard(self):
+	def copyToClipboard(self, notify):
 		self._rangeObj.copy()
+		if notify:
+			ui.reportTextCopiedToClipboard(self.text)
 		return True
 
 	def find(self,text,caseSensitive=False,reverse=False):


### PR DESCRIPTION

### Link to issue number:
Fixes #11839
### Summary of the issue:
PR #9843 changed signature of the `copyToClipboard` method on textInfos but this change has not been reflected in `WordDocumentTextInfo` class.
### Description of how this pull request fixes the issue:
Signature of the `copyToClipboard` for MS Word now matches one from the base class.
### Testing performed:
Ensured that text can once again be reported when copying it in MS Word when in browse mode.
### Known issues with pull request:
- [MS Word method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.office.interop.word.range.copy?view=word-pia#Microsoft_Office_Interop_Word_Range_Copy) which we're using to copy text does not allow to check if the copy actually succeeded or not.  Because of this the success message is reported alwayss if there is a selection in a document.
### Change log entry:
None needed this is not in a release