### PR TITLE
Ensure settings are scrolled to using tab navigation

### DIFF
--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -11,9 +11,9 @@ from .dpiScalingHelper import DpiScalingHelperMixin
 from . import guiHelper
 import winUser
 import winsound
-import math
 
 from collections.abc import Callable
+
 
 class AutoWidthColumnListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
 	"""

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -359,7 +359,8 @@ class EnhancedInputSlider(wx.Slider):
 class TabbableScrolledPanel(scrolledpanel.ScrolledPanel):
 	"""
 	This class was created to ensure a ScrolledPanel scrolls to nested children of the panel when navigating
-	with tabs #12224
+	with tabs (#12224). A PR to wxPython implementing this fix can be tracked on
+	https://github.com/wxWidgets/Phoenix/pull/1950
 	"""
 	def GetChildRectRelativeToSelf(self, child: wx.Window) -> wx.Rect:
 		"""

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -365,7 +365,7 @@ class TabbableScrolledPanel(scrolledpanel.ScrolledPanel):
 	This class was created to ensure a ScrolledPanel scrolls to nested children of the panel when navigating
 	with tabs #12224
 	"""
-	def GetChildRectRelativeToSelf(self, child: wx.Window):
+	def GetChildRectRelativeToSelf(self, child: wx.Window) -> wx.Rect:
 		"""
 		window.GetRect returns the size of a window, and its position relative to its parent.
 		When calculating ScrollChildIntoView, the position relative to its parent is not relevant unless the
@@ -375,7 +375,7 @@ class TabbableScrolledPanel(scrolledpanel.ScrolledPanel):
 		spr = self.GetScreenPosition()
 		return wx.Rect(cr.x - spr.x, cr.y - spr.y, cr.width, cr.height)
 
-	def ScrollChildIntoView(self, child: wx.Window):
+	def ScrollChildIntoView(self, child: wx.Window) -> None:
 		"""
 		Uses the same logic as super().ScrollChildIntoView(self, child)
 		except cr = self.GetChildRectRelativeToSelf(child) instead of cr = GetRect()

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -1,18 +1,14 @@
 # -*- coding: UTF-8 -*-
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016-2018 NV Access Limited, Derek Riemer
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2016-2021 NV Access Limited, Derek Riemer
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
-from ctypes.wintypes import BOOL
-from typing import Any, Tuple, Optional
 import wx
 from wx.lib import scrolledpanel
-from comtypes import GUID
 from wx.lib.mixins import listctrl as listmix
 from .dpiScalingHelper import DpiScalingHelperMixin
 from . import guiHelper
-import oleacc
 import winUser
 import winsound
 import math

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -386,5 +386,8 @@ class TabbableScrolledPanel(scrolledpanel.ScrolledPanel):
 		"""
 		oldChildGetRectFunction = child.GetRect
 		child.GetRect = lambda: self.GetChildRectRelativeToSelf(child)
-		super().ScrollChildIntoView(child)
-		child.GetRect = oldChildGetRectFunction
+		try:
+			super().ScrollChildIntoView(child)
+		finally:
+			# ensure child.GetRect is reset properly even if super().ScrollChildIntoView throws an exception
+			child.GetRect = oldChildGetRectFunction

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -14,7 +14,6 @@ from enum import IntEnum
 import typing
 import wx
 from vision.providerBase import VisionEnhancementProviderSettings
-from wx.lib import scrolledpanel
 from wx.lib.expando import ExpandoTextCtrl
 import wx.lib.newevent
 import winUser
@@ -483,7 +482,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		# The provided column header is just a placeholder, as it is hidden due to the wx.LC_NO_HEADER style flag.
 		self.catListCtrl.InsertColumn(0,categoriesLabelText)
 
-		self.container = scrolledpanel.ScrolledPanel(
+		self.container = nvdaControls.TabbableScrolledPanel(
 			parent = self,
 			style = wx.TAB_TRAVERSAL | wx.BORDER_THEME,
 			size=containerDim


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:

Closes #12224 

### Summary of the issue:

Navigating through settings using tabbing does not visually scroll to the focused control. 

wxPython `ScrolledPanel`s calculate the position to scroll to based on the relative position to a focus elements parent, rather than the relative position to the `ScrolledPanel` itself. 

When fixing right-to-left issues in #12181, another layer of nesting was introduced for controls in our settings panels, which caused the controls to no longer get scrolled to.

### Description of how this pull request fixes the issue:

A patched version of `ScrolledPanel` is created, which calculates relative position to the `ScrolledPanel`. A PR to wxPython has been created which implements this fix: https://github.com/wxWidgets/Phoenix/pull/1950.

### Testing strategy:

Ensure tabbing through long SettingsPanels such as "Document Formatting" scrolls the panel correctly. 

### Known issues with pull request:

None

### Change log entry:

None, fixes regression

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
