### PR TITLE
remove getSpeechForSpelling alias for getSpellingSpeech

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -292,7 +292,7 @@ def getSpellingSpeech(  # noqa: C901
 		if uppercase and synth.isSupported("pitch") and synthConfig["capPitchChange"]:
 			yield PitchCommand()
 		yield EndUtteranceCommand()
-		
+
 def getCharDescListFromText(text,locale):
 	"""This method prepares a list, which contains character and its description for all characters the text is made up of, by checking the presence of character descriptions in characterDescriptions.dic of that locale for all possible combination of consecutive characters in the text.
 	This is done to take care of conjunct characters present in several languages such as Hindi, Urdu, etc.

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -292,14 +292,7 @@ def getSpellingSpeech(  # noqa: C901
 		if uppercase and synth.isSupported("pitch") and synthConfig["capPitchChange"]:
 			yield PitchCommand()
 		yield EndUtteranceCommand()
-
-
-# 'getSpeechForSpelling' should be considered deprecated, use getSpellingSpeech instead.
-# The name 'getSpeechForSpelling' was introduced during the 2019.3 release.
-# The decision was made to rename it to be consistent with the other functions (get*Speech) which create
-# speech sequences.
-getSpeechForSpelling = getSpellingSpeech
-
+		
 def getCharDescListFromText(text,locale):
 	"""This method prepares a list, which contains character and its description for all characters the text is made up of, by checking the presence of character descriptions in characterDescriptions.dic of that locale for all possible combination of consecutive characters in the text.
 	This is done to take care of conjunct characters present in several languages such as Hindi, Urdu, etc.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,6 +53,7 @@ What's New in NVDA
 - `winKernel.GetTimeFormat` has been removed - use `winKernel.GetTimeFormatEx` instead (#12139)
 - `winKernel.GetDateFormat` has been removed - use `winKernel.GetDateFormatEx` instead (#12139)
 - `gui.DriverSettingsMixin` has been removed - use `gui.AutoSettingsMixin` (#12144)
+- `speech.getSpeechForSpelling` has been removed - use `speech.getSpellingSpeech` (#12145)
 
 
 = 2020.4 =


### PR DESCRIPTION
### Link to issue number:

Part of #12123 

Implements deprecation announced in: #10593 

### Summary of the issue:

`speech.getSpeechForSpelling` was deprecated a year ago

### Description of how this pull request fixes the issue:

`speech.getSpeechForSpelling` is removed in favour of the equivalent alias `speech.getSpellingSpeech`

### Testing strategy:

Search the code base for usages of `getSpeechForSpelling` and confirm there is none

```sh
find . -type f -name '*.py' -exec grep -P "\bgetSpeechForSpelling\b" {} +
```

General user testing in the alpha/beta stages will confirm lack of changes

### Known issues with pull request:

None

### Change log entry:

Developer Changes

```markdown
-`speech.getSpeechForSpelling` has been removed - use `speech.getSpellingSpeech` (#12145)
```

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
