### PR TITLE
Fix command line length limit reached

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -426,9 +426,22 @@ userGuideFile=env.Command(outputDir.File("userGuide.html"),userDocsDir.File('en/
 env.Depends(userGuideFile, outputStylesFile)
 env.Alias('userGuide',userGuideFile)
 
+
+def makePotSourceFileList(target, sourceFiles, env):
+	potSourceFiles = [
+		os.path.relpath(str(f), str(sourceDir)) for f in sourceFiles
+	]
+	with open(target.abspath, "w") as fileList:
+		fileList.writelines([f + '\n' for f in potSourceFiles])
+
+
 def makePot(target, source, env):
+	potSourceFileList = outputDir.File("potSourceFileList.txt")
+	makePotSourceFileList(potSourceFileList, source, env)
 	# Generate the pot.
-	if env.Execute([["cd", sourceDir, "&&",
+	if env.Execute([
+		[
+			"cd", sourceDir, "&&",
 			XGETTEXT,
 			"-o", target[0].abspath,
 			"--package-name", versionInfo.name, "--package-version", version,
@@ -438,7 +451,9 @@ def makePot(target, source, env):
 			"--from-code", "utf-8",
 			# Needed because xgettext doesn't recognise the .pyw extension.
 			"--language=python",
-		] + [os.path.relpath(str(f), str(sourceDir)) for f in source]
+			# Too many files to list on commandline, use a file list instead.
+			f"--files-from={potSourceFileList.abspath}",
+		]
 	]) != 0:
 		raise RuntimeError("xgettext failed")
 
@@ -458,17 +473,35 @@ def makePot(target, source, env):
 	os.remove(potFn)
 	os.rename(tmpFn, potFn)
 
+
 env.SConscript("devDocs/sconscript", exports=["env", "outputDir", "sourceDir", "t2tBuildConf"])
 
-pot = env.Command(outputDir.File("%s.pot" % outFilePrefix),
+
+def getSubDirs(path):
+	for root, dirNames, fileNames in os.walk(path):
+		yield root
+
+
+# The Glob() SCons function doesnt have the ability to go recursive. Instead
+# walk the dirs and match patterns.
+potSourceFiles = [
 	# Don't use sourceDir as the source, as this depends on comInterfaces and nvdaHelper.
 	# We only depend on the Python files.
-	[f for pattern in ("*.py", "*.pyw", r"*\*.py", r"*\*\*.py")
-		for f in env.Glob(os.path.join(sourceDir.path, pattern))
+	f for recurseDirs in getSubDirs(sourceDir.path)
+	for pattern in ("*.py", "*.pyw")
+	for f in env.Glob(
+		os.path.join(recurseDirs, pattern),
 		# Exclude comInterfaces, since these don't contain translatable strings
 		# and they cause unknown encoding warnings.
-		if not f.path.startswith("source\\comInterfaces\\")],
-	makePot)
+		exclude="source/comInterfaces/*"
+	)
+]
+
+pot = env.Command(
+	outputDir.File("%s.pot" % outFilePrefix),
+	potSourceFiles,
+	makePot
+)
 
 env.Alias("pot", pot)
 


### PR DESCRIPTION
The number of files passed to xgettext had grown too great, use a file list instead

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None

### Summary of the issue:
When adding new files to NVDA the command line for xgettext (building the translation files) has become too long.

### Description of how this pull request fixes the issue:
First generate a file containing all the paths to be given to xgettext and then use the `--files-from` argument to have xgettext use this list rather than a list of files on the command line.

### Testing strategy:
Tested locally:
- Created new files
- Ran `scons makePot`
- Note new files are in the file list
- Note that translations from new files are in po file.

### Known issues with pull request:
None

### Change log entry:
None

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
