### PR TITLE
Chrome system tests: ensure the page is fully loaded (including all iframes) before testing the page

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -561,7 +561,10 @@ def main():
 		log.debug("initializing updateCheck")
 		updateCheck.initialize()
 	log.info("NVDA initialized")
-	postNvdaStartup.notify()
+	# Queue the firing of the postNVDAStartup notification.
+	# This is queued so that it will run from within the core loop,
+	# and initial focus has been reported.
+	queueHandler.queueFunction(queueHandler.eventQueue, postNvdaStartup.notify)
 
 	log.debug("entering wx application main loop")
 	app.MainLoop()

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -111,7 +111,7 @@ class ChromeLib:
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(
-				"Unable to  locate 'before sample' marker."
+				"Unable to locate 'before sample' marker."
 				f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
 				" See NVDA log for full speech."
 			)

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -62,6 +62,7 @@ class ChromeLib:
 	_testCaseTitle = "NVDA Browser Test Case"
 	_beforeMarker = "Before Test Case Marker"
 	_afterMarker = "After Test Case Marker"
+	_loadCompleteString = "Test page load complete"
 
 	@staticmethod
 	def _writeTestFile(testCase) -> str:
@@ -76,8 +77,9 @@ class ChromeLib:
 			<head>
 				<title>{ChromeLib._testCaseTitle}</title>
 			</head>
-			<body>
+			<body onload="document.getElementById('loadStatus').innerHTML='{ChromeLib._loadCompleteString}'">
 				<p>{ChromeLib._beforeMarker}</p>
+				<p id="loadStatus">Loading...</p>
 				{testCase}
 				<p>{ChromeLib._afterMarker}</p>
 			</body>
@@ -109,7 +111,7 @@ class ChromeLib:
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(
-				"Unable to tab to 'before sample' marker."
+				"Unable to  locate 'before sample' marker."
 				f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
 				" See NVDA log for full speech."
 			)
@@ -136,7 +138,19 @@ class ChromeLib:
 		applicationTitle = f"{self._testCaseTitle}"
 		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
 		self._waitForStartMarker(spy, appTitleIndex)
-
+		# Move to the loading status line, and wait fore it to become complete
+		# the page has fully loaded.
+		spy.emulateKeyPress('downArrow')
+		for x in range(10):
+			builtIn.sleep("0.1 seconds")
+			actualSpeech = ChromeLib.getSpeechAfterKey('NVDA+UpArrow')
+			if actualSpeech == self._loadCompleteString:
+				break
+		else:  # Exceeded the number of tries
+			spy.dump_speech_to_log()
+			builtIn.fail(
+				"Failed to wait for Test page load complete."
+			)
 
 	@staticmethod
 	def getSpeechAfterKey(key) -> str:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -68,7 +68,8 @@ class NVDASpyLib:
 
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
-		self._isNvdaStartupComplete = True
+		queueHandler.queueFunction(queueHandler.eventQueue, lambda: setattr(self, '_isNvdaStartupComplete', True))
+		#self._isNvdaStartupComplete = True
 
 	def _onNvdaSpeech(self, speechSequence=None):
 		if not speechSequence:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -68,9 +68,7 @@ class NVDASpyLib:
 
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
-		# Queue the setting of the completion variable,
-		# To ensure that NvDA's core loop has started running, and it has processed initial focus.
-		queueHandler.queueFunction(queueHandler.eventQueue, lambda: setattr(self, '_isNvdaStartupComplete', True))
+		self._isNvdaStartupComplete = True
 
 	def _onNvdaSpeech(self, speechSequence=None):
 		if not speechSequence:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -69,7 +69,6 @@ class NVDASpyLib:
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
 		queueHandler.queueFunction(queueHandler.eventQueue, lambda: setattr(self, '_isNvdaStartupComplete', True))
-		#self._isNvdaStartupComplete = True
 
 	def _onNvdaSpeech(self, speechSequence=None):
 		if not speechSequence:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -68,6 +68,8 @@ class NVDASpyLib:
 
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
+		# Queue the setting of the completion variable,
+		# To ensure that NvDA's core loop has started running, and it has processed initial focus.
 		queueHandler.queueFunction(queueHandler.eventQueue, lambda: setattr(self, '_isNvdaStartupComplete', True))
 
 	def _onNvdaSpeech(self, speechSequence=None):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None.

### Summary of the issue:
Recently some of our system tests for Chrome started breaking. Specifically the tests that include an iframe.
It looks as if the test logic is starting to run before the content in the iframe is fully loaded.

### Description of how this pull request fixes the issue:
Place an initial line at the top of the test page, before the start marker. NVDA will initially land on this line as soon as the document gets focus, but possibly before iframes have fully loaded.
The page now has an onload event which forces focus to the start marker. This onload event only fires once all content (including iframes) in the document are fully loaded.
When the start marker finally gets focus, NVDA will detect this and start running the test logic.

### Testing strategy:
Successfully ran all system tests locally.

### Known issues with pull request:
None known.

### Change log entry:
None needed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
