### PR TITLE
Fix-up of PR #9843: Impact MS Word browse mode

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,7 +1,8 @@
 # -*- coding: UTF-8 -*-
 # NVDAObjects/window/winword.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V.
+# Copyright (C) 2006-2020 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V., Accessolutions,
+# Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -613,8 +614,10 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		textList.append(_("{distance} from top edge of page").format(distance=distance))
 		return ", ".join(textList)
 
-	def copyToClipboard(self):
+	def copyToClipboard(self, notify=True):
 		self._rangeObj.copy()
+		if notify:
+			ui.reportTextCopiedToClipboard(self._rangeObj.text)
 		return True
 
 	def find(self,text,caseSensitive=False,reverse=False):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Fix-up of PR #9843
Issue reported by @Adriani90 in https://github.com/nvaccess/nvda/pull/9843#issuecomment-731465732

### Summary of the issue:

PR #9843 missed to impact MS Word browse mode.

### Description of how this pull request fixes the issue:

Add and handle the new `notify` parameter to `WordDocumentTextInfo.copyToClipboard`

### Testing performed:

Copied text in MS Word in both focus and browse mode.

### Known issues with pull request:

This change is effective in browse mode.
In focus mode, I couldn't find yet where the announce comes from.

### Change log entry:

On method `TextInfo.copyToClipboard`, PR #9843 added a new `notify` parameter.
Should this change be mentioned in the "Changes for developers" section?