### PR TITLE
Bug issue template: Rewrote COM Reg. Fix Tool question, to make it more action-oriented

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,4 +35,4 @@ Please also note that the NVDA project has a Citizen and Contributor Code of Con
 
 #### If add-ons are disabled, is your problem still occurring?
 
-#### Did you try to run the COM registry fixing tool in NVDA menu / tools?
+#### Does the issue still occur after you run the COM Registration Fixing Tool in NVDA's tools menu??


### PR DESCRIPTION

### Link to issue number:

Closes #12275 

### Summary of the issue:

The current wording of the bug report issue template, makes the question about running the COM Registration Fixing Tool, a passive question that just gathers information.

### Description of how this pull request fixes the issue:

Make the question more likely to provoke the user to try running the tool before submitting the issue, by phrasing it more like the other non-optional questions (such as the one which asks if the issue still happens when you disable add-ons).

Also, this regularizes the name of the tool in the question, to be consistent with the NVDA Tools menu name for the tool.

### Testing strategy:

N/A, no code changes.

### Known issues with pull request:

None

### Change log entry:

None needed.
