### PR TITLE
MS Word: fix line spacing reporting

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -843,8 +843,11 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 				# Translators:  line spacing of 1.5 lines
 				field['line-spacing']=pgettext('line spacing value',"1.5 lines")
 			elif lineSpacingRule==wdLineSpaceExactly:
-				# Translators: exact (minimum) line spacing
-				field['line-spacing']=pgettext('line spacing value',"exact")
+				field['line-spacing'] = pgettext(
+					'line spacing value',
+					# Translators: line spacing of exactly x point
+					"exactly {space:.1f} pt"
+				).format(space=float(lineSpacingVal))
 			elif lineSpacingRule==wdLineSpaceAtLeast:
 				# Translators: line spacing of at least x point
 				field['line-spacing']=pgettext('line spacing value',"at least %.1f pt")%float(lineSpacingVal)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In MS Word, if line spacing is set to be exactly n pts, pressing NVDA+F (once or twice) does report the line spacing type ("exact"), but not the number of points of this line spacing.

### Description of how this pull request fixes the issue:

Report line spacing type ("exactly") with the indication of the number of pts of line spacing as it is already done for "at least" line spacing type.

### Testing performed:

Set line spacing to 7.5 and 12 and checked that "Exactly 7.5 pts" / "Exactly 12.0 pts" was reported.

### Known issues with pull request:

None

### Change log entry:

Section: New features, Changes, Bug fixes

IMO, such a minor fix does not deserve a line in change log.


