### PR TITLE
Fix NVDA may freeze when copying large amount of text (#11843)

### DIFF
--- a/source/ui.py
+++ b/source/ui.py
@@ -106,10 +106,16 @@ def reportTextCopiedToClipboard(text: Optional[str] = None):
 		# or the clipboard content did not match what was just copied.
 		message(_("Unable to copy"))
 		return
+	# Depending on the speech synthesizer, large amount of spoken text can freeze NVDA (#11843)
+	if len(text) < 1024:
+		spokenText = text
+	else:
+		# Translators: Spoken instead of a lengthy text when copied to clipboard.
+		spokenText = _("%d characters") % len(text)
 	message(
 		# Translators: Announced when a text has been copied to clipboard.
 		# {text} is replaced by the copied text.
-		text=_("Copied to clipboard: {text}").format(text=text),
+		text=_("Copied to clipboard: {text}").format(text=spokenText),
 		# Translators: Displayed in braille when a text has been copied to clipboard.
 		# {text} is replaced by the copied text.
 		brailleText=_("Copied: {text}").format(text=text)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Fixes #11843 
Fix-up of #9843 

### Summary of the issue:

Depending on the speech synthesizer in use, NVDA may freeze when attempting to report a lengthy text as it has been copied to clipboard.

### Description of how this pull request fixes the issue:

As when reporting selection or clipboard content, report the number of character instead of the whole text when it exceeds a certain amount.

Clipboard reporting limits to 512. Selection reporting limits to 1024.
`speech._getSelectionMessageSpeech` limits to 512 characters and simply reports "%d characters"
`globalCommands.script_reportClipboardText` limits to 1024 characters and reports "The clipboard contains a large portion of text. It is %s characters long"

I've thus gone the middle way: Limit to 1024 and simply report "%d characters copied to clipboard".


### Testing performed:

Successfully tested #11843 STR.

### Known issues with pull request:

The translatable literal "%d characters" does not meet the new standard ("{nb} characters") but I've thought re-using the existing message would spare translation efforts.

### Change log entry:

I don't think this deserves a change log entry.