### PR TITLE
(mostly) minor smoothing of Readme grammar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,22 +4,22 @@ NVDA (NonVisual Desktop Access) is a free, open source screen reader for Microso
 It is developed by NV Access in collaboration with a global community of contributors.
 To learn more about NVDA or download a copy, visit the main [NV Access](http://www.nvaccess.org/) website.
 
-Please note: the NVDA project has a [Citizen and Contributor Code of Conduct](CODE_OF_CONDUCT.md). NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project.
+Please note: the NVDA project has a [Citizen and Contributor Code of Conduct](CODE_OF_CONDUCT.md). NV Access expects that all contributors and other community members will read and abide by the rules set out in this document while participating or contributing to this project.
 
 ## Get support
-Either if you are a beginner, an advanced user, a new or a long time developer, or if you are an organization willing to know more or to contribute to NVDA, you can get support through the documentation in place as well as several communication channels dedicated for the NVDA screen reader. Here is an overview of the most important support sources.
+Whether you are a beginner, an advanced user, a new or a long time developer; or if you represent an organization wishing to know more or to contribute to NVDA: you can get support through the included documentation as well as several communication channels dedicated to the NVDA screen reader. Here is an overview of the most important support sources.
 
 ### Documentation
 * [NVDA User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html)
 * [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
 * [NVDA Add-ons Development Internals](https://github.com/nvdaaddons/DevGuide/wiki)
 * [NVDA ControllerClient manual](https://github.com/nvaccess/nvda/tree/master/extras/controllerClient)
-* Further documentation is included in the Wiki of this repository and in the [Community Wiki](https://github.com/nvaccess/nvda-community/wiki)
+* Further documentation is available in the NVDA repository's [Wiki](https://github.com/nvaccess/nvda/wiki), and in the [Community Wiki](https://github.com/nvaccess/nvda-community/wiki)
 
 ### Communication channels
 * [NVDA Users Mailing List](https://nvda.groups.io/g/nvda)
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
-* [NVDA Add-ons Mailing List](https://nvda-addons.groups.io/g/nvda-addons)
+* [NVDA Add-ons Mailing List](https://groups.io/g/nvda-addons)
 * [Instant Messaging channel for NVDA Support](https://gitter.im/nvaccess/NVDA)
 * [Other sources including groups and profiles on social media channels, language specific websites and mailing lists etc.](https://github.com/nvaccess/nvda-community/wiki/Connect)
 
@@ -110,7 +110,7 @@ The following dependencies aren't needed by most people, and are not included in
 	```git clone https://github.com/nvaccess/vscode-nvda.git .vscode```
 
 ### Python dependencies
-NVDA and its build system also depend on an extensive list of Python packages. They are all listed with their specific versions in a requirements.txt file in the root of this repository. However, the build system takes care of fetching these itself when needed. these packages will be installed into an isolated Python virtual environment within this repository, and will not affect your system-wide set of packages.
+NVDA and its build system also depend on an extensive list of Python packages. They are all listed with their specific versions in the requirements.txt file in the root of this repository. However, the build system takes care of fetching these itself when needed. These packages will be installed into an isolated Python virtual environment within this repository, and will not affect your system-wide set of packages.
  
 ## Preparing the Source Tree
 Before you can run the NVDA source code, you must prepare the source tree.
@@ -166,7 +166,7 @@ These arguments are also documented in the user guide.
 ## Building NVDA
 A binary build of NVDA can be run on a system without Python and all of NVDA's other dependencies installed (as we do for snapshots and releases).
 
-Binary archives and bundles can be created using scons from the root of the NVDA source distribution. To build any of the following, open a command prompt and change to this directory.
+Binary archives and bundles can be created using scons from the root of the NVDA source distribution. To build any of the following, open a command prompt and change to that directory.
 
 To make a non-archived binary build (equivalent to an extracted portable archive), type:
 
@@ -287,7 +287,7 @@ If you create a Pull Request, the `base` branch you use here should be the same 
 runlint origin/master
 ```
 
-To be warned about linting errors faster, you may wish to integrate Flake8 other development tools you are using.
+To be warned about linting errors faster, you may wish to integrate Flake8 with other development tools you are using.
 For more details, see `tests/lint/readme.md`
 
 ### Unit Tests


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

In reading the README recently, I noticed several areas where minor grammar corrections could be made, and one or two where the grammar in certain paragraphs could be made to flow better for a more clear understanding.

Mostly these are rather insignificant changes, and on their own wouldn't be worth a PR, but collected together I thought they might be considered.

### Description of how this pull request fixes the issue:

Thinking that improving the readability of the readme could aid new devs, I made the following changes:

* Inserted a few missing words with my best guess as to what they should have been.
* Fixed one capitalization error.
* Converted indefinite articles to definite where appropriate.
* Changed the format of a link to be like other links on the same site.
* In one case, added a missing link.
* Rephrased a couple small items, and the Get Support paragraph.

### Testing strategy:

Tested that I didn't break the readme.

### Known issues with pull request:
None

### Change log entry:
N/A