### PR TITLE
Add support for UIA with chromium based browsers 

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -903,6 +903,17 @@ class UIA(Window):
 				clsList.append(spartanEdge.EdgeList)
 			else:
 				clsList.append(spartanEdge.EdgeNode)
+		elif self.windowClassName == "Chrome_RenderWidgetHostHWND":
+			from . import chromium
+			if (
+				self.UIATextPattern
+				and self.role == controlTypes.ROLE_DOCUMENT
+				and self.parent
+				and self.parent.role == controlTypes.ROLE_PANE
+			):
+				clsList.append(chromium.ChromiumUIADocument)
+			else:
+				clsList.append(chromium.ChromiumUIA)
 		elif self.role == controlTypes.ROLE_DOCUMENT and UIAAutomationId == "Microsoft.Windows.PDF.DocumentView":
 			# PDFs
 			from . import spartanEdge

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -883,10 +883,20 @@ class UIA(Window):
 			from . import spartanEdge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
 				clsList.append(spartanEdge.EdgeHTMLRootContainer)
-			elif (self.UIATextPattern and
-				# #6998: Edge normally gives its root node a controlType of pane, but ARIA role="document"  changes the controlType to document
-				self.role in (controlTypes.ROLE_PANE,controlTypes.ROLE_DOCUMENT) and 
-				self.parent and (isinstance(self.parent,spartanEdge.EdgeHTMLRootContainer) or not isinstance(self.parent,spartanEdge.EdgeNode))
+			elif (
+				self.UIATextPattern
+				# #6998:
+				# Edge normally gives its root node a controlType of pane, but ARIA role="document"
+				# changes the controlType to document
+				and self.role in (
+					controlTypes.ROLE_PANE,
+					controlTypes.ROLE_DOCUMENT
+				)
+				and self.parent
+				and (
+					isinstance(self.parent, spartanEdge.EdgeHTMLRootContainer)
+					or not isinstance(self.parent, spartanEdge.EdgeNode)
+				)
 			): 
 				clsList.append(spartanEdge.EdgeHTMLRoot)
 			elif self.role==controlTypes.ROLE_LIST:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -650,6 +650,14 @@ class UIATextInfo(textInfos.TextInfo):
 				clippedStart = False
 				clippedEnd = False
 				if childRange.CompareEndpoints(
+					UIAHandler.TextPatternRangeEndpoint_End,
+					textRange,
+					UIAHandler.TextPatternRangeEndpoint_Start
+				) <= 0:
+					if debug:
+						log.debug("Child completely before textRange. Skipping")
+					continue
+				if childRange.CompareEndpoints(
 					UIAHandler.TextPatternRangeEndpoint_Start,
 					textRange,
 					UIAHandler.TextPatternRangeEndpoint_End

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -880,23 +880,23 @@ class UIA(Window):
 			# But not for Internet Explorer
 			and not self.appModule.appName == 'iexplore'
 		):
-			from . import edge
+			from . import spartanEdge
 			if UIAClassName in ("Internet Explorer_Server","WebView") and self.role==controlTypes.ROLE_PANE:
-				clsList.append(edge.EdgeHTMLRootContainer)
+				clsList.append(spartanEdge.EdgeHTMLRootContainer)
 			elif (self.UIATextPattern and
 				# #6998: Edge normally gives its root node a controlType of pane, but ARIA role="document"  changes the controlType to document
 				self.role in (controlTypes.ROLE_PANE,controlTypes.ROLE_DOCUMENT) and 
-				self.parent and (isinstance(self.parent,edge.EdgeHTMLRootContainer) or not isinstance(self.parent,edge.EdgeNode))
+				self.parent and (isinstance(self.parent,spartanEdge.EdgeHTMLRootContainer) or not isinstance(self.parent,spartanEdge.EdgeNode))
 			): 
-				clsList.append(edge.EdgeHTMLRoot)
+				clsList.append(spartanEdge.EdgeHTMLRoot)
 			elif self.role==controlTypes.ROLE_LIST:
-				clsList.append(edge.EdgeList)
+				clsList.append(spartanEdge.EdgeList)
 			else:
-				clsList.append(edge.EdgeNode)
+				clsList.append(spartanEdge.EdgeNode)
 		elif self.role == controlTypes.ROLE_DOCUMENT and UIAAutomationId == "Microsoft.Windows.PDF.DocumentView":
 			# PDFs
-			from . import edge
-			clsList.append(edge.EdgeHTMLRoot)
+			from . import spartanEdge
+			clsList.append(spartanEdge.EdgeHTMLRoot)
 		elif (
 			UIAAutomationId == "RichEditControl"
 			and "DevExpress.XtraRichEdit" in self.UIAElement.cachedProviderDescription

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -647,21 +647,33 @@ class UIATextInfo(textInfos.TextInfo):
 					if debug:
 						log.debug("NULL childRange. Skipping")
 					continue
-				clippedStart=clippedEnd=False
-				if index==lastChildIndex and childRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_Start,textRange,UIAHandler.TextPatternRangeEndpoint_End)>=0:
+				clippedStart = False
+				clippedEnd = False
+				if childRange.CompareEndpoints(
+					UIAHandler.TextPatternRangeEndpoint_Start,
+					textRange,
+					UIAHandler.TextPatternRangeEndpoint_End
+				) >= 0:
 					if debug:
 						log.debug("Child at or past end of textRange. Breaking")
 					break
-				if index==lastChildIndex:
-					lastChildEndDelta=childRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)
-					if lastChildEndDelta>0:
-						if debug:
-							log.debug(
-								"textRange ended part way through the child. "
-								"Crop end of childRange to fit"
-							)
-						childRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)
-						clippedEnd=True
+				lastChildEndDelta = childRange.CompareEndpoints(
+					UIAHandler.TextPatternRangeEndpoint_End,
+					textRange,
+					UIAHandler.TextPatternRangeEndpoint_End
+				)
+				if lastChildEndDelta > 0:
+					if debug:
+						log.debug(
+							"textRange ended part way through the child. "
+							"Crop end of childRange to fit"
+						)
+					childRange.MoveEndpointByRange(
+						UIAHandler.TextPatternRangeEndpoint_End,
+						textRange,
+						UIAHandler.TextPatternRangeEndpoint_End
+					)
+					clippedEnd = True
 				childStartDelta=childRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_Start,tempRange,UIAHandler.TextPatternRangeEndpoint_End)
 				if childStartDelta>0:
 					# plain text before this child
@@ -914,7 +926,10 @@ class UIA(Window):
 				clsList.append(chromium.ChromiumUIADocument)
 			else:
 				clsList.append(chromium.ChromiumUIA)
-		elif self.role == controlTypes.ROLE_DOCUMENT and UIAAutomationId == "Microsoft.Windows.PDF.DocumentView":
+		elif (
+			self.role == controlTypes.ROLE_DOCUMENT
+			and self.UIAElement.cachedAutomationId == "Microsoft.Windows.PDF.DocumentView"
+		):
 			# PDFs
 			from . import spartanEdge
 			clsList.append(spartanEdge.EdgeHTMLRoot)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -925,6 +925,7 @@ class UIA(Window):
 				clsList.append(spartanEdge.EdgeNode)
 		elif self.windowClassName == "Chrome_RenderWidgetHostHWND":
 			from . import chromium
+			from . import web
 			if (
 				self.UIATextPattern
 				and self.role == controlTypes.ROLE_DOCUMENT
@@ -933,6 +934,8 @@ class UIA(Window):
 			):
 				clsList.append(chromium.ChromiumUIADocument)
 			else:
