### PR TITLE
Speak and Braille aria description in all cases

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -664,6 +664,9 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 		):
 			return None
 
+	description = None
+	if config.conf["presentation"]["reportObjectDescriptions"]:
+		description = field.get("description", None)
 	states = field.get("states", set())
 	value=field.get('value',None)
 	current = field.get('current', controlTypes.IsCurrent.NO)
@@ -676,6 +679,8 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 
 	if presCat == field.PRESCAT_LAYOUT:
 		text = []
+		if description:
+			text.append(getPropertiesBraille(description=description))
 		if current:
 			text.append(getPropertiesBraille(current=current))
 		if role == controlTypes.ROLE_GRAPHIC and content:
@@ -694,6 +699,7 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 			"columnSpan": field.get("table-columnsspanned"),
 			"includeTableCellCoords": reportTableCellCoords,
 			"current": current,
+			"description": description,
 		}
 		if reportTableHeaders:
 			props["columnHeaderText"] = field.get("table-columnheadertext")
@@ -708,7 +714,8 @@ def getControlFieldBraille(info, field, ancestors, reportStart, formatConfig):
 			"value": value,
 			"current": current,
 			"placeholder": placeholder,
-			"roleText": roleText
+			"roleText": roleText,
+			"description": description,
 		}
 		if field.get('alwaysReportName', False):
 			# Ensure that the name of the field gets presented even if normally it wouldn't.

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -128,7 +128,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 	def _isObjectEditableText(self, obj):
 		return obj.role in (controlTypes.ROLE_PARAGRAPH, controlTypes.ROLE_EDITABLETEXT)
 
-	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
+	def _getControlFieldForObject(self, obj: NVDAObject, ignoreEditableText=True):
 		if ignoreEditableText and self._isObjectEditableText(obj):
 			# This is basically just a text node.
 			return None
@@ -140,6 +140,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 		field = textInfos.ControlField()
 		field["role"] = role
 		field['roleText'] = obj.roleText
+		field['description'] = obj.description
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.STATE_EDITABLE)
 		states.discard(controlTypes.STATE_MULTILINE)

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1674,7 +1674,13 @@ def getControlFieldSpeech(  # noqa: C901
 	isCurrent = attrs.get('current', controlTypes.IsCurrent.NO)
 	placeholderValue=attrs.get('placeholder', None)
 	value=attrs.get('value',"")
-	if reason == OutputReason.FOCUS or attrs.get('alwaysReportDescription', False):
+	if (
+		attrs.get('alwaysReportDescription', False)
+		or reason in (
+			OutputReason.REASON_FOCUS,
+			OutputReason.REASON_CARET,
+		)
+	):
 		description=attrs.get('description',"")
 	else:
 		description=""
@@ -1904,6 +1910,8 @@ def getControlFieldSpeech(  # noqa: C901
 		out = []
 		if isCurrent != controlTypes.IsCurrent.NO:
 			out.extend(isCurrentSequence)
+		if descriptionSequence:
+			out.extend(descriptionSequence)
 		# Speak expanded / collapsed / level for treeview items (in ARIA treegrids)
 		if role == controlTypes.ROLE_TREEVIEWITEM:
 			if controlTypes.STATE_EXPANDED in states:

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1674,16 +1674,7 @@ def getControlFieldSpeech(  # noqa: C901
 	isCurrent = attrs.get('current', controlTypes.IsCurrent.NO)
 	placeholderValue=attrs.get('placeholder', None)
 	value=attrs.get('value',"")
-	if (
-		attrs.get('alwaysReportDescription', False)
-		or reason in (
-			OutputReason.REASON_FOCUS,
-			OutputReason.REASON_CARET,
-		)
-	):
-		description=attrs.get('description',"")
-	else:
-		description=""
+	description = attrs.get('description', "")
 	level=attrs.get('level',None)
 
 	if presCat != attrs.PRESCAT_LAYOUT:

--- a/tests/system/libraries/AssertsLib.py
+++ b/tests/system/libraries/AssertsLib.py
@@ -13,6 +13,10 @@ builtIn: BuiltIn = BuiltIn()
 class AssertsLib:
 	@staticmethod
 	def strings_match(actual, expected, ignore_case=False):
+		builtIn.log(
+			f"assert string matches (ignore case: {ignore_case}):  '{expected}'",
+			level="INFO"
+		)
 		try:
 			builtIn.should_be_equal_as_strings(
 				actual,
@@ -26,6 +30,7 @@ class AssertsLib:
 					ignore_case,
 					repr(actual),
 					repr(expected)
-				)
+				),
+				level="DEBUG"
 			)
 			raise

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -345,3 +345,130 @@ def test_ariaCheckbox_browseMode():
 		actualSpeech,
 		"Sandwich Condiments  grouping  list  with 4 items  Lettuce  check box  not checked"
 	)
