### PR TITLE
Fix name of visual highlight in 2020.4 changes

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,10 +29,10 @@ What's New in NVDA
 
 == Changes for Developers ==
 - Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
-- `LiveText._getTextLines` has been removed. (#11639)
-  - Instead, override `_getText` which returns a string of all text in the object.
-- `LiveText` objects can now calculate diffs by character. (#11639)
-  - To alter the diff behaviour for some object, override the `diffAlgo` property (see the docstring for details).
+- <code>LiveText._getTextLines</code> has been removed. (#11639)
+  - Instead, override <code>_getText</code> which returns a string of all text in the object.
+- <code>LiveText</code> objects can now calculate diffs by character. (#11639)
+  - To alter the diff behaviour for some object, override the <code>diffAlgo</code> property (see the docstring for details).
 - When defining a script with the script decorator, the 'allowInSleepMode' boolean argument can be specified to control  if a script is available in sleep mode or not. (#11979)
 - The following functions are removed from the config module:
  - canStartOnSecureScreens - use config.isInstalledCopy instead.
@@ -90,7 +90,7 @@ Plus many other important bug fixes and improvements.
 - Presentation of graphical view table in disk management has been improved. (#10048)
 - Labels for controls are now disabled (greyed out) when the control is disabled. (#11809)
 - Updated CLDR emoji annotation to version 38. (#11817)
-- The inbuilt "Focus Highlight" feature has been renamed "Vision Highlight". (#11700)
+- The inbuilt "Focus Highlight" feature has been renamed "Visual Highlight". (#11700)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
Change "vision highlight" to "visual highlight" in changelog to make more consistent with GUI.

Cc @feerrenrut @michaelDCurran.