### PR TITLE
refactor the exit of nvda and gui.terminate

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -795,10 +795,10 @@ def initialize():
 	):
 		enableBridge()
 	# Accept wm_copydata and any wm_user messages from other processes even if running with higher privileges
-	if not windll.user32.ChangeWindowMessageFilter(winUser.WM_COPYDATA, 1):
+	if not windll.user32.ChangeWindowMessageFilter(winUser.WM_COPYDATA, winUser.MSGFLT.ALLOW):
 		raise WinError()
 	for msg in range(winUser.WM_USER + 1, 0xffff):
-		if not windll.user32.ChangeWindowMessageFilter(msg, 1):
+		if not windll.user32.ChangeWindowMessageFilter(msg, winUser.MSGFLT.ALLOW):
 			raise WinError()
 	bridgeDll.Windows_run()
 	# Register java events

--- a/source/core.py
+++ b/source/core.py
@@ -43,6 +43,8 @@ import garbageHandler  # noqa: E402
 
 # inform those who want to know that NVDA has finished starting up.
 postNvdaStartup = extensionPoints.Action()
+# inform those who want to know that NVDA has begun to exit.
+preNVDAExit = extensionPoints.Action()
 
 PUMP_MAX_DELAY = 10
 
@@ -111,9 +113,8 @@ def doStartupDialogs():
 def restart(disableAddons=False, debugLogging=False):
 	"""Restarts NVDA by starting a new copy."""
 	if globalVars.appArgs.launcher:
-		import gui
 		globalVars.exitCode=3
-		gui.safeAppExit()
+		triggerNVDAExit()
 		return
 	import subprocess
 	import winUser
@@ -228,6 +229,63 @@ def getWxLangOrNone() -> Optional['wx.LanguageInfo']:
 	if not wxLang:
 		log.debugWarning("wx does not support language %s" % lang)
 	return wxLang
+
+
+def triggerNVDAExit():
+	preNVDAExit.notify()
+	# ensure NVDA only runs exit procedures once
+	handlers = list(preNVDAExit.handlers)  # don't mutate .handlers directly with unregister while iterating
+	for handler in handlers:
+		preNVDAExit.unregister(handler)
+
+
+def closeAllWindows():
+	"""
+	Ensures the app is exited by all the top windows being destroyed.
+	wx objects that don't inherit from wx.Window (eg sysTrayIcon, Menu) need to be manually destroyed.
+	"""
+	import gui
+	from gui.settingsDialogs import SettingsDialog
+	from typing import Dict
+	import wx
+
+	app = wx.GetApp()
+
+	# prevent race condition with object deletion
+	# prevent deletion of the object while we work on it.
+	_SettingsDialog = SettingsDialog
+	nonWeak: Dict[_SettingsDialog, _SettingsDialog] = dict(_SettingsDialog._instances)
+
+	for instance, state in nonWeak.items():
+		if state is _SettingsDialog.DialogState.DESTROYED:
+			log.error(
+				"Destroyed but not deleted instance of gui.SettingsDialog exists"
+				f": {instance.title} - {instance.__class__.__qualname__} - {instance}"
+			)
+		else:
+			log.debug("Exiting NVDA with an open settings dialog: {!r}".format(instance))
+
+	# wx.Windows destroy child Windows automatically but wx.Menu and TaskBarIcon don't inherit from wx.Window.
+	# They must be manually destroyed when exiting the app.
+	# Note: this doesn't consistently clean them from the tray and appears to be a wx issue. (#12286, #12238)
+	log.debug("destroying system tray icon and menu")
+	app.ScheduleForDestruction(gui.mainFrame.sysTrayIcon.menu)
+	gui.mainFrame.sysTrayIcon.RemoveIcon()
+	app.ScheduleForDestruction(gui.mainFrame.sysTrayIcon)
+
+	for window in wx.GetTopLevelWindows():
+		if isinstance(window, wx.Dialog) and window.IsModal():
+			log.debug(f"ending modal {window} during exit process")
+			wx.CallAfter(window.EndModal, wx.ID_CLOSE_ALL)
+		elif not isinstance(window, gui.MainFrame):
+			log.debug(f"closing window {window} during exit process")
+			wx.CallAfter(window.Close)
+
+	wx.Yield()  # creates a temporary event loop and uses it instead to process pending messages
+	log.debug("destroying main frame during exit process")
+	# the MainFrame has EVT_CLOSE bound to the ExitDialog
+	# which calls this function on exit, so destroy this window
+	app.ScheduleForDestruction(gui.mainFrame)
 
 
 def main():
