### PR TITLE
Remove backwards compat code from IAccessibleHandler

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -1,4 +1,3 @@
-# IAccessibleHandler.py
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
 # This file is covered by the GNU General Public License.
@@ -7,8 +6,6 @@
 from typing import Tuple
 import struct
 import weakref
-# Kept for backwards compatibility
-from ctypes import *  # noqa: F401, F403
 from ctypes import (
 	wintypes,
 	windll,
@@ -26,80 +23,9 @@ import comtypes.client
 import oleacc
 import UIAHandler
 
-# Kept for backwards compatibility
-from comInterfaces.Accessibility import *  # noqa: F401, F403
-# Specific imports for items we know we use, hopefully in the future we can remove the import for this module.
-from comInterfaces.Accessibility import (
-	IAccessible,
-	IAccIdentity,
-	CAccPropServices,
-)
-# Kept for backwards compatibility
-from comInterfaces.IAccessible2Lib import *  # noqa: F401, F403
-# Specific imports for items we know we use, hopefully in the future we can remove the import for this module.
-from comInterfaces.IAccessible2Lib import (
-	IAccessibleText,
-	IAccessibleHypertext,
-	IAccessible2,
-	IA2_STATE_REQUIRED,
-	IA2_STATE_INVALID_ENTRY,
-	IA2_STATE_MODAL,
-	IA2_STATE_DEFUNCT,
-	IA2_STATE_SUPPORTS_AUTOCOMPLETION,
-	IA2_STATE_MULTI_LINE,
-	IA2_STATE_ICONIFIED,
-	IA2_STATE_EDITABLE,
-	IA2_STATE_PINNED,
-	IA2_STATE_CHECKABLE,
-	IA2_ROLE_UNKNOWN,
-	IA2_ROLE_CANVAS,
-	IA2_ROLE_CAPTION,
-	IA2_ROLE_CHECK_MENU_ITEM,
-	IA2_ROLE_COLOR_CHOOSER,
-	IA2_ROLE_DATE_EDITOR,
-	IA2_ROLE_DIRECTORY_PANE,
-	IA2_ROLE_DESKTOP_PANE,
-	IA2_ROLE_EDITBAR,
-	IA2_ROLE_EMBEDDED_OBJECT,
-	IA2_ROLE_ENDNOTE,
-	IA2_ROLE_FILE_CHOOSER,
-	IA2_ROLE_FONT_CHOOSER,
-	IA2_ROLE_FRAME,
-	IA2_ROLE_FOOTNOTE,
-	IA2_ROLE_FORM,
-	IA2_ROLE_GLASS_PANE,
-	IA2_ROLE_HEADER,
-	IA2_ROLE_HEADING,
-	IA2_ROLE_ICON,
-	IA2_ROLE_IMAGE_MAP,
-	IA2_ROLE_INPUT_METHOD_WINDOW,
-	IA2_ROLE_INTERNAL_FRAME,
-	IA2_ROLE_LABEL,
-	IA2_ROLE_LAYERED_PANE,
-	IA2_ROLE_NOTE,
-	IA2_ROLE_OPTION_PANE,
-	IA2_ROLE_PAGE,
-	IA2_ROLE_PARAGRAPH,
-	IA2_ROLE_RADIO_MENU_ITEM,
-	IA2_ROLE_REDUNDANT_OBJECT,
-	IA2_ROLE_ROOT_PANE,
-	IA2_ROLE_RULER,
-	IA2_ROLE_SCROLL_PANE,
-	IA2_ROLE_SECTION,
-	IA2_ROLE_SHAPE,
-	IA2_ROLE_SPLIT_PANE,
-	IA2_ROLE_TEAR_OFF_MENU,
-	IA2_ROLE_TERMINAL,
-	IA2_ROLE_TEXT_FRAME,
-	IA2_ROLE_TOGGLE_BUTTON,
-	IA2_ROLE_VIEW_PORT,
-	IA2_ROLE_CONTENT_DELETION,
-	IA2_ROLE_CONTENT_INSERTION,
-	IA2_ROLE_BLOCK_QUOTE,
-	IA2_ROLE_DESKTOP_ICON,
-	IA2_ROLE_FOOTER,
-	IA2_ROLE_MARK,
-)
+from comInterfaces import Accessibility as IA
+
+from comInterfaces import IAccessible2Lib as IA2
 import config
 
 
@@ -178,7 +104,6 @@ from .internalWinEventHandler import (  # noqa: F401
 	_shouldGetEvents,
 )
 
-from comInterfaces import IAccessible2Lib as IA2
 from logHandler import log
 import JABHandler
 import eventHandler
@@ -276,55 +201,55 @@ IAccessibleRolesToNVDARoles = {
 	oleacc.ROLE_SYSTEM_OUTLINEBUTTON: controlTypes.ROLE_TREEVIEWBUTTON,
 	oleacc.ROLE_SYSTEM_CLOCK: controlTypes.ROLE_CLOCK,
 	# IAccessible2 roles
-	IA2_ROLE_UNKNOWN: controlTypes.ROLE_UNKNOWN,
-	IA2_ROLE_CANVAS: controlTypes.ROLE_CANVAS,
-	IA2_ROLE_CAPTION: controlTypes.ROLE_CAPTION,
-	IA2_ROLE_CHECK_MENU_ITEM: controlTypes.ROLE_CHECKMENUITEM,
-	IA2_ROLE_COLOR_CHOOSER: controlTypes.ROLE_COLORCHOOSER,
-	IA2_ROLE_DATE_EDITOR: controlTypes.ROLE_DATEEDITOR,
-	IA2_ROLE_DESKTOP_ICON: controlTypes.ROLE_DESKTOPICON,
-	IA2_ROLE_DESKTOP_PANE: controlTypes.ROLE_DESKTOPPANE,
-	IA2_ROLE_DIRECTORY_PANE: controlTypes.ROLE_DIRECTORYPANE,
-	IA2_ROLE_EDITBAR: controlTypes.ROLE_EDITBAR,
-	IA2_ROLE_EMBEDDED_OBJECT: controlTypes.ROLE_EMBEDDEDOBJECT,
-	IA2_ROLE_ENDNOTE: controlTypes.ROLE_ENDNOTE,
-	IA2_ROLE_FILE_CHOOSER: controlTypes.ROLE_FILECHOOSER,
-	IA2_ROLE_FONT_CHOOSER: controlTypes.ROLE_FONTCHOOSER,
-	IA2_ROLE_FOOTER: controlTypes.ROLE_FOOTER,
-	IA2_ROLE_FOOTNOTE: controlTypes.ROLE_FOOTNOTE,
-	IA2_ROLE_FORM: controlTypes.ROLE_FORM,
-	IA2_ROLE_FRAME: controlTypes.ROLE_FRAME,
-	IA2_ROLE_GLASS_PANE: controlTypes.ROLE_GLASSPANE,
-	IA2_ROLE_HEADER: controlTypes.ROLE_HEADER,
-	IA2_ROLE_HEADING: controlTypes.ROLE_HEADING,
-	IA2_ROLE_ICON: controlTypes.ROLE_ICON,
-	IA2_ROLE_IMAGE_MAP: controlTypes.ROLE_IMAGEMAP,
-	IA2_ROLE_INPUT_METHOD_WINDOW: controlTypes.ROLE_INPUTWINDOW,
-	IA2_ROLE_INTERNAL_FRAME: controlTypes.ROLE_INTERNALFRAME,
-	IA2_ROLE_LABEL: controlTypes.ROLE_LABEL,
-	IA2_ROLE_LAYERED_PANE: controlTypes.ROLE_LAYEREDPANE,
-	IA2_ROLE_NOTE: controlTypes.ROLE_NOTE,
-	IA2_ROLE_OPTION_PANE: controlTypes.ROLE_OPTIONPANE,
-	IA2_ROLE_PAGE: controlTypes.ROLE_PAGE,
-	IA2_ROLE_PARAGRAPH: controlTypes.ROLE_PARAGRAPH,
-	IA2_ROLE_RADIO_MENU_ITEM: controlTypes.ROLE_RADIOMENUITEM,
-	IA2_ROLE_REDUNDANT_OBJECT: controlTypes.ROLE_REDUNDANTOBJECT,
-	IA2_ROLE_ROOT_PANE: controlTypes.ROLE_ROOTPANE,
-	IA2_ROLE_RULER: controlTypes.ROLE_RULER,
-	IA2_ROLE_SCROLL_PANE: controlTypes.ROLE_SCROLLPANE,
-	IA2_ROLE_SECTION: controlTypes.ROLE_SECTION,
-	IA2_ROLE_SHAPE: controlTypes.ROLE_SHAPE,
-	IA2_ROLE_SPLIT_PANE: controlTypes.ROLE_SPLITPANE,
-	IA2_ROLE_TEAR_OFF_MENU: controlTypes.ROLE_TEAROFFMENU,
-	IA2_ROLE_TERMINAL: controlTypes.ROLE_TERMINAL,
-	IA2_ROLE_TEXT_FRAME: controlTypes.ROLE_TEXTFRAME,
-	IA2_ROLE_TOGGLE_BUTTON: controlTypes.ROLE_TOGGLEBUTTON,
-	IA2_ROLE_VIEW_PORT: controlTypes.ROLE_VIEWPORT,
-	IA2_ROLE_CONTENT_DELETION: controlTypes.ROLE_DELETED_CONTENT,
-	IA2_ROLE_CONTENT_INSERTION: controlTypes.ROLE_INSERTED_CONTENT,
-	IA2_ROLE_BLOCK_QUOTE: controlTypes.ROLE_BLOCKQUOTE,
+	IA2.IA2_ROLE_UNKNOWN: controlTypes.ROLE_UNKNOWN,
+	IA2.IA2_ROLE_CANVAS: controlTypes.ROLE_CANVAS,
+	IA2.IA2_ROLE_CAPTION: controlTypes.ROLE_CAPTION,
+	IA2.IA2_ROLE_CHECK_MENU_ITEM: controlTypes.ROLE_CHECKMENUITEM,
+	IA2.IA2_ROLE_COLOR_CHOOSER: controlTypes.ROLE_COLORCHOOSER,
+	IA2.IA2_ROLE_DATE_EDITOR: controlTypes.ROLE_DATEEDITOR,
+	IA2.IA2_ROLE_DESKTOP_ICON: controlTypes.ROLE_DESKTOPICON,
+	IA2.IA2_ROLE_DESKTOP_PANE: controlTypes.ROLE_DESKTOPPANE,
+	IA2.IA2_ROLE_DIRECTORY_PANE: controlTypes.ROLE_DIRECTORYPANE,
+	IA2.IA2_ROLE_EDITBAR: controlTypes.ROLE_EDITBAR,
+	IA2.IA2_ROLE_EMBEDDED_OBJECT: controlTypes.ROLE_EMBEDDEDOBJECT,
+	IA2.IA2_ROLE_ENDNOTE: controlTypes.ROLE_ENDNOTE,
+	IA2.IA2_ROLE_FILE_CHOOSER: controlTypes.ROLE_FILECHOOSER,
+	IA2.IA2_ROLE_FONT_CHOOSER: controlTypes.ROLE_FONTCHOOSER,
+	IA2.IA2_ROLE_FOOTER: controlTypes.ROLE_FOOTER,
+	IA2.IA2_ROLE_FOOTNOTE: controlTypes.ROLE_FOOTNOTE,
+	IA2.IA2_ROLE_FORM: controlTypes.ROLE_FORM,
+	IA2.IA2_ROLE_FRAME: controlTypes.ROLE_FRAME,
+	IA2.IA2_ROLE_GLASS_PANE: controlTypes.ROLE_GLASSPANE,
+	IA2.IA2_ROLE_HEADER: controlTypes.ROLE_HEADER,
+	IA2.IA2_ROLE_HEADING: controlTypes.ROLE_HEADING,
+	IA2.IA2_ROLE_ICON: controlTypes.ROLE_ICON,
+	IA2.IA2_ROLE_IMAGE_MAP: controlTypes.ROLE_IMAGEMAP,
+	IA2.IA2_ROLE_INPUT_METHOD_WINDOW: controlTypes.ROLE_INPUTWINDOW,
+	IA2.IA2_ROLE_INTERNAL_FRAME: controlTypes.ROLE_INTERNALFRAME,
+	IA2.IA2_ROLE_LABEL: controlTypes.ROLE_LABEL,
+	IA2.IA2_ROLE_LAYERED_PANE: controlTypes.ROLE_LAYEREDPANE,
+	IA2.IA2_ROLE_NOTE: controlTypes.ROLE_NOTE,
+	IA2.IA2_ROLE_OPTION_PANE: controlTypes.ROLE_OPTIONPANE,
+	IA2.IA2_ROLE_PAGE: controlTypes.ROLE_PAGE,
+	IA2.IA2_ROLE_PARAGRAPH: controlTypes.ROLE_PARAGRAPH,
+	IA2.IA2_ROLE_RADIO_MENU_ITEM: controlTypes.ROLE_RADIOMENUITEM,
+	IA2.IA2_ROLE_REDUNDANT_OBJECT: controlTypes.ROLE_REDUNDANTOBJECT,
+	IA2.IA2_ROLE_ROOT_PANE: controlTypes.ROLE_ROOTPANE,
+	IA2.IA2_ROLE_RULER: controlTypes.ROLE_RULER,
+	IA2.IA2_ROLE_SCROLL_PANE: controlTypes.ROLE_SCROLLPANE,
+	IA2.IA2_ROLE_SECTION: controlTypes.ROLE_SECTION,
+	IA2.IA2_ROLE_SHAPE: controlTypes.ROLE_SHAPE,
+	IA2.IA2_ROLE_SPLIT_PANE: controlTypes.ROLE_SPLITPANE,
+	IA2.IA2_ROLE_TEAR_OFF_MENU: controlTypes.ROLE_TEAROFFMENU,
+	IA2.IA2_ROLE_TERMINAL: controlTypes.ROLE_TERMINAL,
+	IA2.IA2_ROLE_TEXT_FRAME: controlTypes.ROLE_TEXTFRAME,
+	IA2.IA2_ROLE_TOGGLE_BUTTON: controlTypes.ROLE_TOGGLEBUTTON,
+	IA2.IA2_ROLE_VIEW_PORT: controlTypes.ROLE_VIEWPORT,
+	IA2.IA2_ROLE_CONTENT_DELETION: controlTypes.ROLE_DELETED_CONTENT,
+	IA2.IA2_ROLE_CONTENT_INSERTION: controlTypes.ROLE_INSERTED_CONTENT,
+	IA2.IA2_ROLE_BLOCK_QUOTE: controlTypes.ROLE_BLOCKQUOTE,
 	IA2.IA2_ROLE_LANDMARK: controlTypes.ROLE_LANDMARK,
-	IA2_ROLE_MARK: controlTypes.ROLE_MARKED_CONTENT,
+	IA2.IA2_ROLE_MARK: controlTypes.ROLE_MARKED_CONTENT,
 	# some common string roles
 	"frame": controlTypes.ROLE_FRAME,
 	"iframe": controlTypes.ROLE_INTERNALFRAME,
@@ -371,32 +296,32 @@ IAccessibleStatesToNVDAStates = {
 }
 
 IAccessible2StatesToNVDAStates = {
-	IA2_STATE_REQUIRED: controlTypes.STATE_REQUIRED,
-	IA2_STATE_DEFUNCT: controlTypes.STATE_DEFUNCT,
-	# IA2_STATE_STALE:controlTypes.STATE_DEFUNCT,
-	IA2_STATE_INVALID_ENTRY: controlTypes.STATE_INVALID_ENTRY,
-	IA2_STATE_MODAL: controlTypes.STATE_MODAL,
-	IA2_STATE_SUPPORTS_AUTOCOMPLETION: controlTypes.STATE_AUTOCOMPLETE,
-	IA2_STATE_MULTI_LINE: controlTypes.STATE_MULTILINE,
-	IA2_STATE_ICONIFIED: controlTypes.STATE_ICONIFIED,
-	IA2_STATE_EDITABLE: controlTypes.STATE_EDITABLE,
-	IA2_STATE_PINNED: controlTypes.STATE_PINNED,
-	IA2_STATE_CHECKABLE: controlTypes.STATE_CHECKABLE,
+	IA2.IA2_STATE_REQUIRED: controlTypes.STATE_REQUIRED,
+	IA2.IA2_STATE_DEFUNCT: controlTypes.STATE_DEFUNCT,
+	# IA2.IA2_STATE_STALE:controlTypes.STATE_DEFUNCT,
+	IA2.IA2_STATE_INVALID_ENTRY: controlTypes.STATE_INVALID_ENTRY,
+	IA2.IA2_STATE_MODAL: controlTypes.STATE_MODAL,
+	IA2.IA2_STATE_SUPPORTS_AUTOCOMPLETION: controlTypes.STATE_AUTOCOMPLETE,
+	IA2.IA2_STATE_MULTI_LINE: controlTypes.STATE_MULTILINE,
+	IA2.IA2_STATE_ICONIFIED: controlTypes.STATE_ICONIFIED,
+	IA2.IA2_STATE_EDITABLE: controlTypes.STATE_EDITABLE,
+	IA2.IA2_STATE_PINNED: controlTypes.STATE_PINNED,
+	IA2.IA2_STATE_CHECKABLE: controlTypes.STATE_CHECKABLE,
 }
 
 
 def normalizeIAccessible(pacc, childID=0):
-	if not isinstance(pacc, IAccessible):
+	if not isinstance(pacc, IA.IAccessible):
 		try:
-			pacc = pacc.QueryInterface(IAccessible)
+			pacc = pacc.QueryInterface(IA.IAccessible)
 		except COMError:
 			raise RuntimeError("%s Not an IAccessible" % pacc)
 	# #2558: IAccessible2 doesn't support simple children.
 	# Therefore, it doesn't make sense to use IA2 if the child ID is non-0.
-	if childID == 0 and not isinstance(pacc, IAccessible2):
+	if childID == 0 and not isinstance(pacc, IA2.IAccessible2):
 		try:
 			s = pacc.QueryInterface(IServiceProvider)
-			pacc2 = s.QueryService(IAccessible._iid_, IAccessible2)
+			pacc2 = s.QueryService(IA.IAccessible._iid_, IA2.IAccessible2)
 			if not pacc2:
 				# QueryService should fail if IA2 is not supported, but some applications such as AIM 7 misbehave
 				# and return a null COM pointer. Treat this as if QueryService failed.
@@ -1036,7 +961,7 @@ accPropServices = None
 def initialize():
 	global accPropServices
 	try:
-		accPropServices = comtypes.client.CreateObject(CAccPropServices)
+		accPropServices = comtypes.client.CreateObject(IA.CAccPropServices)
 	except (WindowsError, COMError) as e:
 		log.debugWarning("AccPropServices is not available: %s" % e)
 	internalWinEventHandler.initialize(processDestroyWinEvent)
@@ -1128,7 +1053,7 @@ def terminate():
 
 
 def getIAccIdentity(pacc, childID):
-	IAccIdentityObject = pacc.QueryInterface(IAccIdentity)
+	IAccIdentityObject = pacc.QueryInterface(IA.IAccIdentity)
 	stringPtr, stringSize = IAccIdentityObject.getIdentityString(childID)
 	try:
 		if accPropServices:
@@ -1186,16 +1111,16 @@ def findGroupboxObject(obj):
 
 # C901 'getRecursiveTextFromIAccessibleTextObject'
 def getRecursiveTextFromIAccessibleTextObject(obj, startOffset=0, endOffset=-1):  # noqa: C901
-	if not isinstance(obj, IAccessibleText):
+	if not isinstance(obj, IA2.IAccessibleText):
 		try:
-			textObject = obj.QueryInterface(IAccessibleText)
+			textObject = obj.QueryInterface(IA2.IAccessibleText)
 		except:  # noqa: E722 Bare except
 			textObject = None
 	else:
 		textObject = obj
-	if not isinstance(obj, IAccessible):
+	if not isinstance(obj, IA.IAccessible):
 		try:
-			accObject = obj.QueryInterface(IAccessible)
+			accObject = obj.QueryInterface(IA.IAccessible)
 		except:  # noqa: E722 Bare except
 			return ""
 	else:
@@ -1219,7 +1144,7 @@ def getRecursiveTextFromIAccessibleTextObject(obj, startOffset=0, endOffset=-1):
 			description = None
 		return " ".join([x for x in [name, value, description] if x and not x.isspace()])
 	try:
-		hypertextObject = accObject.QueryInterface(IAccessibleHypertext)
+		hypertextObject = accObject.QueryInterface(IA2.IAccessibleHypertext)
 	except:  # noqa: E722 Bare except
 		return text
 	textList = []
@@ -1227,7 +1152,7 @@ def getRecursiveTextFromIAccessibleTextObject(obj, startOffset=0, endOffset=-1):
 		if ord(t) == 0xFFFC:
 			try:
 				index = hypertextObject.hyperlinkIndex(i + startOffset)
-				childTextObject = hypertextObject.hyperlink(index).QueryInterface(IAccessible)
+				childTextObject = hypertextObject.hyperlink(index).QueryInterface(IA.IAccessible)
 				t = " %s " % getRecursiveTextFromIAccessibleTextObject(childTextObject)
 			except:  # noqa: E722 Bare except
 				pass
@@ -1322,7 +1247,7 @@ def isMarshalledIAccessible(IAccessibleObject):
 	"""Looks at the location of the first function in the IAccessible object's vtable (IUnknown::AddRef) to
 	see if it was implemented in oleacc.dll (its local) or ole32.dll (its marshalled).
 	"""
-	if not isinstance(IAccessibleObject, IAccessible):
+	if not isinstance(IAccessibleObject, IA.IAccessible):
 		raise TypeError("object should be of type IAccessible, not %s" % IAccessibleObject)
 	buf = create_unicode_buffer(1024)
 	addr = POINTER(c_void_p).from_address(

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -96,13 +96,6 @@ IAccessibleObjectIdentifierType = Tuple[
 ]
 
 from . import internalWinEventHandler
-# Imported for backwards compat
-from .internalWinEventHandler import (  # noqa: F401
-	winEventHookIDs,
-	winEventLimiter,
-	winEventIDsToNVDAEventNames,
-	_shouldGetEvents,
-)
 
 from logHandler import log
 import JABHandler
@@ -520,7 +513,7 @@ def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
 			f"Creating NVDA event from winEvent: {getWinEventLogInfo(window, objectID, childID, eventID)}, "
 			f"use cache {useCache}"
 		)
-	NVDAEventName = winEventIDsToNVDAEventNames.get(eventID, None)
+	NVDAEventName = internalWinEventHandler.winEventIDsToNVDAEventNames.get(eventID, None)
 	if not NVDAEventName:
 		log.debugWarning(f"No NVDA event name for {getWinEventName(eventID)}")
 		return None
@@ -969,7 +962,7 @@ def initialize():
 
 # C901 'pumpAll' is too complex
 def pumpAll():  # noqa: C901
-	if not _shouldGetEvents():
+	if not internalWinEventHandler._shouldGetEvents():
 		return
 	focusWinEvents = []
 	validFocus = False
@@ -983,7 +976,7 @@ def pumpAll():  # noqa: C901
 		alwaysAllowedObjects.append((focus.event_windowHandle, focus.event_objectID, focus.event_childID))
 
 	# Receive all the winEvents from the limiter for this cycle
-	winEvents = winEventLimiter.flushEvents(alwaysAllowedObjects)
+	winEvents = internalWinEventHandler.winEventLimiter.flushEvents(alwaysAllowedObjects)
 
 	for winEvent in winEvents:
 		isEventOnCaret = winEvent[2] == winUser.OBJID_CARET
@@ -999,7 +992,7 @@ def pumpAll():  # noqa: C901
 			if not focus.shouldAcceptShowHideCaretEvent:
 				continue
 		elif not eventHandler.shouldAcceptEvent(
-			winEventIDsToNVDAEventNames[winEvent[0]],
+			internalWinEventHandler.winEventIDsToNVDAEventNames[winEvent[0]],
 			windowHandle=winEvent[1]
 		):
 			continue

--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -16,13 +16,8 @@ import winUser
 from . import getWinEventLogInfo
 from . import isMSAADebugLoggingEnabled
 
+from comInterfaces import IAccessible2Lib as IA2
 
-from comInterfaces.IAccessible2Lib import (
-	IA2_EVENT_TEXT_CARET_MOVED,
-	IA2_EVENT_DOCUMENT_LOAD_COMPLETE,
-	IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED,
-	IA2_EVENT_PAGE_CHANGED,
-)
 
 from .orderedWinEventLimiter import OrderedWinEventLimiter, MENU_EVENTIDS
 from logHandler import log
@@ -61,10 +56,10 @@ winEventIDsToNVDAEventNames = {
 	winUser.EVENT_OBJECT_STATECHANGE: "stateChange",
 	winUser.EVENT_OBJECT_VALUECHANGE: "valueChange",
 	winUser.EVENT_OBJECT_LIVEREGIONCHANGED: "liveRegionChange",
-	IA2_EVENT_TEXT_CARET_MOVED: "caret",
-	IA2_EVENT_DOCUMENT_LOAD_COMPLETE: "documentLoadComplete",
-	IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED: "IA2AttributeChange",
-	IA2_EVENT_PAGE_CHANGED: "pageChange",
+	IA2.IA2_EVENT_TEXT_CARET_MOVED: "caret",
+	IA2.IA2_EVENT_DOCUMENT_LOAD_COMPLETE: "documentLoadComplete",
+	IA2.IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED: "IA2AttributeChange",
+	IA2.IA2_EVENT_PAGE_CHANGED: "pageChange",
 }
 
 _processDestroyWinEvent = None

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -12,6 +12,7 @@ import re
 import itertools
 import importlib
 from comInterfaces.tom import ITextDocument
+from comInterfaces import IAccessible2Lib as IA2
 import tones
 import languageHandler
 import textInfos.offsets
@@ -124,7 +125,9 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getOffsetFromPoint(self,x,y):
 		if self.obj.IAccessibleTextObject.nCharacters>0:
-			offset = self.obj.IAccessibleTextObject.OffsetAtPoint(x,y,IAccessibleHandler.IA2_COORDTYPE_SCREEN_RELATIVE)
+			offset = self.obj.IAccessibleTextObject.OffsetAtPoint(
+				x, y, IA2.IA2_COORDTYPE_SCREEN_RELATIVE
+			)
 			# IA2 specifies that a result of -1 indicates that
 			# the point is invalid or there is no character under the point.
 			# Note that Chromium does not follow the spec and returns 0 for invalid or no character points.
@@ -138,7 +141,9 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 	@classmethod
 	def _getBoundingRectFromOffsetInObject(cls,obj,offset):
 		try:
-			res=RectLTWH(*obj.IAccessibleTextObject.characterExtents(offset,IAccessibleHandler.IA2_COORDTYPE_SCREEN_RELATIVE))
+			res = RectLTWH(*obj.IAccessibleTextObject.characterExtents(
+				offset, IA2.IA2_COORDTYPE_SCREEN_RELATIVE
+			))
 		except COMError:
 			raise NotImplementedError
 		if not any(res[2:]):
@@ -259,7 +264,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		except COMError:
 			pass
 		try:
-			start,end,text = self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_CHAR)
+			start, end, text = self.obj.IAccessibleTextObject.TextAtOffset(offset, IA2.IA2_TEXT_BOUNDARY_CHAR)
 		except COMError:
 			return super(IA2TextTextInfo,self)._getCharacterOffsets(offset)
 		if text and (textUtils.isHighSurrogate(text) or textUtils.isLowSurrogate(text)):
@@ -275,7 +280,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		except COMError:
 			pass
 		try:
-			start,end,text=self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_WORD)
+			start, end, text = self.obj.IAccessibleTextObject.TextAtOffset(offset, IA2.IA2_TEXT_BOUNDARY_WORD)
 		except COMError:
 			return super(IA2TextTextInfo,self)._getWordOffsets(offset)
 		if start>offset or offset>end:
