### PR TITLE
Manage starting new NVDA instances when exiting through core

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -265,6 +265,10 @@ def _doShutdown(newNVDA: Optional[NewNVDAInstance]):
 
 
 def triggerNVDAExit(newNVDA: Optional[NewNVDAInstance] = None):
+	"""
+	Used to safely exit NVDA. If a new instance is required to start after exit, queue one by specifying
+	instance information with `newNVDA`.
+	"""
 	import queueHandler
 	global _hasShutdownBeenTriggered
 	with _shuttingDownFlagLock:

--- a/source/core.py
+++ b/source/core.py
@@ -43,8 +43,7 @@ import garbageHandler  # noqa: E402
 
 # inform those who want to know that NVDA has finished starting up.
 postNvdaStartup = extensionPoints.Action()
-# inform those who want to know that NVDA has begun to exit.
-preNVDAExit = extensionPoints.Action()
+# used internally to ensure exit events fire in order safely
 _nvdaExitActions = extensionPoints.Action()
 
 PUMP_MAX_DELAY = 10
@@ -260,7 +259,6 @@ def _startNewInstance(newNVDA: NewNVDAInstance):
 
 
 def _doShutdown(newNVDA: Optional[NewNVDAInstance]):
-	preNVDAExit.notifyOnce()
 	_nvdaExitActions.notifyOnce()
 	if newNVDA is not None:
 		_startNewInstance(newNVDA)
@@ -274,6 +272,8 @@ def triggerNVDAExit(newNVDA: Optional[NewNVDAInstance] = None):
 			# queue this so that the calling process can exit safely (eg a Popup menu)
 			queueHandler.queueFunction(queueHandler.eventQueue, _doShutdown, newNVDA)
 			_hasShutdownBeenTriggered = True
+		else:
+			log.warn("NVDA exit has already been triggered")
 
 
 def _closeAllWindows():

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -110,24 +110,9 @@ def doInstall(
 			# Translators: The title of a dialog presented to indicate a successful operation.
 			_("Success"))
 	if startAfterInstall:
-		core.preNVDAExit.register(_startNewInstalledNVDAInstance)
+		installedPath = os.path.join(installer.defaultInstallPath, 'nvda.exe')
+		core.NewNVDAInstanceOnExitManager.queueInstance(installedPath)
 	core.triggerNVDAExit()
