### PR TITLE
Fix reporting of superscript / subscript in Wordpad

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -507,6 +507,9 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			formatField["italic"]=bool(fontObj.italic)
 			formatField["underline"]=bool(fontObj.underline)
 			formatField["strikethrough"]=bool(fontObj.StrikeThrough)
+		if formatConfig["reportSuperscriptsAndSubscripts"]:
+			if not fontObj:
+				fontObj = textRange.font
 			if fontObj.superscript:
 				formatField["text-position"]="super"
 			elif fontObj.subscript:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,6 +42,7 @@ What's New in NVDA
 - The python locale is set to match the language selected in preferences consistently, and will occur when using the default language. (#12214)
 - - TextInfo.getTextInChunks no longer freezes when called on Rich Edit controls such as the NVDA log viewer. (#11613)
 - It is once again possible to use NVDA in a languages containing underscores in the locale name such as de_CH on Windows 10 1803 and 1809. (#12250)
+- In WordPad, configuration of superscript/subscript reporting works as expected. (#12262)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:

In IAccessible edit field such as WordPad, enabling "Superscript and subscript" reporting in Document formatting settings was not enough to have them reported. It was also required to have Font attributes reporting enabled.
This is due to a forgotten part of the code when reporting of superscript/subscript has been separated from reporting of the other attributes in #10919.

### Description of how this pull request fixes the issue:

Added the missing 'if' statement.

### Testing strategy:

Manual tests:
* In Document formatting options, enabled superscript and subscript reporting and disabled attributes reporting. Checked in Wordpad that superscript and subscript text is reported:
  * Moving character by character
  * Making the whole line read (with Report formatting changes after the cursor option enabled)
* In Document formatting options, disabled superscript and subscript reporting and enabled attributes reporting. Checked in Wordpad that bold and underline is reported:
  * Moving character by character
  * Making the whole line read (with Report formatting changes after the cursor option enabled)

No specific unit test or system test.

### Known issues with pull request:
None

### Change log entry:
Section: Bug fixes
`In WordPad, configuration of superscript/subscript reporting works as expected. (#12262)`

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
