### PR TITLE
Update nvda_dmp to possibly address an autoread hang

### DIFF
--- a/source/diffHandler.py
+++ b/source/diffHandler.py
@@ -89,6 +89,8 @@ class DiffMatchPatch(DiffAlgo):
 				(size,) = struct.unpack("=I", sizeb)
 				while len(buf) < size:
 					buf += DiffMatchPatch._proc.stdout.read(size - len(buf))
+				DiffMatchPatch._proc.stdin.flush()
+				DiffMatchPatch._proc.stdout.flush()
 				return [
 					line
 					for line in buf.decode("utf-8").splitlines()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Possible resolution for #11992.

### Summary of the issue:
Currently, nvda_dmp sends the number of Unicode characters in the response header, then sends utf-8 encoded data. NVDA expects the header to contain the number of bytes, resulting in the diff hanging when the number of characters is fewer than the number of bytes.

### Description of how this pull request fixes the issue:
nvda_dmp now sends the number of bytes (not characters) in the response header.

### Testing performed:
I can no longer reproduce the hang described in #11992 and https://github.com/nvaccess/nvda/pull/11639#issuecomment-753325754 (I previously thought it was an issue with locking until further testing revealed this bug).

### Known issues with pull request:
* This PR definitely improves behaviour for me, but should be merged ASAP to allow for testing on master.

### Change log entry:
None needed.