### PR TITLE
Focus chrome after starting in system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -17,7 +17,7 @@ from SystemTestSpy import (
 )
 from SystemTestSpy.windows import (
 	GetForegroundWindowTitle,
-	GetActiveWindowTitles,
+	GetVisibleWindowTitles,
 	SetForegroundWindow,
 )
 import re
@@ -73,11 +73,11 @@ class ChromeLib:
 
 	@staticmethod
 	def getUniqueTestCaseTitle(testCase: str) -> str:
-		return f"{ChromeLib._testCaseTitle} ({hash(testCase)})"
+		return f"{ChromeLib._testCaseTitle} ({abs(hash(testCase))})"
 
 	@staticmethod
 	def getUniqueTestCaseTitleRegex(testCase: str) -> re.Pattern:
-		return re.compile(f"^{ChromeLib._testCaseTitle} \\({hash(testCase)}\\)")
+		return re.compile(f"^{ChromeLib._testCaseTitle} \\({abs(hash(testCase))}\\)")
 
 	@staticmethod
 	def _writeTestFile(testCase) -> str:
@@ -150,7 +150,7 @@ class ChromeLib:
 		windowInformation = ""
 		try:
 			windowInformation = f"Foreground Window: {GetForegroundWindowTitle()}.\n"
-			windowInformation += f"Open Windows: {GetActiveWindowTitles()}"
+			windowInformation += f"Open Windows: {GetVisibleWindowTitles()}"
 		except OSError as e:
 			builtIn.log(f"Couldn't retrieve active window information.\nException: {e}")
 		raise AssertionError(

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -127,9 +127,9 @@ class ChromeLib:
 		""" Ensure chrome started and is focused.
 		Different versions of chrome have variations in how the title is presented.
 		This may mean that there is a separator between document name and application name.
-		E.G. "htmlTest   Google Chrome", "html – Google Chrome" or perhaps no applcation name at all.
+		E.G. "htmlTest   Google Chrome", "html – Google Chrome" or perhaps no application name at all.
 		Rather than try to get this right, just use the doc title.
-		If this continues to be unreliable we could use solenium or similar to start chrome and inform us
+		If this continues to be unreliable we could use Selenium or similar to start chrome and inform us
 		when it is ready.
 		"""
 		startsWithTestCaseTitle = re.compile(f"^{self._testCaseTitle}")

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -77,7 +77,7 @@ class ChromeLib:
 
 	@staticmethod
 	def getUniqueTestCaseTitleRegex(testCase: str) -> re.Pattern:
-		return re.compile(f"{ChromeLib._testCaseTitle} \\({hash(testCase)}\\)")
+		return re.compile(f"^{ChromeLib._testCaseTitle} \\({hash(testCase)}\\)")
 
 	@staticmethod
 	def _writeTestFile(testCase) -> str:

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -1,0 +1,58 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2021 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+"""This module provides functions to interact with the Windows system.
+"""
+
+from ctypes.wintypes import HWND, LPARAM
+from ctypes import c_bool, c_int, create_unicode_buffer, POINTER, WINFUNCTYPE, windll, WinError
+import re
+from typing import List, Tuple
+
+
+def _GetWindowTitle(hwnd: HWND) -> str:
+	length = windll.user32.GetWindowTextLengthW(hwnd)
+	if not length:
+		return ''
+	buff = create_unicode_buffer(length + 1)
+	if not windll.user32.GetWindowTextW(hwnd, buff, length + 1):
+		raise WinError()
+	return str(buff.value)
+
+
+def _GetActiveWindows() -> List[Tuple[HWND, str]]:
+	windows: List[Tuple[HWND, str]] = []
+	EnumWindowsProc = WINFUNCTYPE(c_bool, POINTER(c_int), POINTER(c_int))
+
+	def _append_title(hwnd: HWND, _lParam: LPARAM) -> bool:
+		if windll.user32.IsWindowVisible(hwnd):
+			title = _GetWindowTitle(hwnd)
+			if title:
+				windows.append((hwnd, title))
+		return True
+
+	if not windll.user32.EnumWindows(EnumWindowsProc(_append_title), 0):
+		raise WinError()
+	return windows
+
+
+def SetForegroundWindow(targetTitle: re.Pattern) -> bool:
+	if re.match(targetTitle, GetForegroundWindowTitle()):
+		return True
+	windows = _GetActiveWindows()
+	for hwnd, title in windows:
+		if re.match(targetTitle, title):
+			return windll.user32.SetForegroundWindow(hwnd)
+	return False
+
+
+def GetActiveWindowTitles() -> List[str]:
+	windows = _GetActiveWindows()
+	return [w[1] for w in windows]
+
+
+def GetForegroundWindowTitle() -> str:
+	hwnd = windll.user32.GetForegroundWindow()
+	return _GetWindowTitle(hwnd)

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -13,8 +13,8 @@ from typing import Callable, List, NamedTuple
 
 
 class Window(NamedTuple):
-    hwnd: HWND
-    title: str
+	hwnd: HWND
+	title: str
 
 
 def _GetWindowTitle(hwnd: HWND) -> str:

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -24,7 +24,6 @@ default teardown
 
 default setup
 	start NVDA	standard-dontShowWelcomeDialog.ini
-	Sleep	5s
 
 *** Test Cases ***
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

As discussed in #12293, our systems fail randomly. Usually this is due to another window stealing focus, such as the taskbar or Docker. As system tests are run locally, we shouldn't be killing these processes. 

### Description of how this pull request fixes the issue:

- Use windows API to make the chrome window gain focus
- Adds logging that lists the foreground window and open windows if chrome doesn't gain focus
- Removes extra sleep time after starting NVDA 

### Testing strategy:

Run the system tests locally, and prevent chrome from gaining focus by holding `alt+tab` 

Here's an example log from a local test:

```
checkbox labelled by inner element :: A checkbox labelled by an in... | FAIL |
Unable to focus Chrome.
Foreground Window: speechSpyGlobalPlugin.py (Working Tree) - nvda - Visual Studio Code.
Open Windows: ['speechSpyGlobalPlugin.py (Working Tree) - nvda - Visual Studio Code', 'NVDA Browser Test Case - Google Chrome', 'C:\\nvda\\testOutput\\system', 'Calculator', 'Calculator', 'Settings', 'Settings', 'Microsoft Text Input Application', 'Program Manager']
```

### Known issues with pull request:

None

### Change log entries:

None

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
