### PR TITLE
Ensure NVDA quits from menu by queueing exit process

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -232,7 +232,9 @@ def getWxLangOrNone() -> Optional['wx.LanguageInfo']:
 
 
 def triggerNVDAExit():
-	preNVDAExit.notifyOnce()
+	import queueHandler
+	# queue this so that the calling process can exit safely (eg a Popup menu)
+	queueHandler.queueFunction(queueHandler.eventQueue, preNVDAExit.notifyOnce)
 
 
 def _closeAllWindows():

--- a/tests/system/nvdaSettingsFiles/standard-dontShowExitDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-dontShowExitDialog.ini
@@ -1,0 +1,18 @@
+schemaVersion = 2
+[general]
+	showWelcomeDialogAtStartup = True
+	askToExit = False
+[update]
+	askedAllowUsageStats = True
+	autoCheck = False
+	startupNotification = False
+	allowUsageStats = False
+[speech]
+	synth = speechSpySynthDriver
+[development]
+	enableScratchpadDir = True
+[virtualBuffers]
+	autoSayAllOnPageLoad = False
+	passThroughAudioIndication = False
+[annotations]
+	reportDetails = True

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -32,6 +32,33 @@ def NVDA_Starts():
 	_process.process_should_be_running(_nvdaProcessAlias)
 
 
+def quits_from_menu(showExitDialog=True):
+	"""Ensure NVDA can be quit from menu."""
+	spy = _nvdaLib.getSpyLib()
+	_builtIn.sleep(1)
+	spy.emulateKeyPress("NVDA+n")
+	spy.emulateKeyPress("x")
+	if showExitDialog:
+		exitTitleIndex = spy.wait_for_specific_speech("Exit NVDA")
+
+		spy.wait_for_speech_to_finish()
+		actualSpeech = spy.get_speech_at_index_until_now(exitTitleIndex)
+
+		_asserts.strings_match(
+			actualSpeech,
+			"\n".join([
+				"Exit NVDA  dialog",
+				"What would you like to do?  combo box  Exit  collapsed  Alt plus d"
+			])
+		)
+		_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little for it
+		spy.emulateKeyPress("enter", blockUntilProcessed=False)
+
+	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
+	_process.process_should_be_stopped(_nvdaProcessAlias)
+
+
+
 def quits_from_keyboard():
 	"""Ensure NVDA can be quit from keyboard."""
 	spy = _nvdaLib.getSpyLib()
@@ -40,7 +67,7 @@ def quits_from_keyboard():
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
 	spy.emulateKeyPress("enter")
 
-	spy.emulateKeyPress("insert+q")
+	spy.emulateKeyPress("NVDA+q")
 	exitTitleIndex = spy.wait_for_specific_speech("Exit NVDA")
 
 	spy.wait_for_speech_to_finish()

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -37,7 +37,7 @@ def quits_from_menu(showExitDialog=True):
 	spy = _nvdaLib.getSpyLib()
 	_builtIn.sleep(1)
 	spy.emulateKeyPress("NVDA+n")
-	spy.emulateKeyPress("x")
+	spy.emulateKeyPress("x", blockUntilProcessed=False)  # don't block so NVDA can exit
 	if showExitDialog:
 		exitTitleIndex = spy.wait_for_specific_speech("Exit NVDA")
 
@@ -52,7 +52,7 @@ def quits_from_menu(showExitDialog=True):
 			])
 		)
 		_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little for it
-		spy.emulateKeyPress("enter", blockUntilProcessed=False)
+		spy.emulateKeyPress("enter", blockUntilProcessed=False)  # don't block so NVDA can exit
 
 	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
 	_process.process_should_be_stopped(_nvdaProcessAlias)
@@ -81,7 +81,7 @@ def quits_from_keyboard():
 		])
 	)
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
-	spy.emulateKeyPress("enter", blockUntilProcessed=False)
+	spy.emulateKeyPress("enter", blockUntilProcessed=False)  # don't block so NVDA can exit
 	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
 	_process.process_should_be_stopped(_nvdaProcessAlias)
 

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -30,6 +30,11 @@ Quits from keyboard
 	[Setup]	start NVDA	standard-doShowWelcomeDialog.ini
 	quits_from_keyboard	# run test
 
+Quits from menu
+	[Documentation]	Starts NVDA and ensures that it can be quit using the keyboard
+	[Setup]	start NVDA	standard-dontShowExitDialog.ini
+	quits from menu	False	# run test
+
 Read welcome dialog
 	[Documentation]	Ensure that the welcome dialog can be read in full
 	[Setup]	start NVDA	standard-doShowWelcomeDialog.ini


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes #12498 

### Summary of the issue:

When the exit dialog is disabled, the popup menu stays activated while exiting. The NVDA exit process creates a call to destroy the popup menu while it is still activated. This causes a wx issue. 

### Description of how this pull request fixes the issue:

Always queue the exit process. This allows the PopupMenu to close before attempting to be deleted.

Closing the Popup menu programmatically before destroying it isn't achievable with the current wxPython implementation. Alternatively, we can override the event handlers and invoking window before deleting it. https://stackoverflow.com/questions/54535731/how-to-programmatically-close-wxmenu-used-as-popup-menu-via-wxwindowpopupmenu

### Testing strategy:

System tests for quitting from the menu without the exit dialog activated have been added. These should be run locally (see known issues).

### Known issues with pull request:

System tests still pass before/after the fix as we don't fail a test if NVDA crashes during it. System tests should be run locally to confirm no crash. 

### Change log entries:

None, fixes regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