@@ -285,7 +290,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getLineOffsets(self,offset):
 		try:
-			start,end,text=self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_LINE)
+			start, end, text = self.obj.IAccessibleTextObject.TextAtOffset(offset, IA2.IA2_TEXT_BOUNDARY_LINE)
 			return start,end
 		except COMError:
 			log.debugWarning("IAccessibleText::textAtOffset failed",exc_info=True)
@@ -298,7 +303,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		except COMError:
 			pass
 		try:
-			start,end,text=self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_SENTENCE)
+			start, end, text = self.obj.IAccessibleTextObject.TextAtOffset(offset, IA2.IA2_TEXT_BOUNDARY_SENTENCE)
 			if start==end:
 				raise NotImplementedError
 			return start,end
@@ -312,7 +317,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		except COMError:
 			pass
 		try:
-			start,end,text=self.obj.IAccessibleTextObject.TextAtOffset(offset,IAccessibleHandler.IA2_TEXT_BOUNDARY_PARAGRAPH)
+			start, end, text = self.obj.IAccessibleTextObject.TextAtOffset(offset, IA2.IA2_TEXT_BOUNDARY_PARAGRAPH)
 			if start>=end:
 				raise RuntimeError("did not expand to paragraph correctly")
 			return start,end
@@ -564,7 +569,11 @@ the NVDAObject for IAccessible
 
 		clsList.append(IAccessible)
 
