### PR TITLE
Increase AppVeyor git clone depth and lint try branch builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,20 +176,30 @@ test_script:
 
 # Flake8 Linting
  - ps: |
-    if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
       $lintOutput = (Resolve-Path .\testOutput\lint\)
       $lintSource = (Resolve-Path .\tests\lint\)
+      $flake8Output = "$lintOutput\Flake8.txt"
       # When Appveyor runs for a pr,
       # the build is made from a new temporary commit,
       # resulting from the pr branch being merged into its base branch.
       # Therefore to create a diff for linting, we must fetch the head of the base branch.
       # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
-     git fetch -q --recurse-submodules=on-demand origin $env:APPVEYOR_REPO_BRANCH
-     $flake8Output = "$lintOutput\PR-Flake8.txt"
-      .\runlint.bat FETCH_HEAD "$flake8Output" 
-      if($LastExitCode -ne 0) {
-       $errorCode=$LastExitCode
-       Add-AppveyorMessage "PR introduces Flake8 errors"
+      # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
+      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+        git fetch -q --recurse-submodules=on-demand origin $env:APPVEYOR_REPO_BRANCH
+        .\runlint.bat FETCH_HEAD "$flake8Output" 
+        if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        Add-AppveyorMessage "PR introduces Flake8 errors"
+        }
+      } else {
+        # However in a pushed branch, we must fetch master.
+        git fetch -q --recurse-submodules=on-demand origin master:master
+        .\runlint.bat FETCH_HEAD $flake8Output
+        if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        Add-AppveyorMessage "Branch introduces Flake8 errors"
+        }
       }
       Push-AppveyorArtifact $flake8Output
       $junitXML = "$lintOutput\PR-Flake8.xml"
@@ -198,7 +208,6 @@ test_script:
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
       if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
-    }
 
 # System tests
  - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -186,7 +186,7 @@ test_script:
       # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
       # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
       if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-        git fetch -q --recurse-submodules=on-demand origin $env:APPVEYOR_REPO_BRANCH
+        git fetch -q --recurse-submodules origin $env:APPVEYOR_REPO_BRANCH
         .\runlint.bat FETCH_HEAD "$flake8Output" 
         if($LastExitCode -ne 0) {
         $errorCode=$LastExitCode
@@ -194,7 +194,7 @@ test_script:
         }
       } else {
         # However in a pushed branch, we must fetch master.
-        git fetch -q --recurse-submodules=on-demand origin master:master
+        git fetch -q --recurse-submodules origin master:master
         .\runlint.bat FETCH_HEAD $flake8Output
         if($LastExitCode -ne 0) {
         $errorCode=$LastExitCode

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -186,11 +186,11 @@ test_script:
       # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
       # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
       if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-        git fetch -q --recurse-submodules origin $env:APPVEYOR_REPO_BRANCH
+        git fetch -q origin $env:APPVEYOR_REPO_BRANCH
         $msgBaseLabel = "PR"
       } else {
         # However in a pushed branch, we must fetch master.
-        git fetch -q --recurse-submodules origin master:master
+        git fetch -q origin master:master
         $msgBaseLabel = "Branch"
       }
       .\runlint.bat FETCH_HEAD "$flake8Output" 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -189,16 +189,16 @@ test_script:
         git fetch -q --recurse-submodules origin $env:APPVEYOR_REPO_BRANCH
         .\runlint.bat FETCH_HEAD "$flake8Output" 
         if($LastExitCode -ne 0) {
-        $errorCode=$LastExitCode
-        Add-AppveyorMessage "PR introduces Flake8 errors"
+          $errorCode=$LastExitCode
+          Add-AppveyorMessage "PR introduces Flake8 errors"
         }
       } else {
         # However in a pushed branch, we must fetch master.
         git fetch -q --recurse-submodules origin master:master
         .\runlint.bat FETCH_HEAD $flake8Output
         if($LastExitCode -ne 0) {
-        $errorCode=$LastExitCode
-        Add-AppveyorMessage "Branch introduces Flake8 errors"
+          $errorCode=$LastExitCode
+          Add-AppveyorMessage "Branch introduces Flake8 errors"
         }
       }
       Push-AppveyorArtifact $flake8Output

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,8 +56,6 @@ init:
       Set-AppveyorBuildVariable "versionType" $versionType
      }
 
