### PR TITLE
Add missing formatting information in MS Excel cells (strikethrough, superscript/subscript)

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -994,6 +994,12 @@ class ExcelCellTextInfo(NVDAObjectTextInfo):
 			formatField['italic']=fontObj.italic
 			underline=fontObj.underline
 			formatField['underline']=False if underline is None or underline==xlUnderlineStyleNone else True
+			formatField['strikethrough'] = fontObj.strikethrough
+		if formatConfig['reportSuperscriptsAndSubscripts']:
+			if fontObj.superscript:
+				formatField['text-position'] = 'super'
+			elif fontObj.subscript:
+				formatField['text-position'] = 'sub'
 		if formatConfig['reportStyle']:
 			try:
 				styleName=self.obj.excelCellObject.style.nameLocal
@@ -1471,7 +1477,7 @@ class ExcelCell(ExcelBase):
 				formatField.update(field.field)
 		if not hasattr(self.parent,'_formatFieldSpeechCache'):
 			self.parent._formatFieldSpeechCache = textInfos.Field()
-		if formatField:
+		if formatField or self.parent._formatFieldSpeechCache:
 			sequence = speech.getFormatFieldSpeech(
 				formatField,
 				attrsCache=self.parent._formatFieldSpeechCache,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ What's New in NVDA
 - It is once again possible to use NVDA in a languages containing underscores in the locale name such as de_CH on Windows 10 1803 and 1809. (#12250)
 - In WordPad, configuration of superscript/subscript reporting works as expected. (#12262)
 - NVDA no longer fails to announce the newly focused content on a web page if the old focus disappears and is replaced by the new focus in the same position. (#12147)
+- Strikethrough, superscript and subscript formatting for entire Excel cells are now reported if the corresponding option is enabled. (#12264)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Some formatting information is not reported when navigating from one cell to another in Excel, although the corresponding category is checked in Document formatting settings.
* strikethrough is not reported even if font attributes is checked
* superscript or subscript is not reported even if the corresponding option is checked

### Description of how this pull request fixes the issue:

* Added the missing code to handle strikethrough, superscript and subscript in `_getFormatFieldAndOffsets`
* In `reportFocus`, speak the format field sequence not only if the current cell has format field info to speak but also if the previous cell has it. This is done to report 'baseline' when transitioning from a cell with superscript to a cell without formatting since 'baseline', being the default, is not stored in the cell's format fields.

### Note

This PR allows to have strikethrough and superscript/subscript reported if the whole cell is formatted with these attributes.
If having a whole cell formatted as superscript or subscript is probably not a real-life use case, strikethrough may be quite common.

### Testing strategy:

Manual test:
1. Created an Excel sheet with some cells with various formatting: strikethrough, underline, bold, superscript, subscript. No cell has mixed formatting, i.e. formatting applied to only some characters of the text of a cell.
2. Set NVDA to report font attributes and not superscript/subscript.
3. Moved the active cell with arrows to perform each possible transition on the sheet.
4. Re-test step 3 with the following options:
   * font attributes OFF / superscript and subscript ON
   * font attributes OFF / superscript and subscript OFF
   * font attributes ON / superscript and subscript ON

No specific unit or system test for this PR.


### Known issues with pull request:

This PR does not address the following points that are still issues with NVDA:
* Reporting mixed formatting in the same cell when moving cell by cell, e.g. a cell having text with only one character in exponent and not the rest (#6478 and partly #7277).
* Reporting any formatting when moving in the text inside a cell (#6479).
* Report strikethrough, superscript and subscript at cell level when UIA for Excel advanced option is enabled. Indeed, in this case, the other formatting info (bold, italic, etc.) are not reported either. 

### Change log entry:

Section: Bug fixes
`Strikethrough, superscript and subscript are now reported when navigating through Excel cells if the corresponding option is enabled (#12264)`

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
