### PR TITLE
Fix up of 11738: Force UIA for Outlook messages list even though it doesn't support UIA natively

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -246,10 +246,10 @@ class SuperGridClient2010(IAccessible):
 			return super(SuperGridClient2010,self).event_gainFocus()
 		try:
 			kwargs = {}
-			UIA.kwargsFromSuper(kwargs, relation="focus")
-			obj=UIA(**kwargs)
-		except:
-			log.debugWarning("Retrieving UIA focus failed", exc_info=True)
+			UIA.kwargsFromSuper(kwargs, relation="focus", ignoreNonNativeElementsWithFocus=False)
+			obj = UIA(**kwargs)
+		except Exception:
+			log.error("Retrieving UIA focus failed", exc_info=True)
 			return super(SuperGridClient2010,self).event_gainFocus()
 		if not isinstance(obj,UIAGridRow):
 			return super(SuperGridClient2010,self).event_gainFocus()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -28,6 +28,7 @@ What's New in NVDA
 
 
 == Bug Fixes ==
+- The list of messages in Outlook 2010 is once again readable. (12241)
 - In terminal programs on Windows 10 version 1607 and later, when inserting or deleting characters in the middle of a line, the characters to the right of the caret are no longer read out. (#3200)
   - This experimental fix must be manually enabled in NVDA's advanced settings panel by changing the diff algorithm to Diff Match Patch.
 - Fixed access to edit fields in MCS Electronics IDE's. (#11966) 


### PR DESCRIPTION

### Link to issue number:
None. Reported [here](https://nvda.groups.io/g/nvda/topic/81558234#82657) and [here](https://nvda.groups.io/g/nvda/topic/80761465#82009) on users list.
### Summary of the issue:
PR #11738 made it impossible to use UIA for controls which doesn't report as native UIA. This decreased accessibility of Outlook's messages list in some versions of Outlook (certainly for 2010 and possibly for 2013) which reports as non native UIA.
### Description of how this pull request fixes the issue:
Similar to the fix in #11828 for these controls the fact that they're non native UIA is ignored.
### Testing strategy:
Ensured that list of messages in Outlook 2010 behaves the same way as it did in NVDA 2020.3
I'll post the link to the build from this pr to the both threads mentioned above and ask users there for confirmation.
### Known issues with pull request:
None known.
### Change log entry:

Section: Bug fixes
- List of messages in Outlook 2010 and possibly 2013 is once again readable.
### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
