### PR TITLE
Fixed  typo in PR #12276

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,4 +35,4 @@ Please also note that the NVDA project has a Citizen and Contributor Code of Con
 
 #### If add-ons are disabled, is your problem still occurring?
 
-#### Does the issue still occur after you run the COM Registration Fixing Tool in NVDA's tools menu??
+#### Does the issue still occur after you run the COM Registration Fixing Tool in NVDA's tools menu?


### PR DESCRIPTION

### Link to issue number:

None. Fixes a typeo introduced by PR #12276

### Summary of the issue:

In #12276, I revised the CRFT question in the bug issue template. In so doing, I managed to include two question marks.

### Description of how this pull request fixes the issue:

This removes one of the question marks.

### Testing strategy:

N/A

### Known issues with pull request:

None

### Change log entry:

None
