### PR TITLE
Braille Viewer: Add a close button on the title bar for use with pointing devices

### DIFF
--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2014-2019 NV Access Limited
+# Copyright (C) 2014-2021 NV Access Limited, Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import enum
@@ -280,7 +280,7 @@ class BrailleViewerFrame(
 			gui.mainFrame,
 			title=self._title,
 			pos=dialogPos,
-			style=wx.CAPTION | wx.STAY_ON_TOP
+			style=wx.CAPTION | wx.CLOSE_BOX | wx.STAY_ON_TOP
 		)
 		self.Bind(wx.EVT_CLOSE, self._onClose)
 		self.Bind(wx.EVT_WINDOW_DESTROY, self._onDestroy)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ What's New in NVDA
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)
 - NVDA will exit even with windows still open, the exit process now closes all NVDA windows and dialogs (#1740)
 - The Speech Viewer can now be closed with `alt+F4` and has a standard close button for easier interaction with users of pointing devices. (#12330)
+- The Braille Viewer now has a standard close button for easier interaction with users of pointing devices. (#12328)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

As argued IMHO with reason by @bhavyashah in https://github.com/nvaccess/nvda/issues/10791#issuecomment-646978487
This PR does **not** address #10791 which targets Speech Viewer.

### Summary of the issue:

The Braille Viewer currently presents no close control on its GUI.
It can only be closed with `alt+F4` or by means of the dedicated NVDA Tools menu entry.

### Description of how this pull request fixes the issue:

Add a standard close button on the title bar of the Braille Viewer dialog.

### Testing strategy:

Ensured the dedicated check-able NVDA Tools menu entry gets unchecked as it properly does when closing the dialog with `alt+F4`.
Ensured proper behavior is maintained during restarts with or without "show at start-up" being checked.

### Known issues with pull request:

### Change log entries:

Changes
The Braille Viewer now has a standard close button for easier interaction with users of pointing devices. The other ways of interacting with this dialog remain otherwise unchanged.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
