### PR TITLE
Fixes somes context help issues in advanced settings panel.

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2584,7 +2584,7 @@ class AdvancedPanelControls(
 			pgettext("advanced.uiaWithChromium", "No"),
 		)
 		self.UIAInChromiumCombo = UIAGroup.addLabeledControl(label, wx.Choice, choices=chromiumChoices)
-		self.bindHelpEvent("AdvancedSettingsChromiumUIA", self.UIAInChromiumCombo)
+		self.bindHelpEvent("ChromiumUIA", self.UIAInChromiumCombo)
 		self.UIAInChromiumCombo.SetSelection(config.conf["UIA"]["allowInChromium"])
 		self.UIAInChromiumCombo.defaultValue = self._getDefaultValue(["UIA", "allowInChromium"])
 
@@ -2632,7 +2632,7 @@ class AdvancedPanelControls(
 			"difflib"
 		)
 		self.diffAlgoCombo = terminalsGroup.addLabeledControl(diffAlgoComboText, wx.Choice, choices=diffAlgoChoices)
-		self.bindHelpEvent("AdvancedSettingsDiffAlgo", self.diffAlgoCombo)
+		self.bindHelpEvent("DiffAlgo", self.diffAlgoCombo)
 		curChoice = self.diffAlgoVals.index(
 			config.conf['terminals']['diffAlgo']
 		)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2478,6 +2478,9 @@ class AdvancedPanelControls(
 	"""Holds the actual controls for the Advanced Settings panel, this allows the state of the controls to
 	be more easily managed.
 	"""
+	
+	helpId = "AdvancedSettings"
+	
 	def __init__(self, parent):
 		super().__init__(parent)
 		self._defaultsRestored = False
@@ -2581,6 +2584,7 @@ class AdvancedPanelControls(
 			pgettext("advanced.uiaWithChromium", "No"),
 		)
 		self.UIAInChromiumCombo = UIAGroup.addLabeledControl(label, wx.Choice, choices=chromiumChoices)
+		self.bindHelpEvent("AdvancedSettingsChromiumUIA", self.UIAInChromiumCombo)
 		self.UIAInChromiumCombo.SetSelection(config.conf["UIA"]["allowInChromium"])
 		self.UIAInChromiumCombo.defaultValue = self._getDefaultValue(["UIA", "allowInChromium"])
 
@@ -2628,6 +2632,7 @@ class AdvancedPanelControls(
 			"difflib"
 		)
 		self.diffAlgoCombo = terminalsGroup.addLabeledControl(diffAlgoComboText, wx.Choice, choices=diffAlgoChoices)
+		self.bindHelpEvent("AdvancedSettingsDiffAlgo", self.diffAlgoCombo)
 		curChoice = self.diffAlgoVals.index(
 			config.conf['terminals']['diffAlgo']
 		)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1840,7 +1840,7 @@ When this option is enabled, NVDA will use a new, work in progress version of it
 ==== Speak passwords in UIA consoles ====[AdvancedSettingsWinConsoleSpeakPasswords]
 This setting controls whether characters are spoken by [speak typed characters #KeyboardSettingsSpeakTypedCharacters] or [speak typed words #KeyboardSettingsSpeakTypedWords] in situations where the screen does not update (such as password entry) in the Windows Console with UI automation support enabled. For security purposes, this setting should be left disabled. However, you may wish to enable it if you experience performance issues or instability with typed character and/or word reporting while using NVDA's new experimental console support.
 
-==== Use UIA with Microsoft Edge and other Chromium based browsers when available ====[AdvancedSettingsChromiumUIA]
+==== Use UIA with Microsoft Edge and other Chromium based browsers when available ====[ChromiumUIA]
 Allows specifying when UIA will be used when it is available in Chromium based browsers such as Microsoft Edge.
 UIA support for Chromium based browsers is early in development and may not provide the same level of access as IA2.
 The combo box has the following options:
@@ -1857,7 +1857,7 @@ This feature is available and enabled by default on Windows 10 versions 1607 and
 Warning: with this option enabled, typed characters that do not appear onscreen, such as passwords, will not be suppressed.
 In untrusted environments, you may temporarily disable [speak typed characters #KeyboardSettingsSpeakTypedCharacters] and [speak typed words #KeyboardSettingsSpeakTypedWords] when entering passwords.
 
-==== Diff algorithm ====[AdvancedSettingsDiffAlgo]
+==== Diff algorithm ====[DiffAlgo]
 This setting controls how NVDA determines the new text to speak in terminals.
 The diff algorithm combo box has three options:
 - Automatic: as of NVDA 2021.1, this option is equivalent to Difflib.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1840,7 +1840,7 @@ When this option is enabled, NVDA will use a new, work in progress version of it
 ==== Speak passwords in UIA consoles ====[AdvancedSettingsWinConsoleSpeakPasswords]
 This setting controls whether characters are spoken by [speak typed characters #KeyboardSettingsSpeakTypedCharacters] or [speak typed words #KeyboardSettingsSpeakTypedWords] in situations where the screen does not update (such as password entry) in the Windows Console with UI automation support enabled. For security purposes, this setting should be left disabled. However, you may wish to enable it if you experience performance issues or instability with typed character and/or word reporting while using NVDA's new experimental console support.
 
-==== Use UIA with Microsoft Edge and other Chromium based browsers when available ====[ChromiumUIA]
+==== Use UIA with Microsoft Edge and other Chromium based browsers when available ====[AdvancedSettingsChromiumUIA]
 Allows specifying when UIA will be used when it is available in Chromium based browsers such as Microsoft Edge.
 UIA support for Chromium based browsers is early in development and may not provide the same level of access as IA2.
 The combo box has the following options:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

In #12025 (superseding #11079) and in #11639, new options were added to the advanced settings panel and a dedicated paragraph was added to the user doc corresponding to each of them.
However, context help does not work for these options. I.e. when the focus is on one of this option, pressing F1 reports "No help available here".
This is due to 2 issues:
* No help event was bound to these controls. Thus F1 does not opens the doc on the dedicated paragraph
* No helpId was assigned to AdvancedPanelControls subpanel. Thus the default behaviour when the controls do not have associated help events (i.e. opening the doc on the advanced settings paragraph) was not executed either.

### Description of how this pull request fixes the issue:

1. Bound both controls to the corresponding help events
2. Added helpId to AdvancedPanelControls subpanel.
3. Rename the tag "ChromiumUIA" to "AdvancedSettingsChromiumUIA" to conform to the majority of other help tags formatting, I.e. combining panel name and option name. This is still possible because this option has not been released yet. On the contrary it is not recommended to change tag names once the doc was included in a stable release of NVDA.

### Testing performed:

* Tested point 2 during implementation when point 1 and 3 were not yet implemented to check that pressing F1 on these 2 options jumps to the main "Advanced settings" paragraph.
* Once the three points were implemented, tested that F1 opens the user guide at the appropriate paragraph.

### Known issues with pull request:

None

### Change log entry:

None: this PR only fixes issues that have not yet been released.
