### PR TITLE
Add diff used for linting changes to the list of files ignored by git

### DIFF
--- a/tests/lint/.gitignore
+++ b/tests/lint/.gitignore
@@ -1,2 +1,3 @@
 current.diff
 current.lint
+_lint.diff


### PR DESCRIPTION

### Link to issue number:
None - problem introduced by #12075 
### Summary of the issue:
When linting changes to NVDA it is necessary to create a diff between base branch and the changes. This diff was not ignored by git.
### Description of how this pull request fixes the issue:
`_lint.diff` has been added to the `.gitignore`

### Testing strategy:
Ensured that `_lint.diff` is no longer shown as an untracked file in git.
### Known issues with pull request:
None known
### Change log entry:

None needed


### Code Review Checklist:

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
