### PR TITLE
Speech Viewer: allow to close with alt+F4 & add a close button on the title bar for use with pointing devices (#10791)

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
-# Thomas Stivers, Babbage B.V.
+# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -439,7 +439,8 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			item = menu_tools.Append(wx.ID_ANY, _("View log"))
 			self.Bind(wx.EVT_MENU, frame.onViewLogCommand, item)
 		# Translators: The label for the menu item to toggle Speech Viewer.
-		item=self.menu_tools_toggleSpeechViewer = menu_tools.AppendCheckItem(wx.ID_ANY, _("Speech viewer"))
+		item = self.menu_tools_toggleSpeechViewer = menu_tools.AppendCheckItem(wx.ID_ANY, _("Speech viewer"))
+		item.Check(speechViewer.isActive)
 		self.Bind(wx.EVT_MENU, frame.onToggleSpeechViewerCommand, item)
 
 		self.menu_tools_toggleBrailleViewer: wx.MenuItem = menu_tools.AppendCheckItem(

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -97,7 +97,7 @@ class SpeechViewerFrame(
 			self.shouldShowOnStartupCheckBox.SetFocus()
 
 	def onClose(self, evt):
-		assert isActive
+		assert isActive, "Cannot close Speech Viewer as it is already inactive"
 		deactivate()
 
 	def onShouldShowOnStartupChanged(self, evt):

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Thomas Stivers
+# Copyright (C) 2006-2021 NV Access Limited, Thomas Stivers, Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -38,7 +38,7 @@ class SpeechViewerFrame(
 			title=_("NVDA Speech Viewer"),
 			size=dialogSize,
 			pos=dialogPos,
-			style=wx.CAPTION | wx.RESIZE_BORDER | wx.STAY_ON_TOP
+			style=wx.CAPTION | wx.CLOSE_BOX | wx.RESIZE_BORDER | wx.STAY_ON_TOP
 		)
 		self._isDestroyed = False
 		self.onDestroyCallBack = onDestroyCallBack
@@ -97,10 +97,8 @@ class SpeechViewerFrame(
 			self.shouldShowOnStartupCheckBox.SetFocus()
 
 	def onClose(self, evt):
-		if not evt.CanVeto():
-			deactivate()
-			return
-		evt.Veto()
+		assert isActive
+		deactivate()
 
 	def onShouldShowOnStartupChanged(self, evt):
 		config.conf["speechViewer"]["showSpeechViewerAtStartup"] = self.shouldShowOnStartupCheckBox.IsChecked()
@@ -185,4 +183,3 @@ def deactivate():
 	# #7077: If the window is destroyed, text control will be gone, so save speech viewer position before destroying the window.
 	_guiFrame.savePositionInformation()
 	_guiFrame.Destroy()
-	isActive = False

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -25,6 +25,7 @@ What's New in NVDA
   - New braille tables: Belarusian literary braille, Belarusian computer braille, Urdu grade 1, Urdu grade 2.
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)
 - NVDA will exit even with windows still open, the exit process now closes all NVDA windows and dialogs (#1740)
+- The Speech Viewer can now be closed with `alt+F4` and has a standard close button for easier interaction with users of pointing devices. (#12330)
 
 
 == Bug Fixes ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #10791

### Summary of the issue:

The Speech Viewer currently has no close button nor can be closed with alt+F4.

As described by @Qchristensen in https://github.com/nvaccess/nvda/issues/10791#issuecomment-588047238, most dialogs in NVDA can be closed with alt+F4.
As argued by @bhavyashah in https://github.com/nvaccess/nvda/issues/10791#issuecomment-646978487, the Speech Viewer is especially useful for sighted testers who might be more familiar in using pointing devices than keyboard shortcuts.


### Description of how this pull request fixes the issue:

Handle closing with alt+F4 & add a standard close button in the title bar of the dialog.

### Testing strategy:

Tested all combinations of "show on start-up" and not, opening/closing with the menu/gesture/button of both Speech and Braille viewers.
Ensured the checked state of the menu entry does reflect the state of the dialog.

### Known issues with pull request:

It might be interesting to make the dialog freeze then forcibly close it to ensure the menu entry checked state remains consistent in that case.

### Change log entries:

Changes
The Speech Viewer can now be closed with `alt+F4` and  has a standard close button for easier interaction with users of pointing devices. The other ways of interacting with this dialog remain otherwise unchanged.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
