### PR TITLE
Fix NVDA crash when formatting a timestamp of a log entry under some versions of Universal CRT

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -317,6 +317,14 @@ def main():
 		def OnAssert(self,file,line,cond,msg):
 			message="{file}, line {line}:\nassert {cond}: {msg}".format(file=file,line=line,cond=cond,msg=msg)
 			log.debugWarning(message,codepath="WX Widgets",stack_info=True)
+
+		def InitLocale(self):
+			# Backport of `InitLocale` from wx Python 4.1.2 as the current version tries to set a Python
+			# locale to an nonexistent one when creating an instance of `wx.App`.
+			# This causes a crash when running under a particular version of Universal CRT (#12160)
+			import locale
+			locale.setlocale(locale.LC_ALL, "C")
+
 	app = App(redirect=False)
 	# We support queryEndSession events, but in general don't do anything for them.
 	# However, when running as a Windows Store application, we do want to request to be restarted for updates

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -10,13 +10,13 @@ import os
 import ctypes
 import sys
 import warnings
-from encodings import utf_8
 import logging
 import inspect
 import winsound
 import traceback
-from types import MethodType, FunctionType
+from types import FunctionType
 import globalVars
+import winKernel
 import buildVersion
 from typing import Optional
 
@@ -292,7 +292,6 @@ class Formatter(logging.Formatter):
 		"""Custom implementation of `formatTime` which avoids `time.localtime`
 		since it causes a crash under some versions of Universal CRT ( #12160, Python issue 36792)
 		"""
-		import winKernel
 		timeAsFileTime = winKernel.time_tToFileTime(record.created)
 		timeAsSystemTime = winKernel.SYSTEMTIME()
 		winKernel.FileTimeToSystemTime(timeAsFileTime, timeAsSystemTime)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -288,6 +288,20 @@ class Formatter(logging.Formatter):
 	def formatException(self, ex):
 		return stripBasePathFromTracebackText(super(Formatter, self).formatException(ex))
 
+	def formatTime(self, record, datefmt=None):
+		"""Custom implementation of `formatTime` which avoids `time.localtime`
+		since it causes a crash under some versions of Universal CRT ( #12160, Python issue 36792)
+		"""
+		import winKernel
+		timeAsFileTime = winKernel.time_tToFileTime(record.created)
+		timeAsSystemTime = winKernel.SYSTEMTIME()
+		winKernel.FileTimeToSystemTime(timeAsFileTime, timeAsSystemTime)
+		timeAsLocalTime = winKernel.SYSTEMTIME()
+		winKernel.SystemTimeToTzSpecificLocalTime(None, timeAsSystemTime, timeAsLocalTime)
+		res = f"{timeAsLocalTime.wHour:02d}:{timeAsLocalTime.wMinute:02d}:{timeAsLocalTime.wSecond:02d}"
+		return self.default_msec_format % (res, record.msecs)
+
+
 class StreamRedirector(object):
 	"""Redirects an output stream to a logger.
 	"""

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -288,7 +288,7 @@ class Formatter(logging.Formatter):
 	def formatException(self, ex):
 		return stripBasePathFromTracebackText(super(Formatter, self).formatException(ex))
 
-	def formatTime(self, record, datefmt=None):
+	def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
 		"""Custom implementation of `formatTime` which avoids `time.localtime`
 		since it causes a crash under some versions of Universal CRT ( #12160, Python issue 36792)
 		"""

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -9,9 +9,8 @@
 import contextlib
 import ctypes
 import ctypes.wintypes
-from ctypes import byref, Structure, WinError
-from ctypes import *
-from ctypes.wintypes import *
+from ctypes import byref, c_byte, POINTER, sizeof, Structure, windll, WinError
+from ctypes.wintypes import BOOL, DWORD, HANDLE, LARGE_INTEGER, LPWSTR, LPVOID, WORD
 
 kernel32=ctypes.windll.kernel32
 advapi32 = windll.advapi32
