### PR TITLE
Restore advanced settings layout.

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2578,7 +2578,7 @@ class AdvancedPanelControls(
 		# Translators: This is the label for a checkbox in the
 		#  Advanced settings panel.
 		label = _("Use UI Automation to access Microsoft &Excel spreadsheet controls when available")
-		self.UIAInMSExcelCheckBox = UIAGroup.addItem(wx.CheckBox(self, label=label))
+		self.UIAInMSExcelCheckBox = UIAGroup.addItem(wx.CheckBox(UIABox, label=label))
 		self.bindHelpEvent("UseUiaForExcel", self.UIAInMSExcelCheckBox)
 		self.UIAInMSExcelCheckBox.SetValue(config.conf["UIA"]["useInMSExcelWhenAvailable"])
 		self.UIAInMSExcelCheckBox.defaultValue = self._getDefaultValue(["UIA", "useInMSExcelWhenAvailable"])


### PR DESCRIPTION
### Link to issue number:

None.
Issue described in https://github.com/nvaccess/nvda/pull/12210#issuecomment-806693337

### Summary of the issue:

The new option introduced by #12210 is not located in the "Microsoft UI Automation" option group as it should.
Probably due to missed changes during upmerge of master.

### Description of how this pull request fixes the issue:

Put it in this group as intended.
The static box of the sizer should be used as parent for the checkbox rather than the whole panel.

### Testing strategy:

Manual testing: checked visually that the checkbox is in the correct option group.
No unit test or system test needed for such a fix.

### Known issues with pull request:

None

### Change log entry:

Not needed (fix in alpha stage)

Cc @michaelDCurran, @seanbudd 

