### PR TITLE
WinVersion class follow-up: remove ease of access is supported flag

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -241,8 +241,6 @@ def getStartOnLogonScreen():
 		return False
 
 def _setStartOnLogonScreen(enable):
-	# The installer will have migrated service config to EoA if appropriate,
-	# so we only need to deal with EoA here.
 	easeOfAccess.setAutoStart(winreg.HKEY_LOCAL_MACHINE, enable)
 
 def setSystemConfigToCurrentConfig():

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -190,8 +190,10 @@ def initConfigPath(configPath=None):
 RUN_REGKEY = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
 
 def getStartAfterLogon():
-	if (easeOfAccess.isSupported and easeOfAccess.canConfigTerminateOnDesktopSwitch
-			and easeOfAccess.willAutoStart(winreg.HKEY_CURRENT_USER)):
+	if (
+		easeOfAccess.canConfigTerminateOnDesktopSwitch
+		and easeOfAccess.willAutoStart(winreg.HKEY_CURRENT_USER)
+	):
 		return True
 	try:
 		k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_REGKEY)
@@ -203,7 +205,7 @@ def getStartAfterLogon():
 def setStartAfterLogon(enable):
 	if getStartAfterLogon() == enable:
 		return
-	if easeOfAccess.isSupported and easeOfAccess.canConfigTerminateOnDesktopSwitch:
+	if easeOfAccess.canConfigTerminateOnDesktopSwitch:
 		easeOfAccess.setAutoStart(winreg.HKEY_CURRENT_USER, enable)
 		if enable:
 			return
@@ -230,7 +232,7 @@ SLAVE_FILENAME = os.path.join(globalVars.appDir, "nvda_slave.exe")
 NVDA_REGKEY = r"SOFTWARE\NVDA"
 
 def getStartOnLogonScreen():
-	if easeOfAccess.isSupported and easeOfAccess.willAutoStart(winreg.HKEY_LOCAL_MACHINE):
+	if easeOfAccess.willAutoStart(winreg.HKEY_LOCAL_MACHINE):
 		return True
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -241,13 +241,9 @@ def getStartOnLogonScreen():
 		return False
 
 def _setStartOnLogonScreen(enable):
-	if easeOfAccess.isSupported:
-		# The installer will have migrated service config to EoA if appropriate,
-		# so we only need to deal with EoA here.
-		easeOfAccess.setAutoStart(winreg.HKEY_LOCAL_MACHINE, enable)
-	else:
-		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY, 0, winreg.KEY_WRITE)
-		winreg.SetValueEx(k, u"startOnLogonScreen", None, winreg.REG_DWORD, int(enable))
+	# The installer will have migrated service config to EoA if appropriate,
+	# so we only need to deal with EoA here.
+	easeOfAccess.setAutoStart(winreg.HKEY_LOCAL_MACHINE, enable)
 
 def setSystemConfigToCurrentConfig():
 	fromPath = globalVars.appArgs.configPath

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
+# Copyright (C) 2006-2021 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
 # Joseph Lee, Babbage B.V., Łukasz Golonka, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -11,10 +11,8 @@ import ctypes
 import winUser
 import winVersion
 
-# Windows >= Vista
-isSupported = winVersion.getWinVer().major >= 6
 # Windows >= 8
-canConfigTerminateOnDesktopSwitch = isSupported and winVersion.getWinVer() >= winVersion.WIN8
+canConfigTerminateOnDesktopSwitch: bool = winVersion.getWinVer() >= winVersion.WIN8
 
 ROOT_KEY = r"Software\Microsoft\Windows NT\CurrentVersion\Accessibility"
 APP_KEY_NAME = "nvda_nvda_v1"

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -1,8 +1,7 @@
-#easeOfAccess.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2014 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2014-2021 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Utilities for working with the Windows Ease of Access Center.
 """

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -112,6 +112,7 @@ What's New in NVDA
  - E.g. ti1.start = ti2.end
  - This usage is prefered instead of ti1.SetEndPoint(ti2,"startToEnd")
 - `wx.CENTRE_ON_SCREEN` and `wx.CENTER_ON_SCREEN` are removed, use `self.CentreOnScreen()` instead. (#12309)
+- `easeOfAccess.isSupported` has been removed, NVDA only supports versions of Windows where this evaluates to `True`. (#12222)
 
 
 = 2020.4 =


### PR DESCRIPTION

### Link to issue number:
Follow-up to PR #11909

### Summary of the issue:
NVDA requires Windows 7/Server 2008 R2 SP1 or later, therefore Ease of Access is available.

### Description of how this pull request fixes the issue:
Removes easeOfAccess.isSupported flag.

### Testing strategy:
Code review (Grep used), manual testing to make sure easeOfAccess.isSupported raises AttributeError.

### Known issues with pull request:
None

### Change log entry:
Changes for developers:

easeOfAccess.isSupported has been removed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.

Thanks.