@@ -186,7 +185,7 @@ def FileTimeToSystemTime(lpFileTime: FILETIME, lpSystemTime: SYSTEMTIME) -> None
 
 
 def SystemTimeToTzSpecificLocalTime(lpTimeZoneInformation, lpUniversalTime, lpLocalTime):
-	if lpTimeZoneInformation  is not None:
+	if lpTimeZoneInformation is not None:
 		lpTimeZoneInformation = byref(lpTimeZoneInformation)
 	if kernel32.SystemTimeToTzSpecificLocalTime(
 		lpTimeZoneInformation, byref(lpUniversalTime), byref(lpLocalTime)
@@ -216,8 +215,6 @@ def GetTimeFormatEx(Locale,dwFlags,date,lpFormat):
 	kernel32.GetTimeFormatEx(Locale,dwFlags,lpTime,lpFormat, buf, bufferLength)
 	return buf.value
 
-def openProcess(*args):
-	return kernel32.OpenProcess(*args)
 
 def virtualAllocEx(*args):
 	res = kernel32.VirtualAllocEx(*args)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -41,6 +41,7 @@ What's New in NVDA
    - known issue for right-to-left languages: the right border of groupings clips with labels/controls. (#12181)
 - The python locale is set to match the language selected in preferences consistently, and will occur when using the default language. (#12214)
 - - TextInfo.getTextInChunks no longer freezes when called on Rich Edit controls such as the NVDA log viewer. (#11613)
+- It is once again possible to use NVDA in a languages containing underscores in the locale name such as de_CH on Windows 10 1803 and 1809. (#12250)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #12160
Related to https://bugs.python.org/issue36792



### Summary of the issue:

As described in [This Python bug report](https://bugs.python.org/issue36792) (many thanks to @kvark128  for his research) under some versions of Universal CRT Python can crash when formatting time with `time.localtime` and locale is set to a language which contains underscore it its name.
Unfortunately Python developers decided  not to workaround this bug on their side since this crash is fixed in more recent version of the Universal CRT. Sadly the version containing this bug is present in Windows 10 1809 which is a base version for Server 2019 and Windows 10 LTSC 2019 both are supported until 2028 and we should support them too if possible. For users this manifests in a crash of NVDA since default log formatter attempts to format current time with `time.localtime` when writing anything to the log.

### Description of how this pull request fixes the issue:
1. WX Python no longer tries to set Python locale to an nonexistent one when creating an instance of `wx.app`. While this is not necessary any longer when `time.localtime` is not used we are managing locale ourselves in `languageHandler` so it makes sense to do it just in one place.
2. When formatting time of the log entries `time.localtime` is not used any more. I've provided an alternative implementation which relies on win32 API calls to convert time_t to a string representation.

While at it I've also removed some unused imports from `logHandler` and cleaned up star imports from `winKernel`.
### Testing strategy:
On both Windows 7 and Windows 10 1809 in Polish started NVDA with the following language settings:
1. Language set to User default.
2. Language set to the locale without underscore in the name e.g. English, Polish.
3. Language containing underscore in the name e.g. de_CH.


Confirmed there are no crashes whereas under Windows 10 1809 it was impossible to start NVDA both when set to user default and when set to de_CH before fix from this pr.

In theory it should be possible to create an unit test for this (AppVeyor machines are on Server 2019 after all) annoyingly I am unable to reproduce this crash from the Python interpreter. I'll keep  trying but this should not block this PR.



### Known issues with pull request:
- It might be more performant to use the new `formatTime` method only for Windows versions on which  UCRT has this bug, but since I am not  sure in which version of Windows 10 it started nor on which it has been fixed it seemed safer to always use this new approach.
- While I've made sure that `time.localtime` is not used anywhere in our code it is theoretically possible it is still used in one of our  dependencies or somewhere in standard Python library. This is very hard to track down so unless someone reports a crash I see no way to detect such cases.

### Change log entry:
Bug fixes:

It is once again possible to use NVDA in a languages containing underscores in the locale name such as de_CH on Windows 10 1803 and 1809.



Please note that this crash occurred also in 2020.4 for these languages hence the change log entry.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
