### PR TITLE
Fix-up of #11467 in symbol file

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -179,7 +179,7 @@ _	line	most
 −	minus	some
 ×	times	some
 ⋅	times	some
-⨯	times	some
+⨯	times	none
 ∕	divided by	some
 ⁄	divided by	some
 ÷	divide by	some
@@ -188,12 +188,11 @@ _	line	most
 
 #Set operations
 ∖	set minus	none
-⨯	set times	none
 ⊍	set union	none
 𝒫	power set of the set	none
 𝔓	power set of the set	none
 ℘	power set of the set	none
-∁	complement	of the set	none
+∁	complement of the set	none
 
 #Set relations and set constructions
 ∅	empty set	none
@@ -226,7 +225,7 @@ _	line	most
 ≣	strictly identical to	none
 ≢	not identical to	none
 ∼	similar to	none
-≙	coresponds to	none
+≙	estimates	none
 ≟	questioned equal to	none
 
 #comparison signs
@@ -245,7 +244,7 @@ _	line	most
 
 #Functions
 ⁻	inverse	some
-∘	of	some
+∘	ring Operator	none
 ∂	partial derivative	none
 ∇	gradient of	none
 
@@ -311,13 +310,11 @@ _	line	most
 ≀	wreath product	none
 ≏	difference between	none
 ≐	approaches the limit	none
-∘	ring Operator	none
 ∙	bullet Operator	none
 ∣	divides	none
 ∤	does not divide	none
 ≔	colon equals	none
 ≕	equals colon	none
-≙	estimates	none
 ≺	precedes	none
 ≻	succeeds	none
 ⊀	does not precede	none


### PR DESCRIPTION
### Preliminary note:
This PR is a fix-up of little errors in #11467.. It is not meant to discuss the choices made in #11467, e.g. symbol names or level. This should be discussed in a separate issue if needed.

### Link to issue number:
Fix-up of #11467

### Summary of the issue:

#11467 added some extra math symbols in symbol file. But some little errors were introduced:
1. The following warning appears at NVDA startup:
   `WARNING - external:characterProcessing.SpeechSymbols.load (22:41:44.605) - MainThread (13136):`
   `Invalid line in file D:\Cyrille\Dev\GIT\nvda\source\locale\en\symbols.dic: ∁	complement	of the set	none`
   This is due to an extra tab in the line defining "complement of the set" symbol.
2. Three duplicate symbol definition have been found:
   * Symbol 1:
     `⨯	times	some`
     and
     `⨯	set times	none`
   * Symbol 2:
     `≙	coresponds to	none`
     and
     `≙	estimates	none`
   * Symbol 3:
     `∘	of	some`
     and
     `∘	ring Operator	none`

### Description of how this pull request fixes the issue:

* Removed the extra tab
* Symbol 1:
  Removed the line relative to set operator because this character is not explicitely defined as set operator in unicode; it is defined as "vector or cross product".
  Note: an alternative might have been to delete this line since this character is defined in CLDR as "vector cross product"
* Symbol 2:
  Kept "estimates" that seems more precise and remains short.
* Symbol 3:
  Kept "ring operator" that seems more precise than "of"; set verbosity level to "None" as many specific math symbols that are usually not recognized by TTS. But I moved the line in the "Functions" section.
  Note: personnally, I find "rign operator" too long anyway, this PR is not meant to discuss the choices made in #11467.

### Testing performed:

* Checked that the warning has disappeared
* Checked the symbol announcements

### Known issues with pull request:
None

### Change log entry:

None (fix-up of alpha)

