### PR TITLE
Update OneCore voices URL and instructions

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2253,7 +2253,15 @@ Windows 10 includes new voices known as "OneCore" or "mobile" voices.
 Voices are provided for many languages, and they are more responsive than the Microsoft voices available using Microsoft Speech API version 5.
 On Windows 10, NVDA uses Windows OneCore voices by default ([eSpeak NG #eSpeakNG] is used in other releases).
 
-To add new Windows OneCore voices, go to "Speech Settings", within Windows system settings.  Use the "Add voices" option and search for the desired language.  Many languages include multiple variants.  "United Kingdom" and "Australia" are two of the English variants.  "France", "Canada" and "Switzerland" are French variants available.  Search for the broader language (such as English or French), then locate the variant in the list.  Select any languages desired and use the "add" button to add them.  Once added, restart NVDA.
+To add new Windows OneCore voices, go to "Speech Settings", within Windows system settings. 
+Use the "Add voices" option and search for the desired language.
+Many languages include multiple variants.
+"United Kingdom" and "Australia" are two of the English variants.
+"France", "Canada" and "Switzerland" are French variants available.
+Search for the broader language (such as English or French), then locate the variant in the list.
+Select any languages desired and use the "add" button to add them.
+Once added, restart NVDA.
+
 
 Please see this Microsoft article for a list of available voices: https://support.microsoft.com/en-us/windows/appendix-a-supported-languages-and-voices-4486e345-7730-53da-fcfe-55cc64300f01
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2253,7 +2253,9 @@ Windows 10 includes new voices known as "OneCore" or "mobile" voices.
 Voices are provided for many languages, and they are more responsive than the Microsoft voices available using Microsoft Speech API version 5.
 On Windows 10, NVDA uses Windows OneCore voices by default ([eSpeak NG #eSpeakNG] is used in other releases).
 
-Please see this Microsoft article for a list of available voices and instructions to install them: https://support.microsoft.com/en-us/help/22797/windows-10-narrator-tts-voices
+To add new Windows OneCore voices, go to "Speech Settings", within Windows system settings.  Use the "Add voices" option and search for the desired language.  Many languages include multiple variants.  "United Kingdom" and "Australia" are two of the English variants.  "France", "Canada" and "Switzerland" are French variants available.  Search for the broader language (such as English or French), then locate the variant in the list.  Select any languages desired and use the "add" button to add them.  Once added, restart NVDA.
+
+Please see this Microsoft article for a list of available voices: https://support.microsoft.com/en-us/windows/appendix-a-supported-languages-and-voices-4486e345-7730-53da-fcfe-55cc64300f01
 
 + Supported Braille Displays +[SupportedBrailleDisplays]
 This section contains information about the Braille displays supported by NVDA.


### PR DESCRIPTION
The existing URL in the user guide with the list of OneCore voices languages and installation instructions was out of date.

- Added overview of how to install new voices
- Added updated link to list of available languages / voices

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
No existing issue, but problems with URL and lack of instructions reported by user.

### Summary of the issue:

The User Guide directed users to a Microsoft page for both instructions on installing new voices, and the list of available languages / voices.  This page had moved and so the URL 404'd.  The instructions on the page were also particular to Narrator.

### Description of how this pull request fixes the issue:

- Updated the URL to the current OneCore Voices pages with the list of languages / voices
- Added a couple of sentences with an overview of how to install new voices.

### Testing performed:

I followed the steps and ensured they work
Tested URL and confirmed it also works.

### Known issues with pull request:

None.

### Change log entry:

Section: New features, Changes, Bug fixes

Changes
- User Guide: Added installation instructions for installing OneCore voices and updated URL to list of available voices.