### PR TITLE
remove unused imports from the nvwave module

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1,8 +1,7 @@
-#nvwave.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2021 NV Access Limited, Aleksey Sadovoy, Cyrille Bougot, Peter Vágner
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Provides a simple Python interface to playing audio using the Windows multimedia waveOut functions, as well as other useful utilities.
 """

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -30,11 +30,7 @@ from ctypes.wintypes import (
 	UINT,
 	LPUINT
 )
-from ctypes import *
-from ctypes.wintypes import *
-import time
 import atexit
-import wx
 import garbageHandler
 import winKernel
 import wave

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -33,7 +33,6 @@ import queueHandler
 from logHandler import log
 import ui
 import aria
-import nvwave
 import treeInterceptorHandler
 import watchdog
 from abc import abstractmethod


### PR DESCRIPTION

### Link to issue number:
None, follow-up from pr #11531
### Summary of the issue:
PR #11531  made some imports in the nvwave (mainly usages of `from ctypes import *`) unnecessary. They were left in the code not to break backward compatibility. Since 2021.1 intents to break backward compat anyway it makes sense to remove them.
### Description of how this pull request fixes the issue:
All unused  imports from the nvvwave module were removed. In addition one unused import  of the nvwave itself was identified in the virtualBuffers package - it was also removed,
### Testing strategy:
With git grep ensured that nothing in the code relied on the removed imports.
### Known issues with pull request:
None known
### Change log entry:

Section: Changes for developers:
Some unused imports were removed.
### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Please do a self-review to check these items.
Reviewers will not approve the PR until these are met.

- [X] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [X] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
