### PR TITLE
Elements list is now available in Microsoft Word straight away without having to enable browse mode first

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -21,11 +21,14 @@ from displayModel import EditableTextDisplayModelTextInfo
 from NVDAObjects.window import DisplayModelEditableText
 from ..behaviors import EditableTextWithoutAutoSelectDetection
 from NVDAObjects.window.winword import *
+from NVDAObjects.window.winword import WordDocumentTreeInterceptor
+
 
 class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocument):
  
-	treeInterceptorClass=WordDocumentTreeInterceptor
-	shouldCreateTreeInterceptor=False
+	treeInterceptorClass = WordDocumentTreeInterceptor
+	shouldCreateTreeInterceptor = True
+
 	TextInfo=WordDocumentTextInfo
 
 	def _get_ignoreEditorRevisions(self):

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -298,6 +298,14 @@ class WordDocumentTextInfo(UIATextInfo):
 
 class WordBrowseModeDocument(UIABrowseModeDocument):
 
+	# This treeInterceptor starts in focus mode, thus escape should not switch back to browse mode
+	disableAutoPassThrough = True
+
+	def __init__(self, rootNVDAObject):
+		super(WordBrowseModeDocument, self).__init__(rootNVDAObject)
+		self.passThrough = True
+		browseMode.reportPassThrough.last = True
+
 	def shouldSetFocusToObj(self,obj):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		if obj.role==controlTypes.ROLE_EDITABLETEXT and obj.UIAElement.cachedAutomationID.startswith('UIA_AutomationId_Word_Content'):
@@ -341,8 +349,8 @@ class WordDocumentNode(UIA):
 		return role
 
 class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentBase):
-	treeInterceptorClass=WordBrowseModeDocument
-	shouldCreateTreeInterceptor=False
+	treeInterceptorClass = WordBrowseModeDocument
+	shouldCreateTreeInterceptor = True
 	announceEntireNewLine=True
 
 	# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1069,6 +1069,14 @@ class BrowseModeWordDocumentTextInfo(browseMode.BrowseModeDocumentTextInfo,treeI
 
 class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 
+	# This treeInterceptor starts in focus mode, thus escape should not switch back to browse mode
+	disableAutoPassThrough = True
+
+	def __init__(self, rootNVDAObject):
+		super(WordDocumentTreeInterceptor, self).__init__(rootNVDAObject)
+		self.passThrough = True
+		browseMode.reportPassThrough.last = True
+
 	TextInfo=BrowseModeWordDocumentTextInfo
 
 	def _activateLongDesc(self,controlField):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Fixes #12050

### Summary of the issue:
Documentation for NVDA stated that Elements list (NVDA+f7) was available in focus mode. Although this wa strue for web documents and Excel, it was missed for Microsoft Word.

### Description of how this pull request fixes the issue:
A treeInterceptor is now created for Microsoft Word documents (both with UIA enabled or disabled) but the treeInteceptor is defauled to focus mode. Thus Elements list is available straight away. This is the exact same approach as taken by the treeInterceptor for Microsoft Excel.

### Testing strategy:
Manual testing done:
* Ensured UIA in Microsoft Word document controls was disabled in NVDA's davanced settings.
* Opened Microsoft Word.
* Typed a line of text and formatted it as a heading with shift+alt+rightArrow
* Pressed NVDA+f7 to bring up the Elements list.
* Restarted NvDA.
* Enabled UIA in Microsoft Word document controls in NVDA's advanced settings.
* Typed a line of text and formatted it as a heading with shift+alt+rightArrow
* Pressed NVDA+f7 to bring up the Elements list.

In theory a system test could be created for this, however this would require appveyor vms including Microsoft Word, which is something we would need to look into in the future.
I don't believe unit tests really apply to this kind of infrastructure change.

### Known issues with pull request:
This change means that a treeInterceptor is now always created for Word documents. Although Word document treeInterceptors are not in any way heavy (they don't cache much at all) it is still a change which could affect the lifetime of treeInterceptors or other objects in NVDA.
I think this is very low risk, but either this needs to be tested on another rc for a while by heavy users of Microsoft Word, or we hold off until 2021.1 and make an edit to the 2020.4 documentation excluding Microsoft Word.
 
### Change log entry:
None needed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Please do a self-review to check these items.
Reviewers will not approve the PR until these are met.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
