### PR TITLE
Added a new paragraph to the bug and feature issue templates, explaining where to enter comments

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,6 +10,8 @@ Please thoroughly read NVDA's wiki article on how to fill in this template, incl
 Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
+
+Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
 -->
 
 ### Steps to reproduce:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -38,4 +38,4 @@ Each one of the questions and sections below start with a set of hashmarks (#). 
 
 #### If add-ons are disabled, is your problem still occurring?
 
-#### Did you try to run the COM registry fixing tool in NVDA menu / tools?
+#### Does the issue still occur after you run the COM Registration Fixing Tool in NVDA's tools menu?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@ Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
 
-Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
+Each of the questions and sections below start with multiple hash symbols (#). Place your answers and information on the blank line below each question.
 -->
 
 ### Steps to reproduce:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,8 @@ Please thoroughly read NVDA's wiki article on how to fill in this template, incl
 Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
+
+Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
 -->
 
 ### Steps to reproduce:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
 
-Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
+Each of the questions and sections below start with multiple hash symbols (#). Place your answers and information on the blank line below each question.
 -->
 
 ### Steps to reproduce:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
 
-Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
+Each of the questions and sections below start with multiple hash symbols (#). Place your answers and information on the blank line below each question.
 -->
 
 ### Is your feature request related to a problem? Please describe.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,6 +9,8 @@ Please thoroughly read NVDA's wiki article on how to fill in this template, incl
 Issues may be closed if the required information is not present.
 https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
+
+Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
 -->
 
 ### Is your feature request related to a problem? Please describe.


### PR DESCRIPTION
### Link to issue number:

In response to incidental discussion in #11847 

### Summary of the issue:

At various times, we've seen issue templates filled out in garbled ways, that make it difficult to navigate or work with the issue description.

In the above issue, for example, the initial description--by a sighted user--had the issue's answers and comments entered directly after the colons on the question lines.
This caused all answers to be headers, along with the questions provoking them, which lead to the issue being hard to navigate other than by simply arrowing through it.

In this case the author is a very experienced technical user, but because he did not know Markdown, and had no idea that he should know Markdown, he answered in the way that seemed most logical.

I've also observed worse examples, where the issue details are written after all the section/question headings, and so on.

### Description of how this pull request fixes the issue:

This issue can't be fixed while still using a text based template for issues.
However, it may be possible to mitigate it, by including very basic instructions about where answers should be placed in the template.

This PR adds the following comment, after a blank line to make it stand out, at the bottom of the top HTML issue comment for the bug and feature templates:

```
Each one of the questions and sections below start with a set of hashmarks (#). Place your answers and information on the blank line below each question.
```

This language was the best of a few variations I came up with, but I'm sure it could be improved upon. Still, I think it's better than nothing.

We can't make people read the comment paragraphs, but at least providing the definite instruction will reach those who do.

*Edit*: Subsequently, I added this to the default issue template as well. And while it's unrelated, I added the revised COM Reg. Fix tool question from #12276 to the default template since I was there. If this isn't approved, I'll do a separate PR for that.

### Testing strategy:
N/A

### Known issues with pull request:
The term I used, "hashmark", is both shorter than "number sign", and I think somewhat more global. Whether it needs a space, or whether one of the other terms would be better, is debatable, and I'm fine with anything that improves clarity.
[This Wikipedia article section](https://en.wikipedia.org/wiki/Number_sign#Names_of_the_character) has a list of terms, and Wikipedia's idea of how popular they are.

### Change log entries:

None needed.

### Code Review Checklist:

No code changed.
