### PR TITLE
Dev docs: tell NVDA to treat source directory as app directory, allowing dev docs build with Sphinx to succeed

### DIFF
--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2019 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2019-2020 NV Access Limited, Leonard de Ruijter, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -16,7 +16,7 @@ import sourceEnv  # noqa: F401, E402
 import languageHandler  # noqa: E402
 languageHandler.setLanguage("en")
 
-# Initialize globalvars.appArgs to something sensible.
+# Initialize globalVars.appArgs to something sensible.
 import globalVars  # noqa: E402
 
 
@@ -30,6 +30,11 @@ class AppArgs:
 
 
 globalVars.appArgs = AppArgs()
+# #11971: NVDA is not running, therefore app dir is undefined.
+# Therefore tell NVDA that apt source directory is app dir.
+appDir = os.path.join("..", "source")
+globalVars.appDir = os.path.abspath(appDir)
+
 
 # Import NVDA's versionInfo module.
 import versionInfo  # noqa: E402
@@ -100,11 +105,6 @@ autodoc_mock_imports = [
 # autodoc can only mock modules, not objects.
 from sphinx.ext.autodoc.mock import _make_subclass  # noqa: E402
 
-# #11971: NVDA is not running, therefore app dir is undefined.
-# Therefore tell NVDA that apt source directory is app dir.
-import globalVars  # noqa: E402
-appDir = os.path.join("..", "source")
-globalVars.appDir = os.path.abspath(appDir)
 import config  # noqa: E402
 # Mock an instance of the configuration manager.
 config.conf = _make_subclass("conf", "config")()

--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -100,6 +100,11 @@ autodoc_mock_imports = [
 # autodoc can only mock modules, not objects.
 from sphinx.ext.autodoc.mock import _make_subclass  # noqa: E402
 
+# #11971: NVDA is not running, therefore app dir is undefined.
+# Therefore tell NVDA that apt source directory is app dir.
+import globalVars  # noqa: E402
+appDir = os.path.join("..", "source")
+globalVars.appDir = os.path.abspath(appDir)
 import config  # noqa: E402
 # Mock an instance of the configuration manager.
 config.conf = _make_subclass("conf", "config")()


### PR DESCRIPTION
Hi,
Foundation to allow building source code docs locally and through services suc has Read The Docs:

### Link to issue number:
Fixes #11971 

### Summary of the issue:
When building source code documentation, Python will notice that globalvars.appDir is not found, causing Sphinx to give up when building docs.

### Description of how this pull request fixes the issue:
In Sphinx config file, Sphinx will be told to "define" source code directory as app directory, allowing dev docs build to succeed.

### Testing performed:
Tested with Sphinx 2.2.2 and 3.4.1 with dev docs builds succeeding.

### Known issues with pull request:
None, although Sphinx raises warnings, which can be handled in subsequent pull requests.

### Change log entry:
Changes for developers:

You can now build source code documentation locally using Sphinx. (#11971)

Thanks.