### PR TITLE
Update liblouis to 3.18.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit aafd2e720
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
-* [liblouis](http://www.liblouis.org/), version 3.17.0
+* [liblouis](http://www.liblouis.org/), version 3.18.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 39.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2020 NV Access Limited, Joseph Lee, Babbage B.V.
+# Copyright (C) 2008-2021 NV Access Limited, Joseph Lee, Babbage B.V.
 
 """Manages information about available braille translation tables.
 """

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -74,6 +74,7 @@ RENAMED_TABLES = {
 	"Fr-Ca-g2.ctb":"fr-bfu-g2.ctb",
 	"gr-bb.ctb": "grc-international-en.utb",
 	"gr-gr-g1.utb":"el.ctb",
+	"he.ctb": "he-IL-comp8.utb",
 	"hr.ctb":"hr-comp8.utb",
 	"mn-MN.utb":"mn-MN-g1.utb",
 	"nl-BE-g1.ctb":"nl-BE-g0.utb",
@@ -85,6 +86,7 @@ RENAMED_TABLES = {
 	"sk-sk-g1.utb":"sk-g1.ctb",
 	"UEBC-g1.ctb":"en-ueb-g1.ctb",
 	"UEBC-g2.ctb":"en-ueb-g2.ctb",
+	"vi-g1.ctb": "vi-vn-g1.ctb",
 }
 
 # Add builtin tables.
@@ -121,6 +123,9 @@ addTable("bel.utb", _("Belarusian literary braille"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("bg.ctb", _("Bulgarian 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("bg.utb", _("Bulgarian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ckb-g1.ctb", _("Central Kurdish grade 1"))
@@ -261,13 +266,10 @@ addTable("gu-in-g1.utb", _("Gujarati grade 1"))
 addTable("grc-international-en.utb", _("Greek international braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("he.ctb", _("Hebrew 8 dot computer braille"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable("he-IL.utb", _("Israeli grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("he-IL-comp8.utb", _("Israeli 8 dot computer braille"))
+addTable("he-IL-comp8.utb", _("Hebrew computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("hi-in-g1.utb", _("Hindi grade 1"))
@@ -298,6 +300,15 @@ addTable("it-it-comp8.utb", _("Italian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ka-in-g1.utb", _("Kannada grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("kk.utb", _("Kazakh grade 1"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("km-g1.utb", _("Khmer grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("kmr.tbl", _("Northern Kurdish grade 0"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ko-2006-g1.ctb", _("Korean grade 1 (2006)"))
@@ -342,6 +353,12 @@ addTable("mn-MN-g2.ctb", _("Mongolian grade 2"), contracted=True)
 addTable("mr-in-g1.utb", _("Marathi grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("my-g1.utb", _("Burmese grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("my-g2.ctb", _("Burmese grade 2"), contracted=True, input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("nl-BE-g0.utb", _("Dutch (Belgium) 6 dot"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -367,6 +384,12 @@ addTable("No-No-g3.ctb", _("Norwegian grade 3"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("np-in-g1.utb", _("Nepali grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("nso-za-g1.utb", _("Sepedi grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("nso-za-g2.ctb", _("Sepedi grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("or-in-g1.utb", _("Oriya grade 1"))
@@ -405,6 +428,9 @@ addTable("ru-litbrl-detailed.utb", _("Russian literary braille (detailed)"), inp
 addTable("sa-in-g1.utb", _("Sanskrit grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("sah.utb", _("Yakut grade 1"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("Se-Se.ctb", _("Swedish 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -420,16 +446,31 @@ addTable("sl-si-comp8.ctb", _("Slovenian 8 dot computer braille"))
 addTable("sl-si-g1.utb", _("Slovenian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("sot-za-g1.ctb", _("Sesotho grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sot-za-g2.ctb", _("Sesotho grade 2"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("sr-g1.ctb", _("Serbian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ta-ta-g1.ctb", _("Tamil grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("tt.utb", _("Tatar grade 1"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("te-in-g1.utb", _("Telugu grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("tr.ctb", _("Turkish grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("tsn-za-g1.ctb", _("Setswana grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("tsn-za-g2.ctb", _("Setswana grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("uk.utb", _("Ukrainian grade 1"))
@@ -450,7 +491,22 @@ addTable("uz-g1.utb", _("Uzbek grade 1"))
 addTable("unicode-braille.utb", _("Unicode braille"), output=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("vi-g1.ctb", _("Vietnamese grade 1"))
+addTable("vi-vn-g0.utb", _("Vietnamese grade 0"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("vi-vn-g1.ctb", _("Vietnamese grade 1"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("vi-vn-g2.ctb", _("Vietnamese grade 2"), contracted=True, input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("vi-saigon-g1.ctb", _("Southern Vietnamese grade 1"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("xh-za-g1.utb", _("Xhosa grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("xh-za-g2.ctb", _("Xhosa grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zhcn-g1.ctb", _("Chinese (China, Mandarin) grade 1"))
@@ -463,3 +519,9 @@ addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zh-tw.ctb", _("Chinese (Taiwan, Mandarin)"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("zu-za-g1.utb", _("Zulu grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("zu-za-g2.ctb", _("Zulu grade 2"), contracted=True)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,9 @@ What's New in NVDA
 - In terminal programs on Windows 10 version 1607 and later, when inserting or deleting characters in the middle of a line, the characters to the right of the caret are no longer read out. (#3200)
   - Diff Match Patch now enabled by default. (#12485)
   -
+- Updated liblouis braille translator to [3.18.0 https://github.com/liblouis/liblouis/releases/tag/v3.18.0]. (#12526)
+  - New braille tables: Bulgarian grade 1, Burmese grade 1, Burmese grade 2, Kazakh grade 1, Khmer grade 1, Northern Kurdish grade 0, Sepedi grade 1, Sepedi grade 2, Sesotho grade 1, Sesotho grade 2, Setswana grade 1, Setswana grade 2, Tatar grade 1, Vietnamese grade 0, Vietnamese grade 2, Southern Vietnamese grade 1, Xhosa grade 1, Xhosa grade 2, Yakut grade 1, Zulu grade 1, Zulu grade 2
+  -
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Liblouis 3.18.0 has just been released.

### Description of how this pull request fixes the issue:
Updates liblouis to 3.18.0 which adds support for many new languages and [other awesome things](https://github.com/liblouis/liblouis/releases/tag/v3.18.0).

### Testing strategy:
- Ran from sources.
- Tested new braille tables (input and output).

### Known issues with pull request:
None

### Change log entries:
Section: Changes

```
- Updated liblouis braille translator to [3.18.0 https://github.com/liblouis/liblouis/releases/tag/v3.18.0]. (#12526)
  - New braille tables: Bulgarian grade 1, Burmese grade 1, Burmese grade 2, Kazakh grade 1, Khmer grade 1, Northern Kurdish grade 0, Sepedi grade 1, Sepedi grade 2, Sesotho grade 1, Sesotho grade 2, Setswana grade 1, Setswana grade 2, Tatar grade 1, Vietnamese grade 0, Vietnamese grade 2, Southern Vietnamese grade 1, Xhosa grade 1, Xhosa grade 2, Yakut grade 1, Zulu grade 1, Zulu grade 2
```


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
