### PR TITLE
Fix isCurrent errors for Internet Explorer

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -543,13 +543,24 @@ class MSHTML(IAccessible):
 			return virtualBuffers.MSHTML.MSHTML
 		return super(MSHTML,self).treeInterceptorClass
 
-	def _get_isCurrent(self):
-		isCurrent = self.HTMLAttributes["aria-current"]
+	def _get_isCurrent(self) -> controlTypes.IsCurrent:
+		try:
+			isCurrent = self.HTMLAttributes["aria-current"]
+		except LookupError:
+			return controlTypes.IsCurrent.NO
+
+		# key may be in HTMLAttributes with a value of None
+		if isCurrent is None:
+			return controlTypes.IsCurrent.NO
+
 		try:
 			return controlTypes.IsCurrent(isCurrent)
 		except ValueError:
 			log.debugWarning(f"Unknown aria-current value: {isCurrent}")
 			return controlTypes.IsCurrent.NO
+
+	#: Typing for autoproperty _get_HTMLAttributes
+	HTMLAttributes: HTMLAttribCache
 
 	def _get_HTMLAttributes(self):
 		return HTMLAttribCache(self.HTMLNode)

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -54,7 +54,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 		try:
 			ariaCurrent = controlTypes.IsCurrent(ariaCurrentValue)
 		except ValueError:
-			log.debugWarningdebugWarning(f"Unknown aria-current value: {ariaCurrentValue}")
+			log.debugWarning(f"Unknown aria-current value: {ariaCurrentValue}")
 			ariaCurrent = controlTypes.IsCurrent.NO
 		return ariaCurrent
 

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -58,7 +58,9 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			ariaCurrent = controlTypes.IsCurrent.NO
 		return ariaCurrent
 
-	def _normalizeControlField(self, attrs: dict):
+	# C901 'MSHTMLTextInfo._normalizeControlField' is too complex (42)
+	# Look for opportunities to simplify this function.
+	def _normalizeControlField(self, attrs: dict):  # noqa: C901
 		level = None
 
 		isCurrent = self._getIsCurrentAttribute(attrs)

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -46,18 +46,24 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			attrs['language']=languageHandler.normalizeLanguage(language)
 		return attrs
 
-	def _normalizeControlField(self,attrs):
-		level=None
-
-		ariaCurrentValue = attrs.get('HTMLAttrib::aria-current', 'false')
+	def _getIsCurrentAttribute(self, attrs: dict) -> controlTypes.IsCurrent:
+		defaultAriaCurrentStringVal = "false"
+		ariaCurrentValue = attrs.get('HTMLAttrib::aria-current', defaultAriaCurrentStringVal)
+		# key 'HTMLAttrib::aria-current' may be in attrs with a value of None
+		ariaCurrentValue = defaultAriaCurrentStringVal if ariaCurrentValue is None else ariaCurrentValue
 		try:
 			ariaCurrent = controlTypes.IsCurrent(ariaCurrentValue)
 		except ValueError:
-			log.debugWarning(f"Unknown aria-current value: {ariaCurrentValue}")
+			log.debugWarningdebugWarning(f"Unknown aria-current value: {ariaCurrentValue}")
 			ariaCurrent = controlTypes.IsCurrent.NO
+		return ariaCurrent
 
-		if ariaCurrent != controlTypes.IsCurrent.NO:
-			attrs['current'] = ariaCurrent
+	def _normalizeControlField(self, attrs: dict):
+		level = None
+
+		isCurrent = self._getIsCurrentAttribute(attrs)
+		if isCurrent != controlTypes.IsCurrent.NO:
+			attrs['current'] = isCurrent
 
 		placeholder = self._getPlaceholderAttribute(attrs, 'HTMLAttrib::aria-placeholder')
 		if placeholder:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Fixes #12055

### Summary of the issue:
Errors raised after unhandled value of 'None' for aria-current

### Description of how this pull request fixes the issue:
Handles None value, mapping to isCurrent.No

### Testing strategy:
Manually tested with http://test-cases.tink.uk/aria-current/
In browse mode and focus mode

This code would be hard to unit test.
We don't have system tests for internet explorer yet.

### Known issues with pull request:
None

### Change log entry:
None - bug not included in a release

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Please do a self-review to check these items.
Reviewers will not approve the PR until these are met.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
