### PR TITLE
No longer override isAlive on UIA WordBrowseModeDocument

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -272,9 +272,6 @@ class WordDocumentTextInfo(UIATextInfo):
 
 class WordBrowseModeDocument(UIABrowseModeDocument):
 
-	def _get_isAlive(self):
-		return True
-
 	def shouldSetFocusToObj(self,obj):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		if obj.role==controlTypes.ROLE_EDITABLETEXT and obj.UIAElement.cachedAutomationID.startswith('UIA_AutomationId_Word_Content'):

--- a/source/api.py
+++ b/source/api.py
@@ -138,7 +138,7 @@ Before overriding the last object, this function calls event_loseFocus on the ob
 		try:
 			treeInterceptorObject=treeInterceptorHandler.update(o)
 		except:
-			log.error("Error updating tree interceptor")
+			log.error("Error updating tree interceptor", exc_info=True)
 	#Always make sure that the focus object's treeInterceptor is forced to either the found treeInterceptor (if its in it) or to None
 	#This is to make sure that the treeInterceptor does not have to be looked up, which can cause problems for winInputHook
 	if obj is o or obj in treeInterceptorObject:

--- a/source/api.py
+++ b/source/api.py
@@ -138,7 +138,7 @@ Before overriding the last object, this function calls event_loseFocus on the ob
 		try:
 			treeInterceptorObject=treeInterceptorHandler.update(o)
 		except:
-			log.exception("Error updating tree interceptor")
+			log.error("Error updating tree interceptor")
 	#Always make sure that the focus object's treeInterceptor is forced to either the found treeInterceptor (if its in it) or to None
 	#This is to make sure that the treeInterceptor does not have to be looked up, which can cause problems for winInputHook
 	if obj is o or obj in treeInterceptorObject:


### PR DESCRIPTION
### Link to issue number:
#11741 

### Summary of the issue:
On WordBrowseModeDocument, isAlive was overridden in a way that it would always return True. This would block a clean up of the interceptor.

### Description of how this pull request fixes the issue:
1. No longer override isALive
2. Always log at the error level when a tree interceptor couldn't be updated. Before, exception translated to debugWarning since the underlying was a COMError. If this was error from the start, we probably would have found this issue way earlier.

### Testing performed:
Tested that #11741 no longer occurs. When the TI wasn't killed correctly, it generated an update error that caused speech to cancel somehow.

### Known issues with pull request:
1. I see no reason why the base isAlive wouldn't work. Before accepting this though, it would be helpful to know whether @michaelDCurran remembers something about this.
2. It would be interesting to know why this underlying bug impacted cancellable speech, as I really don't know and therefore I'm not sure whether there's another cause for #11741.

### Change log entry:
Probably not worth mentioning