### PR TITLE
Fix-up of PR #11402: Redeem the copyright holders' names for `source/gui/inputGestures.py` after its split from `source/gui/settingsDialogs.py`

### DIFF
--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited
+# Copyright (C) 2013-2020 NV Access Limited, James Teh, Zahari Yurukov, Joseph Lee, Reef Turner,
+# Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -1,6 +1,8 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2013-2020 NV Access Limited, James Teh, Zahari Yurukov, Joseph Lee, Reef Turner,
+# Copyright (C) 2013-2020 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
+# Rui Batista, Joseph Lee, Heiko Folkerts, Zahari Yurukov, Leonard de Ruijter,
+# Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Bill Dengler, Thomas Stivers
 # Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fix-up of PR #11402

### Summary of the issue:

In PR #11402, part of `source/gui/settingsDialogs.py` has been extracted to the new `source/gui/inputGestures.py` for good reasons.
However, in the process, the name of the copyright holders for this portion of the code has not been reported to the header of the new file.

### Description of how this pull request fixes the issue:
Copy all the names from the copryright headers in `source/gui/settingsDialogs.py`.

### Testing strategy:

### Known issues with pull request:

### Change log entries:


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
