### PR TITLE
recreate or abort if Python virtual environment has been moved from where it was originally located

### DIFF
--- a/devDocs/buildSystemNotes.md
+++ b/devDocs/buildSystemNotes.md
@@ -18,6 +18,7 @@ Version numbers for dependencies should be used to lock in a version.
 The virtual environment is recreated if it is outdated, either due to:
 - Python version.
 - `pip` requirements.
+- It was originally created at a different location to where it is now.
 
 The user is consulted before modifying / removing a virtual environment that can't be identified
 as having been created by NVDA's build system.

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -26,7 +26,7 @@ def verifyExistingVenvPath():
 	Verifies that the Python virtual environment at c{VENV_PATH} was actually created at that location,
 	and not just copied or moved there.
 	"""
-	# Activate the Python virtual environement and capture the content of the VIRTUAL_ENV environment variable.
+	# Activate the Python virtual environment and capture the content of the VIRTUAL_ENV environment variable.
 	existingPath = subprocess.check_output(
 		[
 			os.path.join(venv_path, "scripts", "activate.bat"),
@@ -34,7 +34,7 @@ def verifyExistingVenvPath():
 			"call", "echo", "%VIRTUAL_ENV%",
 		],
 		shell=True,
-	).decode('utf8').rstrip()
+	).decode('oem').rstrip()
 	existingPath = os.path.normpath(existingPath)
 	expectedPath = os.path.normpath(venv_path)
 	if existingPath != expectedPath:
@@ -126,7 +126,7 @@ def ensureVenvAndRequirements():
 		return createVenvAndPopulate()
 	if not verifyExistingVenvPath():
 		if askYesNoQuestion(
-			"A Python virtual environement cannot be activated from a different location "
+			"A Python virtual environment cannot be activated from a different location "
 			"to where it was originally created.\n"
 			"Should the virtual environment be recreated with the updated location?"
 		):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Closes #12166 

### Summary of the issue:
When creating a Python virtual environment, Python's venv package hard-codes the absolute path where the environment was created, in its activation script. This therefore means that it is impossible to use a Python virtual environment if it has been copied or moved to a different location. This is a limitation in venv, and there really is nothing that NvDA can do to work around this.
However, NvDA should at least offer to recreate the virtual environment at the new location if it has been moved or copied. 
As currently, executing runnvda.bat or other scripts while in this state cause hard to understand errors such as NVDA thinking that there is no virtual environment at all.
 
### Description of how this pull request fixes the issue:
ensureVenv.py detects if the Python virtual environment has been moved by temporarily activating it, and capturing the content of the VIRTUAL_ENV environment variable, and then comparing that against the physical venv path.
 If they differ, the user is asked if the virtual environment should be recreated. Saying no causes the script to abort.

### Testing strategy:
* Executed runnvda.bat from a non-moved location, confirming that ensureVenv runs without errors and NVDA starts.
* Renamed the NVDA repository directory, and performed the above step again. This time confirmed that the script asked if the virtual environment should be recreated. Saying no aborted. Running again and saying yes recreated the environment and then ran NVDA.

### Known issues with pull request:
None known.

### Change log entry:
None needed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
