### PR TITLE
Fix compilation of espeak dictionary for language zhy

### DIFF
--- a/include/espeak.md
+++ b/include/espeak.md
@@ -26,6 +26,7 @@ Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
    1. Do `git checkout origin/master` or whichever espeak-ng ref you wish.
 1. Look at changes in `Makefile.am` and update our build.
    1. Diff `Makefile.am` with the previously used commit of espeak.
+   1. Changes to Dictionary compilation should be reflected in `espeakDictionaryCompileList`
    1. Some modules are intentionally excluded from the build.
       If unsure, err on the side of including it and raise it as a question when submitting a PR.
    1. Modify the `<nvda repo root>/nvdaHelper/espeak/config.h` file as required.

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -443,7 +443,8 @@ for dictFileName, (rulesFileName, langCode) in espeakDictionaryCompileList.items
 	try:
 		dictDeps.remove(rulesFilePath)
 	except Exception:
-		print(f"Removing from dictDeps: {rulesFilePath} from \n{dictDeps}")
+		print(f"Failed to remove from dictDeps: {rulesFilePath} from \n{dictDeps}")
+		raise
 	env.Depends(dictFile, dictDeps)
 	env.Depends(dictFile, [espeakLib, phonemeData])
 

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -1,11 +1,19 @@
+import enum
+import typing
+import os
+import ctypes
+import SCons.Node
+import SCons.Node.FS
+import SCons.Environment
+from glob import glob
+
+sourceDir: SCons.Node.FS.Dir
+thirdPartyEnv: SCons.Environment.Environment
+
 Import([
 	'thirdPartyEnv',
 	'sourceDir',
 ])
-
-import os
-import ctypes
-from glob import glob
 
 class AutoFreeCDLL(ctypes.CDLL):
 	def __del__(self):
@@ -16,6 +24,12 @@ espeakRepo=Dir("#include/espeak")
 espeakSrcDir=espeakRepo.Dir('src')
 espeakIncludeDir=espeakSrcDir.Dir('include')
 sonicSrcDir=Dir("#include/sonic")
+
+class espeak_ERROR(enum.IntEnum):
+	EE_OK = 0
+	EE_INTERNAL_ERROR = -1
+	EE_BUFFER_FULL = 1
+	EE_NOT_FOUND = 2
 
 class espeak_VOICE(ctypes.Structure):
 	_fields_=[
@@ -30,7 +44,20 @@ class espeak_VOICE(ctypes.Structure):
 		('spare',ctypes.c_void_p),
 	]
 