@@ -580,16 +638,32 @@ def main():
 
 	queueHandler.queueFunction(queueHandler.eventQueue, _doPostNvdaStartupAction)
 
+	def handleNVDAModuleCleanupBeforeGUIExit():
+		""" Terminates various modules that rely on the GUI. This should be used before closing all windows
+		and terminating the GUI
+		"""
+		import brailleViewer
+		# before the GUI is terminated we must terminate the update checker
+		if updateCheck:
+			_terminate(updateCheck)
+
+		# The core is expected to terminate, so we should not treat this as a crash
+		_terminate(watchdog)
+		# plugins must be allowed to close safely before we terminate the GUI as dialogs may be unsaved
+		_terminate(globalPluginHandler)
+		# the brailleViewer should be destroyed safely before closing the window
+		brailleViewer.destroyBrailleViewer()
+	
+	preNVDAExit.register(handleNVDAModuleCleanupBeforeGUIExit)
+	preNVDAExit.register(closeAllWindows)
 
 	log.debug("entering wx application main loop")
 	app.MainLoop()
 
 	log.info("Exiting")
-	if updateCheck:
-		_terminate(updateCheck)
-
-	_terminate(watchdog)
-	_terminate(globalPluginHandler, name="global plugin handler")
+	# If MainLoop is terminated through WM_QUIT, such as starting an NVDA instance older than 2021.1,
+	# triggerNVDAExit has not been called yet
+	triggerNVDAExit()
 	_terminate(gui)
 	config.saveOnExit()
 

--- a/source/core.py
+++ b/source/core.py
@@ -239,9 +239,10 @@ def triggerNVDAExit():
 		preNVDAExit.unregister(handler)
 
 
-def closeAllWindows():
+def _closeAllWindows():
 	"""
-	Ensures the app is exited by all the top windows being destroyed.
+	Should only be used by calling triggerNVDAExit and after handleNVDAModuleCleanupBeforeGUIExit.
+	Ensures the wx mainloop is exited by all the top windows being destroyed.
 	wx objects that don't inherit from wx.Window (eg sysTrayIcon, Menu) need to be manually destroyed.
 	"""
 	import gui
@@ -655,7 +656,7 @@ def main():
 		brailleViewer.destroyBrailleViewer()
 	
 	preNVDAExit.register(handleNVDAModuleCleanupBeforeGUIExit)
-	preNVDAExit.register(closeAllWindows)
+	preNVDAExit.register(_closeAllWindows)
 
 	log.debug("entering wx application main loop")
 	app.MainLoop()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -5,7 +5,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import typing
 import time
 import os
 import sys
@@ -25,7 +24,7 @@ import speech
 import queueHandler
 import core
 from . import guiHelper
-from . import settingsDialogs
+from .settingsDialogs import SettingsDialog
 from .settingsDialogs import *
 from .inputGestures import InputGesturesDialog
 import speechDictHandler
@@ -197,7 +196,7 @@ class MainFrame(wx.Frame):
 			d.Show()
 			self.postPopup()
 		else:
-			safeAppExit()
+			core.triggerNVDAExit()
 
 	def onNVDASettingsCommand(self,evt):
 		self._popupSettingsDialog(NVDASettingsDialog)
@@ -356,25 +355,6 @@ class MainFrame(wx.Frame):
 		from .configProfiles import ProfilesDialog
 		ProfilesDialog(gui.mainFrame).Show()
 		self.postPopup()
-
-
-def safeAppExit():
-	"""
-	Ensures the app is exited by all the top windows being destroyed
-	"""
-
-	for window in wx.GetTopLevelWindows():
-		if isinstance(window, wx.Dialog) and window.IsModal():
-			log.info(f"ending modal {window} during exit process")
-			wx.CallAfter(window.EndModal, wx.ID_CLOSE_ALL)
-		if isinstance(window, MainFrame):
-			log.info(f"destroying main frame during exit process")
-			# the MainFrame has EVT_CLOSE bound to the ExitDialog
-			# which calls this function on exit, so destroy this window
-			wx.CallAfter(window.Destroy)
-		else:
-			log.info(f"closing window {window} during exit process")
-			wx.CallAfter(window.Close)
 
 class SysTrayIcon(wx.adv.TaskBarIcon):
 
