### PR TITLE
Ensure AppVeyor message is added for translation comment errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,9 +98,13 @@ build_script:
  - scons source %sconsArgs%
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # We don't need launcher to run checkPot, so run the checkPot before launcher.
- - scons checkPot %sconsArgs%
- - if ERRORLEVEL 1 echo "scons checkpot failed"
- - if ERRORLEVEL 1 exit %ERRORLEVEL%
+ -ps: |
+     scons checkPot $sconsArgs
+     if($LastExitCode -ne 0) {
+      $errorCode=$LastExitCode
+      Add-AppveyorMessage "Translation comment error"
+     }
+     if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
  # The pot gets built by tests, but we don't actually need it as a build artifact.
  - 'echo scons output targets: %sconsOutTargets%'
  - scons %sconsOutTargets% %sconsArgs%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,7 +98,7 @@ build_script:
  - scons source %sconsArgs%
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # We don't need launcher to run checkPot, so run the checkPot before launcher.
- -ps: |
+ - ps: |
      scons checkPot $sconsArgs
      if($LastExitCode -ne 0) {
       $errorCode=$LastExitCode

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,7 +99,7 @@ build_script:
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # We don't need launcher to run checkPot, so run the checkPot before launcher.
  - ps: |
-     scons checkPot $sconsArgs
+     cmd.exe /c "scons checkPot $sconsArgs"
      if($LastExitCode -ne 0) {
       $errorCode=$LastExitCode
       Add-AppveyorMessage "Translation comment error"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,6 +99,10 @@ build_script:
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # We don't need launcher to run checkPot, so run the checkPot before launcher.
  - scons checkPot %sconsArgs%
+ - ps: |
+     if ($LastExitCode -ne 0) {
+      Add-AppveyorMessage "Translator comments are missing or unexpectedly included"
+     }
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # The pot gets built by tests, but we don't actually need it as a build artifact.
  - 'echo scons output targets: %sconsOutTargets%'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,10 +99,7 @@ build_script:
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # We don't need launcher to run checkPot, so run the checkPot before launcher.
  - scons checkPot %sconsArgs%
- - ps: |
-     if ($LastExitCode -ne 0) {
-      Add-AppveyorMessage "Translator comments are missing or unexpectedly included"
-     }
+ - if ERRORLEVEL 1 echo "scons checkpot failed"
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # The pot gets built by tests, but we don't actually need it as a build artifact.
  - 'echo scons output targets: %sconsOutTargets%'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,7 +102,7 @@ build_script:
      cmd.exe /c "scons checkPot $sconsArgs"
      if($LastExitCode -ne 0) {
       $errorCode=$LastExitCode
-      Add-AppveyorMessage "Translation comment error"
+      Add-AppveyorMessage "Translation comments missing or unexpectedly included."
      }
      if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
  # The pot gets built by tests, but we don't actually need it as a build artifact.

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2159,6 +2159,7 @@ def getFormatFieldSpeech(  # noqa: C901
 		underline=attrs.get("underline")
 		oldUnderline=attrsCache.get("underline") if attrsCache is not None else None
 		if (underline or oldUnderline is not None) and underline!=oldUnderline:
+			# Translators: Reported when text is underlined.
 			text=(_("underlined") if underline
 				# Translators: Reported when text is not underlined.
 				else _("not underlined"))

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2159,7 +2159,6 @@ def getFormatFieldSpeech(  # noqa: C901
 		underline=attrs.get("underline")
 		oldUnderline=attrsCache.get("underline") if attrsCache is not None else None
 		if (underline or oldUnderline is not None) and underline!=oldUnderline:
-			# Translators: Reported when text is underlined.
 			text=(_("underlined") if underline
 				# Translators: Reported when text is not underlined.
 				else _("not underlined"))


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

If the translation comment checker `checkPot` fails on AppVeyor, no relevant message is posted to the PR comments

### Description of how this pull request fixes the issue:

Post a relevant message when a build fails due to translation comments missing or unexpectedly included

### Testing strategy:

Compare builds with and without expected failures

* Expected fail without message:  https://ci.appveyor.com/project/NVAccess/nvda/builds/38602999
* Expected fail with message: https://ci.appveyor.com/project/NVAccess/nvda/builds/38604603
* Expected pass: https://ci.appveyor.com/project/NVAccess/nvda/builds/38604840

### Known issues with pull request:

None

### Change log entry:

None

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