-env = thirdPartyEnv.Clone()
+
+class espeak_AUDIO_OUTPUT(enum.IntEnum):
+	"""From '/espeak-ng/speak_lib.h'
+	"""
+	#: PLAYBACK mode: plays the audio data, supplies events to the calling program
+	AUDIO_OUTPUT_PLAYBACK = 0
+	#: RETRIEVAL mode: supplies audio data and events to the calling program
+	AUDIO_OUTPUT_RETRIEVAL = 1
+	#: SYNCHRONOUS mode: as RETRIEVAL but doesn't return until synthesis is completed
+	AUDIO_OUTPUT_SYNCHRONOUS = 2
+	#: Synchronous playback
+	AUDIO_OUTPUT_SYNCH_PLAYBACK = 3
+
+env: SCons.Environment.Environment = thirdPartyEnv.Clone()
 env.Append(
 	CCFLAGS=[
 		# Whole-program optimization causes eSpeak to distort and warble with its Klatt4 voice
@@ -84,25 +111,199 @@ def espeak_compilePhonemeData_buildAction(target,source,env):
 
 env['BUILDERS']['espeak_compilePhonemeData']=Builder(action=env.Action(espeak_compilePhonemeData_buildAction,"Compiling phoneme data"),emitter=espeak_compilePhonemeData_buildEmitter)
 
-def espeak_compileDict_buildAction(target,source,env):
+espeakDictionaryCompileList: typing.Dict[
+	str, # expected dict file name EG 'es_dict'
+	typing.Tuple[str, str] # rules file and language code. EG, ('es_rules, 'es'))
+] = {
+	"af_dict": ("af_rules", "af"),
+	"am_dict": ("am_rules", "am"),
+	"an_dict": ("an_rules", "an"),
+	"ar_dict": ("ar_rules", "ar"),
+	"as_dict": ("as_rules", "as"),
+	"az_dict": ("az_rules", "az"),
+	"ba_dict": ("ba_rules", "ba"),
+	"bg_dict": ("bg_rules", "bg"),
+	"bn_dict": ("bn_rules", "bn"),
+	"bpy_dict": ("bpy_rules", "bpy"),
+	"bs_dict": ("bs_rules", "bs"),
+	"ca_dict": ("ca_rules", "ca"),
+	"chr_dict": ("chr_rules", "chr"),
+	"cmn_dict": ("cmn_rules", "cmn"),
+	"cs_dict": ("cs_rules", "cs"),
+	"cv_dict": ("cv_rules", "cv"),
+	"cy_dict": ("cy_rules", "cy"),
+	"da_dict": ("da_rules", "da"),
+	"de_dict": ("de_rules", "de"),
+	"el_dict": ("el_rules", "el"),
+	"en_dict": ("en_rules", "en"),
+	"eo_dict": ("eo_rules", "eo"),
+	"es_dict": ("es_rules", "es"),
+	"et_dict": ("et_rules", "et"),
+	"eu_dict": ("eu_rules", "eu"),
+	"fa_dict": ("fa_rules", "fa"),
+	"fi_dict": ("fi_rules", "fi"),
+	"fr_dict": ("fr_rules", "fr"),
+	"ga_dict": ("ga_rules", "ga"),
+	"gd_dict": ("gd_rules", "gd"),
+	"gn_dict": ("gn_rules", "gn"),
+	"grc_dict": ("grc_rules", "grc"),
+	"gu_dict": ("gu_rules", "gu"),
+	"hak_dict": ("hak_rules", "hak"),
+	"haw_dict": ("haw_rules", "haw"),
+	"he_dict": ("he_rules", "he"),
+	"hi_dict": ("hi_rules", "hi"),
+	"hr_dict": ("hr_rules", "hr"),
+	"ht_dict": ("ht_rules", "ht"),
+	"hu_dict": ("hu_rules", "hu"),
+	"hy_dict": ("hy_rules", "hy"),
+	"ia_dict": ("ia_rules", "ia"),
+	"id_dict": ("id_rules", "id"),
+	"io_dict": ("io_rules", "io"),
+	"is_dict": ("is_rules", "is"),
+	"it_dict": ("it_rules", "it"),
+	"ja_dict": ("ja_rules", "ja"),
+	"jbo_dict": ("jbo_rules", "jbo"),
+	"ka_dict": ("ka_rules", "ka"),
+	"kk_dict": ("kk_rules", "kk"),
+	"kl_dict": ("kl_rules", "kl"),
+	"kn_dict": ("kn_rules", "kn"),
+	"kok_dict": ("kok_rules", "kok"),
+	"ko_dict": ("ko_rules", "ko"),
+	"ku_dict": ("ku_rules", "ku"),
+	"ky_dict": ("ky_rules", "ky"),
+	"la_dict": ("la_rules", "la"),
+	"lfn_dict": ("lfn_rules", "lfn"),
+	"lt_dict": ("lt_rules", "lt"),
+	"lv_dict": ("lv_rules", "lv"),
+	"mi_dict": ("mi_rules", "mi"),
+	"mk_dict": ("mk_rules", "mk"),
+	"ml_dict": ("ml_rules", "ml"),
+	"mr_dict": ("mr_rules", "mr"),
+	"ms_dict": ("ms_rules", "ms"),
+	"mt_dict": ("mt_rules", "mt"),
+	"my_dict": ("my_rules", "my"),
+	"nci_dict": ("nci_rules", "nci"),
+	"ne_dict": ("ne_rules", "ne"),
+	"nl_dict": ("nl_rules", "nl"),
+	"nog_dict": ("nog_rules", "nog"),
+	"no_dict": ("no_rules", "no"),
+	"om_dict": ("om_rules", "om"),
+	"or_dict": ("or_rules", "or"),
+	"pap_dict": ("pap_rules", "pap"),
+	"pa_dict": ("pa_rules", "pa"),
+	"piqd_dict": ("piqd_rules", "piqd"),
+	"pl_dict": ("pl_rules", "pl"),
+	"pt_dict": ("pt_rules", "pt"),
+	"py_dict": ("py_rules", "py"),
+	"qdb_dict": ("qdb_rules", "qdb"),
+	"quc_dict": ("quc_rules", "quc"),
+	"qu_dict": ("qu_rules", "qu"),
+	"ro_dict": ("ro_rules", "ro"),
+	"ru_dict": ("ru_rules", "ru"),
+	"sd_dict": ("sd_rules", "sd"),
+	"shn_dict": ("shn_rules", "shn"),
+	"si_dict": ("si_rules", "si"),
+	"sk_dict": ("sk_rules", "sk"),
+	"sl_dict": ("sl_rules", "sl"),
+	"smj_dict": ("smj_rules", "smj"),
+	"sq_dict": ("sq_rules", "sq"),
+	"sr_dict": ("sr_rules", "sr"),
+	"sv_dict": ("sv_rules", "sv"),
+	"sw_dict": ("sw_rules", "sw"),
+	"ta_dict": ("ta_rules", "ta"),
+	"te_dict": ("te_rules", "te"),
+	"th_dict": ("th_rules", "th"),
+	"tk_dict": ("tk_rules", "tk"),
+	"tn_dict": ("tn_rules", "tn"),
+	"tr_dict": ("tr_rules", "tr"),
+	"tt_dict": ("tt_rules", "tt"),
+	"ug_dict": ("ug_rules", "ug"),
+	"uk_dict": ("uk_rules", "uk"),
+	"ur_dict": ("ur_rules", "ur"),
+	"uz_dict": ("uz_rules", "uz"),
+	"vi_dict": ("vi_rules", "vi"),
+	"yue_dict": ("yue_rules", "yue"),
+}
+
+def espeak_compileDict_buildAction(
+		# SCons docs claim target and source should be a Node, not list, but this is what we get.
+		target: typing.List[SCons.Node.FS.File],
+		source: typing.List[SCons.Node.FS.File],
+		env: SCons.Environment.Environment
+) -> int:
+	"""
+	@param target: The langCode_dict file to build
+	@param source: The langCode_rules file
+	@param env: Scons build environment
+	@return From SCons docs: "Return 0 or None to indicate a successful build of
+		the target file(s). The function may raise an exception or return a non-zero
+		exit status to indicate an unsuccessful build."
+	"""
+	if len(target) != 1:
+		targetStrings = list((str(t) for t in target))
+		raise ValueError(f"Unexpected number of targets: {targetStrings}")
+	target = target[0]
+
+	if len(source) != 1:
+		sourceStrings = list((str(s) for s in source))
+		raise ValueError(f"Unexpected number of source files: {sourceStrings}")
+	source = source[0]
+
+	ACTION_SUCCESS = 0
+	ACTION_FAILURE = 1
+
 	# We want the eSpeak dll to be freed after each dictionary.
 	# This is because it writes to stderr but doesn't flush it.
 	# Unfortunately, there's no way we can flush it or use a different stream
 	# because our eSpeak statically links the CRT.
 	espeak=AutoFreeCDLL(espeakLib[0].abspath)
-	espeak.espeak_Initialize(0,0,os.fsencode(target[0].Dir('..').abspath),0x8000)
-	try:
-		lang=source[0].name.split('_')[0].encode()
-		v=espeak_VOICE(languages=lang+b'\x00')
-		if espeak.espeak_SetVoiceByProperties(ctypes.byref(v))!=0:
-			print("espeak_compileDict_action: failed to switch to language %s"%lang)
-			return 1
-		dictPath=os.fsencode(os.path.split(source[0].abspath)[0]+'/')
-		if espeak.espeak_ng_CompileDictionary(dictPath,None,0,None)!=0:
-			print("espeak_compileDict_action: failed to compile dictionary for  language %s"%lang)
-			return
+
+	# from: espeak-ng/speak_lib.h
+	espeakINITIALIZE_DONT_EXIT = 0x8000
+	# see: libespeak-ng/espeak_api.c for espeak_Initialize
+	espeak.espeak_Initialize(
+		espeak_AUDIO_OUTPUT.AUDIO_OUTPUT_PLAYBACK,  # espeak_AUDIO_OUTPUT output_type
+		0,  # int buf_length
+		os.fsencode(target.Dir('..').abspath),  # const char *path
+		espeakINITIALIZE_DONT_EXIT  # int options
+	)
+
+	try: # ensure that espeak_Terminate is called
+		lang = espeakDictionaryCompileList[target.name][1]
+		langRulesName:str = source.name  # example: "es_rules"
+		dirForRules:SCons.Node.FS.Base = source.dir
+		voice = espeak_VOICE(languages=lang.encode() + b'\x00')
+
+		setVoiceResult = espeak.espeak_SetVoiceByProperties(ctypes.byref(voice))
+		if espeak_ERROR.EE_OK.value != setVoiceResult:
+			print(
+				f"Failed to switch to language: '{lang}'"
+				f"\n rules: '{langRulesName}'"
+				f"\n result: {espeak_ERROR(setVoiceResult)!s}"
+			)
+			return ACTION_FAILURE
+
+		rulesPathEncoded = os.fsencode(dirForRules.abspath + '/')
+		# see: libespeak-ng/compiledict.c for espeak_ng_CompileDictionary
+		compileDictResult = espeak.espeak_ng_CompileDictionary(
+			rulesPathEncoded,  # const char *dsource
+			None,  # const char *dict_name
+			None,  # FILE *log
+			0,  # int flags
+			None,  # espeak_ng_ERROR_CONTEXT *context
+		)
+		if espeak_ERROR.EE_OK.value != compileDictResult:
+			print(
+				f"Failed to compile dictionary: '{target}'"
+				f"\n rules: '{langRulesName}'"
+				f"\n rulesPath: {rulesPathEncoded}"
+				f"\n language: '{lang}'"
+				f"\n result: {espeak_ERROR(compileDictResult)!s}"
+			)
+			return ACTION_FAILURE
 	finally:
 		espeak.espeak_Terminate()
+	return ACTION_SUCCESS
 
 sonicLib=env.StaticLibrary(
 	target='sonic',
@@ -182,8 +383,9 @@ for i in phonemeData:
 env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
 
 #Compile all dictionaries
-missingDicts=['zhy', ] #'mt','tn','tt']
-dictSourcePath=espeakRepo.Dir('dictsource').abspath
+excludeLangs: typing.List[str] = [] # Use to exclude languages which don't compile.
+dictSourcePath: SCons.Node.FS.Dir = espeakRepo.Dir('dictsource')
+
 # Remove emoji files before compiling dictionaries.
 # Currently many of these simply crash eSpeak at runtime.
 # Also, our own emoji processing using CLDR data is preferred.
@@ -191,18 +393,36 @@ emojiGlob = os.path.join(espeakRepo.abspath,'dictsource','*_emoji')
 for f in glob(emojiGlob):
 	print("Removing emoji file: %s"%f)
 	os.remove(f)
-for f in env.Glob(os.path.join(dictSourcePath,'*_rules')):
-	lang=f.name.split('_')[0]
-	if lang in missingDicts: continue
-	dictFileName = lang+'_dict'
-	dictFile=env.Command(espeakRepo.Dir('espeak-ng-data').File(dictFileName),f,espeak_compileDict_buildAction)
-	dictDeps=env.Glob(os.path.join(espeakRepo.abspath,'dictsource',lang+'_*'))
-	dictDeps.remove(f)
-	env.Depends(dictFile,dictDeps)
-	env.Depends(dictFile,[espeakLib,phonemeData])
-	#Dictionaries can not be compiled in parallel, force SCons not to do this
+
+# Create compile commands for all languages
+for dictFileName, (rulesFileName, langCode) in espeakDictionaryCompileList.items():
+	if langCode in excludeLangs: continue
+
+	rulesFilePath = dictSourcePath.File(rulesFileName)
+	dictFilePath = espeakRepo.Dir('espeak-ng-data').File(dictFileName)
+
+	dictFile = env.Command(
+		target=dictFilePath,
+		source=rulesFilePath,
+		action=espeak_compileDict_buildAction
+	)
+
+	# Find all files related to "langCode", these are all dependencies for the language.
+	dictDeps = dictSourcePath.glob(langCode + '_*')
+	# Remove, sourceRulesFilePath, SCons already knows the target depends on the source
+	try:
+		dictDeps.remove(rulesFilePath)
+	except Exception:
+		print(f"Removing from dictDeps: {rulesFilePath} from \n{dictDeps}")
+	env.Depends(dictFile, dictDeps)
+	env.Depends(dictFile, [espeakLib, phonemeData])
+
+	# Dictionaries can not be compiled in parallel, force SCons not to do this
 	env.SideEffect('_espeak_compileDict',dictFile)
-	env.InstallAs(os.path.join(synthDriversDir.Dir('espeak-ng-data').abspath, dictFileName), dictFile)
+	env.InstallAs( # Install files to the "synthDrivers/espeak-ng-data/" dir.
+		os.path.join(synthDriversDir.Dir('espeak-ng-data').abspath, dictFileName),
+		dictFile
+	)
 
 env.Install(synthDriversDir,espeakLib)
 

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -31,6 +31,32 @@ class espeak_ERROR(enum.IntEnum):
 	EE_BUFFER_FULL = 1
 	EE_NOT_FOUND = 2
 
+class espeak_ng_STATUS(enum.IntEnum):
+	ENS_GROUP_MASK = 0x70000000
+	ENS_GROUP_ERRNO = 0x00000000  # Values 0 - 255 map to errno error codes.
+	ENS_GROUP_ESPEAK_NG = 0x10000000  # eSpeak NG error codes.
+
+	#eSpeak NG 1.49 .0
+	ENS_OK = 0
+	ENS_COMPILE_ERROR = 0x100001FF
+	ENS_VERSION_MISMATCH = 0x100002FF
+	ENS_FIFO_BUFFER_FULL = 0x100003FF
+	ENS_NOT_INITIALIZED = 0x100004FF
+	ENS_AUDIO_ERROR = 0x100005FF
+	ENS_VOICE_NOT_FOUND = 0x100006FF
+	ENS_MBROLA_NOT_FOUND = 0x100007FF
+	ENS_MBROLA_VOICE_NOT_FOUND = 0x100008FF
+	ENS_EVENT_BUFFER_FULL = 0x100009FF
+	ENS_NOT_SUPPORTED = 0x10000AFF
+	ENS_UNSUPPORTED_PHON_FORMAT = 0x10000BFF
+	ENS_NO_SPECT_FRAMES = 0x10000CFF
+	ENS_EMPTY_PHONEME_MANIFEST = 0x10000DFF
+	ENS_SPEECH_STOPPED = 0x10000EFF
+
+	# eSpeak NG 1.49 .2
+	ENS_UNKNOWN_PHONEME_FEATURE = 0x10000FFF
+	ENS_UNKNOWN_TEXT_ENCODING = 0x100010FF
+
 class espeak_VOICE(ctypes.Structure):
 	_fields_=[
 		('name',ctypes.c_char_p),
@@ -111,6 +137,7 @@ def espeak_compilePhonemeData_buildAction(target,source,env):
 
 env['BUILDERS']['espeak_compilePhonemeData']=Builder(action=env.Action(espeak_compilePhonemeData_buildAction,"Compiling phoneme data"),emitter=espeak_compilePhonemeData_buildEmitter)
 
+#: See dictionaries section of /include/espeak/Makefile.am
 espeakDictionaryCompileList: typing.Dict[
 	str, # expected dict file name EG 'es_dict'
 	typing.Tuple[str, str] # rules file and language code. EG, ('es_rules, 'es'))
@@ -274,6 +301,8 @@ def espeak_compileDict_buildAction(
 		dirForRules:SCons.Node.FS.Base = source.dir
 		voice = espeak_VOICE(languages=lang.encode() + b'\x00')
 
+		# see: espeak-ng/speak_lib.h for espeak_SetVoiceByProperties
+		# returns: espeak_ERROR
 		setVoiceResult = espeak.espeak_SetVoiceByProperties(ctypes.byref(voice))
 		if espeak_ERROR.EE_OK.value != setVoiceResult:
 			print(
@@ -284,7 +313,8 @@ def espeak_compileDict_buildAction(
 			return ACTION_FAILURE
 
 		rulesPathEncoded = os.fsencode(dirForRules.abspath + '/')
-		# see: libespeak-ng/compiledict.c for espeak_ng_CompileDictionary
+		# see: espeak-ng/espeak_ng.h for espeak_ng_CompileDictionary
+		# returns: espeak_ng_STATUS
 		compileDictResult = espeak.espeak_ng_CompileDictionary(
 			rulesPathEncoded,  # const char *dsource
 			None,  # const char *dict_name
@@ -298,7 +328,7 @@ def espeak_compileDict_buildAction(
 				f"\n rules: '{langRulesName}'"
 				f"\n rulesPath: {rulesPathEncoded}"
 				f"\n language: '{lang}'"
-				f"\n result: {espeak_ERROR(compileDictResult)!s}"
+				f"\n result: {espeak_ng_STATUS(compileDictResult)!s}"
 			)
 			return ACTION_FAILURE
 	finally:

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -140,127 +140,126 @@ env['BUILDERS']['espeak_compilePhonemeData']=Builder(action=env.Action(espeak_co
 #: See dictionaries section of /include/espeak/Makefile.am
 espeakDictionaryCompileList: typing.Dict[
 	str, # expected dict file name EG 'es_dict'
-	typing.Tuple[str, str] # rules file and language code. EG, ('es_rules, 'es'))
+	typing.Tuple[str, typing.List[str]] # language code, list of input files
 ] = {
-	"af_dict": ("af_rules", "af"),
-	"am_dict": ("am_rules", "am"),
-	"an_dict": ("an_rules", "an"),
-	"ar_dict": ("ar_rules", "ar"),
-	"as_dict": ("as_rules", "as"),
-	"az_dict": ("az_rules", "az"),
-	"ba_dict": ("ba_rules", "ba"),
-	"bg_dict": ("bg_rules", "bg"),
-	"bn_dict": ("bn_rules", "bn"),
-	"bpy_dict": ("bpy_rules", "bpy"),
-	"bs_dict": ("bs_rules", "bs"),
-	"ca_dict": ("ca_rules", "ca"),
-	"chr_dict": ("chr_rules", "chr"),
-	"cmn_dict": ("cmn_rules", "cmn"),
-	"cs_dict": ("cs_rules", "cs"),
-	"cv_dict": ("cv_rules", "cv"),
-	"cy_dict": ("cy_rules", "cy"),
-	"da_dict": ("da_rules", "da"),
-	"de_dict": ("de_rules", "de"),
-	"el_dict": ("el_rules", "el"),
-	"en_dict": ("en_rules", "en"),
-	"eo_dict": ("eo_rules", "eo"),
-	"es_dict": ("es_rules", "es"),
-	"et_dict": ("et_rules", "et"),
-	"eu_dict": ("eu_rules", "eu"),
-	"fa_dict": ("fa_rules", "fa"),
-	"fi_dict": ("fi_rules", "fi"),
-	"fr_dict": ("fr_rules", "fr"),
-	"ga_dict": ("ga_rules", "ga"),
-	"gd_dict": ("gd_rules", "gd"),
-	"gn_dict": ("gn_rules", "gn"),
-	"grc_dict": ("grc_rules", "grc"),
-	"gu_dict": ("gu_rules", "gu"),
-	"hak_dict": ("hak_rules", "hak"),
-	"haw_dict": ("haw_rules", "haw"),
-	"he_dict": ("he_rules", "he"),
-	"hi_dict": ("hi_rules", "hi"),
-	"hr_dict": ("hr_rules", "hr"),
-	"ht_dict": ("ht_rules", "ht"),
-	"hu_dict": ("hu_rules", "hu"),
-	"hy_dict": ("hy_rules", "hy"),
-	"ia_dict": ("ia_rules", "ia"),
-	"id_dict": ("id_rules", "id"),
-	"io_dict": ("io_rules", "io"),
-	"is_dict": ("is_rules", "is"),
-	"it_dict": ("it_rules", "it"),
-	"ja_dict": ("ja_rules", "ja"),
-	"jbo_dict": ("jbo_rules", "jbo"),
-	"ka_dict": ("ka_rules", "ka"),
-	"kk_dict": ("kk_rules", "kk"),
-	"kl_dict": ("kl_rules", "kl"),
-	"kn_dict": ("kn_rules", "kn"),
-	"kok_dict": ("kok_rules", "kok"),
-	"ko_dict": ("ko_rules", "ko"),
-	"ku_dict": ("ku_rules", "ku"),
-	"ky_dict": ("ky_rules", "ky"),
-	"la_dict": ("la_rules", "la"),
-	"lfn_dict": ("lfn_rules", "lfn"),
-	"lt_dict": ("lt_rules", "lt"),
-	"lv_dict": ("lv_rules", "lv"),
-	"mi_dict": ("mi_rules", "mi"),
-	"mk_dict": ("mk_rules", "mk"),
-	"ml_dict": ("ml_rules", "ml"),
-	"mr_dict": ("mr_rules", "mr"),
-	"ms_dict": ("ms_rules", "ms"),
-	"mt_dict": ("mt_rules", "mt"),
-	"my_dict": ("my_rules", "my"),
-	"nci_dict": ("nci_rules", "nci"),
-	"ne_dict": ("ne_rules", "ne"),
-	"nl_dict": ("nl_rules", "nl"),
-	"nog_dict": ("nog_rules", "nog"),
-	"no_dict": ("no_rules", "no"),
-	"om_dict": ("om_rules", "om"),
-	"or_dict": ("or_rules", "or"),
-	"pap_dict": ("pap_rules", "pap"),
-	"pa_dict": ("pa_rules", "pa"),
-	"piqd_dict": ("piqd_rules", "piqd"),
-	"pl_dict": ("pl_rules", "pl"),
-	"pt_dict": ("pt_rules", "pt"),
-	"py_dict": ("py_rules", "py"),
-	"qdb_dict": ("qdb_rules", "qdb"),
-	"quc_dict": ("quc_rules", "quc"),
-	"qu_dict": ("qu_rules", "qu"),
-	"ro_dict": ("ro_rules", "ro"),
-	"ru_dict": ("ru_rules", "ru"),
-	"sd_dict": ("sd_rules", "sd"),
-	"shn_dict": ("shn_rules", "shn"),
-	"si_dict": ("si_rules", "si"),
-	"sk_dict": ("sk_rules", "sk"),
-	"sl_dict": ("sl_rules", "sl"),
-	"smj_dict": ("smj_rules", "smj"),
-	"sq_dict": ("sq_rules", "sq"),
-	"sr_dict": ("sr_rules", "sr"),
-	"sv_dict": ("sv_rules", "sv"),
-	"sw_dict": ("sw_rules", "sw"),
-	"ta_dict": ("ta_rules", "ta"),
-	"te_dict": ("te_rules", "te"),
-	"th_dict": ("th_rules", "th"),
-	"tk_dict": ("tk_rules", "tk"),
-	"tn_dict": ("tn_rules", "tn"),
-	"tr_dict": ("tr_rules", "tr"),
-	"tt_dict": ("tt_rules", "tt"),
-	"ug_dict": ("ug_rules", "ug"),
-	"uk_dict": ("uk_rules", "uk"),
-	"ur_dict": ("ur_rules", "ur"),
-	"uz_dict": ("uz_rules", "uz"),
-	"vi_dict": ("vi_rules", "vi"),
-	"yue_dict": ("yue_rules", "yue"),
+	"af_dict": ("af", ["af_list", "af_rules", ]),
+	"am_dict": ("am", ["am_list", "am_rules", ]),
+	"an_dict": ("an", ["an_list", "an_rules", ]),
+	"ar_dict": ("ar", ["ar_listx", "ar_list", "ar_rules"]),
+	"as_dict": ("as", ["as_list", "as_rules", ]),
+	"az_dict": ("az", ["az_list", "az_rules", ]),
+	"ba_dict": ("ba", ["ba_list", "ba_rules", ]),
+	"bg_dict": ("bg", ["bg_listx", "bg_list", "bg_rules"]),
+	"bn_dict": ("bn", ["bn_list", "bn_rules", ]),
+	"bpy_dict": ("bpy", ["bpy_list", "bpy_rules", ]),
+	"bs_dict": ("bs", ["bs_list", "bs_rules", ]),
+	"ca_dict": ("ca", ["ca_list", "ca_rules", ]),
+	"chr_dict": ("chr", ["chr_list", "chr_rules", ]),
+	"cmn_dict": ("cmn", ["cmn_listx", "cmn_list", "cmn_rules"]),
+	"cs_dict": ("cs", ["cs_list", "cs_rules", ]),
+	"cv_dict": ("cv", ["cv_list", "cv_rules", ]),
+	"cy_dict": ("cy", ["cy_list", "cy_rules", ]),
+	"da_dict": ("da", ["da_list", "da_rules", ]),
+	"de_dict": ("de", ["de_list", "de_rules", ]),
+	"el_dict": ("el", ["el_list", "el_rules", ]),
+	"en_dict": ("en", ["en_list", "en_rules", ]),
+	"eo_dict": ("eo", ["eo_list", "eo_rules", ]),
+	"es_dict": ("es", ["es_list", "es_rules", ]),
+	"et_dict": ("et", ["et_list", "et_rules", ]),
+	"eu_dict": ("eu", ["eu_list", "eu_rules", ]),
+	"fa_dict": ("fa", ["fa_list", "fa_rules", ]),
+	"fi_dict": ("fi", ["fi_list", "fi_rules", ]),
+	"fr_dict": ("fr", ["fr_list", "fr_rules", ]),
+	"ga_dict": ("ga", ["ga_list", "ga_rules", ]),
+	"gd_dict": ("gd", ["gd_list", "gd_rules", ]),
+	"gn_dict": ("gn", ["gn_list", "gn_rules", ]),
+	"grc_dict": ("grc", ["grc_list", "grc_rules", ]),
+	"gu_dict": ("gu", ["gu_list", "gu_rules", ]),
+	"hak_dict": ("hak", ["hak_list", "hak_rules", ]),
+	"haw_dict": ("haw", ["haw_list", "haw_rules", ]),
+	"he_dict": ("he", ["he_listx", "he_list", "he_rules"]),
+	"hi_dict": ("hi", ["hi_list", "hi_rules", ]),
+	"hr_dict": ("hr", ["hr_list", "hr_rules", ]),
+	"ht_dict": ("ht", ["ht_list", "ht_rules", ]),
+	"hu_dict": ("hu", ["hu_list", "hu_rules", ]),
+	"hy_dict": ("hy", ["hy_list", "hy_rules", ]),
+	"ia_dict": ("ia", ["ia_listx", "ia_list", "ia_rules"]),
+	"id_dict": ("id", ["id_list", "id_rules", ]),
+	"io_dict": ("io", ["io_list", "io_rules", ]),
+	"is_dict": ("is", ["is_list", "is_rules", ]),
+	"it_dict": ("it", ["it_listx", "it_list", "it_rules"]),
+	"ja_dict": ("ja", ["ja_list", "ja_rules", ]),
+	"jbo_dict": ("jbo", ["jbo_list", "jbo_rules", ]),
+	"ka_dict": ("ka", ["ka_list", "ka_rules", ]),
+	"kk_dict": ("kk", ["kk_list", "kk_rules", ]),
+	"kl_dict": ("kl", ["kl_list", "kl_rules", ]),
+	"kn_dict": ("kn", ["kn_list", "kn_rules", ]),
+	"kok_dict": ("kok", ["kok_list", "kok_rules", ]),
+	"ko_dict": ("ko", ["ko_list", "ko_rules", ]),
+	"ku_dict": ("ku", ["ku_list", "ku_rules", ]),
+	"ky_dict": ("ky", ["ky_list", "ky_rules", ]),
+	"la_dict": ("la", ["la_list", "la_rules", ]),
+	"lfn_dict": ("lfn", ["lfn_list", "lfn_rules", ]),
+	"lt_dict": ("lt", ["lt_list", "lt_rules", ]),
+	"lv_dict": ("lv", ["lv_list", "lv_rules", ]),
+	"mi_dict": ("mi", ["mi_list", "mi_rules", ]),
+	"mk_dict": ("mk", ["mk_list", "mk_rules", ]),
+	"ml_dict": ("ml", ["ml_list", "ml_rules", ]),
+	"mr_dict": ("mr", ["mr_list", "mr_rules", ]),
+	"ms_dict": ("ms", ["ms_list", "ms_rules", ]),
+	"mt_dict": ("mt", ["mt_list", "mt_rules", ]),
+	"my_dict": ("my", ["my_list", "my_rules", ]),
+	"nci_dict": ("nci", ["nci_list", "nci_rules", ]),
+	"ne_dict": ("ne", ["ne_list", "ne_rules", ]),
+	"nl_dict": ("nl", ["nl_list", "nl_rules", ]),
+	"nog_dict": ("nog", ["nog_list", "nog_rules", ]),
+	"no_dict": ("no", ["no_list", "no_rules", ]),
+	"om_dict": ("om", ["om_list", "om_rules", ]),
+	"or_dict": ("or", ["or_list", "or_rules", ]),
+	"pap_dict": ("pap", ["pap_list", "pap_rules", ]),
+	"pa_dict": ("pa", ["pa_list", "pa_rules", ]),
+	"piqd_dict": ("piqd", ["piqd_list", "piqd_rules", ]),
+	"pl_dict": ("pl", ["pl_list", "pl_rules", ]),
+	"pt_dict": ("pt", ["pt_list", "pt_rules", ]),
+	"py_dict": ("py", ["py_list", "py_rules", ]),
+	"qdb_dict": ("qdb", ["qdb_list", "qdb_rules", ]),
+	"quc_dict": ("quc", ["quc_list", "quc_rules", ]),
+	"qu_dict": ("qu", ["qu_list", "qu_rules", ]),
+	"ro_dict": ("ro", ["ro_list", "ro_rules", ]),
+	"ru_dict": ("ru", ["ru_listx", "ru_list", "ru_rules"]),
+	"sd_dict": ("sd", ["sd_list", "sd_rules", ]),
+	"shn_dict": ("shn", ["shn_list", "shn_rules", ]),
+	"si_dict": ("si", ["si_list", "si_rules", ]),
+	"sk_dict": ("sk", ["sk_list", "sk_rules", ]),
+	"sl_dict": ("sl", ["sl_list", "sl_rules", ]),
+	"smj_dict": ("smj", ["smj_list", "smj_rules", ]),
+	"sq_dict": ("sq", ["sq_list", "sq_rules", ]),
+	"sr_dict": ("sr", ["sr_list", "sr_rules", ]),
+	"sv_dict": ("sv", ["sv_list", "sv_rules", ]),
+	"sw_dict": ("sw", ["sw_list", "sw_rules", ]),
+	"ta_dict": ("ta", ["ta_list", "ta_rules", ]),
+	"te_dict": ("te", ["te_list", "te_rules", ]),
+	"th_dict": ("th", ["th_list", "th_rules", ]),
+	"tk_dict": ("tk", ["tk_listx", "tk_list", "tk_rules"]),
+	"tn_dict": ("tn", ["tn_list", "tn_rules", ]),
+	"tr_dict": ("tr", ["tr_listx", "tr_list", "tr_rules"]),
+	"tt_dict": ("tt", ["tt_list", "tt_rules", ]),
+	"ug_dict": ("ug", ["ug_list", "ug_rules", ]),
+	"uk_dict": ("uk", ["uk_list", "uk_rules", ]),
+	"ur_dict": ("ur", ["ur_list", "ur_rules", ]),
+	"uz_dict": ("uz", ["uz_list", "uz_rules", ]),
+	"vi_dict": ("vi", ["vi_list", "vi_rules", ]),
+	"yue_dict": ("yue", ["yue_list", "yue_listx", "yue_rules"]),
 }
 
 def espeak_compileDict_buildAction(
-		# SCons docs claim target and source should be a Node, not list, but this is what we get.
 		target: typing.List[SCons.Node.FS.File],
 		source: typing.List[SCons.Node.FS.File],
 		env: SCons.Environment.Environment
 ) -> int:
 	"""
 	@param target: The langCode_dict file to build
-	@param source: The langCode_rules file
+	@param source: The langCode_[rules|list|listx] files that are used as inputs
 	@param env: Scons build environment
 	@return From SCons docs: "Return 0 or None to indicate a successful build of
 		the target file(s). The function may raise an exception or return a non-zero
@@ -271,10 +270,10 @@ def espeak_compileDict_buildAction(
 		raise ValueError(f"Unexpected number of targets: {targetStrings}")
 	target = target[0]
 
-	if len(source) != 1:
-		sourceStrings = list((str(s) for s in source))
-		raise ValueError(f"Unexpected number of source files: {sourceStrings}")
-	source = source[0]
+	if not source:
+		raise ValueError(f"No source files provided: {source!s}")
+	# All source files are in the same directory, just use the first one.
+	dirForRules: SCons.Node.FS.Base = source[0].dir
 
 	ACTION_SUCCESS = 0
 	ACTION_FAILURE = 1
@@ -296,9 +295,7 @@ def espeak_compileDict_buildAction(
 	)
 
 	try: # ensure that espeak_Terminate is called
-		lang = espeakDictionaryCompileList[target.name][1]
-		langRulesName:str = source.name  # example: "es_rules"
-		dirForRules:SCons.Node.FS.Base = source.dir
+		lang = espeakDictionaryCompileList[target.name][0]
 		voice = espeak_VOICE(languages=lang.encode() + b'\x00')
 
 		# see: espeak-ng/speak_lib.h for espeak_SetVoiceByProperties
@@ -307,7 +304,6 @@ def espeak_compileDict_buildAction(
 		if espeak_ERROR.EE_OK.value != setVoiceResult:
 			print(
 				f"Failed to switch to language: '{lang}'"
-				f"\n rules: '{langRulesName}'"
 				f"\n result: {espeak_ERROR(setVoiceResult)!s}"
 			)
 			return ACTION_FAILURE
@@ -325,7 +321,6 @@ def espeak_compileDict_buildAction(
 		if espeak_ERROR.EE_OK.value != compileDictResult:
 			print(
 				f"Failed to compile dictionary: '{target}'"
-				f"\n rules: '{langRulesName}'"
 				f"\n rulesPath: {rulesPathEncoded}"
 				f"\n language: '{lang}'"
 				f"\n result: {espeak_ng_STATUS(compileDictResult)!s}"
@@ -425,27 +420,17 @@ for f in glob(emojiGlob):
 	os.remove(f)
 
 # Create compile commands for all languages
-for dictFileName, (rulesFileName, langCode) in espeakDictionaryCompileList.items():
+for dictFileName, (langCode, inputFiles) in espeakDictionaryCompileList.items():
 	if langCode in excludeLangs: continue
 
-	rulesFilePath = dictSourcePath.File(rulesFileName)
 	dictFilePath = espeakRepo.Dir('espeak-ng-data').File(dictFileName)
 
 	dictFile = env.Command(
 		target=dictFilePath,
-		source=rulesFilePath,
+		source=list((dictSourcePath.File(f) for f in inputFiles)),
 		action=espeak_compileDict_buildAction
 	)
 
-	# Find all files related to "langCode", these are all dependencies for the language.
-	dictDeps = dictSourcePath.glob(langCode + '_*')
-	# Remove, sourceRulesFilePath, SCons already knows the target depends on the source
-	try:
-		dictDeps.remove(rulesFilePath)
-	except Exception:
-		print(f"Failed to remove from dictDeps: {rulesFilePath} from \n{dictDeps}")
-		raise
-	env.Depends(dictFile, dictDeps)
 	env.Depends(dictFile, [espeakLib, phonemeData])
 
 	# Dictionaries can not be compiled in parallel, force SCons not to do this

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -36,7 +36,7 @@ class espeak_ng_STATUS(enum.IntEnum):
 	ENS_GROUP_ERRNO = 0x00000000  # Values 0 - 255 map to errno error codes.
 	ENS_GROUP_ESPEAK_NG = 0x10000000  # eSpeak NG error codes.
 
-	#eSpeak NG 1.49 .0
+	# eSpeak NG 1.49.0
 	ENS_OK = 0
 	ENS_COMPILE_ERROR = 0x100001FF
 	ENS_VERSION_MISMATCH = 0x100002FF
@@ -53,7 +53,7 @@ class espeak_ng_STATUS(enum.IntEnum):
 	ENS_EMPTY_PHONEME_MANIFEST = 0x10000DFF
 	ENS_SPEECH_STOPPED = 0x10000EFF
 
-	# eSpeak NG 1.49 .2
+	# eSpeak NG 1.49.2
 	ENS_UNKNOWN_PHONEME_FEATURE = 0x10000FFF
 	ENS_UNKNOWN_TEXT_ENCODING = 0x100010FF
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -67,6 +67,7 @@ This release also drops support for Adobe Flash.
 - The NVDA installer now also honors the ``--minimal`` command line parameter and does not play the start-up sound, following the same documented behavior as an installed or portable copy NVDA executable. (#12289)
 - In MS Word or Outlook, the table quick navigation key can now jump to layout table if "Include layout tables" option is enabled in Browse mode settings. (#11899)
 - NVDA will no longer announce "↑↑↑" for emojis in particular languages. (#11963)
+- Espeak now supports Cantonese and Mandarin again. (#10418)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes: #10418

### Summary of the issue:
Compiling the zhy dictionary has failed for a long time, it was excluded because the cause was unknown.
It was suspected that there was an error in the format of the files.
Looking into this I found the issue was caused by trying to set the voice to "zhy" by calling `espeak_SetVoiceByProperties`.
The result was `2` (`ENS_VOICE_NOT_FOUND`)
Compilation was based on using glob to find the `*_rules` files, and splitting the filename to get the language to use for the voice.


### Description of how this pull request fixes the issue:
After getting [advice from espeak-ng devs](https://github.com/espeak-ng/espeak-ng/issues/933) source files for compiling dictionaries in espeak have been updated.

This change makes the compilation of espeak dictionaries more explicit.
An explicit listing of the dictionaries NVDA expects (rather than using glob), allows us to be aware of the introduction or removal of languages.

Links that might help reviewers:
- [Docs for SCons Action Objects](https://scons.org/doc/4.1.0/HTML/scons-man.html#action_objects)
- [`espeak_SetVoiceByProperties` in `espeak-ng/speak_lib.h`](https://github.com/espeak-ng/espeak-ng/blob/467f3f565f9f8d6d1de62b854e3c2b21a52fd8a2/src/include/espeak-ng/speak_lib.h#L638)
- ['espeak_ng_CompileDictionary` in `espeak-ng/espeak_ng.h`](https://github.com/espeak-ng/espeak-ng/blob/467f3f565f9f8d6d1de62b854e3c2b21a52fd8a2/src/include/espeak-ng/espeak_ng.h#L171)
- [`espeak_ERROR` enum](https://github.com/espeak-ng/espeak-ng/blob/467f3f565f9f8d6d1de62b854e3c2b21a52fd8a2/src/include/espeak-ng/speak_lib.h#L184)
- [`espeak_ng_STATUS` enum](https://github.com/espeak-ng/espeak-ng/blob/467f3f565f9f8d6d1de62b854e3c2b21a52fd8a2/src/include/espeak-ng/espeak_ng.h#L41)

### Testing strategy:
Tested building and running with espeak voice set to Chinese(Cantonese)
Ask alpha users more familiar with this language to test.

### Known issues with pull request:
None

### Change log entries:
Bug fixes
`- eSpeak Cantonese and Mandarin voices are now available again.`

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
