### PR TITLE
Fix routing to cell in selection (braille)

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -407,8 +407,7 @@ class Region(object):
 		#: @type: [int, ...]
 		self.brailleToRawPos = []
 		#: The position of the cursor in L{brailleCells}, C{None} if the cursor is not in this region.
-		#: @type: int
-		self.brailleCursorPos = None
+		self.brailleCursorPos: Optional[int] = None
 		#: The position of the selection start in L{brailleCells}, C{None} if there is no selection in this region.
 		#: @type: int
 		self.brailleSelectionStart = None
@@ -1094,15 +1093,20 @@ class TextInfoRegion(Region):
 			return
 
 		dest = self.getTextInfoForBraillePos(braillePos)
-		cursor = self.getTextInfoForBraillePos(self.brailleCursorPos)
-		if dest.compareEndPoints(cursor, "startToStart") == 0:
-			# The cursor is already at this position,
-			# so activate the position.
-			try:
-				self._getSelection().activate()
-			except NotImplementedError:
-				pass
-			return
+		# When there is a selection, brailleCursorPos will be None
+		# Don't activate, but move the cursor to the new cell (dropping the
+		# selection). An alternative behavior may be to activate on the selection.
+		# Moving the cursor was considered more intuitive.
+		if self.brailleCursorPos is not None:
+			cursor = self.getTextInfoForBraillePos(self.brailleCursorPos)
+			if dest.compareEndPoints(cursor, "startToStart") == 0:
+				# The cursor is already at this position,
+				# so activate the position.
+				try:
+					self._getSelection().activate()
+				except NotImplementedError:
+					pass
+				return
 		self._setCursor(dest)
 
 	def nextLine(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Fixes #12010

### Summary of the issue:
When routing to a cell within a selection, an error occured.
When there is a selection self.brailleCursorPos is None.

### Description of how this pull request fixes the issue:
When there is a selection (IE self.brailleCursorPos is None), don't try to determine
if a cell/range should be activated. Instead, just move the cursor to the destination
(routed to) cell.

**Note:** Dropping the selection and setting the new cursor location was considered more intuitive than
activating the selection / range.

### Testing strategy:
Tested locally with the braille viewer and hover to route to cell.
Ask reporters to test on their use cases.
Tested steps in #7447 to ensure it still works as expected. 

### Known issues with pull request:
None

### Change log entry:
None necessary, fixes an issue only in Alpha.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
