### PR TITLE
remove wx.CENTER_ON_SCREEN and wx.CENTRE_ON_SCREEN

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -308,9 +308,6 @@ def main():
 		# Translators: This is spoken when NVDA is starting.
 		speech.speakMessage(_("Loading NVDA. Please wait..."))
 	import wx
-	# wxPython 4 no longer has either of these constants (despite the documentation saying so), some add-ons may rely on
-	# them so we add it back into wx. https://wxpython.org/Phoenix/docs/html/wx.Window.html#wx.Window.Centre
-	wx.CENTER_ON_SCREEN = wx.CENTRE_ON_SCREEN = 0x2
 	import six
 	log.info("Using wx version %s with six version %s"%(wx.version(), six.__version__))
 	class App(wx.App):

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -257,7 +257,7 @@ class AskAllowUsageStatsDialog(
 		mainSizer.Add(sHelper.sizer, border=gui.guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
-		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)
+		self.CentreOnScreen()
 
 	def onYesButton(self, evt):
 		log.debug("Usage stats gathering has been allowed")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -111,6 +111,7 @@ What's New in NVDA
 - TextInfo start and end properties can also be set to each other.
  - E.g. ti1.start = ti2.end
  - This usage is prefered instead of ti1.SetEndPoint(ti2,"startToEnd")
+- `wx.CENTRE_ON_SCREEN` and `wx.CENTER_ON_SCREEN` are removed, use `self.CentreOnScreen()` instead. (#12309)
 
 
 = 2020.4 =


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

We included code to add backwards compatibility for addons for the following deprecated wxPython constants `wx.CENTER_ON_SCREEN = wx.CENTRE_ON_SCREEN` when used with `Dialog.Center()`

### Description of how this pull request fixes the issue:

Remove the deprecated code, and it's only usage in `AskAllowUsageStatsDialog`, replace with `self.CentreOnScreen()`

### Testing strategy:

Search code for usages of `CENTRE_ON_SCREEN` and `CENTER_ON_SCREEN`

Ensure the following dialog centres properly in the NVDA python console

```python
from gui.startupDialogs import AskAllowUsageStatsDialog
AskAllowUsageStatsDialog(None).ShowModal()
```

### Known issues with pull request:

None

### Change log entry:

Developer changes

```markdown
- `wx.CENTRE_ON_SCREEN` and `wx.CENTER_ON_SCREEN` is deprecated, use `self.CentreOnScreen()` instead. 
```

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
