### PR TITLE
Safe screenshot names for system tests

### DIFF
--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -16,6 +16,7 @@ which provide library functions related to monitoring NVDA and asserting NVDA ou
 from os.path import join as _pJoin, abspath as _abspath, expandvars as _expandvars
 import tempfile as _tempFile
 from typing import Optional
+import re
 
 from robotremoteserver import (
 	test_remote_server as _testRemoteServer,
@@ -37,6 +38,8 @@ from robot.libraries.Remote import Remote as _Remote
 builtIn: BuiltIn = BuiltIn()
 opSys: _OpSysLib = _getLib('OperatingSystem')
 process: _Process = _getLib('Process')
+
+RE_INVALID_FILENAME_CHRS = re.compile("[^A-z0-9\\-_ ]")
 
 
 class _NvdaLocationData:
@@ -111,6 +114,7 @@ class NvdaLib:
 		suiteName = builtIn.get_variable_value("${SUITE NAME}")
 		testName = builtIn.get_variable_value("${TEST NAME}")
 		outputFileName = f"{suiteName}-{testName}-{name}".replace(" ", "_")
+		outputFileName = re.sub(RE_INVALID_FILENAME_CHRS, "", outputFileName)
 		return outputFileName
 
 	@staticmethod

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -16,7 +16,7 @@ which provide library functions related to monitoring NVDA and asserting NVDA ou
 from os.path import join as _pJoin, abspath as _abspath, expandvars as _expandvars
 import tempfile as _tempFile
 from typing import Optional
-import re
+from urllib.parse import quote as _quoteStr
 
 from robotremoteserver import (
 	test_remote_server as _testRemoteServer,
@@ -38,8 +38,6 @@ from robot.libraries.Remote import Remote as _Remote
 builtIn: BuiltIn = BuiltIn()
 opSys: _OpSysLib = _getLib('OperatingSystem')
 process: _Process = _getLib('Process')
-
-RE_INVALID_FILENAME_CHRS = re.compile("[^A-z0-9\\-_ ]")
 
 
 class _NvdaLocationData:
@@ -114,7 +112,7 @@ class NvdaLib:
 		suiteName = builtIn.get_variable_value("${SUITE NAME}")
 		testName = builtIn.get_variable_value("${TEST NAME}")
 		outputFileName = f"{suiteName}-{testName}-{name}".replace(" ", "_")
-		outputFileName = re.sub(RE_INVALID_FILENAME_CHRS, "", outputFileName)
+		outputFileName = _quoteStr(outputFileName)
 		return outputFileName
 
 	@staticmethod

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -56,3 +56,5 @@ i12147
 Table in style display: table
 	[Documentation]	Properly announce table row/column count and working table navigation for a HTML table in a div with style display: table
 	test_tableInStyleDisplayTable
+failed: test name ? with special chars
+	Fail	forced fail

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -56,5 +56,3 @@ i12147
 Table in style display: table
 	[Documentation]	Properly announce table row/column count and working table navigation for a HTML table in a div with style display: table
 	test_tableInStyleDisplayTable
-failed: test name ? with special chars
-	Fail	forced fail


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

If a test has a name with special characters, and the test fails, a screenshot is not generated

Example: ["Robot.chromeTests.Table in style display: table"](https://ci.appveyor.com/project/NVAccess/nvda/builds/39142463/tests)

```python

Also teardown failed:
OSError: Bad path: nvdaTestRunLogs\Robot.chromeTests-Table_in_style_display:_table-failedTest.png
```

### Description of how this pull request fixes the issue:

replace special characters with url style escaping from the screenshot filename

### Testing strategy:

See the test failure here and confirm a screenshot was generated: https://ci.appveyor.com/project/NVAccess/nvda/builds/39144582/tests

### Known issues with pull request:

None

### Change log entries:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual tests.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
