### PR TITLE
prevent ExitDialog from being destroyed twice

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -694,6 +694,7 @@ class ExitDialog(wx.Dialog):
 			action += 1
 		if action == 0:
 			core.triggerNVDAExit()
+			return  # there's no need to destroy ExitDialog in this instance as triggerNVDAExit will do this
 		elif action == 1:
 			queueHandler.queueFunction(queueHandler.eventQueue,core.restart)
 		elif action == 2:


### PR DESCRIPTION

### Link to issue number:

None

### Summary of the issue:

the following error happens when exiting NVDA via NVDA+q exit dialog shows, then enter:

```python
DEBUG - core._closeAllWindows (18:25:34.959) - MainThread (8636):
destroying main frame during exit process
ERROR - unhandled exception (18:25:34.959) - MainThread (8636):
Traceback (most recent call last):
  File "C:\work\repo\nvda\7\.venv\lib\site-packages\wx\core.py", line 3407, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
RuntimeError: wrapped C/C++ object of type ExitDialog has been deleted
```

### Description of how this pull request fixes the issue:

Prevents ExitDialog from being destroyed twice

### Testing strategy:

Manual testing

### Known issues with pull request:

None

### Change log entries:

None, regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
