### PR TITLE
start dev cycle for 2021.1

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2020 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2020 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import os
 

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,5 +1,5 @@
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited
+#Copyright (C) 2006-2020 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
@@ -65,8 +65,8 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2020
-version_major = 4
+version_year = 2021
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,21 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2021.1 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+- Note: this is a Add-on API compatibility breaking realease. Add-ons will need to be re-tested and have their manifest updated.
+
+
 = 2020.4 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for 2021.1.

Note that this release will update the add-on API "Backwards comptible to" version. However, the actual change to this version number will [happen in another PR](https://github.com/nvaccess/nvda/pull/11912)(#11912), and won't be merged until 2021.1 branches off for beta.