### PR TITLE
controlTypes: Remove deprecated ROLE_EQUATION

### DIFF
--- a/source/controlTypes.py
+++ b/source/controlTypes.py
@@ -1,8 +1,8 @@
-#controlTypes.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2007-2016 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2007-2021 NV Access Limited, Babbage B.V.
+
 from typing import Dict, Union, Set, Any, Optional, List
 from enum import Enum, auto
 
@@ -111,7 +111,6 @@ ROLE_SPLITBUTTON=101
 ROLE_MENUBUTTON=102
 ROLE_DROPDOWNBUTTONGRID=103
 ROLE_MATH=104
-ROLE_EQUATION=ROLE_MATH # Deprecated; for backwards compatibility.
 ROLE_GRIP=105
 ROLE_HOTKEYFIELD=106
 ROLE_INDICATOR=107

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -69,6 +69,7 @@ What's New in NVDA
 - `speech.getSpeechForSpelling` has been removed - use `speech.getSpellingSpeech` (#12145)
 - Commands cannot be directly imported from speech as `import speech; speech.ExampleCommand()` or `import speech.manager; speech.manager.ExampleCommand()` - use  `from speech.commands import ExampleCommand` instead (#12126)
 - `speakTextInfo` will no longer send speech through `speakWithoutPauses` if reason is `SAYALL`, as `sayAllhandler` does this manually now. (#12150)
+- `ROLE_EQUATION` has been removed from controlTypes - use `ROLE_MATH`` instead. (#12164)
 
 
 = 2020.4 =


### PR DESCRIPTION
### Link to issue number:
None. Implements deprecation from 4fd4fb4470e50e4369614a0ebb8fb6d637953a2c

### Summary of the issue:
`ROLE_EQUATION` in controlTypes has been deprecated since 2015 in favor of `ROLE_MATH`. Since 2021.1 is a compatibility breaking release it makes sense to remove code kept for backward compatibility.

### Description of how this pull request fixes the issue:
`ROLE_EQUATION` has been removed.
### Testing strategy:
With git grep ensured that only occurrence of the `ROLE_EQUATION` has been in the code removed as part of this pr.

### Known issues with pull request:
None known
### Change log entry:

Changes for developers:
```markdown
- `ROLE_EQUATION` has been removed from controlTypes - use `ROLE_MATH`` instead. (#12164)
```

### Code Review Checklist:


- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
