### PR TITLE
remove DriverSettingsMixin alias for AutoSettingsMixin

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1389,11 +1389,6 @@ class AutoSettingsMixin(metaclass=ABCMeta):
 		super().onPanelActivated()
 
 
-#: DriverSettingsMixin name is provided or backwards compatibility.
-# The name DriverSettingsMixin should be considered deprecated, use AutoSettingsMixin instead.
-DriverSettingsMixin = AutoSettingsMixin
-
-
 class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 	# Translators: This is the label for the voice settings panel.
 	title = _("Voice")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -52,6 +52,7 @@ What's New in NVDA
   - EG 'controlTypes.IsCurrent.YES.displayString'
 - `winKernel.GetTimeFormat` has been removed - use `winKernel.GetTimeFormatEx` instead (#12139)
 - `winKernel.GetDateFormat` has been removed - use `winKernel.GetDateFormatEx` instead (#12139)
+- `gui.DriverSettingsMixin` has been removed - use `gui.AutoSettingsMixin` (#12144)
 
 
 = 2020.4 =


### PR DESCRIPTION
### Link to issue number:

Part of #12123 

Implements deprecation announced in: https://github.com/nvaccess/nvda/commit/e8f8a898772892623080a2b189b12f0ebe11fc88

### Summary of the issue:

`gui.DriverSettingsMixin` was deprecated a year ago

### Description of how this pull request fixes the issue:

`gui.DriverSettingsMixin` is removed in favour of the equivalent alias `gui.AutoSettingsMixin`

### Testing strategy:

Search the code base for usages of `DriverSettingsMixin` and confirm there is none

```sh
find . -type f -name '*.py' -exec grep -P "DriverSettingsMixin" {} +
```

General user testing in the alpha/beta stages will confirm lack of changes

### Known issues with pull request:

None

### Change log entry:

Developer Changes

```markdown
-`gui.DriverSettingsMixin` has been removed - use `gui.AutoSettingsMixin` (#12144)
```

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
