### PR TITLE
Developer Guide: Minor fixes (broken link, missing internal link, extraneous/trailing whitespace)

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -179,7 +179,7 @@ However, they do differ in some ways.
 
 Custom appModules and globalPlugins can be packaged into NVDA add-ons. 
 This allows easy distribution, and provides a safe way for the user to install and uninstall the custom code.
-Please refer to the Add-ons section later on in this document.
+Please refer to the [Add-ons section #Addons] later on in this document.
 
 In order to test the code while developing, you can place it in a special 'scratchpad' directory in your NVDA user configuration directory.
 You will also need to configure NVDA to enable loading of custom code from the Developer Scratchpad Directory, by enabling this in the Advanced category of NVDA's Settings dialog.
@@ -194,7 +194,7 @@ For example, an App Module for notepad would be called notepad.py, as notepad's 
 For apps hosted inside host executables, see the section on app modules for hosted apps.
 
 App Module files must be placed in the appModules subdirectory of an add-on, or of the scratchpad directory of the NVDA user configuration directory.
-  
+
 App Modules must define a class called AppModule, which inherits from appModuleHandler.AppModule.
 This class can then define event and script methods, gesture bindings and other code.
 This will all be covered in depth later.
@@ -283,7 +283,7 @@ As wwahost app module provides necessary infrastructure for apps hosted inside, 
 ++ Basics of a Global Plugin ++
 Global Plugin files have a .py extension, and should have a short unique name which identifies what they do.
 
-Global plugin  files must be placed in the globalPlugins subdirectory of an add-on, or of the scratchpad directory of the NVDA user configuration directory.
+Global plugin files must be placed in the globalPlugins subdirectory of an add-on, or of the scratchpad directory of the NVDA user configuration directory.
 
 Global Plugins must define a class called GlobalPlugin, which inherits from globalPluginHandler.GlobalPlugin.
 This class can then define event and script methods, gesture bindings and other code.
@@ -692,17 +692,17 @@ class AppModule(appModuleHandler.AppModule):
 --- end ---
 ```
 
-+ Packaging  Code as  NVDA Add-ons +
++ Packaging Code as NVDA Add-ons +[Addons]
 To make it easy for users to share and install plugins and drivers, they can be packaged in to a single NVDA add-on package which the user can then install into a copy of NVDA via the Add-ons Manager found under Tools in the NVDA menu.
 Add-on packages are only supported in NVDA 2012.2 and later.
-An add-on package is simply a standard zip archive with the file extension of nvda-addon which contains a manifest file,  optional  install/uninstall code and  one or more  directories containing plugins and/or drivers.
+An add-on package is simply a standard zip archive with the file extension of nvda-addon which contains a manifest file, optional install/uninstall code and one or more directories containing plugins and/or drivers.
 
 ++ Non-ASCII File Names in Zip Archives ++
 If your add-on includes files which contain non-ASCII (non-English) characters, you should create the zip archive such that it uses UTF-8 file names.
 This means that these files can be extracted properly on all systems, regardless of the system's configured language.
 Unfortunately, many zip archivers do not support this, including Windows Explorer.
 Generally, it has to be explicitly enabled even in archivers that do support it.
-[http://www.7-zip.org/ 7-Zip] supports this, though it must be enabled by specifying the "cu=on" method parameter.
+[7-Zip http://www.7-zip.org/] supports this, though it must be enabled by specifying the "cu=on" method parameter.
 
 ++ Manifest Files ++
 Each add-on package must contain a manifest file named manifest.ini.
@@ -764,9 +764,9 @@ The following plugins and drivers can be included in an add-on:
 -
 
 ++ Optional install / Uninstall code ++
-If you need to execute code as your add-on is being installed or uninstalled from NVDA (e.g. to validate license information or to copy files to a custom location), you can provide a Python   file called installTasks.py in the archive which contains special functions that NVDA will call while installing or uninstalling your add-on.
-This file should avoid loading any modules that are not absolutely necessary,  especially   Python C extensions or dlls from your own add-on, as this could cause later removal of the add-on to fail.
-However, if this does happen, the add-on directory will be renamed and then   deleted after the next restart of NVDA. 
+If you need to execute code as your add-on is being installed or uninstalled from NVDA (e.g. to validate license information or to copy files to a custom location), you can provide a Python file called installTasks.py in the archive which contains special functions that NVDA will call while installing or uninstalling your add-on.
+This file should avoid loading any modules that are not absolutely necessary, especially Python C extensions or dlls from your own add-on, as this could cause later removal of the add-on to fail.
+However, if this does happen, the add-on directory will be renamed and then deleted after the next restart of NVDA. 
 Finally, it should not depend on the existence or state of other add-ons, as they may not be installed, have already been removed or not yet be initialized.
 
 +++ the onInstall function +++
@@ -792,7 +792,7 @@ All other fields will be ignored.
 +++ Locale-specific Messages +++
 Each language directory can also contain gettext information, which is the system used to translate the rest of NVDA's user interface and reported messages.
 As with the rest of NVDA, an nvda.mo compiled gettext database file should be placed in the LC_MESSAGES directory within this directory.
-to allow plugins in your add-on to access gettext message information via calls to _(), you must initialize  translations at the top of each Python module by calling addonHandler.initTranslation().
+to allow plugins in your add-on to access gettext message information via calls to _(), you must initialize translations at the top of each Python module by calling addonHandler.initTranslation().
 For more information about gettext and NVDA translation in general, please read
 https://github.com/nvaccess/nvda/wiki/Translating
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Found while working on updating the Developer Guide for PR #10172.

### Summary of the issue:

 * There is a broken link to 7-zip
 * An internal link is missing when referring to the "Packaging code as NVDA Add-ons" section
 * There are a few extraneous or trailing whitespace

### Description of how this pull request fixes the issue:

 * Fix broken link to 7-zip
 * Add the missing internal link to the "Packaging code as NVDA Add-ons" section
 * Remove extraneous or trailing whitespace


### Testing strategy:

Generated the HTML rendering from source and proof-read the result.

### Known issues with pull request:

### Change log entries:

These small fixes IMHO do not deserve a change log entry.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
