### PR TITLE
Fix usages of some remaining Python 2 names

### DIFF
--- a/extras/controllerClient/x86/example_python.py
+++ b/extras/controllerClient/x86/example_python.py
@@ -11,7 +11,7 @@ if res!=0:
 	ctypes.windll.user32.MessageBoxW(0,u"Error: %s"%errorMessage,u"Error communicating with NVDA",0)
 
 #Speak and braille some messages
-for count in xrange(4):
+for count in range(4):
 	clientLib.nvdaController_speakText(u"This is a test client for NVDA")
 	clientLib.nvdaController_brailleMessage(u"Time: %g seconds"%(0.75*count))
 	time.sleep(0.625)

--- a/source/locationHelper.py
+++ b/source/locationHelper.py
@@ -1,8 +1,7 @@
-#locationHelper.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2017-2018 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2017-2021 NV Access Limited, Babbage B.V.
 
 """Classes and helper functions for working with rectangles and coordinates."""
 
@@ -39,8 +38,8 @@ class Point(namedtuple("Point",("x","y"))):
 	def fromDWORD(cls, dwPoint):
 		if isinstance(dwPoint,DWORD):
 			dwPoint = dwPoint.value
-		if not isinstance(dwPoint,(int,long)):
-			raise TypeError("dwPoint should be one of int, long or ctypes.wintypes.DWORD (ctypes.ulong)")
+		if not isinstance(dwPoint, int):
+			raise TypeError("dwPoint should be either int or ctypes.wintypes.DWORD (ctypes.ulong)")
 		return Point(winUser.GET_X_LPARAM(dwPoint),winUser.GET_Y_LPARAM(dwPoint))
 
 	def __add__(self,other):

--- a/tests/unit/test_locationHelper.py
+++ b/tests/unit/test_locationHelper.py
@@ -1,14 +1,13 @@
-#tests/unit/test_locationHelper.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2017 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2017-2021 NV Access Limited, Babbage B.V., Łukasz Golonka
 
 """Unit tests for the locationHelper module.
 """
 
 import unittest
-from locationHelper import *
+from locationHelper import Point, RectLTRB, RectLTWH
 from ctypes.wintypes import RECT, POINT
 
 class TestRectOperators(unittest.TestCase):
@@ -193,3 +192,25 @@ class TestPointOperators(unittest.TestCase):
 		# Equality
 		self.assertEqual(POINT(x=4, y=3), Point(x=4, y=3))
 		self.assertNotEqual(POINT(x=3, y=4), Point(x=4, y=3))
+
+
+class TestFailuresFromUnexpectedTypes(unittest.TestCase):
+
+	def test_PointFailures(self):
+		self.assertRaises(TypeError, Point.fromFloatCollection, 22.22, 22, 33)
+		self.assertRaises(TypeError, Point.fromCompatibleType, 22.22)
+		self.assertRaises(TypeError, Point.fromDWORD, 22.22)
+
+	def test_RectLTRBFailures(self):
+		self.assertRaises(TypeError, RectLTRB.fromFloatCollection, 22, 33.33, 44.44)
+		self.assertRaises(TypeError, RectLTRB.fromCompatibleType, 33.33)
+		self.assertRaises(TypeError, RectLTRB.fromPoint, 33.33)
+		self.assertRaises(TypeError, RectLTRB.fromCollection)
+		self.assertRaises(ValueError, RectLTRB.fromCollection, 22.22)
+
+	def test_RectLTWHFailures(self):
+		self.assertRaises(TypeError, RectLTWH.fromFloatCollection, 22, 33.33, 44.44)
+		self.assertRaises(TypeError, RectLTWH.fromCompatibleType, 33.33)
+		self.assertRaises(TypeError, RectLTWH.fromPoint, 33.33)
+		self.assertRaises(TypeError, RectLTWH.fromCollection)
+		self.assertRaises(ValueError, RectLTWH.fromCollection, 22.22)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
During migration from Python 2 to 3 two usages of Python 2 only names in the source code were missed.
### Description of how this pull request fixes the issue:
- In NVDACOntroller client Python example replaced `xrange` with `range`
- in `locationHelper` removed check for `long` as it no longer exists in Python 3.

In addition since some methods in `locationHelper` used to create location classes from various types aren't used in the code at all I've expanded unit tests to ensure that they raise expected exceptions when incompatible arguments are given to them.

### Testing performed:
Newly added unit tests for locationHelper are passing now whereas previously they weren't.
### Known issues with pull request:
None
### Change log entry:
None needed.