### PR TITLE
Launcher: Honor the --minimal command line parameter (#12289)

### DIFF
--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -77,6 +77,9 @@ setOutPath "$PLUGINSDIR"
 ; So $0 may then contain eg. "--minimal --install"
 ; Reference: https://nsis.sourceforge.io/Docs/AppendixE.html#getparameters
 ${GetParameters} $0
+; From the params string, looks for option "--minimal", tries to get it's (unused) value and stores in $1.
+; Sets the error flag if the option is missing.
+; Reference: https://nsis.sourceforge.io/Docs/AppendixE.html#getoptions
 ${GetOptions} $0 "--minimal" $1
 IfErrors 0 +3
 File "..\miscDeps\launcher\nvda_logo.wav"

--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -1,4 +1,5 @@
 !include "fileFunc.nsh"
+!include "LogicLib.nsh"
 !include "mui2.nsh"
 
 !define launcher_appExe "nvdaLauncher.exe"
@@ -72,7 +73,6 @@ Banner::show /nounload
 BringToFront
 
 setOutPath "$PLUGINSDIR"
-;Play NVDA logo sound, unless started with the --minimal command line parameter
 ; Get the full param string and puts it in register $0.
 ; So $0 may then contain eg. "--minimal --install"
 ; Reference: https://nsis.sourceforge.io/Docs/AppendixE.html#getparameters
@@ -81,10 +81,9 @@ ${GetParameters} $0
 ; Sets the error flag if the option is missing.
 ; Reference: https://nsis.sourceforge.io/Docs/AppendixE.html#getoptions
 ${GetOptions} $0 "--minimal" $1
-IfErrors 0 +3
-File "..\miscDeps\launcher\nvda_logo.wav"
-Push "$PLUGINSDIR\nvda_logo.wav"
-Call PlaySound
+${If} ${Errors}
+	Call PlayLogoSound
+${EndIf}
 CreateDirectory "$PLUGINSDIR\app"
 setOutPath "$PLUGINSDIR\app"
 file /R "${NVDADistDir}\"
@@ -96,6 +95,11 @@ execWait "$PLUGINSDIR\app\nvda_noUIAccess.exe $0 -r --launcher" $1
 intcmp $1 3 exec +1
 SectionEnd
 
+Function PlayLogoSound
+File "..\miscDeps\launcher\nvda_logo.wav"
+Push "$PLUGINSDIR\nvda_logo.wav"
+Call PlaySound	
+FunctionEnd
 
 Function PlaySound
 ; Retrieve the file to play

--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -72,7 +72,10 @@ Banner::show /nounload
 BringToFront
 
 setOutPath "$PLUGINSDIR"
-;Play NVDA logo sound
+;Play NVDA logo sound, unless started with the --minimal command line parameter
+${GetParameters} $0
+${GetOptions} $0 "--minimal" $1
+IfErrors 0 +3
 File "..\miscDeps\launcher\nvda_logo.wav"
 Push "$PLUGINSDIR\nvda_logo.wav"
 Call PlaySound

--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -73,6 +73,9 @@ BringToFront
 
 setOutPath "$PLUGINSDIR"
 ;Play NVDA logo sound, unless started with the --minimal command line parameter
+; Get the full param string and puts it in register $0.
+; So $0 may then contain eg. "--minimal --install"
+; Reference: https://nsis.sourceforge.io/Docs/AppendixE.html#getparameters
 ${GetParameters} $0
 ${GetOptions} $0 "--minimal" $1
 IfErrors 0 +3

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -48,6 +48,7 @@ What's New in NVDA
 - Strikethrough, superscript and subscript formatting for entire Excel cells are now reported if the corresponding option is enabled. (#12264)
 - Fixed copying config during installation from a portable copy when default destination config directory is empty. (#12071, #12205)
 - Fixed incorrect announcement of some letters with accents or diacritic when 'Say cap before capitals' option is checked. (#11948)
+- The NVDA installer now also honors the ``--minimal`` command line parameter and does not play the start-up sound, following the same documented behavior as an installed or portable copy NVDA executable. (#12289)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12289

### Summary of the issue:

The `nvda_logo.wav` sound is played even if the launcher is started with the `--minimal` command line parameter.

### Description of how this pull request fixes the issue:

Avoid playing the `nvda_logo.wav` sound if the launcher is started with the `--minimal` command line parameter.

### Testing strategy:

Started with different combinations of command line parameters.
Ensure they are still interpreted as expected.

### Known issues with pull request:

### Change log entries:

Bug fixes
The NVDA installer now also honors the `--minimal` command line parameter and does not play the start-up sound, following the same documented behavior as an installed or portable copy NVDA executable.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [X] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
