### PR TITLE
Centre the progress dialog when downloading update

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -610,6 +610,7 @@ class UpdateDownloader(garbageHandler.TrackedObject):
 			# and waits for the user to press the Close button.
 			style=wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME | wx.PD_REMAINING_TIME | wx.PD_AUTO_HIDE,
 			parent=gui.mainFrame)
+		self._progressDialog.CentreOnScreen()
 		self._progressDialog.Raise()
 		t = threading.Thread(
 			name=f"{self.__class__.__module__}.{self.start.__qualname__}",


### PR DESCRIPTION
### Link to issue number:

Closes #12247, #12192

### Summary of the issue:

The upgrade of wxWidgets changed the behaviour of the `ProgressDialog` so it would no longer automatically center on the screen.

When updating NVDA via "Help > Check for Update > Download Update" the progress dialog of the download is not centred. 

### Description of how this pull request fixes the issue:

Call `CentreOnScreen` after creating the only direct usage of `ProgressDialog`. `IndeterminateProgressDialog` which is used elsewhere and inherits from `ProgressDialog` already calls `CentreOnScreen` in `___init___`.

### Testing strategy:

This cannot be manually tested directly until this is released as alpha, and a subsequent alpha to upgrade to has been released.

To test that the dialog centres properly, spoof `UpdateDownloader` by running the following code in the NVDA python console.

```python
import versionInfo
versionInfo.updateVersionType = "alpha"

from updateCheck import UpdateDownloader

UpdateDownloader({
	"launcherUrl": "https://ci.appveyor.com/api/buildjobs/gdfmuxc7akcop5af/artifacts/output/nvda_snapshot_alpha-22295,49a85788.exe",
	"version": "alpha-22295,49a85788",
	"launcherHash": "",
	"apiVersion": "2020.4",
	"apiCompatTo": "2020.4",
}).start()
```

### Known issues with pull request:

Other issues on #12247 may not have been addressed, the impact of other (intended/non-breaking) GUI changes with the wxPython upgrade have not been explained. 

### Change log entry:

None, fixes regression

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
