### PR TITLE
focus document content manually during chrome system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -165,9 +165,6 @@ class ChromeLib:
 			spy.emulateKeyPress('F6')
 			spy.wait_for_speech_to_finish()
 			actualSpeech = spy.get_speech_at_index_until_now(lastSpeechIndex)
-			if actualSpeech in focusedItemSpeech:
-				# we've done a full revolution through the chrome f6 nav
-				break
 			focusedItemSpeech.append(actualSpeech)
 			if ChromeLib._beforeMarker == actualSpeech:
 				return True

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -110,26 +110,26 @@ class ChromeLib:
 		marker = ChromeLib._beforeMarker
 		return marker in speech and documentIndex < speech.index(marker)
 
-	def _waitForStartMarker(self, spy, lastSpeechIndex):
-		""" Wait until the page loads and NVDA reads the start marker.
-		@param spy:
-		@type spy: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
-		@return: None
-		"""
-		for i in range(10):  # set a limit on the number of tries.
-			builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
-			spy.wait_for_speech_to_finish()
-			actualSpeech = spy.get_speech_at_index_until_now(lastSpeechIndex)
-			if self._wasStartMarkerSpoken(actualSpeech):
-				break
-			lastSpeechIndex = spy.get_last_speech_index()
-		else:  # Exceeded the number of tries
-			spy.dump_speech_to_log()
-			builtIn.fail(
-				"Unable to locate 'before sample' marker."
-				f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
-				" See NVDA log for full speech."
-			)
+	# def _waitForStartMarker(self, spy, lastSpeechIndex):
+	# 	""" Wait until the page loads and NVDA reads the start marker.
+	# 	@param spy:
+	# 	@type spy: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
+	# 	@return: None
+	# 	"""
+	# 	for i in range(10):  # set a limit on the number of tries.
+	# 		builtIn.sleep("0.5 seconds")  # ensure application has time to receive input
+	# 		spy.wait_for_speech_to_finish()
+	# 		actualSpeech = spy.get_speech_at_index_until_now(lastSpeechIndex)
+	# 		if self._wasStartMarkerSpoken(actualSpeech):
+	# 			break
+	# 		lastSpeechIndex = spy.get_last_speech_index()
+	# 	else:  # Exceeded the number of tries
+	# 		spy.dump_speech_to_log()
+	# 		builtIn.fail(
+	# 			"Unable to locate 'before sample' marker."
+	# 			f" Too many attempts looking for '{ChromeLib._beforeMarker}'"
+	# 			" See NVDA log for full speech."
+	# 		)
 
 	def _focusChrome(self, startsWithTestCaseTitle: re.Pattern):
 		""" Ensure chrome started and is focused.
@@ -158,7 +158,7 @@ class ChromeLib:
 			f"{windowInformation}"
 		)
 
-	def _focusDocumentContent(self, spy, testCaseTitle: str):
+	def _focusDocumentContent(self, spy):
 		focusedItemSpeech = []
 		for i in range(10):
 			lastSpeechIndex = spy.get_last_speech_index()
@@ -169,7 +169,7 @@ class ChromeLib:
 				# we've done a full revolution through the chrome f6 nav
 				break
 			focusedItemSpeech.append(actualSpeech)
-			if f"{testCaseTitle}  document" in actualSpeech or ChromeLib._beforeMarker in actualSpeech:
+			if ChromeLib._beforeMarker == actualSpeech:
 				return True
 		raise AssertionError(
 			"Unable to focus Chrome test document content.\n"
@@ -185,13 +185,13 @@ class ChromeLib:
 		path = self._writeTestFile(testCase)
 
 		spy.wait_for_speech_to_finish()
-		lastSpeechIndex = spy.get_last_speech_index()
+		# lastSpeechIndex = spy.get_last_speech_index()
 		self.start_chrome(path)
 		self._focusChrome(ChromeLib.getUniqueTestCaseTitleRegex(testCase))
-		applicationTitle = ChromeLib.getUniqueTestCaseTitle(testCase)
-		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
-		self._focusDocumentContent(spy, applicationTitle)
-		self._waitForStartMarker(spy, appTitleIndex)
+		# applicationTitle = ChromeLib.getUniqueTestCaseTitle(testCase)
+		# appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
+		self._focusDocumentContent(spy)
+		# self._waitForStartMarker(spy, appTitleIndex)
 		# Move to the loading status line, and wait fore it to become complete
 		# the page has fully loaded.
 		spy.emulateKeyPress('downArrow')

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -158,6 +158,24 @@ class ChromeLib:
 			f"{windowInformation}"
 		)
 
+	def _focusWindowContent(self, spy, testCaseTitle: str):
+		focusedItemSpeech = []
+		for i in range(10):
+			lastSpeechIndex = spy.get_last_speech_index()
+			spy.emulateKeyPress('F6')
+			spy.wait_for_speech_to_finish()
+			actualSpeech = spy.get_speech_at_index_until_now(lastSpeechIndex)
+			if actualSpeech in focusedItemSpeech:
+				# we've done a full revolution through the chrome f6 nav
+				break
+			focusedItemSpeech.append(actualSpeech)
+			if f"{testCaseTitle}  document" in actualSpeech or ChromeLib._beforeMarker in actualSpeech:
+				return True
+		raise AssertionError(
+			"Unable to focus Chrome test document content.\n"
+			f"Focused items spoken: {focusedItemSpeech}"
+		)
+
 	def prepareChrome(self, testCase: str) -> None:
 		"""
 		Starts Chrome opening a file containing the HTML sample