+				if self.role == controlTypes.ROLE_LIST:
+					clsList.append(web.List)
 				clsList.append(chromium.ChromiumUIA)
 		elif (
 			self.role == controlTypes.ROLE_DOCUMENT

--- a/source/NVDAObjects/UIA/anaheimEdge.py
+++ b/source/NVDAObjects/UIA/anaheimEdge.py
@@ -1,0 +1,14 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 NV Access Limited
+
+"""
+UIA.anaheim_edge module for specialisations required for Chromium based Edge (code name anaheim).
+Note that the UIA.chromium module provides base behaviour for all Chromium based browsers, whereas this
+(anaheim_edge) module is only concerned with the window chrome / widgets that are specific to the browser.
+
+This file is currently a placeholder, this line can be deleted when this file is populated. Normally blank
+files would not be included in NVDA's repository, however in this case it has been in order to head off any
+confusion between the two very different implementations of Edge.
+"""

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -1,0 +1,31 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2020 NV Access limited, Leonard de Ruijter
+
+import UIAHandler
+from . import web
+import controlTypes
+
+"""
+This module provides UIA behaviour specific to the chromium family of browsers.
+Note this is more specialised than UIA.web but less so than browser specific modules such as UIA.spartan_edge
+or UIA.anaheim_edge.
+"""
+
+
+class ChromiumUIA(web.UIAWeb):
+	...
+
+
+class ChromiumUIATreeInterceptor(web.UIAWebTreeInterceptor):
+
+	def _get_documentConstantIdentifier(self):
+		return self.rootNVDAObject.parent._getUIACacheablePropertyValue(UIAHandler.UIA_AutomationIdPropertyId)
+
+
+class ChromiumUIADocument(ChromiumUIA):
+	treeInterceptorClass = ChromiumUIATreeInterceptor
+
+	def _get_shouldCreateTreeInterceptor(self):
+		return self.role == controlTypes.ROLE_DOCUMENT

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -41,6 +41,13 @@ class ChromiumUIATextInfo(web.UIAWebTextInfo):
 		if field['role'] == controlTypes.ROLE_TABLE:
 			if not obj._getUIACacheablePropertyValue(UIAHandler.UIA_IsTablePatternAvailablePropertyId):
 				field['table-layout'] = True
+		# Currently no way to tell if author has explicitly set name.
+		# Therefore always report the name if the control is not of a type that
+		# by definition uses its name for content.
+		# this may cause some duplicate speaking,
+		# But that is currently better than nothing at all.
+		if not field.get('nameIsContent') and field.get('name'):
+			field['alwaysReportName'] = True
 		return field
 
 

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -14,8 +14,22 @@ or UIA.anaheim_edge.
 """
 
 
+class ChromiumUIATextInfo(web.UIAWebTextInfo):
+
+	def _getFormatFieldAtRange(self, textRange, formatConfig, ignoreMixedValues=False):
+		formatField = super()._getFormatFieldAtRange(textRange, formatConfig, ignoreMixedValues=ignoreMixedValues)
+		# Headings are also exposed in the element tree,
+		# And therefore exposing in a formatField is redundant and causes duplicate reporting.
+		# So remove heading-level from the formatField if it exists.
+		try:
+			del formatField.field['heading-level']
+		except KeyError:
+			pass
+		return formatField
+
+
 class ChromiumUIA(web.UIAWeb):
-	...
+	_TextInfo = ChromiumUIATextInfo
 
 
 class ChromiumUIATreeInterceptor(web.UIAWebTreeInterceptor):

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -27,6 +27,19 @@ class ChromiumUIATextInfo(web.UIAWebTextInfo):
 			pass
 		return formatField
 
+	def _getControlFieldForObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
+		field = super()._getControlFieldForObject(
+			obj,
+			isEmbedded=isEmbedded,
+			startOfNode=startOfNode,
+			endOfNode=endOfNode
+		)
+		# Layout tables do not have the UIA table pattern
+		if field['role'] == controlTypes.ROLE_TABLE:
+			if not obj._getUIACacheablePropertyValue(UIAHandler.UIA_IsTablePatternAvailablePropertyId):
+				field['table-layout'] = True
+		return field
+
 
 class ChromiumUIA(web.UIAWeb):
 	_TextInfo = ChromiumUIATextInfo

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -34,6 +34,9 @@ class ChromiumUIATextInfo(web.UIAWebTextInfo):
 			startOfNode=startOfNode,
 			endOfNode=endOfNode
 		)
+		# use the value of comboboxes as content.
+		if obj.role == controlTypes.ROLE_COMBOBOX:
+			field['content'] = obj.value
 		# Layout tables do not have the UIA table pattern
 		if field['role'] == controlTypes.ROLE_TABLE:
 			if not obj._getUIACacheablePropertyValue(UIAHandler.UIA_IsTablePatternAvailablePropertyId):

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -19,10 +19,10 @@ import textInfos
 import UIAHandler
 from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, UIATextRangeQuickNavItem,UIAControlQuicknavIterator
 from UIAUtils import *
-from . import UIA, UIATextInfo
+from . import UIA, web
 
 
-class EdgeTextInfo(UIATextInfo):
+class EdgeTextInfo(web.UIAWebTextInfo):
 	...
 
 class EdgeTextInfo_preGapRemoval(EdgeTextInfo):
@@ -197,7 +197,8 @@ class EdgeTextInfo_preGapRemoval(EdgeTextInfo):
 		log.debug("Done walking parents to yield controlEnds and recurse unbalanced endRanges")
 		log.debug("_getTextWithFieldsForUIARange (unbalanced) end")
 
-class EdgeNode(UIA):
+
+class EdgeNode(web.UIAWeb):
 
 	_edgeIsPreGapRemoval=winVersion.winVersion.build<15048
 
@@ -240,8 +241,9 @@ class EdgeNode(UIA):
 		return False
 
 
-class EdgeList(EdgeNode):
+class EdgeList(web.List):
 	...
+
 
 class EdgeHTMLRootContainer(EdgeNode):
 
@@ -252,9 +254,8 @@ class EdgeHTMLRootContainer(EdgeNode):
 			return
 		return super(EdgeHTMLRootContainer,self).event_gainFocus()
 
-class EdgeHTMLTreeInterceptor(cursorManager.ReviewCursorManager,UIABrowseModeDocument):
 
-	TextInfo=UIABrowseModeDocumentTextInfo
+class EdgeHTMLTreeInterceptor(web.UIAWebTreeInterceptor):
 
 	def _get_documentConstantIdentifier(self):
 		return self.rootNVDAObject.parent.name

--- a/source/NVDAObjects/UIA/edge.py
+++ b/source/NVDAObjects/UIA/edge.py
@@ -21,229 +21,9 @@ from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, 
 from UIAUtils import *
 from . import UIA, UIATextInfo
 
-def splitUIAElementAttribs(attribsString):
-	"""Split an UIA Element attributes string into a dict of attribute keys and values.
-	An invalid attributes string does not cause an error, but strange results may be returned.
-	@param attribsString: The UIA Element attributes string to convert.
-	@type attribsString: str
-	@return: A dict of the attribute keys and values, where values are strings
-	@rtype: {str: str}
-	"""
-	attribsDict = {}
-	tmp = ""
-	key = ""
-	inEscape = False
-	for char in attribsString:
-		if inEscape:
-			tmp += char
-			inEscape = False
-		elif char == "\\":
-			inEscape = True
-		elif char == "=":
-			# We're about to move on to the value, so save the key and clear tmp.
-			key = tmp
-			tmp = ""
-		elif char == ";":
-			# We're about to move on to a new attribute.
-			if key:
-				# Add this key/value pair to the dict.
-				attribsDict[key] = tmp
-			key = ""
-			tmp = ""
-		else:
-			tmp += char
-	# If there was no trailing semi-colon, we need to handle the last attribute.
-	if key:
-		# Add this key/value pair to the dict.
-		attribsDict[key] = tmp
-	return attribsDict
 
 class EdgeTextInfo(UIATextInfo):
-
-	def _get_UIAElementAtStartWithReplacedContent(self):
-		"""Fetches the deepest UIAElement at the start of the text range whos name has been overridden by the author (such as aria-label)."""
-		element=self.UIAElementAtStart
-		condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:self.UIAControlTypesWhereNameIsContent})
-		# A part from the condition given, we must always match on the root of the document so we know when to stop walking
-		runtimeID=VARIANT()
-		self.obj.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(UIAHandler.UIA_RuntimeIdPropertyId,byref(runtimeID))
-		condition=UIAHandler.handler.clientObject.createOrCondition(UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_RuntimeIdPropertyId,runtimeID),condition)
-		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)
-		cacheRequest=UIAHandler.handler.clientObject.createCacheRequest()
-		cacheRequest.addProperty(UIAHandler.UIA_NamePropertyId)
-		cacheRequest.addProperty(UIAHandler.UIA_AriaPropertiesPropertyId)
-		element=walker.normalizeElementBuildCache(element,cacheRequest)
-		while element and not UIAHandler.handler.clientObject.compareElements(element,self.obj.UIAElement):
-			name=element.getCachedPropertyValue(UIAHandler.UIA_NamePropertyId)
-			if name:
-				ariaProperties=element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
-				if ('label=' in ariaProperties)  or ('labelledby=' in ariaProperties):
-					return element
-				try:
-					textRange=self.obj.UIATextPattern.rangeFromChild(element)
-				except COMError:
-					return
-				text = textRange.getText(-1)
-				if not text or text.isspace():
-					return element
-			element=walker.getParentElementBuildCache(element,cacheRequest)
-
-	def _moveToEdgeOfReplacedContent(self,back=False):
-		"""If within replaced content (E.g. aria-label is used), moves to the first or last character covered, so that a following call to move in the same direction will move out of the replaced content, in order to ensure that the content only takes up one character stop.""" 
-		element=self.UIAElementAtStartWithReplacedContent
-		if not element:
-			return
-		try:
-			textRange=self.obj.UIATextPattern.rangeFromChild(element)
-		except COMError:
-			return
-		if not back:
-			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start, textRange, UIAHandler.TextPatternRangeEndpoint_End)
-			textRange.move(UIAHandler.TextUnit_Character, -1)
-		else:
-			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End, textRange, UIAHandler.TextPatternRangeEndpoint_Start)
-		self._rangeObj=textRange
-
-	def _collapsedMove(self,unit,direction,skipReplacedContent):
-		"""A simple collapsed move (i.e. both ends move together), but whether it classes replaced content as one character stop can be configured via the skipReplacedContent argument."""
-		if not skipReplacedContent: 
-			return super(EdgeTextInfo,self).move(unit,direction)
-		if direction==0: 
-			return
-		chunk=1 if direction>0 else -1
-		finalRes=0
-		while finalRes!=direction:
-			self._moveToEdgeOfReplacedContent(back=direction<0)
-			res=super(EdgeTextInfo,self).move(unit,chunk)
-			if res==0:
-				break
-			finalRes+=res
-		return finalRes
-
-	def move(self,unit,direction,endPoint=None,skipReplacedContent=True):
-		if not endPoint:
-			return self._collapsedMove(unit,direction,skipReplacedContent)
-		else:
-			tempInfo=self.copy()
-			res=tempInfo.move(unit,direction,skipReplacedContent=skipReplacedContent)
-			if res!=0:
-				self.setEndPoint(tempInfo,"endToEnd" if endPoint=="end" else "startToStart")
-			return res
-
-	def _getControlFieldForObject(self,obj,isEmbedded=False,startOfNode=False,endOfNode=False):
-		field=super(EdgeTextInfo,self)._getControlFieldForObject(obj,isEmbedded=isEmbedded,startOfNode=startOfNode,endOfNode=endOfNode)
-		field['embedded']=isEmbedded
-		role=field.get('role')
-		# Fields should be treated as block for certain roles.
-		# This can affect whether the field is presented as a container (e.g.  announcing entering and exiting) 
-		if role in (
-			controlTypes.ROLE_GROUPING,
-			controlTypes.ROLE_SECTION,
-			controlTypes.ROLE_PARAGRAPH,
-			controlTypes.ROLE_ARTICLE,
-			controlTypes.ROLE_LANDMARK,
-			controlTypes.ROLE_REGION,
-		):
-			field['isBlock']=True
-		ariaProperties = splitUIAElementAttribs(
-			obj._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
-		)
-		# ARIA roledescription and landmarks
-		field['roleText'] = ariaProperties.get('roledescription')
-		# provide landmarks
-		field['landmark']=obj.landmark
-		# Combo boxes with a text pattern are editable
-		if obj.role==controlTypes.ROLE_COMBOBOX and obj.UIATextPattern:
-			field['states'].add(controlTypes.STATE_EDITABLE)
-		# report if the field is 'current'
-		field['current'] = obj.isCurrent
-		if obj.placeholder and obj._isTextEmpty:
-			field['placeholder']=obj.placeholder
-		# For certain controls, if ARIA overrides the label, then force the field's content (value) to the label
-		# Later processing in Edge's getTextWithFields will remove descendant content from fields with a content attribute.
-		hasAriaLabel = 'label' in ariaProperties
-		hasAriaLabelledby = 'labelledby' in ariaProperties
-		if field.get('nameIsContent'):
-			content=""
-			field.pop('name',None)
-			if hasAriaLabel or hasAriaLabelledby:
-				content=obj.name
-			if not content:
-				text=self.obj.makeTextInfo(obj).text
-				if not text or text.isspace():
-					content=obj.name or field.pop('description',None)
-			if content:
-				field['content']=content
-		elif isEmbedded:
-			field['content']=obj.value
-			if field['role']==controlTypes.ROLE_GROUPING:
-				field['role']=controlTypes.ROLE_EMBEDDEDOBJECT
-				if not obj.value:
-					field['content']=obj.name
-		elif hasAriaLabel or hasAriaLabelledby:
-			field['alwaysReportName'] = True
-		# Give lists an item count
-		if obj.role==controlTypes.ROLE_LIST:
-			child=UIAHandler.handler.clientObject.ControlViewWalker.GetFirstChildElement(obj.UIAElement)
-			if child:
-				field['_childcontrolcount']=child.getCurrentPropertyValue(UIAHandler.UIA_SizeOfSetPropertyId)
-		return field
-
-	def getTextWithFields(self,formatConfig=None):
-		# We don't want fields for collapsed ranges.
-		# This would normally be a general rule, but MS Word currently needs fields for collapsed ranges, thus this code is not in the base.
-		if self.isCollapsed:
-			return []
-		fields=super(EdgeTextInfo,self).getTextWithFields(formatConfig)
-		seenText=False
-		curStarts=[]
-		# remove clickable state on descendants of controls with clickable state
-		clickableField=None
-		for field in fields:
-			if isinstance(field,textInfos.FieldCommand) and field.command=="controlStart":
-				states=field.field['states']
-				if clickableField:
-					states.discard(controlTypes.STATE_CLICKABLE)
-				elif controlTypes.STATE_CLICKABLE in states:
-					clickableField=field.field
-			elif clickableField and isinstance(field,textInfos.FieldCommand) and field.command=="controlEnd" and field.field is clickableField:
-				clickableField=None
-		# Chop extra whitespace off the end incorrectly put there by Edge
-		numFields=len(fields)
-		index=0
-		while index<len(fields):
-			field=fields[index]
-			if index>1 and isinstance(field,str) and field.isspace():
-				prevField=fields[index-2]
-				if isinstance(prevField,textInfos.FieldCommand) and prevField.command=="controlEnd":
-					del fields[index-1:index+1]
-			index+=1
-		# chop fields off the end incorrectly placed there by Edge
-		# This can happen if expanding to line covers element start chars at its end
-		startCount=0
-		lastStartIndex=None
-		numFields=len(fields)
-		for index in range(numFields-1,-1,-1):
-			field=fields[index]
-			if isinstance(field,str):
-				break
-			elif isinstance(field,textInfos.FieldCommand) and field.command=="controlStart" and not field.field.get('embedded'):
-				startCount+=1
-				lastStartIndex=index
-		if lastStartIndex:
-			del fields[lastStartIndex:lastStartIndex+(startCount*2)]
-		# Remove any content from fields with a content attribute
-		numFields=len(fields)
-		curField=None
-		for index in range(numFields-1,-1,-1):
-			field=fields[index]
-			if not curField and isinstance(field,textInfos.FieldCommand) and field.command=="controlEnd" and field.field.get('content'):
-				curField=field.field
-				endIndex=index
-			elif curField and isinstance(field,textInfos.FieldCommand) and field.command=="controlStart" and field.field is curField:
-				fields[index+1:endIndex]=" "
-				curField=None
-		return fields
+	...
 
 class EdgeTextInfo_preGapRemoval(EdgeTextInfo):
 
@@ -268,7 +48,7 @@ class EdgeTextInfo_preGapRemoval(EdgeTextInfo):
 			elif direction>0:
 				res=self._collapsedMove(unit,direction,skipReplacedContent)
 				if res!=0:
-					# Ensure we move past the start of any elements 
+					# Ensure we move past the start of any elements
 					tempInfo=self.copy()
 					while super(EdgeTextInfo,tempInfo).move(textInfos.UNIT_CHARACTER,1)!=0:
 						tempInfo.setEndPoint(self,"startToStart")
@@ -440,59 +220,6 @@ class EdgeNode(UIA):
 			charInfo.collapse(True)
 		return textRange
 
-	def _get_role(self):
-		role=super(EdgeNode,self).role
-		if not isinstance(self,EdgeHTMLRoot) and role==controlTypes.ROLE_PANE and self.UIATextPattern:
-			return controlTypes.ROLE_INTERNALFRAME
-		ariaRole=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
-		# #7333: It is valid to provide multiple, space separated aria roles in HTML
-		# The role used is the first role in the list that has an associated NVDA role in aria.ariaRolesToNVDARoles
-		for ariaRole in ariaRole.split():
-			newRole=aria.ariaRolesToNVDARoles.get(ariaRole)
-			if newRole:
-				role=newRole
-				break
-		return role
-
-	def _get_states(self):
-		states=super(EdgeNode,self).states
-		if self.role in (controlTypes.ROLE_STATICTEXT,controlTypes.ROLE_GROUPING,controlTypes.ROLE_SECTION,controlTypes.ROLE_GRAPHIC) and self.UIAInvokePattern:
-			states.add(controlTypes.STATE_CLICKABLE)
-		return states
-
-	def _get_ariaProperties(self):
-		return splitUIAElementAttribs(self.UIAElement.currentAriaProperties)
-
-	# RegEx to get the value for the aria-current property. This will be looking for a the value of 'current'
-	# in a list of strings like "something=true;current=date;". We want to capture one group, after the '='
-	# character and before the ';' character.
-	# This could be one of: "false", "true", "page", "step", "location", "date", "time"
-	# "false" is ignored by the regEx and will not produce a match
-	RE_ARIA_CURRENT_PROP_VALUE = re.compile("current=(?!false)(\w+);")
-
-	def _get_isCurrent(self) -> controlTypes.IsCurrent:
-		ariaProperties=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
-		match = self.RE_ARIA_CURRENT_PROP_VALUE.search(ariaProperties)
-		if match:
-			valueOfAriaCurrent = match.group(1)
-			try:
-				return controlTypes.IsCurrent(valueOfAriaCurrent)
-			except ValueError:
-				log.debugWarning(
-					f"Unknown aria-current value: {valueOfAriaCurrent}, ariaProperties: {ariaProperties}"
-				)
-		return controlTypes.IsCurrent.NO
-
-	def _get_roleText(self):
-		roleText = self.ariaProperties.get('roledescription', None)
-		if roleText:
-			return roleText
-		return super().roleText
-
-	def _get_placeholder(self):
-		ariaPlaceholder = self.ariaProperties.get('placeholder', None)
-		return ariaPlaceholder
-
 	def _get__isTextEmpty(self):
 		# NOTE: we can not check the result of the EdgeTextInfo move implementation to determine if we added
 		# any characters to the range, since it seems to return 1 even when the text property has not changed.
@@ -512,30 +239,9 @@ class EdgeNode(UIA):
 			return True
 		return False
 
-	def _get_landmark(self):
-		landmarkId=self._getUIACacheablePropertyValue(UIAHandler.UIA_LandmarkTypePropertyId)
-		if not landmarkId: # will be 0 for non-landmarks
-			return None
-		landmarkRole = UIAHandler.UIALandmarkTypeIdsToLandmarkNames.get(landmarkId)
-		if landmarkRole:
-			return landmarkRole
-		ariaRoles=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
-		# #7333: It is valid to provide multiple, space separated aria roles in HTML
-		# If multiple roles or even multiple landmark roles are provided, the first one is used
-		ariaRole = ariaRoles.split(" ")[0]
-		if ariaRole in aria.landmarkRoles and (ariaRole != 'region' or self.name):
-			return ariaRole
-		return None
-
 
 class EdgeList(EdgeNode):
-
-	# non-focusable lists are readonly lists (ensures correct NVDA presentation category)
-	def _get_states(self):
-		states=super(EdgeList,self).states
-		if controlTypes.STATE_FOCUSABLE not in states:
-			states.add(controlTypes.STATE_READONLY)
-		return states
+	...
 
 class EdgeHTMLRootContainer(EdgeNode):
 
@@ -546,36 +252,6 @@ class EdgeHTMLRootContainer(EdgeNode):
 			return
 		return super(EdgeHTMLRootContainer,self).event_gainFocus()
 
-class EdgeHeadingQuickNavItem(UIATextRangeQuickNavItem):
-
-	@property
-	def level(self):
-		if not hasattr(self,'_level'):
-			styleVal=getUIATextAttributeValueFromRange(self.textInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId)
-			self._level=styleVal-(UIAHandler.StyleId_Heading1-1) if UIAHandler.StyleId_Heading1<=styleVal<=UIAHandler.StyleId_Heading6 else None
-		return self._level
-
-	def isChild(self,parent):
-		return self.level>parent.level
-
-def EdgeHeadingQuicknavIterator(itemType,document,position,direction="next"):
-	"""
-	A helper for L{EdgeHTMLTreeInterceptor._iterNodesByType} that specifically yields L{EdgeHeadingQuickNavItem} objects found in the given document, starting the search from the given position,  searching in the given direction.
-	See L{browseMode._iterNodesByType} for details on these specific arguments.
-	"""
-	# Edge exposes all headings as UIA elements with a controlType of text, and a level. Thus we can quickly search for these.
-	# However, sometimes when ARIA is used, the level on the element may not match the level in the text attributes.
-	# Therefore we need to search for all levels 1 through 6, even if a specific level is specified.
-	# Though this is still much faster than searching text attributes alone
-	# #9078: this must be wrapped inside a list, as Python 3 will treat this as iteration.
-	levels=list(range(1,7))
-	condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_TextControlTypeId,UIAHandler.UIA_LevelPropertyId:levels})
-	levelString=itemType[7:]
-	for item in UIAControlQuicknavIterator(itemType,document,position,condition,direction=direction,itemClass=EdgeHeadingQuickNavItem):
-		# Verify this is the correct heading level via text attributes 
-		if item.level and (not levelString or levelString==str(item.level)): 
-			yield item
-
 class EdgeHTMLTreeInterceptor(cursorManager.ReviewCursorManager,UIABrowseModeDocument):
 
 	TextInfo=UIABrowseModeDocumentTextInfo
@@ -583,34 +259,6 @@ class EdgeHTMLTreeInterceptor(cursorManager.ReviewCursorManager,UIABrowseModeDoc
 	def _get_documentConstantIdentifier(self):
 		return self.rootNVDAObject.parent.name
 
-	def _iterNodesByType(self,nodeType,direction="next",pos=None):
-		if nodeType.startswith("heading"):
-			return EdgeHeadingQuicknavIterator(nodeType,self,pos,direction=direction)
-		else:
-			return super(EdgeHTMLTreeInterceptor,self)._iterNodesByType(nodeType,direction=direction,pos=pos)
-
-	def shouldPassThrough(self,obj,reason=None):
-		# Enter focus mode for selectable list items (<select> and role=listbox)
-		if(
-			reason == controlTypes.OutputReason.FOCUS
-			and obj.role == controlTypes.ROLE_LISTITEM
-			and controlTypes.STATE_SELECTABLE in obj.states
-		):
-			return True
-		return super(EdgeHTMLTreeInterceptor,self).shouldPassThrough(obj,reason=reason)
-
-	def makeTextInfo(self,position):
-		try:
-			return super(EdgeHTMLTreeInterceptor,self).makeTextInfo(position)
-		except RuntimeError as e:
-			# sometimes the stored TextRange we have for the caret/selection can die if the page mutates too much.
-			# Therefore, if we detect this, just give back the first position in the document, updating our stored version as we go.
-			if position in (textInfos.POSITION_SELECTION,textInfos.POSITION_CARET):
-				log.debugWarning("%s died. Using first position instead."%position)
-				info=self.makeTextInfo(textInfos.POSITION_FIRST)
-				self._selection=info
-				return info
-			raise e
 
 class EdgeHTMLRoot(EdgeNode):
 

--- a/source/NVDAObjects/UIA/spartanEdge.py
+++ b/source/NVDAObjects/UIA/spartanEdge.py
@@ -273,8 +273,12 @@ class EdgeHTMLRoot(EdgeNode):
 	def _get_shouldCreateTreeInterceptor(self):
 		return self.role==controlTypes.ROLE_DOCUMENT
 
+	def _isIframe(self):
+		"""Override, the root node is never an iFrame"""
+		return False
+
 	def _get_role(self):
-		role=super(EdgeHTMLRoot,self).role
+		role = super().role
 		if role==controlTypes.ROLE_PANE:
 			role=controlTypes.ROLE_DOCUMENT
 		return role

--- a/source/NVDAObjects/UIA/spartanEdge.py
+++ b/source/NVDAObjects/UIA/spartanEdge.py
@@ -21,6 +21,11 @@ from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, 
 from UIAUtils import *
 from . import UIA, web
 
+"""
+	A module for using the legacy Edge browser (code name spartan) via UIA.
+	Specialisations on the UIA.web module.
+"""
+
 
 class EdgeTextInfo(web.UIAWebTextInfo):
 	...

--- a/source/NVDAObjects/UIA/spartanEdge.py
+++ b/source/NVDAObjects/UIA/spartanEdge.py
@@ -1,24 +1,18 @@
-#NVDAObjects/UIA/edge.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2015-2017 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2015-2021 NV Access Limited, Babbage B.V.
 
-from comtypes import COMError
-from comtypes.automation import VARIANT
-from ctypes import byref
 import winVersion
 from logHandler import log
 import eventHandler
-import config
 import controlTypes
-import cursorManager
-import re
-import aria
 import textInfos
 import UIAHandler
-from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, UIATextRangeQuickNavItem,UIAControlQuicknavIterator
-from UIAUtils import *
+from UIAUtils import (
+	getChildrenWithCacheFromUIATextRange,
+	getEnclosingElementWithCacheFromUIATextRange,
+)
 from . import UIA, web
 
 """
@@ -30,199 +24,334 @@ from . import UIA, web
 class EdgeTextInfo(web.UIAWebTextInfo):
 	...
 
+
 class EdgeTextInfo_preGapRemoval(EdgeTextInfo):
 
 	def _hasEmbedded(self):
-		"""Is this textInfo positioned on an embedded child?"""
-		children=self._rangeObj.getChildren()
+		""" Is this textInfo positioned on an embedded child?
+		"""
+		children = self._rangeObj.getChildren()
 		if children.length:
-			child=children.getElement(0)
+			child = children.getElement(0)
 			if not child.getCurrentPropertyValue(UIAHandler.UIA_IsTextPatternAvailablePropertyId):
-				childRange=self.obj.UIATextPattern.rangeFromChild(child)
+				childRange = self.obj.UIATextPattern.rangeFromChild(child)
 				if childRange:
-					childChildren=childRange.getChildren()
-				if childChildren.length==1 and UIAHandler.handler.clientObject.compareElements(child,childChildren.getElement(0)):
+					childChildren = childRange.getChildren()
+				if (
+					childChildren.length == 1
+					and UIAHandler.handler.clientObject.compareElements(child, childChildren.getElement(0))
+				):
 					return True
 		return False
 
-	def move(self,unit,direction,endPoint=None,skipReplacedContent=True):
+	def move(self, unit, direction, endPoint=None, skipReplacedContent=True):
 		# Skip over non-text element starts and ends
 		if not endPoint:
-			if direction>0 and unit in (textInfos.UNIT_LINE,textInfos.UNIT_PARAGRAPH):
-				return self._collapsedMove(unit,direction,skipReplacedContent)
-			elif direction>0:
-				res=self._collapsedMove(unit,direction,skipReplacedContent)
-				if res!=0:
+			if direction > 0 and unit in (
+				textInfos.UNIT_LINE,
+				textInfos.UNIT_PARAGRAPH
+			):
+				return self._collapsedMove(unit, direction, skipReplacedContent)
+			elif direction > 0:
+				res = self._collapsedMove(unit, direction, skipReplacedContent)
+				if res != 0:
 					# Ensure we move past the start of any elements
-					tempInfo=self.copy()
-					while super(EdgeTextInfo,tempInfo).move(textInfos.UNIT_CHARACTER,1)!=0:
-						tempInfo.setEndPoint(self,"startToStart")
+					tempInfo = self.copy()
+					while 0 != super(EdgeTextInfo, tempInfo).move(textInfos.UNIT_CHARACTER, 1):
+						tempInfo.setEndPoint(self, "startToStart")
 						if tempInfo.text or tempInfo._hasEmbedded():
 							break
 						tempInfo.collapse(True)
-						self._rangeObj=tempInfo._rangeObj.clone()
+						self._rangeObj = tempInfo._rangeObj.clone()
 				return res
-			elif direction<0:
-				tempInfo=self.copy()
-				res=self._collapsedMove(unit,direction,skipReplacedContent)
-				if res!=0:
+			elif direction < 0:
+				tempInfo = self.copy()
+				res = self._collapsedMove(unit, direction, skipReplacedContent)
+				if res != 0:
 					while True:
-						tempInfo.setEndPoint(self,"startToStart")
+						tempInfo.setEndPoint(self, "startToStart")
 						if tempInfo.text or tempInfo._hasEmbedded():
 							break
-						if super(EdgeTextInfo,self).move(textInfos.UNIT_CHARACTER,-1)==0:
+						if 0 == super(EdgeTextInfo, self).move(textInfos.UNIT_CHARACTER, -1):
 							break
 				return res
 		else:
-			tempInfo=self.copy()
-			res=tempInfo.move(unit,direction,skipReplacedContent=skipReplacedContent)
-			if res!=0:
-				self.setEndPoint(tempInfo,"endToEnd" if endPoint=="end" else "startToStart")
+			tempInfo = self.copy()
+			res = tempInfo.move(unit, direction, skipReplacedContent=skipReplacedContent)
+			if res != 0:
+				self.setEndPoint(tempInfo, "endToEnd" if endPoint == "end" else "startToStart")
 			return res
 
-	def expand(self,unit):
+	def expand(self, unit):
 		# Ensure expanding to character/word correctly covers embedded controls
-		if unit in (textInfos.UNIT_CHARACTER,textInfos.UNIT_WORD):
-			tempInfo=self.copy()
-			tempInfo.move(textInfos.UNIT_CHARACTER,1,endPoint="end",skipReplacedContent=False)
+		if unit in (
+			textInfos.UNIT_CHARACTER,
+			textInfos.UNIT_WORD,
+		):
+			tempInfo = self.copy()
+			tempInfo.move(textInfos.UNIT_CHARACTER, 1, endPoint="end", skipReplacedContent=False)
 			if tempInfo._hasEmbedded():
-				self.setEndPoint(tempInfo,"endToEnd")
+				self.setEndPoint(tempInfo, "endToEnd")
 				return
-		super(EdgeTextInfo,self).expand(unit)
+		super(EdgeTextInfo, self).expand(unit)
 		return
 
-	def _getTextWithFieldsForUIARange(self,rootElement,textRange,formatConfig,includeRoot=True,recurseChildren=True,alwaysWalkAncestors=True,_rootElementClipped=(True,True)):
+	# C901 '_getTextWithFieldsForUIARange' is too complex
+	# Note: when working here look for opportunities to simplify
+	# and move logic out into smaller helper functions.
+	def _getTextWithFieldsForUIARange(  # noqa: C901
+		self,
+		rootElement,
+		textRange,
+		formatConfig,
+		includeRoot=True,
+		recurseChildren=True,
+		alwaysWalkAncestors=True,
+		_rootElementClipped=(True, True)
+	):
 		# Edge zooms into its children at the start.
 		# Thus you are already in the deepest first child.
-		# Therefore get the deepest enclosing element at the start, get its content, Then do the whole thing again on the content from the end of the enclosing element to the end of its parent, and repete!
+		# Therefore get the deepest enclosing element at the start, get its content, Then do the whole thing
+		# again on the content from the end of the enclosing element to the end of its parent, and repeat!
 		# In other words, get the content while slowly zooming out from the start.
 		log.debug("_getTextWithFieldsForUIARange (unbalanced)")
 		if not recurseChildren:
 			log.debug("recurseChildren is False. Falling back to super")
-			for field in super(EdgeTextInfo,self)._getTextWithFieldsForUIARange(rootElement,textRange,formatConfig,includeRoot=includeRoot,alwaysWalkAncestors=True,recurseChildren=False,_rootElementClipped=_rootElementClipped):
+			for field in super(EdgeTextInfo, self)._getTextWithFieldsForUIARange(
+				rootElement,
+				textRange,
+				formatConfig,
+				includeRoot=includeRoot,
+				alwaysWalkAncestors=True,
+				recurseChildren=False,
+				_rootElementClipped=_rootElementClipped
+			):
 				yield field
 			return
 		if log.isEnabledFor(log.DEBUG):
-			log.debug("rootElement: %s"%rootElement.currentLocalizedControlType)
-			log.debug("full text: %s"%textRange.getText(-1))
-			log.debug("includeRoot: %s"%includeRoot)
-		startRange=textRange.clone()
-		startRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,startRange,UIAHandler.TextPatternRangeEndpoint_Start)
-		enclosingElement=getEnclosingElementWithCacheFromUIATextRange(startRange,self._controlFieldUIACacheRequest)
+			log.debug(f"rootElement: {rootElement.currentLocalizedControlType}")
+			log.debug(f"full text: {textRange.getText(-1)}")
+			log.debug(f"includeRoot: {includeRoot}")
+		startRange = textRange.clone()
+		startRange.MoveEndpointByRange(
+			UIAHandler.TextPatternRangeEndpoint_End,
+			startRange,
+			UIAHandler.TextPatternRangeEndpoint_Start
+		)
+		enclosingElement = getEnclosingElementWithCacheFromUIATextRange(
+			startRange,
+			self._controlFieldUIACacheRequest
+		)
 		if not enclosingElement:
 			log.debug("No enclosingElement. Returning")
 			return
