### PR TITLE
Remove one and only use of ngettext for now

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -37,7 +37,7 @@ from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA
 from NVDAObjects.UIA.wordDocument import WordDocument as UIAWordDocument
 import languageHandler
-from gettext import ngettext
+
 
 PR_LAST_VERB_EXECUTED=0x10810003
 VERB_REPLYTOSENDER=102
@@ -353,12 +353,10 @@ class CalendarView(IAccessible):
 			bufLength
 		) == 0:
 			raise ctypes.WinError()
-		categoriesCount = len(categories.split(f"{separatorBuf.value} "))
 
 		# Translators: Part of a message reported when on a calendar appointment with one or more categories
 		# in Microsoft Outlook.
-		categoriesText = ngettext("category {categories}", "categories {categories}", categoriesCount)
-		return categoriesText.format(categories=categories)
+		return _("categories {categories}").format(categories=categories)
 
 	def isDuplicateIAccessibleEvent(self,obj):
 		return False


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Recently NVDA began using ngettext to allow translators to provide both singular and plural translations for a particular message.
 However, it seems that our PO validation code in the translation system is not handling plural forms well, and is incorrectly classing translations as missing brace format variables, as it is incorrectly comparing the translation with the message before that one.
It then outputs the following error:
```
Message starting on line 7169
Original: "{startTime} to {endTime}"
Translated: "category {categories}"
Error: missing brace format interpolation, extra brace format interpolation
Expected: these brace format interpolations: {endTime}, {startTime}
Got: these brace format interpolations: {categories} 
```

ngettext was so far only used for one string in NVDA, in source/appModules/outlook.py. Seen by doing `git grep ngettext`.


We have many many strings in NVDA which would benefit from ngettext, but we need to know it works correctly. So until we are sure we can validate this correctly, we should stop using it in the one and only place it exists today.

### Description of how this pull request fixes the issue:
Stop using ngettext for the one string in the Outlook appModule, instead replacing it with a normal use of `_()` providing just the plural form. 

### Testing strategy:
* Manually tested by Opening Outlook. Going to a calendar. Creating an appointment and adding 0, 1 and 2 categories, verifying each time that focusing the appointment NVDA reports  the categories.

### Known issues with pull request:
None.

### Change log entries:
None needed.

New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
