### PR TITLE
Downgrade espeak to aafd2e720

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -110,7 +110,6 @@ env.Append(
 		'#nvdaHelper/espeak',  # ensure that nvdaHelper/espeak/config.h is found first.
 		espeakIncludeDir,
 		espeakIncludeDir.Dir('compat'),
-		espeakSrcDir.Dir('speechPlayer/include'),
 		sonicSrcDir,
 		espeakSrcDir.Dir('ucd-tools/src/include')
 	])
@@ -155,7 +154,6 @@ espeakDictionaryCompileList: typing.Dict[
 	"bs_dict": ("bs", ["bs_list", "bs_rules", ]),
 	"ca_dict": ("ca", ["ca_list", "ca_rules", ]),
 	"chr_dict": ("chr", ["chr_list", "chr_rules", ]),
-	"cmn_dict": ("cmn", ["cmn_listx", "cmn_list", "cmn_rules"]),
 	"cs_dict": ("cs", ["cs_list", "cs_rules", ]),
 	"cv_dict": ("cv", ["cv_list", "cv_rules", ]),
 	"cy_dict": ("cy", ["cy_list", "cy_rules", ]),
@@ -183,9 +181,8 @@ espeakDictionaryCompileList: typing.Dict[
 	"ht_dict": ("ht", ["ht_list", "ht_rules", ]),
 	"hu_dict": ("hu", ["hu_list", "hu_rules", ]),
 	"hy_dict": ("hy", ["hy_list", "hy_rules", ]),
-	"ia_dict": ("ia", ["ia_listx", "ia_list", "ia_rules"]),
+	"ia_dict": ("ia", ["ia_list", "ia_rules"]),
 	"id_dict": ("id", ["id_list", "id_rules", ]),
-	"io_dict": ("io", ["io_list", "io_rules", ]),
 	"is_dict": ("is", ["is_list", "is_rules", ]),
 	"it_dict": ("it", ["it_listx", "it_list", "it_rules"]),
 	"ja_dict": ("ja", ["ja_list", "ja_rules", ]),
@@ -218,11 +215,9 @@ espeakDictionaryCompileList: typing.Dict[
 	"or_dict": ("or", ["or_list", "or_rules", ]),
 	"pap_dict": ("pap", ["pap_list", "pap_rules", ]),
 	"pa_dict": ("pa", ["pa_list", "pa_rules", ]),
-	"piqd_dict": ("piqd", ["piqd_list", "piqd_rules", ]),
 	"pl_dict": ("pl", ["pl_list", "pl_rules", ]),
 	"pt_dict": ("pt", ["pt_list", "pt_rules", ]),
 	"py_dict": ("py", ["py_list", "py_rules", ]),
-	"qdb_dict": ("qdb", ["qdb_list", "qdb_rules", ]),
 	"quc_dict": ("quc", ["quc_list", "quc_rules", ]),
 	"qu_dict": ("qu", ["qu_list", "qu_rules", ]),
 	"ro_dict": ("ro", ["ro_list", "ro_rules", ]),
@@ -232,7 +227,6 @@ espeakDictionaryCompileList: typing.Dict[
 	"si_dict": ("si", ["si_list", "si_rules", ]),
 	"sk_dict": ("sk", ["sk_list", "sk_rules", ]),
 	"sl_dict": ("sl", ["sl_list", "sl_rules", ]),
-	"smj_dict": ("smj", ["smj_list", "smj_rules", ]),
 	"sq_dict": ("sq", ["sq_list", "sq_rules", ]),
 	"sr_dict": ("sr", ["sr_list", "sr_rules", ]),
 	"sv_dict": ("sv", ["sv_list", "sv_rules", ]),
@@ -249,7 +243,8 @@ espeakDictionaryCompileList: typing.Dict[
 	"ur_dict": ("ur", ["ur_list", "ur_rules", ]),
 	"uz_dict": ("uz", ["uz_list", "uz_rules", ]),
 	"vi_dict": ("vi", ["vi_list", "vi_rules", ]),
-	"yue_dict": ("yue", ["yue_list", "yue_listx", "yue_rules"]),
+	"zh_dict": ("zh", ["zh_list", "zh_listx", "zh_rules"]),
+	"zhy_dict": ("zhy", ["zhy_list", "zhy_listx", "zhy_rules"]),
 }
 
 def espeak_compileDict_buildAction(
@@ -364,7 +359,6 @@ espeakLib=env.SharedLibrary(
 		"phonemelist.c",
 		"readclause.c",
 		"setlengths.c",
-		"soundIcon.c",
 		"spect.c",
 		"speech.c",
 		"ssml.c",
@@ -376,14 +370,6 @@ espeakLib=env.SharedLibrary(
 		"voices.c",
 		"wavegen.c",
 		sonicLib,
-		# espeak OPT_SPEECHPLAYER block
-		"sPlayer.c",
-		"../speechPlayer/src/frame.cpp",
-		"../speechPlayer/src/speechPlayer.cpp",
-		"../speechPlayer/src/speechWaveGenerator.cpp",
-		#"../speak-ng.cpp",
-		# if not OPT_SPEECHPLAYER
-		# "../speak-ng.c",
 		# espeak does not need to handle its own audio output so dont include:
 		# pcaudiolib\src\audio.c
 		# pcaudiolib\src\windows.c

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -243,8 +243,8 @@ espeakDictionaryCompileList: typing.Dict[
 	"ur_dict": ("ur", ["ur_list", "ur_rules", ]),
 	"uz_dict": ("uz", ["uz_list", "uz_rules", ]),
 	"vi_dict": ("vi", ["vi_list", "vi_rules", ]),
-	"zh_dict": ("zh", ["zh_list", "zh_listx", "zh_rules"]),
-	"zhy_dict": ("zhy", ["zhy_list", "zhy_listx", "zhy_rules"]),
+	"zh_dict": ("cmn", ["zh_list", "zh_listx", "zh_rules"]),
+	"zhy_dict": ("yue", ["zhy_list", "zhy_listx", "zhy_rules"]),
 }
 
 def espeak_compileDict_buildAction(

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit f6d092a9c
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit aafd2e720
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.17.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,7 +6,7 @@ What's New in NVDA
 = 2021.1 =
 This release includes optional experimental support for UIA in Excel and Chromium browsers.
 There are fixes for several languages, and for accessing links in Braille.
-There are updates to Unicode CLDR and mathematical symbols, eSpeak-NG and LibLouis.
+There are updates to Unicode CLDR, mathematical symbols and LibLouis.
 
 Many bug fixes and improvements, including in Office, Visual Studio and several languages.
 Note: this is an Add-on API compatibility breaking release.
@@ -33,7 +33,6 @@ This release also drops support for Adobe Flash.
 - 'Attempt to cancel speech for expired focus events' option in the advanced settings panel now enabled by default. (#10885)
   - This behaviour can be disabled by setting this option to "No".
   - Web applications (E.G. Gmail) no longer speak outdated information when moving focus rapidly.
-- Espeak-ng has been updated to 1.51-dev commit f6d092a9c13d864ede78c493f64a7d32cde41f09. (#12449, #12202, #12280)
 - Updated liblouis braille translator to [3.17.0 https://github.com/liblouis/liblouis/releases/tag/v3.17.0]. (#12137)
   - New braille tables: Belarusian literary braille, Belarusian computer braille, Urdu grade 1, Urdu grade 2.
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes #12465 

### Summary of the issue:

The latest espeak, used in beta, has a blocking issue. As such, we are reverting to the last known stable espeak. 

### Description of how this pull request fixes the issue:

Reverts to espeak in release 2020.4 which is `aafd2e720`.

The strategy to updating was to follow [the updating espeak readme](https://github.com/nvaccess/nvda/blob/master/include/espeak.md).

Choosing the commit:

```diff
git diff master release-2020.4 include/espeak
diff --git a/include/espeak b/include/espeak
index f6d092a9c..aafd2e720 160000
--- a/include/espeak
+++ b/include/espeak
@@ -1 +1 @@
-Subproject commit f6d092a9c13d864ede78c493f64a7d32cde41f09
+Subproject commit aafd2e720582d7ccdadef675ce656903bc775c1d
```

And then applying the results of `git diff f6d092a9c13d864ede78c493f64a7d32cde41f09 aafd2e720582d7ccdadef675ce656903bc775c1d Makefile.am` within the espeak project.

### Testing strategy:

NVDA builds, ensure espeak continues to work as expected like 2020.4. 

### Known issues with pull request:

None

### Change log entries:

Changes: remove mention of update to espeak. 

Note: 2020.4 didn't mention the upgrade to espeak. As such, those using the changelog to figure out the latest espeak version may be misled. 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
