### PR TITLE
Stop installer from attempting to delete lib directories for the version of NVDA which has just been installed

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -4,6 +4,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2011-2019 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka
 
+import ctypes
 from ctypes import *
 from ctypes.wintypes import *
 import winreg
@@ -531,8 +532,8 @@ def tryCopyFile(sourceFilePath,destFilePath):
 		sourceFilePath=u"\\\\?\\"+sourceFilePath
 	if not destFilePath.startswith('\\\\'):
 		destFilePath=u"\\\\?\\"+destFilePath
-	if windll.kernel32.CopyFileW(sourceFilePath,destFilePath,False)==0:
-		errorCode=GetLastError()
+	if ctypes.windll.kernel32.CopyFileW(sourceFilePath, destFilePath, False) == 0:
+		errorCode = ctypes.GetLastError()
 		log.debugWarning("Unable to copy %s, error %d"%(sourceFilePath,errorCode))
 		if not os.path.exists(destFilePath):
 			raise OSError("error %d copying %s to %s"%(errorCode,sourceFilePath,destFilePath))
@@ -543,8 +544,8 @@ def tryCopyFile(sourceFilePath,destFilePath):
 			log.error("Failed to rename %s after failed overwrite"%destFilePath,exc_info=True)
 			raise RetriableFailure("Failed to rename %s after failed overwrite"%destFilePath) 
 		winKernel.moveFileEx(tempPath,None,winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
-		if windll.kernel32.CopyFileW(sourceFilePath,destFilePath,False)==0:
-			errorCode=GetLastError()
+		if ctypes.windll.kernel32.CopyFileW(sourceFilePath, destFilePath, False) == 0:
+			errorCode = ctypes.GetLastError()
 			raise OSError("Unable to copy file %s to %s, error %d"%(sourceFilePath,destFilePath,errorCode))
 
 def install(shouldCreateDesktopShortcut=True,shouldRunAtLogon=True):

--- a/source/installer.py
+++ b/source/installer.py
@@ -5,10 +5,7 @@
 # Copyright (C) 2011-2019 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka
 
 import ctypes
-from ctypes import *
-from ctypes.wintypes import *
 import winreg
-import threading
 import time
 import os
 import tempfile

--- a/source/installer.py
+++ b/source/installer.py
@@ -166,11 +166,16 @@ def removeOldLibFiles(destPath, rebootOK=False):
 				continue
 			for d in subdirs:
 				path = os.path.join(parent, d)
-				log.debug("Removing old lib directory: %r"%path)
-				try:
-					os.rmdir(path)
-				except OSError:
-					log.warning("Failed to remove a directory no longer needed. This can be manually removed after a reboot or the  installer will try removing it again next time. Directory: %r"%path)
+				if path != currentLibPath:
+					log.debug(f"Removing old lib directory: {repr(path)}")
+					try:
+						os.rmdir(path)
+					except OSError:
+						log.warning(
+							"Failed to remove a directory no longer needed. "
+							"This can be manually removed after a reboot or the  installer will try"
+							f" removing it again next time. Directory: {repr(path)}"
+						)
 			for f in files:
 				path = os.path.join(parent, f)
 				log.debug("Removing old lib file: %r"%path)


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
When installing NVDA entries similar to the following can be seen in the NVDA's log:
```

WARNING - RPC process 4624 (nvda_slave.exe) (08:17:57.958) - Dummy-3 (2408):
installer.removeOldLibFiles:
Failed to remove a directory no longer needed. This can be manually removed after a reboot or the  installer will try removing it again next time. Directory: 'C:\\Program Files (x86)\\NVDA\\lib\\alpha-21882,528d5708'
WARNING - RPC process 4624 (nvda_slave.exe) (08:17:57.958) - Dummy-3 (2408):
installer.removeOldLibFiles:
Failed to remove a directory no longer needed. This can be manually removed after a reboot or the  installer will try removing it again next time. Directory: 'C:\\Program Files (x86)\\NVDA\\lib64\\alpha-21882,528d5708'
WARNING - RPC process 4624 (nvda_slave.exe) (08:17:57.958) - Dummy-3 (2408):
installer.removeOldLibFiles:
Failed to remove a directory no longer needed. This can be manually removed after a reboot or the  installer will try removing it again next time. Directory: 'C:\\Program Files (x86)\\NVDA\\libArm64\\alpha-21882,528d5708'


```


Where alpha-21882,528d5708 is the version which is currently being installed. NVDA's installer has a code which stops installer from removing library files for the current version from being removed but it works only for files not for directories. As far as I can tell this is harmless - these directories aren't empty and therefore cannot be removed succesfuly - but installer shouldn't try to do that in the first place.

### Description of how this pull request fixes the issue:
Now only directories which are for a different version from the one which is currently being installed are removed.  It was impossible to use standard approach for excluding for a `os.walk` since it works only if `topdown` is set to true and in this case we need files to be listed before directories so I've used a  normal if.
While at it I've also removed some unused imports from the  installer.

### Testing strategy:
With a launcher compiled from the code from this pr performed NVDA install, inspected the log and ensured that installer made no attempt at removing lib directories from the current version.
### Known issues with pull request:
None known
### Change log entry:

None needed

### Code Review Checklist:


- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