-		if self.event_objectID==winUser.OBJID_CLIENT and self.event_childID==0 and not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if(
+			self.event_objectID == winUser.OBJID_CLIENT
+			and self.event_childID == 0
+			and not isinstance(self.IAccessibleObject, IA2.IAccessible2)
+		):
 			# This is the main (client) area of the window, so we can use other classes at the window level.
 			# #3872: However, don't do this for IAccessible2 because
 			# IA2 supersedes window level APIs and might conflict with them.
@@ -588,7 +597,7 @@ the NVDAObject for IAccessible
 		self.IAccessibleChildID=IAccessibleChildID
 
 		# Try every trick in the book to get the window handle if we don't have it.
-		if not windowHandle and isinstance(IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if not windowHandle and isinstance(IAccessibleObject, IA2.IAccessible2):
 			windowHandle=self.IA2WindowHandle
 		try:
 			Identity=IAccessibleHandler.getIAccIdentity(IAccessibleObject,IAccessibleChildID)
@@ -614,7 +623,7 @@ the NVDAObject for IAccessible
 		if not windowHandle:
 			raise InvalidNVDAObject("Can't get a window handle from IAccessible")
 
-		if isinstance(IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if isinstance(IAccessibleObject, IA2.IAccessible2):
 			try:
 				self.IA2UniqueID=IAccessibleObject.uniqueID
 			except COMError:
@@ -623,7 +632,7 @@ the NVDAObject for IAccessible
 		# Set the event params based on our calculated/construction info if we must.
 		if event_windowHandle is None:
 			event_windowHandle=windowHandle
-		if event_objectID is None and isinstance(IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if event_objectID is None and isinstance(IAccessibleObject, IA2.IAccessible2):
 			event_objectID=winUser.OBJID_CLIENT
 		if event_childID is None:
 			if self.IA2UniqueID is not None:
@@ -637,18 +646,18 @@ the NVDAObject for IAccessible
 		super(IAccessible,self).__init__(windowHandle=windowHandle)
 
 		try:
-			self.IAccessibleActionObject=IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleAction)
+			self.IAccessibleActionObject = IAccessibleObject.QueryInterface(IA2.IAccessibleAction)
 		except COMError:
 			pass
 		try:
-			self.IAccessibleTable2Object=self.IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleTable2)
+			self.IAccessibleTable2Object = self.IAccessibleObject.QueryInterface(IA2.IAccessibleTable2)
 		except COMError:
 			try:
-				self.IAccessibleTableObject=self.IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleTable)
+				self.IAccessibleTableObject = self.IAccessibleObject.QueryInterface(IA2.IAccessibleTable)
 			except COMError:
 				pass
 		try:
