### PR TITLE
prevent Chrome losing focus during systests

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -588,11 +588,12 @@ def main():
 	# Queue the firing of the postNVDAStartup notification.
 	# This is queued so that it will run from within the core loop,
 	# and initial focus has been reported.
-	def _postNvdaStartupLogMessage():
-		log.debug("postNvdaStartup event fired")
+	def _doPostNvdaStartupAction():
+		log.debug("Notify of postNvdaStartup action")
+		postNvdaStartup.notify()
 
-	postNvdaStartup.register(_postNvdaStartupLogMessage)
-	queueHandler.queueFunction(queueHandler.eventQueue, postNvdaStartup.notify)
+	queueHandler.queueFunction(queueHandler.eventQueue, _doPostNvdaStartupAction)
+
 
 	log.debug("entering wx application main loop")
 	app.MainLoop()

--- a/source/core.py
+++ b/source/core.py
@@ -584,9 +584,14 @@ def main():
 		log.debug("initializing updateCheck")
 		updateCheck.initialize()
 	log.info("NVDA initialized")
+
 	# Queue the firing of the postNVDAStartup notification.
 	# This is queued so that it will run from within the core loop,
 	# and initial focus has been reported.
+	def _postNvdaStartupLogMessage():
+		log.debug("postNvdaStartup event fired")
+
+	postNvdaStartup.register(_postNvdaStartupLogMessage)
 	queueHandler.queueFunction(queueHandler.eventQueue, postNvdaStartup.notify)
 
 	log.debug("entering wx application main loop")

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -221,7 +221,6 @@ class NVDASpyLib:
 				return True
 		return False
 
-
 	def wait_for_speech_to_finish(
 			self,
 			maxWaitSeconds=5.0,

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -214,8 +214,9 @@ class NVDASpyLib:
 				"process_name": "Docker Desktop.exe"
 			},
 		]
+		last_speech = self.get_last_speech()
 		for popup in KNOWN_POPUPS:
-			if self.get_last_speech() == popup["speech"]:
+			if last_speech == popup["speech"]:
 				log.debug(f"{popup['process_name']} stole focus, killing the process")
 				os.system(f'taskkill /im "{popup["process_name"]}"')
 				return True

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -159,9 +159,7 @@ class NVDASpyLib:
 			giveUpAfterSeconds=self._minTimeout(10),
 			errorMessage="Unable to connect to nvdaSpy",
 		)
-		with self._speechLock:
-			self.reset_all_speech_index()
-			self.wait_for_speech_to_finish()
+		self.reset_all_speech_index()
 
 	def get_last_speech(self) -> str:
 		return self._getSpeechAtIndex(-1)
@@ -198,29 +196,12 @@ class NVDASpyLib:
 			errorMessage=None
 		)
 		if not success:
-			if self._popup_stole_focus():
-				return self.wait_for_specific_speech(speech, afterIndex, maxWaitSeconds)
 			self.dump_speech_to_log()
 			raise AssertionError(
 				"Specific speech did not occur before timeout: {}\n"
 				"See NVDA log for dump of all speech.".format(speech)
 			)
 		return speechIndex
-
-	def _popup_stole_focus(self):
-		KNOWN_POPUPS = [
-			{
-				"speech": "Your feedback is important to us",
-				"process_name": "Docker Desktop.exe"
-			},
-		]
-		last_speech = self.get_last_speech()
-		for popup in KNOWN_POPUPS:
-			if last_speech == popup["speech"]:
-				log.debug(f"{popup['process_name']} stole focus, killing the process")
-				os.system(f'taskkill /im "{popup["process_name"]}"')
-				return True
-		return False
 
 	def wait_for_speech_to_finish(
 			self,

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -12,7 +12,7 @@ Library	NvdaLib.py
 Library	chromeTests.py
 Library	ScreenCapLibrary
 
-Test Setup	start NVDA	standard-dontShowWelcomeDialog.ini
+Test Setup	default setup
 Test Teardown	default teardown
 
 *** Keywords ***
@@ -21,6 +21,10 @@ default teardown
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
 	exit chrome
 	quit NVDA
+
+default setup
+	start NVDA	standard-dontShowWelcomeDialog.ini
+	Sleep	2s
 
 *** Test Cases ***
 


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

Our system tests randomly fail due to chrome not having focus, and so NVDA does not read the expected speech. Sometimes this is due to a Docker popup asking for feedback such as [this one](https://ci.appveyor.com/project/NVAccess/nvda/builds/38691294/tests) .

### Description of how this pull request fixes the issue:

- Log when the event `postNvdaStartup` fires
- sleep for 2s before launching chrome

### Testing strategy:

Run many builds to ensure system tests don't fail.

### Known issues with pull request:

- Docker popups may still block the build
- 2s of sleep might not be long enough (we have confidence that 10s is)
- Lint checking randomly blocks builds due to a failed merge (likely due to a rare GitHub issue)

### Change log entry:

None

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
