### PR TITLE
Recognize Windows 10 build 19043 as Version 21H1 (May 2021 Update)

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -24,7 +24,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.18990.0" 
-			MaxVersionTested="10.0.18995.0" 
+			MaxVersionTested="10.0.19043.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -96,6 +96,7 @@ WIN10_1903 = WinVersion(major=10, minor=0, build=18362)
 WIN10_1909 = WinVersion(major=10, minor=0, build=18363)
 WIN10_2004 = WinVersion(major=10, minor=0, build=19041)
 WIN10_20H2 = WinVersion(major=10, minor=0, build=19042)
+WIN10_21H1 = WinVersion(major=10, minor=0, build=19043)
 
 
 def getWinVer():
@@ -135,6 +136,7 @@ WIN10_RELEASE_NAME_TO_BUILDS = {
 	"1909": 18363,
 	"2004": 19041,
 	"20H2": 19042,
+	"21H1": 19043,
 }
 
 


### PR DESCRIPTION
Hi,

I guess ti has become sort of a tradition to do this semi-annually:

### Link to issue number:
None

### Summary of the issue:
Windows 10 build 19043 is Version 21H1 as noted in the following Windows Insider Program blog post:
https://blogs.windows.com/windows-insider/2021/03/25/releasing-windows-10-build-19043-906-21h1-to-beta-channel/

### Description of how this pull request fixes the issue:
Recognize build 19043 as Version 21H1. This is done in winVersion module and AppX XML.

### Testing strategy:
Manual testing - running NVDA from source on a computer running build 19043 to make sure the system is recognized as running 21H1.

### Known issues with pull request:
None

### Change log entry:
None

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.

## Additional context:
For @MichaelDCurran, I think it is safe to update AppX XML, as 19041/19042/19043 would support UIA Access privilege for converted desktop app such as NVDA.

Thanks.