### PR TITLE
Fix-up of #12232: No longer falsely report that objects are inside GeckoIA2 virtual buffer if they aren't.

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -214,8 +214,8 @@ class Gecko_ia2(VirtualBuffer):
 			yield accId
 
 	def __contains__(self,obj):
-		if not (
-			(
+		if (
+			not (
 				isinstance(obj, NVDAObjects.IAccessible.IAccessible)
 				and isinstance(obj.IAccessibleObject, IA2.IAccessible2)
 			)


### PR DESCRIPTION

### Link to issue number:
Fixes #12234-  Regression introduced in #12232

### Summary of the issue:
When working on #12232 I had to reformat quite a bit of code to comply with the style enforced by Linter. In the  process logic responsible for checking if the given object is inside GeckoIA2 virtual buffer got broken. I haven't noticed it when testing because of #12227

### Description of how this pull request fixes the issue:
The logic has been corrected.
### Testing strategy:
After navigating in Firefox opened Windows Explorer, navigated in the list of files ensured that errors no longer occur.
### Known issues with pull request:
None known
### Change log entry:

None needed - regression in Alpha.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