-			self.IAccessibleTextObject=IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleText)
+			self.IAccessibleTextObject = IAccessibleObject.QueryInterface(IA2.IAccessibleText)
 		except COMError:
 			pass
 		if None not in (event_windowHandle,event_objectID,event_childID):
@@ -698,7 +707,10 @@ the NVDAObject for IAccessible
 			return False
 		if self.IAccessibleObject==other.IAccessibleObject: 
 			return True
-		if isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2) and isinstance(other.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if (
+			isinstance(self.IAccessibleObject, IA2.IAccessible2)
+			and isinstance(other.IAccessibleObject, IA2.IAccessible2)
+		):
 			# These are both IAccessible2 objects, so we can test unique ID.
 			# Unique ID is only guaranteed to be unique within a given window, so we must check window handle as well.
 			selfIA2Window=self.IA2WindowHandle
@@ -810,7 +822,7 @@ the NVDAObject for IAccessible
 		return self._IAccessibleIdentity
 
 	def _get_IAccessibleRole(self):
-		if isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			try:
 				role=self.IAccessibleObject.role()
 			except COMError:
@@ -857,7 +869,7 @@ the NVDAObject for IAccessible
 			log.debugWarning("could not get IAccessible states",exc_info=True)
 		else:
 			states.update(IAccessibleHandler.IAccessibleStatesToNVDAStates[x] for x in (y for y in (1<<z for z in range(32)) if y&IAccessibleStates) if x in IAccessibleHandler.IAccessibleStatesToNVDAStates)
-		if not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if not isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			# Not an IA2 object.
 			return states
 		IAccessible2States=self.IA2States
@@ -1076,7 +1088,7 @@ the NVDAObject for IAccessible
 		return self.correctAPIForRelation(IAccessible(IAccessibleObject=child[0], IAccessibleChildID=child[1]))
 
 	def _get_IA2Attributes(self):
-		if not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if not isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			return {}
 		try:
 			attribs = self.IAccessibleObject.attributes
@@ -1229,7 +1241,7 @@ the NVDAObject for IAccessible
 	def _get__IATableCell(self):
 		# Permanently cache the result.
 		try:
-			self._IATableCell = self.IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleTableCell)
+			self._IATableCell = self.IAccessibleObject.QueryInterface(IA2.IAccessibleTableCell)
 		except COMError:
 			self._IATableCell = None
 		return self._IATableCell
