### PR TITLE
Fixes in the user guide: broken link and typo.

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1746,7 +1746,7 @@ You can configure reporting of:
 - Pages and spacing
  - Page numbers
  - Line numbers
- - Line indentation reporting [(Off, Speech, Tones, Both Speech and Tones) #lineIndentationOptions]
+ - Line indentation reporting [(Off, Speech, Tones, Both Speech and Tones) #DocumentFormattingSettingsLineIndentation]
  - Paragraph indentation (e.g. hanging indent, first line indent)
  - Line spacing (single, double, etc.)
  - Alignment
@@ -1754,7 +1754,7 @@ You can configure reporting of:
  - Tables
  - Row/column headers
  - Cell coordinates
- - Cell borders [(Off, Styles, Both Colours and Styles)
+ - Cell borders (Off, Styles, Both Colours and Styles)
 - Elements
  - Headings
  - Links


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:

* Found a broken link in the user guide: link target does not match the anchor.
* While checking links, I also found a typo (extra "[" )

### Description of how this pull request fixes the issue:
* Fixed the link to make target match the anchor. I did it this way and not the other way (make the anchor match the link target) since it is recommended not to modify the anchors names, more specifically now that context help is available.
* Removed the typo

### Testing strategy:

* Generated the English user guide and checked that the link is now working.
  * Checked with this [checkT2t.py](https://github.com/nvaccess/nvda/files/6321310/checkT2t.py.txt) script that:
  * All the internal links point to a valid anchor.
  * There are no duplicate anchor with the same id.
  * Unbalanced square brackets ("[" and "]") are only where expected, i.e. where shortcut keys involving these characters are described (4 lines).

### Known issues with pull request:
None

### Change log entry:
N/A


This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.

## Note
Integrating the `` script in NVDA code base as done for checkPot.py could be interesting to avoid future such errors. I decided not to integrate it in this PR in order to be able to merge it quickly (i.e. before beta and translations).
I plan to open a second PR for this script's integration, but I expect more discussions about it.