-clone_depth: 1
-
 install:
  - cd appveyor
  # Decrypt files.
@@ -186,7 +184,7 @@ test_script:
       # resulting from the pr branch being merged into its base branch.
       # Therefore to create a diff for linting, we must fetch the head of the base branch.
       # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
-     git fetch -q origin $env:APPVEYOR_REPO_BRANCH
+     git fetch -q --recurse-submodules=on-demand origin $env:APPVEYOR_REPO_BRANCH
      $flake8Output = "$lintOutput\PR-Flake8.txt"
       .\runlint.bat FETCH_HEAD "$flake8Output" 
       if($LastExitCode -ne 0) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -187,19 +187,16 @@ test_script:
       # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
       if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         git fetch -q --recurse-submodules origin $env:APPVEYOR_REPO_BRANCH
-        .\runlint.bat FETCH_HEAD "$flake8Output" 
-        if($LastExitCode -ne 0) {
-          $errorCode=$LastExitCode
-          Add-AppveyorMessage "PR introduces Flake8 errors"
-        }
+        $msgBaseLabel = "PR"
       } else {
         # However in a pushed branch, we must fetch master.
         git fetch -q --recurse-submodules origin master:master
-        .\runlint.bat FETCH_HEAD $flake8Output
-        if($LastExitCode -ne 0) {
-          $errorCode=$LastExitCode
-          Add-AppveyorMessage "Branch introduces Flake8 errors"
-        }
+        $msgBaseLabel = "Branch"
+      }
+      .\runlint.bat FETCH_HEAD "$flake8Output" 
+      if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        Add-AppveyorMessage "$msgBaseLabel introduces Flake8 errors"
       }
       Push-AppveyorArtifact $flake8Output
       $junitXML = "$lintOutput\PR-Flake8.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,20 +176,30 @@ test_script:
 
 # Flake8 Linting
  - ps: |
-    if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
       $lintOutput = (Resolve-Path .\testOutput\lint\)
       $lintSource = (Resolve-Path .\tests\lint\)
+      $flake8Output = "$lintOutput\Flake8.txt"
       # When Appveyor runs for a pr,
       # the build is made from a new temporary commit,
       # resulting from the pr branch being merged into its base branch.
       # Therefore to create a diff for linting, we must fetch the head of the base branch.
       # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
-     git fetch -q --recurse-submodules=on-demand origin $env:APPVEYOR_REPO_BRANCH
-     $flake8Output = "$lintOutput\PR-Flake8.txt"
-      .\runlint.bat FETCH_HEAD "$flake8Output" 
-      if($LastExitCode -ne 0) {
-       $errorCode=$LastExitCode
-       Add-AppveyorMessage "PR introduces Flake8 errors"
+      # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
+    if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+        git fetch -q --recurse-submodules=on-demand origin $env:APPVEYOR_REPO_BRANCH
+        .\runlint.bat FETCH_HEAD "$flake8Output" 
+        if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        Add-AppveyorMessage "PR introduces Flake8 errors"
+        }
+      } else {
+        # However in a pushed branch, we must fetch master.
+        git fetch -q --recurse-submodules=on-demand origin master:master
+        .\runlint.bat FETCH_HEAD $flake8Output
+        if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        Add-AppveyorMessage "Branch introduces Flake8 errors"
+        }
       }
       Push-AppveyorArtifact $flake8Output
       $junitXML = "$lintOutput\PR-Flake8.xml"
@@ -198,7 +208,6 @@ test_script:
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
       if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
-    }
 
 # System tests
  - ps: |


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

