### PR TITLE
Prevent infinite recursion for unspeakable chars

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -547,7 +547,7 @@ class SpeechManager(object):
 		)
 		for index in cancelledIndexes:
 			if (
-				not latestCancelledUtteranceIndex
+				latestCancelledUtteranceIndex is None
 				or self._isIndexABeforeIndexB(latestCancelledUtteranceIndex, index)
 			):
 				latestCancelledUtteranceIndex = index

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -333,7 +333,7 @@ class SpeechManager(object):
 			else:
 				lastOutSeq = outSeqs[-1] if outSeqs else None
 			lastCommand = lastOutSeq[-1] if lastOutSeq else None
-			if not lastCommand or isinstance(lastCommand, (EndUtteranceCommand, ConfigProfileTriggerCommand)):
+			if lastCommand is None or isinstance(lastCommand, (EndUtteranceCommand, ConfigProfileTriggerCommand)):
 				# It doesn't make sense to start with or repeat EndUtteranceCommands.
 				# We also don't want an EndUtteranceCommand immediately after a ConfigProfileTriggerCommand.
 				return
@@ -458,13 +458,18 @@ class SpeechManager(object):
 		# apply any parameters changed before the preemption.
 		params = self._curPriQueue.paramTracker.getChanged()
 		utterance.extend(params)
-		for seq in self._curPriQueue.pendingSequences:
+		lastSequenceIndexAddedToUtterance = None
+		for seqIndex, seq in enumerate(self._curPriQueue.pendingSequences):
 			if isinstance(seq[0], EndUtteranceCommand):
 				# The utterance ends here.
 				break
 			utterance.extend(seq)
+			lastSequenceIndexAddedToUtterance = seqIndex
 		# if any items are cancelled, cancel the whole utterance.
 		if utterance and not self._checkForCancellations(utterance):
+			log.error(f"Checking for cancellations failed, cancelling sequence: {utterance}")
+			# Avoid infinite recursion by removing the problematic sequences:
+			del self._curPriQueue.pendingSequences[:lastSequenceIndexAddedToUtterance + 1]
 			return self._buildNextUtterance()
 		return utterance
 


### PR DESCRIPTION
### Link to issue number:
Fixes #11752

### Summary of the issue:
When reading characters that do not have any description in NVDA, a 'no content' utterance can be produced. In this case the empty string is the last 'command' in the sequence passed to `ensureEndUtterance`, resulting in the sequence not being given an `indexCommand` or an `EndUtteranceCommand`. The `indexCommand` is required for the cancellable speech processing, to
be able to track which utterance a `cancellableSpeechCommand` belongs to. 

### Description of how this pull request fixes the issue:
- Adds tests for this case. 
- Prevents an empty string being interpreted as a lack of speech commands.
- Fixes a similar possible error for an optional index.

### Testing performed:
- Unit tests
- Steps as per #11752 
  - Visit https://www.htmlsymbols.xyz/unicode/U+000B
  - Press `h` until 'Preview' heading is found
  - Press `right arrow` until the character is encountered. The text for this part of the page will make this obvious.

### Known issues with pull request:
- This is allowing the speech module to continue to send the speech sequences with no useful speech. Fixing this would be more complicated / risky.

### Change log entry:
None
