### PR TITLE
Developer Guide: Fix not parsed headers

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -738,6 +738,7 @@ The lastTestedNVDAVersion field in particular is used to ensure that users can b
 It allows the add-on author to make an assurance that the add-on will not cause instability, or break the users system.
 When this is not provided, or is less than the current version of NVDA (ignoring minor point updates EG 2018.3.1) then the user will be warned not to install the add-on.
 
+
 +++ An Example Manifest File +++
 ```
 --- start ---
@@ -751,7 +752,7 @@ docFileName = "readme.html"
 minimumNVDAVersion = "2018.1.0"
 lastTestedNVDAVersion = "2019.1.0"
 --- end ---
-``` 
+```
 
 ++ Plugins and Drivers ++
 The following plugins and drivers can be included in an add-on:

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -724,12 +724,14 @@ Otherwise, the add-on will not install.
   - e.g "2019.1.1"
   - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
-  - Must be less than or equal to `lastTestedNVDAVersion`
+  - Must be less than or equal to ``lastTestedNVDAVersion``
+  -
 - lastTestedNVDAVersion (string): The last version of NVDA this add-on has been tested with.
   - e.g "2019.1.0"
   - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
-  - Must be greater than or equal to `minimumNVDAVersion`
+  - Must be greater than or equal to ``minimumNVDAVersion``
+  -
 -
 
 All string values must be enclosed in quotes as shown in the example below.
@@ -737,7 +739,6 @@ All string values must be enclosed in quotes as shown in the example below.
 The lastTestedNVDAVersion field in particular is used to ensure that users can be confident about installing an add-on.
 It allows the add-on author to make an assurance that the add-on will not cause instability, or break the users system.
 When this is not provided, or is less than the current version of NVDA (ignoring minor point updates EG 2018.3.1) then the user will be warned not to install the add-on.
-
 
 +++ An Example Manifest File +++
 ```


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

The following two snippets can be found in the current Developer Guide as rendered in HTML format:
 - `+++ An Example Manifest File +++`
 - `++ Plugins and Drivers ++

These have been around for quite some time.
It seems quite obvious they should be rendered as headers, respectively:
 - `4.2.2. An Example Manifest File`
 - `4.3. Plugins and Drivers`


### Description of how this pull request fixes the issue:

Adding a blank line above the first snippet fixes both issues.
I have no clue why this is.
I also removed a trailing whitespace before the second one, which does not seem to change anything.

Oddly enough, I've first discovered the second snippet, which can be also fixed on its own by adding a blank line before it.
It turns out to be unnecessary once the first snippet is fixed, though, as both get automagically rendered correctly.

### Testing strategy:

Rendered the modified Developer Guide and checked both snippets are now rendered as expected.

### Known issues with pull request:

`4.3. Optional install / Uninstall code`
becomes
`4.4. Optional install / Uninstall code`
and so forth.

Any eventual external reference should be updated accordingly.
I'm not aware of any.

### Change log entries:

This IMHO does not deserve a change log entry.
If deemed otherwise, I would propose the following:

For Developers
A few rendering issues have been fixed in the Developer Guide, impacting headers numbering from 4.3 to 4.6.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
