### PR TITLE
Update comtypes to 1.1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 SCons==4.1.0.post1
 
 # NVDA's runtime dependencies
-comtypes==1.1.7
+comtypes==1.1.8
 pyserial==3.5
 wxPython==4.1.1
 git+git://github.com/DiffSK/configobj@3e2f4cc#egg=configobj

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -130,6 +130,8 @@ IDispatch._GetTypeInfo=newGetTypeInfo
 # comtypes doesn't let us disable this when running from source, so we need to monkey patch.
 # This is just the code from the original comtypes._check_version excluding the time check.
 import comtypes
+
+
 def _check_version(actual, tlib_cached_mtime=None):
 	from comtypes.tools.codegenerator import version as required
 	if actual != required:

--- a/source/comtypesMonkeyPatches.py
+++ b/source/comtypesMonkeyPatches.py
@@ -130,7 +130,7 @@ IDispatch._GetTypeInfo=newGetTypeInfo
 # comtypes doesn't let us disable this when running from source, so we need to monkey patch.
 # This is just the code from the original comtypes._check_version excluding the time check.
 import comtypes
-def _check_version(actual):
+def _check_version(actual, tlib_cached_mtime=None):
 	from comtypes.tools.codegenerator import version as required
 	if actual != required:
 		raise ImportError("Wrong version")


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Comtypes 1.1.8 was released in december. It contains several bug fixes, including a bug we suffered from in the past (https://github.com/enthought/comtypes/issues/186)

### Description of how this pull request fixes the issue:
Bump dependency to 1.1.8.

### Testing strategy:
This requires extensive testing in Alpha.

### Known issues with pull request:
None

### Change log entry:
* Changes for developers
     + Updated Comtypes to [version 1.1.8](https://github.com/enthought/comtypes/releases/tag/1.1.8)

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