-		enclosingRange=self.obj.getNormalizedUIATextRangeFromElement(enclosingElement)
+		enclosingRange = self.obj.getNormalizedUIATextRangeFromElement(enclosingElement)
 		if not enclosingRange:
 			log.debug("enclosingRange is NULL. Returning")
 			return
 		if log.isEnabledFor(log.DEBUG):
-			log.debug("enclosingElement: %s"%enclosingElement.currentLocalizedControlType)
-		startRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,enclosingRange,UIAHandler.TextPatternRangeEndpoint_End)
-		if startRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)>0:
-			startRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)
+			log.debug(f"enclosingElement: {enclosingElement.currentLocalizedControlType}")
+		startRange.MoveEndpointByRange(
+			UIAHandler.TextPatternRangeEndpoint_End,
+			enclosingRange,
+			UIAHandler.TextPatternRangeEndpoint_End
+		)
+		if 0 < startRange.CompareEndpoints(
+			UIAHandler.TextPatternRangeEndpoint_End,
+			textRange,
+			UIAHandler.TextPatternRangeEndpoint_End
+		):
+			startRange.MoveEndpointByRange(
+				UIAHandler.TextPatternRangeEndpoint_End,
+				textRange,
+				UIAHandler.TextPatternRangeEndpoint_End
+			)
 		# Ensure we don't now have a collapsed range
-		if startRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,startRange,UIAHandler.TextPatternRangeEndpoint_Start)<=0:
+		if 0 >= startRange.CompareEndpoints(
+			UIAHandler.TextPatternRangeEndpoint_End,
+			startRange,
+			UIAHandler.TextPatternRangeEndpoint_Start
+		):
 			log.debug("Collapsed range. Returning")
 			return
 		# check for an embedded child
-		childElements=getChildrenWithCacheFromUIATextRange(startRange,self._controlFieldUIACacheRequest)
-		if childElements.length==1 and UIAHandler.handler.clientObject.compareElements(rootElement,childElements.getElement(0)):
+		childElements = getChildrenWithCacheFromUIATextRange(startRange, self._controlFieldUIACacheRequest)
+		if (
+			childElements.length == 1
+			and UIAHandler.handler.clientObject.compareElements(
+				rootElement,
+				childElements.getElement(0)
+			)
+		):
 			log.debug("Using single embedded child as enclosingElement")