-
-
-def _startNewInstalledNVDAInstance():
-	_startNewNVDAInstance(installer.defaultInstallPath)
-
-
-def _startNewNVDAInstance(path: str):
-	# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
-	shellapi.ShellExecute(
-		None,
-		None,
-		os.path.join(path, 'nvda.exe'),
-		None,
-		None,
-		winUser.SW_SHOWNORMAL
-	)
 
 
 def doSilentInstall(
@@ -479,8 +464,6 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 		gui.messageBox(_("Successfully created a portable copy of NVDA at %s")%portableDirectory,
 			_("Success"))
 		if startAfterCreate:
-			def startNewPortableNVDAInstance():
-				_startNewNVDAInstance(portableDirectory)
-			core.preNVDAExit.register(startNewPortableNVDAInstance)
+			core.NewNVDAInstanceOnExitManager.queueInstance(os.path.join(portableDirectory, 'nvda.exe'))
 	if silent or startAfterCreate:
 		core.triggerNVDAExit()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -109,9 +109,11 @@ def doInstall(
 		gui.messageBox(msg+_("Please press OK to start the installed copy."),
 			# Translators: The title of a dialog presented to indicate a successful operation.
 			_("Success"))
+
+	newNVDA = None
 	if startAfterInstall:
-		installedPath = os.path.join(installer.defaultInstallPath, 'nvda.exe')
-	core.triggerNVDAExit(newNVDA=core.NewNVDAInstance(installedPath))
+		newNVDA = core.NewNVDAInstance(os.path.join(installer.defaultInstallPath, 'nvda.exe'))
+	core.triggerNVDAExit(newNVDA)
 
 
 def doSilentInstall(

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -111,8 +111,7 @@ def doInstall(
 			_("Success"))
 	if startAfterInstall:
 		installedPath = os.path.join(installer.defaultInstallPath, 'nvda.exe')
-		core.NewNVDAInstanceOnExitManager.queueInstance(installedPath)
-	core.triggerNVDAExit()
+	core.triggerNVDAExit(newNVDA=core.NewNVDAInstance(installedPath))
 
 
 def doSilentInstall(
@@ -463,7 +462,8 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 		# %s will be replaced with the destination directory.
 		gui.messageBox(_("Successfully created a portable copy of NVDA at %s")%portableDirectory,
 			_("Success"))
-		if startAfterCreate:
-			core.NewNVDAInstanceOnExitManager.queueInstance(os.path.join(portableDirectory, 'nvda.exe'))
 	if silent or startAfterCreate:
-		core.triggerNVDAExit()
+		newNVDA = None
+		if startAfterCreate:
+			newNVDA = core.NewNVDAInstance(os.path.join(portableDirectory, 'nvda.exe'))
+		core.triggerNVDAExit(newNVDA)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -1,8 +1,7 @@
-#updateCheck.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2012-2019 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2012-2021 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
 
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.
@@ -10,7 +9,7 @@
 import garbageHandler
 import globalVars
 import config
-
+import core
 if globalVars.appArgs.secure:
 	raise RuntimeError("updates disabled in secure mode")
 elif config.isAppX:
@@ -222,10 +221,8 @@ def _executeUpdate(destPath):
 		else:
 			executeParams = u"--launcher"
 	# #4475: ensure that the new process shows its first window, by providing SW_SHOWNORMAL
-	shellapi.ShellExecute(None, None,
-		destPath,
-		executeParams,
-		None, winUser.SW_SHOWNORMAL)
+	core.NewNVDAInstanceOnExitManager.queueInstance(destPath, executeParams)
+	core.triggerNVDAExit()
 
 
 class UpdateChecker(garbageHandler.TrackedObject):

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -221,8 +221,7 @@ def _executeUpdate(destPath):
 		else:
 			executeParams = u"--launcher"
 	# #4475: ensure that the new process shows its first window, by providing SW_SHOWNORMAL
-	core.NewNVDAInstanceOnExitManager.queueInstance(destPath, executeParams)
-	core.triggerNVDAExit()
+	core.triggerNVDAExit(core.NewNVDAInstance(destPath, executeParams))
 
 
 class UpdateChecker(garbageHandler.TrackedObject):

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -9,6 +9,7 @@
 from ctypes.wintypes import HWND, LPARAM
 from ctypes import c_bool, c_int, create_unicode_buffer, POINTER, WINFUNCTYPE, windll, WinError
 import re
+from SystemTestSpy.blockUntilConditionMet import _blockUntilConditionMet
 from typing import Callable, List, NamedTuple
 
 
@@ -76,3 +77,11 @@ def GetVisibleWindowTitles() -> List[str]:
 def GetForegroundWindowTitle() -> str:
 	hwnd = windll.user32.GetForegroundWindow()
 	return _GetWindowTitle(hwnd)
+
+
+def waitUntilWindowFocused(targetWindowTitle: str):
+	_blockUntilConditionMet(
+		getValue=lambda: GetForegroundWindowTitle() == targetWindowTitle,
+		giveUpAfterSeconds=5,
+		errorMessage=f"Timed out waiting {targetWindowTitle} to focus",
+	)

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -12,6 +12,7 @@ from robot.libraries.BuiltIn import BuiltIn
 from SystemTestSpy import (
 	_getLib,
 )
+from SystemTestSpy.windows import waitUntilWindowFocused
 
 # Imported for type information
 from robot.libraries.Process import Process as _ProcessLib
@@ -108,3 +109,21 @@ def read_welcome_dialog():
 	)
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
 	spy.emulateKeyPress("enter")
+
+
+def NVDA_restarts():
+	"""Ensure NVDA can be restarted from keyboard."""
+	spy = _nvdaLib.getSpyLib()
+	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present.
+	spy.wait_for_speech_to_finish()
+
+	spy.emulateKeyPress("NVDA+q")
+	spy.wait_for_specific_speech("Exit NVDA")
+
+	_builtIn.sleep(0.5)  # the dialog is not always receiving the enter keypress, wait a little longer for it
+	spy.emulateKeyPress("downArrow")
+	spy.wait_for_specific_speech("Restart")
+	spy.emulateKeyPress("enter", blockUntilProcessed=False)  # don't block so NVDA can exit
+	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
+	_process.process_should_be_stopped(_nvdaProcessAlias)
+	waitUntilWindowFocused("Welcome to NVDA")

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -39,3 +39,8 @@ Read welcome dialog
 	[Documentation]	Ensure that the welcome dialog can be read in full
 	[Setup]	start NVDA	standard-doShowWelcomeDialog.ini
 	read_welcome_dialog	# run test
+
+Restarts
+	[Documentation]	Ensure that NVDA can restart from keyboard
+	[Setup]	start NVDA	standard-doShowWelcomeDialog.ini
+	NVDA restarts


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes (when backported to beta) #12503 

### Summary of the issue:

#12431 made it so when installing NVDA, the GUI should exit before queueing the new instance.

The change in #12431 was not applied to updating NVDA or restarting NVDA.

### Description of how this pull request fixes the issue:

Applies the queueing process for all cases where a new NVDA instance is expected to start. Searching for `ShellExecute` can confirm this. 

### Testing strategy:

Manual testing

- Confirm #12431/#12421 remains fixed: Test the installer process exit and starts a new instance properly with the build from this PR. Try with a portable copy as well. 
- Test the update process when this is merged to master

System tests:
- Existing system tests exist for the exit process.
- NEW: Test restarting NVDA through exit dialog.


### Known issues with pull request:

This needs to be backported to beta after it is a confirmed fix on master.

### Change log entries:

N/A

### Code Review Checklist:


- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
