### PR TITLE
Performance increase interacting with Visual Studio

### DIFF
--- a/source/NVDAObjects/UIA/VisualStudio.py
+++ b/source/NVDAObjects/UIA/VisualStudio.py
@@ -85,7 +85,7 @@ class CompletionToolTip(ToolTip):
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAAutomationId in _INTELLISENSE_LIST_AUTOMATION_IDS:
 		clsList.insert(0, IntelliSenseList)
-	elif isinstance(obj.parent, IntelliSenseList) and obj.UIAElement.cachedClassName == "IntellisenseMenuItem":
+	elif obj.UIAElement.cachedClassName == "IntellisenseMenuItem" and isinstance(obj.parent, IntelliSenseList):
 		clsList.insert(0, IntelliSenseItem)
 	elif (
 		obj.UIAElement.cachedClassName == "LiveTextBlock"

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ What's New in NVDA
 - In the Python Console, inserting a tab for indentation at the beginning of a non-empty input line and performing tab-completion in the middle of an input line are now supported. (#11532)
 - Formatting information and other browseable messages no longer present unexpected blank lines when screen layout is turned off. (#12004)
 - It is now possible to read comments in MS Word with UIA enabled. (#9285)
+- Performance when interacting with Visual Studio has been improved. (#12171)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Users are reporting bad performance in NVDA 2020.4 when interacting with Visual Studio.
Performance seemed to decrease after NVDA 2020.3 due to PR #11421.
In NVDAObjects.UIA.visualStudio.findExtraOverlayClasses, parent is fetched for any object given. This causes a great deal of recursion as many ancestors of a given object in Visual Studio will also run through this findExtraOverlayClasses.

### Description of how this pull request fixes the issue:
In NVDAObjects.UIA.visualStudio.findExtraOverlayClasses: make sure to only fetch parent when absolutely necessary. 
Specifically, reverse a check that would look at parent's type and then check a UIA property on self.


### Testing strategy:
* Moved up and down Solution explorer, opening and closing branches of the solution. Confirming that there is much less of a delay.
* Tabbing into a property page in Visual Studio options. NVDA starts speaking sometimes up to 4 times quicker.

Other users should try and confirm that performance has improved for them.
Users should confirm that support for auto complete / intellisense s is still read correctly by NVDA.

### Known issues with pull request:
None known.

### Change log entry:
Bug fixes:
* Performance when interacting with Visual Studio has been improved.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
