### PR TITLE
No longer fail to restart NVDA when running from sources and started given relative path to nvda.pyw

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -116,29 +116,28 @@ def restart(disableAddons=False, debugLogging=False):
 	import subprocess
 	import winUser
 	import shellapi
-	options=[]
-	try:
-		sys.argv.remove('--disable-addons')
-	except ValueError:
-		pass
-	try:
-		sys.argv.remove('--debug-logging')
-	except ValueError:
-		pass
+	for paramToRemove in ("--disable-addons", "--debug-logging", "--ease-of-access"):
+		try:
+			sys.argv.remove(paramToRemove)
+		except ValueError:
+			pass
+	options = []
+	if not hasattr(sys, "frozen"):
+		options.append(os.path.basename(sys.argv[0]))
 	if disableAddons:
 		options.append('--disable-addons')
 	if debugLogging:
 		options.append('--debug-logging')
-	try:
-		sys.argv.remove("--ease-of-access")
-	except ValueError:
-		pass
-	shellapi.ShellExecute(None, None,
-		sys.executable,
-		subprocess.list2cmdline(sys.argv + options),
-		None,
+	shellapi.ShellExecute(
+		hwnd=None,
+		operation=None,
+		file=sys.executable,
+		parameters=subprocess.list2cmdline(options + sys.argv[1:]),
+		directory=globalVars.appDir,
 		# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
-		winUser.SW_SHOWNORMAL)
+		showCmd=winUser.SW_SHOWNORMAL
+	)
+
 
 def resetConfiguration(factoryDefaults=False):
 	"""Loads the configuration, installs the correct language support and initialises audio so that it will use the configured synth and speech settings.


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
When running nvda from sources  using a relative path such as `pythonw source\nvda.pyw` NVDA failed to restart. This was caused by the fact that `shellapi.ShellExecute` executes given process using cwd as the directory from which the given command should be running and when NVDA starts it changes cwd to its own source directory.
### Description of how this pull request fixes the issue:
When restarting NVDA `globalVars.appdir` is used as a directory from which new process should be started. While at it I've also made the restart code more compact by removing unneeded parameters from `sys.argv.` in a loop.
### Testing performed:
with NVDA repository at `d:\my_repos\nvda` started  NVDA with the following invocations and ensured it can be restarted successfully:
- pythonw nvda.pyw from the source directory
-  pythonw source\nvda.pyw from the main directory of the repo

I've also ensured that binary version of NVDA can be restarted successfully with these changes.
### Known issues with pull request:
None known
### Change log entry:
I don't think changelog entry is needed here - this would affect only developers and this issue was present for a long time.