### PR TITLE
Prevent creating a portable copy always exiting NVDA

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -482,4 +482,5 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 			def startNewPortableNVDAInstance():
 				_startNewNVDAInstance(portableDirectory)
 			core.preNVDAExit.register(startNewPortableNVDAInstance)
-	core.triggerNVDAExit()
+	if silent or startAfterCreate:
+		core.triggerNVDAExit()


### PR DESCRIPTION
### Link to issue number:

fixes #12452 

### Summary of the issue:

#12431 introduced a change where NVDA always exits at the end of creating a portable copy. The intention was to change the behaviour from

- exit NVDA if it is a silent install

to

- exit NVDA if it is a silent install, or if we are starting the portable copy. 

As a result of #12431, finishing the install of a portable copy without starting it also results in NVDA exiting.

### Description of how this pull request fixes the issue:

Restores intended change in #12431

### Testing strategy:

Create a portable copy using the binary from this build. 

System tests would add a lot of time for the build without much gain. 

### Known issues with pull request:

None

### Change log entries:

None, unreleased bug

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
