### PR TITLE
Fix-up of pr #9679: Once again allow to copy configuration when installing from a portable NVDA.

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -250,17 +250,6 @@ def main():
 	log.debug("loading config")
 	import config
 	config.initialize()
-	if globalVars.appArgs.configPath == config.getUserDefaultConfigPath(useInstalledPathIfExists=True):
-		# Make sure not to offer the ability to copy the current configuration to the user account.
-		# This case always applies to the launcher when configPath is not overridden by the user,
-		# which is the default.
-		# However, if a user wants to run the launcher with a custom configPath,
-		# it is likely that he wants to copy that configuration when installing.
-		# This check also applies to cases where a portable copy is run using the installed configuration,
-		# in which case we want to avoid copying a configuration to itself.
-		# We set the value to C{None} in order for the gui to determine
-		# when to disable the checkbox for this feature.
-		globalVars.appArgs.copyPortableConfig = None
 	if config.conf['development']['enableScratchpadDir']:
 		log.info("Developer Scratchpad mode enabled")
 	if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -207,7 +207,9 @@ class InstallerDialog(
 		createPortableBox = wx.CheckBox(optionsBox, label=createPortableText)
 		self.copyPortableConfigCheckbox = optionsHelper.addItem(createPortableBox)
 		self.bindHelpEvent("CopyPortableConfigurationToCurrentUserAccount", self.copyPortableConfigCheckbox)
-		self.copyPortableConfigCheckbox.Value = bool(globalVars.appArgs.copyPortableConfig)
+		self.copyPortableConfigCheckbox.Value = (
+			bool(globalVars.appArgs.copyPortableConfig) and self._shouldEnableCopyConfig()
+		)
 		self.copyPortableConfigCheckbox.Enable(self._shouldEnableCopyConfig())
 
 		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL))

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -1,8 +1,8 @@
-#gui/installerGui.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2011-2018 NV Access Limited, Babbage B.v.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2011-2021 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
+# Bill Dengler, Joseph Lee, Takuya Nishimoto
 
 import os
 import ctypes

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -229,9 +229,9 @@ class InstallerDialog(
 		self.copyPortableConfigCheckbox = optionsHelper.addItem(createPortableBox)
 		self.bindHelpEvent("CopyPortableConfigurationToCurrentUserAccount", self.copyPortableConfigCheckbox)
 		self.copyPortableConfigCheckbox.Value = (
-			bool(globalVars.appArgs.copyPortableConfig) and self._canPortableConfigBeCopied()
+			bool(globalVars.appArgs.copyPortableConfig) and _canPortableConfigBeCopied()
 		)
-		self.copyPortableConfigCheckbox.Enable(self._canPortableConfigBeCopied())
+		self.copyPortableConfigCheckbox.Enable(_canPortableConfigBeCopied())
 
 		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL))
 		if shouldAskAboutAddons:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -21,7 +21,7 @@ import systemUtils
 
 
 def _canPortableConfigBeCopied() -> bool:
-	# In some cases even though user requested to copy config from the portable copy during installation 
+	# In some cases even though user requested to copy config from the portable copy during installation
 	# it should not be done.
 	if globalVars.appArgs.launcher:
 		# Normally when running from the launcher

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -5,22 +5,18 @@
 # Bill Dengler, Joseph Lee, Takuya Nishimoto
 
 import os
-import ctypes
 
-import buildVersion
 import shellapi
 import winUser
 import wx
 import config
 import globalVars
-import versionInfo
 import installer
 from logHandler import log
 import gui
 from gui import guiHelper
 import gui.contextHelp
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
-import tones
 import systemUtils
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -46,6 +46,7 @@ What's New in NVDA
 - In WordPad, configuration of superscript/subscript reporting works as expected. (#12262)
 - NVDA no longer fails to announce the newly focused content on a web page if the old focus disappears and is replaced by the new focus in the same position. (#12147)
 - Strikethrough, superscript and subscript formatting for entire Excel cells are now reported if the corresponding option is enabled. (#12264)
+- Fixed copying config during installation from a portable copy when default destination config directory is empty. (#12071, #12205)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #12071
Fixes #12205

### Summary of the issue:
PR #9679 introduced additional command line parameter which allows to copy config from a portable NVDA during installation. Unfortunately it also made it impossible to copy config from a portable copy when installing manually on an user account  without NVDA config in appdata (the corresponding option was disabled in the GUI).
### Description of how this pull request fixes the issue:
Rather than disabling  this option when result of `config.getUserDefaultConfigPath`  is the same as the current config path (which was also true for portable copies) I've added additional method which disables this option only when NVDA is started from the launcher and configPath is not overridden by the user, or in case of portable copies when config currently in use is placed in appdata, and therefore NVDA would copy it into itself.
Please note that first two commits are merely updating copyright header (1f8a0fa), and cleaning up unused imports from the installer GUI (741c20b) there are no functional changes in them.
### Testing strategy:
Manual testing:
1. With nvda started from the launcher and NVDA config in appdata ensured that "copy config to the current user account" was disabled in the install dialog.
2. With NVDA started from the launcher with the custom config path ensured that the checkbox in question was enabled.
3. With NVDA started from the portable copy and no config in appdata ensured that this option was shown.
4. with portable NVDA started with the `-c %appdata%\nvda` ensured that "copy portable config to the current user account" was disabled.
5. With portable NVDA and config in appdata ensured that the option was enabled.

It should be possible to create system test for this PR but it would require a big refactoring so that first test is executed in a portable copy and ensures that right options are shown in the installer and then subsequent tests are being run for an installed NVDA. I don't thing small change like this justifies the required effort.


I've also repeated tests from #9679:
1. Started a portable copy, started the installation gui. Made sure that "copy the current user config" check box was unchecked.
2. Started a portable copy with --copy-portable-config parameter, started the installation gui. Made sure that "copy the current user config" check box was checked.
3. Started a portable copy with --copy-portable-config -c %appdata%\nvda, started the installation gui. Made sure that "copy the current user config" check box was disabled.
4. Started a snapshot from the launcher with --copy-portable-config -c somepath. Made sure that the checkbox was enabled and checked.
5. Started a portable copy with --copy-portable-config --install. Made sure that the configuration was successfully kopied after the installation.


### Known issues with pull request:
None known
### Change log entry:

Section:  Bug fixes
- It is once again possible to copy config from a portable NVDA when installing it under user account without previous NVDA config.
### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
