### PR TITLE
Wait until GUI exits before starting new NVDA instance from installer

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -232,11 +232,7 @@ def getWxLangOrNone() -> Optional['wx.LanguageInfo']:
 
 
 def triggerNVDAExit():
-	preNVDAExit.notify()
-	# ensure NVDA only runs exit procedures once
-	handlers = list(preNVDAExit.handlers)  # don't mutate .handlers directly with unregister while iterating
-	for handler in handlers:
-		preNVDAExit.unregister(handler)
+	preNVDAExit.notifyOnce()
 
 
 def _closeAllWindows():

--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -48,6 +48,20 @@ class Action(HandlerRegistrar):
 			except:
 				log.exception("Error running handler %r for %r" % (handler, self))
 
+	def notifyOnce(self, **kwargs):
+		"""Notify all registered handlers that the action has occurred.
+		Unregister handlers after calling.
+		@param kwargs: Arguments to pass to the handlers.
+		"""
+		oldHandlers = list(self.handlers)
+		for handler in oldHandlers:
+			try:
+				callWithSupportedKwargs(handler, **kwargs)
+				self.unregister(handler)
+			except Exception as e:
+				log.exception(f"Error running handler {handler} for {self}. Exception {e}")
+
+
 class Filter(HandlerRegistrar):
 	"""Allows interested parties to register to modify a specific kind of data.
 	For example, this might be used to allow modification of spoken messages before they are passed to the synthesizer.

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -269,7 +269,7 @@ class InstallerDialog(
 			copyPortableConfig=self.copyPortableConfigCheckbox.Value,
 			silent=self.isUpdate
 		)
-		self.Destroy()
+		wx.GetApp().ScheduleForDestruction(self)
 
 	def onCancel(self, evt):
 		self.Destroy()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -110,17 +110,24 @@ def doInstall(
 			# Translators: The title of a dialog presented to indicate a successful operation.
 			_("Success"))
 	if startAfterInstall:
-		# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL  
-		shellapi.ShellExecute(
-			None,
-			None,
-			os.path.join(installer.defaultInstallPath,'nvda.exe'),
-			None,
-			None,
-			winUser.SW_SHOWNORMAL
-		)
-	else:
-		core.triggerNVDAExit()
+		core.preNVDAExit.register(_startNewInstalledNVDAInstance)
+	core.triggerNVDAExit()
+
+
+def _startNewInstalledNVDAInstance():
+	_startNewNVDAInstance(installer.defaultInstallPath)
+
+
+def _startNewNVDAInstance(path: str):
+	# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
+	shellapi.ShellExecute(
+		None,
+		None,
+		os.path.join(path, 'nvda.exe'),
+		None,
+		None,
+		winUser.SW_SHOWNORMAL
+	)
 
 
 def doSilentInstall(
@@ -466,20 +473,13 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 			wx.OK | wx.ICON_ERROR)
 		return
 	d.done()
-	if silent:
-		core.triggerNVDAExit()
-	else:
+	if not silent:
 		# Translators: The message displayed when a portable copy of NVDA has been successfully created.
 		# %s will be replaced with the destination directory.
 		gui.messageBox(_("Successfully created a portable copy of NVDA at %s")%portableDirectory,
 			_("Success"))
 		if startAfterCreate:
-			# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL  
-			shellapi.ShellExecute(
-				None,
-				None,
-				os.path.join(portableDirectory, 'nvda.exe'),
-				None,
-				None,
-				winUser.SW_SHOWNORMAL
-			)
+			def startNewPortableNVDAInstance():
+				_startNewNVDAInstance(portableDirectory)
+			core.preNVDAExit.register(startNewPortableNVDAInstance)
+	core.triggerNVDAExit()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12421

### Summary of the issue:

NVDA (usually) crashes after a successful install. This occurs directly after "NVDA exit" is logged, and happens during the system exit process. Debugging the crash dump in #12421 finds that a window is processing an activate event after the wx app has been destroyed. 

We know that:
- the installer crashes at the end, when `WM_QUIT` is sent from another NVDA instance
- the installer only crashes for non-silent installs, otherwise appveyor would be crashing regularly

I've found that:
- the installer exits normally when another NVDA instance is started before the install finishes
- running subsequent instances of NVDA exits the running instance using `WM_QUIT` without crashing

### Description of how this pull request fixes the issue:

If we exit the GUI before starting the new instance of NVDA, then the new instance will not use `WM_QUIT` to exit the GUI. This PR adds a handler to start a new NVDA instance, to the NVDA exit event, after the wx mainloop is exited safely. 

### Testing strategy:

Run the installer of the `exe` this PR builds.

The order of extension points firing is covered by `test_registerMultiple` in `tests\unit\test_extensionPoints.py`

### Known issues with pull request:

None

### Change log entries:

None needed, unreleased regression

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
