### PR TITLE
Fixing table navigation commands by caching last column/row index

### DIFF
--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -158,8 +158,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			return
 
 		# The follwoing lines check whether user has been issuing table navigation commands repeatedly.
-		# In this case, instead of using current column/row index, we used cached value 
-		# # to allow users being able to skip merged cells without affecting the initial column/row index.
+		# In this case, instead of using current column/row index, we used cached value
+		# to allow users being able to skip merged cells without affecting the initial column/row index.
 		# For more info see issue #11919 and #7278.
 		if (self.selection == self.lastTableSelection) and (self.lastTableAxis == axis):
 			if axis == "row":

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -158,7 +158,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			return
 
 		# The follwoing lines check whether user has been issuing table navigation commands repeatedly.
-		# In this case, instead of using current column/row index, we used cached value to allow users being able to skip merged cells without affecting the initial column/row index.
+		# In this case, instead of using current column/row index, we used cached value 
+		# # to allow users being able to skip merged cells without affecting the initial column/row index.
 		# For more info see issue #11919 and #7278.
 		if (self.selection == self.lastTableSelection) and (self.lastTableAxis == axis):
 			if axis == "row":

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -140,10 +140,12 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 				destCol+=1 if movement=="next" else -1
 		raise LookupError
 
-	lastTableSelection = None
-	lastTableAxis = None
-	lastTableCoordinate = None
-	lastTableCoordinateSpan = None
+	_lastTableSelection = None
+	_lastTableAxis = None
+	_lastTableRow = None
+	_lastTableRowSpan = None
+	_lastTableCol = None
+	_lastTableColSpan = None
 	def _tableMovementScriptHelper(self, movement="next", axis=None):
 		if isScriptWaiting():
 			return
@@ -157,17 +159,17 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			ui.message(_("Not in a table cell"))
 			return
 
-		# The follwoing lines check whether user has been issuing table navigation commands repeatedly.
+		# The following lines check whether user has been issuing table navigation commands repeatedly.
 		# In this case, instead of using current column/row index, we used cached value
 		# to allow users being able to skip merged cells without affecting the initial column/row index.
 		# For more info see issue #11919 and #7278.
-		if (self.selection == self.lastTableSelection) and (self.lastTableAxis == axis):
+		if (self.selection == self._lastTableSelection) and (self._lastTableAxis == axis):
 			if axis == "row":
-				origCol = self.lastTableCoordinate
-				origColSpan = self.lastTableCoordinateSpan
+				origCol = self._lastTableCol
+				origColSpan = self._lastTableColSpan
 			else:
-				origRow = self.lastTableCoordinate
-				origRowSpan = self.lastTableCoordinateSpan
+				origRow = self._lastTableRow
+				origRowSpan = self._lastTableRowSpan
 
 		try:
 			info = self._getNearestTableCell(tableID, self.selection, origRow, origCol, origRowSpan, origColSpan, movement, axis)
@@ -181,14 +183,14 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		speech.speakTextInfo(info,formatConfig=formatConfig,reason=controlTypes.REASON_CARET)
 		info.collapse()
 		self.selection = info
-		self.lastTableSelection = self.selection
-		self.lastTableAxis = axis
+		self._lastTableSelection = self.selection
+		self._lastTableAxis = axis
 		if axis == "row":
-			self.lastTableCoordinate = origCol
-			self.lastTableCoordinateSpan = origColSpan
+			self._lastTableCol = origCol
+			self._lastTableColSpan = origColSpan
 		else:
-			self.lastTableCoordinate = origRow
-			self.lastTableCoordinateSpan = origRowSpan
+			self._lastTableRow = origRow
+			self._lastTableRowSpan = origRowSpan
 
 
 	def script_nextRow(self, gesture):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
#11919, #7278
### Summary of the issue:
When issuing table navigation commands repeadetly, e.g. pressing Control+Alt+Down several times in a row, the original column index is currently not preserved. Thus, if there happens to be a merged cell on the way, the column index will be reset to the minimal column index of merged cell.
### Description of how this pull request fixes the issue:
This PR caches original column index for vertical table navigation and original row index for horizontal table navigation.
### Testing performed:
Performed test described in #11919.
### Known issues with pull request:
None known at the moment.
### Change log entry:
Fix table navigation commands to preserve column/row index in the presence of merged cells.
Section: Bug fixes

