### PR TITLE
Fix wx assertion error

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -402,7 +402,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 	"""
 
 	title=""
-	categoryClasses:typing.List[typing.Type[SettingsPanel]] = []
+	categoryClasses: typing.List[typing.Type[SettingsPanel]] = []
 
 	class CategoryUnavailableError(RuntimeError): pass
 
@@ -428,7 +428,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.setPostInitFocus = None
 		# dictionary key is index of category in self.catList, value is the instance.
 		# Partially filled, check for KeyError
-		self.catIdToInstanceMap:typing.Dict[int, SettingsPanel] = {}
+		self.catIdToInstanceMap: typing.Dict[int, SettingsPanel] = {}
 
 		super(MultiCategorySettingsDialog, self).__init__(
 			parent,
@@ -659,7 +659,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 			log.debugWarning("Error while saving settings:", exc_info=True)
 			return
 
-	def onOk(self,evt):
+	def onOk(self, evt):
 		self._doSave()
 		super(MultiCategorySettingsDialog,self).onOk(evt)
 


### PR DESCRIPTION


<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes: #12336
Fixes: #12220

### Summary of the issue:
#12220 Causes a wx assertion message when either the Braille or Speech settings panels are open.
This seems to be related to the expando text control used on both panels.
The assertion is in wx's accessibility code, which has been introduced in our latest upgrade of wxPython.
The PR #12292 attempted to fix this by explicitly destroying the expando text control when closing.
In #12292 it was missed that the onSave callback was also called for the apply button.

### Description of how this pull request fixes the issue:
While looking at adding an explicit close callback for panels, I noticed that Destroy was being called manually during the event handler.
Scheduling a destroy call after the event handler seems to resolve this issue.
As I understand, destroying children explicitly is not required.

While here also:
- Tidy onSave / onApply
- Add type info for 'catIdToInstanceMap' and 'categoryClasses'

### Testing strategy:
Manually Testing
Open and exit settigns dialog speech/braille panel open via:
- Save button
- Cancel button
- Close button
- Apply followed by save

Open braille and speech panels, then open advanced panel, change a setting, apply and save.

### Known issues with pull request:
The change that introduced the explicit destroy calls was part of a very large change, I don't know for sure if they were working around some other unwanted behaviour.

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
