### PR TITLE
UI Automation in Windows Console: Cache isImprovedTextRangeAvailable and infrastructure for UIA by default

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2009-2020 NV Access Limited, Joseph Lee, Mohammad Suliman,
+# Copyright (C) 2009-2021 NV Access Limited, Joseph Lee, Mohammad Suliman,
 # Babbage B.V., Leonard de Ruijter, Bill Dengler
 
 """Support for UI Automation (UIA) controls."""
@@ -1027,10 +1027,7 @@ class UIA(Window):
 			VisualStudio.findExtraOverlayClasses(self, clsList)
 
 		# Support Windows Console's UIA interface
-		if (
-			self.windowClassName == "ConsoleWindowClass"
-			and config.conf['UIA']['winConsoleImplementation'] == "UIA"
-		):
+		if self.windowClassName == "ConsoleWindowClass":
 			from . import winConsoleUIA
 			winConsoleUIA.findExtraOverlayClasses(self, clsList)
 		elif UIAClassName == "TermControl":

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -11,6 +11,7 @@ import UIAHandler
 
 from comtypes import COMError
 from logHandler import log
+from UIAUtils import _isImprovedConhostTextRangeAvailable
 from . import UIATextInfo
 from ..behaviors import EnhancedTermTypedCharSupport, KeyboardHandlerBasedTypedCharSupport
 from ..window import Window
@@ -356,10 +357,7 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		internally to determine whether to activate workarounds and as a
 		convenience when debugging.
 		"""
-		# microsoft/terminal#4495: In newer consoles,
-		# IUIAutomationTextRange::getVisibleRanges returns one visible range.
-		# Therefore, if exactly one range is returned, it is almost definitely a newer console.
-		return self.UIATextPattern.GetVisibleRanges().length == 1
+		return _isImprovedConhostTextRangeAvailable(self.windowHandle)
 
 	def _get_TextInfo(self):
 		"""Overriding _get_ConsoleUIATextInfo and thus the ConsoleUIATextInfo property

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -334,8 +334,10 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Only process text changes every 30 ms, in case the console is getting
 	#: a lot of text.
 	STABILIZE_DELAY = 0.03
-	#: the caret in consoles can take a while to move on Windows 10 1903 and later.
-	_caretMovementTimeoutMultiplier = 1.5
+
+	def _get__caretMovementTimeoutMultiplier(self):
+		"On older consoles, the caret can take a while to move."
+		return 1 if self.isImprovedTextRangeAvailable else 1.5
 
 	def _get_windowThreadID(self):
 		# #10113: Windows forces the thread of console windows to match the thread of the first attached process.

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -298,7 +298,7 @@ def _shouldUseUIAConsole(hwnd: int) -> bool:
 		# #7497: the UIA implementation in old conhost is incomplete, therefore we
 		# should ignore it.
 		# When the UIA implementation is improved, the below line will be replaced
-		# with a call to _shouldUseUIAConsole.
+		# with a call to _isImprovedConhostTextRangeAvailable.
 		return False
 
 

--- a/source/UIAUtils.py
+++ b/source/UIAUtils.py
@@ -314,8 +314,9 @@ def _isImprovedConhostTextRangeAvailable(hwnd):
 		)
 		textAreaCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
 		textAreaCacheRequest.TreeScope = UIAHandler.TreeScope_Children
