### PR TITLE
Fix-up of #10973: Fallback to POSITION_FIRST when reporting formatting info at caret to report in MS Excel

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1552,7 +1552,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_SYSTEMCARET,
 	)
 	def script_reportFormattingAtCaret(self, gesture):
-		self._reportFormattingHelper(self._getTIAtCaret(), False)
+		self._reportFormattingHelper(self._getTIAtCaret(True), False)
 
 	@script(
 		# Translators: Input help mode message for show formatting at caret position command.
@@ -1560,7 +1560,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_SYSTEMCARET,
 	)
 	def script_showFormattingAtCaret(self, gesture):
-		self._reportFormattingHelper(self._getTIAtCaret(), True)
+		self._reportFormattingHelper(self._getTIAtCaret(True), True)
 
 	@script(
 		description=_(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -60,6 +60,7 @@ What's New in NVDA
 - When using Outlook (French locale), the shortcut for 'Reply all' (control+shift+R) works again. (#11196)
 - In Visual Studio, IntelliSense tool tips that provide additional details about the currently selected IntelliSense item are now only reported once. (#11611)
 - In Windows 10 Calculator, NVDA will not announce progress of calculations if speak typed characters is disabled. (#9428)
+- It is again possible to report formatting information for the focused Excel cell using NVDA+F. (#11914)
 
 
 == Changes for Developers ==


### PR DESCRIPTION

### Link to issue number:
Discussion in #6479

### Summary of the issue:
It is currently impossible to request formatting info for an Excel cell with NVDA+F.

### Description of how this pull request fixes the issue:
NVDA+F now falls back to POSITION_FIRST if there is no caret.
### Testing performed:
- Ensured that NVDA+F reports formatting info for an Excel cell.
- Ensured that 'No formatting information' is reported for cases in which there is none such as a 'browse' button in the run dialog.
 ### Known issues with pull request:
None known
### Change log entry:

Section: Bug fixes
It is now possible to report formatting information for the focused Excel cell using NVDA+F.
