### PR TITLE
always reset speechWithoutPauses instance when sayAll cancelled

### DIFF
--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -61,7 +61,7 @@ class _SayAllHandler:
 		active = self._getActiveSayAll()
 		if active:
 			active.stop()
-			self.speechWithoutPausesInstance.reset()
+		self.speechWithoutPausesInstance.reset()
 
 	def isRunning(self):
 		"""Determine whether say all is currently running.


### PR DESCRIPTION

### Link to issue number:

None

### Summary of the issue:

The function header for `sayAllHandler` is incorrect, and the behaviour of cancelling `sayAll` speech changed in #12251 

See the change of behaviour as noted here:

- https://github.com/nvaccess/nvda/pull/12251#discussion_r629829569
- https://github.com/nvaccess/nvda/pull/12251#discussion_r629827668

### Description of how this pull request fixes the issue:

Restores intended change of behaviour in #12251 

### Testing strategy:

TBD

### Known issues with pull request:

None

### Change log entries:

None, message in changelog already

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
