### PR TITLE
Revert "Elements list is now available in Microsoft Word straight away without having to enable browse mode first"

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -21,14 +21,11 @@ from displayModel import EditableTextDisplayModelTextInfo
 from NVDAObjects.window import DisplayModelEditableText
 from ..behaviors import EditableTextWithoutAutoSelectDetection
 from NVDAObjects.window.winword import *
-from NVDAObjects.window.winword import WordDocumentTreeInterceptor
-
 
 class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocument):
  
-	treeInterceptorClass = WordDocumentTreeInterceptor
-	shouldCreateTreeInterceptor = True
-
+	treeInterceptorClass=WordDocumentTreeInterceptor
+	shouldCreateTreeInterceptor=False
 	TextInfo=WordDocumentTextInfo
 
 	def _get_ignoreEditorRevisions(self):

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -298,14 +298,6 @@ class WordDocumentTextInfo(UIATextInfo):
 
 class WordBrowseModeDocument(UIABrowseModeDocument):
 
-	# This treeInterceptor starts in focus mode, thus escape should not switch back to browse mode
-	disableAutoPassThrough = True
-
-	def __init__(self, rootNVDAObject):
-		super(WordBrowseModeDocument, self).__init__(rootNVDAObject)
-		self.passThrough = True
-		browseMode.reportPassThrough.last = True
-
 	def shouldSetFocusToObj(self,obj):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		if obj.role==controlTypes.ROLE_EDITABLETEXT and obj.UIAElement.cachedAutomationID.startswith('UIA_AutomationId_Word_Content'):
@@ -349,8 +341,8 @@ class WordDocumentNode(UIA):
 		return role
 
 class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentBase):
-	treeInterceptorClass = WordBrowseModeDocument
-	shouldCreateTreeInterceptor = True
+	treeInterceptorClass=WordBrowseModeDocument
+	shouldCreateTreeInterceptor=False
 	announceEntireNewLine=True
 
 	# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1069,14 +1069,6 @@ class BrowseModeWordDocumentTextInfo(browseMode.BrowseModeDocumentTextInfo,treeI
 
 class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 
-	# This treeInterceptor starts in focus mode, thus escape should not switch back to browse mode
-	disableAutoPassThrough = True
-
-	def __init__(self, rootNVDAObject):
-		super(WordDocumentTreeInterceptor, self).__init__(rootNVDAObject)
-		self.passThrough = True
-		browseMode.reportPassThrough.last = True
-
 	TextInfo=BrowseModeWordDocumentTextInfo
 
 	def _activateLongDesc(self,controlField):


### PR DESCRIPTION
Reverts nvaccess/nvda#12051

### Link to issue number:
Fixes #12117 

### Summary of the issue:
In both Outlook and Windows 10 Mail, a Microsoft Word document control is used to display content of received emails and emails currently being composed. In NVDA 2020.4, NVDA would use browse mode for reading emails, but not for writing emails.
However, after merging of pr #12051  browse mode is no longer used by default when reading emails. This is because the base Microsoft Word document NVDAObject now creates a TreeInterceptor all the time, but set to focus mode, so that elements list is always available in Microsoft Word.
But as hxMail and Outlook implementations assumed browse mode would be available for the TreeInterceptor always, and only created the TreeInterceptor in the reading pane, Windows 10 mail and Outlook ended up getting no treeInterceptor for writing email (ok) but for reading email it got a treeInterceptor but set to focus mode (not okay).

### Description of how this pull request fixes the issue:
Revert pr #12051 .

### Testing strategy:
For both Outlook and Windows 10 mail:
Opened a received email, and verified that the arrow keys could again be used to navigate / read the content of the email message and that quick navigation was available. Then pressed control+n to create a new message, tabbed to the message document, and ensured that NVDA was not in browse mode, and that the arrow keys moved the physical caret.

### Known issues with pull request:
Reverting PR #12051 does mean that again Elements List is no longer available in Microsoft Word, unless browse mode is switched to at least once. I think this is however much more acceptable for this release rather than broken email reading. 
An alternative way to fix this was worked on in pr #12320  but this had at first assumed only Windows 10 mail had the issue. But once it was realised that Outlook also had the issue, it was felt that perhaps a more generalised and cleaner solution could be worked out. But that work should not hold back NVDA 2021.1.

### Change log entries:
None needed.


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
