### PR TITLE
Python Console: Fix handling of the tab key in the input pane (#11532)

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -308,7 +308,7 @@ class ConsoleUI(
 	RE_COMPLETE_UNIT = re.compile(r"[\w.]*$")
 
 	def complete(self):
-		textBeforeCursor = self.inputCtrl.GetRange(0, self.inputCtrl.GetInsertionPoint())
+		textBeforeCursor = self.inputCtrl.GetRange(0, self.inputCtrl.GetSelection()[0])
 		try:
 			original = self.RE_COMPLETE_UNIT.search(textBeforeCursor).group(0)
 		except AttributeError:
@@ -376,18 +376,18 @@ class ConsoleUI(
 		if not insert:
 			return
 		inputCtrl = self.inputCtrl
-		curPos = inputCtrl.GetInsertionPoint()
-		prefix = inputCtrl.GetRange(0, curPos)
-		suffix = inputCtrl.GetRange(curPos, inputCtrl.GetLastPosition())
+		selStartPos, selEndPos = inputCtrl.GetSelection()
+		prefix = inputCtrl.GetRange(0, selStartPos)
+		suffix = inputCtrl.GetRange(selEndPos, inputCtrl.GetLastPosition())
 		inputCtrl.SetValue(prefix + insert + suffix)
 		queueHandler.queueFunction(queueHandler.eventQueue, speech.speakText, insert)
-		inputCtrl.SetInsertionPoint(curPos + len(insert))
+		inputCtrl.SetInsertionPoint(selStartPos + len(insert))
 
 	def onInputChar(self, evt):
 		key = evt.GetKeyCode()
 
 		if key == wx.WXK_TAB:
-			textBeforeCursor = self.inputCtrl.GetRange(0, self.inputCtrl.GetInsertionPoint())
+			textBeforeCursor = self.inputCtrl.GetRange(0, self.inputCtrl.GetSelection()[0])
 			if textBeforeCursor and not textBeforeCursor.isspace():
 				if not self.complete():
 					wx.Bell()

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -306,9 +306,11 @@ class ConsoleUI(
 		return True
 
 	RE_COMPLETE_UNIT = re.compile(r"[\w.]*$")
+
 	def complete(self):
+		textBeforeCursor = self.inputCtrl.GetRange(0, self.inputCtrl.GetInsertionPoint())
 		try:
-			original = self.RE_COMPLETE_UNIT.search(self.inputCtrl.GetValue()).group(0)
+			original = self.RE_COMPLETE_UNIT.search(textBeforeCursor).group(0)
 		except AttributeError:
 			return False
 
@@ -373,16 +375,20 @@ class ConsoleUI(
 		insert = completed[len(original):]
 		if not insert:
 			return
-		self.inputCtrl.SetValue(self.inputCtrl.GetValue() + insert)
+		inputCtrl = self.inputCtrl
+		curPos = inputCtrl.GetInsertionPoint()
+		prefix = inputCtrl.GetRange(0, curPos)
+		suffix = inputCtrl.GetRange(curPos, inputCtrl.GetLastPosition())
+		inputCtrl.SetValue(prefix + insert + suffix)
 		queueHandler.queueFunction(queueHandler.eventQueue, speech.speakText, insert)
-		self.inputCtrl.SetInsertionPointEnd()
+		inputCtrl.SetInsertionPoint(curPos + len(insert))
 
 	def onInputChar(self, evt):
 		key = evt.GetKeyCode()
 
 		if key == wx.WXK_TAB:
-			line = self.inputCtrl.GetValue()
-			if line and not line.isspace():
+			textBeforeCursor = self.inputCtrl.GetRange(0, self.inputCtrl.GetInsertionPoint())
+			if textBeforeCursor and not textBeforeCursor.isspace():
 				if not self.complete():
 					wx.Bell()
 				return


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Fixes #11532

### Summary of the issue:

Currently, when editing a non-empty input line, NVDA's Python Console does not support inserting a tab at the beginning of the line for indentation.
It does not support either performing tab-completion anywhere but at the end of an input line: This is fine when typing a new line, but limiting when editing an existing one.

### Description of how this pull request fixes the issue:

### Testing performed:

### Known issues with pull request:

### Change log entry:

Section: Bug fixes

In the Python Console, inserting a tab for indentation at the beginning of a non-empty input line and performing tab-completion in the middle of an input line are now supported.