### PR TITLE
Allow UIA to work again on Win7 after pr #12210

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1193,13 +1193,13 @@ class UIA(Window):
 		return self.UIASelectionPattern
 
 	def _get_UIASelectionPattern2(self):
-		# SelectionPattern2 is not available on older Operating Systems such as Windows 7
 		try:
 			self.UIASelectionPattern2 = self._getUIAPattern(
 				UIAHandler.UIA_SelectionPattern2Id,
 				UIAHandler.IUIAutomationSelectionPattern2
 			)
 		except COMError:
+			# SelectionPattern2 is not available on older Operating Systems such as Windows 7
 			self.UIASelectionPattern2 = None
 		return self.UIASelectionPattern2
 
@@ -1466,10 +1466,10 @@ class UIA(Window):
 				states.add(controlTypes.STATE_CHECKABLE)
 				if s==UIAHandler.ToggleState_On:
 					states.add(controlTypes.STATE_CHECKED)
-		# annotationTypes cannot be fetched on older Operating Systems such as Windows 7.
 		try:
 			annotationTypes = self._getUIACacheablePropertyValue(UIAHandler.UIA_AnnotationTypesPropertyId)
 		except COMError:
+			# annotationTypes cannot be fetched on older Operating Systems such as Windows 7.
 			annotationTypes = None
 		if annotationTypes:
 			if UIAHandler.AnnotationType_Comment in annotationTypes:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1462,7 +1462,11 @@ class UIA(Window):
 				states.add(controlTypes.STATE_CHECKABLE)
 				if s==UIAHandler.ToggleState_On:
 					states.add(controlTypes.STATE_CHECKED)
-		annotationTypes = self._getUIACacheablePropertyValue(UIAHandler.UIA_AnnotationTypesPropertyId)
+		# annotationTypes cannot be fetched on older Operating Systems such as Windows 7.
+		try:
+			annotationTypes = self._getUIACacheablePropertyValue(UIAHandler.UIA_AnnotationTypesPropertyId)
+		except COMError:
+			annotationTypes = None
 		if annotationTypes:
 			if UIAHandler.AnnotationType_Comment in annotationTypes:
 				states.add(controlTypes.STATE_HASCOMMENT)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1193,10 +1193,14 @@ class UIA(Window):
 		return self.UIASelectionPattern
 
 	def _get_UIASelectionPattern2(self):
-		self.UIASelectionPattern2 = self._getUIAPattern(
-			UIAHandler.UIA_SelectionPattern2Id,
-			UIAHandler.IUIAutomationSelectionPattern2
-		)
+		# SelectionPattern2 is not available on older Operating Systems such as Windows 7
+		try:
+			self.UIASelectionPattern2 = self._getUIAPattern(
+				UIAHandler.UIA_SelectionPattern2Id,
+				UIAHandler.IUIAutomationSelectionPattern2
+			)
+		except COMError:
+			self.UIASelectionPattern2 = None
 		return self.UIASelectionPattern2
 
 	def getSelectedItemsCount(self, maxItems=None):


### PR DESCRIPTION
### Link to issue number:
Fixes #12227 

### Summary of the issue:
With the merging of pr #12210 it became impossible to interact with UI Automation controls on Windows 7.

* Fetching the annotationTypes UIA property raises a COMError if not implemented by the control. On newer Operating Systems UIA core returns a default.
 * Fetching the SelectionPattern2 interface also causes a COMError on older Operating Systems if not implemented by the control.
 
### Description of how this pull request fixes the issue:
* Catch COMError when fetching UIA annotationTypes.
* Catch COMError when fetching the UIA SelectionPattern2 interface.

### Testing strategy:
On Windows 10, With UIA in Excel turned on in NVDA's Advanced settings, interacted with the Excel test spreadsheet on pr #12210, confirming that all properties still read.
- [x] Get confirmation from a Win7 user that steps in #12227 now work.

### Known issues with pull request:
None.

### Change log entry:
None needed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