@@ -558,6 +538,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			appModules.nvda.nvdaMenuIaIdentity = None
 		mainFrame.postPopup()
 
+
 def initialize():
 	global mainFrame
 	if mainFrame:
@@ -584,34 +565,9 @@ def initialize():
 			winUser.PostMessage(topHandle, winUser.WM_NULL, 0, 0)
 	wx.CallAfter = wx_CallAfter_wrapper
 
+
 def terminate():
-	import brailleViewer
-	brailleViewer.destroyBrailleViewer()
-
-	# prevent race condition with object deletion
-	# prevent deletion of the object while we work on it.
-	_SettingsDialog = settingsDialogs.SettingsDialog
-	nonWeak: typing.Dict[_SettingsDialog, _SettingsDialog] = dict(_SettingsDialog._instances)
-
-	for instance, state in nonWeak.items():
-		if state is _SettingsDialog.DialogState.DESTROYED:
-			log.error(
-				"Destroyed but not deleted instance of gui.SettingsDialog exists"
-				f": {instance.title} - {instance.__class__.__qualname__} - {instance}"
-			)
-		else:
-			log.debug("Exiting NVDA with an open settings dialog: {!r}".format(instance))
 	global mainFrame
-	# This is called after the main loop exits because WM_QUIT exits the main loop
-	# without destroying all objects correctly and we need to support WM_QUIT.
-	# Therefore, any request to exit should exit the main loop.
-	safeAppExit()
-	# #4460: We need another iteration of the main loop
-	# so that everything (especially the TaskBarIcon) is cleaned up properly.
-	# ProcessPendingEvents doesn't seem to work, but MainLoop does.
-	# Because the top window gets destroyed,
-	# MainLoop thankfully returns pretty quickly.
-	wx.GetApp().MainLoop()
 	mainFrame = None
 
 def showGui():
@@ -732,7 +688,7 @@ class ExitDialog(wx.Dialog):
 		if action >= 2 and config.isAppX:
 			action += 1
 		if action == 0:
-			safeAppExit()
+			core.triggerNVDAExit()
 		elif action == 1:
 			queueHandler.queueFunction(queueHandler.eventQueue,core.restart)
 		elif action == 2:
@@ -754,7 +710,7 @@ class ExitDialog(wx.Dialog):
 					confirmUpdateDialog.ShowModal()
 				else:
 					updateCheck.executePendingUpdate()
-		self.Destroy()
+		wx.CallAfter(self.Destroy)
 
 	def onCancel(self, evt):
 		self.Destroy()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -10,6 +10,7 @@ import shellapi
 import winUser
 import wx
 import config
+import core
 import globalVars
 import installer
 from logHandler import log
@@ -119,7 +120,7 @@ def doInstall(
 			winUser.SW_SHOWNORMAL
 		)
 	else:
