### PR TITLE
Fix empty edit fields not speaking in Microsoft Edge

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -940,6 +940,9 @@ class UIA(Window):
 				clsList.append(spartanEdge.EdgeList)
 			else:
 				clsList.append(spartanEdge.EdgeNode)
+		elif self.windowClassName == "Chrome_WidgetWin_1" and self.UIATextPattern:
+			from . import chromium
+			clsList.append(chromium.ChromiumUIA)
 		elif self.windowClassName == "Chrome_RenderWidgetHostHWND":
 			from . import chromium
 			from . import web
@@ -1265,8 +1268,9 @@ class UIA(Window):
 
 	_TextInfo=UIATextInfo
 	def _get_TextInfo(self):
-		if self.UIATextPattern: return self._TextInfo
-		textInfo=super(UIA,self).TextInfo
+		if self.UIATextPattern:
+			return self._TextInfo
+		textInfo = super(UIA, self).TextInfo
 		if textInfo is NVDAObjectTextInfo and self.UIAIsWindowElement and self.role==controlTypes.ROLE_WINDOW:
 			import displayModel
 			return displayModel.DisplayModelTextInfo

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1267,6 +1267,8 @@ class UIA(Window):
 		return self.UIALegacyIAccessiblePattern
 
 	_TextInfo=UIATextInfo
+	_cache_TextInfo = False
+
 	def _get_TextInfo(self):
 		if self.UIATextPattern:
 			return self._TextInfo

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -6,6 +6,8 @@
 import UIAHandler
 from . import web
 import controlTypes
+from comtypes import COMError
+from logHandler import log
 
 """
 This module provides UIA behaviour specific to the chromium family of browsers.
@@ -15,6 +17,16 @@ or UIA.anaheim_edge.
 
 
 class ChromiumUIATextInfo(web.UIAWebTextInfo):
+
+	def expand(self, unit):
+		# #12474: Expanding to line breaks when the underlying text range is empty.
+		copy = self._rangeObj.Clone()
+		super().expand(unit)
+		try:
+			self._rangeObj.Compare(copy)
+		except COMError:
+			log.debugWarning(f"Expand to {unit} failed for {self}, resorting to backup range before expand")
+			self._rangeObj = copy
 
 	def _getFormatFieldAtRange(self, textRange, formatConfig, ignoreMixedValues=False):
 		formatField = super()._getFormatFieldAtRange(textRange, formatConfig, ignoreMixedValues=ignoreMixedValues)

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -1,13 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2020 NV Access limited, Leonard de Ruijter
+# Copyright (C) 2020-2021 NV Access limited, Leonard de Ruijter
 
 import UIAHandler
 from . import web
 import controlTypes
-from comtypes import COMError
-from logHandler import log
 
 """
 This module provides UIA behaviour specific to the chromium family of browsers.
@@ -20,13 +18,12 @@ class ChromiumUIATextInfo(web.UIAWebTextInfo):
 
 	def expand(self, unit):
 		# #12474: Expanding to line breaks when the underlying text range is empty.
-		copy = self._rangeObj.Clone()
+		if (
+			UIAHandler.NVDAUnitsToUIAUnits.get(unit) == UIAHandler.UIA.TextUnit_Line
+			and self.obj.UIATextPattern.documentRange.GetText(1) == ""
+		):
+			return
 		super().expand(unit)
-		try:
-			self._rangeObj.Compare(copy)
-		except COMError:
-			log.debugWarning(f"Expand to {unit} failed for {self}, resorting to backup range before expand")
-			self._rangeObj = copy
 
 	def _getFormatFieldAtRange(self, textRange, formatConfig, ignoreMixedValues=False):
 		formatField = super()._getFormatFieldAtRange(textRange, formatConfig, ignoreMixedValues=ignoreMixedValues)

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -159,9 +159,6 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 				log.exception(f"Exception in event_NVDAObject_init for {appModule}")
 				pass
 
-		# Ensure the property cache is cleared since overlays can change property values
-		obj.invalidateCache()
-
 		return obj
 
 	@classmethod

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -159,6 +159,9 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 				log.exception(f"Exception in event_NVDAObject_init for {appModule}")
 				pass
 
+		# Ensure the property cache is cleared since overlays can change property values
+		obj.invalidateCache()
+
 		return obj
 
 	@classmethod

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -68,6 +68,7 @@ This release also drops support for Adobe Flash.
 - In MS Word or Outlook, the table quick navigation key can now jump to layout table if "Include layout tables" option is enabled in Browse mode settings. (#11899)
 - NVDA will no longer announce "↑↑↑" for emojis in particular languages. (#11963)
 - Espeak now supports Cantonese and Mandarin again. (#10418)
+- In the new Chromium based Microsoft Edge, text fields such as the address bar are now announced when empty. (#12474)
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #12474 
Fixes #12189

### Summary of the issue:
Empty edit fields aren't spoken in Edge. There's a bug in the UIA implementation that causes expand to line to fail when there is no text content in the object

### Description of how this pull request fixes the issue:
1. Use the ChromiumUIA object overlay for text boxes in the Chrome/Edge interface. For Edge, this applies by default. For Chrome, this only applies to cases where experimental UIA support is enabled, but this is far from stable in Chrome itself.
2. On the ChromeUIATextInfo when expanding to line, check whether there's any text in the document range. If not, don't try to expand as it will break the range.
3. Make sure not to cache the TextInfo property on UIA objects.ChromiumUIATextInfo. This is necessary because the property is fetched before the overlay classes are added that might change the result of evaluating the property. This ensures the proper TextInfo is used on focus.

### Testing strategy:
Tested that the address bar of Edge is read correctly when empty and focused.

### Known issues with pull request:
None known.

### Change log entries:
Bug fixes
* In the new Chromium based Microsoft Edge, text fields such as the address bar are now announced when empty. (#12474)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
