### PR TITLE
Backport "cache isImprovedTextRangeAvailable and infrastructure for UIA by default" to beta

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2009-2020 NV Access Limited, Joseph Lee, Mohammad Suliman,
+# Copyright (C) 2009-2021 NV Access Limited, Joseph Lee, Mohammad Suliman,
 # Babbage B.V., Leonard de Ruijter, Bill Dengler
 
 """Support for UI Automation (UIA) controls."""
@@ -1030,10 +1030,7 @@ class UIA(Window):
 			VisualStudio.findExtraOverlayClasses(self, clsList)
 
 		# Support Windows Console's UIA interface
-		if (
-			self.windowClassName == "ConsoleWindowClass"
-			and config.conf['UIA']['winConsoleImplementation'] == "UIA"
-		):
+		if self.windowClassName == "ConsoleWindowClass":
 			from . import winConsoleUIA
 			winConsoleUIA.findExtraOverlayClasses(self, clsList)
 		elif UIAClassName == "TermControl":

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2011-2021 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2011-2021 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -55,12 +55,12 @@ HorizontalTextAlignment_Justified=3
 # The name of the WDAG (Windows Defender Application Guard) process
 WDAG_PROCESS_NAME=u'hvsirdpclient'
 
-goodUIAWindowClassNames=[
+goodUIAWindowClassNames = (
 	# A WDAG (Windows Defender Application Guard) Window is always native UIA, even if it doesn't report as such.
 	'RAIL_WINDOW',
-]
+)
 
-badUIAWindowClassNames=[
+badUIAWindowClassNames = (
 	# UIA events of candidate window interfere with MSAA events.
 	"Microsoft.IME.CandidateWindow.View",
 	"SysTreeView32",
@@ -78,7 +78,7 @@ badUIAWindowClassNames=[
 	"Button",
 	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 	"FoxitDocWnd",
-]
+)
 
 # #8405: used to detect UIA dialogs prior to Windows 10 RS5.
 UIADialogClassNames=[
@@ -704,17 +704,6 @@ class UIAHandler(COMObject):
 			return
 		eventHandler.queueEvent("UIA_activeTextPositionChanged", obj, textRange=textRange)
 
-	def _isBadUIAWindowClassName(self, windowClass):
-		"Given a windowClassName, returns True if this is a known problematic UIA implementation."
-		# #7497: Windows 10 Fall Creators Update has an incomplete UIA
-		# implementation for console windows, therefore for now we should
-		# ignore it.
-		# It does not implement caret/selection, and probably has no new text
-		# events.
-		if windowClass == "ConsoleWindowClass" and config.conf['UIA']['winConsoleImplementation'] != "UIA":
-			return True
-		return windowClass in badUIAWindowClassNames
-
 	def _isUIAWindowHelper(self,hwnd):
 		# UIA in NVDA's process freezes in Windows 7 and below
 		processID=winUser.getWindowThreadProcessID(hwnd)[0]
@@ -731,7 +720,7 @@ class UIAHandler(COMObject):
 		if appModule and appModule.isGoodUIAWindow(hwnd):
 			return True
 		# There are certain window classes that just had bad UIA implementations
-		if self._isBadUIAWindowClassName(windowClass):
+		if windowClass in badUIAWindowClassNames:
 			return False
 		# allow the appModule for the window to also choose if this window is bad
 		if appModule and appModule.isBadUIAWindow(hwnd):
@@ -807,6 +796,8 @@ class UIAHandler(COMObject):
 				)
 			):
 				return False
+			if windowClass == "ConsoleWindowClass":
+				return UIAUtils._shouldUseUIAConsole(hwnd)
 		return bool(res)
 
 	def isUIAWindow(self,hwnd):


### PR DESCRIPTION
This PR backports #12453 to beta. It has been in master for a bit without complaint, does not include any string changes, is unlikely to cause regressions, and meaningfully improves performance by minimizing cross-process calls in UIA consoles. Cc @seanbudd.