-			for field in super(EdgeTextInfo,self)._getTextWithFieldsForUIARange(rootElement,startRange,formatConfig,_rootElementClipped=_rootElementClipped,includeRoot=includeRoot,alwaysWalkAncestors=False,recurseChildren=False):
+			for field in super(EdgeTextInfo, self)._getTextWithFieldsForUIARange(
+				rootElement,
+				startRange,
+				formatConfig,
+				_rootElementClipped=_rootElementClipped,
+				includeRoot=includeRoot,
+				alwaysWalkAncestors=False,
+				recurseChildren=False
+			):
 				yield field
 			return
-		parents=[]
-		parentElement=enclosingElement
+		parents = []
+		parentElement = enclosingElement
 		log.debug("Generating ancestors:")
-		hasAncestors=False
+		hasAncestors = False
 		while parentElement:
 			if log.isEnabledFor(log.DEBUG):
-				log.debug("parentElement: %s"%parentElement.currentLocalizedControlType)
-			isRoot=UIAHandler.handler.clientObject.compareElements(parentElement,rootElement)
-			log.debug("isRoot: %s"%isRoot)
+				log.debug(f"parentElement: {parentElement.currentLocalizedControlType}")
+			isRoot = UIAHandler.handler.clientObject.compareElements(parentElement, rootElement)
+			log.debug(f"isRoot: {isRoot}")
 			if not isRoot:
-				hasAncestors=True
+				hasAncestors = True
 			if parentElement is not enclosingElement:
 				if includeRoot or not isRoot:
 					try:
-						obj=UIA(windowHandle=self.obj.windowHandle,UIAElement=parentElement,initialUIACachedPropertyIDs=self._controlFieldUIACachedPropertyIDs)
-						field=self._getControlFieldForObject(obj)
+						obj = UIA(
+							windowHandle=self.obj.windowHandle,
+							UIAElement=parentElement,
+							initialUIACachedPropertyIDs=self._controlFieldUIACachedPropertyIDs
+						)
+						field = self._getControlFieldForObject(obj)
 					except LookupError:
 						log.debug("Failed to fetch controlField data for parentElement. Breaking")
 						break
-					parents.append((parentElement,field))
+					parents.append((parentElement, field))
 				else:
 					# This is the root but it was not requested for inclusion
 					# However we still need the root element itself for further recursion
-					parents.append((parentElement,None))
+					parents.append((parentElement, None))
 			if isRoot:
 				log.debug("Hit root. Breaking")
 				break
 			log.debug("Fetching next parentElement")
-			parentElement=UIAHandler.handler.baseTreeWalker.getParentElementBuildCache(parentElement,self._controlFieldUIACacheRequest)
+			parentElement = UIAHandler.handler.baseTreeWalker.getParentElementBuildCache(
+				parentElement,
+				self._controlFieldUIACacheRequest
+			)
 		log.debug("Done generating parents")
 		log.debug("Yielding parents in reverse order")
-		for parentElement,field in reversed(parents):
-			if field: yield textInfos.FieldCommand("controlStart",field)
+		for parentElement, field in reversed(parents):
+			if field:
+				yield textInfos.FieldCommand("controlStart", field)
 		log.debug("Done yielding parents")
 		log.debug("Yielding balanced fields for startRange")
-		clippedStart=enclosingRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_Start,startRange,UIAHandler.TextPatternRangeEndpoint_Start)<0
-		clippedEnd=enclosingRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,startRange,UIAHandler.TextPatternRangeEndpoint_End)>0
-		for field in super(EdgeTextInfo,self)._getTextWithFieldsForUIARange(enclosingElement,startRange,formatConfig,_rootElementClipped=(clippedStart,clippedEnd),includeRoot=includeRoot or hasAncestors,alwaysWalkAncestors=False,recurseChildren=True):
+		clippedStart = 0 > enclosingRange.CompareEndpoints(
+			UIAHandler.TextPatternRangeEndpoint_Start,
+			startRange,
+			UIAHandler.TextPatternRangeEndpoint_Start
+		)
+		clippedEnd = 0 < enclosingRange.CompareEndpoints(
+			UIAHandler.TextPatternRangeEndpoint_End,
+			startRange,
+			UIAHandler.TextPatternRangeEndpoint_End
+		)
+		for field in super(EdgeTextInfo, self)._getTextWithFieldsForUIARange(
+			enclosingElement,
+			startRange,
+			formatConfig,
+			_rootElementClipped=(clippedStart, clippedEnd),
+			includeRoot=includeRoot or hasAncestors,
+			alwaysWalkAncestors=False,
+			recurseChildren=True
+		):
 			yield field
-		tempRange=startRange.clone()
+		tempRange = startRange.clone()
 		log.debug("Walking parents to yield controlEnds and recurse unbalanced endRanges")
-		for parentElement,field in parents:
+		for parentElement, field in parents:
 			if log.isEnabledFor(log.DEBUG):
-				log.debug("parentElement: %s"%parentElement.currentLocalizedControlType)
-			tempRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start,tempRange,UIAHandler.TextPatternRangeEndpoint_End)
-			parentRange=self.obj.getNormalizedUIATextRangeFromElement(parentElement)
+				log.debug(f"parentElement: {parentElement.currentLocalizedControlType}")
+			tempRange.MoveEndpointByRange(
+				UIAHandler.TextPatternRangeEndpoint_Start,
+				tempRange,
+				UIAHandler.TextPatternRangeEndpoint_End
+			)
+			parentRange = self.obj.getNormalizedUIATextRangeFromElement(parentElement)
 			if parentRange:
-				tempRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,parentRange,UIAHandler.TextPatternRangeEndpoint_End)
-				if tempRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)>0:
-					tempRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End,textRange,UIAHandler.TextPatternRangeEndpoint_End)
-					clippedEnd=True
+				tempRange.MoveEndpointByRange(
+					UIAHandler.TextPatternRangeEndpoint_End,
+					parentRange,
+					UIAHandler.TextPatternRangeEndpoint_End
+				)
+				if 0 < tempRange.CompareEndpoints(
+					UIAHandler.TextPatternRangeEndpoint_End,
+					textRange,
+					UIAHandler.TextPatternRangeEndpoint_End
+				):
+					tempRange.MoveEndpointByRange(
+						UIAHandler.TextPatternRangeEndpoint_End,
+						textRange,
+						UIAHandler.TextPatternRangeEndpoint_End
+					)
+					clippedEnd = True
 				else:
-					clippedEnd=False
+					clippedEnd = False
 				if field:
-					clippedStart=parentRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_Start,textRange,UIAHandler.TextPatternRangeEndpoint_Start)<0
-					field['_startOfNode']=not clippedStart
-					field['_endOfNode']=not clippedEnd
-				if tempRange.CompareEndpoints(UIAHandler.TextPatternRangeEndpoint_End,tempRange,UIAHandler.TextPatternRangeEndpoint_Start)>0:
+					clippedStart = 0 > parentRange.CompareEndpoints(
+						UIAHandler.TextPatternRangeEndpoint_Start,
+						textRange,
+						UIAHandler.TextPatternRangeEndpoint_Start
+					)
+					field['_startOfNode'] = not clippedStart
+					field['_endOfNode'] = not clippedEnd
+				if 0 < tempRange.CompareEndpoints(
+					UIAHandler.TextPatternRangeEndpoint_End,
+					tempRange,
+					UIAHandler.TextPatternRangeEndpoint_Start
+				):
 					log.debug("Recursing endRange")
-					for endField in self._getTextWithFieldsForUIARange(parentElement,tempRange,formatConfig,_rootElementClipped=(clippedStart,clippedEnd),includeRoot=False,alwaysWalkAncestors=True,recurseChildren=True):
+					for endField in self._getTextWithFieldsForUIARange(
+						parentElement,
+						tempRange,
+						formatConfig,
+						_rootElementClipped=(clippedStart, clippedEnd),
+						includeRoot=False,
+						alwaysWalkAncestors=True,
+						recurseChildren=True
+					):
 						yield endField
 					log.debug("Done recursing endRange")
 				else:
 					log.debug("No content after parent")
 			if field:
 				log.debug("Yielding controlEnd for parent")
-				yield textInfos.FieldCommand("controlEnd",field)
+				yield textInfos.FieldCommand("controlEnd", field)
 		log.debug("Done walking parents to yield controlEnds and recurse unbalanced endRanges")
 		log.debug("_getTextWithFieldsForUIARange (unbalanced) end")
 
 
 class EdgeNode(web.UIAWeb):
 
-	_edgeIsPreGapRemoval=winVersion.winVersion.build<15048
+	_edgeIsPreGapRemoval = winVersion.winVersion.build < 15048
 
-	_TextInfo=EdgeTextInfo_preGapRemoval if _edgeIsPreGapRemoval else EdgeTextInfo
+	_TextInfo = EdgeTextInfo_preGapRemoval if _edgeIsPreGapRemoval else EdgeTextInfo
 
-	def getNormalizedUIATextRangeFromElement(self,UIAElement):
+	def getNormalizedUIATextRangeFromElement(self, UIAElement):
 		textRange = super().getNormalizedUIATextRangeFromElement(UIAElement)
 		if not textRange or not self._edgeIsPreGapRemoval:
 			return textRange
-		#Move the start of a UIA text range past any element start character stops
-		lastCharInfo = EdgeTextInfo_preGapRemoval(self,None, _rangeObj=textRange)
+		# Move the start of a UIA text range past any element start character stops
+		lastCharInfo = EdgeTextInfo_preGapRemoval(
+			obj=self,
+			position=None,
+			_rangeObj=textRange
+		)
 		lastCharInfo._rangeObj = textRange
 		charInfo = lastCharInfo.copy()
 		charInfo.collapse()
-		while super(EdgeTextInfo,charInfo).move(textInfos.UNIT_CHARACTER,1)!=0:
-			charInfo.setEndPoint(lastCharInfo,"startToStart")
+		# charInfo is a EdgeTextInfo_preGapRemoval, so why is
+		# EdgeTextInfo.move used instead of
+		# EdgeTextInfo_preGapRemoval.move?
+		while 0 != super(EdgeTextInfo, charInfo).move(
+			textInfos.UNIT_CHARACTER,
+			1
+		):
+			charInfo.setEndPoint(lastCharInfo, "startToStart")
 			if charInfo.text or charInfo._hasEmbedded():
 				break
-			lastCharInfo.setEndPoint(charInfo,"startToEnd")
+			lastCharInfo.setEndPoint(charInfo, "startToEnd")
 			charInfo.collapse(True)
 		return textRange
 
@@ -253,11 +382,11 @@ class EdgeList(web.List):
 class EdgeHTMLRootContainer(EdgeNode):
 
 	def event_gainFocus(self):
-		firstChild=self.firstChild
-		if isinstance(firstChild,UIA):
-			eventHandler.executeEvent("gainFocus",firstChild)
+		firstChild = self.firstChild
+		if isinstance(firstChild, UIA):
+			eventHandler.executeEvent("gainFocus", firstChild)
 			return
-		return super(EdgeHTMLRootContainer,self).event_gainFocus()
+		return super().event_gainFocus()
 
 
 class EdgeHTMLTreeInterceptor(web.UIAWebTreeInterceptor):
@@ -268,10 +397,10 @@ class EdgeHTMLTreeInterceptor(web.UIAWebTreeInterceptor):
 
 class EdgeHTMLRoot(EdgeNode):
 
-	treeInterceptorClass=EdgeHTMLTreeInterceptor
+	treeInterceptorClass = EdgeHTMLTreeInterceptor
 
 	def _get_shouldCreateTreeInterceptor(self):
-		return self.role==controlTypes.ROLE_DOCUMENT
+		return self.role == controlTypes.ROLE_DOCUMENT
 
 	def _isIframe(self):
 		"""Override, the root node is never an iFrame"""
@@ -279,6 +408,6 @@ class EdgeHTMLRoot(EdgeNode):
 
 	def _get_role(self):
 		role = super().role
-		if role==controlTypes.ROLE_PANE:
-			role=controlTypes.ROLE_DOCUMENT
+		if role == controlTypes.ROLE_PANE:
+			role = controlTypes.ROLE_DOCUMENT
 		return role

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -6,10 +6,13 @@
 from comtypes import COMError
 from comtypes.automation import VARIANT
 from ctypes import byref
-import winVersion
+
+from . import (
+	UIATextInfo,
+	UIA,
+)
+
 from logHandler import log
-import eventHandler
-import config
 import controlTypes
 import cursorManager
 import re
@@ -75,84 +78,112 @@ def splitUIAElementAttribs(attribsString):
 class UIAWebTextInfo(UIATextInfo):
 
 	def _get_UIAElementAtStartWithReplacedContent(self):
-		"""Fetches the deepest UIAElement at the start of the text range whos name has been overridden by the author (such as aria-label)."""
-		element=self.UIAElementAtStart
-		condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:self.UIAControlTypesWhereNameIsContent})
-		# A part from the condition given, we must always match on the root of the document so we know when to stop walking
-		runtimeID=VARIANT()
-		self.obj.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(UIAHandler.UIA_RuntimeIdPropertyId,byref(runtimeID))
-		condition=UIAHandler.handler.clientObject.createOrCondition(UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_RuntimeIdPropertyId,runtimeID),condition)
-		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)
-		cacheRequest=UIAHandler.handler.clientObject.createCacheRequest()
+		"""Fetches the deepest UIAElement at the start of the text range
+		whose name has been overridden by the author (such as aria-label).
+		"""
+		element = self.UIAElementAtStart
+		condition = createUIAMultiPropertyCondition({
+			UIAHandler.UIA_ControlTypePropertyId: self.UIAControlTypesWhereNameIsContent
+		})
+		# A part from the condition given, we must always match on the root of the document
+		# so we know when to stop walking
+		runtimeID = VARIANT()
+		self.obj.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(
+			UIAHandler.UIA_RuntimeIdPropertyId,
+			byref(runtimeID)
+		)
+		condition = UIAHandler.handler.clientObject.createOrCondition(
+			UIAHandler.handler.clientObject.createPropertyCondition(
+				UIAHandler.UIA_RuntimeIdPropertyId,
+				runtimeID
+			),
+			condition
+		)
+		walker = UIAHandler.handler.clientObject.createTreeWalker(condition)
+		cacheRequest = UIAHandler.handler.clientObject.createCacheRequest()
 		cacheRequest.addProperty(UIAHandler.UIA_NamePropertyId)
 		cacheRequest.addProperty(UIAHandler.UIA_AriaPropertiesPropertyId)
