### PR TITLE
Windows 10 Calculator (follow-up to PR #9429): results announcement in compact overlay and unit converter

### DIFF
--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -98,7 +98,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Hack: only announce display text when an actual calculator button (usually equals button) is pressed.
 		# In redstone, pressing enter does not move focus to equals button.
 		if isinstance(focus, UIA):
-			if focus.UIAAutomationId == "CalculatorResults":
+			if focus.UIAAutomationId in ("CalculatorResults", "CalculatorAlwaysOnTopResults"):
 				queueHandler.queueFunction(queueHandler.eventQueue, focus.reportFocus)
 			else:
 				resultsScreen = api.getForegroundObject().children[1].lastChild

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -53,7 +53,8 @@ class AppModule(appModuleHandler.AppModule):
 			obj.UIAAutomationId not in noCalculatorEntryAnnouncements
 			and obj.name != self._resultsCache
 		):
-			# For unit conversion, UIA notification event presents much better messages.
+			# For unit conversion, both name change and notification events are fired,
+			# although UIA notification event presents much better messages.
 			# For date calculation, live region change event is also fired for difference between dates.
 			if obj.UIAAutomationId != "DateDiffAllUnitsResultLabel":
 				ui.message(obj.name)

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -55,7 +55,7 @@ class AppModule(appModuleHandler.AppModule):
 		):
 			# For unit conversion, UIA notification event presents much better messages.
 			# For date calculation, live region change event is also fired for difference between dates.
-			if obj.UIAAutomationId not in ("Value1", "Value2", "DateDiffAllUnitsResultLabel"):
+			if obj.UIAAutomationId != "DateDiffAllUnitsResultLabel":
 				ui.message(obj.name)
 			self._resultsCache = obj.name
 		if not self._shouldAnnounceResult:

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -26,6 +26,10 @@ noCalculatorEntryAnnouncements = [
 	"ContentPresenter",
 	# Briefly shown when closing date calculation calendar.
 	"Light Dismiss",
+	# Unit conversion/convert from.
+	"Value1",
+	# Unit conversion/converts into.
+	"Value2",
 ]
 
 


### PR DESCRIPTION
### Link to issue number:
Follow-up to #9429 
Fixes #11880 
Fixes #11881 

### Summary of the issue:
Improve result announcements in compact overlay mode and unit converters. Specifically:

* NVDA will now announce calculator results in compact overlay (alwasy on top) mode.
* NVDA will not announce convert from/converts into fields multiple times in unit converter.

### Description of how this pull request fixes the issue:
For compact overlay: add a UIA Automation Id used in alwasy on top mode to represent calculator results, resulting in results being announced when Enter, Numpad Enter, or Escape is pressed.

Unit converter: NVDA will no longer announce convert from/converts into fields multiple times, resolved by adding "Value1" and "Value2" Automation Id strings for unit conversion fields to a list of no result announcement list.

### Testing performed:
Tested via Windows 10 App Essentials and from source code with Calculator version 10.2010 and later running on Windows 10 Version 20H2.

### Known issues with pull request:
None

### Change log entry:
Not needed (see #9429).
