### PR TITLE
Support retrieving the status bar of Windows File Explorer (#6769)

### DIFF
--- a/source/api.py
+++ b/source/api.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, James Teh, Michael Curran, Peter Vagner, Derek Riemer,
+# Copyright (C) 2006-2021 NV Access Limited, James Teh, Michael Curran, Peter Vagner, Derek Riemer,
 # Davy Kager, Babbage B.V., Leonard de Ruijter, Joseph Lee, Accessolutions, Julien Cochuyt
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
@@ -373,6 +373,10 @@ def getStatusBarText(obj):
 	@return: The status bar text.
 	@rtype: str
 	"""
+	try:
+		return obj.appModule.getStatusBarText(obj)
+	except NotImplementedError:
+		pass
 	text = obj.name or ""
 	if text:
 		text += " "

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
-# Babbage B.V., Mozilla Corporation
+# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
+# Babbage B.V., Mozilla Corporation, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -599,6 +599,13 @@ class AppModule(baseObject.ScriptableObject):
 		"""
 		raise NotImplementedError()
 
+	def getStatusBarText(self, obj: NVDAObjects.NVDAObject) -> str:
+		"""Get the text from the given status bar.
+		If C{NotImplementedError} is raised, L{api.getStatusBarText} will resort to
+		retrieve the name of the status bar and the names and values of all of its children.
+		"""
+		raise NotImplementedError()
+
 	def _get_statusBarTextInfo(self):
 		"""Retrieve a L{TextInfo} positioned at the status bar of the application.
 		This is used by L{GlobalCommands.script_reportStatusLine} in cases where
@@ -608,6 +615,7 @@ class AppModule(baseObject.ScriptableObject):
 		@rtype: TextInfo
 		"""
 		raise NotImplementedError()
+
 
 class AppProfileTrigger(config.ProfileTrigger):
 	"""A configuration profile trigger for when a particular application has focus.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -378,7 +378,7 @@ class AppModule(appModuleHandler.AppModule):
 	def getStatusBarText(self, obj) -> str:
 		if not isinstance(obj, UIA) or obj.UIAElement.cachedClassname != "StatusBarModuleInner":
 			# This is not the file explorer status bar. Resort to standard behavior.
-			raise not NotImplementedError()
+			raise NotImplementedError
 		# The expected status bar, as of Windows 10 20H2 at least, contains:
 		#  - A grouping with a single static text child presenting the total number of elements
 		#  - Optionally, a grouping with a single static text child presenting the number of

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -393,7 +393,7 @@ class AppModule(appModuleHandler.AppModule):
 			):
 				parts.append(child.firstChild.name)
 			elif (
-				False and child.role == controlTypes.ROLE_GROUPING
+				child.role == controlTypes.ROLE_GROUPING
 				and child.childCount > 1
 				and not any(
 					grandChild for grandChild in child.children


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #6769

### Summary of the issue:

Currently, the Window File Explorer cannot be retrieved using the `reportStatusLine` global command.

### Description of how this pull request fixes the issue:

 - Take advantage of #4640 to implement custom status bar retrieval by the `explorer` app module.
 - Use a UIAWalker to retrieve it, as hinted by @josephsl in https://github.com/nvaccess/nvda/issues/6769#issuecomment-624532165
 - Still, instead of overlaying the status bar of its children for concerns expressed in https://github.com/nvaccess/nvda/issues/6769#issuecomment-833432110, allow app modules to provide their custom implementation of `api.getStatusBarText`
 - Implement `explorer.AppModule.getStatusBarText` as inspired by @ruifontes prototype in https://github.com/nvaccess/nvda/issues/6842#issuecomment-410670910 (hinted by @feerrenrut in https://github.com/nvaccess/nvda/issues/6769#issuecomment-411251846) but in a slightly more complex way - trying to cover more unexpected cases.

### Testing strategy:

 - Ran from source under Windows 10 20H2 19042.928 & 19042.964 both with a French locale.
 - Ensured expected result whether files are actually selected or not.

### Known issues with pull request:

This is my first UIA work ever: Review with caution!
I've tried to set safeguards on expectations, but there might be huge differences between Windows versions and I'm not able to test all of them.

### Change log entries:
New features
Changes
In Windows 10, the File Explorer status bar can now be retrieved using the standard gesture `NVDA+end` (desktop) / `NVDA+shift+end` (laptop).

For Developers
- Status bar text retrieval may now be customized by an AppModule.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