+
+
+ariaDescriptionSample = """
+		<div>
+			<div
+				contenteditable=""
+				spellcheck="false"
+				role="textbox"
+				aria-multiline="true"
+			><p>This is a line with no annotation</p>
+			<p><span
+					aria-description="User nearby, Boaty McBoatface"
+				>Here is a sentence that is being edited by someone else.</span>
+				<b>Multiple authors can edit this document at the same time.</b></p>
+			<p>An element with a role, follow <a
+				href="www.google.com"
+				aria-description="opens in a new tab"
+				>to google's</a
+			> website</p>
+			<p>Testing the title attribute, <a
+				href="www.google.com"
+				title="conduct a search"
+				>to google's</a
+			> website</p>
+			</div>
+		</div>
+	"""
+
+
+def test_ariaDescription_focusMode():
+	""" Ensure aria description is read in focus mode.
+	"""
+	_chrome.prepareChrome(ariaDescriptionSample)
+	# Focus the contenteditable and automatically switch to focus mode (due to contenteditable)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"edit  multi line  This is a line with no annotation\nFocus mode"
+	)
+
+	annotation = "User nearby, Boaty Mc Boatface"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"{annotation}  Here is a sentence that is being edited by someone else."
+		"  Multiple authors can edit this document at the same time."
+	)
+	linkAnnotation = "opens in a new tab"
+	linkRole = "link"
+	linkName = "to google's"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"An element with a role, follow  {linkRole}  {linkAnnotation}  {linkName}  website"
+	)
+	linkTitle = "conduct a search"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"Testing the title attribute,  {linkRole}  {linkTitle}  {linkName}  website"
+	)
+
+
+def test_ariaDescription_browseMode():
+	""" Ensure aria description is read in browse mode.
+	"""
+	_chrome.prepareChrome(ariaDescriptionSample)
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"edit  multi line  This is a line with no annotation"
+	)
+
+	annotation = "User nearby, Boaty Mc Boatface"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"{annotation}  Here is a sentence that is being edited by someone else."
+		"  Multiple authors can edit this document at"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		"the same time."
+	)
+	linkAnnotation = "opens in a new tab"
+	linkRole = "link"
+	linkName = "to google's"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"An element with a role, follow  {linkRole}  {linkAnnotation}  {linkName}  website"
+	)
+
+	linkTitle = "conduct a search"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"Testing the title attribute,  {linkRole}  {linkTitle}  {linkName}  website"
+	)
+
+
+def test_ariaDescription_sayAll():
+	""" Ensure aria description is read by say all.
+	"""
+	_chrome.prepareChrome(ariaDescriptionSample)
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+downArrow")
+
+	annotation = "User nearby, Boaty Mc Boatface"
+	linkAnnotation = "opens in a new tab"
+	linkRole = "link"
+	linkName = "to google's"
+	linkTitle = "conduct a search"
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"Before Test Case Marker",
+			"edit  multi line  This is a line with no annotation",
+			f"{annotation}  Here is a sentence that is being edited by someone else.",
+			"Multiple authors can edit this document at  the same time.",
+			"An element with a role, "  # no comma, concat these two long strings.
+			f"follow  {linkRole}  {linkAnnotation}  {linkName}  website",
+			f"Testing the title attribute,  {linkRole}  {linkTitle}  {linkName}  website"
+			"  out of edit",
+			"After Test Case Marker"
+		])
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -47,3 +47,12 @@ ARIA checkbox
 	[Documentation]	Navigate to an unchecked checkbox in reading mode.
 	[Tags]	aria-at
 	test_ariaCheckbox_browseMode
+ARIA description Focus Mode
+	[Documentation]	Navigate to a span with aria-description in focus mode
+	test_ariaDescription_focusMode
+ARIA description Browse Mode
+	[Documentation]	Navigate to a span with aria-description in browse mode
+	test_ariaDescription_browseMode
+ARIA description Say All
+	[Documentation]	Say all, contents includes aria-description
+	test_ariaDescription_sayAll


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None

### Summary of the issue:
Support for simplest aspect of ARIA annotations: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Annotations

Adds support for aria-description which is intended to provide a detailed description of an HTML element, as opposed to the brief label provided by aria-label.

### Description of how this pull request fixes the issue:
In Chromium based browsers aria-description is mapped to accDescription. 
This PR adds support for reading accDescription in all cases when it is present.

Braille and speech are supported.
Config option Object Pesentation Report Object Descriptions is honored. 

### Testing performed:

### Known issues with pull request:
- This change may result in unwanted higher verbosity, we'll monitor for this and may subsequently adjust the approach taken. 
- Attributes such as 'title' (when name is already present eg via 'alt') will be mapped to accDescription, despite the [use of title being discouraged](https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute), there are still many usages of it. 
- Descriptions in braille can be a little confusing, because they are not delineated.

### Change log entry:

Changes:
```
- Descriptions will now be read in all modes, this is to support Aria-annotations.
```