### PR TITLE
No longer copy Python dll manually as latest version of Py2exe no longer invalidates its signature.

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -1,5 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2020 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee, Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt  # noqa: E501
+# Copyright (C) 2010-2021 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee,
+# Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -52,7 +53,6 @@ import sourceEnv
 sys.path.remove(sourceEnvPath)
 import time
 from glob import glob
-from py2exe.dllfinder import pydll
 import importlib.util
 import winreg
 
@@ -307,11 +307,6 @@ def NVDADistGenerator(target, source, env, for_signature):
 		buildCmd.append("--enable-uiAccess")
 
 	action.append(buildCmd)
-
-	# Python3 has started signing its main python dll.
-	# However, Py2exe currently tries to add a string resource to it, invalidating the signature and possibly currupting the certificate.
-	# Therefore, copy a fresh version  of the dll one more time once py2exe has completed.
-	action.append(Copy(target[0],pydll))
 
 	# #10031: Apps written in Python 3 require Universal CRT to be installed. We cannot assume users have it on their systems.
 	# Therefore , copy required libraries from Windows 10 SDK.


### PR DESCRIPTION

### Link to issue number:
None, Related to #9762 and #9796

### Summary of the issue:
The build of Py2exe that we were using up to now had a bug which caused signature of Python's dll to be corrupted effectively making it impossible to sign  .appx packages. This problem has been worked around in #9796. Since we're updating to a later version of Py2exe without this bug it makes sense to remove our workaround.
### Description of how this pull request fixes the issue:
The code from #9796 has been removed.
### Testing strategy:
Created .appx package with a certificate ensured that signing process succeeded.
### Known issues with pull request:
This should be tested on AppVeyor with a try branch just to make sure.

### Change log entry:
None needed this affects build system.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
