### PR TITLE
Fix-up of PR 12195: Properly reset say all when cancelling speech

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -117,7 +117,7 @@ def cancelSpeech():
 	# Import only for this function to avoid circular import.
 	import sayAllHandler
 	sayAllHandler.stop()
-	_speakWithoutPauses.reset()
+	sayAllHandler.getSpeechWithoutPauses().reset()
 	if beenCanceled:
 		return
 	elif speechMode==speechMode_off:
@@ -2532,9 +2532,6 @@ class SpeechWithoutPauses:
 			pendingSpeechSequence.reverse()
 			self._pendingSpeechSequence.extend(pendingSpeechSequence)
 		return finalSpeechSequence
-
-
-_speakWithoutPauses = SpeechWithoutPauses(speakFunc=speak)
 
 
 #: The singleton _SpeechManager instance used for speech functions.


### PR DESCRIPTION
### Link to issue number:
Fixes #12225 
### Summary of the issue:
PR #12195 removed `speech.speakWithoutPauses` which was an alias for `speech._speakWithoutPauses`. While all usages of `speech.speakWithoutPauses` were found and fixed it turned out than when cancelling speech during say all `speech._speakWithoutPauses` was cleared rather than instance of `SpeakWithoutPauses` used for say all.
### Description of how this pull request fixes the issue:
Now the instance of `SpeechWithoutPauses` which is used during say all is cleared. I've added function to `sayAllHandler` which creates it first if necessary, and ensures that the single instance is being used for say all.
### Testing strategy:
I've ensured that say all no longer mixes content from different runs.
### Known issues with pull request:
None known
### Change log entry:
None needed: bug not in a release.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
