### PR TITLE
Fix-up of 12025: No longer fail to report content of nonfocused text fields in Firefox

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -568,7 +568,7 @@ def getObjectSpeech(  # noqa: C901
 	if shouldReportTextContent:
 		try:
 			info = obj.makeTextInfo(textInfos.POSITION_SELECTION)
-		except NotImplementedError:
+		except (NotImplementedError, RuntimeError):
 			info = None
 		if info and not info.isCollapsed:
 			# if there is selected text, then there is a value and we do not report placeholder


### PR DESCRIPTION

### Link to issue number:
Fixes #12114 
### Summary of the issue:
PR #12025 started catching only very specific exceptions when getting selection of edit fields. However in Firefox attempting to get caret for non focused edit fields results in RuntimeError  which made it impossible to speak these controls.

### Description of how this pull request fixes the issue:
When getting content of edit fields were catching RuntimeError as well and threading this situation like no selection.
### Testing strategy:
Ensured that STR from #12114 is no longer reproducible
Ensured that error sound no longer plays each time when accepting autocomplete in Firefox address bar

This code cannot be unit tested and we do not have system tests for Firefox.

### Known issues with pull request:
None known
### Change log entries:
None needed - bug not in a release.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
