### PR TITLE
Check if `hasUiAccess` to determine if `isAudioDuckingSupported`

### DIFF
--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -1,8 +1,7 @@
-#audioDucking.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2015-2016 NV Access Limited 
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2015-2021 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import threading
 from ctypes import *
@@ -10,6 +9,7 @@ from ctypes import oledll
 import time
 import config
 from logHandler import log
+import systemUtils
 
 def _isDebug():
 	return config.conf["debugLog"]["audioDucking"]
@@ -146,6 +146,7 @@ def isAudioDuckingSupported():
 			config.isInstalledCopy()
 			or config.isAppX
 		) and hasattr(oledll.oleacc, 'AccSetRunningUtilityState')
+		_isAudioDuckingSupported &= systemUtils.hasUiAccess()
 	return _isAudioDuckingSupported
 
 def handlePostConfigProfileSwitch():


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

>UI access privilege is also required to use audio ducking functionality (this is why the user guide states that you must be running an installed copy of NVDA in order to use audio ducking feature). As far as internals are concerned, PR builds are seen as portable NVDA because it lacks privileges (no signing as folks pointed out).

_Originally posted by @josephsl in https://github.com/nvaccess/nvda/issues/12440#issuecomment-844627388_

This creates noise in system test logs as audio ducking fails to initialise. Such as:

```python
WARNING - nvwave.WavePlayer.open (23:29:21.518) - MainThread (1460):
Unable to open WAVE_MAPPER device, there may be no audio devices.
ERROR - audioDucking._setDuckingState (23:29:21.518) - MainThread (1460):
Unknown error when setting ducking state:  Error number: 0X800706BA
Traceback (most recent call last):
  File "audioDucking.pyc", line 65, in _setDuckingState
  File "_ctypes/callproc.c", line 935, in GetResult
OSError: [WinError -2147023174] The RPC server is unavailable
WARNING - nvwave.WavePlayer.open (23:29:21.518) - MainThread (1460):
Unable to open WAVE_MAPPER device, there may be no audio devices.
ERROR - unhandled exception (23:29:21.518) - MainThread (1460):
Traceback (most recent call last):
  File "wx\core.pyc", line 3407, in <lambda>
  File "audioDucking.pyc", line 137, in initialize
  File "audioDucking.pyc", line 82, in _setDuckingState
  File "audioDucking.pyc", line 65, in _setDuckingState
  File "_ctypes/callproc.c", line 935, in GetResult
OSError: [WinError -2147023174] The RPC server is unavailable
```

### Description of how this pull request fixes the issue:

Check if `systemUtils.hasUiAccess` to determine if `isAudioDuckingSupported`, using approach similar to #12447 

### Testing strategy:

Check system test logs for warning about failing to initialise audio ducking. 

### Known issues with pull request:

None

### Change log entries:

None needed, no change of behaviour just fixes logging

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