-		gui.safeAppExit()
+		core.triggerNVDAExit()
 
 
 def doSilentInstall(
@@ -466,7 +467,7 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 		return
 	d.done()
 	if silent:
-		gui.safeAppExit()
+		core.triggerNVDAExit()
 	else:
 		# Translators: The message displayed when a portable copy of NVDA has been successfully created.
 		# %s will be replaced with the destination directory.

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -117,7 +117,7 @@ class WelcomeDialog(
 		gui.mainFrame.prePopup()
 		d = cls(gui.mainFrame)
 		d.ShowModal()
-		d.Destroy()
+		wx.CallAfter(d.Destroy)
 		gui.mainFrame.postPopup()
 
 
@@ -193,7 +193,7 @@ class LauncherDialog(
 		core.doStartupDialogs()
 
 	def onExit(self, evt):
-		gui.safeAppExit()
+		core.triggerNVDAExit()
 
 	@classmethod
 	def run(cls):

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -13,6 +13,7 @@ from ctypes.wintypes import *
 from ctypes.wintypes import HWND, RECT, DWORD
 import winKernel
 from textUtils import WCHAR_ENCODING
+import enum
 
 #dll handles
 user32=windll.user32
@@ -114,12 +115,6 @@ LBS_HASSTRINGS=0x0040
 CBS_OWNERDRAWFIXED=0x0010
 CBS_OWNERDRAWVARIABLE=0x0020
 CBS_HASSTRINGS=0x00200
-WM_NULL=0
-WM_QUIT=18
-WM_COPYDATA=74
-WM_NOTIFY=78
-WM_DEVICECHANGE=537
-WM_USER=1024
 #PeekMessage
 PM_REMOVE=1
 PM_NOYIELD=2
@@ -146,6 +141,7 @@ WM_COPYDATA = 74
 WM_NOTIFY = 78
 WM_USER = 1024
 WM_QUIT = 18
+WM_DEVICECHANGE = 537
 WM_DISPLAYCHANGE = 0x7e
 WM_GETTEXT=13
 WM_GETTEXTLENGTH=14
@@ -376,6 +372,19 @@ SM_YVIRTUALSCREEN = 77
 SM_CXVIRTUALSCREEN = 78
 # The height of the virtual screen, in pixels.
 SM_CYVIRTUALSCREEN = 79
+
+
+class MSGFLT(enum.IntEnum):
+	# Actions associated with ChangeWindowMessageFilterEx
+	# https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-changewindowmessagefilterex
+	# Adds the message to the filter. This has the effect of allowing the message to be received.
+	ALLOW = 1
+	# Removes the message from the filter. This has the effect of blocking the message.
+	DISALLOW = 2
+	# Resets the window message filter to the default.
+	# Any message allowed globally or process-wide will get through.
+	RESET = 0
+
 
 def setSystemScreenReaderFlag(val):
 	user32.SystemParametersInfoW(SPI_SETSCREENREADER,val,0,SPIF_UPDATEINIFILE|SPIF_SENDCHANGE)


### PR DESCRIPTION
### Link to issue number:

Closes #12238, #12325

### Changes 

### Summary of the issue:

PR #12286 Introduced the following issues:

- Logging via prints caused a wx error dialog to appear in binary builds. This is confusing, but is also seeming to freeze up the Windows shell, or at very least, NVDA is struggling to read much after this occurs.
- Prevented the addon handler from properly closing addons 
- Added unnecessary wait time for exiting NVDA to check whether to send WM_QUIT after WM_EXIT_NVDA fails. 

PR #12286 addressed:

When restarting NVDA, `WM_QUIT` is posted as an event to the window, forcibly exiting the app. This leaves objects such as the system tray icon left behind. 

Additionally, changes introduced in #12183

- caused the braille viewer to be closed without saving state properly
- lost code that destroyed the system tray and menu in some instances
- made most of `gui.terminate` no longer necessary/redundant

### Description of how this pull request fixes the issue:

This PR:

- Creates `core.triggerNVDAExit` which terminates necessary modules and then closes all windows
- Uses a parser error message if an new NVDA instance fails to end a running instances. 
- Uses an enum for ChangeWindowMessageFilter filters. 

PR #12286 addressed it's issues by:

- A windows event `winUser.WM_EXIT_NVDA` is registered that triggers `safeAppExit` and can be called across instances of NVDA.
- move the safe destruction of the brailleviewer to `safeAppExit` so that it is exited properly before destruction
- reintroduce the destruction of the system tray icon and menu, and remove the icon manually.
- ensured `safeAppExit` is not called from `gui.terminate` if it has been called elsewhere to terminate the app. `WM_QUIT` is the other way to exit the MainLoop other than `safeAppExit`
- removed restarting the MainLoop in `gui.terminate` to process pending events as this doesn't work. 

### Testing strategy:

- Ensure NVDA system tray icons are cleaned on any exit. 
- Ensure NVDA exits properly on restart and when starting the process subsequently. Check `nvda-old.log` when restarting NVDA. 
- Ensure NVDA can exit and restart correctly without errors or crashes. Existing system tests exist for this process. 
- Test these with the build binary for this branch as well as source 
    - Running 2020.4 (leave it running) and start this build. This build should cause 2020.4 to exit, and this build should replace it as the running version. Confirm by checking about -> version
    - Running this build (leave it running) and start 2020.4 which should cause this build to exit, and 2020.4 should replace it as the running version. Confirm by checking about -> version
    - Running latest alpha (leave it running) and start this build. This build should cause latest alpha to exit, and this build should replace it as the running version. Confirm by checking about -> version
    - Running this build (leave it running) and start latest alpha which should cause this build to exit, and latest alpha should replace it as the running version. Confirm by checking about -> version


### Known issues with pull request:

`WM_QUIT` will not exit the app safely (called from a new NVDA instance) when a dialog such as `WelcomeDialog` is still open

### Change log entry:

None

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
