### PR TITLE
Fix up from #12210: Excel without UIA enabled: again allow typing and editing in cells 

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -58,7 +58,6 @@ WDAG_PROCESS_NAME=u'hvsirdpclient'
 goodUIAWindowClassNames=[
 	# A WDAG (Windows Defender Application Guard) Window is always native UIA, even if it doesn't report as such.
 	'RAIL_WINDOW',
-	"EXCEL6",
 ]
 
 badUIAWindowClassNames=[

--- a/source/appModules/excel.py
+++ b/source/appModules/excel.py
@@ -5,6 +5,7 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import time
+import config
 import eventHandler
 import api
 import UIAHandler
@@ -15,6 +16,8 @@ from NVDAObjects.window import DisplayModelEditableText
 from NVDAObjects.window.edit import UnidentifiedEdit
 from NVDAObjects.window import Window
 from NVDAObjects.window.excel import ExcelCell
+from NVDAObjects.IAccessible import IAccessible
+
 
 class Excel6(Window):
 	"""
@@ -43,6 +46,17 @@ class Excel6(Window):
 					self.focusRedirect=obj
 					return obj
 
+
+class Excel6_WhenUIAEnabled(IAccessible):
+	"""
+	#12303: When accessing Microsoft Excel via UI Automation
+	MSAA focus events on the old formula edit window should be completely ignored.
+	UI Automation will fire its own ones.
+	"""
+
+	shouldAllowIAccessibleFocusEvent = False
+
+
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
@@ -55,4 +69,14 @@ class AppModule(appModuleHandler.AppModule):
 				pass
 			clsList.insert(0, DisplayModelEditableText)
 		if windowClass=="EXCEL6":
-			clsList.insert(0,Excel6)
+			if config.conf["UIA"]["useInMSExcelWhenAvailable"]:
+				# #12303: When accessing Microsoft Excel via UI Automation
+				# MSAA focus events on the old formula edit window should be completely ignored.
+				# UI Automation will fire its own ones.
+				clsList.insert(0, Excel6_WhenUIAEnabled)
+			else:
+				# #12303: The old Formula Edit window in recent versions of Excel
+				# may not be accessible with display models as GDI is no longer used.
+				# However, UI Automation does expose an accessible edit control within the active cell,
+				# So use a class that will redirect focus to that.
+				clsList.insert(0, Excel6)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12303

### Summary of the issue:
After merging of pr #12210 editing cells in Excel without UIA enabled became im possible as NVDA did not report / track focus had ented the Cell Edit control. 
This was due to the EXCEL6 window accidentally being marked as having a good UIA implementation. This was testing code left over from the early implementation of #12210.
 
### Description of how this pull request fixes the issue:
Remove EXCEL6 from the good UIA windows list.
Also ensure that MSAA focus events on this window are ignored when using Excel with UIA enabled, as Excel will fire its own UIA focus event on an edit control within the active cell.

### Testing strategy:
Testing with all combinations of NvDA's use Microsoft Excel with UI Automation setting, and Excel's allow directly editing in a cell setting (4 different variations possible):
In an Excel spreadsheet:
* Started typing into a cell. Ensured that NVDA was announcing the typed characterrs, and that it announced focus moving into the edit control.
* Pressed f2 on a cell, ensured that NVDA announced focus on the edit control, that characters were announced when typed, and that moving the cursor with left and right arrows would speak the characters in the edit control.

This was successful for all 4 variations of the two settings.
 
### Known issues with pull request:
None known.

### Change log entries:
None needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
