### PR TITLE
Elements List dialog: Remove the accelerator key on the "Activate" button (#6167)

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -972,9 +972,10 @@ class ElementsListDialog(
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
 		bHelper = gui.guiHelper.ButtonHelper(wx.HORIZONTAL)
-		# Translators: The label of a button to activate an element
-		# in the browse mode Elements List dialog.
-		self.activateButton = bHelper.addButton(self, label=_("&Activate"))
+		# Translators: The label of a button to activate an element in the browse mode Elements List dialog.
+		# Beware not to set an accelerator that would collide with other controls in this dialog, such as an
+		# element type radio label.
+		self.activateButton = bHelper.addButton(self, label=_("Activate"))
 		self.activateButton.Bind(wx.EVT_BUTTON, lambda evt: self.onAction(True))
 		
 		# Translators: The label of a button to move to an element


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #6167

### Summary of the issue:

In the English locale, there is an accelerator key collision between the "Annotation" element type and the "Activate" button, both set to the letter "A".
In the French locale, there is collision between the element type "Form field" ("Champs de formulaire") and the same button ("Activer"), both set to the letter "C".

This changes the behavior of the accelerator key that focuses the radio button but does not activate it.
This is not a bug at all, but is not ergonomically optimum, especially for less advanced users.

### Description of how this pull request fixes the issue:

As suggested by @Qchristensen, remove the accelerator key setting from the "Activate" button as it is, when available, the default action of the dialog upon pressing the `enter` key.

In most locale, this change should not raise the need for a new translation, as the "Activate" label already exists without an accelerator marker as "a message reported when the action at the position of the review cursor or navigator object is performed.".
Just to be sure, I also added a warning in the translators comment for the button label to ask them to beware of the risk of collision.

### Testing strategy:

Rendered the dialog from a source copy.
Ensured the accelerator key is removed from the button.

### Known issues with pull request:

If some locale did set a more explicit message for the "a message reported when the action at the position of the review cursor or navigator object is performed." use, they might not be warned by the translation system that they need to review this label.
I guess most locales would have keep it short though, retaining the same meaning as the button.
Would separation of the two translatable strings be needed, this would be a task for `pgettext`, but then require every locale to be provided a new translation.

### Change log entries:
Changes
In the Elements List dialog, the accelerator key on the "Activate" button has been removed in some locales to avoid collision with an element type radio button label. When available, the button is still the default of the dialog and as such can still be invoked by simply pressing `enter` from the elements list itself.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
