### PR TITLE
Build NVDA with Python 3.8 32-bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ branches:
   - /release-.*/
   
 environment:
- PY_PYTHON: 3.7-32
+ PY_PYTHON: 3.8-32
  encFileKey:
   secure: ekOvuyywHuDdGZmRmoj+b3jfrq39A2xlx4RD5ZUGd/8=
  mozillaSymsAuthToken:

--- a/readme.md
+++ b/readme.md
@@ -55,9 +55,8 @@ The NVDA source depends on several other packages to run correctly.
 ### Installed Dependencies
 The following dependencies need to be installed on your system:
 
-* [Python](https://www.python.org/), version 3.7, 32 bit
+* [Python](https://www.python.org/), version 3.8, 32 bit
 	* Use latest minor version if possible.
-	* Don't use `3.7.6` it causes an error while building, see #10696.
 * Microsoft Visual Studio 2019 Community, Version 16.3 or later:
 	* Download from https://visualstudio.microsoft.com/vs/
 	* When installing Visual Studio, you need to enable the following:

--- a/scons.bat
+++ b/scons.bat
@@ -6,7 +6,7 @@ where py 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	rem Python launcher is present in the PATH
 	rem Call python 3.7 for 32 bits
-	py -3.7-32 "%~dp0\scons.py" %*
+	py -3.8-32 "%~dp0\scons.py" %*
 ) else (
 	rem Python registers itself with the .py extension, so call scons.py.
 	"%~dp0\scons.py" %*

--- a/scons.bat
+++ b/scons.bat
@@ -5,7 +5,7 @@ rem Instead, find the python launcher (installed by python 3)
 where py 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	rem Python launcher is present in the PATH
-	rem Call python 3.7 for 32 bits
+	rem Call python 3.8 32-bit
 	py -3.8-32 "%~dp0\scons.py" %*
 ) else (
 	rem Python registers itself with the .py extension, so call scons.py.

--- a/sconstruct
+++ b/sconstruct
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2021 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee, Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt  # noqa: E501
+# Copyright (C) 2010-2020 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee, Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt  # noqa: E501
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/sconstruct
+++ b/sconstruct
@@ -34,10 +34,6 @@ if (
 		requiredPythonArchitecture
 	)
 	)
-if sys.version_info.micro == 6:
-	# #10696: Building with Python 3.7.6 fails. Innform user and exit.
-	Py376FailMsg = "Building with Python 3.7.6 is not possible.\nPlease use more  recent version of Python 3."
-	raise RuntimeError(Py376FailMsg)
 sourceEnvPath = os.path.abspath(os.path.join(Dir('.').srcnode().path, "source"))
 sys.path.append(sourceEnvPath)
 import sourceEnv

--- a/sconstruct
+++ b/sconstruct
@@ -9,7 +9,7 @@ import platform
 
 # Variables for storing required version of Python, and the version which is used to run this script.
 requiredPythonMajor ="3"
-requiredPythonMinor = "7"
+requiredPythonMinor = "8"
 requiredPythonArchitecture = "32bit"
 installedPythonMajor = str(sys.version_info.major)
 installedPythonMinor = str(sys.version_info.minor)

--- a/sconstruct
+++ b/sconstruct
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2020 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee, Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt  # noqa: E501
+# Copyright (C) 2010-2021 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee, Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt  # noqa: E501
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Hi,

Required to build NVDA under Python 3.8:

### Link to issue number:
None

### Summary of the issue:
Currently SConstruct runs Python 3.7 to build NVDA.

### Description of how this pull request fixes the issue:
Directs SConstruct to build NVDA under Python 3.8 32-bit.

### Testing strategy:
1. Build NVDA from source code locally (you'll need Python 3.8 32-bit to do this). If possible, testthis after installing Python 3.8 versions of our dependencies.
2. Build NVDA on the cloud via AppVeyor (the yml file wasn't modified yet).

### Known issues with pull request:
None

### Change log entry:
None

### Code Review Checklist:
As this is an internal change, only applicable tests are shown:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] Manual tests.

Note: system tests is excluded as it is not really required to build the PR build until AppVeyor is ready to run Python 3.8 to build NvDA.

Thanks.