### PR TITLE
Enable activating a control with cursor routing on any of its braille cells (#7447)

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1087,7 +1087,9 @@ class TextInfoRegion(Region):
 			brailleInput.handler.updateDisplay()
 			return
 
-		if braillePos == self.brailleCursorPos:
+		dest = self.getTextInfoForBraillePos(braillePos)
+		cursor = self.getTextInfoForBraillePos(self.brailleCursorPos)
+		if dest.compareEndPoints(cursor, "startToStart") == 0:
 			# The cursor is already at this position,
 			# so activate the position.
 			try:
@@ -1095,7 +1097,6 @@ class TextInfoRegion(Region):
 			except NotImplementedError:
 				pass
 			return
-		dest = self.getTextInfoForBraillePos(braillePos)
 		self._setCursor(dest)
 
 	def nextLine(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Fixes #7447

### Summary of the issue:

In browse mode, a control can be activated with braille cursor routing only at the positions of its text, but not at the positions of eg. its role descriptor.
That is, cursor routing on "lnk" for a link moves the cursor on first press to the link text but does not activate on second press.
It is especially disturbing on check-boxes with no labels - as often found as line selectors in tables: Despite braille rendering a check-box shape, a single cell can be used to activate, located one space after "chk"… while most new comers would expect to be able to click within the rendered check-box shape.

### Description of how this pull request fixes the issue:

In `TextInfoRegion.routeTo` do not compare the routing cell with the cursor cell, but rather the underlying `TextInfo` offsets.

### Testing performed:

### Known issues with pull request:

The solution proposed here maybe widens the scope a bit too much:
Considering a check-box with no label at the start of a table cell, cursor routing on the row/column braille indications also activates the check-box.

### Change log entry:

Section: Changes

In browse mode, controls can now be activated with braille cursor routing on their descriptor (ie. "lnk" for a link). This is especially useful for activating eg. check-boxes with no labels.