### PR TITLE
Improve system tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -132,7 +132,6 @@ before_test:
      if(!$env:release) {
       $nvdaLauncherFile+="_snapshot"
      }
-     Get-ComputerInfo >> ".\output\systemInfo.txt"
      $nvdaLauncherFile+="_${env:version}.exe"
      Set-AppveyorBuildVariable "nvdaLauncherFile" $nvdaLauncherFile
      echo NVDALauncherFile: $NVDALauncherFile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,7 @@ init:
      if ($versionType) {
       Set-AppveyorBuildVariable "versionType" $versionType
      }
+     Get-ComputerInfo >> systemInfo.txt
 
 clone_depth: 1
 
@@ -216,6 +217,7 @@ test_script:
 artifacts:
   - path: output\*
   - path: output\*\*
+  - path: systemInfo.txt
 
 # Still upload artifacts on failure, they are useful for testing PR builds despite the build perhaps
 # failing for a minor reason (eg linting)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,6 @@ init:
      if ($versionType) {
       Set-AppveyorBuildVariable "versionType" $versionType
      }
-     Get-ComputerInfo >> systemInfo.txt
 
 clone_depth: 1
 
@@ -133,6 +132,7 @@ before_test:
      if(!$env:release) {
       $nvdaLauncherFile+="_snapshot"
      }
+     Get-ComputerInfo >> ".\output\systemInfo.txt"
      $nvdaLauncherFile+="_${env:version}.exe"
      Set-AppveyorBuildVariable "nvdaLauncherFile" $nvdaLauncherFile
      echo NVDALauncherFile: $NVDALauncherFile
@@ -217,7 +217,6 @@ test_script:
 artifacts:
   - path: output\*
   - path: output\*\*
-  - path: systemInfo.txt
 
 # Still upload artifacts on failure, they are useful for testing PR builds despite the build perhaps
 # failing for a minor reason (eg linting)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -207,6 +207,7 @@ test_script:
       $errorCode=$LastExitCode
       Add-AppveyorMessage "System test failure"
      }
+     Stop-Process -Name chrome
      Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
      Push-AppveyorArtifact "$testOutput\systemTestResult.zip"
      $wc = New-Object 'System.Net.WebClient'

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -159,7 +159,7 @@ class ChromeLib:
 			actualSpeech = ChromeLib.getSpeechAfterKey('NVDA+UpArrow')
 			if actualSpeech == self._loadCompleteString:
 				break
-			spy.emulateKeyPress('alt+shift+esc')  # switches to the previous open window
+			spy.emulateKeyPress('alt+shift+escape')  # switches to the previous open window
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -44,9 +44,8 @@ class ChromeLib:
 		return _pJoin(ChromeLib._testFileStagingPath, filename)
 
 	def exit_chrome(self, isMainChromeProcess: bool = False):
-		if not isMainChromeProcess:
-			spy = _NvdaLib.getSpyLib()
-			spy.emulateKeyPress('control+w')
+		spy = _NvdaLib.getSpyLib()
+		spy.emulateKeyPress('control+w')
 		chromeAlias = self._mainChromeAlias if isMainChromeProcess else self.chromeAlias
 		process.wait_for_process(chromeAlias, timeout="1 minute", on_timeout="terminate")
 		process.process_should_be_stopped(chromeAlias)

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -9,6 +9,7 @@ Google Chrome with a HTML sample and assert NVDA interacts with it in the expect
 
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
 from os.path import join as _pJoin
