### PR TITLE
Fix frequent error sounds with Cancellable speech

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -466,12 +466,21 @@ class SpeechManager(object):
 			utterance.extend(seq)
 			lastSequenceIndexAddedToUtterance = seqIndex
 		# if any items are cancelled, cancel the whole utterance.
-		if utterance and not self._checkForCancellations(utterance):
-			log.error(f"Checking for cancellations failed, cancelling sequence: {utterance}")
+		try:
+			utteranceValid = len(utterance) == 0 or self._checkForCancellations(utterance)
+		except IndexError:
+			log.error(
+				f"Checking for cancellations failed, cancelling sequence: {utterance}",
+				exc_info=True
+			)
 			# Avoid infinite recursion by removing the problematic sequences:
 			del self._curPriQueue.pendingSequences[:lastSequenceIndexAddedToUtterance + 1]
+			utteranceValid = False
+
+		if utteranceValid:
+			return utterance
+		else:
 			return self._buildNextUtterance()
-		return utterance
 
 	def _checkForCancellations(self, utterance: SpeechSequence) -> bool:
 		"""
@@ -485,8 +494,9 @@ class SpeechManager(object):
 			return True
 		utteranceIndex = self._getUtteranceIndex(utterance)
 		if utteranceIndex is None:
-			log.error("no utterance index, cant save cancellable commands")
-			return False
+			raise IndexError(
+				f"no utterance index({utteranceIndex}, cant save cancellable commands"
+			)
 		cancellableItems = list(
 			item for item in reversed(utterance) if isinstance(item, _CancellableSpeechCommand)
 		)


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:
When moving through email items in focus mode in Gmail, errors occur, you may have to wait for the utterance to finish speaking.

Fix an issue introduced with #11865, which incorrectly used the return value of _checkForCancellations
to indicate error/success, rather than utterance canceled (correctly) or no cancellations found.

### Description of how this pull request fixes the issue:
Instead, an exception is raised when the method can not complete, and the error is logged in this case.

### Testing performed:
Ran locally with cancellable speech enabled.

### Known issues with pull request:
None

### Change log entry:
None