### PR TITLE
Move report formatting changes box to the correct parent

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2421,10 +2421,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
 		detectFormatAfterCursorText = _("Report formatting chan&ges after the cursor (can cause a lag)")
-		self.detectFormatAfterCursorCheckBox = wx.CheckBox(
-			elementsGroupBox,
-			label=detectFormatAfterCursorText
-		)
+		self.detectFormatAfterCursorCheckBox = wx.CheckBox(self, label=detectFormatAfterCursorText)
 		self.bindHelpEvent(
 			"DocumentFormattingDetectFormatAfterCursor",
 			self.detectFormatAfterCursorCheckBox


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

In #12181, the setting "Report formatting changes after the cursor" in "Document Formatting" was incorrectly moved to the wrong parent, the static box grouping above it, making it invisible to the user. It is currently readable using NVDA but not graphically visible to the user

This was noticed when testing #12300 

### Description of how this pull request fixes the issue:

Revert the change in #12181, making the parent the Settings Panel itself

### Testing strategy:

Ensure the new control is visible

This can be done using the tools made in https://github.com/nvaccess/nvda/pull/12308

### Known issues with pull request:

None

### Change log entry:

None, regression

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
