### PR TITLE
EditableText: Do not treat "\r\n" as two characters when `backspace` is pressed

### DIFF
--- a/source/editableText.py
+++ b/source/editableText.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2020 NV Access Limited, Davy Kager, Julien Cochuyt
+# Copyright (C) 2006-2021 NV Access Limited, Davy Kager, Julien Cochuyt
 
 """Common support for editable text.
 @note: If you want editable text functionality for an NVDAObject,
@@ -260,7 +260,8 @@ class EditableText(TextContainerObject,ScriptableObject):
 		caretMoved,newInfo=self._hasCaretMoved(oldBookmark)
 		if not caretMoved:
 			return
-		if len(delChunk)>1:
+		delChunk = delChunk.replace("\r\n", "\n")  # Occurs with at least with Scintilla
+		if len(delChunk) > 1:
 			speech.speakMessage(delChunk)
 		else:
 			speech.speakSpelling(delChunk)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Found while investigating on #12375

### Summary of the issue:

In Notepad++, when hitting `backspace` to delete a line break, NVDA announces "blank" instead of "new line".

The `TextInfo` of the Scintilla implementation may contain "`\r\n`" instead of "`\n`".
The current implementation of `EditableText._backspaceScriptHelper` treats it as two characters and thus fails to trigger a proper announce.

### Description of how this pull request fixes the issue:

Replace "`\r\n`" by "`\n`" before further treatment of the deleted chunk.

### Testing strategy:

Manually tested from a source copy with Notepad++ 7.8.7 and a bunch of other editors.

### Known issues with pull request:

### Change log entries:

I do not think this small fix deserves a change log entry.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