-		element=walker.normalizeElementBuildCache(element,cacheRequest)
-		while element and not UIAHandler.handler.clientObject.compareElements(element,self.obj.UIAElement):
-			name=element.getCachedPropertyValue(UIAHandler.UIA_NamePropertyId)
+		element = walker.normalizeElementBuildCache(element, cacheRequest)
+		while element and not UIAHandler.handler.clientObject.compareElements(element, self.obj.UIAElement):
+			name = element.getCachedPropertyValue(UIAHandler.UIA_NamePropertyId)
 			if name:
-				ariaProperties=element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
-				if ('label=' in ariaProperties)  or ('labelledby=' in ariaProperties):
+				ariaProperties = element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
+				if ('label=' in ariaProperties) or ('labelledby=' in ariaProperties):
 					return element
 				try:
-					textRange=self.obj.UIATextPattern.rangeFromChild(element)
+					textRange = self.obj.UIATextPattern.rangeFromChild(element)
 				except COMError:
 					return
 				text = textRange.getText(-1)
 				if not text or text.isspace():
 					return element
-			element=walker.getParentElementBuildCache(element,cacheRequest)
+			element = walker.getParentElementBuildCache(element, cacheRequest)
 
-	def _moveToEdgeOfReplacedContent(self,back=False):
-		"""If within replaced content (E.g. aria-label is used), moves to the first or last character covered, so that a following call to move in the same direction will move out of the replaced content, in order to ensure that the content only takes up one character stop."""
-		element=self.UIAElementAtStartWithReplacedContent
+	def _moveToEdgeOfReplacedContent(self, back=False):
+		"""If within replaced content (E.g. aria-label is used),
+		moves to the first or last character covered, so that a following call to move in the same direction
+		will move out of the replaced content, in order to ensure
+		that the content only takes up one character stop.
+		"""
+		element = self.UIAElementAtStartWithReplacedContent
 		if not element:
 			return
 		try:
-			textRange=self.obj.UIATextPattern.rangeFromChild(element)
+			textRange = self.obj.UIATextPattern.rangeFromChild(element)
 		except COMError:
 			return
 		if not back:
-			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start, textRange, UIAHandler.TextPatternRangeEndpoint_End)
+			textRange.MoveEndpointByRange(
+				UIAHandler.TextPatternRangeEndpoint_Start,
+				textRange,
+				UIAHandler.TextPatternRangeEndpoint_End
+			)
 			textRange.move(UIAHandler.TextUnit_Character, -1)
 		else:
-			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End, textRange, UIAHandler.TextPatternRangeEndpoint_Start)
-		self._rangeObj=textRange
+			textRange.MoveEndpointByRange(
+				UIAHandler.TextPatternRangeEndpoint_End,
+				textRange,
+				UIAHandler.TextPatternRangeEndpoint_Start
+			)
+		self._rangeObj = textRange
 
-	def _collapsedMove(self,unit,direction,skipReplacedContent):
-		"""A simple collapsed move (i.e. both ends move together), but whether it classes replaced content as one character stop can be configured via the skipReplacedContent argument."""
+	def _collapsedMove(self, unit, direction, skipReplacedContent):
+		"""A simple collapsed move (i.e. both ends move together),
+		but whether it classes replaced content as one character stop
+		can be configured via the skipReplacedContent argument."""
 		if not skipReplacedContent:
 			return super().move(unit, direction)
-		if direction==0:
+		if direction == 0:
 			return
-		chunk=1 if direction>0 else -1
-		finalRes=0
-		while finalRes!=direction:
-			self._moveToEdgeOfReplacedContent(back=direction<0)
+		chunk = 1 if direction > 0 else -1
+		finalRes = 0
+		while finalRes != direction:
+			self._moveToEdgeOfReplacedContent(back=direction < 0)
 			res = super().move(unit, chunk)
-			if res==0:
+			if res == 0:
 				break
-			finalRes+=res
+			finalRes += res
 		return finalRes
 
-	def move(self,unit,direction,endPoint=None,skipReplacedContent=True):
+	def move(self, unit, direction, endPoint=None, skipReplacedContent=True):
 		if not endPoint:
-			return self._collapsedMove(unit,direction,skipReplacedContent)
+			return self._collapsedMove(unit, direction, skipReplacedContent)
 		else:
-			tempInfo=self.copy()
-			res=tempInfo.move(unit,direction,skipReplacedContent=skipReplacedContent)
-			if res!=0:
-				self.setEndPoint(tempInfo,"endToEnd" if endPoint=="end" else "startToStart")
+			tempInfo = self.copy()
+			res = tempInfo.move(unit, direction, skipReplacedContent=skipReplacedContent)
+			if res != 0:
+				self.setEndPoint(tempInfo, "endToEnd" if endPoint == "end" else "startToStart")
 			return res
 
-	def _getControlFieldForObject(self,obj,isEmbedded=False,startOfNode=False,endOfNode=False):
+	def _getControlFieldForObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
 		field = super()._getControlFieldForObject(
 			obj,
 			isEmbedded=isEmbedded,
 			startOfNode=startOfNode,
 			endOfNode=endOfNode
 		)
-		field['embedded']=isEmbedded
-		role=field.get('role')
+		field['embedded'] = isEmbedded
+		role = field.get('role')
 		# Fields should be treated as block for certain roles.
 		# This can affect whether the field is presented as a container (e.g.  announcing entering and exiting)
 		if role in (
@@ -163,105 +194,127 @@ class UIAWebTextInfo(UIATextInfo):
 			controlTypes.ROLE_LANDMARK,
 			controlTypes.ROLE_REGION,
 		):
-			field['isBlock']=True
+			field['isBlock'] = True
 		ariaProperties = splitUIAElementAttribs(
 			obj._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
 		)
 		# ARIA roledescription and landmarks
 		field['roleText'] = ariaProperties.get('roledescription')
 		# provide landmarks
-		field['landmark']=obj.landmark
+		field['landmark'] = obj.landmark
 		# Combo boxes with a text pattern are editable
-		if obj.role==controlTypes.ROLE_COMBOBOX and obj.UIATextPattern:
+		if obj.role == controlTypes.ROLE_COMBOBOX and obj.UIATextPattern:
 			field['states'].add(controlTypes.STATE_EDITABLE)
 		# report if the field is 'current'
-		field['current']=obj.isCurrent
+		field['current'] = obj.isCurrent
 		if obj.placeholder and obj._isTextEmpty:
-			field['placeholder']=obj.placeholder
+			field['placeholder'] = obj.placeholder
 		# For certain controls, if ARIA overrides the label, then force the field's content (value) to the label
-		# Later processing in Edge's getTextWithFields will remove descendant content from fields with a content attribute.
+		# Later processing in getTextWithFields will remove descendant content from fields
+		# with a content attribute.
 		hasAriaLabel = 'label' in ariaProperties
 		hasAriaLabelledby = 'labelledby' in ariaProperties
 		if field.get('nameIsContent'):
-			content=""
-			field.pop('name',None)
+			content = ""
+			field.pop('name', None)
 			if hasAriaLabel or hasAriaLabelledby:
-				content=obj.name
+				content = obj.name
 			if not content:
-				text=self.obj.makeTextInfo(obj).text
+				text = self.obj.makeTextInfo(obj).text
 				if not text or text.isspace():
-					content=obj.name or field.pop('description',None)
+					content = obj.name or field.pop('description', None)
 			if content:
-				field['content']=content
+				field['content'] = content
 		elif isEmbedded:
-			field['content']=obj.value
-			if field['role']==controlTypes.ROLE_GROUPING:
-				field['role']=controlTypes.ROLE_EMBEDDEDOBJECT
+			field['content'] = obj.value
+			if field['role'] == controlTypes.ROLE_GROUPING:
+				field['role'] = controlTypes.ROLE_EMBEDDEDOBJECT
 				if not obj.value:
-					field['content']=obj.name
+					field['content'] = obj.name
 		elif hasAriaLabel or hasAriaLabelledby:
 			field['alwaysReportName'] = True
 		# Give lists an item count
-		if obj.role==controlTypes.ROLE_LIST:
-			child=UIAHandler.handler.clientObject.ControlViewWalker.GetFirstChildElement(obj.UIAElement)
+		if obj.role == controlTypes.ROLE_LIST:
+			child = UIAHandler.handler.clientObject.ControlViewWalker.GetFirstChildElement(obj.UIAElement)
 			if child:
-				field['_childcontrolcount']=child.getCurrentPropertyValue(UIAHandler.UIA_SizeOfSetPropertyId)
+				field['_childcontrolcount'] = child.getCurrentPropertyValue(UIAHandler.UIA_SizeOfSetPropertyId)
 		return field
 
-	def getTextWithFields(self,formatConfig=None):
+	# C901 'getTextWithFields' is too complex
+	# Note: when working on getTextWithFields, look for opportunities to simplify
+	# and move logic out into smaller helper functions.
+	def getTextWithFields(self, formatConfig=None):  # noqa: C901
 		# We don't want fields for collapsed ranges.
-		# This would normally be a general rule, but MS Word currently needs fields for collapsed ranges, thus this code is not in the base.
+		# This would normally be a general rule, but MS Word currently needs fields for collapsed ranges,
+		# thus this code is not in the base.
 		if self.isCollapsed:
 			return []
 		fields = super().getTextWithFields(formatConfig)
-		seenText=False
-		curStarts=[]
 		# remove clickable state on descendants of controls with clickable state
-		clickableField=None
+		clickableField = None
 		for field in fields:
-			if isinstance(field,textInfos.FieldCommand) and field.command=="controlStart":
-				states=field.field['states']
+			if isinstance(field, textInfos.FieldCommand) and field.command == "controlStart":
+				states = field.field['states']
 				if clickableField:
 					states.discard(controlTypes.STATE_CLICKABLE)
 				elif controlTypes.STATE_CLICKABLE in states:
-					clickableField=field.field
-			elif clickableField and isinstance(field,textInfos.FieldCommand) and field.command=="controlEnd" and field.field is clickableField:
-				clickableField=None
+					clickableField = field.field
+			elif (
+				clickableField
+				and isinstance(field, textInfos.FieldCommand)
+				and field.command == "controlEnd"
+				and field.field is clickableField
+			):
+				clickableField = None
 		# Chop extra whitespace off the end incorrectly put there by Edge
-		numFields=len(fields)
-		index=0
-		while index<len(fields):
-			field=fields[index]
-			if index>1 and isinstance(field,str) and field.isspace():
-				prevField=fields[index-2]
-				if isinstance(prevField,textInfos.FieldCommand) and prevField.command=="controlEnd":
-					del fields[index-1:index+1]
-			index+=1
+		numFields = len(fields)
+		index = 0
+		while index < len(fields):
+			field = fields[index]
+			if index > 1 and isinstance(field, str) and field.isspace():
+				prevField = fields[index - 2]
+				if isinstance(prevField, textInfos.FieldCommand) and prevField.command == "controlEnd":
+					del fields[index - 1:index + 1]
+			index += 1
 		# chop fields off the end incorrectly placed there by Edge
 		# This can happen if expanding to line covers element start chars at its end
-		startCount=0
-		lastStartIndex=None
-		numFields=len(fields)
-		for index in range(numFields-1,-1,-1):
-			field=fields[index]
-			if isinstance(field,str):
+		startCount = 0
+		lastStartIndex = None
+		numFields = len(fields)
+		for index in range(numFields - 1, -1, -1):
+			field = fields[index]
+			if isinstance(field, str):
 				break
-			elif isinstance(field,textInfos.FieldCommand) and field.command=="controlStart" and not field.field.get('embedded'):
-				startCount+=1
-				lastStartIndex=index
+			elif (
+				isinstance(field, textInfos.FieldCommand)
+				and field.command == "controlStart"
+				and not field.field.get('embedded')
+			):
+				startCount += 1
+				lastStartIndex = index
 		if lastStartIndex:
-			del fields[lastStartIndex:lastStartIndex+(startCount*2)]
+			del fields[lastStartIndex: lastStartIndex + (startCount * 2)]
 		# Remove any content from fields with a content attribute
-		numFields=len(fields)
-		curField=None
-		for index in range(numFields-1,-1,-1):
-			field=fields[index]
-			if not curField and isinstance(field,textInfos.FieldCommand) and field.command=="controlEnd" and field.field.get('content'):
-				curField=field.field
-				endIndex=index
-			elif curField and isinstance(field,textInfos.FieldCommand) and field.command=="controlStart" and field.field is curField:
-				fields[index+1:endIndex]=" "
-				curField=None
+		numFields = len(fields)
+		curField = None
+		for index in range(numFields - 1, -1, -1):
+			field = fields[index]
+			if (
+				not curField
+				and isinstance(field, textInfos.FieldCommand)
+				and field.command == "controlEnd"
+				and field.field.get('content')
+			):
+				curField = field.field
+				endIndex = index
+			elif (
+				curField
+				and isinstance(field, textInfos.FieldCommand)
+				and field.command == "controlStart"
+				and field.field is curField
+			):
+				fields[index + 1: endIndex] = " "
+				curField = None
 		return fields
 
 
@@ -279,18 +332,23 @@ class UIAWeb(UIA):
 	def _get_role(self):
 		if self._isIframe():
 			return controlTypes.ROLE_INTERNALFRAME
-		ariaRole=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
+		ariaRole = self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
 		# #7333: It is valid to provide multiple, space separated aria roles in HTML
 		# The role used is the first role in the list that has an associated NVDA role in aria.ariaRolesToNVDARoles
 		for ariaRole in ariaRole.split():
-			newRole=aria.ariaRolesToNVDARoles.get(ariaRole)
+			newRole = aria.ariaRolesToNVDARoles.get(ariaRole)
 			if newRole:
 				return newRole
 		return super().role
 
 	def _get_states(self):
 		states = super().states
-		if self.role in (controlTypes.ROLE_STATICTEXT, controlTypes.ROLE_GROUPING, controlTypes.ROLE_SECTION, controlTypes.ROLE_GRAPHIC) and self.UIAInvokePattern:
+		if self.role in (
+			controlTypes.ROLE_STATICTEXT,
+			controlTypes.ROLE_GROUPING,
+			controlTypes.ROLE_SECTION,
+			controlTypes.ROLE_GRAPHIC,
+		) and self.UIAInvokePattern:
 			states.add(controlTypes.STATE_CLICKABLE)
 		return states
 
@@ -302,10 +360,10 @@ class UIAWeb(UIA):
 	# character and before the ';' character.
 	# This could be one of: "false", "true", "page", "step", "location", "date", "time"
 	# "false" is ignored by the regEx and will not produce a match
-	RE_ARIA_CURRENT_PROP_VALUE = re.compile("current=(?!false)(\w+);")
+	RE_ARIA_CURRENT_PROP_VALUE = re.compile(r"current=(?!false)(\w+);")
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
-		ariaProperties=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
+		ariaProperties = self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
 		match = self.RE_ARIA_CURRENT_PROP_VALUE.search(ariaProperties)
 		if match:
 			valueOfAriaCurrent = match.group(1)
