### PR TITLE
remove winKernel.GetTimeFormat, winKernel.GetDateFormat and usages

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -365,9 +365,31 @@ class CalendarView(IAccessible):
 				except COMError:
 					return super(CalendarView,self).reportFocus()
 				timeSlotText=self._generateTimeRangeText(selectedStartTime,selectedEndTime)
-				startLimit=u"%s %s"%(winKernel.GetDateFormatEx(winKernel.LOCALE_NAME_USER_DEFAULT, winKernel.DATE_LONGDATE, selectedStartTime, None),winKernel.GetTimeFormat(winKernel.LOCALE_USER_DEFAULT, winKernel.TIME_NOSECONDS, selectedStartTime, None))
-				endLimit=u"%s %s"%(winKernel.GetDateFormatEx(winKernel.LOCALE_NAME_USER_DEFAULT, winKernel.DATE_LONGDATE, selectedEndTime, None),winKernel.GetTimeFormat(winKernel.LOCALE_USER_DEFAULT, winKernel.TIME_NOSECONDS, selectedEndTime, None))
-				query=u'[Start] < "{endLimit}" And [End] > "{startLimit}"'.format(startLimit=startLimit,endLimit=endLimit)
+				startDate = winKernel.GetDateFormatEx(
+					winKernel.LOCALE_NAME_USER_DEFAULT,
+					winKernel.DATE_LONGDATE,
+					selectedStartTime,
+					None
+				)
+				startTime = winKernel.GetTimeFormatEx(
+					winKernel.LOCALE_NAME_USER_DEFAULT,
+					winKernel.TIME_NOSECONDS,
+					selectedStartTime,
+					None
+				)
+				endDate = winKernel.GetDateFormatEx(
+					winKernel.LOCALE_NAME_USER_DEFAULT,
+					winKernel.DATE_LONGDATE,
+					selectedEndTime,
+					None
+				)
+				endTime = winKernel.GetTimeFormatEx(
+					winKernel.LOCALE_NAME_USER_DEFAULT,
+					winKernel.TIME_NOSECONDS,
+					selectedEndTime,
+					None
+				)
+				query = f'[Start] < "{endDate} {endTime}" And [End] > "{startDate} {startTime}"'
 				i=e.currentFolder.items
 				i.sort('[Start]')
 				i.IncludeRecurrences =True

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -160,18 +160,6 @@ class SYSTEMTIME(ctypes.Structure):
 		("wMilliseconds", WORD)
 	)
 
-def GetDateFormat(Locale,dwFlags,date,lpFormat):
-	"""@Deprecated: use GetDateFormatEx instead."""
-	if date is not None:
-		date=SYSTEMTIME(date.year,date.month,0,date.day,date.hour,date.minute,date.second,0)
-		lpDate=byref(date)
-	else:
-		lpDate=None
-	bufferLength=kernel32.GetDateFormatW(Locale, dwFlags, lpDate, lpFormat, None, 0)
-	buf=ctypes.create_unicode_buffer("", bufferLength)
-	kernel32.GetDateFormatW(Locale, dwFlags, lpDate, lpFormat, buf, bufferLength)
-	return buf.value
-
 def GetDateFormatEx(Locale,dwFlags,date,lpFormat):
 	if date is not None:
 		date=SYSTEMTIME(date.year,date.month,0,date.day,date.hour,date.minute,date.second,0)
@@ -181,18 +169,6 @@ def GetDateFormatEx(Locale,dwFlags,date,lpFormat):
 	bufferLength=kernel32.GetDateFormatEx(Locale, dwFlags, lpDate, lpFormat, None, 0, None)
 	buf=ctypes.create_unicode_buffer("", bufferLength)
 	kernel32.GetDateFormatEx(Locale, dwFlags, lpDate, lpFormat, buf, bufferLength, None)
-	return buf.value
-
-def GetTimeFormat(Locale,dwFlags,date,lpFormat):
-	"""@Deprecated: use GetTimeFormatEx instead."""
-	if date is not None:
-		date=SYSTEMTIME(date.year,date.month,0,date.day,date.hour,date.minute,date.second,0)
-		lpTime=byref(date)
-	else:
-		lpTime=None
-	bufferLength=kernel32.GetTimeFormatW(Locale,dwFlags,lpTime,lpFormat, None, 0)
-	buf=ctypes.create_unicode_buffer("", bufferLength)
-	kernel32.GetTimeFormatW(Locale,dwFlags,lpTime,lpFormat, buf, bufferLength)
 	return buf.value
 
 def GetTimeFormatEx(Locale,dwFlags,date,lpFormat):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,8 @@ What's New in NVDA
   - 'isCurrent' is no longer Optional, and thus will not return None, when an object is not current 'controlTypes.IsCurrent.NO' is returned.
 - The 'controlTypes.isCurrentLabels' has been removed, instead use the 'displayString' property on a 'controlTypes.IsCurrent' enum value. (#11782)
   - EG 'controlTypes.IsCurrent.YES.displayString'
+- `winKernel.GetTimeFormat` has been removed - use `winKernel.GetTimeFormatEx` instead (#12139)
+- `winKernel.GetDateFormat` has been removed - use `winKernel.GetDateFormatEx` instead (#12139)
 
 
 = 2020.4 =
@@ -3124,4 +3126,3 @@ Major highlights of this release include support for 64 bit editions of Windows;
 - NVDA now asks if it should save configuration and restart if the user has just changed the language in the User Interface Settings Dialog. NVDA must be restarted for the language change to fully take effect.
 - If a synthesizer can not be loaded, when choosing it from the synthesizer dialog, a message box alerts the user to the fact.
 - When loading a synthesizer for the first time, NVDA lets the synthesizer choose the most suitable voice, rate and pitch parameters, rather than forcing it to defaults it thinks are ok. This fixes a problem where Eloquence and Viavoice sapi4 synths start speaking way too fast for the first time.
-


### PR DESCRIPTION
### Link to issue number:

Implement deprecations announced in #7949 

Part of: #12123 

### Summary of the issue:

`winKernel.GetTimeFormat` and `winKernel.GetDateFormat` relied on deprecated Windows API functionality, as described [here](https://archive.is/OAB4k) and [here](https://archive.is/oONRl). "Any application that will be run only on Windows Vista and later should use GetTimeFormatEx."

### Description of how this pull request fixes the issue:

This deprecated functionality was removed and any usages replaced with `winKernel.GetTimeFormatEx` and `winKernel.GetDateFormatEx` equivalents. 

### Testing strategy:

The only current usage was for focusing on selecting ranges in the Calendar View for Outlook (>=13). This can be done by selecting ranges in the Calendar View in outlook and ensuring the output (eg Speech Viewer) is consistently formatted. 

Check for usages with
```sh
find . -type f -name '*.py' -exec grep -P "\bGetDateFormat\b" {} +
find . -type f -name '*.py' -exec grep -P "\bGetTimeFormat\b" {} +
```

### Known issues with pull request:

None

### Change log entry:

Section: Developer Changes

```markdown 
 - `winKernel.GetTimeFormat` has been removed - use `winKernel.GetTimeFormatEx` instead (#12139)
 - `winKernel.GetDateFormat` has been removed - use `winKernel.GetDateFormatEx` instead (#12139)
 ```

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation. (N/A)
- [x] Change log entry.
- [x] Context sensitive help for GUI changes. (N/A)
