### PR TITLE
Windows 10 Calculator: let braille output expressions, even when Delete key is pressed to clear calculator expressions

### DIFF
--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -90,7 +90,13 @@ class AppModule(appModuleHandler.AppModule):
 			nextHandler()
 
 	# A list of native commands to handle calculator result announcement.
-	_calculatorResultGestures = ("kb:enter", "kb:numpadEnter", "kb:escape")
+	_calculatorResultGestures = (
+		"kb:enter",
+		"kb:numpadEnter",
+		"kb:escape",
+		"kb:delete",
+		"kb:numpadDelete"
+	)
 
 	@scriptHandler.script(gestures=_calculatorResultGestures)
 	def script_calculatorResult(self, gesture):

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -11,6 +11,7 @@ from NVDAObjects.UIA import UIA
 import queueHandler
 import ui
 import scriptHandler
+import braille
 
 # #9428: do not announce current values until calculations are done in order to avoid repetitions.
 noCalculatorEntryAnnouncements = [
@@ -64,7 +65,10 @@ class AppModule(appModuleHandler.AppModule):
 		self._shouldAnnounceResult = False
 		nextHandler()
 
-	def event_UIA_notification(self, obj, nextHandler, activityId=None, **kwargs):
+	def event_UIA_notification(self, obj, nextHandler, displayString=None, activityId=None, **kwargs):
+		# #12268: for "DisplayUpdated", announce display strings in braille and move on.
+		if activityId == "DisplayUpdated":
+			braille.handler.message(displayString)
 		try:
 			shouldAnnounceNotification = (
 				obj.previous.UIAAutomationId in

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -110,9 +110,9 @@ class AppModule(appModuleHandler.AppModule):
 		# In redstone, pressing enter does not move focus to equals button.
 		if isinstance(focus, UIA):
 			if focus.UIAAutomationId in ("CalculatorResults", "CalculatorAlwaysOnTopResults"):
-				queueHandler.queueFunction(queueHandler.eventQueue, focus.reportFocus)
+				queueHandler.queueFunction(queueHandler.eventQueue, ui.message, focus.name)
 			else:
 				resultsScreen = api.getForegroundObject().children[1].lastChild
 				if isinstance(resultsScreen, UIA) and resultsScreen.UIAElement.cachedClassName == "LandmarkTarget":
 					# And no, do not allow focus to move.
-					queueHandler.queueFunction(queueHandler.eventQueue, resultsScreen.firstChild.reportFocus)
+					queueHandler.queueFunction(queueHandler.eventQueue, ui.message, resultsScreen.firstChild.name)

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 202002921 NV Access Limited, Joseph Lee
+# Copyright (C) 2020-2021 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited, Joseph Lee
+# Copyright (C) 202002921 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,12 +9,16 @@ What's New in NVDA
 - Support for ARIA annotations:
   - adds a command to read a summary of details of an object with aria-details. (#12364)
   - adds an option in advanced to report if an object has details in browse mode. (#12439) 
+  -
+-
 
 
 == Changes ==
 
 
 == Bug Fixes ==
+- In Windows 10 Calculator, NVDA will announce calculator expressions on a braille display. (#12268)
+-
 
 
 == Changes for Developers ==


### PR DESCRIPTION
Hi,

Tested via Windows 10 App Essentials add-on for a while:

### Link to issue number:
Closes #12268 

### Summary of the issue:
When entering expressions, no braille feedback is given, including when Delete key is pressed to clear expressions.

### Description of how this pull request fixes the issue:
Adds Delete (including Numpad Delete) as a Calculator command, along with changing from reportfocus to ui.message in results script so braille output can function.

### Testing strategy:
Manual testing required (cannot be tested via AppVeyor as the VM runs Windows Server 2016/2019 which does not come with modern Windows 10 Calculator):

1. Have a braille display handy.
2. Start Calculator.
3. Enter expressions.
4. Press one of the following keys: Enter, Escape, Delete.

### Known issues with pull request:
None

### Change log entries:
Bug fixes:

In Windows 10 Calculator, NVDA will announce calculator expressions on a braille display. (#12268)


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers

Thanks.