### PR TITLE
Announce deselection when jumping to top/bottom of page

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -127,6 +127,11 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 
 	def _caretMovementScriptHelper(self,gesture,unit,direction=None,posConstant=textInfos.POSITION_SELECTION,posUnit=None,posUnitEnd=False,extraDetail=False,handleSymbols=False):
 		oldInfo=self.makeTextInfo(posConstant)
+		# #5549 - Make sure oldInfo is not collapsed when going to top/bottom of page so that the deselection is announced.
+		oldSelection=self.makeTextInfo(textInfos.POSITION_SELECTION)
+		if not oldSelection.isCollapsed and (posConstant == textInfos.POSITION_FIRST or posConstant == textInfos.POSITION_LAST):
+			oldInfo.isCollapsed = False
+
 		info=oldInfo.copy()
 		info.collapse(end=self.isTextSelectionAnchoredAtStart)
 		if self.isTextSelectionAnchoredAtStart and not oldInfo.isCollapsed:

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -126,10 +126,12 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 		vision.handler.handleCaretMove(self)
 
 	def _caretMovementScriptHelper(self,gesture,unit,direction=None,posConstant=textInfos.POSITION_SELECTION,posUnit=None,posUnitEnd=False,extraDetail=False,handleSymbols=False):
-		oldInfo=self.makeTextInfo(posConstant)
-		# #5549 - Make sure oldInfo is not collapsed when going to top/bottom of page so that the deselection is announced.
-		oldSelection=self.makeTextInfo(textInfos.POSITION_SELECTION)
-		if not oldSelection.isCollapsed and (posConstant == textInfos.POSITION_FIRST or posConstant == textInfos.POSITION_LAST):
+		oldInfo = self.makeTextInfo(posConstant)
+		# #5549 - Make sure oldInfo is not collapsed when going to top/bottom
+		# of page so that the deselection is announced.
+		oldSelection = self.makeTextInfo(textInfos.POSITION_SELECTION)
+		isJumpToTopOrBottom = posConstant == textInfos.POSITION_FIRST or posConstant == textInfos.POSITION_LAST
+		if not oldSelection.isCollapsed and isJumpToTopOrBottom:
 			oldInfo.isCollapsed = False
 
 		info=oldInfo.copy()


### PR DESCRIPTION
### Link to issue number:

Fixes #5549

### Summary of the issue:

Movement to the top/bottom of page using ctrl+home/end causes deselection of text but this deselection is not announced.

### Description of how this pull request fixes the issue:
This pull-request modifies `caretMovementScriptHelper` so that movement to the top or bottom of the page sets the `isCollapsed` field when there was a prior text selection. This results in announcing the deselection of text.

### Testing strategy:
I first reproduced the bug in question, video: https://www.youtube.com/watch?v=R1362g2nRYE

Then I applied this patch and tested again. In this video the same movement is applied but the text deselection is announced: https://www.youtube.com/watch?v=v5iOY-_augE

### Known issues with pull request:
It was not clear to me how to add unit tests for this case.

### Change log entries:
Bug fixes

### Code Review Checklist:
- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
