### PR TITLE
Python 3.8/liblouis helper: add NVDA executable path by calling os.add_dll_directory

### DIFF
--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -9,7 +9,7 @@
 # Thus manually add NVDA executable path to DLL lookup path for loading liblouis.dll.
 import os
 import globalVars
-with os.add_dll_directory(os.path.dirname(globalVars.appDir)):
+with os.add_dll_directory(globalVars.appDir):
 	import louis
 from logHandler import log
 import config

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -1,4 +1,3 @@
-# louisHelper.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -9,7 +8,8 @@
 # Python 3.8 changes the way DLL's are loaded due to security.
 # Thus manually add NVDA executable path to DLL lookup path for loading liblouis.dll.
 import os
-with os.add_dll_directory(os.path.dirname(__file__)):
+import globalVars
+with os.add_dll_directory(os.path.dirname(globalVars.appDir)):
 	import louis
 from logHandler import log
 import config

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -6,7 +6,11 @@
 
 """Helper module to ease communication to and from liblouis."""
 
-import louis
+# Python 3.8 changes the way DLL's are loaded due to security.
+# Thus manually add NVDA executable path to DLL lookup path for loading liblouis.dll.
+import os
+with os.add_dll_directory(os.path.dirname(__file__)):
+	import louis
 from logHandler import log
 import config
 

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -1,8 +1,8 @@
-#louisHelper.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2018 NV Access Limited, Babbage B.V.
+# louisHelper.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2018-2021 NV Access Limited, Babbage B.V., Joseph Lee
 
 """Helper module to ease communication to and from liblouis."""
 


### PR DESCRIPTION
Hi,

Required in Python 3.8:

### Link to issue number:
Fixes #10416

### Summary of the issue:
Python 3.8 adds os.add_dll_directory function to add a specified path to known DLL folders, used to load DLL's more securely. Without this call, liblouis.dll cannot be imported - instead, Python says "ModuleNotFoundError".

### Description of how this pull request fixes the issue:
Calls os.add_dll_directory function (context manager form) from louisHelper.py to add NVDA executable path to known DLL's directory in order to import liblouis.dll.

### Testing performed:
Tested from source code version of Python 3.8 NVDA with no problems - braille input and output works as expected.

### Known issues with pull request:
None

### Change log entry:
None

Thanks.