### PR TITLE
Fix error in user guide due to DMP retargetting

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1854,7 +1854,7 @@ However, it may be incompatible with some applications.
 This feature is supported in Windows Console on Windows 10 versions 1607 and later.
 Additionally, it may be available in other terminals on earlier Windows releases.
 - force Difflib: this option causes NVDA to calculate changes to terminal text by line.
-It is identical to NVDA's behaviour in versions 2020.3 and earlier.
+It is identical to NVDA's behaviour in versions 2020.4 and earlier.
 -
 
 ==== Attempt to cancel speech for expired focus events ====[CancelExpiredFocusSpeech]


### PR DESCRIPTION
Follow-up of #11639.

Just a small edit to the DMP section of the user guide, since the PR was targeted for 2021.1 (not 2020.4).

The referenced version for "previous behaviour" was changed from 2020.3 to 2020.4.