### PR TITLE
Use pre-processed cldr production data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,4 +29,4 @@
 	url = https://github.com/w3c/aria-practices
 [submodule "include/cldr"]
 	path = include/cldr
-	url = https://github.com/unicode-org/cldr.git
+	url = https://github.com/unicode-org/cldr-staging.git

--- a/cldrDict_sconscript
+++ b/cldrDict_sconscript
@@ -119,8 +119,8 @@ NVDAToCLDRLocales = {
 	"zh_tw":("zh","zh_Hant"),
 }
 
-annotationsDir = env.Dir("include/cldr/common/annotations")
-annotationsDerivedDir = env.Dir("include/cldr/common/annotationsDerived")
+annotationsDir = env.Dir("include/cldr/production/common/annotations")
+annotationsDerivedDir = env.Dir("include/cldr/production/common/annotationsDerived")
 for destLocale, sourceLocales in NVDAToCLDRLocales.items():
 	cldrSources = []
 	# First add all annotations, then the derived ones.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -67,6 +67,7 @@ This release also drops support for Adobe Flash.
 - Fixed the pitch change failure in SAPI4 speech synthesizer. (#12311)
 - The NVDA installer now also honors the ``--minimal`` command line parameter and does not play the start-up sound, following the same documented behavior as an installed or portable copy NVDA executable. (#12289)
 - In MS Word or Outlook, the table quick navigation key can now jump to layout table if "Include layout tables" option is enabled in Browse mode settings. (#11899)
+- NVDA will no longer announce "↑↑↑" for emojis in particular languages. (#11963)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #11963 

### Summary of the issue:
Some time around CLDR release 36, CLDR started including "↑↑↑"  in annotation values as a placeholder which meant that the value should be inherited from a parent locale.
These ↑↑↑ values were being put straight into NVDA's cldr dictionaries without any further processing, causing languages such as Chinese (Hongkong) and others to speak these ↑↑↑ values instead of useful emoji labels.
 
### Description of how this pull request fixes the issue:
NVDA now includes the cldr-staging repository as a submodule, rather than the cldr repository. The cldr-staging repository contains a production directory, with all its xml files pre-processed to include inherited values rather than the ↑↑↑ placeholders.

### Testing strategy:
* Compiled NVDA locally, and ensured that NVDA's CLDR dictionaries did not contain any ↑↑↑ values. 

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
NVDA will no longer announce "↑↑↑" for emojis in particular languages.

For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
