### PR TITLE
Improve logging of test for panel destruction

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -37,7 +37,7 @@ from logHandler import log
 import UIAUtils
 from comInterfaces import UIAutomationClient as UIA
 # F403: unable to detect undefined names
-from comInterfaces .UIAutomationClient import *  # noqa:  F403
+from comInterfaces.UIAutomationClient import *  # noqa:  F403
 import textInfos
 from typing import Dict
 from queue import Queue

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -5,6 +5,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+import typing
 import time
 import os
 import sys
@@ -24,6 +25,7 @@ import speech
 import queueHandler
 import core
 from . import guiHelper
+from . import settingsDialogs
 from .settingsDialogs import *
 from .inputGestures import InputGesturesDialog
 import speechDictHandler
@@ -587,10 +589,11 @@ def terminate():
 
 	# prevent race condition with object deletion
 	# prevent deletion of the object while we work on it.
-	nonWeak: typing.Dict[SettingsDialog, SettingsDialog.DialogState] = dict(gui.SettingsDialog._instances)
+	_SettingsDialog = settingsDialogs.SettingsDialog
+	nonWeak: typing.Dict[_SettingsDialog, _SettingsDialog] = dict(_SettingsDialog._instances)
 
 	for instance, state in nonWeak.items():
-		if state is gui.SettingsDialog.DialogState.DESTROYED:
+		if state is _SettingsDialog.DialogState.DESTROYED:
 			log.error(
 				"Destroyed but not deleted instance of gui.SettingsDialog exists"
 				f": {instance.title} - {instance.__class__.__qualname__} - {instance}"

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -585,10 +585,15 @@ def terminate():
 	import brailleViewer
 	brailleViewer.destroyBrailleViewer()
 
-	for instance, state in gui.SettingsDialog._instances.items():
+	# prevent race condition with object deletion
+	# prevent deletion of the object while we work on it.
+	nonWeak: typing.Dict[SettingsDialog, SettingsDialog.DialogState] = dict(gui.SettingsDialog._instances)
+
+	for instance, state in nonWeak.items():
 		if state is gui.SettingsDialog.DialogState.DESTROYED:
 			log.error(
-				"Destroyed but not deleted instance of settings dialog exists: {!r}".format(instance)
+				"Destroyed but not deleted instance of gui.SettingsDialog exists"
+				f": {instance.title} - {instance.__class__.__qualname__} - {instance}"
 			)
 		else:
 			log.debug("Exiting NVDA with an open settings dialog: {!r}".format(instance))

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -586,7 +586,7 @@ def terminate():
 	brailleViewer.destroyBrailleViewer()
 
 	for instance, state in gui.SettingsDialog._instances.items():
-		if state is gui.SettingsDialog._DIALOG_DESTROYED_STATE:
+		if state is gui.SettingsDialog.DialogState.DESTROYED:
 			log.error(
 				"Destroyed but not deleted instance of settings dialog exists: {!r}".format(instance)
 			)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -87,7 +87,7 @@ class SettingsDialog(
 		DESTROYED = 1
 
 	# holds instances of SettingsDialogs as keys, and state as the value
-	_instances=weakref.WeakKeyDictionary()
+	_instances = weakref.WeakKeyDictionary()
 	title = ""
 	helpId = "NVDASettings"
 	shouldSuspendConfigProfileTriggers = True

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -9,7 +9,9 @@ import logging
 from abc import ABCMeta, abstractmethod
 import copy
 import os
+from enum import IntEnum
 
+import typing
 import wx
 from vision.providerBase import VisionEnhancementProviderSettings
 from wx.lib import scrolledpanel
@@ -80,8 +82,10 @@ class SettingsDialog(
 
 	class MultiInstanceError(RuntimeError): pass
 
-	_DIALOG_CREATED_STATE = 0
-	_DIALOG_DESTROYED_STATE = 1
+	class DialogState(IntEnum):
+		CREATED = 0
+		DESTROYED = 1
+
 	# holds instances of SettingsDialogs as keys, and state as the value
 	_instances=weakref.WeakKeyDictionary()
 	title = ""
@@ -102,25 +106,39 @@ class SettingsDialog(
 				"Creating new settings dialog (multiInstanceAllowed:{}). "
 				"State of _instances {!r}".format(multiInstanceAllowed, instancesState)
 			)
-		if state is cls._DIALOG_CREATED_STATE and not multiInstanceAllowed:
+		if state is cls.DialogState.CREATED and not multiInstanceAllowed:
 			raise SettingsDialog.MultiInstanceError("Only one instance of SettingsDialog can exist at a time")
-		if state is cls._DIALOG_DESTROYED_STATE and not multiInstanceAllowed:
+		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
 			# the dialog has been destroyed by wx, but the instance is still available. This indicates there is something
 			# keeping it alive.
 			log.error("Opening new settings dialog while instance still exists: {!r}".format(firstMatchingInstance))
 		obj = super(SettingsDialog, cls).__new__(cls, *args, **kwargs)
-		SettingsDialog._instances[obj] = cls._DIALOG_CREATED_STATE
+		SettingsDialog._instances[obj] = cls.DialogState.CREATED
 		return obj
 
 	def _setInstanceDestroyedState(self):
-		if log.isEnabledFor(log.DEBUG):
-			instancesState = dict(SettingsDialog._instances)
-			log.debug(
-				"Setting state to destroyed for instance: {!r}\n"
-				"Current _instances {!r}".format(self, instancesState)
-			)
-		if self in SettingsDialog._instances:
-			SettingsDialog._instances[self] = self._DIALOG_DESTROYED_STATE
+		# prevent race condition with object deletion
+		# prevent deletion of the object while we work on it.
+		nonWeak: typing.Dict[SettingsDialog, SettingsDialog.DialogState] = dict(SettingsDialog._instances)
+
+		if (
+			self in SettingsDialog._instances
+			# Because destroy handlers are use evt.skip, _setInstanceDestroyedState may be called many times
+			# prevent noisy logging.
+			and self.DialogState.DESTROYED != SettingsDialog._instances[self]
+		):
+			if log.isEnabledFor(log.DEBUG):
+				instanceStatesGen = (
+					f"{instance.title} - {state.name}"
+					for instance, state in nonWeak.items()
+				)
+				instancesList = list(instanceStatesGen)
+				log.debug(
+					f"Setting state to destroyed for instance: {self.title} - {self.__class__.__qualname__} - {self}\n"
+					f"Current _instances {instancesList}"
+				)
+			SettingsDialog._instances[self] = self.DialogState.DESTROYED
+
 
 	def __init__(
 			self, parent,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
None

### Summary of the issue:
While looking into #12220, I noticed a lot of logging noise for the tests for destruction of settings panels.

A little investigation showed that the same settings dialogs was being marked as destroyed previously because the `evt.skip()`
was not called.
Calling `skip` is not appropriate, but it is also not necessary to log that the dialog which is already marked as destoyed, will be again.


### Description of how this pull request fixes the issue:
Use an enum for destroyed state, this logs better.
Only log if the dialog is not already marked as destoyed.
Improve what is logged so that the dialog is actually identifiable.

Example log message after PR:
```
Input: kb(desktop):escape
DEBUG - gui.settingsDialogs.SettingsDialog._setInstanceDestroyedState (18:46:00.444) - MainThread (15748):
Setting state to destroyed for instance: Input Gestures - InputGesturesDialog - <gui.inputGestures.InputGesturesDialog object at 0x1AB17DA8>
Current _instances ['NVDA Settings - CREATED', 'Input Gestures - CREATED']
IO - speech.speak (18:46:00.517) - MainThread (15748):
Speaking [LangChangeCommand ('en'), 'NVDA Settings: General (normal configuration)', 'dialog', CancellableSpeech (still valid)]
IO - speech.speak (18:46:00.519) - MainThread (15748):
Speaking [LangChangeCommand ('en'), 'Categories:', 'list', CancellableSpeech (still valid)]
IO - speech.speak (18:46:00.521) - MainThread (15748):
Speaking [LangChangeCommand ('en'), 'General', '1 of 13', CancellableSpeech (still valid)]
IO - inputCore.InputManager.executeGesture (18:46:00.802) - winInputHook (12364):
Input: kb(desktop):escape
DEBUG - gui.settingsDialogs.SettingsDialog._setInstanceDestroyedState (18:46:00.804) - MainThread (15748):
Setting state to destroyed for instance: NVDA Settings - NVDASettingsDialog - <gui.settingsDialogs.NVDASettingsDialog object at 0x1A8F8100>
Current _instances ['NVDA Settings - CREATED']
```

### Testing strategy:
Ran locally with the NVDA settings dialog, checked log.

### Known issues with pull request:
None

### Change log entry:
None, these were internal constants, meant for debugging purposes only.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
