### PR TITLE
Symbols: test regex group references through the symbols engine

### DIFF
--- a/tests/unit/test_characterProcessing.py
+++ b/tests/unit/test_characterProcessing.py
@@ -125,6 +125,6 @@ class TestComplex(unittest.TestCase):
 		"""Test inclusion of group replacement in engine
 		"""
 		replaced = process("fr_FR", "Le 03.04.05.", SYMLVL_ALL)
-		self.assertEqual(replaced, "Le  03 point 04 point 05   point.")
+		self.assertEqual(replaced, "Le  03 point 04 point 05  point.")
 		replaced = process("fr_FR", "Le 03/04/05.", SYMLVL_ALL)
-		self.assertEqual(replaced, "Le  03 barre oblique 04 barre oblique 05   point.")
+		self.assertEqual(replaced, "Le  03 barre oblique 04 barre oblique 05  point.")

--- a/tests/unit/test_characterProcessing.py
+++ b/tests/unit/test_characterProcessing.py
@@ -9,6 +9,8 @@
 import unittest
 import re
 from characterProcessing import SpeechSymbolProcessor
+from characterProcessing import SYMLVL_ALL
+from characterProcessing import processSpeechSymbols as process
 
 
 class TestComplex(unittest.TestCase):
@@ -118,3 +120,11 @@ class TestComplex(unittest.TestCase):
 			name="foo"
 		)
 		self.assertEqual(replaced, "BAT>bar")
+
+	def test_engine(self):
+		"""Test inclusion of group replacement in engine
+		"""
+		replaced = process("fr_FR", "Le 03.04.05.", SYMLVL_ALL)
+		self.assertEqual(replaced, "Le  03 point 04 point 05   point.")
+		replaced = process("fr_FR", "Le 03/04/05.", SYMLVL_ALL)
+		self.assertEqual(replaced, "Le  03 barre oblique 04 barre oblique 05   point.")


### PR DESCRIPTION
This adds a test for regex group reference replacement that goes through
the complete speech symbol processor, using the French locale.

### Link to issue number:

https://github.com/nvaccess/nvda/issues/11107

### Summary of the issue:

The issue above was completed by PR https://github.com/nvaccess/nvda/pull/11116 ; this was however waiting for the French locale to add a usage, before being able to add a test that goes through the whole symbol processing.

### Description of how this pull request fixes the issue:

This adds a test using the French locale

### Change log entry:

Section: New features, Changes, Bug fixes

*New test*
`Symbols: test regex group references through the symbols engine.  (#11107)`