### PR TITLE
Still report the new focus in browse mode if fetching the states from the old focus causes an exception when checking for defunct 

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1566,8 +1566,16 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		# If the previous focus object was removed, we might hit a false positive for overlap detection.
 		# Track the previous focus target so that we can account for this scenario.
 		previousFocusObjIsDefunct = False
-		if self._lastFocusObj and controlTypes.STATE_DEFUNCT in self._lastFocusObj.states:
-			previousFocusObjIsDefunct = True
+		if self._lastFocusObj:
+			try:
+				states = self._lastFocusObj.states
+				previousFocusObjIsDefunct = controlTypes.STATE_DEFUNCT in states
+			except Exception:
+				log.debugWarning(
+					"Error fetching states when checking for defunct object. Treating object as defunct anyway.",
+					exc_info=True
+				)
+				previousFocusObjIsDefunct = True
 
 		self._lastFocusObj=obj
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12527 

### Summary of the issue:
In UI Automation browse mode implementations, sometimes the new focus is not announced if the old focus is removed from the DOM as the focus changes. This is true even in focus mode.
PR #12252  introduced a check for STATE_DEFUNCT on the old focus's states property. Although this works fine in Firefox / Chrome (they leave dead objects around with a defunct state), some UI Automation elements become completely unusable, and therefore an exception is raised when trying to fetch the states property.
As reported in issue #12527  The newly focused tweet in the Twitter app is no longer announced when pressing j /  keys. And If using Edge/Chromium with UIA, some focus changes in Microsoft Word 365 Online are not announced.

### Description of how this pull request fixes the issue:
In BrowseMode document's event_gainFocus method, Catch all exceptions when fetching states to check for defunct, and if an exception is raised, log the error and treat the object as being defunct.

### Testing strategy:
Performed the testcase in the Twitter app, reported in issue #12527. Confirmed that the new focus is again reported, even though an exception is logged at debugWarning.
 
### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
