### PR TITLE
Flexibility of outlook categories translation

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -357,8 +357,8 @@ class CalendarView(IAccessible):
 
 		# Translators: Part of a message reported when on a calendar appointment with one or more categories
 		# in Microsoft Outlook.
-		categoriesText = ngettext("category", "categories", categoriesCount)
-		return f"{categoriesText} {categories}"
+		categoriesText = ngettext("category {categories}", "categories {categories}", categoriesCount)
+		return categoriesText.format(categories)
 
 	def isDuplicateIAccessibleEvent(self,obj):
 		return False


### PR DESCRIPTION
Allow translators to adjust order and spacing for categories in outlook

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
fixes #12417

### Summary of the issue:
We use ngettext in one location, essentially a trial for now.
Currently this does not allow translators to change spacing, or to change word order.
Two strings are essentially joined together without consideration of the language grammar.

### Description of how this pull request fixes the issue:
Give the translators more flexibility by allowing them to place the translation text.

### Testing strategy:
Build and run locally.
Ensured that annoucing categories in outlook works as expected.

### Known issues with pull request:
Due to the format of the categories list provided by outlook, it may not be possible to create completely natural sentances in all languages.

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
