### PR TITLE
Report aria-description always

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
+# Copyright (C) 2006-2021 NV Access Limited, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -23,6 +23,7 @@ import comtypes.client
 import oleacc
 import JABHandler
 import UIAHandler
+import textUtils
 
 from comInterfaces import Accessibility as IA
 
@@ -1073,7 +1074,7 @@ def getRecursiveTextFromIAccessibleTextObject(obj, startOffset=0, endOffset=-1):
 		return text
 	textList = []
 	for i, t in enumerate(text):
-		if ord(t) == 0xFFFC:
+		if ord(t) == ord(textUtils.OBJ_REPLACEMENT_CHAR):
 			try:
 				index = hypertextObject.hyperlinkIndex(i + startOffset)
 				childTextObject = hypertextObject.hyperlink(index).QueryInterface(IA.IAccessible)

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1,7 +1,8 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Babbage B.V.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2021 NV Access Limited, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+import typing
 
 from comtypes.automation import IEnumVARIANT, VARIANT
 from comtypes import COMError, IServiceProvider, GUID
@@ -328,7 +329,11 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _lineNumFromOffset(self,offset):
 		return -1
 
-	def _iterTextWithEmbeddedObjects(self, withFields, formatConfig=None):
+	def _iterTextWithEmbeddedObjects(
+			self,
+			withFields,
+			formatConfig=None
+	) -> typing.Generator[typing.Union[textInfos.FieldCommand, str, int], None, None]:
 		"""Iterate through the text, splitting at embedded object characters.
 		Where an embedded object character occurs, its offset is provided.
 		@param withFields: Whether to output control/format fields.

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -177,11 +177,11 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			if not text:
 				return
 			try:
-				self._startOffset=text.rindex(u'\ufffc',0,oldStart-self._startOffset)
+				self._startOffset = text.rindex(textUtils.OBJ_REPLACEMENT_CHAR, 0, oldStart - self._startOffset)
 			except ValueError:
 				pass
 			try:
-				self._endOffset=text.index(u'\ufffc',oldEnd-self._startOffset)
+				self._endOffset = text.index(textUtils.OBJ_REPLACEMENT_CHAR, oldEnd - self._startOffset)
 			except ValueError:
 				pass
 
@@ -357,7 +357,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			while chunkStart < itemLen:
 				# Find the next embedded object character.
 				try:
-					chunkEnd = item.index(u"\uFFFC", chunkStart)
+					chunkEnd = item.index(textUtils.OBJ_REPLACEMENT_CHAR, chunkStart)
 				except ValueError:
 					# This is the last chunk of text.
 					yield item[chunkStart:]

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -13,9 +13,27 @@ import controlTypes
 from NVDAObjects.IAccessible import IAccessible
 from virtualBuffers.gecko_ia2 import Gecko_ia2 as GeckoVBuf, Gecko_ia2_TextInfo as GeckoVBufTextInfo
 from . import ia2Web
+from logHandler import log
 
 
 class ChromeVBufTextInfo(GeckoVBufTextInfo):
+
+	def _calculateDescriptionFrom(self, attrs) -> controlTypes.DescriptionFrom:
+		"""Overridable calculation of DescriptionFrom
+		@param attrs: source attributes for the TextInfo
+		@return: the origin for accDescription.
+		@note: Chrome provides 'IAccessible2::attribute_description-from' which declares the origin used for
+			accDescription. Chrome also provides `IAccessible2::attribute_description` to maintain compatibility
+			with FireFox.
+		"""
+		ia2attrDescriptionFrom = attrs.get("IAccessible2::attribute_description-from")
+		try:
+			return controlTypes.DescriptionFrom(ia2attrDescriptionFrom)
+		except ValueError:
+			if ia2attrDescriptionFrom:
+				log.debugWarning(f"Unknown 'description-from' IA2Attribute value: {ia2attrDescriptionFrom}")
+		# fallback to Firefox approach
+		return super()._calculateDescriptionFrom(attrs)
 
 	def _normalizeControlField(self, attrs):
 		attrs = super()._normalizeControlField(attrs)

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -65,8 +65,8 @@ def _getEmbedded(obj, offset) -> typing.Optional[IAccessible]:
 
 class MozillaCompoundTextInfo(CompoundTextInfo):
 
-	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
-		controlField = super()._getControlFieldForObject(obj, ignoreEditableText=ignoreEditableText)
+	def _getControlFieldForObject(self, obj):
+		controlField = super()._getControlFieldForObject(obj)
 		if controlField is None:
 			return None
 		# Set the uniqueID of the controlField if we can get one
@@ -267,7 +267,13 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			elif isinstance(item, int): # Embedded object.
 				embedded: typing.Optional[IAccessible] = _getEmbedded(ti.obj, item)
 				notText = _getRawTextInfo(embedded) is NVDAObjectTextInfo
-				if controlStack is not None:
+				if (
+					controlStack is not None
+					and not (
+						self._isObjectEditableText(embedded)
+						or self._isNamedlinkDestination(embedded)
+					)
+				):
 					controlField = self._getControlFieldForObject(embedded)
 					controlStack.append(controlField)
 					if controlField:
@@ -313,8 +319,11 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			ti = self._start
 			cannotBeStart = False
 			while obj and obj != rootObj:
-				field = self._getControlFieldForObject(obj)
-				if field:
+				if not (
+					self._isObjectEditableText(obj)
+					or self._isNamedlinkDestination(obj)
+				):
+					field = self._getControlFieldForObject(obj)
 					if ti._startOffset == 0:
 						if not cannotBeStart:
 							field["_startOfNode"] = True
@@ -322,7 +331,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 						# We're not at the start of this object, which also means we're not at the start of any ancestors.
 						cannotBeStart = True
 					fields.insert(0, textInfos.FieldCommand("controlStart", field))
-				controlStack.insert(0, field)
+					controlStack.insert(0, field)
 				ti = self._getEmbedding(obj)
 				if not ti:
 					log.debugWarning(
@@ -341,7 +350,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			# (We already handled collapsed above.)
 			return fields
 		obj = self._startObj
-		while fields[-1] is not None:
+		while fields[-1] is not None and controlStack:
 			# The end hasn't yet been reached, which means it isn't a descendant of obj.
 			# Therefore, continue from where obj was embedded.
 			if withFields:
@@ -354,10 +363,9 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 					# range is invalid, so just return nothing.
 					log.debugWarning("Tried to walk up past the root. Objects probably dead.")
 					return []
-				if field:
-					# This object had a control field.
-					field["_endOfNode"] = True
-					fields.append(textInfos.FieldCommand("controlEnd", None))
+				# This object had a control field.
+				field["_endOfNode"] = True
+				fields.append(textInfos.FieldCommand("controlEnd", None))
 			ti = self._getEmbedding(obj)
 			if not ti:
 				log.debugWarning(
@@ -377,13 +385,11 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			# Determine whether the range covers the end of any ancestors of endObj.
 			obj = self._endObj
 			ti = self._end
-			while obj and obj != rootObj:
+			while obj and obj != rootObj and controlStack:
 				field = controlStack.pop()
-				if field:
-					fields.append(textInfos.FieldCommand("controlEnd", None))
+				fields.append(textInfos.FieldCommand("controlEnd", None))
 				if ti.compareEndPoints(self._makeRawTextInfo(obj, textInfos.POSITION_ALL), "endToEnd") == 0:
-					if field:
-						field["_endOfNode"] = True
+					field["_endOfNode"] = True
 				else:
 					# We're not at the end of this object, which also means we're not at the end of any ancestors.
 					break

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -1,16 +1,17 @@
-#NVDAObjects/IAccessible/ia2TextMozilla.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2015-2019 NV Access Limited, Mozilla Corporation
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2015-2021 NV Access Limited, Mozilla Corporation
 
 """Support for the IAccessible2 rich text model first implemented by Mozilla.
 This is now used by other applications as well.
 """
+import typing
 
 from comtypes import COMError
 import winUser
 import textInfos
+from textInfos import offsets
 import controlTypes
 from comInterfaces import IAccessible2Lib as IA2
 import api
@@ -20,28 +21,35 @@ from compoundDocuments import CompoundTextInfo
 import locationHelper
 from logHandler import log
 
-class FakeEmbeddingTextInfo(textInfos.offsets.OffsetsTextInfo):
+
+class FakeEmbeddingTextInfo(offsets.OffsetsTextInfo):
 	encoding = None
 
 	def _getStoryLength(self):
 		return self.obj.childCount
 
-	def _iterTextWithEmbeddedObjects(self, withFields, formatConfig=None):
-		return range(self._startOffset, self._endOffset)
+	def _iterTextWithEmbeddedObjects(
+			self,
+			withFields,
+			formatConfig=None
+	) -> typing.Generator[int, None, None]:
+		yield from range(self._startOffset, self._endOffset)
 
 	def _getUnitOffsets(self,unit,offset):
 		if unit in (textInfos.UNIT_WORD,textInfos.UNIT_LINE):
 			unit=textInfos.UNIT_CHARACTER
 		return super(FakeEmbeddingTextInfo,self)._getUnitOffsets(unit,offset)
 
-def _getRawTextInfo(obj):
+
+def _getRawTextInfo(obj) -> type(offsets.OffsetsTextInfo):
 	if not hasattr(obj, "IAccessibleTextObject") and obj.role in (controlTypes.Role.TABLE, controlTypes.Role.TABLEROW):
 		return FakeEmbeddingTextInfo
 	elif obj.TextInfo is NVDAObjectTextInfo:
 		return NVDAObjectTextInfo
 	return IA2TextTextInfo
 
-def _getEmbedded(obj, offset):
+
+def _getEmbedded(obj, offset) -> typing.Optional[IAccessible]:
 	if not hasattr(obj, "IAccessibleTextObject"):
 		return obj.getChild(offset)
 	# Mozilla uses IAccessibleHypertext to facilitate quick retrieval of embedded objects.
@@ -179,7 +187,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			return ti, obj
 		raise RuntimeError("No selection or caret")
 
-	def _makeRawTextInfo(self, obj, position):
+	def _makeRawTextInfo(self, obj, position) -> offsets.OffsetsTextInfo:
 		return _getRawTextInfo(obj)(obj, position)
 
 	def _getEmbedding(self, obj):
@@ -244,7 +252,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		ti._startOffset=ti._endOffset=descendantOffset.value
 		return ti,obj
 
-	def _iterRecursiveText(self, ti, controlStack, formatConfig):
+	def _iterRecursiveText(self, ti: offsets.OffsetsTextInfo, controlStack, formatConfig):
 		if ti.obj == self._endObj:
 			end = True
 			ti.setEndPoint(self._end, "endToEnd")
@@ -257,7 +265,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			elif isinstance(item, str):
 				yield item
 			elif isinstance(item, int): # Embedded object.
-				embedded = _getEmbedded(ti.obj, item)
+				embedded: typing.Optional[IAccessible] = _getEmbedded(ti.obj, item)
 				notText = _getRawTextInfo(embedded) is NVDAObjectTextInfo
 				if controlStack is not None:
 					controlField = self._getControlFieldForObject(embedded)

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -280,8 +280,9 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 					# Note #11291:
 					# Using a space character (EG " ") causes 'space' to be announced after objects like graphics.
 					# If this is replaced with an empty string, routing to cell becomes innaccurate.
-					# Using the OBJECT REPLACEMENT CHARACTER (EG "\uFFFC") results in '"0xFFFC' being displayed on
-					# the braille device.
+					# Using the textUtils.OBJ_REPLACEMENT_CHAR which is the
+					# "OBJECT REPLACEMENT CHARACTER" (EG "\uFFFC")
+					# results in '"0xFFFC' being displayed on the braille device.
 					yield " "
 				else:
 					for subItem in self._iterRecursiveText(self._makeRawTextInfo(embedded, textInfos.POSITION_ALL), controlStack, formatConfig):

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -1,12 +1,11 @@
-#NVDAObjects/IAccessible/ia2Web.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2021 NV Access Limited
 
 """Base classes with common support for browsers exposing IAccessible2.
 """
-
+import typing
 from ctypes import c_short
 from comtypes import COMError, BSTR
 import oleacc
@@ -33,6 +32,15 @@ class Ia2Web(IAccessible):
 			if level:
 				info['level']=level
 		return info
+
+	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
+		ia2attrDescriptionFrom: typing.Optional[str] = self.IA2Attributes.get("description-from")
+		try:
+			return controlTypes.DescriptionFrom(ia2attrDescriptionFrom)
+		except ValueError:
+			if ia2attrDescriptionFrom:
+				log.debugWarning(f"Unknown 'description-from' IA2Attribute value: {ia2attrDescriptionFrom}")
+			return controlTypes.DescriptionFrom.UNKNOWN
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
 		ia2attrCurrent: str = self.IA2Attributes.get("current", "false")

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-#NVDAObjects/IAccessible/mozilla.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner
 
 import IAccessibleHandler
 from comInterfaces import IAccessible2Lib as IA2
@@ -22,6 +21,31 @@ class Mozilla(ia2Web.Ia2Web):
 		if self.IAccessibleStates & oleacc.STATE_SYSTEM_MARQUEED:
 			states.add(controlTypes.STATE_CHECKABLE)
 		return states
+
+	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
+		"""Firefox does not yet support 'description-from' attribute (which informs
+		NVDA of the source of accDescription after the name/description computation
+		is complete. However, a primary use-case can be supported via the IA2attribute
+		'description' which is exposed by Firefox and tells us the value of the "aria-description"
+		attribute. If the value of accDescription matches, we can infer that the source
+		of accDescription is 'aria-description'. Note: At the time of development not all
+		HTML elements result in the IA2attribute 'description' being exposed. EG on a 'span'
+		element it is not exposed.
+		"""
+		log.debug("Getting mozilla descriptionFrom")
+		ariaDesc = self.IA2Attributes.get("description", "")
+		log.debug(f"description IA2Attribute is: {ariaDesc}")
+		if (
+			ariaDesc == ""  # aria-description is missing or empty
+			# Ensure that aria-description is actually the value used.
+			# I.E. accDescription is sourced from the aria-description attribute as a result of the
+			# name/description computation.
+			# If the values don't match, some other source must have been used.
+			or self.description != ariaDesc
+		):
+			return controlTypes.DescriptionFrom.UNKNOWN
+		else:
+			return controlTypes.DescriptionFrom.ARIA_DESCRIPTION
 
 	def _get_presentationType(self):
 		presType=super(Mozilla,self).presentationType

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -28,9 +28,11 @@ class Mozilla(ia2Web.Ia2Web):
 		is complete. However, a primary use-case can be supported via the IA2attribute
 		'description' which is exposed by Firefox and tells us the value of the "aria-description"
 		attribute. If the value of accDescription matches, we can infer that the source
-		of accDescription is 'aria-description'. Note: At the time of development not all
-		HTML elements result in the IA2attribute 'description' being exposed. EG on a 'span'
-		element it is not exposed.
+		of accDescription is 'aria-description'.
+		Note:
+			At the time of development some 'generic HTML elements' (E.G. 'span') may not be exposed by Firefox,
+			even if the element has an aria-description attribute.
+			Other more significant ARIA attributes such as role may cause the element to be exposed.
 		"""
 		log.debug("Getting mozilla descriptionFrom")
 		ariaDesc = self.IA2Attributes.get("description", "")

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,9 +1,15 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2021 NV Access Limited, Leonard de Ruijter, Joseph Lee, Renaud Paquay, pvagner
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
 import ctypes
 import re
 import eventHandler
 import keyLabels
 import JABHandler
 import controlTypes
+import textUtils
 from ..window import Window
 from ..behaviors import EditableTextWithoutAutoSelectDetection, Dialog
 import textInfos.offsets
@@ -174,7 +180,7 @@ class JABTextInfo(textInfos.offsets.OffsetsTextInfo):
 		# We need to count the embedded objects to determine which child to use.
 		# This could possibly be optimised by caching.
 		text = self._getTextRange(0, offset + 1)
-		childIndex = text.count(u"\uFFFC") - 1
+		childIndex = text.count(textUtils.OBJ_REPLACEMENT_CHAR) - 1
 		jabContext=self.obj.jabContext.getAccessibleChildFromContext(childIndex)
 		if jabContext:
 			return JAB(jabContext=jabContext)

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -394,20 +394,20 @@ class UIATextInfo(textInfos.TextInfo):
 		UIAHandler.UIA_SplitButtonControlTypeId
 	}
 