@@ -1250,7 +1262,7 @@ the NVDAObject for IAccessible
 			# as it gets released when it gets garbage collected.
 			for i in range(nHeaders):
 				try:
-					text = headers[i].QueryInterface(IAccessibleHandler.IAccessible2).accName(0)
+					text = headers[i].QueryInterface(IA2.IAccessible2).accName(0)
 				except COMError:
 					continue
 				if not text:
@@ -1312,7 +1324,7 @@ the NVDAObject for IAccessible
 
 
 	def _get_table(self):
-		if not isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if not isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			return None
 		table=getattr(self,'_table',None)
 		if table:
@@ -1356,9 +1368,9 @@ the NVDAObject for IAccessible
 			pass
 
 	def scrollIntoView(self):
-		if isinstance(self.IAccessibleObject, IAccessibleHandler.IAccessible2):
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			try:
-				self.IAccessibleObject.scrollTo(IAccessibleHandler.IA2_SCROLL_TYPE_ANYWHERE)
+				self.IAccessibleObject.scrollTo(IA2.IA2_SCROLL_TYPE_ANYWHERE)
 			except COMError:
 				log.debugWarning("IAccessible2::scrollTo failed", exc_info=True)
 
@@ -1367,7 +1379,7 @@ the NVDAObject for IAccessible
 		return config.conf["presentation"]["guessObjectPositionInformationWhenUnavailable"]
 
 	def _get_positionInfo(self):
-		if isinstance(self.IAccessibleObject,IAccessibleHandler.IAccessible2):
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			try:
 				info={}
 				info["level"],info["similarItemsInGroup"],info["indexInGroup"]=self.IAccessibleObject.groupPosition
@@ -1397,7 +1409,7 @@ the NVDAObject for IAccessible
 		return {}
 
 	def _get_indexInParent(self):
-		if isinstance(self.IAccessibleObject, IAccessibleHandler.IAccessible2):
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			try:
 				return self.IAccessibleObject.indexInParent
 			except COMError:
@@ -1405,7 +1417,7 @@ the NVDAObject for IAccessible
 		raise NotImplementedError
 
 	def _get__IA2Relations(self):
-		if not isinstance(self.IAccessibleObject, IAccessibleHandler.IAccessible2):
+		if not isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			raise NotImplementedError
 		import ctypes
 		import comtypes.hresult
@@ -1415,7 +1427,7 @@ the NVDAObject for IAccessible
 			raise NotImplementedError
 		if size <= 0:
 			return ()
-		relations = (ctypes.POINTER(IAccessibleHandler.IAccessibleRelation) * size)()
+		relations = (ctypes.POINTER(IA2.IAccessibleRelation) * size)()
 		count = ctypes.c_int()
 		# The client allocated relations array is an [out] parameter instead of [in, out], so we need to use the raw COM method.
 		res = self.IAccessibleObject._IAccessible2__com__get_relations(size, relations, ctypes.byref(count))
