### PR TITLE
Allow NVDA build system to still function if NvDA repository is moved or copied to another location

### DIFF
--- a/venvUtils/ensureAndActivate.bat
+++ b/venvUtils/ensureAndActivate.bat
@@ -6,9 +6,18 @@ rem This is an internal script and should not be used directly.
 rem Ensure the environment is created and up to date
 py -3.8-32 "%~dp0\ensureVenv.py"
 if ERRORLEVEL 1 goto :EOF
-rem unset the PYTHONHOME variable so as to not pick up possible global site-packages
+
+rem Set the necessary environment variables to have Python use this virtual environment.
+rem This should set all the necessary environment variables that the standard .venv\scripts\activate.bat does
+rem Except that we set VIRTUAL_ENV to a path relative to this script,
+rem rather than it being hard-coded to where the virtual environment was first created. 
+
+rem unset the PYTHONHOME variable so as to ensure that Python does not use a customized Python standard library. 
 set PYTHONHOME=
 rem set the VIRTUAL_ENV variable instructing Python to use a virtual environment
+rem py.exe will honor VIRTUAL_ENV and launch the python.exe that it finds in %VIRTUAL_ENV%\scripts.
+rem %VIRTUAL_ENV%\scripts\python.exe will find pyvenv.cfg in its parent directory,
+rem which is actually what then causes Python to use the site-packages found in this virtual environment.
 set VIRTUAL_ENV=%~dp0..\.venv
 rem Add the virtual environment's scripts directory to the path
 set PATH=%VIRTUAL_ENV%\scripts;%PATH%

--- a/venvUtils/ensureAndActivate.bat
+++ b/venvUtils/ensureAndActivate.bat
@@ -1,9 +1,19 @@
 @echo off
 rem this script ensures the NVDA build system Python virtual environment is created and up to date,
 rem and then activates it.
-rem this script should be used only in the case where many commands will be executed within the environment and the shell will be eventually thrown away. 
-rem E.g. an Appveyor build.
+rem This is an internal script and should not be used directly.
+
+rem Ensure the environment is created and up to date
 py -3.8-32 "%~dp0\ensureVenv.py"
 if ERRORLEVEL 1 goto :EOF
-call "%~dp0\..\.venv\scripts\activate.bat"
+rem unset the PYTHONHOME variable so as to not pick up possible global site-packages
+set PYTHONHOME=
+rem set the VIRTUAL_ENV variable instructing Python to use a virtual environment
+set VIRTUAL_ENV=%~dp0..\.venv
+rem Add the virtual environment's scripts directory to the path
+set PATH=%VIRTUAL_ENV%\scripts;%PATH%
+rem Set an NVDA-specific variable to identify this official NVDA virtual environment from other 3rd party ones
 set NVDA_VENV=%VIRTUAL_ENV%
+rem mention the environment in the prompt to make it obbvious it is active
+rem just in case this script is executed outside of a local block and not cleaned up.
+set PROMPT=[NVDA Venv] %PROMPT%

--- a/venvUtils/venvCmd.bat
+++ b/venvUtils/venvCmd.bat
@@ -23,5 +23,4 @@ if ERRORLEVEL 1 goto :EOF
 echo call %*
 call %*
 echo Deactivating NVDA Python virtual environment
-call "%~dp0\..\.venv\scripts\deactivate.bat"
 endlocal

--- a/venvUtils/venvCmd.bat
+++ b/venvUtils/venvCmd.bat
@@ -16,11 +16,14 @@ if "%VIRTUAL_ENV%" NEQ "" (
 	goto :EOF
 )
 
+rem call setlocal to make sure that any environment variable changes made by activating the virtual environment
+rem can be completely undone when endlocal is called or this script exits.
 setlocal
 echo Ensuring NVDA Python virtual environment
 call "%~dp0\ensureAndActivate.bat"
 if ERRORLEVEL 1 goto :EOF
 echo call %*
 call %*
+rem the virtual environment will now be deactivated as endlocal will be reached.
 echo Deactivating NVDA Python virtual environment
 endlocal


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Replaces #12171 
Closes #12166 

### Summary of the issue:
When creating a Python virtual environment, Python's venv package hard-codes the absolute path where the environment was created, in its activation script. This therefore means that it is impossible to use a Python virtual environment if it has been copied or moved to a different location. 

### Description of how this pull request fixes the issue:
Rather than relying on the generated venv's standard activation script, our ensureAndActivate script now sets the needed environment variables (such as VIRTUAL_ENV, PATH etc) manually, and ensures the path to the venv is relative to our script.
this allows the NVDA repository to be renamed or moved, and the virtual environment can still successfully be activated.
However, if you want to run the build system or NvDA from source on another machine via a shared network drive, Python must be installed at the same location on both systems. there is no workaround for this.
 
 
### Testing strategy:
Ran the NVDA build system commands such as scons, runnvda, runlint successfully.
Renamed the NVDA repository and performed the above test again.

### Known issues with pull request:
None known.

### Change log entry:
None needed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
