### PR TITLE
Elements List: Don't remove the label of a filled spin button input field (#12317)

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2020 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter,
-# Thomas Stivers
+# Copyright (C) 2007-2021 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter,
+# Thomas Stivers, Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -252,7 +252,15 @@ class TextInfoQuickNavItem(QuickNavItem):
 			realStates = labelPropertyGetter("states")
 			labeledStates = " ".join(controlTypes.processAndLabelStates(role, realStates, OutputReason.FOCUS))
 			if self.itemType == "formField":
-				if role in (controlTypes.ROLE_BUTTON,controlTypes.ROLE_DROPDOWNBUTTON,controlTypes.ROLE_TOGGLEBUTTON,controlTypes.ROLE_SPLITBUTTON,controlTypes.ROLE_MENUBUTTON,controlTypes.ROLE_DROPDOWNBUTTONGRID,controlTypes.ROLE_SPINBUTTON,controlTypes.ROLE_TREEVIEWBUTTON):
+				if role in (
+					controlTypes.ROLE_BUTTON,
+					controlTypes.ROLE_DROPDOWNBUTTON,
+					controlTypes.ROLE_TOGGLEBUTTON,
+					controlTypes.ROLE_SPLITBUTTON,
+					controlTypes.ROLE_MENUBUTTON,
+					controlTypes.ROLE_DROPDOWNBUTTONGRID,
+					controlTypes.ROLE_TREEVIEWBUTTON
+				):
 					# Example output: Mute; toggle button; pressed
 					labelParts = (content or name or unlabeled, roleText, labeledStates)
 				else:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12317 
Fix-up of PR #6131

### Summary of the issue:

In browse mode documents, when a spin button input field is filled with a value, its label goes missing from the Elements List dialog.

### Description of how this pull request fixes the issue:

Remove the role ROLE_SPINBUTTON from the set of exceptions for which the content replaces the label.

### Testing strategy:

In Firefox / Chrome / Edge Chromium:
Ensure the label is present with empty spin button input field.
Ensure the label is present with non-empty spin button input field.

### Known issues with pull request:

There might be other roles for which both the label and content are desirable.
For the record, remaining exceptions as of this PR are:
 - ROLE_BUTTON
 - ROLE_DROPDOWNBUTTON
 - ROLE_TOGGLEBUTTON
 - ROLE_SPLITBUTTON
 - ROLE_MENUBUTTON
 - ROLE_DROPDOWNBUTTONGRID
 - ROLE_TREEVIEWBUTTON


### Change log entries:

I do not think this small fix deserves a change log entry.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