-
-	def _getControlFieldForObject(self, obj,isEmbedded=False,startOfNode=False,endOfNode=False):
+	def _getControlFieldForUIAObject(
+			self,
+			obj: "UIA",
+			isEmbedded=False,
+			startOfNode=False,
+			endOfNode=False
+	) -> textInfos.ControlField:
 		"""
 		Fetch control field information for the given UIA NVDAObject.
 		@param obj: the NVDAObject the control field is for.
-		@type obj: L{UIA}
 		@param isEmbedded: True if this NVDAObject is for a leaf node (has no useful children).
-		@type isEmbedded: bool
 		@param startOfNode: True if the control field represents the very start of this object.
-		@type startOfNode: bool
 		@param endOfNode: True if the control field represents the very end of this object.
-		@type endOfNode: bool
 		@return: The control field for this object
-		@rtype: textInfos.ControlField containing NVDA control field data.
 		"""
 		role = obj.role
 		field = textInfos.ControlField()
@@ -592,7 +592,13 @@ class UIATextInfo(textInfos.TextInfo):
 			endOfNode=not parentClipped[1]
 			try:
 				obj=controlFieldNVDAObjectClass(windowHandle=windowHandle,UIAElement=parentElement,initialUIACachedPropertyIDs=self._controlFieldUIACachedPropertyIDs)