@@ -328,13 +386,13 @@ class UIAWeb(UIA):
 		return ariaPlaceholder
 
 	def _get_landmark(self):
-		landmarkId=self._getUIACacheablePropertyValue(UIAHandler.UIA_LandmarkTypePropertyId)
-		if not landmarkId: # will be 0 for non-landmarks
+		landmarkId = self._getUIACacheablePropertyValue(UIAHandler.UIA_LandmarkTypePropertyId)
+		if not landmarkId:  # will be 0 for non-landmarks
 			return None
 		landmarkRole = UIAHandler.UIALandmarkTypeIdsToLandmarkNames.get(landmarkId)
 		if landmarkRole:
 			return landmarkRole
-		ariaRoles=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
+		ariaRoles = self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
 		# #7333: It is valid to provide multiple, space separated aria roles in HTML
 		# If multiple roles or even multiple landmark roles are provided, the first one is used
 		ariaRole = ariaRoles.split(" ")[0]
@@ -357,64 +415,78 @@ class HeadingControlQuickNavItem(UIATextRangeQuickNavItem):
 
 	@property
 	def level(self):
-		if not hasattr(self,'_level'):
-			styleVal=getUIATextAttributeValueFromRange(self.textInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId)
-			self._level=styleVal-(UIAHandler.StyleId_Heading1-1) if UIAHandler.StyleId_Heading1<=styleVal<=UIAHandler.StyleId_Heading6 else None
+		if not hasattr(self, '_level'):
+			styleVal = getUIATextAttributeValueFromRange(self.textInfo._rangeObj, UIAHandler.UIA_StyleIdAttributeId)
+			if UIAHandler.StyleId_Heading1 <= styleVal <= UIAHandler.StyleId_Heading6:
+				self._level = styleVal - (UIAHandler.StyleId_Heading1 - 1)
+			else:
+				self._level = None
 		return self._level
 
-	def isChild(self,parent):
-		return self.level>parent.level
+	def isChild(self, parent):
+		return self.level > parent.level
 
 
-def HeadingControlQuicknavIterator(itemType,document,position,direction="next"):
+def HeadingControlQuicknavIterator(itemType, document, position, direction="next"):
 	"""
-	A helper for L{UIAWebTreeInterceptor._iterNodesByType} that specifically yields L{HeadingControlQuickNavItem} objects found in the given document, starting the search from the given position,  searching in the given direction.
+	A helper for L{UIAWebTreeInterceptor._iterNodesByType}
+	that specifically yields L{HeadingControlQuickNavItem} objects
+	found in the given document, starting the search from the given position,  searching in the given direction.
 	See L{browseMode._iterNodesByType} for details on these specific arguments.
 	"""
-	# Some UI Automation web implementations expose all headings as UIA elements with a controlType of text, and a level. Thus we can quickly search for these.
-	# However, sometimes when ARIA is used, the level on the element may not match the level in the text attributes.
-	# Therefore we need to search for all levels 1 through 6, even if a specific level is specified.
+	# Some UI Automation web implementations expose all headings as UIA elements
+# 	with a controlType of text, and a level.
+	# Thus we can quickly search for these.
+	# However, sometimes when ARIA is used,
+	# the level on the element may not match the level in the text attributes.
+	# Therefore we need to search for all levels 1 through 6,
+	# even if a specific level is specified.
 	# Though this is still much faster than searching text attributes alone
 	# #9078: this must be wrapped inside a list, as Python 3 will treat this as iteration.
-	levels=list(range(1,7))
-	condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_TextControlTypeId,UIAHandler.UIA_LevelPropertyId:levels})
-	levelString=itemType[7:]
-	for item in UIAControlQuicknavIterator(itemType,document,position,condition,direction=direction,itemClass=HeadingControlQuickNavItem):
-		# Verify this is the correct heading level via text attributes 
-		if item.level and (not levelString or levelString==str(item.level)): 
+	levels = list(range(1, 7))
+	condition = createUIAMultiPropertyCondition({
+		UIAHandler.UIA_ControlTypePropertyId: UIAHandler.UIA_TextControlTypeId,
+		UIAHandler.UIA_LevelPropertyId: levels
+	})
+	levelString = itemType[7:]
+	itemIter = UIAControlQuicknavIterator(
+		itemType, document, position, condition, direction=direction, itemClass=HeadingControlQuickNavItem
+	)
+	for item in itemIter:
+		# Verify this is the correct heading level via text attributes
+		if item.level and (not levelString or levelString == str(item.level)):
 			yield item
 
 
-class UIAWebTreeInterceptor(cursorManager.ReviewCursorManager,UIABrowseModeDocument):
+class UIAWebTreeInterceptor(cursorManager.ReviewCursorManager, UIABrowseModeDocument):
+	TextInfo = UIABrowseModeDocumentTextInfo
 
-	TextInfo=UIABrowseModeDocumentTextInfo
-	
-	def makeTextInfo(self,position):
+	def makeTextInfo(self, position):
 		try:
 			return super().makeTextInfo(position)
 		except RuntimeError as e:
 			# sometimes the stored TextRange we have for the caret/selection can die if the page mutates too much.
-			# Therefore, if we detect this, just give back the first position in the document, updating our stored version as we go.
-			if position in (textInfos.POSITION_SELECTION,textInfos.POSITION_CARET):
-				log.debugWarning("%s died. Using first position instead."%position)
-				info=self.makeTextInfo(textInfos.POSITION_FIRST)
-				self._selection=info
+			# Therefore, if we detect this, just give back the first position in the document,
+			# updating our stored version as we go.
+			if position in (textInfos.POSITION_SELECTION, textInfos.POSITION_CARET):
+				log.debugWarning(f"{position} died. Using first position instead")
+				info = self.makeTextInfo(textInfos.POSITION_FIRST)
+				self._selection = info
 				return info
 			raise e
 
-	def shouldPassThrough(self,obj,reason=None):
+	def shouldPassThrough(self, obj, reason=None):
 		# Enter focus mode for selectable list items (<select> and role=listbox)
 		if (
-				reason == controlTypes.OutputReason.FOCUS
-				and obj.role == controlTypes.ROLE_LISTITEM
-				and controlTypes.STATE_SELECTABLE in obj.states
+			reason == controlTypes.OutputReason.FOCUS
+			and obj.role == controlTypes.ROLE_LISTITEM
+			and controlTypes.STATE_SELECTABLE in obj.states
 		):
 			return True
 		return super().shouldPassThrough(obj, reason=reason)
 
-	def _iterNodesByType(self,nodeType,direction="next",pos=None):
+	def _iterNodesByType(self, nodeType, direction="next", pos=None):
 		if nodeType.startswith("heading"):
-			return HeadingControlQuicknavIterator(nodeType,self,pos,direction=direction)
+			return HeadingControlQuicknavIterator(nodeType, self, pos, direction=direction)
 		else:
