### PR TITLE
Added release blurb and fixed grammar in api breaking sentence

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,8 +4,14 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2021.1 =
-This release includes optional experimental support for UIA in Excel and
-Chromium browsers. There are fixes for several languages, and for accessing links in Braille. There are updates to Unicode CLDR and maths symbols, eSpeak-NG and LibLouis. Many bug fixes and improvements, including in Office, Visual Studio and several languages. Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated. This release also drops support for Adobe Flash.
+This release includes optional experimental support for UIA in Excel and Chromium browsers.
+There are fixes for several languages, and for accessing links in Braille.
+There are updates to Unicode CLDR and maths symbols, eSpeak-NG and LibLouis.
+Many bug fixes and improvements, including in Office, Visual Studio and several languages.
+Note: this is an Add-on API compatibility breaking release.
+Add-ons will need to be re-tested and have their manifest updated.
+This release also drops support for Adobe Flash.
+
 
 == New Features ==
 - Early support for UIA with Chromium based browsers (such as Edge). (#12025)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,7 +6,7 @@ What's New in NVDA
 = 2021.1 =
 This release includes optional experimental support for UIA in Excel and Chromium browsers.
 There are fixes for several languages, and for accessing links in Braille.
-There are updates to Unicode CLDR and maths symbols, eSpeak-NG and LibLouis.
+There are updates to Unicode CLDR and mathematics symbols, eSpeak-NG and LibLouis.
 Many bug fixes and improvements, including in Office, Visual Studio and several languages.
 Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
@@ -52,7 +52,7 @@ This release also drops support for Adobe Flash.
    - known issue for right-to-left languages: the right border of groupings clips with labels/controls. (#12181)
 - The python locale is set to match the language selected in preferences consistently, and will occur when using the default language. (#12214)
 - - TextInfo.getTextInChunks no longer freezes when called on Rich Edit controls such as the NVDA log viewer. (#11613)
-- It is once again possible to use NVDA in a languages containing underscores in the locale name such as de_CH on Windows 10 1803 and 1809. (#12250)
+- It is once again possible to use NVDA in languages containing underscores in the locale name such as de_CH on Windows 10 1803 and 1809. (#12250)
 - In WordPad, configuration of superscript/subscript reporting works as expected. (#12262)
 - NVDA no longer fails to announce the newly focused content on a web page if the old focus disappears and is replaced by the new focus in the same position. (#12147)
 - Strikethrough, superscript and subscript formatting for entire Excel cells are now reported if the corresponding option is enabled. (#12264)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,8 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2021.1 =
+This release includes optional experimental support for UIA in Excel and
+Chromium browsers. There are fixes for several languages, and for accessing links in Braille. There are updates to Unicode CLDR and maths symbols, eSpeak-NG and LibLouis. Many bug fixes and improvements, including in Office, Visual Studio and several languages. Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated. This release also drops support for Adobe Flash.
 
 == New Features ==
 - Early support for UIA with Chromium based browsers (such as Edge). (#12025)
@@ -55,7 +57,7 @@ What's New in NVDA
 
 
 == Changes for Developers ==
-- Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
+- Note: this is an Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
 - NVDA's build system now fetches all Python dependencies with pip and stores them in a Python virtual environment. This is all done transparently.
  - To build NVDA, SCons should continue to be used in the usual way. E.g. executing scons.bat in the root of the repository. Running ``py -m SCons``  is no longer supported, and ``scons.py`` has also been removed. 
  - To run NVDA from source, rather than executing ``source/nvda.pyw`` directly, the developer should now use ``runnvda.bat`` in the root of the repository. If you do try to execute ``source/nvda.pyw``, a message box will alert you this is no longer supported.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,7 +6,8 @@ What's New in NVDA
 = 2021.1 =
 This release includes optional experimental support for UIA in Excel and Chromium browsers.
 There are fixes for several languages, and for accessing links in Braille.
-There are updates to Unicode CLDR and mathematics symbols, eSpeak-NG and LibLouis.
+There are updates to Unicode CLDR and mathematical symbols, eSpeak-NG and LibLouis.
+
 Many bug fixes and improvements, including in Office, Visual Studio and several languages.
 Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

### Summary of the issue:
Needed a release blurb for 2021.1 and also there was a grammar error in the "API breaking sentence" in the what's new document.

### Description of how this pull request fixes the issue:

With words

### Testing strategy:

Read text, and ran past others when writing.

### Known issues with pull request:

### Change log entries:

For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [X] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [ ] User Documentation.
- [X] Change log entry.
- [ ] Context sensitive help for GUI changes.
