### PR TITLE
log focusing chrome better during system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -141,7 +141,7 @@ class ChromeLib:
 		when it is ready.
 		"""
 		success, _success = _blockUntilConditionMet(
-			getValue=lambda: SetForegroundWindow(startsWithTestCaseTitle),
+			getValue=lambda: SetForegroundWindow(startsWithTestCaseTitle, builtIn.log),
 			giveUpAfterSeconds=3,
 			intervalBetweenSeconds=0.5
 		)

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -53,7 +53,7 @@ def _GetVisibleWindows() -> List[Window]:
 def SetForegroundWindow(targetTitle: re.Pattern, logger: Callable[[str], None] = lambda _: None) -> bool:
 	currentTitle = GetForegroundWindowTitle()
 	if re.match(targetTitle, currentTitle):
-		logger(f"Curret window {currentTitle} already matches the title")
+		logger(f"Current window {currentTitle} already matches the title")
 		return True
 	windows = _GetWindows(
 		filterUsingWindow=lambda window: re.match(targetTitle, window.title)

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -50,14 +50,21 @@ def _GetVisibleWindows() -> List[Window]:
 	)
 
 
-def SetForegroundWindow(targetTitle: re.Pattern) -> bool:
-	if re.match(targetTitle, GetForegroundWindowTitle()):
+def SetForegroundWindow(targetTitle: re.Pattern, logger: Callable[[str], None] = lambda _: None) -> bool:
+	currentTitle = GetForegroundWindowTitle()
+	if re.match(targetTitle, currentTitle):
+		logger(f"Curret window {currentTitle} already matches the title")
 		return True
 	windows = _GetWindows(
 		filterUsingWindow=lambda window: re.match(targetTitle, window.title)
 	)
-	for window in windows:
-		return windll.user32.SetForegroundWindow(window.hwnd)
+	if len(windows) == 1:
+		logger(f"Focusing window to (HWND: {windows[0].hwnd}) (title: {windows[0].title})")
+		return windll.user32.SetForegroundWindow(windows[0].hwnd)
+	elif len(windows) == 0:
+		logger("No windows matching the pattern found")
+	else:
+		logger(f"Too many windows to focus {windows}")
 	return False
 
 

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -53,7 +53,7 @@ def _GetVisibleWindows() -> List[Window]:
 def SetForegroundWindow(targetTitle: re.Pattern, logger: Callable[[str], None] = lambda _: None) -> bool:
 	currentTitle = GetForegroundWindowTitle()
 	if re.match(targetTitle, currentTitle):
-		logger(f"Current window {currentTitle} already matches the title")
+		logger(f"Window '{currentTitle}' already focused")
 		return True
 	windows = _GetWindows(
 		filterUsingWindow=lambda window: re.match(targetTitle, window.title)


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

It is hard to know why a certain system test is failing. The test seems to be unable to focus the content of the focused chrome window. Logging information about the focus windows will help compare failing and succeeding tests.

Example tests:
https://ci.appveyor.com/project/NVAccess/nvda/builds/39048272/tests
https://ci.appveyor.com/project/NVAccess/nvda/builds/39082965/tests

Some further investigation in this PR https://github.com/nvaccess/nvda/pull/12408 led me to think that the incorrect window is gaining focus

Specifically this test failure: https://ci.appveyor.com/project/NVAccess/nvda/builds/39143536/tests where the "before test sample marker" was unable to be read when cycling focus using F6

### Description of how this pull request fixes the issue:

Adds additional logging to know what windows could be focused and which currently have focus. Don't focus a window if many windows match our targeted window filter. 

### Testing strategy:

Merge and monitor future tests for failures

### Known issues with pull request:

None 

### Change log entries:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