-			return super()._iterNodesByType(nodeType,direction=direction,pos=pos)
-
+			return super()._iterNodesByType(nodeType, direction=direction, pos=pos)

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -82,9 +82,15 @@ class UIAWebTextInfo(UIATextInfo):
 		whose name has been overridden by the author (such as aria-label).
 		"""
 		element = self.UIAElementAtStart
-		condition = createUIAMultiPropertyCondition({
-			UIAHandler.UIA_ControlTypePropertyId: self.UIAControlTypesWhereNameIsContent
-		})
+		condition = createUIAMultiPropertyCondition(
+			{
+				UIAHandler.UIA_ControlTypePropertyId: self.UIAControlTypesWhereNameIsContent
+			},
+			{
+				UIAHandler.UIA_ControlTypePropertyId: UIAHandler.UIA_ListControlTypeId,
+				UIAHandler.UIA_IsKeyboardFocusablePropertyId: True,
+			}
+		)
 		# A part from the condition given, we must always match on the root of the document
 		# so we know when to stop walking
 		runtimeID = VARIANT()
@@ -101,10 +107,19 @@ class UIAWebTextInfo(UIATextInfo):
 		)
 		walker = UIAHandler.handler.clientObject.createTreeWalker(condition)
 		cacheRequest = UIAHandler.handler.clientObject.createCacheRequest()
+		cacheRequest.addProperty(UIAHandler.UIA_ControlTypePropertyId)
+		cacheRequest.addProperty(UIAHandler.UIA_IsKeyboardFocusablePropertyId)
 		cacheRequest.addProperty(UIAHandler.UIA_NamePropertyId)
 		cacheRequest.addProperty(UIAHandler.UIA_AriaPropertiesPropertyId)
 		element = walker.normalizeElementBuildCache(element, cacheRequest)
 		while element and not UIAHandler.handler.clientObject.compareElements(element, self.obj.UIAElement):
+			# Interactive lists
+			controlType = element.getCachedPropertyValue(UIAHandler.UIA_ControlTypePropertyId)
+			if controlType == UIAHandler.UIA_ListControlTypeId:
+				isFocusable = element.getCachedPropertyValue(UIAHandler.UIA_IsKeyboardFocusablePropertyId)
+				if isFocusable:
+					return element
+			# Nodes with an aria label or labelledby attribute
 			name = element.getCachedPropertyValue(UIAHandler.UIA_NamePropertyId)
 			if name:
 				ariaProperties = element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
@@ -221,6 +236,10 @@ class UIAWebTextInfo(UIATextInfo):
 				content = obj.name
 			if not content:
 				text = self.obj.makeTextInfo(obj).text
+				# embedded object characters (which can appear in Edgium)
+				# should also be treated as whitespace
+				# allowing to be replaced by an overridden label
+				text = text.replace('\ufffc', '')
 				if not text or text.isspace():
 					content = obj.name or field.pop('description', None)
 			if content:

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -271,7 +271,7 @@ class UIAWeb(UIA):
 
 	def _get_role(self):
 		role = super().role
-		from .edge import EdgeHTMLRoot
+		from .spartanEdge import EdgeHTMLRoot
 		if not isinstance(self, EdgeHTMLRoot) and role==controlTypes.ROLE_PANE and self.UIATextPattern:
 			return controlTypes.ROLE_INTERNALFRAME
 		ariaRole=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -269,10 +269,15 @@ class UIAWeb(UIA):
 
 	_TextInfo = UIAWebTextInfo
 
-	def _get_role(self):
+	def _isIframe(self):
 		role = super().role
-		from .spartanEdge import EdgeHTMLRoot
-		if not isinstance(self, EdgeHTMLRoot) and role==controlTypes.ROLE_PANE and self.UIATextPattern:
+		return (
+			role == controlTypes.ROLE_PANE
+			and self.UIATextPattern
+		)
+
+	def _get_role(self):
+		if self._isIframe():
 			return controlTypes.ROLE_INTERNALFRAME
 		ariaRole=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
 		# #7333: It is valid to provide multiple, space separated aria roles in HTML
@@ -280,9 +285,8 @@ class UIAWeb(UIA):
 		for ariaRole in ariaRole.split():
 			newRole=aria.ariaRolesToNVDARoles.get(ariaRole)
 			if newRole:
-				role=newRole
-				break
-		return role
+				return newRole
+		return super().role
 
 	def _get_states(self):
 		states = super().states

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -1,0 +1,391 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2015-2020 NV Access Limited, Babbage B.V., Leonard de Ruijter
+
+from comtypes import COMError
+from comtypes.automation import VARIANT
+from ctypes import byref
+import winVersion
+from logHandler import log
+import eventHandler
+import config
+import controlTypes
+import cursorManager
+import re
+import aria
+import textInfos
+import UIAHandler
+from UIABrowseMode import UIABrowseModeDocument, UIABrowseModeDocumentTextInfo, UIATextRangeQuickNavItem,UIAControlQuicknavIterator
+from UIAUtils import *
+from . import UIA, UIATextInfo
+
+
+def splitUIAElementAttribs(attribsString):
+	"""Split an UIA Element attributes string into a dict of attribute keys and values.
+	An invalid attributes string does not cause an error, but strange results may be returned.
+	@param attribsString: The UIA Element attributes string to convert.
+	@type attribsString: str
+	@return: A dict of the attribute keys and values, where values are strings
+	@rtype: {str: str}
+	"""
+	attribsDict = {}
+	tmp = ""
+	key = ""
+	inEscape = False
+	for char in attribsString:
+		if inEscape:
+			tmp += char
+			inEscape = False
+		elif char == "\\":
+			inEscape = True
+		elif char == "=":
+			# We're about to move on to the value, so save the key and clear tmp.
+			key = tmp
+			tmp = ""
+		elif char == ";":
+			# We're about to move on to a new attribute.
+			if key:
+				# Add this key/value pair to the dict.
+				attribsDict[key] = tmp
+			key = ""
+			tmp = ""
+		else:
+			tmp += char
+	# If there was no trailing semi-colon, we need to handle the last attribute.
+	if key:
+		# Add this key/value pair to the dict.
+		attribsDict[key] = tmp
+	return attribsDict
+
+
+class EdgeTextInfo(UIATextInfo):
+
+	def _get_UIAElementAtStartWithReplacedContent(self):
+		"""Fetches the deepest UIAElement at the start of the text range whos name has been overridden by the author (such as aria-label)."""
+		element=self.UIAElementAtStart
+		condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:self.UIAControlTypesWhereNameIsContent})
+		# A part from the condition given, we must always match on the root of the document so we know when to stop walking
+		runtimeID=VARIANT()
+		self.obj.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(UIAHandler.UIA_RuntimeIdPropertyId,byref(runtimeID))
+		condition=UIAHandler.handler.clientObject.createOrCondition(UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_RuntimeIdPropertyId,runtimeID),condition)
+		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)
+		cacheRequest=UIAHandler.handler.clientObject.createCacheRequest()
+		cacheRequest.addProperty(UIAHandler.UIA_NamePropertyId)
+		cacheRequest.addProperty(UIAHandler.UIA_AriaPropertiesPropertyId)
+		element=walker.normalizeElementBuildCache(element,cacheRequest)
+		while element and not UIAHandler.handler.clientObject.compareElements(element,self.obj.UIAElement):
+			name=element.getCachedPropertyValue(UIAHandler.UIA_NamePropertyId)
+			if name:
+				ariaProperties=element.getCachedPropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
+				if ('label=' in ariaProperties)  or ('labelledby=' in ariaProperties):
+					return element
+				try:
+					textRange=self.obj.UIATextPattern.rangeFromChild(element)
+				except COMError:
+					return
+				text = textRange.getText(-1)
+				if not text or text.isspace():
+					return element
+			element=walker.getParentElementBuildCache(element,cacheRequest)
+
+	def _moveToEdgeOfReplacedContent(self,back=False):
+		"""If within replaced content (E.g. aria-label is used), moves to the first or last character covered, so that a following call to move in the same direction will move out of the replaced content, in order to ensure that the content only takes up one character stop."""
+		element=self.UIAElementAtStartWithReplacedContent
+		if not element:
+			return
+		try:
+			textRange=self.obj.UIATextPattern.rangeFromChild(element)
+		except COMError:
+			return
+		if not back:
+			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_Start, textRange, UIAHandler.TextPatternRangeEndpoint_End)
+			textRange.move(UIAHandler.TextUnit_Character, -1)
+		else:
+			textRange.MoveEndpointByRange(UIAHandler.TextPatternRangeEndpoint_End, textRange, UIAHandler.TextPatternRangeEndpoint_Start)
+		self._rangeObj=textRange
+
+	def _collapsedMove(self,unit,direction,skipReplacedContent):
+		"""A simple collapsed move (i.e. both ends move together), but whether it classes replaced content as one character stop can be configured via the skipReplacedContent argument."""
+		if not skipReplacedContent:
+			return super(EdgeTextInfo,self).move(unit,direction)
+		if direction==0:
+			return
+		chunk=1 if direction>0 else -1
+		finalRes=0
+		while finalRes!=direction:
+			self._moveToEdgeOfReplacedContent(back=direction<0)
+			res=super(EdgeTextInfo,self).move(unit,chunk)
+			if res==0:
+				break
+			finalRes+=res
+		return finalRes
+
+	def move(self,unit,direction,endPoint=None,skipReplacedContent=True):
+		if not endPoint:
+			return self._collapsedMove(unit,direction,skipReplacedContent)
+		else:
+			tempInfo=self.copy()
+			res=tempInfo.move(unit,direction,skipReplacedContent=skipReplacedContent)
+			if res!=0:
+				self.setEndPoint(tempInfo,"endToEnd" if endPoint=="end" else "startToStart")
+			return res
+
+	def _getControlFieldForObject(self,obj,isEmbedded=False,startOfNode=False,endOfNode=False):
+		field=super(EdgeTextInfo,self)._getControlFieldForObject(obj,isEmbedded=isEmbedded,startOfNode=startOfNode,endOfNode=endOfNode)
+		field['embedded']=isEmbedded
+		role=field.get('role')
+		# Fields should be treated as block for certain roles.
+		# This can affect whether the field is presented as a container (e.g.  announcing entering and exiting)
+		if role in (
+			controlTypes.ROLE_GROUPING,
+			controlTypes.ROLE_SECTION,
+			controlTypes.ROLE_PARAGRAPH,
+			controlTypes.ROLE_ARTICLE,
+			controlTypes.ROLE_LANDMARK,
+			controlTypes.ROLE_REGION,
+		):
+			field['isBlock']=True
+		ariaProperties = splitUIAElementAttribs(
+			obj._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
+		)
+		# ARIA roledescription and landmarks
+		field['roleText'] = ariaProperties.get('roledescription')
+		# provide landmarks
+		field['landmark']=obj.landmark
+		# Combo boxes with a text pattern are editable
+		if obj.role==controlTypes.ROLE_COMBOBOX and obj.UIATextPattern:
+			field['states'].add(controlTypes.STATE_EDITABLE)
+		# report if the field is 'current'
+		field['current']=obj.isCurrent
+		if obj.placeholder and obj._isTextEmpty:
+			field['placeholder']=obj.placeholder
+		# For certain controls, if ARIA overrides the label, then force the field's content (value) to the label
+		# Later processing in Edge's getTextWithFields will remove descendant content from fields with a content attribute.
+		hasAriaLabel = 'label' in ariaProperties
+		hasAriaLabelledby = 'labelledby' in ariaProperties
+		if field.get('nameIsContent'):
+			content=""
+			field.pop('name',None)
+			if hasAriaLabel or hasAriaLabelledby:
+				content=obj.name
+			if not content:
+				text=self.obj.makeTextInfo(obj).text
+				if not text or text.isspace():
+					content=obj.name or field.pop('description',None)
+			if content:
+				field['content']=content
+		elif isEmbedded:
+			field['content']=obj.value
+			if field['role']==controlTypes.ROLE_GROUPING:
+				field['role']=controlTypes.ROLE_EMBEDDEDOBJECT
+				if not obj.value:
+					field['content']=obj.name
+		elif hasAriaLabel or hasAriaLabelledby:
+			field['alwaysReportName'] = True
+		# Give lists an item count
+		if obj.role==controlTypes.ROLE_LIST:
+			child=UIAHandler.handler.clientObject.ControlViewWalker.GetFirstChildElement(obj.UIAElement)
+			if child:
+				field['_childcontrolcount']=child.getCurrentPropertyValue(UIAHandler.UIA_SizeOfSetPropertyId)
+		return field
+
+	def getTextWithFields(self,formatConfig=None):
+		# We don't want fields for collapsed ranges.
+		# This would normally be a general rule, but MS Word currently needs fields for collapsed ranges, thus this code is not in the base.
+		if self.isCollapsed:
+			return []
+		fields=super(EdgeTextInfo,self).getTextWithFields(formatConfig)
+		seenText=False
+		curStarts=[]
+		# remove clickable state on descendants of controls with clickable state
+		clickableField=None
+		for field in fields:
+			if isinstance(field,textInfos.FieldCommand) and field.command=="controlStart":
+				states=field.field['states']
+				if clickableField:
+					states.discard(controlTypes.STATE_CLICKABLE)
+				elif controlTypes.STATE_CLICKABLE in states:
+					clickableField=field.field
+			elif clickableField and isinstance(field,textInfos.FieldCommand) and field.command=="controlEnd" and field.field is clickableField:
+				clickableField=None
+		# Chop extra whitespace off the end incorrectly put there by Edge
+		numFields=len(fields)
+		index=0
+		while index<len(fields):
+			field=fields[index]
+			if index>1 and isinstance(field,str) and field.isspace():
+				prevField=fields[index-2]
+				if isinstance(prevField,textInfos.FieldCommand) and prevField.command=="controlEnd":
+					del fields[index-1:index+1]
+			index+=1
+		# chop fields off the end incorrectly placed there by Edge
+		# This can happen if expanding to line covers element start chars at its end
+		startCount=0
+		lastStartIndex=None
+		numFields=len(fields)
+		for index in range(numFields-1,-1,-1):
+			field=fields[index]
+			if isinstance(field,str):
+				break
+			elif isinstance(field,textInfos.FieldCommand) and field.command=="controlStart" and not field.field.get('embedded'):
+				startCount+=1
+				lastStartIndex=index
+		if lastStartIndex:
+			del fields[lastStartIndex:lastStartIndex+(startCount*2)]
+		# Remove any content from fields with a content attribute
+		numFields=len(fields)
+		curField=None
+		for index in range(numFields-1,-1,-1):
+			field=fields[index]
+			if not curField and isinstance(field,textInfos.FieldCommand) and field.command=="controlEnd" and field.field.get('content'):
+				curField=field.field
+				endIndex=index
+			elif curField and isinstance(field,textInfos.FieldCommand) and field.command=="controlStart" and field.field is curField:
+				fields[index+1:endIndex]=" "
+				curField=None
+		return fields
+
+
+class EdgeNode(UIA):
+	def _get_role(self):
+		role=super(EdgeNode,self).role
+		if not isinstance(self,EdgeHTMLRoot) and role==controlTypes.ROLE_PANE and self.UIATextPattern:
+			return controlTypes.ROLE_INTERNALFRAME
+		ariaRole=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
+		# #7333: It is valid to provide multiple, space separated aria roles in HTML
+		# The role used is the first role in the list that has an associated NVDA role in aria.ariaRolesToNVDARoles
+		for ariaRole in ariaRole.split():
+			newRole=aria.ariaRolesToNVDARoles.get(ariaRole)
+			if newRole:
+				role=newRole
+				break
+		return role
+
+	def _get_states(self):
+		states=super(EdgeNode,self).states
+		if self.role in (controlTypes.ROLE_STATICTEXT,controlTypes.ROLE_GROUPING,controlTypes.ROLE_SECTION,controlTypes.ROLE_GRAPHIC) and self.UIAInvokePattern:
+			states.add(controlTypes.STATE_CLICKABLE)
+		return states
+
+	def _get_ariaProperties(self):
+		return splitUIAElementAttribs(self.UIAElement.currentAriaProperties)
+
+	# RegEx to get the value for the aria-current property. This will be looking for a the value of 'current'
+	# in a list of strings like "something=true;current=date;". We want to capture one group, after the '='
+	# character and before the ';' character.
+	# This could be one of: "false", "true", "page", "step", "location", "date", "time"
+	# "false" is ignored by the regEx and will not produce a match
+	RE_ARIA_CURRENT_PROP_VALUE = re.compile("current=(?!false)(\w+);")
+
+	def _get_isCurrent(self) -> controlTypes.IsCurrent:
+		ariaProperties=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaPropertiesPropertyId)
+		match = self.RE_ARIA_CURRENT_PROP_VALUE.search(ariaProperties)
+		if match:
+			valueOfAriaCurrent = match.group(1)
+			try:
+				return controlTypes.IsCurrent(valueOfAriaCurrent)
+			except ValueError:
+				log.debugWarning(
+					f"Unknown aria-current value: {valueOfAriaCurrent}, ariaProperties: {ariaProperties}"
+				)
+		return controlTypes.IsCurrent.NO
+
+	def _get_roleText(self):
+		roleText = self.ariaProperties.get('roledescription', None)
+		if roleText:
+			return roleText
+		return super().roleText
+
+	def _get_placeholder(self):
+		ariaPlaceholder = self.ariaProperties.get('placeholder', None)
+		return ariaPlaceholder
+
+	def _get_landmark(self):
+		landmarkId=self._getUIACacheablePropertyValue(UIAHandler.UIA_LandmarkTypePropertyId)
+		if not landmarkId: # will be 0 for non-landmarks
+			return None
+		landmarkRole = UIAHandler.UIALandmarkTypeIdsToLandmarkNames.get(landmarkId)
+		if landmarkRole:
+			return landmarkRole
+		ariaRoles=self._getUIACacheablePropertyValue(UIAHandler.UIA_AriaRolePropertyId).lower()
+		# #7333: It is valid to provide multiple, space separated aria roles in HTML
+		# If multiple roles or even multiple landmark roles are provided, the first one is used
+		ariaRole = ariaRoles.split(" ")[0]
+		if ariaRole in aria.landmarkRoles and (ariaRole != 'region' or self.name):
+			return ariaRole
+		return None
+
+
+class EdgeList(EdgeNode):
+
+	# non-focusable lists are readonly lists (ensures correct NVDA presentation category)
+	def _get_states(self):
+		states=super(EdgeList,self).states
+		if controlTypes.STATE_FOCUSABLE not in states:
+			states.add(controlTypes.STATE_READONLY)
+		return states
+
+
+class EdgeHeadingQuickNavItem(UIATextRangeQuickNavItem):
+
+	@property
+	def level(self):
+		if not hasattr(self,'_level'):
+			styleVal=getUIATextAttributeValueFromRange(self.textInfo._rangeObj,UIAHandler.UIA_StyleIdAttributeId)
+			self._level=styleVal-(UIAHandler.StyleId_Heading1-1) if UIAHandler.StyleId_Heading1<=styleVal<=UIAHandler.StyleId_Heading6 else None
+		return self._level
+
+	def isChild(self,parent):
+		return self.level>parent.level
+
+
+def EdgeHeadingQuicknavIterator(itemType,document,position,direction="next"):
+	"""
+	A helper for L{EdgeHTMLTreeInterceptor._iterNodesByType} that specifically yields L{EdgeHeadingQuickNavItem} objects found in the given document, starting the search from the given position,  searching in the given direction.
+	See L{browseMode._iterNodesByType} for details on these specific arguments.
+	"""
+	# Edge exposes all headings as UIA elements with a controlType of text, and a level. Thus we can quickly search for these.
+	# However, sometimes when ARIA is used, the level on the element may not match the level in the text attributes.
+	# Therefore we need to search for all levels 1 through 6, even if a specific level is specified.
+	# Though this is still much faster than searching text attributes alone
+	# #9078: this must be wrapped inside a list, as Python 3 will treat this as iteration.
+	levels=list(range(1,7))
+	condition=createUIAMultiPropertyCondition({UIAHandler.UIA_ControlTypePropertyId:UIAHandler.UIA_TextControlTypeId,UIAHandler.UIA_LevelPropertyId:levels})
+	levelString=itemType[7:]
+	for item in UIAControlQuicknavIterator(itemType,document,position,condition,direction=direction,itemClass=EdgeHeadingQuickNavItem):
+		# Verify this is the correct heading level via text attributes 
+		if item.level and (not levelString or levelString==str(item.level)): 
+			yield item
+
+
+class EdgeHTMLTreeInterceptor(cursorManager.ReviewCursorManager,UIABrowseModeDocument):
+	def makeTextInfo(self,position):
+		try:
+			return super().makeTextInfo(position)
+		except RuntimeError as e:
+			# sometimes the stored TextRange we have for the caret/selection can die if the page mutates too much.
+			# Therefore, if we detect this, just give back the first position in the document, updating our stored version as we go.
+			if position in (textInfos.POSITION_SELECTION,textInfos.POSITION_CARET):
+				log.debugWarning("%s died. Using first position instead."%position)
+				info=self.makeTextInfo(textInfos.POSITION_FIRST)
+				self._selection=info
+				return info
+			raise e
+
+	def shouldPassThrough(self,obj,reason=None):
+		# Enter focus mode for selectable list items (<select> and role=listbox)
+		if (
+				reason == controlTypes.OutputReason.FOCUS
+				and obj.role == controlTypes.ROLE_LISTITEM
+				and controlTypes.STATE_SELECTABLE in obj.states
+		):
+			return True
+		return super(EdgeHTMLTreeInterceptor,self).shouldPassThrough(obj,reason=reason)
+
+	def _iterNodesByType(self,nodeType,direction="next",pos=None):
+		if nodeType.startswith("heading"):
+			return EdgeHeadingQuicknavIterator(nodeType,self,pos,direction=direction)
+		else:
+			return super(EdgeHTMLTreeInterceptor,self)._iterNodesByType(nodeType,direction=direction,pos=pos)
+

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -417,10 +417,12 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""
 		return ""
 
-	def _get_role(self):
+	#: Type definition for auto prop '_get_role'
+	role: int
+
+	def _get_role(self) -> int:
 		"""The role or type of control this object represents (example: button, list, dialog).
 		@return: a ROLE_* constant from L{controlTypes}
