### PR TITLE
Update espeak to latest master

### DIFF
--- a/include/espeak.md
+++ b/include/espeak.md
@@ -31,7 +31,8 @@ Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
    1. Modify the `<nvda repo root>/nvdaHelper/espeak/config.h` file as required.
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
-   1. Update the package version in `<nvda repo root>/nvdaHelper/espeak/config.h`
+   1. Update the `/DPACKAGE_VERSION` in `espeak/sconscript`
+      - The preprocessor definition is used to create `<nvda repo root>/nvdaHelper/espeak/config.h`
       - Compare to espeak source info: `<nvda repo root>/include/espeak/src/windows/config.h`.
    1. Update NVDA `readme.md` with espeak version and commit.
    1. Build NVDA

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -32,7 +32,8 @@ Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
    1. Update the `/DPACKAGE_VERSION` in `espeak/sconscript`
-      - The preprocessor definition is used to create `<nvda repo root>/nvdaHelper/espeak/config.h`
+      - The preprocessor definition is used to supply these definitions instead of `<nvda repo root>/nvdaHelper/espeak/config.h`
+      - `<nvda repo root>/nvdaHelper/espeak/config.h` must exist (despite being empty) since a "congig.h" is included within espeak.
       - Compare to espeak source info: `<nvda repo root>/include/espeak/src/windows/config.h`.
    1. Update NVDA `readme.md` with espeak version and commit.
    1. Build NVDA

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -33,7 +33,7 @@ Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
    1. Change back to the NVDA repo root
    1. Update the `/DPACKAGE_VERSION` in `espeak/sconscript`
       - The preprocessor definition is used to supply these definitions instead of `<nvda repo root>/nvdaHelper/espeak/config.h`
-      - `<nvda repo root>/nvdaHelper/espeak/config.h` must exist (despite being empty) since a "congig.h" is included within espeak.
+      - `<nvda repo root>/nvdaHelper/espeak/config.h` must exist (despite being empty) since a "config.h" is included within espeak.
       - Compare to espeak source info: `<nvda repo root>/include/espeak/src/windows/config.h`.
    1. Update NVDA `readme.md` with espeak version and commit.
    1. Build NVDA
@@ -54,4 +54,3 @@ any changes in our `sconscript` file.
 Due to problems with emoji support (causing crashes), emoji dictionary files are being excluded
 from the build, they are deleted prior to compiling the dictionaries in the
 `<nvda repo root>/nvdaHelper/espeak/sconscript` file.
-

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit cad1c8e8
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit f6d092a9c
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.17.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,7 +33,7 @@ This release also drops support for Adobe Flash.
 - 'Attempt to cancel speech for expired focus events' option in the advanced settings panel now enabled by default. (#10885)
   - This behaviour can be disabled by setting this option to "No".
   - Web applications (E.G. Gmail) no longer speak outdated information when moving focus rapidly.
-- Espeak-ng has been updated to 1.51-dev commit f6d092a9c13d864ede78c493f64a7d32cde41f09. (#PRNum, #12202, #12280)
+- Espeak-ng has been updated to 1.51-dev commit f6d092a9c13d864ede78c493f64a7d32cde41f09. (#12449, #12202, #12280)
 - Updated liblouis braille translator to [3.17.0 https://github.com/liblouis/liblouis/releases/tag/v3.17.0]. (#12137)
   - New braille tables: Belarusian literary braille, Belarusian computer braille, Urdu grade 1, Urdu grade 2.
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,7 +33,7 @@ This release also drops support for Adobe Flash.
 - 'Attempt to cancel speech for expired focus events' option in the advanced settings panel now enabled by default. (#10885)
   - This behaviour can be disabled by setting this option to "No".
   - Web applications (E.G. Gmail) no longer speak outdated information when moving focus rapidly.
-- Espeak-ng has been updated to 1.51-dev commit cad1c8e87fcccf677a445202e340f61980450a84. (#12202, #12280)
+- Espeak-ng has been updated to 1.51-dev commit f6d092a9c13d864ede78c493f64a7d32cde41f09. (#PRNum, #12202, #12280)
 - Updated liblouis braille translator to [3.17.0 https://github.com/liblouis/liblouis/releases/tag/v3.17.0]. (#12137)
   - New braille tables: Belarusian literary braille, Belarusian computer braille, Urdu grade 1, Urdu grade 2.
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
In order to start getting feedback as soon as possible before making a beta release, we can update espeak (and merge back to alpha).
If no problems are found for alpha users over the weekend we will use this version of espeak in the beta release.
Once this version of espeak is accepted we will work on fixing Cantonese and Mandarin voices.

### Description of how this pull request fixes the issue:
Updates Espeak-ng to latest master commit f6d092a9c13d864ede78c493f64a7d32cde41f09

### Testing strategy:
Build and run locally, with espeak voice
Feedback from alpha users over the weekend

### Known issues with pull request:

### Change log entries:

Changes
Update existing specify new commit: f6d092a9c13d864ede78c493f64a7d32cde41f09

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
