### PR TITLE
Work around wxWidgets assertion

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -983,9 +983,17 @@ class SpeechSettingsPanel(SettingsPanel):
 		super(SpeechSettingsPanel,self).onPanelDeactivated()
 
 	def onDiscard(self):
+		# Work around wxAssertion error #12220
+		# Manually destroying the ExpandoTextCtrl when the settings dialog is
+		# exited prevents the wxAssertion.
+		self.synthNameCtrl.Destroy()
 		self.voicePanel.onDiscard()
 
 	def onSave(self):
+		# Work around wxAssertion error #12220
+		# Manually destroying the ExpandoTextCtrl when the settings dialog is
+		# exited prevents the wxAssertion.
+		self.synthNameCtrl.Destroy()
 		self.voicePanel.onSave()
 
 class SynthesizerSelectionDialog(SettingsDialog):
@@ -3194,9 +3202,17 @@ class BrailleSettingsPanel(SettingsPanel):
 		super(BrailleSettingsPanel,self).onPanelDeactivated()
 
 	def onDiscard(self):
+		# Work around wxAssertion error #12220
+		# Manually destroying the ExpandoTextCtrl when the settings dialog is
+		# exited prevents the wxAssertion.
+		self.displayNameCtrl.Destroy()
 		self.brailleSubPanel.onDiscard()
 
 	def onSave(self):
+		# Work around wxAssertion error #12220
+		# Manually destroying the ExpandoTextCtrl when the settings dialog is
+		# exited prevents the wxAssertion.
+		self.displayNameCtrl.Destroy()
 		self.brailleSubPanel.onSave()
 
 


### PR DESCRIPTION
### Link to issue number:
#12220

### Summary of the issue:
There is a wxAssertion error when closing braille or speech settings panels.

```
ERROR - unhandled exception (09:33:35.263) - MainThread (7112):
wx._core.wxAssertionError: C++ assertion ""GetWindow() != 0"" failed at ..\..\src\common\wincmn.cpp(3919) in wxWindowAccessible::GetDescription(): 

The above exception was the direct cause of the following exception:
SystemError: <class 'wx._core.WindowDestroyEvent'> returned a result with an error set
```

There is a lot more information about the investigation on the issue.

### Description of how this pull request fixes the issue:
This PR provides a workaround, the true cause of this assertion has not yet been determined.
However in the meantime this PR will prevent the log error, and any aditional instability in WX that may occur due to ending up
in this situation.

### Testing strategy:
Exited both the speech and the braille settings panels via pressing enter, esc, clicking on ok, and clicking on cancel.

### Known issues with pull request:
None

### Change log entry:
None, this issue has not been in a release yet.

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
