### PR TITLE
Add `showTechnicalFormattingAtReview` global command, with RGB color info (#8674)

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1732,7 +1732,7 @@ class GlobalCommands(ScriptableObject):
 				formatField.update(field.field)
 
 		if not browseable:
-			if formatField:
+			if formatField:  # In which case is this dict expected to be empty?
 				sequence = info.getFormatFieldSpeech(formatField, formatConfig=formatConfig)
 				textList.extend(sequence)
 
@@ -1743,7 +1743,9 @@ class GlobalCommands(ScriptableObject):
 				
 			ui.message(" ".join(textList))
 		else:
-			if formatField:
+			if formatField:  # In which case is this dict expected to be empty?
+				if browseable == "technical":
+					formatConfig["technical"] = True
 				sequence = info.getFormatFieldSpeech(formatField, formatConfig=formatConfig)
 				textList.extend(sequence)
 
@@ -1798,6 +1800,18 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_showFormattingAtReview(self, gesture):
 		self._reportFormattingHelper(api.getReviewPosition(), True)
+
+	@script(
+		description=_(
+			# Translators: Input help mode message for show technical formatting at review cursor command.
+			"Presents, in browse mode, technical formatting info "
+			"for the current review cursor position."
+		),
+		gesture="kb:NVDA+alt+shift+f",
+		category=SCRCAT_TEXTREVIEW
+	)
+	def script_showTechnicalFormattingAtReview(self, gesture):
+		self._reportFormattingHelper(api.getReviewPosition(), browseable="technical")
 
 	@script(
 		description=_(


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #8674

### Summary of the issue:

Developers and content authors often need to know the exact color of the text they review in more precise terms than the human-readable form commonly served to end users.

### Description of how this pull request fixes the issue:

Add a `showTechnicalFormattingAtReview` global command to provide this information along with the rest of the formatting in a browsable message.

### Testing strategy:

Ran and manually tested from a source copy.

### Known issues with pull request:

### Change log entries:
New features
More technical information regarding the formatting of the text at the review position can now be obtained by pressing `NVDA+alt+shift+f`. For now, it differs from the usual formatting information by providing the exact RGB values for foreground and background colors.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
