### PR TITLE
Use Diff Match Patch by default when available

### DIFF
--- a/source/diffHandler.py
+++ b/source/diffHandler.py
@@ -174,14 +174,13 @@ class Difflib(DiffAlgo):
 def get_dmp_algo():
 	"""
 		This function returns a Diff Match Patch object if allowed by the user.
-		DMP is experimental and can be explicitly enabled/disabled by a user
-		setting to opt in or out of the experiment. If config does not allow
-		DMP, this function returns a Difflib instance instead.
+		DMP is new and can be explicitly disabled by a user setting. If config
+		does not allow DMP, this function returns a Difflib instance instead.
 	"""
 	return (
-		_dmp
-		if config.conf["terminals"]["diffAlgo"] == "dmp"
-		else _difflib
+		_difflib
+		if config.conf["terminals"]["diffAlgo"] == "difflib"
+		else _dmp
 	)
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2681,7 +2681,7 @@ class AdvancedPanelControls(
 			# Translators: A choice in a combo box in the advanced settings
 			# panel to have NVDA determine the method of detecting changed
 			# content in terminals automatically.
-			_("Automatic (Difflib)"),
+			_("Automatic (Diff Match Patch)"),
 			# Translators: A choice in a combo box in the advanced settings
 			# panel to have NVDA detect changes in terminals
 			# by character when supported, using the diff match patch algorithm.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -18,6 +18,9 @@ What's New in NVDA
 
 == Bug Fixes ==
 - In Windows 10 Calculator, NVDA will announce calculator expressions on a braille display. (#12268)
+- In terminal programs on Windows 10 version 1607 and later, when inserting or deleting characters in the middle of a line, the characters to the right of the caret are no longer read out. (#3200)
+  - Diff Match Patch now enabled by default. (#12485)
+  -
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1875,7 +1875,7 @@ In untrusted environments, you may temporarily disable [speak typed characters #
 ==== Diff algorithm ====[DiffAlgo]
 This setting controls how NVDA determines the new text to speak in terminals.
 The diff algorithm combo box has three options:
-- Automatic: as of NVDA 2021.2, this option is equivalent to allow Diff Match Patch.
+- Automatic: as of NVDA 2021.2, this option is equivalent to "allow Diff Match Patch".
 - allow Diff Match Patch: This option causes NVDA to calculate changes to terminal text by character.
 It may improve performance when large volumes of text are written to the console and allow more accurate reporting of changes made in the middle of lines.
 However, it may be incompatible with some applications, so Diff Match Patch is not always used.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1875,11 +1875,10 @@ In untrusted environments, you may temporarily disable [speak typed characters #
 ==== Diff algorithm ====[DiffAlgo]
 This setting controls how NVDA determines the new text to speak in terminals.
 The diff algorithm combo box has three options:
-- Automatic: as of NVDA 2021.1, this option is equivalent to Difflib.
-In a future release, it may be changed to Diff Match Patch pending positive user testing.
+- Automatic: as of NVDA 2021.2, this option is equivalent to allow Diff Match Patch.
 - allow Diff Match Patch: This option causes NVDA to calculate changes to terminal text by character.
 It may improve performance when large volumes of text are written to the console and allow more accurate reporting of changes made in the middle of lines.
-However, it may be incompatible with some applications.
+However, it may be incompatible with some applications, so Diff Match Patch is not always used.
 This feature is supported in Windows Console on Windows 10 versions 1607 and later.
 Additionally, it may be available in other terminals on earlier Windows releases.
 - force Difflib: this option causes NVDA to calculate changes to terminal text by line.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#3200.

### Summary of the issue:
Diff Match Patch (DMP) was included but disabled by default in 2021.1. It fixes #3200 and allows for drastically fewer cross-process calls in UIA console, improving performance in busy applications.

### Description of how this pull request fixes the issue:
This PR enables DMP by default to allow for wider user testing in master snapshots. If user feedback is positive, use by default in 2021.2.

### Testing strategy:
Verified that DMP is used by default when feature flag is set to auto and Difflib when feature flag is set to force Difflib.

### Known issues with pull request:
None.

### Change log entries:
== Bug Fixes ==
- In terminal programs on Windows 10 version 1607 and later, when inserting or deleting characters in the middle of a line, the characters to the right of the caret are no longer read out. (#3200)
    - Diff Match Patch now enabled by default. (#12485)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
