### PR TITLE
Allow Outlook attachment list to read again

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1217,6 +1217,10 @@ class UIA(Window):
 		if not p:
 			return None
 		e = p.currentSelectionContainer
+		if not e:
+			# Some implementations of SelectionItemPattern, such as the Outlook attachment list
+			# give back a NULL selectionContainer
+			return None
 		e = e.buildUpdatedCache(UIAHandler.handler.baseCacheRequest)
 		obj = UIA(UIAElement=e)
 		if obj.UIASelectionPattern2:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Fixes #12265

### Summary of the issue:
After merging of pr #12210 , The attachment list in Outlook no longer read with NVDA, and an error was produced in the log.
It seems that Outlook's attachment list, gives back a NULL pointer for the SelectionContainer property on its UIA SelectionItemPattern.

### Description of how this pull request fixes the issue:
Check to see if CurrentSelectionContainer is NULL and return None as there is nothing further we can do with that pattern.

### Testing strategy:
* Ran steps to reproduce listed in #12265 and verified that the Outlook attachment list reads again.
* Ensured that selections are still read in Microsoft Excel with UIA enabled, related to pr #12210.

### Known issues with pull request:
None.

### Change log entry:
None needed.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
