### PR TITLE
Remove blank lines in browseable message

### DIFF
--- a/source/message.html
+++ b/source/message.html
@@ -15,16 +15,11 @@ function escapeKeyPress(e) {
 function windowOnLoad() {
 	// #5875: string.prototype.split strips the tail when a limit is supplied,
 	// so use a regexp instead.
-	var args = window.dialogArguments.match(/^(.*?);(.*?);([\s\S]*)$/);
+	var args = window.dialogArguments.match(/^(.*?);([\s\S]*)$/);
 	// args[0] is the whole string.
-	if (args && args.length == 4){
-		document.title= args[2];
-		if ( args[1] == "true") {
-			messageID.innerHTML= args[3];
-		}
-		else if ( args[1] == "false") {
-			textID.innerText= args[3];
-		}
+	if (args && args.length == 3){
+		document.title= args[1];
+		messageID.innerHTML= args[2];
 	}
 } 
 //-->
@@ -32,6 +27,5 @@ function windowOnLoad() {
 </HEAD>
 <BODY tabindex='0' id='main_body' LANGUAGE=javascript onload="return windowOnLoad()" onkeypress="return escapeKeyPress()" >
 <div id=messageID></div>
-<pre id=textID></pre>
 </body>
 </html>

--- a/source/ui.py
+++ b/source/ui.py
@@ -57,7 +57,7 @@ def browseableMessage(message,title=None,isHtml=False):
 		title = _("NVDA Message")
 	if not isHtml:
 		message = f"<pre>{message.replace('<', '&lt;')}</pre>"
-	dialogString = u"true;{title};{message}".format(title=title, message=message)
+	dialogString = f"{title};{message}"
 	dialogArguements = automation.VARIANT( dialogString )
 	gui.mainFrame.prePopup() 
 	windll.mshtml.ShowHTMLDialogEx( 

--- a/source/ui.py
+++ b/source/ui.py
@@ -55,8 +55,9 @@ def browseableMessage(message,title=None,isHtml=False):
 	if not title:
 		# Translators: The title for the dialog used to present general NVDA messages in browse mode.
 		title = _("NVDA Message")
-	isHtmlArgument = "true" if isHtml else "false"
-	dialogString = u"{isHtml};{title};{message}".format( isHtml = isHtmlArgument , title=title , message=message ) 
+	if not isHtml:
+		message = f"<pre>{message.replace('<', '&lt;')}</pre>"
+	dialogString = u"true;{title};{message}".format(title=title, message=message)
 	dialogArguements = automation.VARIANT( dialogString )
 	gui.mainFrame.prePopup() 
 	windll.mshtml.ShowHTMLDialogEx( 

--- a/source/ui.py
+++ b/source/ui.py
@@ -15,6 +15,7 @@ import sys
 from ctypes import windll, byref, POINTER, addressof
 from comtypes import IUnknown
 from comtypes import automation 
+from html import escape
 from logHandler import log
 import gui
 import speech
@@ -56,7 +57,7 @@ def browseableMessage(message,title=None,isHtml=False):
 		# Translators: The title for the dialog used to present general NVDA messages in browse mode.
 		title = _("NVDA Message")
 	if not isHtml:
-		message = f"<pre>{message.replace('<', '&lt;')}</pre>"
+		message = f"<pre>{escape(message)}</pre>"^M
 	dialogString = f"{title};{message}"
 	dialogArguements = automation.VARIANT( dialogString )
 	gui.mainFrame.prePopup() 

--- a/source/ui.py
+++ b/source/ui.py
@@ -57,7 +57,7 @@ def browseableMessage(message,title=None,isHtml=False):
 		# Translators: The title for the dialog used to present general NVDA messages in browse mode.
 		title = _("NVDA Message")
 	if not isHtml:
-		message = f"<pre>{escape(message)}</pre>"^M
+		message = f"<pre>{escape(message)}</pre>"
 	dialogString = f"{title};{message}"
 	dialogArguements = automation.VARIANT( dialogString )
 	gui.mainFrame.prePopup() 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,7 @@ What's New in NVDA
 - Fixed access to edit fields in MCS Electronics IDE's. (#11966) 
 - In MS Outlook, inappropriate distance reporting when shift+tabbing from the message body to the subject field should not occur anymore. (#10254)
 - In the Python Console, inserting a tab for indentation at the beginning of a non-empty input line and performing tab-completion in the middle of an input line are now supported. (#11532)
+- Formatting information and other browseable messages no longer present unexpected blank lines when screen layout is turned off. (#12004)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:

Fixes #12004

### Summary of the issue:
When reading a text in a browseable message (such as formatting information) line by line pressing down arrow, there is one blank line between each line of text.

### Description of how this pull request fixes the issue:

* Modified the HTML message template to use only `innerHTML` attribute and not `innerText` anymore.
* The raw text formatting is done in Python code by adding `<pre>` tag and escaping `<` character.

### Testing performed:

* Tested with formatting info message, with "Hello world" message in raw text.
* Tested HTML message with [Character information](https://addons.nvda-project.org/addons/charInfo.en.html) add-on.
* Tested long raw text (1000000 character) with [Clip Contents Designer](https://addons.nvda-project.org/addons/clipContentsDesigner.en.html) from @nvdaes and @abdel792.
Incidentally, this PR also fixes a visual issue in raw text browseable message containing lines longer than the window: moving the cursor on blank lines would pane the whole text to its right-most position, making the beginning of the lines disappear. This was visually strange. This is not the case anymore with this PR since the unexpected blank lines have been removed.

### Known issues with pull request:
None.

### Change log entry:

Bug fixes!
`Formatting information and other browseable messages do not present unexpected blank lines anymore. (#12004)`
