### PR TITLE
Increase sleep to 5s after starting NVDA in chromeTests

### DIFF
--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -24,7 +24,7 @@ default teardown
 
 default setup
 	start NVDA	standard-dontShowWelcomeDialog.ini
-	Sleep	2s
+	Sleep	5s
 
 *** Test Cases ***
 


### PR DESCRIPTION
### Link to issue number:

Follow up from #12293

### Summary of the issue:

Chrome was still losing focus in systetests

These builds failed with the 2s sleep included due to taskbar gaining focus

- https://ci.appveyor.com/project/NVAccess/nvda/builds/38799243/tests
- https://ci.appveyor.com/project/NVAccess/nvda/builds/38800164/tests 

### Description of how this pull request fixes the issue:

Increase sleep time to 5s. 

### Testing strategy:

Low impact, see if system tests continue to fail due to taskbar gaining focus

### Known issues with pull request:

- Docker popups may still block the build: https://github.com/nvaccess/nvda/pull/12293#issuecomment-822892994 (I plan to follow up add better logging for this, and try to set them to re-run on appveyor)
- 5s of sleep might not be long enough (we have confidence that 10s is)
- Lint checking occasionally blocks builds due to a failed merge (I plan to follow up and fix this soon)

### Change log entries:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