AppVeyor builds occasionally fail, such as [this one](https://ci.appveyor.com/project/NVAccess/nvda/builds/38780964), due to `git merge-base FETCH_HEAD HEAD` failing after `git fetch -q origin $env:APPVEYOR_REPO_BRANCH`. 

We have a clone_depth set to 1. There is a warning in the [appveyor docs](https://www.appveyor.com/docs/how-to/repository-shallow-clone/) as follows

>Be aware that if you do a lot of commits producing queued builds and depth number is too small git checkout operation following git clone can fail because requested commit is not present in a cloned repository.

Relevant stack trace

```
[00:10:47] if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
[00:10:47]   $lintOutput = (Resolve-Path .\testOutput\lint\)
[00:10:47]   $lintSource = (Resolve-Path .\tests\lint\)
[00:10:47]   # When Appveyor runs for a pr,
[00:10:47]   # the build is made from a new temporary commit,
[00:10:47]   # resulting from the pr branch being merged into its base branch.
[00:10:47]   # Therefore to create a diff for linting, we must fetch the head of the base branch.
[00:10:47]   # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
[00:10:47]  git fetch -q origin $env:APPVEYOR_REPO_BRANCH
[00:10:47]  $flake8Output = "$lintOutput\PR-Flake8.txt"
[00:10:47]   .\runlint.bat FETCH_HEAD "$flake8Output" 
[00:10:47]   if($LastExitCode -ne 0) {
[00:10:47]    $errorCode=$LastExitCode
[00:10:47]    Add-AppveyorMessage "PR introduces Flake8 errors"
[00:10:47]   }
[00:10:47]   Push-AppveyorArtifact $flake8Output
[00:10:47]   $junitXML = "$lintOutput\PR-Flake8.xml"
[00:10:47]   py "$lintSource\createJunitReport.py" "$flake8Output" "$junitXML"
[00:10:47]   Push-AppveyorArtifact $junitXML
[00:10:47]   $wc = New-Object 'System.Net.WebClient'
[00:10:47]   $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
[00:10:47]   if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
[00:10:47] }
[00:10:47] 
[00:10:47] Ensuring NVDA Python virtual environment
[00:10:47] call py "C:\projects\nvda\\tests\lint\genDiff.py" FETCH_HEAD "C:\projects\nvda\\tests\lint\_lint.diff"
[00:10:48] .\runlint.bat : Traceback (most recent call last):
[00:10:48] At line:11 char:3
[00:10:48] +   .\runlint.bat FETCH_HEAD "$flake8Output"
[00:10:48] +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[00:10:48]     + CategoryInfo          : NotSpecified: (Traceback (most recent call last)::String) [], RemoteException
[00:10:48]     + FullyQualifiedErrorId : NativeCommandError
[00:10:48]  
[00:10:48]   File "C:\projects\nvda\\tests\lint\genDiff.py", line 65, in <module>
[00:10:48]     main(*getArgs(argv))
[00:10:48]   File "C:\projects\nvda\\tests\lint\genDiff.py", line 42, in main
[00:10:48]     diff = getDiff(baseBranch)
[00:10:48]   File "C:\projects\nvda\\tests\lint\genDiff.py", line 33, in getDiff
[00:10:48]     mergeBase: bytes = subprocess.check_output(mergeBaseCommand)
[00:10:48]   File "C:\Python38\lib\subprocess.py", line 411, in check_output
[00:10:48]     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
[00:10:48]   File "C:\Python38\lib\subprocess.py", line 512, in run
[00:10:48]     raise CalledProcessError(retcode, process.args,
[00:10:48] subprocess.CalledProcessError: Command 'git merge-base FETCH_HEAD HEAD' returned non-zero exit status 1.
[00:10:48] 
[00:10:48] Deactivating NVDA Python virtual environment
[00:10:48] Resolve-Path : Cannot find path 'C:\projects\nvda\testOutput\lint\PR-Flake8.txt' because it does not exist.
[00:10:48] At C:\Program Files\AppVeyor\BuildAgent\Modules\build-worker-api\build-worker-api.psm1:207 char:18
[00:10:48] +     $fullPath = (Resolve-Path $Path).Path
[00:10:48] +                  ~~~~~~~~~~~~~~~~~~
[00:10:48]     + CategoryInfo          : ObjectNotFound: (C:\projects\nvd...t\PR-Flake8.txt:String) [Resolve-Path], ItemNotFoundException
[00:10:48]     + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand
[00:10:48]  
[00:10:48] Push-AppveyorArtifactInternal : Cannot bind argument to parameter 'FullPath' because it is null.
[00:10:48] At C:\Program Files\AppVeyor\BuildAgent\Modules\build-worker-api\build-worker-api.psm1:209 char:42
[00:10:48] +     Push-AppveyorArtifactInternal -FullPath $fullPath -FileName $File ...
[00:10:48] +                                             ~~~~~~~~~
[00:10:48]     + CategoryInfo          : InvalidData: (:) [Push-AppveyorArtifactInternal], ParameterBindingValidationException
[00:10:48]     + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Appveyor.BuildAgent.Api.Utils.PushAppveyorArtifactInternalCmdlet
[00:10:48]  
[00:10:48] Flake8_output_file does not exist at C:\projects\nvda\testOutput\lint\\PR-Flake8.txt
[00:10:48] py : Traceback (most recent call last):
[00:10:48] At line:18 char:3
[00:10:48] +   py "$lintSource\createJunitReport.py" "$flake8Output" "$junitXML"
[00:10:48] +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[00:10:48]     + CategoryInfo          : NotSpecified: (Traceback (most recent call last)::String) [], RemoteException
[00:10:48]     + FullyQualifiedErrorId : NativeCommandError
[00:10:48]  
[00:10:48]   File "C:\projects\nvda\tests\lint\\createJunitReport.py", line 65, in <module>
[00:10:48]     main()
[00:10:48]   File "C:\projects\nvda\tests\lint\\createJunitReport.py", line 60, in main
[00:10:48]     raise e
[00:10:48]   File "C:\projects\nvda\tests\lint\\createJunitReport.py", line 54, in main
[00:10:48]     raise RuntimeError(
[00:10:48] RuntimeError: Flake8_output_file does not exist at C:\projects\nvda\testOutput\lint\\PR-Flake8.txt
[00:10:48] 
[00:10:48] Resolve-Path : Cannot find path 'C:\projects\nvda\testOutput\lint\PR-Flake8.xml' because it does not exist.
[00:10:48] At C:\Program Files\AppVeyor\BuildAgent\Modules\build-worker-api\build-worker-api.psm1:207 char:18
[00:10:48] +     $fullPath = (Resolve-Path $Path).Path
[00:10:48] +                  ~~~~~~~~~~~~~~~~~~
[00:10:48]     + CategoryInfo          : ObjectNotFound: (C:\projects\nvd...t\PR-Flake8.xml:String) [Resolve-Path], ItemNotFoundException
[00:10:48]     + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand
[00:10:48]  
[00:10:48] Push-AppveyorArtifactInternal : Cannot bind argument to parameter 'FullPath' because it is null.
[00:10:48] At C:\Program Files\AppVeyor\BuildAgent\Modules\build-worker-api\build-worker-api.psm1:209 char:42
[00:10:48] +     Push-AppveyorArtifactInternal -FullPath $fullPath -FileName $File ...
[00:10:48] +                                             ~~~~~~~~~
[00:10:48]     + CategoryInfo          : InvalidData: (:) [Push-AppveyorArtifactInternal], ParameterBindingValidationException
[00:10:48]     + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Appveyor.BuildAgent.Api.Utils.PushAppveyorArtifactInternalCmdlet
[00:10:48]  
[00:10:48] Exception calling "UploadFile" with "2" argument(s): "An exception occurred during a WebClient request."
[00:10:48] At line:21 char:67
[00:10:48] + ... /ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $jun ...
[00:10:48] +                                              ~~~~~~~~~~~~~~~~~~~~
[00:10:48]     + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
[00:10:48]     + FullyQualifiedErrorId : WebException
[00:10:48]  
```

Additional issue tackled here: Linting isn't checked on try-builds. 

### Description of how this pull request fixes the issue:

- Up the clone depth to unlimited (by removing setting the value)
- Fetch master directly when performing a try-branch build so that lint checks can now run on try branch builds
- recursively fetch submodules on demand.

### Testing strategy:

Perform try builds and builds to master. 

- [try-build](https://ci.appveyor.com/project/NVAccess/nvda/builds/38888375)

### Known issues with pull request:

None

### Changelog entry

None, effects build process

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