-		textAreaCacheRequest.treeFilter = createUIAMultiPropertyCondition(
-			{UIAHandler.UIA_AutomationIdPropertyId: ["Text Area"]}
+		textAreaCacheRequest.treeFilter = UIAHandler.handler.clientObject.createPropertyCondition(
+			UIAHandler.UIA_AutomationIdPropertyId,
+			"Text Area"
 		)
 		textArea = UIAElement.buildUpdatedCache(
 			textAreaCacheRequest

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2011-2021 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2011-2021 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -60,7 +60,7 @@ goodUIAWindowClassNames=[
 	'RAIL_WINDOW',
 ]
 
-badUIAWindowClassNames=[
+badUIAWindowClassNames = (
 	# UIA events of candidate window interfere with MSAA events.
 	"Microsoft.IME.CandidateWindow.View",
 	"SysTreeView32",
@@ -78,7 +78,7 @@ badUIAWindowClassNames=[
 	"Button",
 	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 	"FoxitDocWnd",
-]
+)
 
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.
 UIADialogClassNames=[
@@ -704,17 +704,6 @@ class UIAHandler(COMObject):
 			return
 		eventHandler.queueEvent("UIA_activeTextPositionChanged", obj, textRange=textRange)
 
-	def _isBadUIAWindowClassName(self, windowClass):
-		"Given a windowClassName, returns True if this is a known problematic UIA implementation."
-		# #7497: Windows 10 Fall Creators Update has an incomplete UIA
-		# implementation for console windows, therefore for now we should
-		# ignore it.
-		# It does not implement caret/selection, and probably has no new text
-		# events.
-		if windowClass == "ConsoleWindowClass" and config.conf['UIA']['winConsoleImplementation'] != "UIA":
-			return True
-		return windowClass in badUIAWindowClassNames
-
 	def _isUIAWindowHelper(self,hwnd):
 		# UIA in NVDA's process freezes in Windows 7 and below
 		processID=winUser.getWindowThreadProcessID(hwnd)[0]
@@ -731,7 +720,7 @@ class UIAHandler(COMObject):
 		if appModule and appModule.isGoodUIAWindow(hwnd):
 			return True
 		# There are certain window classes that just had bad UIA implementations
-		if self._isBadUIAWindowClassName(windowClass):
+		if windowClass in badUIAWindowClassNames:
 			return False
 		# allow the appModule for the window to also choose if this window is bad
 		if appModule and appModule.isBadUIAWindow(hwnd):
@@ -807,6 +796,8 @@ class UIAHandler(COMObject):
 				)
 			):
 				return False
+			if windowClass == "ConsoleWindowClass":
+				return UIAUtils._shouldUseUIAConsole(hwnd)
 		return bool(res)
 
 	def isUIAWindow(self,hwnd):

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -55,10 +55,10 @@ HorizontalTextAlignment_Justified=3
 # The name of the WDAG (Windows Defender Application Guard) process
 WDAG_PROCESS_NAME=u'hvsirdpclient'
 
-goodUIAWindowClassNames=[
+goodUIAWindowClassNames = (
 	# A WDAG (Windows Defender Application Guard) Window is always native UIA, even if it doesn't report as such.
 	'RAIL_WINDOW',
-]
+)
 
 badUIAWindowClassNames = (
 	# UIA events of candidate window interfere with MSAA events.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Split from #10964.

### Summary of the issue:
In UIA consoles:
* If UIA support is disabled but UIA console somehow starts, the custom overlay class is not applied.
* `badUIWindowClassNames` and `goodUIWindowClassNames`  are mutable, which is inconsistent with other UIA implementations.
* `isImprovedTextRangeAvailable` is queried many times, resulting in excessive cross-process calls.
* In newer consoles, caret movement is not delayed, so the timeout is excessively long leading to performance problems in some cases.

### Description of how this pull request fixes the issue:
This PR:
* Removes the setting check when applying the overlay class (this shouldn't have been there, as the object is already UIA at the step of applying an overlay class).
* Removes `_UIAHandler._isBadWindowClassName` (added for UIA console)
* makes `badUIWindowClassNames` and `goodUIWindowClassNames`  immutable, as tuples
* Adds `UIAUtils._isImprovedConhostTextRangeAvailable` which checks the number of visible ranges in a console at a given `hwnd`. This function is decorated with [functools.lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache).
* Adds `UIAUtils._shouldUseUIAConsole` which currently just checks the config as before (when UIA console becomes default, a call to `_isImprovedConhostTextRangeAvailable` will be added to this function to handle the default/auto case).
* Removes the caret movement timeout multiplier override on consoles where `isImprovedTextRangeAvailable`.

### Testing strategy:
Tested that the use UIA console checkbox in advanced settings works as expected.

Ran Windows Console, moved the review cursor over a few words/lines, then connected and disconnected from another system over `ssh`:

```python console
>>> UIAUtils._isImprovedConhostTextRangeAvailable.cache_info()
CacheInfo(hits=84, misses=1, maxsize=10, currsize=1)
```

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.

