### PR TITLE
comInterfaces_sconscript: correct case of MathPlayer.py string.

### DIFF
--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -81,7 +81,7 @@ comtypes.client.gen_dir=Dir('comInterfaces').abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
-	"mathPlayer.py": "typelibs/mathPlayerDLL.tlb",
+	"MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
 	"Accessibility.py": ('{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}',1,0),
 	"tom.py": ('{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}',1,0),
 	"SpeechLib.py": ('{C866CA3A-32F7-11D2-9602-00C04F8EE628}',5,0),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
-->

### Link to issue number:
Fixes #12281 

### Summary of the issue:
Math can no longer be read in NVDA with mathPlayer.
a regression introduced by pr #12201
comInterfaces_sconscript instructs comtypes to generate Python files from typelibs/mathPlayer.tlb. Comtypes produces MathPlayer.py (note the uppercase M). However, the sconscript target was hardcoded as "mathPlayer.py" (note the lowercase m). This has always been the case, and has not been a problem as scons and Windows is case insensitive and so Scons thought the target had been correctly created. However, pr #12201 makes use of the target's abspath property to rewrite the file with some extra imports. However, the path is made from the hardcoded target, so it has the lowercase m and therefore when the file is written out again, it has a lowercase m, and mathPres cannot then import MathPlayer with an uppercase M.

### Description of how this pull request fixes the issue:
Correct the "mathPlayer.py" string in comInterfaces_sconscript to "MathPlayer.py".

### Testing strategy:
Ensured that I could read the math equations with MathPlayer in NVDA on https://www.w3.org/Math/XSL/csmall2.xml
Before this pr, an exception was raised. With this pr, the math reads correctly.

### Known issues with pull request:
None.

### Change log entry:
None needed.

Section: New features, Changes, Bug fixes

### Code Review Checklist:

This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
