### PR TITLE
System tests: run Chrome in kiosk mode to stop treeGrid test failing

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -94,7 +94,7 @@ class ChromeLib:
 		return marker in speech and documentIndex < speech.index(marker)
 
 	def _waitForStartMarker(self, spy, lastSpeechIndex):
-		""" Wait until the page loads and NVDA reads the start marker. 
+		""" Wait until the page loads and NVDA reads the start marker.
 		@param spy:
 		@type spy: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
 		@return: None

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -51,6 +51,7 @@ class ChromeLib:
 			" --force-renderer-accessibility"
 			" --suppress-message-center-popups"
 			" --disable-notifications"
+			" -kiosk"
 			f' "{filePath}"',
 			shell=True,
 			alias='chromeAlias',
@@ -92,18 +93,19 @@ class ChromeLib:
 		marker = ChromeLib._beforeMarker
 		return marker in speech and documentIndex < speech.index(marker)
 
-	def _moveToStartMarker(self, spy):
-		""" Press F6 until the start marker is spoken
+	def _waitForStartMarker(self, spy, lastSpeechIndex):
+		""" Wait until the page loads and NVDA reads the start marker. 
 		@param spy:
 		@type spy: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
 		@return: None
 		"""
 		for i in range(10):  # set a limit on the number of tries.
-			# Small changes in Chrome mean the number of tab presses to get into the document can vary.
 			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
-			actualSpeech = self.getSpeechAfterKey('f6')
+			spy.wait_for_speech_to_finish()
+			actualSpeech = spy.get_speech_at_index_until_now(lastSpeechIndex)
 			if self._wasStartMarkerSpoken(actualSpeech):
 				break
+			lastSpeechIndex = spy.get_last_speech_index()
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(
@@ -133,11 +135,7 @@ class ChromeLib:
 		# it is ready.
 		applicationTitle = f"{self._testCaseTitle}"
 		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
-		spy.wait_for_speech_to_finish()
-
-		afterTitleSpeech = spy.get_speech_at_index_until_now(appTitleIndex)
-		if not self._wasStartMarkerSpoken(afterTitleSpeech):
-			self._moveToStartMarker(spy)
+		self._waitForStartMarker(spy, appTitleIndex)
 
 
 	@staticmethod


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None.

### Summary of the issue:
Around 50% of the time, NVDA builds (including prs) fail on the ARIA treegrid system test. This seems to be because the test is needlessly pressing f6 when already on the document, most likely because of a delay in focus events caused by Chrome loading the content of an iframe (the treeGrid system test embeds a standard ARIA accessibility test in our normal test page using an iFrame).

### Description of how this pull request fixes the issue:
The test framework now always starts Chrome in kiosk mode (meaning that the address bar and other parts of the chrome are hidden, leaving only the document content visible). The test framework no longer has to worry about pressing f6 a number of times to get to the document, rather it only needs to wait until NVDA lands on the "Before test" marker itself.


### Testing performed:
* Produced a try build twice with no system test failures.
* PR has been built multiple times now with no system test failures.

### Known issues with pull request:
Before this pr, the system test never failed on my machine, but only on appveyor. This change so far seems to run fine on both appveyor and my machine, but only time will tell with appveyor. We have tried to fix this in the past. Let's hope this one works.
 
### Change log entry:
None.
