### PR TITLE
Follow up of PR 12250: Use FILETIME from winKernel rather than define it multiple times.

### DIFF
--- a/source/objidl.py
+++ b/source/objidl.py
@@ -1,9 +1,9 @@
-#objidl.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2010-2021 NV Access Limited, Leonard de Ruijter, Joseph Lee
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-from ctypes import *
+from ctypes import c_int, c_longlong, c_ubyte, c_ulong, c_ulonglong, c_wchar_p, POINTER, Structure, windll
 from ctypes.wintypes import HWND, BOOL
 from comtypes import HRESULT, GUID, COMMETHOD, IUnknown, tagBIND_OPTS2
 from comtypes.persist import IPersist

--- a/source/objidl.py
+++ b/source/objidl.py
@@ -235,10 +235,14 @@ IMoniker._methods_ = [
 		( ['in'], POINTER(IBindCtx), 'pbc' ),
 		( ['in'], POINTER(IMoniker), 'pmkToLeft' ),
 		( ['in'], POINTER(IMoniker), 'pmkNewlyRunning' )),
-	COMMETHOD([], HRESULT, 'GetTimeOfLastChange',
+	COMMETHOD(
+		[],
+		HRESULT,
+		'GetTimeOfLastChange',
 		( ['in'], POINTER(IBindCtx), 'pbc' ),
 		( ['in'], POINTER(IMoniker), 'pmkToLeft' ),
-		(['out'], POINTER(winKernel.FILETIME), 'pfiletime')),
+		(['out'], POINTER(winKernel.FILETIME), 'pfiletime')
+	),
 	COMMETHOD([], HRESULT, 'Inverse',
 		( ['out'], POINTER(POINTER(IMoniker)), 'ppmk' )),
 	COMMETHOD([], HRESULT, 'CommonPrefixWith',
@@ -274,12 +278,20 @@ IRunningObjectTable._methods_ = [
 	COMMETHOD([], HRESULT, 'GetObject',
 		( ['in'], POINTER(IMoniker), 'pmkObjectName' ),
 		( ['out'], POINTER(POINTER(IUnknown)), 'ppunkObject' )),
-	COMMETHOD([], HRESULT, 'NoteChangeTime',
+	COMMETHOD(
+		[],
+		HRESULT,
+		'NoteChangeTime',
 		( ['in'], c_ulong, 'dwRegister' ),
-		(['in'], POINTER(winKernel.FILETIME), 'pfiletime')),
-	COMMETHOD([], HRESULT, 'GetTimeOfLastChange',
+		(['in'], POINTER(winKernel.FILETIME), 'pfiletime')
+	),
+	COMMETHOD(
+		[],
+		HRESULT,
+		'GetTimeOfLastChange',
 		( ['in'], POINTER(IMoniker), 'pmkObjectName' ),
-		(['out'], POINTER(winKernel.FILETIME), 'pfiletime')),
+		(['out'], POINTER(winKernel.FILETIME), 'pfiletime')
+	),
 	COMMETHOD([], HRESULT, 'EnumRunning',
 		( ['out'], POINTER(POINTER(IEnumMoniker)), 'ppenumMoniker' )),
 ]

--- a/source/objidl.py
+++ b/source/objidl.py
@@ -7,6 +7,8 @@ from ctypes import *
 from ctypes.wintypes import HWND, BOOL
 from comtypes import HRESULT, GUID, COMMETHOD, IUnknown, tagBIND_OPTS2
 from comtypes.persist import IPersist
+import winKernel
+
 WSTRING = c_wchar_p
 
 class IOleWindow(IUnknown):
@@ -30,20 +32,15 @@ class _ULARGE_INTEGER(Structure):
 		('QuadPart', c_ulonglong),
 	]
 
-class _FILETIME(Structure):
-	_fields_ = [
-		('dwLowDateTime', c_ulong),
-		('dwHighDateTime', c_ulong),
-	]
 
 class tagSTATSTG(Structure):
 	_fields_ = [
 		('pwcsName', WSTRING),
 		('type', c_ulong),
 		('cbSize', _ULARGE_INTEGER),
-		('mtime', _FILETIME),
-		('ctime', _FILETIME),
-		('atime', _FILETIME),
+		('mtime', winKernel.FILETIME),
+		('ctime', winKernel.FILETIME),
+		('atime', winKernel.FILETIME),
 		('grfMode', c_ulong),
 		('grfLocksSupported', c_ulong),
 		('clsid', GUID),
@@ -241,7 +238,7 @@ IMoniker._methods_ = [
 	COMMETHOD([], HRESULT, 'GetTimeOfLastChange',
 		( ['in'], POINTER(IBindCtx), 'pbc' ),
 		( ['in'], POINTER(IMoniker), 'pmkToLeft' ),
-		( ['out'], POINTER(_FILETIME), 'pfiletime' )),
+		(['out'], POINTER(winKernel.FILETIME), 'pfiletime')),
 	COMMETHOD([], HRESULT, 'Inverse',
 		( ['out'], POINTER(POINTER(IMoniker)), 'ppmk' )),
 	COMMETHOD([], HRESULT, 'CommonPrefixWith',
@@ -279,10 +276,10 @@ IRunningObjectTable._methods_ = [
 		( ['out'], POINTER(POINTER(IUnknown)), 'ppunkObject' )),
 	COMMETHOD([], HRESULT, 'NoteChangeTime',
 		( ['in'], c_ulong, 'dwRegister' ),
-		( ['in'], POINTER(_FILETIME), 'pfiletime' )),
+		(['in'], POINTER(winKernel.FILETIME), 'pfiletime')),
 	COMMETHOD([], HRESULT, 'GetTimeOfLastChange',
 		( ['in'], POINTER(IMoniker), 'pmkObjectName' ),
-		( ['out'], POINTER(_FILETIME), 'pfiletime' )),
+		(['out'], POINTER(winKernel.FILETIME), 'pfiletime')),
 	COMMETHOD([], HRESULT, 'EnumRunning',
 		( ['out'], POINTER(POINTER(IEnumMoniker)), 'ppenumMoniker' )),
 ]