@@ -1544,7 +1556,7 @@ the NVDAObject for IAccessible
 		except Exception as e:
 			ret = "exception: %s" % e
 		info.append("IAccessible accValue: %s" % ret)
-		if isinstance(iaObj, IAccessibleHandler.IAccessible2):
+		if isinstance(iaObj, IA2.IAccessible2):
 			try:
 				ret = iaObj.windowHandle
 			except Exception as e:
@@ -1557,7 +1569,7 @@ the NVDAObject for IAccessible
 			info.append("IAccessible2 uniqueID: %s" % ret)
 			try:
 				ret = iaObj.role()
-				for name, const in itertools.chain(oleacc.__dict__.items(), IAccessibleHandler.__dict__.items()):
+				for name, const in itertools.chain(oleacc.__dict__.items(), IA2.__dict__.items()):
 					if not name.startswith("ROLE_") and not name.startswith("IA2_ROLE_"):
 						continue
 					if ret == const:
@@ -1571,7 +1583,7 @@ the NVDAObject for IAccessible
 			try:
 				temp = iaObj.states
 				ret = ", ".join(
-					name for name, const in IAccessibleHandler.__dict__.items()
+					name for name, const in IA2.__dict__.items()
 					if name.startswith("IA2_STATE_") and temp & const
 				) + " (%d)" % temp
 			except Exception as e:
@@ -1596,13 +1608,13 @@ the NVDAObject for IAccessible
 		return None
 
 	def _get_iaHypertext(self):
-		ht = self.IAccessibleTextObject.QueryInterface(IAccessibleHandler.IAccessibleHypertext)
+		ht = self.IAccessibleTextObject.QueryInterface(IA2.IAccessibleHypertext)
 		self.iaHypertext = ht # Cache forever.
 		return ht
 
 	def _get_IA2WindowHandle(self):
 		window = None
-		if isinstance(self.IAccessibleObject, IAccessibleHandler.IAccessible2):
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			try:
 				window = self.IAccessibleObject.windowHandle
 			except COMError as e:
@@ -1614,16 +1626,16 @@ the NVDAObject for IAccessible
 	_cache_IA2WindowHandle = False
 
 	def _get_IA2States(self):
-		if not isinstance(self.IAccessibleObject, IAccessibleHandler.IAccessible2):
+		if not isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			return 0
 		try:
 			return self.IAccessibleObject.states
 		except COMError:
 			log.debugWarning("could not get IAccessible2 states", exc_info=True)
-			return IAccessibleHandler.IA2_STATE_DEFUNCT
+			return IA2.IA2_STATE_DEFUNCT
 
 	def __contains__(self, obj):
-		if not isinstance(obj, IAccessible) or not isinstance(obj.IAccessibleObject, IAccessibleHandler.IAccessible2):
+		if not isinstance(obj, IAccessible) or not isinstance(obj.IAccessibleObject, IA2.IAccessible2):
 			return False
 		try:
 			self.IAccessibleObject.accChild(obj.IA2UniqueID)

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -10,7 +10,6 @@
 from comtypes import COMError
 import oleacc
 import controlTypes
-import IAccessibleHandler
 from NVDAObjects.IAccessible import IAccessible
 from virtualBuffers.gecko_ia2 import Gecko_ia2 as GeckoVBuf, Gecko_ia2_TextInfo as GeckoVBufTextInfo
 from . import ia2Web

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -13,6 +13,7 @@ import winUser
 import textInfos
 import controlTypes
 import IAccessibleHandler
+from comInterfaces import IAccessible2Lib as IA2
 import api
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 from . import IA2TextTextInfo, IAccessible
@@ -50,7 +51,7 @@ def _getEmbedded(obj, offset):
 		hi = ht.hyperlinkIndex(offset)
 		if hi != -1:
 			hl = ht.hyperlink(hi)
-			return IAccessible(IAccessibleObject=hl.QueryInterface(IAccessibleHandler.IAccessible2), IAccessibleChildID=0)
+			return IAccessible(IAccessibleObject=hl.QueryInterface(IA2.IAccessible2), IAccessibleChildID=0)
 	except COMError:
 		pass
 	return None
@@ -194,7 +195,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			info._endOffset = info._startOffset + 1
 			return info
 		try:
-			hl = obj.IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleHyperlink)
+			hl = obj.IAccessibleObject.QueryInterface(IA2.IAccessibleHyperlink)
 			hlOffset = hl.startIndex
 			info._startOffset = hlOffset
 			info._endOffset = hlOffset + 1

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -12,7 +12,6 @@ from comtypes import COMError
 import winUser
 import textInfos
 import controlTypes
-import IAccessibleHandler
 from comInterfaces import IAccessible2Lib as IA2
 import api
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -10,7 +10,6 @@
 from ctypes import c_short
 from comtypes import COMError, BSTR
 import oleacc
-import IAccessibleHandler
 from comInterfaces import IAccessible2Lib as IA2
 import controlTypes
 from logHandler import log

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -6,6 +6,7 @@
 #Copyright (C) 2006-2017 NV Access Limited, Peter Vágner
 
 import IAccessibleHandler
+from comInterfaces import IAccessible2Lib as IA2
 import oleacc
 import winUser
 import controlTypes
@@ -95,7 +96,7 @@ def findExtraOverlayClasses(obj, clsList):
 	"""Determine the most appropriate class if this is a Mozilla object.
 	This works similarly to L{NVDAObjects.NVDAObject.findOverlayClasses} except that it never calls any other findOverlayClasses method.
 	"""
-	if not isinstance(obj.IAccessibleObject, IAccessibleHandler.IAccessible2):
+	if not isinstance(obj.IAccessibleObject, IA2.IAccessible2):
 		return
 
 	iaRole = obj.IAccessibleRole
@@ -108,7 +109,7 @@ def findExtraOverlayClasses(obj, clsList):
 		# Not unavailable excludes disabled editable text fields (which also aren't focusable).
 		if not (iaStates & oleacc.STATE_SYSTEM_FOCUSABLE or iaStates & oleacc.STATE_SYSTEM_UNAVAILABLE):
 			# This excludes a non-focusable @role="textbox".
-			if not (obj.IA2States & IAccessibleHandler.IA2_STATE_EDITABLE):
+			if not (obj.IA2States & IA2.IA2_STATE_EDITABLE):
 				cls = TextLeaf
 	if not cls:
 		cls = _IAccessibleRolesToOverlayClasses.get(iaRole)
@@ -135,7 +136,7 @@ def findExtraOverlayClasses(obj, clsList):
 
 #: Maps IAccessible roles to NVDAObject overlay classes.
 _IAccessibleRolesToOverlayClasses = {
-	IAccessibleHandler.IA2_ROLE_EMBEDDED_OBJECT: EmbeddedObject,
+	IA2.IA2_ROLE_EMBEDDED_OBJECT: EmbeddedObject,
 	"embed": EmbeddedObject,
 	"object": EmbeddedObject,
 }

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -24,7 +24,6 @@ import winUser
 import textInfos.offsets
 from keyboardHandler import KeyboardInputGesture
 from scriptHandler import isScriptWaiting
-import IAccessibleHandler
 import controlTypes
 from . import Window
 from .. import NVDAObjectTextInfo

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -5,7 +5,6 @@
 # See the file COPYING for more details.
 
 import ctypes
