### PR TITLE
Remove backwards compat aliases from PR 10593

### DIFF
--- a/source/sayAllHandler.py
+++ b/source/sayAllHandler.py
@@ -16,6 +16,10 @@ import winKernel
 
 from speech.commands import CallbackCommand, EndUtteranceCommand
 
+
+speakWithoutPauses = speech.SpeechWithoutPauses(speakFunc=speech.speak).speakWithoutPauses
+
+
 CURSOR_CARET = 0
 CURSOR_REVIEW = 1
 
@@ -150,7 +154,7 @@ class _TextReader(garbageHandler.TrackedObject):
 			if isinstance(self.reader.obj, textInfos.DocumentWithPageTurns):
 				# Once the last line finishes reading, try turning the page.
 				cb = CallbackCommand(self.turnPage, name="say-all:turnPage")
-				speech.speakWithoutPauses([cb, EndUtteranceCommand()])
+				speakWithoutPauses([cb, EndUtteranceCommand()])
 			else:
 				self.finish()
 			return
@@ -182,7 +186,7 @@ class _TextReader(garbageHandler.TrackedObject):
 		seq = list(speech._flattenNestedSequences(speechGen))
 		seq.insert(0, cb)
 		# Speak the speech sequence.
-		spoke = speech.speakWithoutPauses(seq)
+		spoke = speakWithoutPauses(seq)
 		# Update the textInfo state ready for when speaking the next line.
 		self.speakTextInfoState = state.copy()
 
@@ -204,7 +208,7 @@ class _TextReader(garbageHandler.TrackedObject):
 			else:
 				# We don't want to buffer too much.
 				# Force speech. lineReached will resume things when speech catches up.
-				speech.speakWithoutPauses(None)
+				speakWithoutPauses(None)
 				# The first buffered line has now started speaking.
 				self.numBufferedLines -= 1
 
@@ -241,7 +245,7 @@ class _TextReader(garbageHandler.TrackedObject):
 		# we might switch synths too early and truncate the final speech.
 		# We do this by putting a CallbackCommand at the start of a new utterance.
 		cb = CallbackCommand(self.stop, name="say-all:stop")
-		speech.speakWithoutPauses([
+		speakWithoutPauses([
 			EndUtteranceCommand(),
 			cb,
 			EndUtteranceCommand()

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -51,7 +51,6 @@ from typing import (
 	Generator,
 	Union,
 	Callable,
-	Iterator,
 	Tuple,
 )
 from logHandler import log
@@ -466,7 +465,6 @@ def getObjectSpeech(  # noqa: C901
 		reason: OutputReason = OutputReason.QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
 ):
-	from NVDAObjects import NVDAObjectTextInfo
 	role=obj.role
 	# Choose when we should report the content of this object's textInfo, rather than just the object's value
 	import browseMode

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2540,8 +2540,6 @@ _speakWithoutPauses = SpeechWithoutPauses(speakFunc=speak)
 
 #: Alias for class SpeakWithoutPauses.speakWithoutPauses. Kept for backwards compatibility
 speakWithoutPauses = _speakWithoutPauses.speakWithoutPauses
-#: Kept for backwards compatibility.
-re_last_pause = _speakWithoutPauses.re_last_pause
 
 #: The singleton _SpeechManager instance used for speech functions.
 #: @type: L{manager.SpeechManager}

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2538,8 +2538,6 @@ class SpeechWithoutPauses:
 
 _speakWithoutPauses = SpeechWithoutPauses(speakFunc=speak)
 
-#: Alias for class SpeakWithoutPauses.speakWithoutPauses. Kept for backwards compatibility
-speakWithoutPauses = _speakWithoutPauses.speakWithoutPauses
 
 #: The singleton _SpeechManager instance used for speech functions.
 #: @type: L{manager.SpeechManager}

--- a/tests/unit/test_SpeechWithoutPauses.py
+++ b/tests/unit/test_SpeechWithoutPauses.py
@@ -10,7 +10,7 @@ from typing import List
 
 from speech.types import SpeechSequence
 from speech.commands import EndUtteranceCommand, LangChangeCommand, CallbackCommand
-from speech import re_last_pause, SpeechWithoutPauses
+from speech import SpeechWithoutPauses
 from logHandler import log
 
 
@@ -89,7 +89,7 @@ def old_speakWithoutPauses(  # noqa: C901
 		for index in range(len(speechSequence) - 1, -1, -1):
 			item = speechSequence[index]
 			if isinstance(item, str):
-				m = re_last_pause.match(item)
+				m = SpeechWithoutPauses.re_last_pause.match(item)
 				if m:
 					before, after = m.groups()
 					if after:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -81,7 +81,7 @@ What's New in NVDA
 - `autoSettingsUtils.driverSetting` classes are removed from `driverHandler` - please use them from `autoSettingUtils.driverSetting`. (#12168)
 - `autoSettingsUtils.utils` classes are removed from `driverHandler` - please use them from `autoSettingUtils.utils`. (#12168)
 - Support of `TextInfo`s that do not inherit from `contentRecog.BaseContentRecogTextInfo` is removed. (#12157)
-- `speech.speakWithoutPauses` has been removed - please use `speech.SpeechWithoutPauses(speakFunc=speech.speak).speakWithoutPauses` instead (#12195)
+- `speech.speakWithoutPauses` has been removed - please use `speech.SpeechWithoutPauses(speakFunc=speech.speak).speakWithoutPauses` instead. (#12195)
 - `speech.re_last_pause` has been removed - please use `speech.SpeechWithoutPauses.re_last_pause` instead. (#12195)
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -81,6 +81,8 @@ What's New in NVDA
 - `autoSettingsUtils.driverSetting` classes are removed from `driverHandler` - please use them from `autoSettingUtils.driverSetting`. (#12168)
 - `autoSettingsUtils.utils` classes are removed from `driverHandler` - please use them from `autoSettingUtils.utils`. (#12168)
 - Support of `TextInfo`s that do not inherit from `contentRecog.BaseContentRecogTextInfo` is removed. (#12157)
+- `speech.speakWithoutPauses` has been removed - please use `speech.SpeechWithoutPauses(speakFunc=speech.speak).speakWithoutPauses` instead (#12195)
+- `speech.re_last_pause` has been removed - please use `speech.SpeechWithoutPauses.re_last_pause` instead. (#12195)
 
 
 = 2020.4 =


### PR DESCRIPTION

### Link to issue number:
None, Removes code provided for backwards compatibility in PR #10593

### Summary of the issue:
PR #10593 introduced `speech.speakWithoutPauses ` as an alias for `speech._speakWithoutPauses.speakWithoutPauses` and `speech.re_last_pause` as an alias for `speech._speakWithoutPauses.re_last_pause` for backwards compatibility. Since 2021.1 is going to be backwards compatibility breaking release it makes sense to remove these.

### Description of how this pull request fixes the issue:
These aliases are removed and their usages are replaces with `speech.SpeechWithoutPauses(speakFunc=speech.speak).speakWithoutPauses` and `speech.SpeechWithoutPauses.re_last_pause` respectively.

### Testing strategy:
- With git grep inspected usages of these aliases and ensured that all of them are replaced.
- Performed say all on several text's - ensured that it still works as before.
### Known issues with pull request:
None known
### Change log entry:
Changes for developers:
- `speech.speakWithoutPauses ` has been removed - please use `speech.SpeechWithoutPauses(speakFunc=speech.speak).speakWithoutPauses` instead
- `speech.re_last_pause` has been removed - please use `speech.SpeechWithoutPauses.re_last_pause` instead.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
