### PR TITLE
Microsoft Edge with UIA: support following same-page links 

### DIFF
--- a/source/UIABrowseMode.py
+++ b/source/UIABrowseMode.py
@@ -360,6 +360,14 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 	# Because UIA TextRanges are opaque and are tied specifically to one particular document.
 	shouldRememberCaretPositionAcrossLoads=False
 
+	def event_UIA_activeTextPositionChanged(self, obj, nextHandler, textRange=None):
+		if not self.isReady:
+			self._initialScrollObj = obj
+			return nextHandler()
+		scrollInfo = self.makeTextInfo(textRange)
+		if not self._handleScrollTo(scrollInfo):
+			return nextHandler()
+
 	def _iterNodesByType(self,nodeType,direction="next",pos=None):
 		if nodeType.startswith("heading"):
 			return UIAHeadingQuicknavIterator(nodeType,self,pos,direction=direction)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

### Summary of the issue:
When following a same-page link in a web browser, the page is scrolled to the target of the same-page link, and it is expected that the screen reader will move its browse mode caret to that location as well.

Recently a new ActiveTextPositionchanged event was added to UI Automation to allow browsers to communicate this to screen readers. Only in the last week or so, Microsoft Edge Canary has started firing this event when same-page links are activated.
NVDA should make use of this.
 
### Description of how this pull request fixes the issue:
NVDA now registeres for UI Automation's ActiveTextPositionChanged event globally, and when one is received, fires its own UIA_activetextPositionChanged NvDA event. This NVDA event is implemented on UIABrowseModeDocument, which uses BrowseMode's _handleScrollTo to move the browse mode caret to the new location.
_handleScrollTo had to be changed to accept not just an NvDAObject, but now also a TextInfo, as the ActiveTextPositionChanged event is actually passed a IUIAutomationTextRange.

### Testing strategy:
* Enabled UIA in Chromium browsers in NvDA's advanced settings
* Loaded the NvDA User Guide in Microsoft Edge Canary
* Followed one of the same-page links in the table of contents.
* Confirmed that the browse mode caret moved to the target of the same-page link (above the heading) and that then pressing down arrow or starting a sayAll would read the appropriate content.

### Known issues with pull request:
None.

### Change log entry:
Same-page links are now supported in Microsoft Edge when using UI automation.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