--- a/source/synthDrivers/_sapi4.py
+++ b/source/synthDrivers/_sapi4.py
@@ -6,7 +6,6 @@
 #See the file COPYING for more details.
 
 from ctypes import (
-	BYTE,
 	cast,
 	c_int,
 	c_uint,
@@ -20,7 +19,7 @@ from ctypes import (
 	sizeof,
 	Structure
 )
-from ctypes.wintypes import DWORD, LPCWSTR, WORD
+from ctypes.wintypes import BYTE, DWORD, LPCWSTR, WORD
 from comtypes import GUID, IUnknown, STDMETHOD
 
 import winKernel

--- a/source/synthDrivers/_sapi4.py
+++ b/source/synthDrivers/_sapi4.py
@@ -5,9 +5,23 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
-from ctypes import *
-from ctypes.wintypes import *
-from comtypes import *
+from ctypes import (
+	BYTE,
+	cast,
+	c_int,
+	c_uint,
+	c_ulong,
+	c_ulonglong,
+	c_wchar,
+	c_wchar_p,
+	c_void_p,
+	HRESULT,
+	POINTER,
+	sizeof,
+	Structure
+)
+from ctypes.wintypes import DWORD, LPCWSTR, WORD
+from comtypes import GUID, IUnknown, STDMETHOD
 
 import winKernel
 

--- a/source/synthDrivers/_sapi4.py
+++ b/source/synthDrivers/_sapi4.py
@@ -9,6 +9,8 @@ from ctypes import *
 from ctypes.wintypes import *
 from comtypes import *
 
+import winKernel
+
 S_OK=0
 
 ###comtypes class definitions
@@ -37,8 +39,6 @@ class VOICECHARSET(c_int):
     CHARSET_IPAPHONETIC = 1
     CHARSET_ENGINEPHONETIC = 2
 
-class FILETIME(Structure):
-    _fields_ = [("dwLowDateTime", DWORD), ("dwHighDateTime", DWORD)]
 
 class LANGUAGEW(Structure):
     _fields_ = [("LanguageID", LANGID),
@@ -111,7 +111,7 @@ ITTSCentralW._methods_ = [
     STDMETHOD(HRESULT, "Phoneme", [VOICECHARSET, DWORD, SDATA, POINTER(SDATA)]),
     STDMETHOD(HRESULT, "PosnGet", [POINTER(QWORD)]),
     STDMETHOD(HRESULT, "TextData", [VOICECHARSET, DWORD, SDATA, c_void_p, GUID]),
-    STDMETHOD(HRESULT, "ToFileTime", [POINTER(QWORD), POINTER(FILETIME)]),
+    STDMETHOD(HRESULT, "ToFileTime", [POINTER(QWORD), POINTER(winKernel.FILETIME)]),
     STDMETHOD(HRESULT, "AudioPause"),
     STDMETHOD(HRESULT, "AudioResume"),
     STDMETHOD(HRESULT, "AudioReset"),

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -7,12 +7,33 @@
 import locale
 from collections import OrderedDict
 import winreg
-from comtypes import COMObject, COMError
-from ctypes import *
+from comtypes import CoCreateInstance, COMObject, COMError, GUID
+from ctypes import byref, c_ulong, POINTER
+from ctypes.wintypes import DWORD, WORD
 from synthDriverHandler import SynthDriver,VoiceInfo, synthIndexReached, synthDoneSpeaking
 from logHandler import log
-import speech
-from ._sapi4 import *
+from ._sapi4 import (
+	CLSID_MMAudioDest,
+	CLSID_TTSEnumerator,
+	IAudioMultiMediaDevice,
+	ITTSAttributes,
+	ITTSBufNotifySink,
+	ITTSCentralW,
+	ITTSEnumW,
+	TextSDATA,
+	TTSATTR_MAXPITCH,
+	TTSATTR_MAXSPEED,
+	TTSATTR_MAXVOLUME,
+	TTSATTR_MINPITCH,
+	TTSATTR_MINSPEED,
+	TTSATTR_MINVOLUME,
+	TTSDATAFLAG_TAGGED,
+	TTSFEATURE_PITCH,
+	TTSFEATURE_SPEED,
+	TTSFEATURE_VOLUME,
+	TTSMODEINFO,
+	VOICECHARSET
+)
 import config
 import nvwave
 import weakref


### PR DESCRIPTION
### Link to issue number:
None, follow up from PR #12250 
### Summary of the issue:
PR #12250 added definition of `FILETIME` structure from Windows.h to the winKernel module. This structure was already used  throout NVDA's source code but it was defined in every file in which it was used. It makes sense to define it just once in winKernel and use from there.



 ### Description of how this pull request fixes the issue:
For both `objidl` and `_sapi4` the definition for `FILETIME` has been removed and every usage has been replaced with the definition from winKernel.
To comply with the style enforced by Linter it was necessary to fix star imports in `_sapi4` which also necessitated fixing them in the main SAPI4 driver since  it imported everything from the private driver and therefore stopped working after  linting,.
### Testing strategy:
Ensured that SAPI4 still works.
 with git grep ensured that no usages of `FILETIME` were missed.

### Known issues with pull request:
None known,

### Change log entries:
I don't think this deserves change log entry.


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
