### PR TITLE
Fix Sapi4 pitch change #12311

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -131,7 +131,7 @@ class SynthDriver(SynthDriver):
 				charMode=item.state
 			elif isinstance(item, PitchCommand):
 				offset = int(config.conf["speech"]['sapi4']["capPitchChange"])
-				offset = int((self._maxPitch - self._minPitch)*offset / 100)
+				offset = int((self._maxPitch - self._minPitch) * offset / 100)
 				val = oldPitch + offset
 				if val > self._maxPitch:
 					val = self._maxPitch
@@ -172,7 +172,7 @@ class SynthDriver(SynthDriver):
 				TextSDATA(text),
 				self._bufSinkPtr,
 				ITTSBufNotifySink._iid_
-				)
+			)
 
 	def cancel(self):
 		self._ttsCentral.AudioReset()

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -35,10 +35,10 @@ from ._sapi4 import (
 	VOICECHARSET
 )
 import config
-import speech
 import nvwave
 import weakref
 
+from speech.commands import PitchCommand
 from speech.commands import IndexCommand, SpeechCommand, CharacterModeCommand
 
 class SynthDriverBufSink(COMObject):
@@ -68,7 +68,7 @@ class SynthDriverBufSink(COMObject):
 class SynthDriver(SynthDriver):
 
 	name="sapi4"
-	description="NewSpeech 4"
+	description="Microsoft Speech API version 4"
 	supportedSettings=[SynthDriver.VoiceSetting()]
 	supportedNotifications={synthIndexReached,synthDoneSpeaking}
 
@@ -129,7 +129,7 @@ class SynthDriver(SynthDriver):
 			elif isinstance(item, CharacterModeCommand):
 				textList.append("\\RmS=1\\" if item.state else "\\RmS=0\\")
 				charMode=item.state
-			elif isinstance(item, speech.PitchCommand):
+			elif isinstance(item, PitchCommand):
 				offset=int(config.conf["speech"]['sapi4']["capPitchChange"])
 				offset=int((self._maxPitch-self._minPitch)*offset/100)
 				val=oldPitch+offset

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -116,10 +116,10 @@ class SynthDriver(SynthDriver):
 		textList=[]
 		charMode=False
 		item=None
-		isPitchCommand=False
-		pitch=WORD()
+		isPitchCommand = False
+		pitch = WORD()
 		self._ttsAttrs.PitchGet(byref(pitch))
-		oldPitch=pitch.value
+		oldPitch = pitch.value
 
 		for item in speechSequence:
 			if isinstance(item,str):
@@ -130,15 +130,15 @@ class SynthDriver(SynthDriver):
 				textList.append("\\RmS=1\\" if item.state else "\\RmS=0\\")
 				charMode=item.state
 			elif isinstance(item, PitchCommand):
-				offset=int(config.conf["speech"]['sapi4']["capPitchChange"])
-				offset=int((self._maxPitch-self._minPitch)*offset/100)
-				val=oldPitch+offset
-				if val>self._maxPitch:
-					val=self._maxPitch
-				if val<self._minPitch:
-					val=self._minPitch
+				offset = int(config.conf["speech"]['sapi4']["capPitchChange"])
+				offset = int((self._maxPitch - self._minPitch)*offset / 100)
+				val = oldPitch + offset
+				if val > self._maxPitch:
+					val = self._maxPitch
+				if val < self._minPitch:
+					val = self._minPitch
 				self._ttsAttrs.PitchSet(val)
-				isPitchCommand=True
+				isPitchCommand = True
 			elif isinstance(item, SpeechCommand):
 				log.debugWarning("Unsupported speech command: %s"%item)
 			else:
@@ -156,11 +156,23 @@ class SynthDriver(SynthDriver):
 		text="".join(textList)
 		flags=TTSDATAFLAG_TAGGED
 		if isPitchCommand:
-			self._ttsCentral.TextData(VOICECHARSET.CHARSET_TEXT, flags,TextSDATA(text),self._bufSinkPtr,ITTSBufNotifySink._iid_)
+			self._ttsCentral.TextData(
+				VOICECHARSET.CHARSET_TEXT,
+				flags,
+				TextSDATA(text),
+				self._bufSinkPtr,
+				ITTSBufNotifySink._iid_
+			)
 			self._ttsAttrs.PitchSet(oldPitch)
-			isPitchCommand=False
+			isPitchCommand = False
 		else:
-			self._ttsCentral.TextData(VOICECHARSET.CHARSET_TEXT, flags,TextSDATA(text),self._bufSinkPtr,ITTSBufNotifySink._iid_)
+			self._ttsCentral.TextData(
+				VOICECHARSET.CHARSET_TEXT,
+				flags,
+				TextSDATA(text),
+				self._bufSinkPtr,
+				ITTSBufNotifySink._iid_
+				)
 
 	def cancel(self):
 		self._ttsCentral.AudioReset()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,7 @@ What's New in NVDA
 - Strikethrough, superscript and subscript formatting for entire Excel cells are now reported if the corresponding option is enabled. (#12264)
 - Fixed copying config during installation from a portable copy when default destination config directory is empty. (#12071, #12205)
 - Fixed incorrect announcement of some letters with accents or diacritic when 'Say cap before capitals' option is checked. (#11948)
+- Fixed the pitch change failure in Sapi4 speech synthesizer. (#12311)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
#12311 

### Summary of the issue:
This pr solves the problem in #12311 , To put it simply, Starting with version 2019.3, the "Capital pitch change" when using the SAPI4 synthesizer was invalid.
But this must be incorrect behavior.
For visually impaired developers, this feature is especially important when typing and checking code.

### Description of how this pull request fixes the issue,
I don't know why.
this function is marked as unavailable in the speak function, I managed to add this part of the code, and tested it, it works well.

### Testing strategy:

1. Start NVDA and press NVDA + CTRL + S to select "Microsoft Speech API version 4" and confirm.
2. At this point the NVDA should have switched to the SAPI4 synthesizer and you will need to press NVDA + CTRL + V to open the Voice Setup dialog.
3. Use the Tab key to navigate until you hear "Capital pitch change percentageeditselected 30" You can change this value to 40 (or higher, or leave it unchanged).
4. Then use Windows + R to open the Run dialog and type notepad and confirm, this will open notepad allowing you to type some text.
5. Press the Caps lock key (it may be located to the left of the letter A) You may need to press it twice in a row until you hear "Caps lock on".
6. Try to enter some letters, such as the letter "C" (or "D" or something else)
7. Use Left Arrow or Right Arrow to move between these letters.

**You will hear NVDA report these capital letters in a higher pitch.**


### Known issues with pull request:
None

### Change log entries:
Bug fixes: 
- Fixed the pitch change failure in Sapi4 speech synthesizer. (#12311)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
