### PR TITLE
NVDA announces "Article" before every article.

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1709,6 +1709,7 @@ def getControlFieldSpeech(  # noqa: C901
 			controlTypes.ROLE_LIST,
 			controlTypes.ROLE_LANDMARK,
 			controlTypes.ROLE_REGION,
+			controlTypes.ROLE_ARTICLE,
 		)
 		and not tableID
 		and controlTypes.STATE_EDITABLE not in states

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1703,13 +1703,13 @@ def getControlFieldSpeech(  # noqa: C901
 		reason == OutputReason.FOCUS
 		and presCat != attrs.PRESCAT_CONTAINER
 		and role not in (
+			controlTypes.ROLE_ARTICLE,
 			controlTypes.ROLE_EDITABLETEXT,
 			controlTypes.ROLE_COMBOBOX,
 			controlTypes.ROLE_TREEVIEW,
 			controlTypes.ROLE_LIST,
 			controlTypes.ROLE_LANDMARK,
 			controlTypes.ROLE_REGION,
-			controlTypes.ROLE_ARTICLE,
 		)
 		and not tableID
 		and controlTypes.STATE_EDITABLE not in states


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

#11103

### Summary of the issue:

When using quick keys to navigate articles on a web page, the article text/label should be announced first and then "article" should be announced after it in order to streamline the browsing process.

### Description of how this pull request fixes the issue:

Article is added to the boolean which decided whether or the content should be spoken first.

### Testing strategy:

Manually tried it out on web pages.

### Known issues with pull request:

None.

### Change log entry:

Section:  Changes

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [ ] Change log entry.
- [x] Context sensitive help for GUI changes.
