### PR TITLE
Revert PR 11966 to fix errors when interacting with edit fields in MS Excel

### DIFF
--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -1,7 +1,8 @@
-# A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Babbage B.V., Bill Dengler
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+#NVDAObjects/window.py
+#A part of NonVisual Desktop Access (NVDA)
+#Copyright (C) 2006-2019 NV Access Limited, Babbage B.V., Bill Dengler
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
 
 import re
 import ctypes
@@ -135,7 +136,7 @@ An NVDAObject for a window
 		if not any(issubclass(cls,EditableText) for cls in clsList):
 			gi=winUser.getGUIThreadInfo(self.windowThreadID)
 			if gi.hwndCaret==self.windowHandle and gi.flags&winUser.GUI_CARETBLINKING:
-				if self.windowTextLineCount and self.windowText:
+				if self.windowTextLineCount:
 					from .edit import UnidentifiedEdit
 					clsList.append(UnidentifiedEdit)
 				else:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -47,7 +47,6 @@ This release also drops support for Adobe Flash.
 - The list of messages in Outlook 2010 is once again readable. (#12241)
 - In terminal programs on Windows 10 version 1607 and later, when inserting or deleting characters in the middle of a line, the characters to the right of the caret are no longer read out. (#3200)
   - This experimental fix must be manually enabled in NVDA's advanced settings panel by changing the diff algorithm to Diff Match Patch.
-- Fixed access to edit fields in MCS Electronics IDE's. (#11966)
 - In MS Outlook, inappropriate distance reporting when shift+tabbing from the message body to the subject field should not occur anymore. (#10254)
 - In the Python Console, inserting a tab for indentation at the beginning of a non-empty input line and performing tab-completion in the middle of an input line are now supported. (#11532)
 - Formatting information and other browseable messages no longer present unexpected blank lines when screen layout is turned off. (#12004)


### PR DESCRIPTION
This is opened against beta.

### Link to issue number:
Work around for issue #12402 
### Summary of the issue:
PR #11966 started using `DisplayModelEditableText` for edit fields with empty window text to improve access to IDE's by MCS Electronic - this unfortunately broke access to some edit fields in Excel as they were forcibly using `DisplayModelEditableText` and now they were getting this class twice in the MRO. When trying to come up with a fix I've found another problems with the approach from #11966 namely edit fields which require `UnidentifiedEdit` weren't getting it in the MRO when they are initially empty.
### Description of how this pull request fixes the issue:
Since we're quite close to the release it makes sense to revert #11966 for now and investigate another approach - the program for which the original fix was needed is quite niche and therefore I don't consider this to be a big loss. I'll try to come up with something better for the next release.
### Testing strategy:
Asked reporter from #12402 to test - they have confirmed that the problem no longer occurs.
### Known issues with pull request:
- Edit fields in IDE's by MCS Electronic are not accessible.
### Change log entries:
I've removed entry from #11966 as part of this PR.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual tests.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.


Linting failure is expected here as this just reverts the commit.