### PR TITLE
Windows 10 Mail: ensure browse mode is used in the reading pane.

### DIFF
--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -13,12 +13,26 @@ from NVDAObjects.UIA.wordDocument import WordDocument
 class MailWordDocumentTreeInterceptor(WordDocument.treeInterceptorClass):
 
 	def _get_isAlive(self):
-		return super(MailWordDocumentTreeInterceptor,self).isAlive and self.rootNVDAObject.shouldCreateTreeInterceptor
+		return super().isAlive and self.rootNVDAObject.isInReadingPane
+
+	def __init__(self, rootNVDAObject: "MailWordDocument"):
+		super().__init__(rootNVDAObject)
+		if rootNVDAObject.isInReadingPane:
+			# The base WordDocument TreeInterceptorClass forces focus mode by default
+			# As a TreeInterceptor is created for all word documents
+			# so that the NVDA elements list is available.
+			# However, Windows 10 Mail's reading pane should start in browse mode.
+			self.disableAutoPassThrough = False
+			self.passThrough = False
 
 class MailWordDocument(WordDocument):
 
 	treeInterceptorClass=MailWordDocumentTreeInterceptor
-	def _get_shouldCreateTreeInterceptor(self):
+
+	# typing information for isInReadingPane property
+	isInReadingPane: bool
+
+	def _get_isInReadingPane(self) -> bool:
 		# Locate the Reading pane in the ancestors
 		condition=UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_ClassNamePropertyId,"ReadingPaneModern")
 		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)

--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -12,18 +12,23 @@ from NVDAObjects.UIA.wordDocument import WordDocument
 
 class MailWordDocumentTreeInterceptor(WordDocument.treeInterceptorClass):
 
-	def _get_isAlive(self):
-		return super().isAlive and self.rootNVDAObject.isInReadingPane
+	_wasInReadingPane: bool = False
 
-	def __init__(self, rootNVDAObject: "MailWordDocument"):
-		super().__init__(rootNVDAObject)
-		if rootNVDAObject.isInReadingPane:
+	def event_treeInterceptor_gainFocus(self):
+		isInReadingPane = self.rootNVDAObject.isInReadingPane
+		if isInReadingPane != self._wasInReadingPane:
+			self._wasInReadingPane = isInReadingPane
 			# The base WordDocument TreeInterceptorClass forces focus mode by default
 			# As a TreeInterceptor is created for all word documents
 			# so that the NVDA elements list is available.
-			# However, Windows 10 Mail's reading pane should start in browse mode.
-			self.disableAutoPassThrough = False
-			self.passThrough = False
+			# However, Windows 10 Mail's reading pane should use browse mode.
+			if isInReadingPane:
+				self.disableAutoPassThrough = False
+				self.passThrough = False
+			else:
+				self.disableAutoPassThrough = True
+				self.passThrough = True
+		super().event_treeInterceptor_gainFocus()
 
 class MailWordDocument(WordDocument):
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12117 

### Summary of the issue:
In Windows 10 Mail, a Microsoft Word document control is used to display content of received emails and emails currently being composed. In NVDA 2020.4, NVDA would use browse mode for reading emails, but not for writing emails.
However, after merging of pr #12051  browse mode is no longer used by default when reading emails. This is because the base Microsoft Word document NVDAObject now creates a TreeInterceptor all the time, but set to focus mode, so that elements list is always available in Microsoft Word.
But as the hxMail implementation assumed browse mode would be available for the TreeInterceptor always, and only created the TreeInterceptor in the reading pane, Windows 10 mail ended up getting no treeInterceptor for writing email (ok) but for reading email it got a treeInterceptor but set to focus mode (not okay).

### Description of how this pull request fixes the issue:
In the hxMail appModule: rather than overriding shouldCreateTreeInterceptor, expose an isInReadingPane property, and in the treeInterceptor's treeInterceptor_gainFocus event, correctly set browse mode or focus mode based on whether we are now in the reading pane, and if we were or not before.
Aso the overriding of the treeInterceptor's isAlive property has been removed, as the treeInterceptor should now stay around as long as that physical control exists.
Note that Mail uses the same physical instance of the same control for both reading and composing mail.
 
### Testing strategy:
Opened Windows 10 mail. Opened a received email, and verified that the arrow keys could again be used to navigate / read the content of the email message and that quick navigation was available. Then pressed control+n to create a new message, tabbed to the message document, and ensured that 

### Known issues with pull request:
None known.

### Change log entries:
None needed.


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
