### PR TITLE
Update pySerial to 3.5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [MinHook](https://github.com/RaMMicHaeL/minhook), tagged version 1.2.2
 * brlapi Python bindings, version 0.8 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html), version 6.1
 * lilli.dll, version 2.1.0.0
-* [pySerial](https://pypi.python.org/pypi/pyserial), version 3.4
+* [pySerial](https://pypi.python.org/pypi/pyserial), version 3.5
 * [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)
 * Java Access Bridge 32 bit, from Zulu Community OpenJDK build 13.0.1+10Zulu (13.28.11)
 


### PR DESCRIPTION
### Link to issue number:
None

### Description of this pull request
Updates pySerial to version 3.5 (November 2020). While not strictly necessary as far as I know, this ensures we are on the most recent version for our switch to Python 3.8

### Testing strategy:
Should be tested with a serial braille display in production for several days to ensure there are no regressions. I have such a display.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
*     + Updated pySerial to version 3.5.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Please do a self-review to check these items.
Reviewers will not approve the PR until these are met.

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
