### PR TITLE
Toasts and modern keyboard: use winVersion.WIN10_* constants for public builds

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -12,7 +12,6 @@ from comtypes import COMError
 from comtypes.automation import VARIANT
 import time
 import weakref
-import sys
 import numbers
 import colors
 import languageHandler

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1969,7 +1969,7 @@ class Toast_win8(Notification, UIA):
 class Toast_win10(Notification, UIA):
 
 	# #6096: Windows 10 build 14366 and later does not fire tooltip event when toasts appear.
-	if sys.getwindowsversion().build > 10586:
+	if winVersion.getWinVer() > winVersion.WIN10_1511:
 		event_UIA_window_windowOpen=Notification.event_alert
 	else:
 		event_UIA_toolTipOpened=Notification.event_alert
@@ -1979,7 +1979,7 @@ class Toast_win10(Notification, UIA):
 	_lastToastRuntimeID = None
 
 	def event_UIA_window_windowOpen(self):
-		if sys.getwindowsversion().build >= 15063:
+		if winVersion.getWinVer() >= winVersion.WIN10_1703:
 			toastTimestamp = time.time()
 			toastRuntimeID = self.UIAElement.getRuntimeID()
 			if toastRuntimeID == self._lastToastRuntimeID and toastTimestamp-self._lastToastTimestamp < 1.0:

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -228,7 +228,7 @@ class AppModule(appModuleHandler.AppModule):
 		or (self._recentlySelected is not None and self._recentlySelected in obj.name)):
 			return
 		# The word "blank" is kept announced, so suppress this on build 17666 and later.
-		if winVersion.getWinVer().build > 17134:
+		if winVersion.getWinVer() > winVersion.WIN10_1803:
 			# In build 17672 and later,
 			# return immediately when element selected event on clipboard item was fired just prior to this.
 			# In some cases, parent will be None, as seen when emoji panel is closed in build 18267.


### PR DESCRIPTION
Hi,

If @feerrenrut says yes, I'm willing to target beta.

### Link to issue number:
None

### Summary of the issue:
There are places that compares Windows 10 builds, specificlaly publicly released builds. These include modern keyboard and UIA toast objects.

### Description of how this pull request fixes the issue:
Change to use winVersion.WIN10_* constants as follows:

* Modern keyboard/name change event: winVersion.getWinVer().build > 17134 -> winVersion.getWinVer() > winVersion.WIN10_1803
* Windows 10 toast objects (UIA): sys.getwindowsversion().build > 10586 -> winVersion.getWinVer() > winVersion.WIN10_1511, sys.getwindowsversion().build >= 15063 -> winVersion.getWinVer() >= winVersion.WIN10_1703
* Removed unused "sys" module imoport from NVDAObjects/UIA/__init__.py
* There exists a winVersion.getWinVer().build comparison in Spartan Edge support but it points to an Insider Preview build (15048) and therefore excluded from this PR unless @MichaelDCurran says it is okay to compare against winVersion.WIN10_1703 (build 15063).

### Testing strategy:
Python Console tests:

1. Open Python Console.
2. Try comparing current Windows 10 release against known releases such as:

import winVersion
winVersion.getWinVer() > winVersion.WIN10_1803
winVersion.getWinVer() >= winVersion.WIN10_1511

Or, you can compare builds like so:
winVersion.getWinVer().build > winVersion.WIN10_1703.build

The third test case is there for completeness, as winVersion.WinVersion object (the one that winVersion.getWinVer() returns) can be compared on its own with other constants.

### Known issues with pull request:
None

### Change log entries:
None needed (this is purely cosmetic nad finishes an earlier PR that introduced winVersion.WIN10_* constants)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers

Thanks.
P.S. This PR is dedicated to folks I met throughout my time volunteering for NVDA screen reader project (June 2012 to May 2021), along with NVDA volunteer contributors from the past, present, and future.