-import IAccessibleHandler
 import speech
 import textInfos.offsets
 import winKernel

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -20,11 +20,10 @@ from browseMode import BrowseModeDocumentTreeInterceptor
 import textInfos
 from speech.types import SpeechSequence
 from textInfos import DocumentWithPageTurns
-from IAccessibleHandler import IAccessible2
 from NVDAObjects.IAccessible import IAccessible
 from globalCommands import SCRCAT_SYSTEMCARET
 from NVDAObjects.IAccessible.ia2TextMozilla import MozillaCompoundTextInfo
-import IAccessibleHandler
+from comInterfaces import IAccessible2Lib as IA2
 import winUser
 import mouseHandler
 from logHandler import log
@@ -78,7 +77,9 @@ class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,Brow
 			raise LookupError
 		table = obj.table
 		try:
-			cell = table.IAccessibleTable2Object.cellAt(destRow - 1, destCol - 1).QueryInterface(IAccessible2)
+			cell = table.IAccessibleTable2Object.cellAt(
+				destRow - 1, destCol - 1
+			).QueryInterface(IA2.IAccessible2)
 			cell = IAccessible(IAccessibleObject=cell, IAccessibleChildID=0)
 			# If the cell we fetched is marked as hidden, raise LookupError which will instruct calling code to try an adjacent cell instead.
 			if cell.IA2Attributes.get('hidden'):
@@ -160,7 +161,7 @@ class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,Brow
 		log.debug("Starting at hyperlink index %d" % startIndex)
 		for index in range(startIndex, hypertext.nHyperlinks if direction == "next" else -1, 1 if direction == "next" else -1):
 			hl = hypertext.hyperlink(index)
-			obj = IAccessible(IAccessibleObject=hl.QueryInterface(IAccessibleHandler.IAccessible2), IAccessibleChildID=0)
+			obj = IAccessible(IAccessibleObject=hl.QueryInterface(IA2.IAccessible2), IAccessibleChildID=0)
 			log.debug("Yielding object at index %d" % index)
 			yield obj
 			try:
@@ -227,7 +228,7 @@ class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,Brow
 			if not getattr(parent,'IAccessibleTextObject',None):
 				obj=parent
 				continue
-			hl = obj.IAccessibleObject.QueryInterface(IAccessibleHandler.IAccessibleHyperlink)
+			hl = obj.IAccessibleObject.QueryInterface(IA2.IAccessibleHyperlink)
 			offset = hl.startIndex
 			obj=parent
 			hli = obj.iaHypertext.hyperlinkIndex(offset)
@@ -409,7 +410,11 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
 		if isinstance(obj,IAccessible):
 			clsList.insert(0,PageTurnFocusIgnorer)
