### PR TITLE
Only run AppVeyor linting check on branches which aren't master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,7 +176,7 @@ test_script:
 
 # Flake8 Linting
  - ps: |
-    if ($env:APPVEYOR_REPO_BRANCH -ne "master") {
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
       $lintOutput = (Resolve-Path .\testOutput\lint\)
       $lintSource = (Resolve-Path .\tests\lint\)
       $flake8Output = "$lintOutput\Flake8.txt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,6 +176,7 @@ test_script:
 
 # Flake8 Linting
  - ps: |
+    if ($env:APPVEYOR_REPO_BRANCH -ne "master") {
       $lintOutput = (Resolve-Path .\testOutput\lint\)
       $lintSource = (Resolve-Path .\tests\lint\)
       $flake8Output = "$lintOutput\Flake8.txt"
@@ -205,6 +206,7 @@ test_script:
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
       if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
+    }
 
 # System tests
  - ps: |


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

Master builds are currently failing at the linting step such as 

* https://ci.appveyor.com/project/NVAccess/nvda/builds/39046507
* https://ci.appveyor.com/project/NVAccess/nvda/builds/39045879

Lint checking doesn't need to occur for master builds

### Description of how this pull request fixes the issue:

Don't run the appveyor lint checking on master branches

### Testing strategy:

* try build: https://ci.appveyor.com/project/NVAccess/nvda/builds/39048440
* PR build: https://ci.appveyor.com/project/NVAccess/nvda/builds/39048273
* does this subsequent AppVeyor build from this PR succeed and produce an alpha 

### Known issues with pull request:

### Change log entries:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