-		@rtype: int
 		"""  
 		return controlTypes.ROLE_UNKNOWN
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -69,9 +69,6 @@ badUIAWindowClassNames=[
 	"Button",
 	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 	"FoxitDocWnd",
-	# All Chromium implementations (including Edge) should not be UIA,
-	# As their IA2 implementation is still better at the moment.
-	"Chrome_RenderWidgetHostHWND",
 ]
 
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.
@@ -644,6 +641,9 @@ class UIAHandler(COMObject):
 			return
 		eventHandler.queueEvent("UIA_notification",obj, notificationKind=NotificationKind, notificationProcessing=NotificationProcessing, displayString=displayString, activityId=activityId)
 
+	def _allowUiaInChromium(self):
+		return True  # todo: config.conf['UIA']['allowInChromium']
+
 	def _isBadUIAWindowClassName(self, windowClass):
 		"Given a windowClassName, returns True if this is a known problematic UIA implementation."
 		# #7497: Windows 10 Fall Creators Update has an incomplete UIA
@@ -652,6 +652,10 @@ class UIAHandler(COMObject):
 		# It does not implement caret/selection, and probably has no new text
 		# events.
 		if windowClass == "ConsoleWindowClass" and config.conf['UIA']['winConsoleImplementation'] != "UIA":
+			return True
+		# Unless explicitly allowed, all Chromium implementations (including Edge) should not be UIA,
+		# As their IA2 implementation is still better at the moment.
+		elif windowClass == "Chrome_RenderWidgetHostHWND" and not self._allowUiaInChromium():
 			return True
 		return windowClass in badUIAWindowClassNames
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -6,6 +6,8 @@
 
 from ctypes import *
 from ctypes.wintypes import *
+from enum import Enum
+
 import comtypes.client
 from comtypes.automation import VT_EMPTY
 from comtypes import COMError
@@ -203,6 +205,21 @@ ignoreWinEventsMap = {
 }
 for id in UIAEventIdsToNVDAEventNames.keys():
 	ignoreWinEventsMap[id] = [0]
+
+
+class AllowUiaInChromium(Enum):
+	_DEFAULT = 0  # maps to 'when necessary'
+	WHEN_NECESSARY = 1  # the current default
+	YES = 2
+	NO = 3
+
+	@staticmethod
+	def getConfig() -> 'AllowUiaInChromium':
+		allow = AllowUiaInChromium(config.conf['UIA']['allowInChromium'])
+		if allow == AllowUiaInChromium._DEFAULT:
+			return AllowUiaInChromium.WHEN_NECESSARY
+		return allow
+
 
 class UIAHandler(COMObject):
 	_com_interfaces_ = [
@@ -641,9 +658,6 @@ class UIAHandler(COMObject):
 			return
 		eventHandler.queueEvent("UIA_notification",obj, notificationKind=NotificationKind, notificationProcessing=NotificationProcessing, displayString=displayString, activityId=activityId)
 
-	def _allowUiaInChromium(self):
-		return True  # todo: config.conf['UIA']['allowInChromium']
-
 	def _isBadUIAWindowClassName(self, windowClass):
 		"Given a windowClassName, returns True if this is a known problematic UIA implementation."
 		# #7497: Windows 10 Fall Creators Update has an incomplete UIA
@@ -652,10 +666,6 @@ class UIAHandler(COMObject):
 		# It does not implement caret/selection, and probably has no new text
 		# events.
 		if windowClass == "ConsoleWindowClass" and config.conf['UIA']['winConsoleImplementation'] != "UIA":
-			return True
-		# Unless explicitly allowed, all Chromium implementations (including Edge) should not be UIA,
-		# As their IA2 implementation is still better at the moment.
-		elif windowClass == "Chrome_RenderWidgetHostHWND" and not self._allowUiaInChromium():
 			return True
 		return windowClass in badUIAWindowClassNames
 
@@ -706,13 +716,28 @@ class UIAHandler(COMObject):
 			# Builds of MS Office 2016 before build 9000 or so had bugs which we cannot work around.
 			# And even current builds of Office 2016 are still missing enough info from UIA that it is still impossible to switch to UIA completely.
 			# Therefore, if we can inject in-process, refuse to use UIA and instead fall back to the MS Word object model.
+			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 			if (
 				# An MS Word document window 
 				windowClass=="_WwG" 
 				# Disabling is only useful if we can inject in-process (and use our older code)
-				and appModule.helperLocalBindingHandle 
+				and canUseOlderInProcessApproach
 				# Allow the user to explisitly force UIA support for MS Word documents no matter the Office version 
 				and not config.conf['UIA']['useInMSWordWhenAvailable']
+			):
+				return False
+			# Unless explicitly allowed, all Chromium implementations (including Edge) should not be UIA,
+			# As their IA2 implementation is still better at the moment.
+			elif (
+				windowClass == "Chrome_RenderWidgetHostHWND"
+				and (
+					AllowUiaInChromium.getConfig() == AllowUiaInChromium.NO
+					# Disabling is only useful if we can inject in-process (and use our older code)
+					or (
+						canUseOlderInProcessApproach
+						and AllowUiaInChromium.getConfig() != AllowUiaInChromium.YES  # Users can prefer to use UIA
+					)
+				)
 			):
 				return False
 		return bool(res)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -221,6 +221,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	useInMSWordWhenAvailable = boolean(default=false)
 	winConsoleImplementation= option("auto", "legacy", "UIA", default="auto")
 	selectiveEventRegistration = boolean(default=false)
+	# 0:default, 1:Only when necessary, 2:yes, 3:no
+	allowInChromium = integer(0, 3, default=0)
 
 [terminals]
 	speakPasswords = boolean(default=false)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2563,6 +2563,27 @@ class AdvancedPanelControls(
 		self.winConsoleSpeakPasswordsCheckBox.SetValue(config.conf["terminals"]["speakPasswords"])
 		self.winConsoleSpeakPasswordsCheckBox.defaultValue = self._getDefaultValue(["terminals", "speakPasswords"])
 
+		label = pgettext(
+			"advanced.uiaWithChromium",
+			# Translators: Label for the Use UIA with Chromium combobox, in the Advanced settings panel.
+			# Note the '\n' is used to split this long label approximately in half.
+			"Use UIA with Microsoft Edge and other \n&Chromium based browsers when available:"
+		)
+		chromiumChoices = (
+			# Translators: Label for the default value of the Use UIA with Chromium combobox,
+			# in the Advanced settings panel.
+			pgettext("advanced.uiaWithChromium", "Default (Only when necessary)"),
+			# Translators: Label for a value in the Use UIA with Chromium combobox, in the Advanced settings panel.
+			pgettext("advanced.uiaWithChromium", "Only when necessary"),
+			# Translators: Label for a value in the Use UIA with Chromium combobox, in the Advanced settings panel.
+			pgettext("advanced.uiaWithChromium", "Yes"),
+			# Translators: Label for a value in the Use UIA with Chromium combobox, in the Advanced settings panel.
+			pgettext("advanced.uiaWithChromium", "No"),
+		)
+		self.UIAInChromiumCombo = UIAGroup.addLabeledControl(label, wx.Choice, choices=chromiumChoices)
+		self.UIAInChromiumCombo.SetSelection(config.conf["UIA"]["allowInChromium"])
+		self.UIAInChromiumCombo.defaultValue = self._getDefaultValue(["UIA", "allowInChromium"])
+
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
 		label = _("Terminal programs")
@@ -2735,6 +2756,7 @@ class AdvancedPanelControls(
 			and self.ConsoleUIACheckBox.IsChecked() == (self.ConsoleUIACheckBox.defaultValue == 'UIA')
 			and self.winConsoleSpeakPasswordsCheckBox.IsChecked() == self.winConsoleSpeakPasswordsCheckBox.defaultValue
 			and self.cancelExpiredFocusSpeechCombo.GetSelection() == self.cancelExpiredFocusSpeechCombo.defaultValue
+			and self.UIAInChromiumCombo.selection == self.UIAInChromiumCombo.defaultValue
 			and self.keyboardSupportInLegacyCheckBox.IsChecked() == self.keyboardSupportInLegacyCheckBox.defaultValue
 			and self.diffAlgoCombo.GetSelection() == self.diffAlgoCombo.defaultValue
 			and self.caretMoveTimeoutSpinControl.GetValue() == self.caretMoveTimeoutSpinControl.defaultValue
@@ -2747,6 +2769,7 @@ class AdvancedPanelControls(
 		self.selectiveUIAEventRegistrationCheckBox.SetValue(self.selectiveUIAEventRegistrationCheckBox.defaultValue)
 		self.UIAInMSWordCheckBox.SetValue(self.UIAInMSWordCheckBox.defaultValue)
 		self.ConsoleUIACheckBox.SetValue(self.ConsoleUIACheckBox.defaultValue == 'UIA')
+		self.UIAInChromiumCombo.SetSelection(self.UIAInChromiumCombo.defaultValue)
 		self.winConsoleSpeakPasswordsCheckBox.SetValue(self.winConsoleSpeakPasswordsCheckBox.defaultValue)
 		self.cancelExpiredFocusSpeechCombo.SetSelection(self.cancelExpiredFocusSpeechCombo.defaultValue)
 		self.keyboardSupportInLegacyCheckBox.SetValue(self.keyboardSupportInLegacyCheckBox.defaultValue)
@@ -2766,6 +2789,7 @@ class AdvancedPanelControls(
 			config.conf['UIA']['winConsoleImplementation'] = "auto"
 		config.conf["terminals"]["speakPasswords"] = self.winConsoleSpeakPasswordsCheckBox.IsChecked()
 		config.conf["featureFlag"]["cancelExpiredFocusSpeech"] = self.cancelExpiredFocusSpeechCombo.GetSelection()
+		config.conf["UIA"]["allowInChromium"] = self.UIAInChromiumCombo.GetSelection()
 		config.conf["terminals"]["keyboardSupportInLegacy"]=self.keyboardSupportInLegacyCheckBox.IsChecked()
 		diffAlgoChoice = self.diffAlgoCombo.GetSelection()
 		config.conf['terminals']['diffAlgo'] = (

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -526,31 +526,23 @@ def getObjectSpeech(  # noqa: C901
 	if shouldReportTextContent:
 		try:
 			info = obj.makeTextInfo(textInfos.POSITION_SELECTION)
-			if not info.isCollapsed:
-				# if there is selected text, then there is a value and we do not report placeholder
-				sequence.extend(getPreselectedTextSpeech(info.text))
-			else:
-				info.expand(textInfos.UNIT_LINE)
-				textEmpty, placeholderSeq = _getPlaceholderSpeechIfTextEmpty(obj, reason)
-				sequence.extend(placeholderSeq)
-				speechGen = getTextInfoSpeech(
-					info,
-					unit=textInfos.UNIT_LINE,
-					reason=OutputReason.CARET
-				)
-				sequence.extend(_flattenNestedSequences(speechGen))
-		except:  # noqa E722 legacy bare except. Unknown what exceptions may be raised.
-			newInfo = obj.makeTextInfo(textInfos.POSITION_ALL)
+		except NotImplementedError:
+			info = None
+		if info and not info.isCollapsed:
+			# if there is selected text, then there is a value and we do not report placeholder
+			sequence.extend(getPreselectedTextSpeech(info.text))
+		else:
+			if not info:
+				info = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			info.expand(textInfos.UNIT_LINE)
 			textEmpty, placeholderSeq = _getPlaceholderSpeechIfTextEmpty(obj, reason)
-			if textEmpty:
-				sequence.extend(placeholderSeq)
-			else:
-				speechGen = getTextInfoSpeech(
-					newInfo,
-					unit=textInfos.UNIT_PARAGRAPH,
-					reason=OutputReason.CARET,
-				)
-				sequence.extend(_flattenNestedSequences(speechGen))
+			sequence.extend(placeholderSeq)
+			speechGen = getTextInfoSpeech(
+				info,
+				unit=textInfos.UNIT_LINE,
+				reason=OutputReason.CARET,
+			)
+			sequence.extend(_flattenNestedSequences(speechGen))
 	elif role == controlTypes.ROLE_MATH:
 		import mathPres
 		mathPres.ensureInit()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,6 +6,7 @@ What's New in NVDA
 = 2021.1 =
 
 == New Features ==
+- Early support for UIA with Chromium based browsers (such as Edge). (#12025)
 
 
 == Changes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1840,6 +1840,16 @@ When this option is enabled, NVDA will use a new, work in progress version of it
 ==== Speak passwords in UIA consoles ====[AdvancedSettingsWinConsoleSpeakPasswords]
 This setting controls whether characters are spoken by [speak typed characters #KeyboardSettingsSpeakTypedCharacters] or [speak typed words #KeyboardSettingsSpeakTypedWords] in situations where the screen does not update (such as password entry) in the Windows Console with UI automation support enabled. For security purposes, this setting should be left disabled. However, you may wish to enable it if you experience performance issues or instability with typed character and/or word reporting while using NVDA's new experimental console support.
 
+==== Use UIA with Microsoft Edge and other Chromium based browsers when available ====[ChromiumUIA]
+Allows specifying when UIA will be used when it is available in Chromium based browsers such as Microsoft Edge.
+UIA support for Chromium based browsers is early in development and may not provide the same level of access as IA2.
+The combo box has the following options:
+- Default (Only when necessary): The NVDA default, currently this is "Only when necessary". This default may change in the future as the technology matures.
+- Only when necessary: When NVDA is unable to inject into the browser process in order to use IA2 and UIA is available, then NVDA will fall back to using UIA.
+- Yes: If the browser makes UIA available, NVDA will use it.
+- No: Don't use UIA, even if NVDA is unable to inject in process. This may be useful for developers debugging issues with IA2 and want to ensure that NVDA does not fall back to UIA.
+-
+
 ==== Use the new typed character support in Windows Console when available ====[AdvancedSettingsKeyboardSupportInLegacy]
 This option enables an alternative method for detecting typed characters in Windows command consoles.
 While it improves performance and prevents some console output from being spelled out, it may be incompatible with some terminal programs.


### PR DESCRIPTION
This is based off of PR "Add advanced setting to allow UIA in chromium based browsers #11079"

However, due to the large amount of moved code, NV Access has decided not to squash this PR. Instead the commits have been cleaned up to make following the history as easy as possible. The changes from #11079 are as follows:
- Code is moved between files verbatim, in commits independent from any other changes. It should be noted that these commits will not run, but serve to make diffs / blame easier to follow.
- Linting is done in independent commits. This allows logic changes to be differentiated from "clean up"
- UIA/edge becomes UIA/spartan_edge and a placeholder is added for UIA/anaheim_edge

This PR supersedes and thus closes #11079, however the history there is still relevant and useful.
 
### Link to issue number:
Related to #10555

### Summary of the issue:
Chromium based browsers now contain a UIA implementation which may be exposed (E.G. in Edge Anaheim). Allowing this to be used will allow developers to work to stabilize and mature this technology. For users on systems where process injection is not possible, access to UIA in Edge can act as a fallback option.

### Description of how this pull request fixes the issue:
Provides an advanced setting to use UIA when available. Moves significant portions of the UIA code for reuse:
- Web
- Legacy Edge (Spartan)
- Chromium based browsers such as Edge Anaheim

### Testing performed:
Manual testing.

### Known issues with pull request:
None

### Change log entry:

New features
```
- Early support for UIA with Chromium based browsers (such as Edge).
```
