### PR TITLE
Manage starting new NVDA instances when exiting through core (#12515)

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -276,7 +276,7 @@ def triggerNVDAExit(newNVDA: Optional[NewNVDAInstance] = None):
 			queueHandler.queueFunction(queueHandler.eventQueue, _doShutdown, newNVDA)
 			_hasShutdownBeenTriggered = True
 		else:
-			log.warn("NVDA exit has already been triggered")
+			log.debugWarning("NVDA exit has already been triggered")
 
 
 def _closeAllWindows():

--- a/source/core.py
+++ b/source/core.py
@@ -3,7 +3,7 @@
 # Derek Riemer, Babbage B.V., Zahari Yurukov, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-
+from dataclasses import dataclass
 from typing import Optional
 
 """NVDA core"""
@@ -43,8 +43,6 @@ import garbageHandler  # noqa: E402
 
 # inform those who want to know that NVDA has finished starting up.
 postNvdaStartup = extensionPoints.Action()
-# inform those who want to know that NVDA has begun to exit.
-preNVDAExit = extensionPoints.Action()
 
 PUMP_MAX_DELAY = 10
 
@@ -65,6 +63,10 @@ post_windowMessageReceipt = extensionPoints.Action()
 
 _pump = None
 _isPumpPending = False
+
+_hasShutdownBeenTriggered = False
+_shuttingDownFlagLock = threading.Lock()
+
 
 def doStartupDialogs():
 	import config
@@ -110,6 +112,14 @@ def doStartupDialogs():
 			# Ask the user if usage stats can be collected.
 			gui.runScriptModalDialog(gui.startupDialogs.AskAllowUsageStatsDialog(None), onResult)
 
+
+@dataclass
+class NewNVDAInstance:
+	filePath: Optional[str] = None
+	parameters: Optional[str] = None
+	directory: Optional[str] = None
+
+
 def restart(disableAddons=False, debugLogging=False):
 	"""Restarts NVDA by starting a new copy."""
 	if globalVars.appArgs.launcher:
@@ -117,8 +127,6 @@ def restart(disableAddons=False, debugLogging=False):
 		triggerNVDAExit()
 		return
 	import subprocess
-	import winUser
-	import shellapi
 	for paramToRemove in ("--disable-addons", "--debug-logging", "--ease-of-access"):
 		try:
 			sys.argv.remove(paramToRemove)
@@ -131,15 +139,12 @@ def restart(disableAddons=False, debugLogging=False):
 		options.append('--disable-addons')
 	if debugLogging:
 		options.append('--debug-logging')
-	shellapi.ShellExecute(
-		hwnd=None,
-		operation=None,
-		file=sys.executable,
-		parameters=subprocess.list2cmdline(options + sys.argv[1:]),
-		directory=globalVars.appDir,
-		# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
-		showCmd=winUser.SW_SHOWNORMAL
-	)
+
+	triggerNVDAExit(NewNVDAInstance(
+		sys.executable,
+		subprocess.list2cmdline(options + sys.argv[1:]),
+		globalVars.appDir
+	))
 
 
 def resetConfiguration(factoryDefaults=False):
@@ -231,15 +236,52 @@ def getWxLangOrNone() -> Optional['wx.LanguageInfo']:
 	return wxLang
 
 
-def triggerNVDAExit():
+def _startNewInstance(newNVDA: NewNVDAInstance):
+	"""
+	If something (eg the installer or exit dialog) has requested a new NVDA instance to start, start it.
+	Should only be used by calling triggerNVDAExit and after handleNVDAModuleCleanupBeforeGUIExit and
+	_closeAllWindows.
+	"""
+	import shellapi
+	from winUser import SW_SHOWNORMAL
+	log.debug(f"Starting new NVDA instance: {newNVDA}")
+	shellapi.ShellExecute(
+		hwnd=None,
+		operation=None,
+		file=newNVDA.filePath,
+		parameters=newNVDA.parameters,
+		directory=newNVDA.directory,
+		# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
+		showCmd=SW_SHOWNORMAL
+	)
+
+
+def _doShutdown(newNVDA: Optional[NewNVDAInstance]):
+	_handleNVDAModuleCleanupBeforeGUIExit()
+	_closeAllWindows()
+	if newNVDA is not None:
+		_startNewInstance(newNVDA)
+
+
+def triggerNVDAExit(newNVDA: Optional[NewNVDAInstance] = None):
+	"""
+	Used to safely exit NVDA. If a new instance is required to start after exit, queue one by specifying
+	instance information with `newNVDA`.
+	"""
 	import queueHandler
-	# queue this so that the calling process can exit safely (eg a Popup menu)
-	queueHandler.queueFunction(queueHandler.eventQueue, preNVDAExit.notifyOnce)
+	global _hasShutdownBeenTriggered
+	with _shuttingDownFlagLock:
+		if not _hasShutdownBeenTriggered:
+			# queue this so that the calling process can exit safely (eg a Popup menu)
+			queueHandler.queueFunction(queueHandler.eventQueue, _doShutdown, newNVDA)
+			_hasShutdownBeenTriggered = True
+		else:
+			log.warn("NVDA exit has already been triggered")
 
 
 def _closeAllWindows():
 	"""
-	Should only be used by calling triggerNVDAExit and after handleNVDAModuleCleanupBeforeGUIExit.
+	Should only be used by calling triggerNVDAExit and after _handleNVDAModuleCleanupBeforeGUIExit.
 	Ensures the wx mainloop is exited by all the top windows being destroyed.
 	wx objects that don't inherit from wx.Window (eg sysTrayIcon, Menu) need to be manually destroyed.
 	"""
@@ -289,6 +331,29 @@ def _closeAllWindows():
 	# the MainFrame has EVT_CLOSE bound to the ExitDialog
 	# which calls this function on exit, so destroy this window
 	app.ScheduleForDestruction(gui.mainFrame)
+
+
+def _handleNVDAModuleCleanupBeforeGUIExit():
+	""" Terminates various modules that rely on the GUI. This should be used before closing all windows
+	and terminating the GUI.
+	"""
+	import brailleViewer
+	import globalPluginHandler
+	import watchdog
+
+	try:
+		import updateCheck
+		# before the GUI is terminated we must terminate the update checker
+		_terminate(updateCheck)
+	except RuntimeError:
+		pass
+
+	# The core is expected to terminate, so we should not treat this as a crash
+	_terminate(watchdog)
+	# plugins must be allowed to close safely before we terminate the GUI as dialogs may be unsaved
+	_terminate(globalPluginHandler)
+	# the brailleViewer should be destroyed safely before closing the window
+	brailleViewer.destroyBrailleViewer()
 
 
 def main():
@@ -640,25 +705,6 @@ def main():
 		postNvdaStartup.notify()
 
 	queueHandler.queueFunction(queueHandler.eventQueue, _doPostNvdaStartupAction)
-
-	def handleNVDAModuleCleanupBeforeGUIExit():
-		""" Terminates various modules that rely on the GUI. This should be used before closing all windows
-		and terminating the GUI
-		"""
-		import brailleViewer
-		# before the GUI is terminated we must terminate the update checker
-		if updateCheck:
-			_terminate(updateCheck)
-
-		# The core is expected to terminate, so we should not treat this as a crash
-		_terminate(watchdog)
-		# plugins must be allowed to close safely before we terminate the GUI as dialogs may be unsaved
-		_terminate(globalPluginHandler)
-		# the brailleViewer should be destroyed safely before closing the window
-		brailleViewer.destroyBrailleViewer()
-	
-	preNVDAExit.register(handleNVDAModuleCleanupBeforeGUIExit)
-	preNVDAExit.register(_closeAllWindows)
 
 	log.debug("entering wx application main loop")
 	app.MainLoop()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -109,25 +109,11 @@ def doInstall(
 		gui.messageBox(msg+_("Please press OK to start the installed copy."),
 			# Translators: The title of a dialog presented to indicate a successful operation.
 			_("Success"))
+
+	newNVDA = None
 	if startAfterInstall:
-		core.preNVDAExit.register(_startNewInstalledNVDAInstance)
-	core.triggerNVDAExit()
-
-
-def _startNewInstalledNVDAInstance():
-	_startNewNVDAInstance(installer.defaultInstallPath)
-
-
-def _startNewNVDAInstance(path: str):
-	# #4475: ensure that the first window of the new process is not hidden by providing SW_SHOWNORMAL
-	shellapi.ShellExecute(
-		None,
-		None,
-		os.path.join(path, 'nvda.exe'),
-		None,
-		None,
-		winUser.SW_SHOWNORMAL
-	)
+		newNVDA = core.NewNVDAInstance(os.path.join(installer.defaultInstallPath, 'nvda.exe'))
+	core.triggerNVDAExit(newNVDA)
 
 
 def doSilentInstall(
@@ -478,9 +464,8 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 		# %s will be replaced with the destination directory.
 		gui.messageBox(_("Successfully created a portable copy of NVDA at %s")%portableDirectory,
 			_("Success"))
-		if startAfterCreate:
-			def startNewPortableNVDAInstance():
-				_startNewNVDAInstance(portableDirectory)
-			core.preNVDAExit.register(startNewPortableNVDAInstance)
 	if silent or startAfterCreate:
-		core.triggerNVDAExit()
+		newNVDA = None
+		if startAfterCreate:
+			newNVDA = core.NewNVDAInstance(os.path.join(portableDirectory, 'nvda.exe'))
+		core.triggerNVDAExit(newNVDA)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -1,8 +1,7 @@
-#updateCheck.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2012-2019 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2012-2021 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
 
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.
@@ -10,7 +9,7 @@
 import garbageHandler
 import globalVars
 import config
-
+import core
 if globalVars.appArgs.secure:
 	raise RuntimeError("updates disabled in secure mode")
 elif config.isAppX:
@@ -222,10 +221,7 @@ def _executeUpdate(destPath):
 		else:
 			executeParams = u"--launcher"
 	# #4475: ensure that the new process shows its first window, by providing SW_SHOWNORMAL
-	shellapi.ShellExecute(None, None,
-		destPath,
-		executeParams,
-		None, winUser.SW_SHOWNORMAL)
+	core.triggerNVDAExit(core.NewNVDAInstance(destPath, executeParams))
 
 
 class UpdateChecker(garbageHandler.TrackedObject):

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -9,6 +9,7 @@
 from ctypes.wintypes import HWND, LPARAM
 from ctypes import c_bool, c_int, create_unicode_buffer, POINTER, WINFUNCTYPE, windll, WinError
 import re
+from SystemTestSpy.blockUntilConditionMet import _blockUntilConditionMet
 from typing import Callable, List, NamedTuple
 
 
@@ -76,3 +77,11 @@ def GetVisibleWindowTitles() -> List[str]:
 def GetForegroundWindowTitle() -> str:
 	hwnd = windll.user32.GetForegroundWindow()
 	return _GetWindowTitle(hwnd)
+
+
+def waitUntilWindowFocused(targetWindowTitle: str):
+	_blockUntilConditionMet(
+		getValue=lambda: GetForegroundWindowTitle() == targetWindowTitle,
+		giveUpAfterSeconds=5,
+		errorMessage=f"Timed out waiting {targetWindowTitle} to focus",
+	)

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -12,6 +12,7 @@ from robot.libraries.BuiltIn import BuiltIn
 from SystemTestSpy import (
 	_getLib,
 )
+from SystemTestSpy.windows import waitUntilWindowFocused
 
 # Imported for type information
 from robot.libraries.Process import Process as _ProcessLib
@@ -108,3 +109,21 @@ def read_welcome_dialog():
 	)
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
 	spy.emulateKeyPress("enter")
+
+
+def NVDA_restarts():
+	"""Ensure NVDA can be restarted from keyboard."""
+	spy = _nvdaLib.getSpyLib()
+	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present.
+	spy.wait_for_speech_to_finish()
+
+	spy.emulateKeyPress("NVDA+q")
+	spy.wait_for_specific_speech("Exit NVDA")
+
+	_builtIn.sleep(0.5)  # the dialog is not always receiving the enter keypress, wait a little longer for it
+	spy.emulateKeyPress("downArrow")
+	spy.wait_for_specific_speech("Restart")
+	spy.emulateKeyPress("enter", blockUntilProcessed=False)  # don't block so NVDA can exit
+	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
+	_process.process_should_be_stopped(_nvdaProcessAlias)
+	waitUntilWindowFocused("Welcome to NVDA")

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -39,3 +39,8 @@ Read welcome dialog
 	[Documentation]	Ensure that the welcome dialog can be read in full
 	[Setup]	start NVDA	standard-doShowWelcomeDialog.ini
 	read_welcome_dialog	# run test
+
+Restarts
+	[Documentation]	Ensure that NVDA can restart from keyboard
+	[Setup]	start NVDA	standard-doShowWelcomeDialog.ini
+	NVDA restarts


### PR DESCRIPTION
Backports #12515 to beta

#12431 made it so when installing NVDA, the GUI should exit before queueing the new instance.
The change in #12431 was not applied to updating NVDA or restarting NVDA.

Description of how this pull request fixes the issue:
Applies the queueing process for all cases where a new NVDA instance is expected to start. Searching for ShellExecute can confirm this.