### PR TITLE
update espeak

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 82d5b7b04
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 53915bf0a
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.16.1


### PR DESCRIPTION
Now using 1.51-dev commit 53915bf0a7cd48f90c4a38ac52fff697723d9f4d

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
https://github.com/espeak-ng/espeak-ng/pull/886

### Summary of the issue:
Espeak hasn't been updated in a while. As requested on https://github.com/espeak-ng/espeak-ng/pull/886, updating to latest commit.

### Description of how this pull request fixes the issue:
Updates espeak-ng to 1.51-dev commit 53915bf0a7cd48f90c4a38ac52fff697723d9f4d

### Testing strategy:
Built and test locally.
Let alpha users test in more detail.

### Known issues with pull request:
None

### Change log entry:

Changes
```
- Espeak-ng has been updated to commit 53915bf0a7cd48f90c4a38ac52fff697723d9f4d
```

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
