### PR TITLE
nvda now disables the java access bridge on uninstallation, fix for #12159

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -46,9 +46,14 @@ import globalVars
 #: to enable JAB.
 A11Y_PROPS_PATH = os.path.expanduser(r"~\.accessibility.properties")
 #: The content of ".accessibility.properties" when JAB is enabled.
-A11Y_PROPS_CONTENT = (
+A11Y_PROPS_CONTENT_ENABLED = (
 	"assistive_technologies=com.sun.java.accessibility.AccessBridge\n"
 	"screen_magnifier_present=true\n"
+)
+#: The content of ".accessibility.properties" when JAB is disabled.
+A11Y_PROPS_CONTENT_DISABLED = (
+	"#assistive_technologies=com.sun.java.accessibility.AccessBridge\n"
+	"#screen_magnifier_present=true\n"
 )
 
 #Some utility functions to help with function defines
@@ -773,13 +778,24 @@ def isBridgeEnabled():
 
 
 def enableBridge():
+	"""enables the java access bridge by modifing the .accessibility.properties file in the users path"""
 	try:
 		props = open(A11Y_PROPS_PATH, "wt")
-		props.write(A11Y_PROPS_CONTENT)
+		props.write(A11Y_PROPS_CONTENT_ENABLED)
 		log.info("Enabled Java Access Bridge for user")
 	except OSError:
 		log.warning("Couldn't enable Java Access Bridge for user", exc_info=True)
 
+
+def disableBridge():
+	"""disables the java access bridge by modifing the .accessibility.properties file in the users path
+	This is needed in case of uninstallation, see issue#12159"""
+	try:
+		props = open(A11Y_PROPS_PATH, "wt")
+		props.write(A11Y_PROPS_CONTENT_DISABLED)
+		log.info("disabled Java Access Bridge for user")
+	except OSError:
+		log.warning("Couldn't disable Java Access Bridge for user", exc_info=True)
 
 def initialize():
 	global bridgeDll, isRunning

--- a/source/installer.py
+++ b/source/installer.py
@@ -443,6 +443,10 @@ def unregisterInstallation(keepDesktopShortcut=False):
 	except WindowsError:
 		pass
 	unregisterAddonFileAssociation()
+	# disable java access bridge
+	import JABHandler
+	if (JABHandler.isBridgeEnabled()):
+		JABHandler.disableBridge()
 
 def registerAddonFileAssociation(slaveExe):
 	try:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
#12159 
### Summary of the issue:
NVDA has the feature to automatecly enable the java access bridge if it is not avaiable. Also NVDA delivers the DLL itselfs, the problem is that if NVDA is removed, the enabled settings of Java searches for the DLL of NVDA and don't find it.
This caused an exception in GUI Frameworks, if no other access bridge is installed but the .accessibility.properties is still enabled from NVDA.

### Description of how this pull request fixes the issue:
I simply write a disableBridge function in JABHandler.py, and define the contents for the file  right under the other variable, that have now the subfix "ENABLED".
In "installer.py" I called the "disableBridge" function, after checking whether the the brigde is enabled.

### Testing strategy:
I called the function "disableBridge" manualy on my system and have confirmed that the access bridge was  disabled.
### Known issues with pull request:
N/A
### Change log entry:
Section: Changes
`If NVDA is removed from the system, it now disables the Java Access Bridge to prevent errors of no existing DLL-File (#12159 )`


### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