-				field=self._getControlFieldForObject(obj,isEmbedded=(index==0 and not recurseChildren),startOfNode=startOfNode,endOfNode=endOfNode)
+				objIsEmbedded = (index == 0 and not recurseChildren)
+				field = self._getControlFieldForUIAObject(
+					obj,
+					isEmbedded=objIsEmbedded,
+					startOfNode=startOfNode,
+					endOfNode=endOfNode
+				)
 			except LookupError:
 				if debug:
 					log.debug("Failed to fetch controlField data for parentElement. Breaking")

--- a/source/NVDAObjects/UIA/chromium.py
+++ b/source/NVDAObjects/UIA/chromium.py
@@ -36,8 +36,8 @@ class ChromiumUIATextInfo(web.UIAWebTextInfo):
 			pass
 		return formatField
 
-	def _getControlFieldForObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
-		field = super()._getControlFieldForObject(
+	def _getControlFieldForUIAObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
+		field = super()._getControlFieldForUIAObject(
 			obj,
 			isEmbedded=isEmbedded,
 			startOfNode=startOfNode,

--- a/source/NVDAObjects/UIA/spartanEdge.py
+++ b/source/NVDAObjects/UIA/spartanEdge.py
@@ -214,7 +214,7 @@ class EdgeTextInfo_preGapRemoval(EdgeTextInfo):
 							UIAElement=parentElement,
 							initialUIACachedPropertyIDs=self._controlFieldUIACachedPropertyIDs
 						)
-						field = self._getControlFieldForObject(obj)
+						field = self._getControlFieldForUIAObject(obj)
 					except LookupError:
 						log.debug("Failed to fetch controlField data for parentElement. Breaking")
 						break

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -7,6 +7,7 @@ from comtypes import COMError
 from comtypes.automation import VARIANT
 from ctypes import byref
 
+import textUtils
 from . import (
 	UIATextInfo,
 	UIA,
@@ -239,7 +240,7 @@ class UIAWebTextInfo(UIATextInfo):
 				# embedded object characters (which can appear in Edgium)
 				# should also be treated as whitespace
 				# allowing to be replaced by an overridden label
-				text = text.replace('\ufffc', '')
+				text = text.replace(textUtils.OBJ_REPLACEMENT_CHAR, '')
 				if not text or text.isspace():
 					content = obj.name or field.pop('description', None)
 			if content:

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2015-2020 NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2015-2021 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 from comtypes import COMError
 from comtypes.automation import VARIANT
@@ -190,8 +190,8 @@ class UIAWebTextInfo(UIATextInfo):
 				self.setEndPoint(tempInfo, "endToEnd" if endPoint == "end" else "startToStart")
 			return res
 
-	def _getControlFieldForObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
-		field = super()._getControlFieldForObject(
+	def _getControlFieldForUIAObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
+		field = super()._getControlFieldForUIAObject(
 			obj,
 			isEmbedded=isEmbedded,
 			startOfNode=startOfNode,

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -141,10 +141,15 @@ class WordDocumentTextInfo(UIATextInfo):
 	def _get_controlFieldNVDAObjectClass(self):
 		return WordDocumentNode
 
-	def _getControlFieldForObject(self,obj,isEmbedded=False,startOfNode=False,endOfNode=False):
+	def _getControlFieldForUIAObject(self, obj, isEmbedded=False, startOfNode=False, endOfNode=False):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		automationID=obj.UIAElement.cachedAutomationID
-		field=super(WordDocumentTextInfo,self)._getControlFieldForObject(obj,isEmbedded=isEmbedded,startOfNode=startOfNode,endOfNode=endOfNode)
+		field = super(WordDocumentTextInfo, self)._getControlFieldForUIAObject(
+			obj,
+			isEmbedded=isEmbedded,
+			startOfNode=startOfNode,
+			endOfNode=endOfNode
+		)
 		if automationID.startswith('UIA_AutomationId_Word_Page_'):
 			field['page-number']=automationID.rsplit('_',1)[-1]
 		elif obj.UIAElement.cachedControlType==UIAHandler.UIA_GroupControlTypeId and obj.name:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -470,6 +470,12 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""
 		return ""
 
+	#: Typing information for auto property _get_descriptionFrom
+	descriptionFrom: controlTypes.DescriptionFrom
+
+	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
+		return controlTypes.DescriptionFrom.UNKNOWN
+
 	def _get_controllerFor(self):
 		"""Retrieves the object/s that this object controls."""
 		return []

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -13,6 +13,8 @@ import time
 import re
 import typing
 import weakref
+
+import textUtils
 from logHandler import log
 import review
 import eventHandler
@@ -1123,7 +1125,7 @@ Tries to force this object to take the focus.
 			notBlank=False
 			if text:
 				for ch in text:
-					if not ch.isspace() and ch!=u'\ufffc':
+					if not ch.isspace() and ch != textUtils.OBJ_REPLACEMENT_CHAR:
 						notBlank=True
 			if notBlank:
 				if not speechWasCanceled:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2019 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
+# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
 # Davy Kager
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -412,9 +412,11 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		else:
 			return self._appModuleRef()
 
-	def _get_name(self):
+	#: Type definition for auto prop '_get_name'
+	name: str
+
+	def _get_name(self) -> str:
 		"""The name or label of this object (example: the text of a button).
-		@rtype: str
 		"""
 		return ""
 
@@ -426,7 +428,10 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""  
 		return controlTypes.Role.UNKNOWN
 
-	def _get_roleText(self):
+	#: Type definition for auto prop '_get_roleText'
+	roleText: typing.Optional[str]
+
+	def _get_roleText(self) -> typing.Optional[str]:
 		"""
 		A custom role string for this object, which is used for braille and speech presentation, which will override the standard label for this object's role property.
 		No string is provided by default, meaning that NVDA will fall back to using role.
@@ -564,24 +569,35 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""
 		return None
 
-	def _get_firstChild(self):
+	#: Type definition for auto prop '_get_firstChild'
+	firstChild: typing.Optional["NVDAObject"]
+
+	def _get_firstChild(self) -> typing.Optional["NVDAObject"]:
 		"""Retrieves the first object that this object contains.
 		@return: the first child object if it exists else None.
-		@rtype: L{NVDAObject} or None
 		"""
 		return None
 
-	def _get_lastChild(self):
+	#: Type definition for auto prop '_get_lastChild'
+	lastChild: typing.Optional["NVDAObject"]
+
+	def _get_lastChild(self) -> typing.Optional["NVDAObject"]:
 		"""Retrieves the last object that this object contains.
 		@return: the last child object if it exists else None.
-		@rtype: L{NVDAObject} or None
 		"""
 		return None
+
+	#: Type definition for auto prop '_get_children'
+	children: typing.List["NVDAObject"]
 
 	def _get_children(self):
 		"""Retrieves a list of all the objects directly contained by this object (who's parent is this object).
 		@rtype: list of L{NVDAObject}
 		"""
+		log.debugWarning(
+			"Base implementation used."
+			" Relies on child.next which is error prone in many IA2 implementations."
+		)
 		children=[]
 		child=self.firstChild
 		while child:
@@ -589,14 +605,12 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 			child=child.next
 		return children
 
-	def getChild(self, index):
+	def getChild(self, index: int) -> "NVDAObject":
 		"""Retrieve a child by index.
 		@note: Subclasses may override this if they have an efficient way to retrieve a single, arbitrary child.
 			The base implementation uses L{children}.
 		@param index: The 0-based index of the child to retrieve.
-		@type index: int
 		@return: The child.
-		@rtype: L{NVDAObject}
 		"""
 		return self.children[index]
 

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2018 NV Access Limited, Babbage B.V.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2021 NV Access Limited, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import locale
 import comtypes.client
@@ -631,7 +631,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		newTextList=[]
 		start=rangeObj.start
 		for offset in range(len(bufText)):
-			if ord(bufText[offset])==0xfffc:
+			if ord(bufText[offset]) == ord(textUtils.OBJ_REPLACEMENT_CHAR):
 				if embedRangeObj is None: embedRangeObj=rangeObj.duplicate
 				embedRangeObj.setRange(start+offset,start+offset+1)
 				label=self._getEmbeddedObjectLabel(embedRangeObj)

--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -1,13 +1,15 @@
-#XMLFormatting.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2008-2019 NV Access Limited, Babbage B.V.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2008-2021 NV Access Limited, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
+import typing
 from xml.parsers import expat
 import textInfos
 from logHandler import log
 from textUtils import WCHAR_ENCODING, isLowSurrogate
+
+CommandListT = typing.List[typing.Union[textInfos.FieldCommand, typing.Optional[str]]]
 
 class XMLTextParser(object): 
 
@@ -48,8 +50,11 @@ class XMLTextParser(object):
 		else:
 			raise ValueError("unknown tag name: %s"%tagName)
 
-	def _CharacterDataHandler(self,data, processBufferedSurrogates=False):
+	def _CharacterDataHandler(self, data: typing.Optional[str], processBufferedSurrogates=False):
 		cmdList=self._commandList
+		if not isinstance(data, str):
+			dataStr = repr(data)
+			log.warning(f"unknown type for data: {dataStr}")
 		if cmdList and isinstance(cmdList[-1],str):
 			cmdList[-1] += data
 			if processBufferedSurrogates:
@@ -57,12 +62,12 @@ class XMLTextParser(object):
 		else:
 			cmdList.append(data)
 
-	def parse(self,XMLText):
+	def parse(self, XMLText) -> CommandListT:
 		parser = expat.ParserCreate('utf-8')
 		parser.StartElementHandler = self._startElementHandler
 		parser.EndElementHandler = self._EndElementHandler
 		parser.CharacterDataHandler = self._CharacterDataHandler
-		self._commandList = []
+		self._commandList: XMLTextParser.CommandListT = []
 		try:
 			parser.Parse(XMLText)
 		except Exception:

--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -6,6 +6,7 @@
 import typing
 from xml.parsers import expat
 import textInfos
+import textUtils
 from logHandler import log
 from textUtils import WCHAR_ENCODING, isLowSurrogate
 
@@ -20,7 +21,7 @@ class XMLTextParser(object):
 				try:
 					data=chr(int(data))
 				except ValueError:
-					data=u'\ufffd'
+					data = textUtils.REPLACEMENT_CHAR
 				self._CharacterDataHandler(data, processBufferedSurrogates=isLowSurrogate(data))
 			return
 		elif tagName=='control':

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -346,8 +346,8 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 		log.debug("Setting selection to (%d, %d)" % (sel._startOffset, sel._endOffset))
 		sel.updateSelection()
 
-	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
-		field = super(BookPageViewTextInfo, self)._getControlFieldForObject(obj, ignoreEditableText=ignoreEditableText)
+	def _getControlFieldForObject(self, obj):
+		field = super(BookPageViewTextInfo, self)._getControlFieldForObject(obj)
 		if field and field["role"] == controlTypes.Role.MATH:
 			try:
 				field["mathMl"] = obj.mathMl

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -1,13 +1,14 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016-2017 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2016-2021 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 from typing import Optional, Dict
 
 from comtypes import COMError
 from comtypes.hresult import S_OK
 import appModuleHandler
 import speech
+import textUtils
 from speech import sayAll
 import api
 from scriptHandler import willSayAllResume, isScriptWaiting
@@ -199,13 +200,13 @@ class BookPageViewTreeInterceptor(DocumentWithPageTurns,ReviewCursorManager,Brow
 		offset = pos.innerTextInfo._start._startOffset
 		if direction == "next":
 			text = obj.IAccessibleTextObject.text(offset + 1, obj.IAccessibleTextObject.nCharacters)
-			embed = text.find(u"\uFFFC")
+			embed = text.find(textUtils.OBJ_REPLACEMENT_CHAR)
 			if embed != -1:
 				embed += offset + 1
 		else:
 			if offset > 0:
 				text = obj.IAccessibleTextObject.text(0, offset)
-				embed = text.rfind(u"\uFFFC")
+				embed = text.rfind(textUtils.OBJ_REPLACEMENT_CHAR)
 			else:
 				# We're at the start; we can't go back any further.
 				embed = -1

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -142,6 +142,8 @@ class CompoundTextInfo(textInfos.TextInfo):
 		field = textInfos.ControlField()
 		field["role"] = role
 		field['roleText'] = obj.roleText
+		field['description'] = obj.description
+		field['_description-from'] = obj.descriptionFrom
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.STATE_EDITABLE)
 		states.discard(controlTypes.STATE_MULTILINE)

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -279,29 +279,29 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 
 		embedIndex = None
 		for ti in self._getTextInfos():
-			for field in ti._iterTextWithEmbeddedObjects(True, formatConfig=formatConfig):
-				if isinstance(field, str):
-					fields.append(field)
-				elif isinstance(field, int): # Embedded object
+			for textWithEmbeddedObjectsItem in ti._iterTextWithEmbeddedObjects(True, formatConfig=formatConfig):
+				if isinstance(textWithEmbeddedObjectsItem, int):  # Embedded object
 					if embedIndex is None:
 						embedIndex = self._getFirstEmbedIndex(ti)
 					else:
 						embedIndex += 1
-					field = ti.obj.getChild(embedIndex)
+					childObject: NVDAObject = ti.obj.getChild(embedIndex)
 					if not (
 						# Don't check for self._isObjectEditableText
 						# Only for named link destinations.
 						self._isNamedlinkDestination(obj)
 					):
-						controlField = self._getControlFieldForObject(field)
-						controlField["content"] = field.name
+						controlField = self._getControlFieldForObject(childObject)
+						controlField["content"] = childObject.name
 						fields.extend((
 							textInfos.FieldCommand("controlStart", controlField),
 							textUtils.OBJ_REPLACEMENT_CHAR,
 							textInfos.FieldCommand("controlEnd", None),
 						))
-				else:
-					fields.append(field)
+				else:  # str or fieldCommand
+					if not isinstance(textWithEmbeddedObjectsItem, (str, textInfos.FieldCommand)):
+						log.error(f"Unexpected type: {textWithEmbeddedObjectsItem!r}")
+					fields.append(textWithEmbeddedObjectsItem)
 		return fields
 
 	def _findNextContent(self, origin, moveBack=False):

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -1,9 +1,8 @@
-#compoundDocuments.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2010-2018 NV Access Limited, Bram Duvigneau
-
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2010-2021 NV Access Limited, Bram Duvigneau
+import textUtils
 import winUser
 import textInfos
 import controlTypes
@@ -259,7 +258,7 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 		# Get the number of embeds before the start.
 		# The index is 0 based, so this is the index of the first embed after start.
 		text = info._getTextRange(0, info._startOffset)
-		return text.count(u"\uFFFC")
+		return text.count(textUtils.OBJ_REPLACEMENT_CHAR)
 
 	def getTextWithFields(self, formatConfig=None):
 		# Get the initial control fields.
@@ -285,9 +284,11 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 					field = ti.obj.getChild(embedIndex)
 					controlField = self._getControlFieldForObject(field, ignoreEditableText=False)
 					controlField["content"] = field.name
-					fields.extend((textInfos.FieldCommand("controlStart", controlField),
-						u"\uFFFC",
-						textInfos.FieldCommand("controlEnd", None)))
+					fields.extend((
+						textInfos.FieldCommand("controlStart", controlField),
+						textUtils.OBJ_REPLACEMENT_CHAR,
+						textInfos.FieldCommand("controlEnd", None)
+					))
 				else:
 					fields.append(field)
 		return fields

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -229,6 +229,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 [annotations]
 	reportDetails = boolean(default=false)
+	reportAriaDescription = boolean(default=true)
 
 [terminals]
 	speakPasswords = boolean(default=false)

--- a/source/controlTypes/__init__.py
+++ b/source/controlTypes/__init__.py
@@ -10,6 +10,7 @@ from .outputReason import OutputReason
 from .processAndLabelStates import processAndLabelStates
 from .role import Role, silentRolesOnFocus, silentValuesForRoles
 from .state import State, STATES_SORTED
+from .descriptionFrom import DescriptionFrom
 
 
 # To maintain backwards compatibility, all symbols are exported from the package until 2022.1
@@ -25,6 +26,7 @@ if version_year >= 2022:
 		"silentValuesForRoles",
 		"State",
 		"STATES_SORTED",
+		"DescriptionFrom",
 	]
 
 

--- a/source/controlTypes/descriptionFrom.py
+++ b/source/controlTypes/descriptionFrom.py
@@ -1,0 +1,23 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2021 NV Access Limited
+
+from enum import (
+	auto,
+	Enum,
+)
+
+
+class DescriptionFrom(Enum):
+	"""Values to use within NVDA to denote possible values for DescriptionFrom.
+	These are used to determine how the source of the 'description' property if an NVDAObject.
+	"""
+	UNKNOWN = auto()
+	ARIA_DESCRIPTION = "aria-description"
+	ARIA_DESCRIBED_BY = "aria-describedby"
+	RUBY_ANNOTATION = "ruby-annotation"
+	SUMMARY = "summary"
+	TABLE_CAPTION = "table-caption"
+	TOOLTIP = "tooltip"  # (either via @title or aria-describedby + role="tooltip")
+	BUTTON_LABEL = "button-label"

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -8,6 +8,7 @@
 # jakubl7545, mltony
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 import logging
 from abc import ABCMeta, abstractmethod
 import copy
@@ -2661,6 +2662,15 @@ class AdvancedPanelControls(
 		self.annotationsDetailsCheckBox.SetValue(config.conf["annotations"]["reportDetails"])
 		self.annotationsDetailsCheckBox.defaultValue = self._getDefaultValue(["annotations", "reportDetails"])
 
+		# Translators: This is the label for a checkbox in the
+		#  Advanced settings panel.
+		label = _("Report aria-description always:")
+		self.ariaDescCheckBox: wx.CheckBox = AnnotationsGroup.addItem(
+			wx.CheckBox(AnnotationsBox, label=label)
+		)
+		self.ariaDescCheckBox.SetValue(config.conf["annotations"]["reportAriaDescription"])
+		self.ariaDescCheckBox.defaultValue = self._getDefaultValue(["annotations", "reportAriaDescription"])
+
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
 		label = _("Terminal programs")
@@ -2856,6 +2866,7 @@ class AdvancedPanelControls(
 			and self.reportTransparentColorCheckBox.GetValue() == self.reportTransparentColorCheckBox.defaultValue
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.annotationsDetailsCheckBox.IsChecked() == self.annotationsDetailsCheckBox.defaultValue
+			and self.ariaDescCheckBox.IsChecked() == self.ariaDescCheckBox.defaultValue
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -2872,6 +2883,7 @@ class AdvancedPanelControls(
 		self.diffAlgoCombo.SetSelection(self.diffAlgoCombo.defaultValue == 'auto')
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.annotationsDetailsCheckBox.SetValue(self.annotationsDetailsCheckBox.defaultValue)
+		self.ariaDescCheckBox.SetValue(self.ariaDescCheckBox.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self._defaultsRestored = True
@@ -2899,6 +2911,7 @@ class AdvancedPanelControls(
 			self.reportTransparentColorCheckBox.IsChecked()
 		)
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
+		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -8,6 +8,7 @@
 """ 
 
 import itertools
+import typing
 import weakref
 import unicodedata
 import time
@@ -59,6 +60,8 @@ from enum import IntEnum
 from dataclasses import dataclass
 from copy import copy
 
+if typing.TYPE_CHECKING:
+	import NVDAObjects
 
 _speechState: Optional['SpeechState'] = None
 _curWordChars: List[str] = []
@@ -406,7 +409,7 @@ def speakObjectProperties(  # noqa: C901
 # Note: when working on getObjectPropertiesSpeech, look for opportunities to simplify
 # and move logic out into smaller helper functions.
 def getObjectPropertiesSpeech(  # noqa: C901
-		obj,
+		obj: "NVDAObjects.NVDAObject",
 		reason: OutputReason = OutputReason.QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
 		**allowedProperties
@@ -425,6 +428,11 @@ def getObjectPropertiesSpeech(  # noqa: C901
 			# getPropertiesSpeech names this "current", but the NVDAObject property is
 			# named "isCurrent", it's type should always be controltypes.IsCurrent
 			newPropertyValues['current'] = obj.isCurrent
+		elif value and name == "descriptionFrom" and (
+			obj.descriptionFrom == controlTypes.DescriptionFrom.ARIA_DESCRIPTION
+		):
+			newPropertyValues['_description-from'] = obj.descriptionFrom
+			newPropertyValues['description'] = obj.description
 		elif value:
 			# Certain properties such as row and column numbers have presentational versions, which should be used for speech if they are available.
 			# Therefore redirect to those values first if they are available, falling back to the normal properties if not.
@@ -624,6 +632,7 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		'states': True,
 		'value': True,
 		'description': True,
+		'descriptionFrom': config.conf["annotations"]["reportAriaDescription"],
 		'keyboardShortcut': True,
 		'positionInfo_level': True,
 		'positionInfo_indexInGroup': True,
@@ -1762,10 +1771,34 @@ def getControlFieldSpeech(  # noqa: C901
 	isCurrent = attrs.get('current', controlTypes.IsCurrent.NO)
 	placeholderValue=attrs.get('placeholder', None)
 	value=attrs.get('value',"")
-	if reason == OutputReason.FOCUS or attrs.get('alwaysReportDescription', False):
-		description=attrs.get('description',"")
-	else:
-		description=""
+
+	description: Optional[str] = None
+	_descriptionFrom = attrs.get('_description-from', controlTypes.DescriptionFrom.UNKNOWN)
+	if (
+		(
+			config.conf["presentation"]["reportObjectDescriptions"]
+			and (
+				reason == OutputReason.FOCUS
+				# 'alwaysReportDescription' provides symmetry with 'alwaysReportName'.
+				# Not used internally, but may be used by addons.
+				or attrs.get('alwaysReportDescription', False)
+			)
+		)
+		or (
+			# Don't report other sources of description like "title" all the time
+			# The usages of these is not consistent and often does not seem to have
+			# Screen Reader users in mind
+			config.conf["annotations"]["reportAriaDescription"]
+			and controlTypes.DescriptionFrom.ARIA_DESCRIPTION == _descriptionFrom
+			and reason in (
+				OutputReason.FOCUS,
+				OutputReason.CARET,
+				OutputReason.SAYALL,
+			)
+		)
+	):
+		description = attrs.get('description')
+
 	level=attrs.get('level',None)
 
 	if presCat != attrs.PRESCAT_LAYOUT:
@@ -1794,7 +1827,7 @@ def getControlFieldSpeech(  # noqa: C901
 	nameSequence = getPropertiesSpeech(reason=reason, name=name)
 	valueSequence = getPropertiesSpeech(reason=reason, value=value)
 	descriptionSequence = []
-	if config.conf["presentation"]["reportObjectDescriptions"]:
+	if description is not None:
 		descriptionSequence = getPropertiesSpeech(
 			reason=reason, description=description
 		)
@@ -1979,6 +2012,8 @@ def getControlFieldSpeech(  # noqa: C901
 		out = []
 		if isCurrent != controlTypes.IsCurrent.NO:
 			out.extend(isCurrentSequence)
+		if descriptionSequence:
+			out.extend(descriptionSequence)
 		# Speak expanded / collapsed / level for treeview items (in ARIA treegrids)
 		if role == controlTypes.Role.TREEVIEWITEM:
 			if controlTypes.STATE_EXPANDED in states:

--- a/source/speechXml.py
+++ b/source/speechXml.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016-2017 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2016-2021 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Utilities for converting NVDA speech sequences to XML.
 Several synthesizers accept XML, either SSML or their own schemas.
@@ -13,6 +13,7 @@ L{SsmlConverter} is an implementation for conversion to SSML.
 from collections import namedtuple, OrderedDict
 import re
 import speech
+import textUtils
 from speech.commands import SpeechCommand
 from logHandler import log
 
@@ -46,8 +47,7 @@ def _buildInvalidXmlRegexp():
 			trailing=trailingSurrogate))
 
 RE_INVALID_XML_CHARS = _buildInvalidXmlRegexp()
-# The Unicode replacement character. See https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
-REPLACEMENT_CHAR = u"\uFFFD"
+REPLACEMENT_CHAR = textUtils.REPLACEMENT_CHAR
 
 def toXmlLang(nvdaLang):
 	"""Convert an NVDA language to an XML language.

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2020 NV Access Limited, Babbage B.V., Accessolutions, Julien Cochuyt
+# Copyright (C) 2006-2021 NV Access Limited, Babbage B.V., Accessolutions, Julien Cochuyt
 
 """Framework for accessing text content in widgets.
 The core component of this framework is the L{TextInfo} class.
@@ -12,6 +12,7 @@ A default implementation, L{NVDAObjects.NVDAObjectTextInfo}, is used to enable t
 from abc import abstractmethod
 import weakref
 import re
+import typing
 from typing import (
 	Any,
 	Union,
@@ -28,6 +29,8 @@ from controlTypes import OutputReason
 import locationHelper
 from logHandler import log
 
+if typing.TYPE_CHECKING:
+	import NVDAObjects
 
 SpeechSequence = List[Union[Any, str]]
 
@@ -333,19 +336,25 @@ class TextInfo(baseObject.AutoPropertyObject):
 	def _set_end(self, otherEndpoint: "TextInfoEndpoint"):
 		self.end.moveTo(otherEndpoint)
 
-	def _get_obj(self):
+	#: Typing information for auto-property: _get_obj
+	obj: "NVDAObjects.NVDAObject"
+
+	def _get_obj(self) -> "NVDAObjects.NVDAObject":
 		"""The object containing the range of text being represented."""
 		return self._obj()
 
 	def _get_unit_mouseChunk(self):
 		return config.conf["mouse"]["mouseTextUnit"]
 
+	#: Typing information for auto-property: _get_text
+	text: str
+
 	_abstract_text = True
-	def _get_text(self):
+
+	def _get_text(self) -> str:
 		"""The text with in this range.
 		Subclasses must implement this.
 		@return: The text.
-		@rtype: str
 		@note: The text is not guaranteed to be the exact length of the range in offsets.
 		"""
 		raise NotImplementedError

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -202,7 +202,6 @@ class FieldCommand(object):
 			"controlEnd", indicating the end of a L{ControlField}; or
 			"formatChange", indicating a L{FormatField} change.
 		@param field: The field associated with this command; may be C{None} for controlEnd.
-		@type field: L{Field}
 		"""
 		if command not in ("controlStart","controlEnd","formatChange"):
 			raise ValueError("Unknown command: %s"%command)

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -1,7 +1,8 @@
+# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2020 NV Access Limited, Babbage B.V., Łukasz Golonka
+# Copyright (C) 2018-2021 NV Access Limited, Babbage B.V., Łukasz Golonka
 
 """
 Classes and utilities to deal with offsets variable width encodings, particularly utf_16.
@@ -235,3 +236,14 @@ LOW_SURROGATE_LAST = u"\uDFFF"
 def isLowSurrogate(ch: str) -> bool:
 	"""Returns if the given character is a low surrogate UTF-16 character."""
 	return LOW_SURROGATE_FIRST <= ch <= LOW_SURROGATE_LAST
+
+
+#: ￼ OBJECT REPLACEMENT CHARACTER,
+# placeholder in the text for another unspecified object, for example in a compound document.
+# https://en.wikipedia.org/wiki/Specials_(Unicode_block)
+OBJ_REPLACEMENT_CHAR = u"\uFFFC"
+
+#: � REPLACEMENT CHARACTER,
+# used to replace an unknown, unrecognized, or unrepresentable character.
+# https://en.wikipedia.org/wiki/Specials_(Unicode_block)
+REPLACEMENT_CHAR = u"\uFFFD"

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -10,6 +10,7 @@ import threading
 import ctypes
 import collections
 import itertools
+import typing
 import weakref
 import wx
 import review
@@ -263,14 +264,16 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		text=NVDAHelper.VBuf_getTextInRange(self.obj.VBufHandle,start,end,True)
 		if not text:
 			return ""
-		commandList=XMLFormatting.XMLTextParser().parse(text)
-		for index in range(len(commandList)):
-			if isinstance(commandList[index],textInfos.FieldCommand):
-				field=commandList[index].field
-				if isinstance(field,textInfos.ControlField):
-					commandList[index].field=self._normalizeControlField(field)
-				elif isinstance(field,textInfos.FormatField):
-					commandList[index].field=self._normalizeFormatField(field)
+		commandList: typing.List[textInfos.FieldCommand] = XMLFormatting.XMLTextParser().parse(text)
+		for command in commandList:
+			if not isinstance(command, textInfos.FieldCommand):
+				continue  # no need to normalize str or None
+
+			field = command.field
+			if isinstance(field, textInfos.ControlField):
+				command.field = self._normalizeControlField(field)
+			elif isinstance(field, textInfos.FormatField):
+				command.field = self._normalizeFormatField(field)
 		return commandList
 
 	def getTextWithFields(self,formatConfig=None):
@@ -300,7 +303,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		NVDAHelper.localLib.VBuf_getLineOffsets(self.obj.VBufHandle,offset,0,True,ctypes.byref(lineStart),ctypes.byref(lineEnd))
 		return lineStart.value,lineEnd.value
 
-	def _normalizeControlField(self,attrs):
+	def _normalizeControlField(self, attrs: textInfos.ControlField):
 		tableLayout=attrs.get('table-layout')
 		if tableLayout:
 			attrs['table-layout']=tableLayout=="1"
@@ -342,7 +345,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 
 		return attrs
 
-	def _normalizeFormatField(self, attrs):
+	def _normalizeFormatField(self, attrs: textInfos.FormatField):
 		strippedCharsFromStart = attrs.get("strippedCharsFromStart")
 		if strippedCharsFromStart is not None:
 			assert strippedCharsFromStart.isdigit(), "strippedCharsFromStart isn't a digit, %r" % strippedCharsFromStart

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -1,9 +1,9 @@
-# virtualBuffers/gecko_ia2.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2020 NV Access Limited, Babbage B.V., Mozilla Corporation, Accessolutions, Julien Cochuyt
+# Copyright (C) 2008-2021 NV Access Limited, Babbage B.V., Mozilla Corporation, Accessolutions, Julien Cochuyt
 
+import typing
 import weakref
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
@@ -24,6 +24,21 @@ import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
 
 IA2_RELATION_CONTAINING_DOCUMENT = "containingDocument"
+
+
+def _getNormalizedCurrentAttrs(attrs: textInfos.ControlField) -> typing.Dict[str, typing.Any]:
+	valForCurrent = attrs.get("IAccessible2::attribute_current", "false")
+	try:
+		isCurrent = controlTypes.IsCurrent(valForCurrent)
+	except ValueError:
+		log.debugWarning(f"Unknown isCurrent value: {valForCurrent}")
+		isCurrent = controlTypes.IsCurrent.NO
+	if isCurrent != controlTypes.IsCurrent.NO:
+		return {
+			'current': isCurrent
+		}
+	return {}
+
 
 class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 
@@ -47,20 +62,38 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 			return IA2TextTextInfo._getBoundingRectFromOffsetInObject(obj, relOffset)
 		return super(Gecko_ia2_TextInfo, self)._getBoundingRectFromOffset(offset)
 
-	def _normalizeControlField(self,attrs):
+	def _calculateDescriptionFrom(self, attrs: textInfos.ControlField) -> controlTypes.DescriptionFrom:
+		"""Overridable calculation of DescriptionFrom
+		Match behaviour of NVDAObjects.IAccessible.mozilla.Mozilla._get_descriptionFrom
+		@param attrs: source attributes for the TextInfo
+		@return: the origin for accDescription.
+		@remarks: Firefox does not yet have a 'IAccessible2::attribute_description-from'
+			(IA2 attribute "description-from").
+			We can infer that the origin of accDescription is 'aria-description' because Firefox will include
+			a 'IAccessible2::attribute_description' (IA2 attribute "description") when the aria-description
+			HTML attribute is used.
+			If 'IAccessible2::attribute_description' matches the accDescription value, we can infer that
+			aria-description was the original source.
+		"""
+		IA2Attr_desc = attrs.get("IAccessible2::attribute_description")
+		accDesc = attrs.get("description")
+		if not IA2Attr_desc or accDesc != IA2Attr_desc:
+			return controlTypes.DescriptionFrom.UNKNOWN
+		else:
+			return controlTypes.DescriptionFrom.ARIA_DESCRIPTION
+
+	# C901 '_normalizeControlField' is too complex
+	# Note: when working on _normalizeControlField, look for opportunities to simplify
+	# and move logic out into smaller helper functions.
+	def _normalizeControlField(self, attrs):  # noqa: C901
 		for attr in ("table-rownumber-presentational","table-columnnumber-presentational","table-rowcount-presentational","table-columncount-presentational"):
 			attrVal=attrs.get(attr)
 			if attrVal is not None:
 				attrs[attr]=int(attrVal)
 
-		valForCurrent = attrs.get("IAccessible2::attribute_current", "false")
-		try:
-			isCurrent = controlTypes.IsCurrent(valForCurrent)
-		except ValueError:
-			log.debugWarning(f"Unknown isCurrent value: {valForCurrent}")
-			isCurrent = controlTypes.IsCurrent.NO
-		if isCurrent != controlTypes.IsCurrent.NO:
-			attrs['current'] = isCurrent
+		attrs["_description-from"] = self._calculateDescriptionFrom(attrs)
+		attrs.update(_getNormalizedCurrentAttrs(attrs))
+
 		placeholder = self._getPlaceholderAttribute(attrs, "IAccessible2::attribute_placeholder")
 		if placeholder is not None:
 			attrs['placeholder']= placeholder

--- a/source/virtualBuffers/webKit.py
+++ b/source/virtualBuffers/webKit.py
@@ -1,10 +1,11 @@
-#virtualBuffers/webKit.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2011-2016 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2011-2021 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import ctypes
+import typing
+
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufRemote_nodeHandle_t
 import controlTypes
 import NVDAObjects.IAccessible
@@ -18,7 +19,7 @@ import NVDAHelper
 
 class WebKit_TextInfo(VirtualBufferTextInfo):
 
-	def _normalizeControlField(self,attrs):
+	def _normalizeControlField(self, attrs: typing.Dict[str, typing.Any]):
 		accRole=attrs['IAccessible::role']
 		role = level = None
 		if accRole.isdigit():
@@ -33,7 +34,14 @@ class WebKit_TextInfo(VirtualBufferTextInfo):
 		if not role:
 			role = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(accRole, controlTypes.Role.UNKNOWN)
 
-		states = set(IAccessibleHandler.IAccessibleStatesToNVDAStates[x] for x in [1 << y for y in range(32)] if int(attrs.get('IAccessible::state_%s' % x, 0)) and x in IAccessibleHandler.IAccessibleStatesToNVDAStates)
+		states = set(
+			IAccessibleHandler.IAccessibleStatesToNVDAStates[x]
+			for x in [1 << y for y in range(32)]
+			if (
+				int(attrs.get('IAccessible::state_%s' % x, 0))
+				and x in IAccessibleHandler.IAccessibleStatesToNVDAStates
+			)
+		)
 
 		attrs["role"] = role
 		attrs["states"] = states

--- a/tests/system/libraries/AssertsLib.py
+++ b/tests/system/libraries/AssertsLib.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited
+# Copyright (C) 2021 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,10 @@ builtIn: BuiltIn = BuiltIn()
 class AssertsLib:
 	@staticmethod
 	def strings_match(actual, expected, ignore_case=False):
+		builtIn.log(
+			f"assert string matches (ignore case: {ignore_case}):  '{expected}'",
+			level="INFO"
+		)
 		try:
 			builtIn.should_be_equal_as_strings(
 				actual,
@@ -26,6 +30,7 @@ class AssertsLib:
 					ignore_case,
 					repr(actual),
 					repr(expected)
-				)
+				),
+				level="DEBUG"
 			)
 			raise

--- a/tests/system/libraries/AssertsLib.py
+++ b/tests/system/libraries/AssertsLib.py
@@ -13,6 +13,8 @@ builtIn: BuiltIn = BuiltIn()
 class AssertsLib:
 	@staticmethod
 	def strings_match(actual, expected, ignore_case=False):
+		# Include expected text in robot test report so that the actual behavior
+		# can be determined entirely from the report, even when the test passes.
 		builtIn.log(
 			f"assert string matches (ignore case: {ignore_case}):  '{expected}'",
 			level="INFO"
@@ -25,6 +27,7 @@ class AssertsLib:
 				ignore_case=ignore_case
 			)
 		except AssertionError:
+			# Occasionally on assert failure the repr of the string makes it easier to determine the differences.
 			builtIn.log(
 				"repr of actual vs expected (ignore_case={}):\n{}\nvs\n{}".format(
 					ignore_case,

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -468,3 +468,173 @@ def test_tableInStyleDisplayTable():
 		nextActualSpeech,
 		"row 2  First content cell"
 	)
+
+
+annotation = "User nearby, Aaron"
+linkDescription = "opens in a new tab"
+linkTitle = "conduct a search"
+ariaDescriptionSample = f"""
+		<div>
+			<div
+				contenteditable=""
+				spellcheck="false"
+				role="textbox"
+				aria-multiline="true"
+			><p>This is a line with no annotation</p>
+			<p><span
+					aria-description="{annotation}"
+				>Here is a sentence that is being edited by someone else.</span>
+				<b>Multiple can edit this.</b></p>
+			<p>An element with a role, follow <a
+				href="www.google.com"
+				aria-description="{linkDescription}"
+				>to google's</a
+			> website</p>
+			<p>Testing the title attribute, <a
+				href="www.google.com"
+				title="{linkTitle}"
+				>to google's</a
+			> website</p>
+			</div>
+		</div>
+	"""
+
+
+def test_ariaDescription_focusMode():
+	""" Ensure aria description is read in focus mode.
+	"""
+	_chrome.prepareChrome(ariaDescriptionSample)
+	# Focus the contenteditable and automatically switch to focus mode (due to contenteditable)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"edit  multi line  This is a line with no annotation\nFocus mode"
+	)
+
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	# description-from hasn't reached Chrome stable yet.
+	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
+	_builtIn.run_keyword_and_expect_error(
+		# expected_error
+		"Actual speech != Expected speech:"
+		" Here is a sentence that is being edited by someone else."
+		"  Multiple can edit this. != *",
+		# keyword
+		"strings_match",
+		# args
+		actualSpeech,
+		f"{annotation}  Here is a sentence that is being edited by someone else."
+		"  Multiple authors can edit this."
+	)
+
+	linkRole = "link"
+	linkName = "to google's"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	# description-from hasn't reached Chrome stable yet.
+	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
+	_builtIn.run_keyword_and_expect_error(
+		# expected_error
+		"Actual speech != Expected speech:"
+		f" An element with a role, follow  {linkRole}  {linkName}  website"
+		" != *",
+		# keyword
+		"strings_match",
+		# args
+		actualSpeech,
+		f"An element with a role, follow  {linkRole}  {linkDescription}  {linkName}  website"
+	)
+
+	# 'title' attribute for link ("conduct a search") should not be announced.
+	# too often title is used without screen reader users in mind, and is overly verbose.
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"Testing the title attribute,  {linkRole}  {linkName}  website"
+	)
+
+
+def test_ariaDescription_browseMode():
+	""" Ensure aria description is read in browse mode.
+	"""
+	_chrome.prepareChrome(ariaDescriptionSample)
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"edit  multi line  This is a line with no annotation"
+	)
+
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	# description-from hasn't reached Chrome stable yet.
+	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
+	_builtIn.run_keyword_and_expect_error(
+		# expected_error
+		"Actual speech != Expected speech:"
+		" Here is a sentence that is being edited by someone else."
+		"  Multiple can edit this. != *",
+		# keyword
+		"strings_match",
+		# args
+		actualSpeech,
+		f"{annotation}  Here is a sentence that is being edited by someone else."
+		"  Multiple authors can edit this."
+	)
+
+	linkRole = "link"
+	linkName = "to google's"
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	# description-from hasn't reached Chrome stable yet.
+	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
+	_builtIn.run_keyword_and_expect_error(
+		# expected_error
+		"Actual speech != Expected speech:"
+		f" An element with a role, follow  {linkRole}  {linkName}  website"
+		" != *",
+		# keyword
+		"strings_match",
+		# args
+		actualSpeech,
+		f"An element with a role, follow  {linkRole}  {linkDescription}  {linkName}  website"
+	)
+
+	# 'title' attribute for link ("conduct a search") should not be announced.
+	# too often title is used without screen reader users in mind, and is overly verbose.
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		f"Testing the title attribute,  {linkRole}  {linkName}  website"
+	)
+
+
+def test_ariaDescription_sayAll():
+	""" Ensure aria description is read by say all.
+	"""
+	_chrome.prepareChrome(ariaDescriptionSample)
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+downArrow")
+
+	linkRole = "link"
+	linkName = "to google's"
+
+	# description-from hasn't reached Chrome stable yet.
+	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
+	_builtIn.run_keyword_and_expect_error(
+		# asserting multiline error messages doesn't seem to work, instead just Glob the details
+		# of the error message:
+		"Multiline strings are different:*",
+		# keyword
+		"strings_match",
+		# args
+		actualSpeech,
+		"\n".join([
+			"Test page load complete",
+			"edit  multi line  This is a line with no annotation",
+			f"{annotation}  Here is a sentence that is being edited by someone else.",
+			"Multiple authors can edit this.",
+			"An element with a role, "  # no comma, concat these two long strings.
+			f"follow  {linkRole}  {linkDescription}  {linkName}  website",
+			# 'title' attribute for link ("conduct a search") should not be announced.
+			# too often title is used without screen reader users in mind, and is overly verbose.
+			f"Testing the title attribute,  {linkRole}  {linkName}  website"
+			"  out of edit",
+			"After Test Case Marker"
+		])
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -60,3 +60,12 @@ i12147
 Table in style display: table
 	[Documentation]	Properly announce table row/column count and working table navigation for a HTML table in a div with style display: table
 	test_tableInStyleDisplayTable
+ARIA description Focus Mode
+	[Documentation]	Navigate to a span with aria-description in focus mode
+	test_ariaDescription_focusMode
+ARIA description Browse Mode
+	[Documentation]	Navigate to a span with aria-description in browse mode
+	test_ariaDescription_browseMode
+ARIA description Say All
+	[Documentation]	Say all, contents includes aria-description
+	test_ariaDescription_sayAll

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1862,6 +1862,15 @@ Some of these features may be incomplete.
 The following options exist: 
 - "Report details in browse mode": enables reporting if an object has details in browse mode.
 Reporting the summary of those details can be done by assigning a gesture using the [Input Gestures dialog #InputGestures].
+- "Report aria-description always":
+  When the source of ``accDescription`` is aria-description, the description is reported.
+  This is useful for annotations on the web.
+  Note:
+  - There are many sources for ``accDescription`` several have mixed or unreliable semantics.
+    Historically AT has not been able to differentiate sources of ``accDescription`` typically it wasn't spoken due to the mixed semantics.
+  - This option is in very early development, it relies on browser features not yet widely available.
+  - Expected to work with Chromium 92.0.4479.0+
+  -
 -
 
 ==== Use UI automation to access Microsoft  Excel spreadsheet controls when available ====[UseUiaForExcel]


### PR DESCRIPTION
**Reviewers - There are several commits to refactor / fix issues encountered. It will be easier to review the changes one commit at a time. I have already grouped and squashed related changes. Commits with messages starting with "Fixup / squash" will be squashed into the commit they reference**

### Link to issue number:
None

### Summary of the issue:
The HTML attribute `aria-description` has been introduced as one aspect of supporting a broader concept of annotations on the web. It maps to `accDescription`. In contrast to other sources for `accDescription` such as `title`, our expectation is annotations should be reported whenever present.

### Description of how this pull request fixes the issue:
Experimental support has been added for reporting aria-description.

### Testing strategy:
System tests for Chrome checking speech output in browse mode, focus mode, and say-all.
- The feature for `description-from` is only available in Chrome ` 92.0.4479.0+`
- The [most recent Appveyor has is Chrome `90.0.4430.72`](https://www.appveyor.com/docs/windows-images-software/#web-browsers)
- For now the assert for reporting description is expected to fail.

Manual testing with Braille, mouse, and object navigation.

### Known issues with pull request:
- Firefox and Edge do not yet support aria-description as expected.
- Reporting due to mouse seems broken in Chrome?
- [x] Garbage handler warnings: Fixed with #12617

### Change log entries:
New features:
`aria-description will now be reported by default.`

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
