### PR TITLE
Check if `hasUiAccess` to determine if `touchSupported`

### DIFF
--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2020 NV Access Limited, Joseph Lee, Babbage B.V.
+# Copyright (C) 2012-2021 NV Access Limited, Joseph Lee, Babbage B.V.
 
 """handles touchscreen interaction (Windows 8 and later).
 Used to provide input gestures for touchscreens, touch modes and other support facilities.
@@ -14,18 +14,15 @@ from ctypes.wintypes import *
 import re
 import gui
 import winVersion
-import globalPluginHandler
 import config
 import winUser
-import speech
-import api
-import ui
 import inputCore
 import screenExplorer
 from logHandler import log
 import touchTracker
-import gui
 import core
+import systemUtils
+
 
 availableTouchModes=['text','object']
 
@@ -310,6 +307,10 @@ def touchSupported(debugLog: bool = False):
 	if maxTouches<=0:
 		if debugLog:
 			log.debugWarning("No touch devices found")
+		return False
+	if not systemUtils.hasUiAccess():
+		if debugLog:
+			log.debugWarning("NVDA doesn't have UI Access so touch isn't supported.")
 		return False
 	return True
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

fixes #12440 

### Summary of the issue:

Unsigned installed builds (such as PRs) fail to start on touchscreen devices

Touch handler fails to initialise.

### Description of how this pull request fixes the issue:

this is due to NVDA not having the UIAccess permission without being a signed copy. touchHandler.touchSupported should return False if systemUtils.hasUIAccess returns False

### Testing strategy:

Run an installed copy of this PR build on a device with a touchscreen

### Known issues with pull request:

None.

### Change log entries:
None need

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
