### PR TITLE
Fix up #11969: Fixed case issue.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1277,7 +1277,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 
 		if not self.passThrough:
 			if doSayAll:
-				speech.speakObjectProperties(self.rootNVDAObject, name=True, states=True, reason=OutputReason.Focus)
+				speech.speakObjectProperties(self.rootNVDAObject, name=True, states=True, reason=OutputReason.FOCUS)
 				sayAllHandler.readText(sayAllHandler.CURSOR_CARET)
 			else:
 				# Speak it like we would speak focus on any other document object.


### PR DESCRIPTION
### Link to issue number:

Fixes #12014
Fixes #12013
Fix-up of #11969

### Summary of the issue:

In #11969, a typo has been introduced: "Focus" (title case) instead of "FOCUS" (upper case)

### Description of how this pull request fixes the issue:

Fixed the typo

### Testing performed:

Called NVDA+F where I have also seen this issue.

### Known issues with pull request:

None

### Change log entry:
None: fix-up in alpha stage.
