### PR TITLE
Synth drivers/eSpeak NG internal: pass in a NULL pointer (path string) when obtaining eSpeak NG version string

### DIFF
--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# synthDrivers/_espeak.py
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2007-2020 NV Access Limited, Peter Vágner
 # This file is covered by the GNU General Public License.
@@ -370,7 +369,7 @@ def terminate():
 
 def info():
 	# Python 3.8: a path string must be specified, a NULL is fine when what we need is version string.
-	return espeakDLL.espeak_Info(None)
+	return espeakDLL.espeak_Info(None).decode()
 
 def getVariantDict():
 	dir = os.path.join(globalVars.appDir, "synthDrivers", "espeak-ng-data", "voices", "!v")

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -369,7 +369,8 @@ def terminate():
 	onIndexReached = None
 
 def info():
-	return espeakDLL.espeak_Info()
+	# Python 3.8: a path string must be specified, a NULL is fine when what we need is version string.
+	return espeakDLL.espeak_Info(None)
 
 def getVariantDict():
 	dir = os.path.join(globalVars.appDir, "synthDrivers", "espeak-ng-data", "voices", "!v")

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#synthDrivers/_espeak.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Peter Vágner
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# synthDrivers/_espeak.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2020 NV Access Limited, Peter Vágner
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import time
 import nvwave


### PR DESCRIPTION
Hi,

Needed for Python 3.8, although it is equally applicable to Python 3.7 and makes NVDA code more compliant with eSpeak NG API:

### Link to issue number:
None

### Summary of the issue:
eSpeak NG fails to load on Python 3.8 version of NVDA, traced to espeak.dll::espeak_Info function not receiving path string.

### Description of how this pull request fixes the issue:
Pass in NULL (None) when eSepak NG asks for path string in sepak_Info function because what NVDA is interested in is eSpeak NG version string.

### Testing performed:
Tested under source code and via a private binary copy:

* Success in Python 3.7 version
* Success in Python 3.8 version

### Known issues with pull request:
None

### Change log entry:
None

### Impact:
This is one of the major changes required to move NVDA to Python 3.8, especially given that eSpeak NG will be set as default speech synthesizer on Windows releases other than 10.

Thanks.