### PR TITLE
remove unused flag from horizontal sizer

### DIFF
--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -608,7 +608,7 @@ class InputGesturesDialog(SettingsDialog):
 		bHelper.sizer.AddStretchSpacer()
 		# Translators: The label of a button to reset all gestures in the Input Gestures dialog.
 		resetButton = wx.Button(self, label=_("Reset to factory &defaults"))
-		bHelper.sizer.Add(resetButton, flag=wx.ALIGN_RIGHT)
+		bHelper.sizer.Add(resetButton)
 		resetButton.Bind(wx.EVT_BUTTON, self.onReset)
 
 		settingsSizer.Add(bHelper.sizer, flag=wx.EXPAND)


### PR DESCRIPTION
### Link to issue number:

closes #12151 

### Summary of the issue:

The settings dialog `NVDA Menu/Preferences/Input Gestures` does not open. This is because an alignment flag that was previously ignored now throws an error in the latest wxWidgets. 

Traceback:

```python
ERROR - unhandled exception (22:33:34.752) - MainThread (8792):
Traceback (most recent call last):
  File "gui\__init__.pyc", line 301, in onInputGesturesCommand
  File "gui\__init__.pyc", line 193, in _popupSettingsDialog
  File "gui\inputGestures.pyc", line 575, in __init__
  File "gui\settingsDialogs.pyc", line 158, in __init__
  File "gui\inputGestures.pyc", line 611, in makeSettings
wx._core.wxAssertionError: C++ assertion "!(flags & wxALIGN_RIGHT)" failed at ..\..\src\common\sizer.cpp(2168) in wxBoxSizer::DoInsert(): Horizontal alignment flags are ignored in horizontal sizers
NVDA version alpha-21895,52bf1ed6
```

### Description of how this pull request fixes the issue:

Removes the alignment flag.

### Testing strategy:

Open the `Input Gestures` settings dialog and ensure the layout and functionality is the same.

Ensure that the flags `wx.ALIGN_LEFT`, `wx.ALIGH_RIGHT`, `wx.ALIGN_CENTER_HORIZONTAL`, are only used in `wx.VERTICAL` oriented sizers

Ensure that the flag `wx.ALIGN_CENTER_VERTICAL` is only used in `wx.HORIZONTAL` oriented sizers

### Known issues with pull request:

None

### Change log entry:

None (fixes regression with unreleased python3.8/wxWidgets alpha upgrade)

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