+import os
 import tempfile as _tempfile
 from typing import Optional as _Optional
 from SystemTestSpy import (
@@ -33,6 +34,7 @@ class ChromeLib:
 	_testFileStagingPath = _tempfile.mkdtemp()
 
 	def __init__(self):
+		self._original_chrome_log = os.environ.get('CHROME_LOG_FILE', '')
 		self.chromeHandle: _Optional[int] = None
 
 	@staticmethod
@@ -43,15 +45,18 @@ class ChromeLib:
 		spy = _NvdaLib.getSpyLib()
 		spy.emulateKeyPress('control+w')
 		process.wait_for_process(self.chromeHandle, timeout="1 minute", on_timeout="continue")
+		os.environ['CHROME_LOG_FILE'] = self._original_chrome_log
 
 	def start_chrome(self, filePath):
 		builtIn.log(f"starting chrome: {filePath}")
+		os.environ['CHROME_LOG_FILE'] = _NvdaLib.NvdaLib.createLogsFullTestIdPath("chrome.log")
 		self.chromeHandle = process.start_process(
 			"start chrome"
 			" --force-renderer-accessibility"
 			" --suppress-message-center-popups"
 			" --disable-notifications"
 			" -kiosk"
+			f' --enable-logging --v=1'
 			f' "{filePath}"',
 			shell=True,
 			alias='chromeAlias',

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -58,6 +58,7 @@ class ChromeLib:
 			" --force-renderer-accessibility"
 			" --suppress-message-center-popups"
 			" --disable-notifications"
+			" --keep-alive-for-test"
 			" -kiosk"
 			f' --enable-logging --v=1'
 			f' "{filePath}"',

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -159,6 +159,7 @@ class ChromeLib:
 			actualSpeech = ChromeLib.getSpeechAfterKey('NVDA+UpArrow')
 			if actualSpeech == self._loadCompleteString:
 				break
+			spy.emulateKeyPress('alt+shift+esc')  # switches to the previous open window
 		else:  # Exceeded the number of tries
 			spy.dump_speech_to_log()
 			builtIn.fail(

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -34,7 +34,7 @@ class ChromeLib:
 	_testFileStagingPath = _tempfile.mkdtemp()
 
 	def __init__(self):
-		self._original_chrome_log = os.environ.get('CHROME_LOG_FILE', '')
+		self._original_chrome_log = os.environ.get('CHROME_LOG_FILE', None)
 		self.chromeHandle: _Optional[int] = None
 
 	@staticmethod
@@ -44,8 +44,11 @@ class ChromeLib:
 	def exit_chrome(self):
 		spy = _NvdaLib.getSpyLib()
 		spy.emulateKeyPress('control+w')
-		process.wait_for_process(self.chromeHandle, timeout="1 minute", on_timeout="continue")
-		os.environ['CHROME_LOG_FILE'] = self._original_chrome_log
+		process.wait_for_process(self.chromeHandle, timeout="1 minute", on_timeout="terminate")
+		if self._original_chrome_log is not None:
+			os.environ['CHROME_LOG_FILE'] = self._original_chrome_log
+		else:
+			del os.environ['CHROME_LOG_FILE']
 
 	def start_chrome(self, filePath):
 		builtIn.log(f"starting chrome: {filePath}")

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -63,7 +63,6 @@ class ChromeLib:
 			" --force-renderer-accessibility"
 			" --suppress-message-center-popups"
 			" --disable-notifications"
-			" --keep-alive-for-test"
 			" -kiosk"
 			f' --enable-logging --v=1'
 			f' {f"{filePath}" if filePath is not None else ""}',

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -282,6 +282,9 @@ class NvdaLib:
 
 	def quit_NVDAInstaller(self):
 		builtIn.log("Stopping nvdaSpy server: {}".format(self._spyServerURI))
+		self.nvdaSpy.emulateKeyPress("insert+q")
+		self.nvdaSpy.wait_for_specific_speech("Exit NVDA")
+		self.nvdaSpy.emulateKeyPress("enter", blockUntilProcessed=False)
 		try:
 			_stopRemoteServer(self._spyServerURI, log=False)
 			process.terminate_process(self.nvdaProcessAlias)

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -102,6 +102,10 @@ class NvdaLib:
 		return outputFileName
 
 	@staticmethod
+	def createLogsFullTestIdPath(name):
+		return _pJoin(_locations.preservedLogsDir, NvdaLib._createTestIdFileName(name))
+
+	@staticmethod
 	def setup_nvda_profile(configFileName):
 		configManager.setupProfile(
 			_locations.repoRoot,
@@ -136,8 +140,8 @@ class NvdaLib:
 			command,
 			shell=True,
 			alias=self.nvdaProcessAlias,
-			stdout=_pJoin(_locations.preservedLogsDir, self._createTestIdFileName("stdout.txt")),
-			stderr=_pJoin(_locations.preservedLogsDir, self._createTestIdFileName("stderr.txt")),
+			stdout=self.createLogsFullTestIdPath("stdout.txt"),
+			stderr=self.createLogsFullTestIdPath("stderr.txt"),
 		)
 		return handle
 
@@ -157,8 +161,8 @@ class NvdaLib:
 			command,
 			shell=True,
 			alias=self.nvdaProcessAlias,
-			stdout=_pJoin(_locations.preservedLogsDir, self._createTestIdFileName("stdout.txt")),
-			stderr=_pJoin(_locations.preservedLogsDir, self._createTestIdFileName("stderr.txt")),
+			stdout=self.createLogsFullTestIdPath("stdout.txt"),
+			stderr=self.createLogsFullTestIdPath("stderr.txt"),
 		)
 		return handle
 

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -282,13 +282,11 @@ class NvdaLib:
 
 	def quit_NVDAInstaller(self):
 		builtIn.log("Stopping nvdaSpy server: {}".format(self._spyServerURI))
-		self.nvdaSpy.emulateKeyPress("insert+q")
-		self.nvdaSpy.wait_for_specific_speech("Exit NVDA")
-		self.nvdaSpy.emulateKeyPress("enter", blockUntilProcessed=False)
-		process.wait_for_process(self.nvdaProcessAlias, timeout="10 sec", on_timeout="terminate")
-		process.process_should_be_stopped(self.nvdaProcessAlias)
 		try:
 			_stopRemoteServer(self._spyServerURI, log=False)
+			process.terminate_process(self.nvdaProcessAlias)
+			process.wait_for_process(self.nvdaProcessAlias, timeout="10 sec", on_timeout="terminate")
+			process.process_should_be_stopped(self.nvdaProcessAlias)
 		except Exception:
 			raise
 		finally:

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -285,7 +285,8 @@ class NvdaLib:
 		self.nvdaSpy.emulateKeyPress("insert+q")
 		self.nvdaSpy.wait_for_specific_speech("Exit NVDA")
 		self.nvdaSpy.emulateKeyPress("enter", blockUntilProcessed=False)
-		builtIn.sleep(1)
+		process.wait_for_process(self.nvdaProcessAlias, timeout="10 sec", on_timeout="terminate")
+		process.process_should_be_stopped(self.nvdaProcessAlias)
 		try:
 			_stopRemoteServer(self._spyServerURI, log=False)
 		except Exception:

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -6,7 +6,7 @@
 Documentation	HTML test cases in Chrome
 Force Tags	NVDA	smoke test	browser	chrome
 Suite Setup	start chrome
-Suite Teardown	exit chrome	True
+Suite Teardown	default suite teardown
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py
@@ -22,6 +22,11 @@ default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
 	exit chrome
+	quit NVDA
+
+default suite teardown
+	start NVDA	standard-dontShowWelcomeDialog.ini
+	exit chrome	True
 	quit NVDA
 
 *** Test Cases ***

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -5,6 +5,8 @@
 *** Settings ***
 Documentation	HTML test cases in Chrome
 Force Tags	NVDA	smoke test	browser	chrome
+Suite Setup	start chrome
+Suite Teardown	exit chrome	True
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

Our system tests randomly fail due to chrome not having focus, and so NVDA does not read the expected speech

### Description of how this pull request fixes the issue:

- Run chrome with debug logging and push those files with the system tests as an appveyor artifact
- Open a new chrome window before running the tests, this keeps a background chrome open to minimise the loading times for tabs and prevents adding tabs to a developer's active chrome window
- terminate chrome and NVDA Installer processes better on timeout

### Testing strategy:

None

### Known issues with pull request:

The system tests still fail randomly

### Change log entry:

None

### Code Review Checklist:


- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
