### PR TITLE
Python 3.8/gettext: replace custom pgettext implementation with built--in pgettext

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#addonHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2012-2019 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V., Arnold Loubriat
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2012-2021 NV Access Limited, Rui Batista, Noelia Ruiz Martínez,
+# Joseph Lee, Babbage B.V., Arnold Loubriat
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import sys
 import os.path

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -539,8 +539,8 @@ def initTranslation():
 	try:
 		callerFrame = inspect.currentframe().f_back
 		callerFrame.f_globals['_'] = translations.gettext
-		# Install our pgettext function.
-		callerFrame.f_globals['pgettext'] = languageHandler.makePgettext(translations)
+		# Install pgettext function.
+		callerFrame.f_globals['pgettext'] = translations.pgettext
 	finally:
 		del callerFrame # Avoid reference problems with frames (per python docs)
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -539,6 +539,8 @@ def initTranslation():
 	try:
 		callerFrame = inspect.currentframe().f_back
 		callerFrame.f_globals['_'] = translations.gettext
+		# Install our pgettext function.
+		callerFrame.f_globals['pgettext'] = languageHandler.makePgettext(translations)
 	finally:
 		del callerFrame # Avoid reference problems with frames (per python docs)
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -539,8 +539,6 @@ def initTranslation():
 	try:
 		callerFrame = inspect.currentframe().f_back
 		callerFrame.f_globals['_'] = translations.gettext
-		# Install our pgettext function.
-		callerFrame.f_globals['pgettext'] = languageHandler.makePgettext(translations)
 	finally:
 		del callerFrame # Avoid reference problems with frames (per python docs)
 

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -123,27 +123,6 @@ def getAvailableLanguages(presentational=False):
 	)
 	return langs
 
-def makePgettext(translations):
-	"""Obtaina  pgettext function for use with a gettext translations instance.
-	pgettext is used to support message contexts,
-	but Python's gettext module doesn't support this,
-	so NVDA must provide its own implementation.
-	"""
-	if isinstance(translations, gettext.GNUTranslations):
-		def pgettext(context, message):
-			try:
-				# Look up the message with its context.
-				return translations._catalog[u"%s\x04%s" % (context, message)]
-			except KeyError:
-				return message
-	elif isinstance(translations, gettext.NullTranslations):
-		# A language with out a translation catalog, such as English.
-		def pgettext(context, message):
-			return message
-	else:
-		raise ValueError("%s is Not a GNUTranslations or NullTranslations object"%translations)
-	return pgettext
-
 def getWindowsLanguage():
 	"""
 	Fetches the locale name of the user's configured language in Windows.
@@ -199,9 +178,6 @@ def setLanguage(lang):
 		trans=gettext.translation("nvda",fallback=True)
 		curLang="en"
 	trans.install()
-	# Install our pgettext function.
-	import builtins
-	builtins.pgettext = makePgettext(trans)
 
 def getLanguage():
 	return curLang

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -8,7 +8,6 @@
 This module assists in NVDA going global through language services such as converting Windows locale ID's to friendly names and presenting available languages.
 """
 
-import builtins
 import os
 import sys
 import ctypes

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -176,7 +176,8 @@ def setLanguage(lang):
 	except IOError:
 		trans=gettext.translation("nvda",fallback=True)
 		curLang="en"
-	trans.install()
+	# #9207: Python 3.8 adds gettext.pgettext, so add it to the built-in namespace.
+	trans.install(names=["pgettext"])
 
 def getLanguage():
 	return curLang

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -1,8 +1,7 @@
-#languageHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2007-2018 NV access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2021 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Language and localization support.
 This module assists in NVDA going global through language services such as converting Windows locale ID's to friendly names and presenting available languages.


### PR DESCRIPTION
Hi,

This will impact localization and resolves a long-standing issue with it:

### Link to issue number:
Closes #9207

### Summary of the issue:
Python 3.8 introduces gettext.pgettext to obtain translated text based on context. Prior to this, NVDA defined a custom implementation of pgettext function.

### Description of how this pull request fixes the issue:
Replace custom pgettext implementation and built-in namespace assignment with Python 3.8's gettext.pgettext by using translation.install function's "names" sequence parameter.

### Testing strategy:
Two ways:

1. Perform a diff between current master and this PR's locale/* data after generating pot files.
2. Manual: have translators test this change to make sure localizations are correct.

### Known issues with pull request:
None

### Change log entry:
None needed, unless a note to developers is needed to highlight pgettext function.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
