### PR TITLE
Fix-up of #9079: Move _nvdaControllerInternal_reportLiveRegion to the end of interface definitions to fix add-ons installs.

### DIFF
--- a/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.acf
+++ b/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.acf
@@ -17,7 +17,6 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 ]
 interface NvdaControllerInternal {
 	[fault_status,comm_status] requestRegistration();
-	[fault_status,comm_status] reportLiveRegion();
 	[fault_status,comm_status] inputLangChangeNotify();
 	[fault_status,comm_status] typedCharacterNotify();
 	[fault_status,comm_status] displayModelTextChangeNotify();
@@ -25,4 +24,5 @@ interface NvdaControllerInternal {
 	[fault_status,comm_status] vbufChangeNotify();
 	[fault_status,comm_status] installAddonPackageFromPath();
 	[fault_status,comm_status] drawFocusRectNotify();
+	[fault_status,comm_status] reportLiveRegion();
 }

--- a/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
+++ b/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
@@ -38,13 +38,6 @@ interface NvdaControllerInternal {
 	error_status_t __stdcall requestRegistration([in,string] const wchar_t* uuidString);
 
 /**
- * Notifies NVDA that a live region was updated.
- * @param text the text to report for the live region.
- * @param level The level of live region, I.E. "polite"
- */
-	error_status_t __stdcall reportLiveRegion([in,string] const wchar_t* text, [in,string] const wchar_t* level);
-
-/**
  * Notifies NVDA that the keyboard layout has changed for this thread. 
  * @param threadID the thread the layout change occured in
  * @param hkl the current layout retreaved either by GetKeyboardLayout or the lParam of wm_inputLangChange.
@@ -97,4 +90,11 @@ interface NvdaControllerInternal {
  * Notifies NVDA that a focus rect has been drawn in the given window.
  */
 	error_status_t __stdcall drawFocusRectNotify([in] const long hwnd, [in] const long left, [in] const long top, [in] const long right, [in] const long bottom);   
+
+/**
+ * Notifies NVDA that a live region was updated.
+ * @param text the text to report for the live region.
+ * @param level The level of live region, I.E. "polite"
+ */
+	error_status_t __stdcall reportLiveRegion([in,string] const wchar_t* text, [in,string] const wchar_t* level);
 };

--- a/nvdaHelper/local/nvdaControllerInternal.c
+++ b/nvdaHelper/local/nvdaControllerInternal.c
@@ -19,11 +19,6 @@ error_status_t __stdcall nvdaControllerInternal_requestRegistration(const wchar_
 	return _nvdaControllerInternal_requestRegistration(uuidString);
 }
 
-error_status_t(__stdcall *_nvdaControllerInternal_reportLiveRegion)(const wchar_t*, const wchar_t*);
-error_status_t __stdcall nvdaControllerInternal_reportLiveRegion(const wchar_t* text, const wchar_t* politeness) {
-	return _nvdaControllerInternal_reportLiveRegion(text, politeness);
-}
-
 error_status_t(__stdcall *_nvdaControllerInternal_inputLangChangeNotify)(const long, const unsigned long, const wchar_t*);
 error_status_t __stdcall nvdaControllerInternal_inputLangChangeNotify(const long threadID, const unsigned long hkl, const wchar_t* layoutString) {
 	return _nvdaControllerInternal_inputLangChangeNotify(threadID,hkl,layoutString);
@@ -78,4 +73,9 @@ error_status_t __stdcall nvdaControllerInternal_installAddonPackageFromPath(cons
 error_status_t(__stdcall *_nvdaControllerInternal_drawFocusRectNotify)(const long, const long, const long, const long, const long);
 error_status_t __stdcall nvdaControllerInternal_drawFocusRectNotify(const long hwnd, const long left, const long top, const long right, const long bottom) { 
 	return _nvdaControllerInternal_drawFocusRectNotify(hwnd,left,top,right,bottom);
+}
+
+error_status_t(__stdcall *_nvdaControllerInternal_reportLiveRegion)(const wchar_t*, const wchar_t*);
+error_status_t __stdcall nvdaControllerInternal_reportLiveRegion(const wchar_t* text, const wchar_t* politeness) {
+	return _nvdaControllerInternal_reportLiveRegion(text, politeness);
 }

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -33,7 +33,6 @@ EXPORTS
 	VBuf_locateTextFieldNodeAtOffset
 	VBuf_setSelectionOffsets
 	_nvdaControllerInternal_requestRegistration
-	_nvdaControllerInternal_reportLiveRegion
 	_nvdaControllerInternal_displayModelTextChangeNotify
 	_nvdaControllerInternal_inputLangChangeNotify
 	_nvdaControllerInternal_inputCompositionUpdate
@@ -61,3 +60,4 @@ EXPORTS
 	audioDucking_shouldDelay
 	logMessage
 	getOleClipboardText
+	_nvdaControllerInternal_reportLiveRegion

--- a/nvdaHelper/remote/nvdaHelperRemote.def
+++ b/nvdaHelper/remote/nvdaHelperRemote.def
@@ -12,7 +12,6 @@ EXPORTS
 	logMessage
 	NVDALogCrtReportHook
 	nvdaInProcUtils_winword_expandToLine
-	nvdaControllerInternal_reportLiveRegion
 	nvdaControllerInternal_logMessage
 	nvdaControllerInternal_vbufChangeNotify
 	nvdaControllerInternal_installAddonPackageFromPath
@@ -20,3 +19,4 @@ EXPORTS
 	nvdaController_speakText
 	nvdaController_cancelSpeech
 	nvdaController_brailleMessage
+	nvdaControllerInternal_reportLiveRegion


### PR DESCRIPTION

### Link to issue number:
Fixes #11867

### Summary of the issue:
PR #9079  added a new function to the NVDA Helper interface. This made it impossible to install add-ons when older version of NVDA is installed on the system.
### Description of how this pull request fixes the issue:
If `_nvdaControllerInternal_reportLiveRegion` is placed at the end of the interface definition files this problem does not occur anymore. Since I can't see any reason not to do that `_nvdaControllerInternal_reportLiveRegion` is moved to the end.
### Testing performed:
With NVDA 2019.2.1 installed and build from this PR running as portable:
- Tested that add-ons can be installed from Windows Explorer
- In firefox ensured that live regions are still suppressed when Report dynamic content changes is disabled.
### Known issues with pull request:
Perhaps the fact that new functions need to be added ad the end of interface files not to break backward compatibility should be documented somewhere?
### Change log entry:
None needed - this issue is not in a release yet.