-			if ((isinstance(obj.IAccessibleObject, IAccessibleHandler.IAccessible2) and obj.IA2Attributes.get("class") == "KindleBookPageView")
+			if (
+				(
+					isinstance(obj.IAccessibleObject, IA2.IAccessible2)
+					and obj.IA2Attributes.get("class") == "KindleBookPageView"
+				)
 				# We must rely on .name in Kindle <= 1.19.
 				or (hasattr(obj,'IAccessibleTextObject') and obj.name=="Book Page View")
 			):
@@ -419,7 +424,11 @@ class AppModule(appModuleHandler.AppModule):
 		return clsList
 
 	def event_NVDAObject_init(self, obj):
-		if isinstance(obj, IAccessible) and isinstance(obj.IAccessibleObject, IAccessibleHandler.IAccessible2) and obj.role == controlTypes.ROLE_LINK:
+		if (
+			isinstance(obj, IAccessible)
+			and isinstance(obj.IAccessibleObject, IA2.IAccessible2)
+			and obj.role == controlTypes.ROLE_LINK
+		):
 			xRoles = obj.IA2Attributes.get("xml-roles", "").split(" ")
 			if "kindle-footnoteref" in xRoles:
 				obj.role = controlTypes.ROLE_FOOTNOTE

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -5,6 +5,7 @@
 #Copyright (C) 2006-2019 NV Access Limited, Bill Dengler
 
 from comtypes import COMError
+from comInterfaces import IAccessible2Lib as IA2
 import IAccessibleHandler
 import appModuleHandler
 import controlTypes
@@ -150,7 +151,7 @@ class SymphonyTextInfo(IA2TextTextInfo):
 
 		# optimisation: Assume a hyperlink occupies a full attribute run.
 		try:
-			if obj.IAccessibleTextObject.QueryInterface(IAccessibleHandler.IAccessibleHypertext).hyperlinkIndex(offset) != -1:
+			if obj.IAccessibleTextObject.QueryInterface(IA2.IAccessibleHypertext).hyperlinkIndex(offset) != -1:
 				formatField["link"] = True
 		except COMError:
 			pass

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -17,6 +17,7 @@ import oleacc
 from logHandler import log
 import textInfos
 from comtypes.gen.IAccessible2Lib import IAccessible2
+from comInterfaces import IAccessible2Lib as IA2
 from comtypes import COMError
 import aria
 import config
@@ -153,19 +154,19 @@ class Gecko_ia2(VirtualBuffer):
 		"""
 		try:
 			# 1. Get the containing document.
-			if not isinstance(acc, IAccessibleHandler.IAccessible2_2):
+			if not isinstance(acc, IA2.IAccessible2_2):
 				# IAccessible NVDAObjects currently fetch IA2, but we need IA2_2 for relationTargetsOfType.
 				# (Out-of-process, for a single relation, this is cheaper than IA2::relations.)
-				acc = acc.QueryInterface(IAccessibleHandler.IAccessible2_2)
+				acc = acc.QueryInterface(IA2.IAccessible2_2)
 			targets, count = acc.relationTargetsOfType(IA2_RELATION_CONTAINING_DOCUMENT, 1)
 			if count == 0:
 				return None
-			doc = targets[0].QueryInterface(IAccessibleHandler.IAccessible2_2)
+			doc = targets[0].QueryInterface(IA2.IAccessible2_2)
 			# 2. Get its parent (the embedder); e.g. iframe.
 			embedder = doc.accParent
 			if not embedder:
 				return None
-			embedder = embedder.QueryInterface(IAccessibleHandler.IAccessible2_2)
+			embedder = embedder.QueryInterface(IA2.IAccessible2_2)
 			# 3. Make sure this is an iframe/frame.
 			attribs = embedder.attributes
 			if "tag:browser;" in attribs:
@@ -213,7 +214,14 @@ class Gecko_ia2(VirtualBuffer):
 			yield accId
 
 	def __contains__(self,obj):
-		if not (isinstance(obj,NVDAObjects.IAccessible.IAccessible) and isinstance(obj.IAccessibleObject,IAccessibleHandler.IAccessible2)) or not obj.windowClassName.startswith('Mozilla') or not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle,obj.windowHandle):
+		if not (
+			(
+				isinstance(obj, NVDAObjects.IAccessible.IAccessible)
+				and isinstance(obj.IAccessibleObject, IA2.IAccessible2)
+			)
+			or not obj.windowClassName.startswith('Mozilla')
+			or not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle, obj.windowHandle)
+		):
 			return False
 		for accId in self._iterIdsToTryWithAccChild(obj):
 			if accId == self.rootID:
@@ -246,7 +254,7 @@ class Gecko_ia2(VirtualBuffer):
 			# stops responding; e.g. it froze, crashed or is being debugged.
 			return True
 		try:
-			isDefunct=bool(root.IAccessibleObject.states&IAccessibleHandler.IA2_STATE_DEFUNCT)
+			isDefunct = bool(root.IAccessibleObject.states & IA2.IA2_STATE_DEFUNCT)
 		except COMError:
 			# If IAccessible2 states can not be fetched at all, defunct should be assumed as the object has clearly been disconnected or is dead
 			isDefunct=True
@@ -312,11 +320,13 @@ class Gecko_ia2(VirtualBuffer):
 
 	def _searchableAttribsForNodeType(self,nodeType):
 		if nodeType.startswith('heading') and nodeType[7:].isdigit():
-			attrs={"IAccessible::role":[IAccessibleHandler.IA2_ROLE_HEADING],"IAccessible2::attribute_level":[nodeType[7:]]}
+			attrs = {"IAccessible::role": [IA2.IA2_ROLE_HEADING], "IAccessible2::attribute_level": [nodeType[7:]]}
 		elif nodeType == "annotation":
-			attrs={"IAccessible::role":[IAccessibleHandler.IA2_ROLE_CONTENT_DELETION,IAccessibleHandler.IA2_ROLE_CONTENT_INSERTION]}
+			attrs = {
+				"IAccessible::role": [IA2.IA2_ROLE_CONTENT_DELETION, IA2.IA2_ROLE_CONTENT_INSERTION]
+			}
 		elif nodeType=="heading":
-			attrs={"IAccessible::role":[IAccessibleHandler.IA2_ROLE_HEADING]}
+			attrs = {"IAccessible::role": [IA2.IA2_ROLE_HEADING]}
 		elif nodeType=="table":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_TABLE]}
 			if not config.conf["documentFormatting"]["includeLayoutTables"]:
@@ -339,7 +349,7 @@ class Gecko_ia2(VirtualBuffer):
 						oleacc.ROLE_SYSTEM_PUSHBUTTON,
 						oleacc.ROLE_SYSTEM_RADIOBUTTON,
 						oleacc.ROLE_SYSTEM_PAGETAB,
-						IAccessibleHandler.IA2_ROLE_TOGGLE_BUTTON,
+						IA2.IA2_ROLE_TOGGLE_BUTTON,
 					],
 					f"IAccessible::state_{oleacc.STATE_SYSTEM_READONLY}": [None],
 				},
@@ -348,11 +358,11 @@ class Gecko_ia2(VirtualBuffer):
 						oleacc.ROLE_SYSTEM_COMBOBOX,
 						oleacc.ROLE_SYSTEM_TEXT
 					],
-					f"IAccessible2::state_{IAccessibleHandler.IA2_STATE_EDITABLE}": [1],
+					f"IAccessible2::state_{IA2.IA2_STATE_EDITABLE}": [1],
 				},
 				{
-					f"IAccessible2::state_{IAccessibleHandler.IA2_STATE_EDITABLE}": [1],
-					f"parent::IAccessible2::state_{IAccessibleHandler.IA2_STATE_EDITABLE}": [None],
+					f"IAccessible2::state_{IA2.IA2_STATE_EDITABLE}": [1],
+					f"parent::IAccessible2::state_{IA2.IA2_STATE_EDITABLE}": [None],
 				},
 			]
 		elif nodeType=="list":
@@ -360,14 +370,26 @@ class Gecko_ia2(VirtualBuffer):
 		elif nodeType=="listItem":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_LISTITEM]}
 		elif nodeType=="button":
-			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_PUSHBUTTON,oleacc.ROLE_SYSTEM_BUTTONMENU,IAccessibleHandler.IA2_ROLE_TOGGLE_BUTTON]}
+			attrs = {
+				"IAccessible::role": [
+					oleacc.ROLE_SYSTEM_PUSHBUTTON,
+					oleacc.ROLE_SYSTEM_BUTTONMENU,
+					IA2.IA2_ROLE_TOGGLE_BUTTON
+				]
+			}
 		elif nodeType=="edit":
 			attrs=[
-				{"IAccessible::role":[oleacc.ROLE_SYSTEM_TEXT],"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1]},
-				{"IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[1],"parent::IAccessible2::state_%s"%IAccessibleHandler.IA2_STATE_EDITABLE:[None]},
+				{
+					"IAccessible::role": [oleacc.ROLE_SYSTEM_TEXT],
+					f"IAccessible2::state_{IA2.IA2_STATE_EDITABLE}":[1]
+				},
+				{
+					f"IAccessible2::state_{IA2.IA2_STATE_EDITABLE}": [1],
+					f"parent::IAccessible2::state_{IA2.IA2_STATE_EDITABLE}":[None]
+				},
 			]
 		elif nodeType=="frame":
-			attrs={"IAccessible::role":[IAccessibleHandler.IA2_ROLE_INTERNAL_FRAME]}
+			attrs = {"IAccessible::role": [IA2.IA2_ROLE_INTERNAL_FRAME]}
 		elif nodeType=="separator":
 			attrs={"IAccessible::role":[oleacc.ROLE_SYSTEM_SEPARATOR]}
 		elif nodeType=="radioButton":
@@ -386,13 +408,13 @@ class Gecko_ia2(VirtualBuffer):
 				# Search for a tag of blockquote for older implementations before the blockquote IAccessible2 role existed.
 				{"IAccessible2::attribute_tag":self._searchableTagValues(["blockquote"])},
 				# Also support the new blockquote IAccessible2 role
-				{"IAccessible::role":[IAccessibleHandler.IA2_ROLE_BLOCK_QUOTE]},
+				{"IAccessible::role": [IA2.IA2_ROLE_BLOCK_QUOTE]},
 			]
 		elif nodeType=="focusable":
 			attrs={"IAccessible::state_%s"%oleacc.STATE_SYSTEM_FOCUSABLE:[1]}
 		elif nodeType=="landmark":
 			attrs = [
-				{"IAccessible::role": [IAccessibleHandler.IA2_ROLE_LANDMARK]},
+				{"IAccessible::role": [IA2.IA2_ROLE_LANDMARK]},
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word(lr) for lr in aria.landmarkRoles]},
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("region")],
 					"name": [VBufStorage_findMatch_notEmpty]}

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -98,6 +98,7 @@ What's New in NVDA
   - class winVersion.WinVersion is a comparable and order-able type encapsulating Windows version information.
   - Function winVersion.getWinVer has been added to get a winVersion.WinVersion representing the currently running OS.
   - Convenience constants have been added for known Windows releases, see winVersion.WIN* constants.
+- IAccessibleHandler no longer star imports everything from IAccessible and IA2 COM interfaces - please use them directly. (#12232)
 
 
 = 2020.4 =


### PR DESCRIPTION
### Link to issue number:
None, removes code marked as deprecated in #10934

### Summary of the issue:
PR #10934 refactored `IAccessibleHandler` into a package. This necessitated keeping some unused imports but marking them as deprecated. Also various parts of NVDA relied on the fact that `IAccessibleHandler` star imported all variables from IAccessible and IAccessible2 COM interfaces.

### Description of how this pull request fixes the issue:
- Unused imports are removed from `IAccessibleHandler`
- NVDA's source has been modified to use IAccessible2 names from the COM interface rather than from `IAccessibleHandler`.
### Testing strategy:
Manual testing:
Ensured that NVDA still starts, and works in general. Spend about an hour browsing in Firefox without any apparent changes in behavior.

With git grep inspected all usages of `IAccessibleHandler` to make sure that nothing in NVDA's source relies on things star imported there any longer.
### Known issues with pull request:
None known
### Change log entry:

Section: Changes for developers:
- IAccessibleHandler no longer star imports everything from IAccessible and IA2 COM interfaces - please use them directly.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
