### PR TITLE
don't rely on star imports from synthDriverHandler

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -6,11 +6,9 @@
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
 # Julien Cochuyt
 
-import time
 import itertools
 from typing import Optional
 
-import tones
 import audioDucking
 import touchHandler
 import keyboardHandler
@@ -25,7 +23,6 @@ import sayAllHandler
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 import globalVars
 from logHandler import log
-from synthDriverHandler import *
 import gui
 import wx
 import config
@@ -34,13 +31,13 @@ import appModuleHandler
 import winKernel
 import treeInterceptorHandler
 import browseMode
+import languageHandler
 import scriptHandler
 from scriptHandler import script
 import ui
 import braille
 import brailleInput
 import inputCore
-import virtualBuffers
 import characterProcessing
 from baseObject import ScriptableObject
 import core

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6,8 +6,9 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import logging
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 import copy
+import os
 
 import wx
 from vision.providerBase import VisionEnhancementProviderSettings
@@ -17,8 +18,7 @@ import wx.lib.newevent
 import winUser
 import logHandler
 import installer
-from synthDriverHandler import *
-from synthDriverHandler import SynthDriver, getSynth
+from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 import languageHandler
 import speech

--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -6,7 +6,6 @@
 import weakref
 import garbageHandler
 import speech
-import synthDriverHandler
 from logHandler import log
 import config
 import controlTypes

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -1,19 +1,15 @@
-# -*- coding: UTF-8 -*-
-# synthDriverHandler.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
 # Joseph Lee, Arnold Loubriat, Leonard de Ruijter
 
-import os
 import pkgutil
 import importlib
 from typing import Optional
 from locale import strxfrm
 
 import config
-import baseObject
 import winVersion
 import globalVars
 from logHandler import log
@@ -23,7 +19,6 @@ import speechDictHandler
 import extensionPoints
 import synthDrivers
 import driverHandler
-from driverHandler import StringParameterInfo  # noqa: F401 # Backwards compatibility
 from abc import abstractmethod
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -70,7 +70,7 @@ What's New in NVDA
 - `speech.getSpeechForSpelling` has been removed - use `speech.getSpellingSpeech` (#12145)
 - Commands cannot be directly imported from speech as `import speech; speech.ExampleCommand()` or `import speech.manager; speech.manager.ExampleCommand()` - use  `from speech.commands import ExampleCommand` instead (#12126)
 - `speakTextInfo` will no longer send speech through `speakWithoutPauses` if reason is `SAYALL`, as `sayAllhandler` does this manually now. (#12150)
-
+- The `synthDriverHandler` module is no longer star imported into `globalCommands` and `gui.settingsDialogs` - use `from synthDriverHandler import synthFunctionExample` instead. (#12172)
 
 = 2020.4 =
 This release includes new Chinese Input methods, an update to Liblouis and the elements list (NVDA+f7) now works in focus mode.


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Currently a few modules relies on star imports from `synthDriverHandler` making it unnecessarily difficult to perform refactoring (I've stumbled on this when writing code for #12168)

### Description of how this pull request fixes the issue:
Now both `settingsDialogs` and `globalCommands` are importing what they need explicitly.

### Testing strategy:
- With git grep checked what modules imports `synthDriverHander`
- For those which imported everything i.e `from synthDriver import *` I've executed flake8 for the entire file and imported explicitly only whatever they were using.
### Known issues with pull request:
None known
### Change log entry:

```markdown
- the `synthDriverHandler` module is no longer star imported into `globalCommands` and `gui.settingsDialogs`  - use `from synthDriverHandler import synthFunctionExample` instead. (#12172)
```

### Code Review Checklist:


- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
