### PR TITLE
Remove the option to file a default issue from the NVDA new issue chooser page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION

### Link to issue number:

None

### Summary of the issue:

The current [issue chooser](https://github.com/nvaccess/nvda/issues/new/choose) page for nvaccess/nvda, looks like this:
```
Bug report
Create a report to help us improve 
Get started 
Feature request
Suggest an idea for this project 
Get started 
Don’t see your issue here? Open a blank issue.
```
There is no value to the "open a blank issue" link.
1. We close blank (non-templated) issues as a matter of course, so we wouldn't want that.
2. The name is misleading, because:
3. The issue it opens isn't blank; it's a copy of the bug template with a default issue explanation at the top. In other words: it duplicates the bug template's function, but less well.
4. Some people actually do file that one, leading to bug issues with a lot of pointless extra text at the top.

### Description of how this pull request fixes the issue:

Add a config.yml file to the Github issue templates directory, disabling the filing of default issues from the chooser page.

### Testing strategy:

This can not be tested in branches.
Created a test repository, and confirmed that the intended result is achieved.

### Known issues with pull request:

I am not 100% sure that there remains no way for a user to file a default issue template by API or direct URL manipulation. I'm only sure that they won't be able to select a link on the chooser page to do it.
Because of this uncertainty, I suggest leaving the default issue template as a relic in the repository.

### Change log entries:

None needed.

### Code Review Checklist:
- [X] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [X] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
