### PR TITLE
Fix up of #11969: correct logic for heading levels in getFormatfieldSpeech

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2026,8 +2026,8 @@ def getFormatFieldSpeech(  # noqa: C901
 			and (
 				initialFormat
 				and (reason == OutputReason.FOCUS or unit in (textInfos.UNIT_LINE, textInfos.UNIT_PARAGRAPH))
+				or headingLevel != oldHeadingLevel
 			)
-			or headingLevel != oldHeadingLevel
 		):
 			# Translators: Speaks the heading level (example output: heading level 2).
 			text=_("heading level %d")%headingLevel


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None.

### Summary of the issue:
In pr #11969 REASON_* constants were replaced with OutputReason.* enum constants.
However, a logic error was introduced in speech.getFormatFieldSpeech which caused NVDA to no longer  be able to read content in edgeHTML (Edge classic) documents. Causing the following exception:
```
File "speech\__init__.py", line 2033, in getFormatFieldSpeech
    text=_("heading level %d")%headingLevel
TypeError: %d format: a number is required, not NoneType
```

This is due to the 
```
headingLevel != oldHeadingLevel
  ```
being moved out of its original brackets and into a new set of outer brackets.


### Description of how this pull request fixes the issue:
Moves the code back into the original place, maintaining linting rules.

### Testing performed:
Did a search in the start screen, and arrowed down into the extra content (which is an Edge classic document). Previusly this caused an exception. Now all the content reads again.

### Known issues with pull request:
None.

### Change log entry:
None.
