### PR TITLE
Making KeyboardInputGesture.fromName to use en_us locale by default.

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -548,6 +548,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 				time.sleep(0.01)
 				wx.Yield()
 
+	en_us_input_Hkl = 1033 + (1033 << 16)
 	@classmethod
 	def fromName(cls, name):
 		"""Create an instance given a key name.
@@ -569,7 +570,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 				vk, ext = getNVDAModifierKeys()[0]
 			elif len(keyName) == 1:
 				ext = False
-				requiredMods, vk = winUser.VkKeyScanEx(keyName, getInputHkl())
+				requiredMods, vk = winUser.VkKeyScanEx(keyName, en_us_input_Hkl)
 				if requiredMods & 1:
 					keys.append((winUser.VK_SHIFT, False))
 				if requiredMods & 2:

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -570,7 +570,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 				vk, ext = getNVDAModifierKeys()[0]
 			elif len(keyName) == 1:
 				ext = False
-				requiredMods, vk = winUser.VkKeyScanEx(keyName, en_us_input_Hkl)
+				requiredMods, vk = winUser.VkKeyScanEx(keyName, cls.en_us_input_Hkl)
 				if requiredMods & 1:
 					keys.append((winUser.VK_SHIFT, False))
 				if requiredMods & 2:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
N/A
### Summary of the issue:
KeyboardInputGesture.fromName() function by default tries to resolve key names in current system locale. A user of my BrowserNav add-ons complained to me that the add-on wouldn't start. After investigating I found that statements like:
```
KeyboardInputGesture.fromName("Control+C")
```
wouldn't work when the default locale on computer is set to non-latin, e.g. Russian in this case. This happens, because the letter C cannot be resolved in Russian locale. This change doesn't seem to affect NVDA core at all, since it doesn't seem to be resolving keystrokes including any Latin letters, however it affects my BrowserNav add-on and possibly others.
### Description of how this pull request fixes the issue:
I propose to resolve keyboard shortcuts in English locale, en_us for example. I think it is unlikely someone will ever need to create keyboard shortcuts that include non-Latin letters.
### Testing performed:
Tested using NVDA Python console that shortcuts can now be successfully created regardless of current system locale.
### Known issues with pull request:
N/A
### Change log entry:
Making KeyboardInputGesture.fromName to use en_us locale by default.
Section: Bug fixes

