### PR TITLE
Update liblouis to 3.16.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [ConfigObj](https://github.com/DiffSK/configobj), commit f9a265c
 * [Six](https://pypi.python.org/pypi/six), version 1.12.0, required by wxPython and ConfigObj
-* [liblouis](http://www.liblouis.org/), version 3.15.0
+* [liblouis](http://www.liblouis.org/), version 3.16.1
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/) Emoji Annotations, version 38.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -384,10 +384,10 @@ addTable("ro.ctb", _("Romanian"))
 addTable("ru.ctb", _("Russian computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru-litbrl.ctb", _("Russian grade 1"), input=False)
+addTable("ru-litbrl.ctb", _("Russian literary braille"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru-litbrl-detailed.utb", _("Russian grade 1 (detailed)"), input=False)
+addTable("ru-litbrl-detailed.utb", _("Russian literary braille (detailed)"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sa-in-g1.utb", _("Sanskrit grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -81,6 +81,7 @@ RENAMED_TABLES = {
 	"no-no.ctb":"no-no-8dot.utb",
 	"no-no-comp8.ctb":"no-no-8dot.utb",
 	"ru-compbrl.ctb":"ru.ctb",
+	"ru-ru-g1.utb": "ru-litbrl-detailed.utb",
 	"sk-sk-g1.utb":"sk-g1.ctb",
 	"UEBC-g1.ctb":"en-ueb-g1.ctb",
 	"UEBC-g2.ctb":"en-ueb-g2.ctb",
@@ -102,6 +103,9 @@ addTable("ar-ar-g2.ctb", _("Arabic grade 2"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("as-in-g1.utb", _("Assamese grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("ba.utb", _("Bashkir grade 1"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("be-in-g1.utb", _("Bengali grade 1"))
@@ -380,7 +384,10 @@ addTable("ro.ctb", _("Romanian"))
 addTable("ru.ctb", _("Russian computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ru-ru-g1.utb", _("Russian grade 1"))
+addTable("ru-litbrl.ctb", _("Russian grade 1"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("ru-litbrl-detailed.utb", _("Russian grade 1 (detailed)"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sa-in-g1.utb", _("Sanskrit grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -117,6 +117,9 @@ addTable("bg.ctb", _("Bulgarian 8 dot computer braille"))
 addTable("ckb-g1.ctb", _("Central Kurdish grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("cop-eg-comp8.utb", _("Coptic 8 dot computer braille"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("cy-cy-g1.utb", _("Welsh grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,7 +19,12 @@ What's New in NVDA
 
 
 == Changes ==
-- Updated liblouis braille translator to version 3.15.0
+- Updated liblouis braille translator to version 3.16.1:
+ - Addresses multiple crashes
+ - Adds Bashkir grade 1 Braille table
+ - adds Coptic 8 dot computer braille table
+ - Adds Russian literary braille and Russian literary braille (detailed) tables.
+ - Removes the Russian grade 1 Braille table
 - When reading with say all in browse mode, the find next and find previous commands do not stop reading anymore if Allow skim reading option is enabled; say all rather resumes from after the next or previous found term. (#11563)
 - For HIMS braille displays F3 has been remapped to Space + dots 148. (#11710)
 - Improvements to the UX of the "braille message timeout" and "Show messages indefinitely" options. (#11602)
@@ -60,6 +65,7 @@ What's New in NVDA
 - When using Outlook (French locale), the shortcut for 'Reply all' (control+shift+R) works again. (#11196)
 - In Visual Studio, IntelliSense tool tips that provide additional details about the currently selected IntelliSense item are now only reported once. (#11611)
 - In Windows 10 Calculator, NVDA will not announce progress of calculations if speak typed characters is disabled. (#9428)
+- NVDA no longer crashes when using English US grade 2 and expand to computer Braille at the cursor is on, when displaying certain content such as a URL in Braille. (#11754)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #11013
Fixes #11754

### Summary of the issue:
[Liblouis 3.16.0 has just been released](https://github.com/liblouis/liblouis/tree/v3.16.0).
EDIT: update to [3.16.1](https://github.com/liblouis/liblouis/tree/v3.16.1).

### Description of how this pull request fixes the issue:
- Updates the liblouis submodule (commit 48633b8).
- Changes the readme.
- Adds the following braille tables to the interface:
  - Bashkir grade 1
  - Russian grade 1
  - Russian grade 1 (detailed)
  - Coptic 8 dot computer
- Removes the ru-ru-g1.utb entry

### Testing performed:
Tested from source.

### Known issues with pull request:
None

### Change log entry:
* Changes
  - Updated liblouis braille translator to 3.16.1 (#11888)
