### PR TITLE
Updated developer guide to clarify that the Remote Python Console is unavailable in binary builds

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -860,11 +860,11 @@ If the input is "nav._", attribute names with a single leading underscore are pr
 Similarly, if the input is "nav.__", attribute names with two leading underscores are proposed.
 
 + Remote Python Console +
-A remote Python console is available for situations where remote debugging of NVDA is useful.
+A remote Python console is available in source builds of NVDA, for situations where remote debugging of NVDA is useful.
 It is similar to the [local Python console #PythonConsole] discussed above, but is accessed via TCP.
 
 Please be aware that this is a huge security risk.
-You should only enable it if you are connected to trusted networks.
+You should only enable it if you are connected to trusted networks, and it is not available in binary builds distributed by NV Access.
 
 ++ Usage ++
 To enable the remote Python console, use the local Python console to import remotePythonConsole and call remotePythonConsole.initialize().

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -864,7 +864,7 @@ A remote Python console is available in source builds of NVDA, for situations wh
 It is similar to the [local Python console #PythonConsole] discussed above, but is accessed via TCP.
 
 Please be aware that this is a huge security risk.
-You should only enable it if you are connected to trusted networks, and it is not available in binary builds distributed by NV Access.
+It is not available in binary builds distributed by NV Access, and You should only enable it if you are connected to trusted networks.
 
 ++ Usage ++
 To enable the remote Python console, use the local Python console to import remotePythonConsole and call remotePythonConsole.initialize().


### PR DESCRIPTION

### Link to issue number:

Closes #12315 

### Summary of the issue:

The Remote Python Console is referenced in section 6 of the Developer Guide, with instructions on its activation in section 6.1.
However nowhere in the guide is it mentioned that the Remote Python Console is only available in source builds / is not included in normal binary builds.

### Description of how this pull request fixes the issue:

In section 6, where the Remote Python Console is first described, there is now a statement that it is only in source builds, and a reiterative statement further down that it is not included in NV Access's binary builds.

### Testing strategy:

Read the statements. Found the matter to be clarified.

### Known issues with pull request:

None

### Change log entries:

None needed, I think. This is apparently old behavior that has just never been documented, but is evidently known by most of the feature's target users.

### Code Review Checklist:

- [X] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [X] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