@@ -172,6 +190,7 @@ class ChromeLib:
 		self._focusChrome(ChromeLib.getUniqueTestCaseTitleRegex(testCase))
 		applicationTitle = ChromeLib.getUniqueTestCaseTitle(testCase)
 		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
+		self._focusWindowContent(spy, applicationTitle)
 		self._waitForStartMarker(spy, appTitleIndex)
 		# Move to the loading status line, and wait fore it to become complete
 		# the page has fully loaded.

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -158,7 +158,7 @@ class ChromeLib:
 			f"{windowInformation}"
 		)
 
-	def _focusWindowContent(self, spy, testCaseTitle: str):
+	def _focusDocumentContent(self, spy, testCaseTitle: str):
 		focusedItemSpeech = []
 		for i in range(10):
 			lastSpeechIndex = spy.get_last_speech_index()
@@ -190,7 +190,7 @@ class ChromeLib:
 		self._focusChrome(ChromeLib.getUniqueTestCaseTitleRegex(testCase))
 		applicationTitle = ChromeLib.getUniqueTestCaseTitle(testCase)
 		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
-		self._focusWindowContent(spy, applicationTitle)
+		self._focusDocumentContent(spy, applicationTitle)
 		self._waitForStartMarker(spy, appTitleIndex)
 		# Move to the loading status line, and wait fore it to become complete
 		# the page has fully loaded.

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -53,6 +53,6 @@ ARIA checkbox
 i12147
 	[Documentation]	New focus target should be announced if the triggering element is removed when activated
 	test_i12147
-table using display attrbiute
+table using display attribute
 	[Documentation]	Properly announce table row/column count and working table navigation for a HTML table in a div with style display: table
 	test_tableInStyleDisplayTable

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -53,6 +53,6 @@ ARIA checkbox
 i12147
 	[Documentation]	New focus target should be announced if the triggering element is removed when activated
 	test_i12147
-Table in style display: table
+table using display attrbiute
 	[Documentation]	Properly announce table row/column count and working table navigation for a HTML table in a div with style display: table
 	test_tableInStyleDisplayTable


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

The document content sometimes fails to focus in chrome system tests such as these:

- https://ci.appveyor.com/project/NVAccess/nvda/builds/39048272/tests
- https://ci.appveyor.com/project/NVAccess/nvda/builds/39082965/tests

Example zip: 
[systemTestResult.zip](https://github.com/nvaccess/nvda/files/6470199/systemTestResult.22.zip)

### Description of how this pull request fixes the issue:

Adds code to focus the document content using F6. 

### Testing strategy:

Run several builds, see if tests improve

### Known issues with pull request:

None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
