### PR TITLE
Simplify appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ branches:
   - beta
   - rc
   - /try-.*/
-  # For tags, branch = tag if GitHub couldn't work out the base branch.
   - /release-.*/
   
 environment:
@@ -20,72 +19,40 @@ environment:
   secure: p37Fxo78fsRdmR8v8TPz978QvVaqvbjdIBzFe8ZOpX0FUprm46rkhd374QM1CqMO
  symstore: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\symstore.exe
 
-init:
- - ps: |
-
 install:
- - cd appveyor
- # Decrypt files.
- - ps: |
- - type ssh_known_hosts >> %userprofile%\.ssh\known_hosts
- - cd ..
+ - ps: appveyor\scripts\setBuildVersionVars.ps1
+ - ps: appveyor\scripts\decryptFilesForSigning.ps1
  - git submodule update --init
 
 build_script:
- - ps: |
- - 'echo scons args: %sconsArgs%'
+ - ps: appveyor\scripts\setSconsArgs.ps1
  - scons source %sconsArgs%
- - if ERRORLEVEL 1 exit %ERRORLEVEL%
- # We don't need launcher to run checkPot, so run the checkPot before launcher.
- - ps: |
- # The pot gets built by tests, but we don't actually need it as a build artifact.
- - 'echo scons output targets: %sconsOutTargets%'
  - scons %sconsOutTargets% %sconsArgs%
- - if ERRORLEVEL 1 exit %ERRORLEVEL%
- # Build symbol store.
- - ps: |
- - cd symbols
- - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
- - if ERRORLEVEL 1 exit %ERRORLEVEL%
- - cd ..
+ - ps: appveyor\scripts\buildSymbolStore.ps1
+ - 7z a -tzip -r output\symbols.zip symbols\*.dl_ symbols\*.ex_ symbols\*.pd_
 
 before_test:
- - mkdir testOutput
- - mkdir testOutput\unit
- - mkdir testOutput\system
- - mkdir testOutput\lint
- - ps: |
+ - ps: appveyor\scripts\tests\beforeTests.ps1
+ - ps: appveyor\scripts\installNVDA.ps1
 
 test_script:
-# Unit Tests (Python)
- - ps: |
-
-# Flake8 Linting
- - ps: |
-
-# System tests
- - ps: |
+ - ps: appveyor\scripts\tests\translationCheck.ps1
+ - ps: appveyor\scripts\tests\unitTests.ps1
+ - ps: appveyor\scripts\tests\lintCheck.ps1
+ - ps: appveyor\scripts\tests\systemTests.ps1
 
 after_test:
- # fail build if any tests failed
- - ps: |
+ - ps: appveyor\scripts\tests\checkTestFailure.ps1
 
-# Artifacts are required by deploy code,
 artifacts:
-  - path: output\*
-  - path: output\*\*
+ - path: output\*
+ - path: output\*\*
 
-# Still upload artifacts on failure, they are useful for testing PR builds despite the build perhaps
-# failing for a minor reason (eg linting)
-on_failure:
-#  `- path` is not allowed in `on_failure` use powerShell instead
- - ps: |
-
-# The server side deploy code ('nvdaAppveyorHook') relies on artifacts, they must be uploaded first.
-# For ordering of appveyor yml phases, see: https://www.appveyor.com/docs/build-configuration/#build-pipeline
 deploy_script:
- - ps: |
+ - ps: appveyor\scripts\deployScript.ps1
+
+on_failure:
+ - ps: appveyor\scripts\uploadArtifacts.ps1
 
 on_finish:
-  # add a message to point to the NVDA build, to make testing PR's easier.
-  - ps: |
+ - ps: appveyor\scripts\pushPackagingInfo.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,116 +22,28 @@ environment:
 
 init:
  - ps: |
-     # iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-     $pythonVersion = (py --version)
-     echo $pythonVersion
-     if ($env:APPVEYOR_REPO_TAG_NAME -and $env:APPVEYOR_REPO_TAG_NAME.StartsWith("release-")) {
-      # Strip "release-" prefix.
-      $version = $env:APPVEYOR_REPO_TAG_NAME.Substring(8)
-      Set-AppveyorBuildVariable "release" "1"
-      if ($env:APPVEYOR_REPO_TAG_NAME.Contains("rc") -or $env:APPVEYOR_REPO_TAG_NAME.Contains("beta")) {
-       $versionType = "beta"
-      } else {
-       $versionType = "stable"
-      }
-     } else {
-      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-       $version = "pr$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
-      } elseif($env:APPVEYOR_REPO_BRANCH -eq "master") {
-       $version = "alpha-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
-      } else {
-       $version = "$env:APPVEYOR_REPO_BRANCH-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
-       if($env:APPVEYOR_REPO_BRANCH.StartsWith("try-release-")) {
-        Set-AppveyorBuildVariable "release" "1"
-       }
-      }
-      # The version is unique even for rebuilds, so we can use it for the AppVeyor version.
-      Update-AppveyorBuild -Version $version
-      if($env:APPVEYOR_REPO_BRANCH -eq "master") {
-       $versionType = "snapshot:alpha"
-      } elseif (!$env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
-       $versionType = "snapshot:$env:APPVEYOR_REPO_BRANCH"
-      }
-     }
-     Set-AppveyorBuildVariable "version" $version
-     if ($versionType) {
-      Set-AppveyorBuildVariable "versionType" $versionType
-     }
-     Set-AppveyorBuildVariable "testFailExitCode" 0
 
 install:
  - cd appveyor
  # Decrypt files.
  - ps: |
-    if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
-     openssl enc -d -md sha256 -aes-256-cbc -pbkdf2 -salt -pass pass:$env:secure_authenticode_pass -in authenticode.pfx.enc -out authenticode.pfx
-     if($LastExitCode -ne 0) {
-      $errorCode=$LastExitCode
-      Add-AppveyorMessage "Unable to decrypt authenticode certificate"
-     }
-     openssl enc -md md5 -aes-256-cbc -d -pass pass:$env:secure_ssh_pass -in ssh_id_rsa.enc -out ssh_id_rsa
-     if($LastExitCode -ne 0) {
-      $errorCode=$LastExitCode
-      Add-AppveyorMessage "Unable to decrypt ssh key"
-     }
-     # Install ssh stuff.
-     copy ssh_id_rsa $env:userprofile\.ssh\id_rsa
-     if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
-    }
  - type ssh_known_hosts >> %userprofile%\.ssh\known_hosts
  - cd ..
  - git submodule update --init
 
 build_script:
  - ps: |
-     $sconsOutTargets = "launcher developerGuide  changes userGuide client"
-     if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $sconsOutTargets += " appx"
-     }
-     $sconsArgs = "version=$env:version"
-     if ($env:release) {
-      $sconsArgs += " release=1"
-     }
-     if ($env:versionType) {
-      $sconsArgs += " updateVersionType=$env:versionType"
-     }
-     $sconsArgs += ' publisher="NV Access"'
-     if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
-     }
-     $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
-     # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
-     # It's possible to work around this, but the workarounds have annoying side effects.
-     Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets
-     Set-AppveyorBuildVariable "sconsArgs" $sconsArgs
  - 'echo scons args: %sconsArgs%'
  - scons source %sconsArgs%
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # We don't need launcher to run checkPot, so run the checkPot before launcher.
  - ps: |
-     cmd.exe /c "scons checkPot $sconsArgs"
-     if($LastExitCode -ne 0) {
-      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-      Add-AppveyorMessage "FAIL: Translation comments check. Translation comments missing or unexpectedly included. See build log for more information."
-     } else {
-      Add-AppveyorMessage "PASS: Translation comments check."
-     }
  # The pot gets built by tests, but we don't actually need it as a build artifact.
  - 'echo scons output targets: %sconsOutTargets%'
  - scons %sconsOutTargets% %sconsArgs%
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # Build symbol store.
  - ps: |
-     foreach ($syms in
-      # We don't just include source\*.dll because that would include system dlls.
-      "source\liblouis.dll", "source\*.pdb",
-      "source\lib\*.dll", "source\lib\*.pdb",
-      # We include source\lib64\*.exe to cover nvdaHelperRemoteLoader.
-      "source\lib64\*.dll", "source\lib64\*.exe", "source\lib64\*.pdb",
-      "source\synthDrivers\*.dll", "source\synthDrivers\*.pdb"
-     ) {
-      & $env:symstore add /s symbols /compress -:NOREFS /t NVDA /f $syms
-     }
  - cd symbols
  - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
@@ -143,105 +55,20 @@ before_test:
  - mkdir testOutput\system
  - mkdir testOutput\lint
  - ps: |
-     $errorCode=0
-     $nvdaLauncherFile=".\output\nvda"
-     if(!$env:release) {
-      $nvdaLauncherFile+="_snapshot"
-     }
-     $nvdaLauncherFile+="_${env:version}.exe"
-     Set-AppveyorBuildVariable "nvdaLauncherFile" $nvdaLauncherFile
-     echo NVDALauncherFile: $NVDALauncherFile
-     $outputDir=$(resolve-path .\testOutput)
-     $installerLogFilePath="$outputDir\nvda_install.log"
-     $installerProcess=start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
-     try {
-      $installerProcess | wait-process -Timeout 180
-      $errorCode=$installerProcess.ExitCode
-     } catch {
-      echo "NVDA installer process timed out"
-      $errorCode=1
-      Add-AppveyorMessage "Unable to install NVDA prior to tests."
-     }
-     Push-AppveyorArtifact $installerLogFilePath
-     $crashDump = "$outputDir\nvda_crash.dmp"
-     if (Test-Path -Path $crashDump){
-      Push-AppveyorArtifact $crashDump -FileName "nvda_install_crash.dmp"
-      Add-AppveyorMessage "Install process crashed"
-      $errorCode=1
-     }
-     if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
 
 test_script:
 # Unit Tests (Python)
  - ps: |
-     $outDir = (Resolve-Path .\testOutput\unit\)
-     $unitTestsXml = "$outDir\unitTests.xml"
-     .\rununittests.bat --with-xunit --xunit-file="$unitTestsXml"
-     if($LastExitCode -ne 0) {
-      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-      Add-AppveyorMessage "FAIL: Unit tests. See test results for more information."
-     } else {
-      Add-AppveyorMessage "PASS: Unit tests."
-     }
-     Push-AppveyorArtifact $unitTestsXml
-     $wc = New-Object 'System.Net.WebClient'
-     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $unitTestsXml)
 
 # Flake8 Linting
  - ps: |
-    if ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
-      $lintOutput = (Resolve-Path .\testOutput\lint\)
-      $lintSource = (Resolve-Path .\tests\lint\)
-      $flake8Output = "$lintOutput\Flake8.txt"
-      # When Appveyor runs for a pr,
-      # the build is made from a new temporary commit,
-      # resulting from the pr branch being merged into its base branch.
-      # Therefore to create a diff for linting, we must fetch the head of the base branch.
-      # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
-      # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
-      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-        git fetch -q origin $env:APPVEYOR_REPO_BRANCH
-        $msgBaseLabel = "PR"
-      } else {
-        # However in a pushed branch, we must fetch master.
-        git fetch -q origin master:master
-        $msgBaseLabel = "Branch"
-      }
-      .\runlint.bat FETCH_HEAD "$flake8Output" 
-      if($LastExitCode -ne 0) {
-        Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-        Add-AppveyorMessage "FAIL: Lint check. See test results for more information."
-      } else {
-        Add-AppveyorMessage "PASS: Lint check."
-      }
-      Push-AppveyorArtifact $flake8Output
-      $junitXML = "$lintOutput\PR-Flake8.xml"
-      py "$lintSource\createJunitReport.py" "$flake8Output" "$junitXML"
-      Push-AppveyorArtifact $junitXML
-      $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
-    }
 
 # System tests
  - ps: |
-     $testOutput = (Resolve-Path .\testOutput\)
-     $systemTestOutput = (Resolve-Path "$testOutput\system")
-     .\runsystemtests.bat --variable whichNVDA:installed --variable installDir:"${env:nvdaLauncherFile}" --include installer
-     if($LastExitCode -ne 0) {
-      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-      Add-AppveyorMessage "FAIL: System tests. See test results for more information."
-     } else {
-      Add-AppveyorMessage "PASS: System tests."
-     }
-     Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
-     Push-AppveyorArtifact "$testOutput\systemTestResult.zip"
-     $wc = New-Object 'System.Net.WebClient'
-     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$systemTestOutput\systemTests.xml"))
 
 after_test:
  # fail build if any tests failed
  - ps: |
-     if($env:testFailExitCode -ne 0) { $host.SetShouldExit($env:testFailExitCode) }
 
 # Artifacts are required by deploy code,
 artifacts:
@@ -253,67 +80,12 @@ artifacts:
 on_failure:
 #  `- path` is not allowed in `on_failure` use powerShell instead
  - ps: |
-    # Upload artifacts, preserving directory structure.
-    $uploadFromFolder = "output\"
-    if( Test-Path $uploadFromFolder ){
-      $root = Resolve-Path .\
-      $output = Resolve-Path $uploadFromFolder
-      $paths = [IO.Directory]::GetFiles($output.Path, '*.*', 'AllDirectories')
-      $paths | % {
-        Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)
-      }
-    }
 
 # The server side deploy code ('nvdaAppveyorHook') relies on artifacts, they must be uploaded first.
 # For ordering of appveyor yml phases, see: https://www.appveyor.com/docs/build-configuration/#build-pipeline
 deploy_script:
  - ps: |
-     if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
-      # Not a try build.
-      # Notify our server.
-      $exe = Get-ChildItem -Name output\*.exe
-      $hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
-      $apiVersion = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))")
-      echo apiversion: $apiVersion
-      $apiCompatTo = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))")
-      echo apiBackCompatTo: $apiCompatTo
-      $data = @{
-       jobId=$env:APPVEYOR_JOB_ID;
-       commit=$env:APPVEYOR_REPO_COMMIT;
-       version=$env:version; versionType=$env:versionType;
-       apiVersion=$apiVersion; apiCompatTo=$apiCompatTo;
-       avVersion=$env:APPVEYOR_BUILD_VERSION;
-       branch=$env:APPVEYOR_REPO_BRANCH;
-       exe=$exe; hash=$hash;
-       artifacts=$artifacts
-      }
-      ConvertTo-Json -InputObject $data -Compress | Out-File -FilePath deploy.json
-      Push-AppveyorArtifact deploy.json
-      # Execute the deploy script on the NV Access server via ssh.
-      # Warning: if the server address is changed, 
-      # The new address must be also included in appveyor\ssh_known_hosts in this repo
-      # Otherwise ssh will freeze on input!
-      cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
-
-      # Upload symbols to Mozilla.
-      py -m pip install --no-warn-script-location requests
-      py appveyor\mozillaSyms.py
-      if($LastExitCode -ne 0) {
-        $errorCode=$LastExitCode
-        echo "Unable to upload symbols to Mozilla"
-        Add-AppveyorMessage "Unable to upload symbols to Mozilla"
-      }
-     }
 
 on_finish:
   # add a message to point to the NVDA build, to make testing PR's easier.
   - ps: |
-      # Save an exact list of the actual Python packages and their versions that got installed, to aide in reproducing a build
-      .\venvUtils\exportPackageList.bat installed_python_packages.txt
-      Push-AppveyorArtifact installed_python_packages.txt
-      $appVeyorUrl = "https://ci.appveyor.com"
-      $exe = Get-ChildItem -Name output\*.exe
-      if($?){
-        $exeUrl="$appVeyorUrl/api/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/output/$exe"
-        Add-AppveyorMessage "[Build (for testing PR)]($exeUrl)"
-      }

--- a/appveyor/README.md
+++ b/appveyor/README.md
@@ -1,0 +1,59 @@
+`appveyor.yml` specifies build settings which generally [override online UI driven settings](https://www.appveyor.com/docs/build-configuration/#appveyoryml-and-ui-coexistence). 
+
+# Branch and tag filtering
+
+Tags and branches that trigger a build are filtered by [whitelisting](https://www.appveyor.com/docs/branches/#white--and-blacklisting). Despite the option name, filtering via `branches: only` is applied to tag names too.
+
+# Build pipeline
+
+For ordering of `appveyor.yml` phases, see: [build pipeline docs](https://www.appveyor.com/docs/build-configuration/#build-pipeline).
+
+Builds will fail if any command has a non-zero exit code. PowerShell scripts continue on non-terminating errors unless the file is prefixed with `$ErrorActionPreference = "Stop";`.
+
+## Setup process
+
+Before we be begin the install process, AppVeyor clones our repository and checks out the commit of the build. 
+
+### `install`
+
+* Set environment variables about the build version
+* Bump up the AppVeyor build number
+* Decrypt files to be used for signing builds and deployment using secure environment variables
+* Update git submodules
+
+### `build_script`
+
+Performs a build of NVDA and related artifacts for testing and deployment.
+
+* Set the scons variables
+* Call scons to build from source
+* Build the symbol store and package it to an artifact with 7zip
+
+## Testing
+
+Unlike the rest of the build, tests do not exit early if they fail or raise an error. If any test fails, `testFailExitCode` is set to 1. The `after_test` build phase will exit the build if any tests fail so that all test failures can be recorded where possible. 
+
+Before testing we:
+
+* Create directories for test output
+* Set `testFailExitCode` to 0
+* Install NVDA for system tests
+
+The tests we perform are:
+
+* check translation comments
+* unit tests
+* lint check
+* system tests
+
+## Artifacts
+
+Artifacts are added to the build throughout the process. 
+
+Artifacts in `output\*` and `output\*\*` are automatically packaged after successful tests. If something fails before then, we manually push these artifacts in `on_failure`. Artifacts outside of `output` are pushed manually as they are created. 
+
+At the end of the build, regardless of failure, we upload the list of successfully installed python packages in `pushPackagingInfo.ps1`. This is performed here in case scons (partially) fails.
+
+## Deploying
+
+The server side deploy code (`nvdaAppveyorHook`) is triggered from `deployScript.ps1`. The server-side deployment relies on our artifacts, so they must be uploaded first.

--- a/appveyor/scripts/buildSymbolStore.ps1
+++ b/appveyor/scripts/buildSymbolStore.ps1
@@ -1,10 +1,11 @@
-     foreach ($syms in
-      # We don't just include source\*.dll because that would include system dlls.
-      "source\liblouis.dll", "source\*.pdb",
-      "source\lib\*.dll", "source\lib\*.pdb",
-      # We include source\lib64\*.exe to cover nvdaHelperRemoteLoader.
-      "source\lib64\*.dll", "source\lib64\*.exe", "source\lib64\*.pdb",
-      "source\synthDrivers\*.dll", "source\synthDrivers\*.pdb"
-     ) {
-      & $env:symstore add /s symbols /compress -:NOREFS /t NVDA /f $syms
-     }
+$ErrorActionPreference = "Stop";
+foreach ($syms in
+	# We don't just include source\*.dll because that would include system dlls.
+	"source\liblouis.dll", "source\*.pdb",
+	"source\lib\*.dll", "source\lib\*.pdb",
+	# We include source\lib64\*.exe to cover nvdaHelperRemoteLoader.
+	"source\lib64\*.dll", "source\lib64\*.exe", "source\lib64\*.pdb",
+	"source\synthDrivers\*.dll", "source\synthDrivers\*.pdb"
+) {
+	& $env:symstore add /s symbols /compress -:NOREFS /t NVDA /f $syms
+}

--- a/appveyor/scripts/buildSymbolStore.ps1
+++ b/appveyor/scripts/buildSymbolStore.ps1
@@ -1,0 +1,10 @@
+     foreach ($syms in
+      # We don't just include source\*.dll because that would include system dlls.
+      "source\liblouis.dll", "source\*.pdb",
+      "source\lib\*.dll", "source\lib\*.pdb",
+      # We include source\lib64\*.exe to cover nvdaHelperRemoteLoader.
+      "source\lib64\*.dll", "source\lib64\*.exe", "source\lib64\*.pdb",
+      "source\synthDrivers\*.dll", "source\synthDrivers\*.pdb"
+     ) {
+      & $env:symstore add /s symbols /compress -:NOREFS /t NVDA /f $syms
+     }

--- a/appveyor/scripts/decryptFilesForSigning.ps1
+++ b/appveyor/scripts/decryptFilesForSigning.ps1
@@ -1,15 +1,17 @@
-    if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
-     openssl enc -d -md sha256 -aes-256-cbc -pbkdf2 -salt -pass pass:$env:secure_authenticode_pass -in authenticode.pfx.enc -out authenticode.pfx
-     if($LastExitCode -ne 0) {
-      $errorCode=$LastExitCode
-      Add-AppveyorMessage "Unable to decrypt authenticode certificate"
-     }
-     openssl enc -md md5 -aes-256-cbc -d -pass pass:$env:secure_ssh_pass -in ssh_id_rsa.enc -out ssh_id_rsa
-     if($LastExitCode -ne 0) {
-      $errorCode=$LastExitCode
-      Add-AppveyorMessage "Unable to decrypt ssh key"
-     }
-     # Install ssh stuff.
-     copy ssh_id_rsa $env:userprofile\.ssh\id_rsa
-     if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
-    }
+$ErrorActionPreference = "Stop";
+if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+	openssl enc -d -md sha256 -aes-256-cbc -pbkdf2 -salt -pass pass:$env:secure_authenticode_pass -in appveyor\authenticode.pfx.enc -out appveyor\authenticode.pfx
+	if($LastExitCode -ne 0) {
+		$errorCode=$LastExitCode
+		Add-AppveyorMessage "Unable to decrypt authenticode certificate"
+	}
+	openssl enc -md md5 -aes-256-cbc -d -pass pass:$env:secure_ssh_pass -in appveyor\ssh_id_rsa.enc -out appveyor\ssh_id_rsa
+	if($LastExitCode -ne 0) {
+		$errorCode=$LastExitCode
+		Add-AppveyorMessage "Unable to decrypt ssh key"
+	}
+	# Install ssh stuff.
+	copy ssh_id_rsa $env:userprofile\.ssh\id_rsa
+	if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
+}
+Get-Content appveyor\ssh_known_hosts >> $env:userprofile\.ssh\known_hosts

--- a/appveyor/scripts/decryptFilesForSigning.ps1
+++ b/appveyor/scripts/decryptFilesForSigning.ps1
@@ -1,0 +1,15 @@
+    if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+     openssl enc -d -md sha256 -aes-256-cbc -pbkdf2 -salt -pass pass:$env:secure_authenticode_pass -in authenticode.pfx.enc -out authenticode.pfx
+     if($LastExitCode -ne 0) {
+      $errorCode=$LastExitCode
+      Add-AppveyorMessage "Unable to decrypt authenticode certificate"
+     }
+     openssl enc -md md5 -aes-256-cbc -d -pass pass:$env:secure_ssh_pass -in ssh_id_rsa.enc -out ssh_id_rsa
+     if($LastExitCode -ne 0) {
+      $errorCode=$LastExitCode
+      Add-AppveyorMessage "Unable to decrypt ssh key"
+     }
+     # Install ssh stuff.
+     copy ssh_id_rsa $env:userprofile\.ssh\id_rsa
+     if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
+    }

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -1,0 +1,36 @@
+     if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
+      # Not a try build.
+      # Notify our server.
+      $exe = Get-ChildItem -Name output\*.exe
+      $hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
+      $apiVersion = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))")
+      echo apiversion: $apiVersion
+      $apiCompatTo = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))")
+      echo apiBackCompatTo: $apiCompatTo
+      $data = @{
+       jobId=$env:APPVEYOR_JOB_ID;
+       commit=$env:APPVEYOR_REPO_COMMIT;
+       version=$env:version; versionType=$env:versionType;
+       apiVersion=$apiVersion; apiCompatTo=$apiCompatTo;
+       avVersion=$env:APPVEYOR_BUILD_VERSION;
+       branch=$env:APPVEYOR_REPO_BRANCH;
+       exe=$exe; hash=$hash;
+       artifacts=$artifacts
+      }
+      ConvertTo-Json -InputObject $data -Compress | Out-File -FilePath deploy.json
+      Push-AppveyorArtifact deploy.json
+      # Execute the deploy script on the NV Access server via ssh.
+      # Warning: if the server address is changed, 
+      # The new address must be also included in appveyor\ssh_known_hosts in this repo
+      # Otherwise ssh will freeze on input!
+      cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
+
+      # Upload symbols to Mozilla.
+      py -m pip install --no-warn-script-location requests
+      py appveyor\mozillaSyms.py
+      if($LastExitCode -ne 0) {
+        $errorCode=$LastExitCode
+        echo "Unable to upload symbols to Mozilla"
+        Add-AppveyorMessage "Unable to upload symbols to Mozilla"
+      }
+     }

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -1,36 +1,37 @@
-     if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
-      # Not a try build.
-      # Notify our server.
-      $exe = Get-ChildItem -Name output\*.exe
-      $hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
-      $apiVersion = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))")
-      echo apiversion: $apiVersion
-      $apiCompatTo = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))")
-      echo apiBackCompatTo: $apiCompatTo
-      $data = @{
-       jobId=$env:APPVEYOR_JOB_ID;
-       commit=$env:APPVEYOR_REPO_COMMIT;
-       version=$env:version; versionType=$env:versionType;
-       apiVersion=$apiVersion; apiCompatTo=$apiCompatTo;
-       avVersion=$env:APPVEYOR_BUILD_VERSION;
-       branch=$env:APPVEYOR_REPO_BRANCH;
-       exe=$exe; hash=$hash;
-       artifacts=$artifacts
-      }
-      ConvertTo-Json -InputObject $data -Compress | Out-File -FilePath deploy.json
-      Push-AppveyorArtifact deploy.json
-      # Execute the deploy script on the NV Access server via ssh.
-      # Warning: if the server address is changed, 
-      # The new address must be also included in appveyor\ssh_known_hosts in this repo
-      # Otherwise ssh will freeze on input!
-      cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
+$ErrorActionPreference = "Stop";
+if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
+	# Not a try build.
+	# Notify our server.
+	$exe = Get-ChildItem -Name output\*.exe
+	$hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
+	$apiVersion = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))")
+	echo apiversion: $apiVersion
+	$apiCompatTo = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))")
+	echo apiBackCompatTo: $apiCompatTo
+	$data = @{
+		jobId=$env:APPVEYOR_JOB_ID;
+		commit=$env:APPVEYOR_REPO_COMMIT;
+		version=$env:version; versionType=$env:versionType;
+		apiVersion=$apiVersion; apiCompatTo=$apiCompatTo;
+		avVersion=$env:APPVEYOR_BUILD_VERSION;
+		branch=$env:APPVEYOR_REPO_BRANCH;
+		exe=$exe; hash=$hash;
+		artifacts=$artifacts
+	}
+	ConvertTo-Json -InputObject $data -Compress | Out-File -FilePath deploy.json
+	Push-AppveyorArtifact deploy.json
+	# Execute the deploy script on the NV Access server via ssh.
+	# Warning: if the server address is changed, 
+	# The new address must be also included in appveyor\ssh_known_hosts in this repo
+	# Otherwise ssh will freeze on input!
+	cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
 
-      # Upload symbols to Mozilla.
-      py -m pip install --no-warn-script-location requests
-      py appveyor\mozillaSyms.py
-      if($LastExitCode -ne 0) {
-        $errorCode=$LastExitCode
-        echo "Unable to upload symbols to Mozilla"
-        Add-AppveyorMessage "Unable to upload symbols to Mozilla"
-      }
-     }
+	# Upload symbols to Mozilla.
+	py -m pip install --no-warn-script-location requests
+	py appveyor\mozillaSyms.py
+	if($LastExitCode -ne 0) {
+		$errorCode=$LastExitCode
+		echo "Unable to upload symbols to Mozilla"
+		Add-AppveyorMessage "Unable to upload symbols to Mozilla"
+	}
+}

--- a/appveyor/scripts/installNVDA.ps1
+++ b/appveyor/scripts/installNVDA.ps1
@@ -1,0 +1,27 @@
+     $errorCode=0
+     $nvdaLauncherFile=".\output\nvda"
+     if(!$env:release) {
+      $nvdaLauncherFile+="_snapshot"
+     }
+     $nvdaLauncherFile+="_${env:version}.exe"
+     Set-AppveyorBuildVariable "nvdaLauncherFile" $nvdaLauncherFile
+     echo NVDALauncherFile: $NVDALauncherFile
+     $outputDir=$(resolve-path .\testOutput)
+     $installerLogFilePath="$outputDir\nvda_install.log"
+     $installerProcess=start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
+     try {
+      $installerProcess | wait-process -Timeout 180
+      $errorCode=$installerProcess.ExitCode
+     } catch {
+      echo "NVDA installer process timed out"
+      $errorCode=1
+      Add-AppveyorMessage "Unable to install NVDA prior to tests."
+     }
+     Push-AppveyorArtifact $installerLogFilePath
+     $crashDump = "$outputDir\nvda_crash.dmp"
+     if (Test-Path -Path $crashDump){
+      Push-AppveyorArtifact $crashDump -FileName "nvda_install_crash.dmp"
+      Add-AppveyorMessage "Install process crashed"
+      $errorCode=1
+     }
+     if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }

--- a/appveyor/scripts/installNVDA.ps1
+++ b/appveyor/scripts/installNVDA.ps1
@@ -1,27 +1,28 @@
-     $errorCode=0
-     $nvdaLauncherFile=".\output\nvda"
-     if(!$env:release) {
-      $nvdaLauncherFile+="_snapshot"
-     }
-     $nvdaLauncherFile+="_${env:version}.exe"
-     Set-AppveyorBuildVariable "nvdaLauncherFile" $nvdaLauncherFile
-     echo NVDALauncherFile: $NVDALauncherFile
-     $outputDir=$(resolve-path .\testOutput)
-     $installerLogFilePath="$outputDir\nvda_install.log"
-     $installerProcess=start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
-     try {
-      $installerProcess | wait-process -Timeout 180
-      $errorCode=$installerProcess.ExitCode
-     } catch {
-      echo "NVDA installer process timed out"
-      $errorCode=1
-      Add-AppveyorMessage "Unable to install NVDA prior to tests."
-     }
-     Push-AppveyorArtifact $installerLogFilePath
-     $crashDump = "$outputDir\nvda_crash.dmp"
-     if (Test-Path -Path $crashDump){
-      Push-AppveyorArtifact $crashDump -FileName "nvda_install_crash.dmp"
-      Add-AppveyorMessage "Install process crashed"
-      $errorCode=1
-     }
-     if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
+$ErrorActionPreference = "Stop";
+$errorCode=0
+$nvdaLauncherFile=".\output\nvda"
+if(!$env:release) {
+	$nvdaLauncherFile+="_snapshot"
+}
+$nvdaLauncherFile+="_${env:version}.exe"
+Set-AppveyorBuildVariable "nvdaLauncherFile" $nvdaLauncherFile
+echo NVDALauncherFile: $NVDALauncherFile
+$outputDir=$(resolve-path .\testOutput)
+$installerLogFilePath="$outputDir\nvda_install.log"
+$installerProcess=start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
+try {
+	$installerProcess | wait-process -Timeout 180
+	$errorCode=$installerProcess.ExitCode
+} catch {
+	echo "NVDA installer process timed out"
+	$errorCode=1
+	Add-AppveyorMessage "Unable to install NVDA prior to tests."
+}
+Push-AppveyorArtifact $installerLogFilePath
+$crashDump = "$outputDir\nvda_crash.dmp"
+if (Test-Path -Path $crashDump){
+	Push-AppveyorArtifact $crashDump -FileName "nvda_install_crash.dmp"
+	Add-AppveyorMessage "Install process crashed"
+	$errorCode=1
+}
+if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }

--- a/appveyor/scripts/pushPackagingInfo.ps1
+++ b/appveyor/scripts/pushPackagingInfo.ps1
@@ -1,9 +1,10 @@
-      # Save an exact list of the actual Python packages and their versions that got installed, to aide in reproducing a build
-      .\venvUtils\exportPackageList.bat installed_python_packages.txt
-      Push-AppveyorArtifact installed_python_packages.txt
-      $appVeyorUrl = "https://ci.appveyor.com"
-      $exe = Get-ChildItem -Name output\*.exe
-      if($?){
-        $exeUrl="$appVeyorUrl/api/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/output/$exe"
-        Add-AppveyorMessage "[Build (for testing PR)]($exeUrl)"
-      }
+$ErrorActionPreference = "Stop";
+# Save an exact list of the actual Python packages and their versions that got installed, to aide in reproducing a build
+.\venvUtils\exportPackageList.bat installed_python_packages.txt
+Push-AppveyorArtifact installed_python_packages.txt
+$appVeyorUrl = "https://ci.appveyor.com"
+$exe = Get-ChildItem -Name output\*.exe
+if($?){
+	$exeUrl="$appVeyorUrl/api/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/output/$exe"
+	Add-AppveyorMessage "Build (for testing PR): $exeUrl"
+}

--- a/appveyor/scripts/pushPackagingInfo.ps1
+++ b/appveyor/scripts/pushPackagingInfo.ps1
@@ -1,0 +1,9 @@
+      # Save an exact list of the actual Python packages and their versions that got installed, to aide in reproducing a build
+      .\venvUtils\exportPackageList.bat installed_python_packages.txt
+      Push-AppveyorArtifact installed_python_packages.txt
+      $appVeyorUrl = "https://ci.appveyor.com"
+      $exe = Get-ChildItem -Name output\*.exe
+      if($?){
+        $exeUrl="$appVeyorUrl/api/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/output/$exe"
+        Add-AppveyorMessage "[Build (for testing PR)]($exeUrl)"
+      }

--- a/appveyor/scripts/setBuildVersionVars.ps1
+++ b/appveyor/scripts/setBuildVersionVars.ps1
@@ -1,36 +1,37 @@
-     # iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-     $pythonVersion = (py --version)
-     echo $pythonVersion
-     if ($env:APPVEYOR_REPO_TAG_NAME -and $env:APPVEYOR_REPO_TAG_NAME.StartsWith("release-")) {
-      # Strip "release-" prefix.
-      $version = $env:APPVEYOR_REPO_TAG_NAME.Substring(8)
-      Set-AppveyorBuildVariable "release" "1"
-      if ($env:APPVEYOR_REPO_TAG_NAME.Contains("rc") -or $env:APPVEYOR_REPO_TAG_NAME.Contains("beta")) {
-       $versionType = "beta"
-      } else {
-       $versionType = "stable"
-      }
-     } else {
-      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-       $version = "pr$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
-      } elseif($env:APPVEYOR_REPO_BRANCH -eq "master") {
-       $version = "alpha-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
-      } else {
-       $version = "$env:APPVEYOR_REPO_BRANCH-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
-       if($env:APPVEYOR_REPO_BRANCH.StartsWith("try-release-")) {
-        Set-AppveyorBuildVariable "release" "1"
-       }
-      }
-      # The version is unique even for rebuilds, so we can use it for the AppVeyor version.
-      Update-AppveyorBuild -Version $version
-      if($env:APPVEYOR_REPO_BRANCH -eq "master") {
-       $versionType = "snapshot:alpha"
-      } elseif (!$env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
-       $versionType = "snapshot:$env:APPVEYOR_REPO_BRANCH"
-      }
-     }
-     Set-AppveyorBuildVariable "version" $version
-     if ($versionType) {
-      Set-AppveyorBuildVariable "versionType" $versionType
-     }
-     Set-AppveyorBuildVariable "testFailExitCode" 0
+$ErrorActionPreference = "Stop";
+# iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+$pythonVersion = (py --version)
+echo $pythonVersion
+if ($env:APPVEYOR_REPO_TAG_NAME -and $env:APPVEYOR_REPO_TAG_NAME.StartsWith("release-")) {
+	# Strip "release-" prefix.
+	$version = $env:APPVEYOR_REPO_TAG_NAME.Substring(8)
+	Set-AppveyorBuildVariable "release" "1"
+	if ($env:APPVEYOR_REPO_TAG_NAME.Contains("rc") -or $env:APPVEYOR_REPO_TAG_NAME.Contains("beta")) {
+		$versionType = "beta"
+	} else {
+		$versionType = "stable"
+	}
+} else {
+	$commitVersion = $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
+	if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+		$version = "pr$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER," + $commitVersion
+	} elseif($env:APPVEYOR_REPO_BRANCH -eq "master") {
+		$version = "alpha-$env:APPVEYOR_BUILD_NUMBER," + $commitVersion
+	} else {
+		$version = "$env:APPVEYOR_REPO_BRANCH-$env:APPVEYOR_BUILD_NUMBER," + $commitVersion
+		if($env:APPVEYOR_REPO_BRANCH.StartsWith("try-release-")) {
+			Set-AppveyorBuildVariable "release" "1"
+		}
+	}
+	# The version is unique even for rebuilds, so we can use it for the AppVeyor version.
+	Update-AppveyorBuild -Version $version
+	if($env:APPVEYOR_REPO_BRANCH -eq "master") {
+		$versionType = "snapshot:alpha"
+	} elseif (!$env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
+		$versionType = "snapshot:$env:APPVEYOR_REPO_BRANCH"
+	}
+}
+Set-AppveyorBuildVariable "version" $version
+if ($versionType) {
+	Set-AppveyorBuildVariable "versionType" $versionType
+}

--- a/appveyor/scripts/setBuildVersionVars.ps1
+++ b/appveyor/scripts/setBuildVersionVars.ps1
@@ -1,0 +1,36 @@
+     # iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+     $pythonVersion = (py --version)
+     echo $pythonVersion
+     if ($env:APPVEYOR_REPO_TAG_NAME -and $env:APPVEYOR_REPO_TAG_NAME.StartsWith("release-")) {
+      # Strip "release-" prefix.
+      $version = $env:APPVEYOR_REPO_TAG_NAME.Substring(8)
+      Set-AppveyorBuildVariable "release" "1"
+      if ($env:APPVEYOR_REPO_TAG_NAME.Contains("rc") -or $env:APPVEYOR_REPO_TAG_NAME.Contains("beta")) {
+       $versionType = "beta"
+      } else {
+       $versionType = "stable"
+      }
+     } else {
+      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+       $version = "pr$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
+      } elseif($env:APPVEYOR_REPO_BRANCH -eq "master") {
+       $version = "alpha-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
+      } else {
+       $version = "$env:APPVEYOR_REPO_BRANCH-$env:APPVEYOR_BUILD_NUMBER," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
+       if($env:APPVEYOR_REPO_BRANCH.StartsWith("try-release-")) {
+        Set-AppveyorBuildVariable "release" "1"
+       }
+      }
+      # The version is unique even for rebuilds, so we can use it for the AppVeyor version.
+      Update-AppveyorBuild -Version $version
+      if($env:APPVEYOR_REPO_BRANCH -eq "master") {
+       $versionType = "snapshot:alpha"
+      } elseif (!$env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
+       $versionType = "snapshot:$env:APPVEYOR_REPO_BRANCH"
+      }
+     }
+     Set-AppveyorBuildVariable "version" $version
+     if ($versionType) {
+      Set-AppveyorBuildVariable "versionType" $versionType
+     }
+     Set-AppveyorBuildVariable "testFailExitCode" 0

--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -1,0 +1,20 @@
+     $sconsOutTargets = "launcher developerGuide  changes userGuide client"
+     if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      $sconsOutTargets += " appx"
+     }
+     $sconsArgs = "version=$env:version"
+     if ($env:release) {
+      $sconsArgs += " release=1"
+     }
+     if ($env:versionType) {
+      $sconsArgs += " updateVersionType=$env:versionType"
+     }
+     $sconsArgs += ' publisher="NV Access"'
+     if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      $sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
+     }
+     $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
+     # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
+     # It's possible to work around this, but the workarounds have annoying side effects.
+     Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets
+     Set-AppveyorBuildVariable "sconsArgs" $sconsArgs

--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -1,20 +1,23 @@
-     $sconsOutTargets = "launcher developerGuide  changes userGuide client"
-     if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $sconsOutTargets += " appx"
-     }
-     $sconsArgs = "version=$env:version"
-     if ($env:release) {
-      $sconsArgs += " release=1"
-     }
-     if ($env:versionType) {
-      $sconsArgs += " updateVersionType=$env:versionType"
-     }
-     $sconsArgs += ' publisher="NV Access"'
-     if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
-     }
-     $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
-     # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
-     # It's possible to work around this, but the workarounds have annoying side effects.
-     Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets
-     Set-AppveyorBuildVariable "sconsArgs" $sconsArgs
+$ErrorActionPreference = "Stop";
+$sconsOutTargets = "launcher developerGuide  changes userGuide client"
+if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+	$sconsOutTargets += " appx"
+}
+$sconsArgs = "version=$env:version"
+if ($env:release) {
+	$sconsArgs += " release=1"
+}
+if ($env:versionType) {
+	$sconsArgs += " updateVersionType=$env:versionType"
+}
+$sconsArgs += ' publisher="NV Access"'
+if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+	$sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
+}
+$sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
+# We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
+# It's possible to work around this, but the workarounds have annoying side effects.
+Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets
+Set-AppveyorBuildVariable "sconsArgs" $sconsArgs
+Write-Host "scons args: $sconsArgs"
+Write-Host "scons output targets: $sconsOutTargets"

--- a/appveyor/scripts/tests/beforeTests.ps1
+++ b/appveyor/scripts/tests/beforeTests.ps1
@@ -1,0 +1,5 @@
+New-Item -ItemType directory -Path testOutput
+New-Item -ItemType directory -Path testOutput\unit
+New-Item -ItemType directory -Path testOutput\system
+New-Item -ItemType directory -Path testOutput\lint
+Set-AppveyorBuildVariable "testFailExitCode" 0

--- a/appveyor/scripts/tests/checkTestFailure.ps1
+++ b/appveyor/scripts/tests/checkTestFailure.ps1
@@ -1,1 +1,2 @@
-     if($env:testFailExitCode -ne 0) { $host.SetShouldExit($env:testFailExitCode) }
+$ErrorActionPreference = "Stop";
+if($env:testFailExitCode -ne 0) { $host.SetShouldExit($env:testFailExitCode) }

--- a/appveyor/scripts/tests/checkTestFailure.ps1
+++ b/appveyor/scripts/tests/checkTestFailure.ps1
@@ -1,0 +1,1 @@
+     if($env:testFailExitCode -ne 0) { $host.SetShouldExit($env:testFailExitCode) }

--- a/appveyor/scripts/tests/lintCheck.ps1
+++ b/appveyor/scripts/tests/lintCheck.ps1
@@ -1,0 +1,32 @@
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
+      $lintOutput = (Resolve-Path .\testOutput\lint\)
+      $lintSource = (Resolve-Path .\tests\lint\)
+      $flake8Output = "$lintOutput\Flake8.txt"
+      # When Appveyor runs for a pr,
+      # the build is made from a new temporary commit,
+      # resulting from the pr branch being merged into its base branch.
+      # Therefore to create a diff for linting, we must fetch the head of the base branch.
+      # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
+      # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
+      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+        git fetch -q origin $env:APPVEYOR_REPO_BRANCH
+        $msgBaseLabel = "PR"
+      } else {
+        # However in a pushed branch, we must fetch master.
+        git fetch -q origin master:master
+        $msgBaseLabel = "Branch"
+      }
+      .\runlint.bat FETCH_HEAD "$flake8Output" 
+      if($LastExitCode -ne 0) {
+        Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+        Add-AppveyorMessage "FAIL: Lint check. See test results for more information."
+      } else {
+        Add-AppveyorMessage "PASS: Lint check."
+      }
+      Push-AppveyorArtifact $flake8Output
+      $junitXML = "$lintOutput\PR-Flake8.xml"
+      py "$lintSource\createJunitReport.py" "$flake8Output" "$junitXML"
+      Push-AppveyorArtifact $junitXML
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
+    }

--- a/appveyor/scripts/tests/lintCheck.ps1
+++ b/appveyor/scripts/tests/lintCheck.ps1
@@ -1,32 +1,32 @@
-    if ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
-      $lintOutput = (Resolve-Path .\testOutput\lint\)
-      $lintSource = (Resolve-Path .\tests\lint\)
-      $flake8Output = "$lintOutput\Flake8.txt"
-      # When Appveyor runs for a pr,
-      # the build is made from a new temporary commit,
-      # resulting from the pr branch being merged into its base branch.
-      # Therefore to create a diff for linting, we must fetch the head of the base branch.
-      # In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
-      # Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
-      if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-        git fetch -q origin $env:APPVEYOR_REPO_BRANCH
-        $msgBaseLabel = "PR"
-      } else {
-        # However in a pushed branch, we must fetch master.
-        git fetch -q origin master:master
-        $msgBaseLabel = "Branch"
-      }
-      .\runlint.bat FETCH_HEAD "$flake8Output" 
-      if($LastExitCode -ne 0) {
-        Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-        Add-AppveyorMessage "FAIL: Lint check. See test results for more information."
-      } else {
-        Add-AppveyorMessage "PASS: Lint check."
-      }
-      Push-AppveyorArtifact $flake8Output
-      $junitXML = "$lintOutput\PR-Flake8.xml"
-      py "$lintSource\createJunitReport.py" "$flake8Output" "$junitXML"
-      Push-AppveyorArtifact $junitXML
-      $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
-    }
+if ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH.StartsWith("try-")) {
+	$lintOutput = (Resolve-Path .\testOutput\lint\)
+	$lintSource = (Resolve-Path .\tests\lint\)
+	$flake8Output = "$lintOutput\Flake8.txt"
+	# When Appveyor runs for a pr,
+	# the build is made from a new temporary commit,
+	# resulting from the pr branch being merged into its base branch.
+	# Therefore to create a diff for linting, we must fetch the head of the base branch.
+	# In a PR, APPVEYOR_REPO_BRANCH points to the head of the base branch. 
+	# Additionally, we can not use a clone_depth of 1, but must use an unlimited clone.
+	if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+		git fetch -q origin $env:APPVEYOR_REPO_BRANCH
+		$msgBaseLabel = "PR"
+	} else {
+		# However in a pushed branch, we must fetch master.
+		git fetch -q origin master:master
+		$msgBaseLabel = "Branch"
+	}
+	.\runlint.bat FETCH_HEAD "$flake8Output" 
+	if($LastExitCode -ne 0) {
+		Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+		Add-AppveyorMessage "FAIL: Lint check. See test results for more information."
+	} else {
+		Add-AppveyorMessage "PASS: Lint check."
+	}
+	Push-AppveyorArtifact $flake8Output
+	$junitXML = "$lintOutput\PR-Flake8.xml"
+	py "$lintSource\createJunitReport.py" "$flake8Output" "$junitXML"
+	Push-AppveyorArtifact $junitXML
+	$wc = New-Object 'System.Net.WebClient'
+	$wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $junitXML)
+}

--- a/appveyor/scripts/tests/systemTests.ps1
+++ b/appveyor/scripts/tests/systemTests.ps1
@@ -1,0 +1,13 @@
+     $testOutput = (Resolve-Path .\testOutput\)
+     $systemTestOutput = (Resolve-Path "$testOutput\system")
+     .\runsystemtests.bat --variable whichNVDA:installed --variable installDir:"${env:nvdaLauncherFile}" --include installer
+     if($LastExitCode -ne 0) {
+      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+      Add-AppveyorMessage "FAIL: System tests. See test results for more information."
+     } else {
+      Add-AppveyorMessage "PASS: System tests."
+     }
+     Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
+     Push-AppveyorArtifact "$testOutput\systemTestResult.zip"
+     $wc = New-Object 'System.Net.WebClient'
+     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$systemTestOutput\systemTests.xml"))

--- a/appveyor/scripts/tests/systemTests.ps1
+++ b/appveyor/scripts/tests/systemTests.ps1
@@ -1,13 +1,13 @@
-     $testOutput = (Resolve-Path .\testOutput\)
-     $systemTestOutput = (Resolve-Path "$testOutput\system")
-     .\runsystemtests.bat --variable whichNVDA:installed --variable installDir:"${env:nvdaLauncherFile}" --include installer
-     if($LastExitCode -ne 0) {
-      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-      Add-AppveyorMessage "FAIL: System tests. See test results for more information."
-     } else {
-      Add-AppveyorMessage "PASS: System tests."
-     }
-     Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
-     Push-AppveyorArtifact "$testOutput\systemTestResult.zip"
-     $wc = New-Object 'System.Net.WebClient'
-     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$systemTestOutput\systemTests.xml"))
+$testOutput = (Resolve-Path .\testOutput\)
+$systemTestOutput = (Resolve-Path "$testOutput\system")
+.\runsystemtests.bat --variable whichNVDA:installed --variable installDir:"${env:nvdaLauncherFile}" --include installer
+if($LastExitCode -ne 0) {
+	Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+	Add-AppveyorMessage "FAIL: System tests. See test results for more information."
+} else {
+	Add-AppveyorMessage "PASS: System tests."
+}
+Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
+Push-AppveyorArtifact "$testOutput\systemTestResult.zip"
+$wc = New-Object 'System.Net.WebClient'
+$wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$systemTestOutput\systemTests.xml"))

--- a/appveyor/scripts/tests/translationCheck.ps1
+++ b/appveyor/scripts/tests/translationCheck.ps1
@@ -1,0 +1,7 @@
+     cmd.exe /c "scons checkPot $sconsArgs"
+     if($LastExitCode -ne 0) {
+      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+      Add-AppveyorMessage "FAIL: Translation comments check. Translation comments missing or unexpectedly included. See build log for more information."
+     } else {
+      Add-AppveyorMessage "PASS: Translation comments check."
+     }

--- a/appveyor/scripts/tests/translationCheck.ps1
+++ b/appveyor/scripts/tests/translationCheck.ps1
@@ -1,7 +1,7 @@
-     cmd.exe /c "scons checkPot $sconsArgs"
-     if($LastExitCode -ne 0) {
-      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-      Add-AppveyorMessage "FAIL: Translation comments check. Translation comments missing or unexpectedly included. See build log for more information."
-     } else {
-      Add-AppveyorMessage "PASS: Translation comments check."
-     }
+cmd.exe /c "scons checkPot $sconsArgs"
+if($LastExitCode -ne 0) {
+	Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+	Add-AppveyorMessage "FAIL: Translation comments check. Translation comments missing or unexpectedly included. See build log for more information."
+} else {
+	Add-AppveyorMessage "PASS: Translation comments check."
+}

--- a/appveyor/scripts/tests/unitTests.ps1
+++ b/appveyor/scripts/tests/unitTests.ps1
@@ -1,12 +1,12 @@
-     $outDir = (Resolve-Path .\testOutput\unit\)
-     $unitTestsXml = "$outDir\unitTests.xml"
-     .\rununittests.bat --with-xunit --xunit-file="$unitTestsXml"
-     if($LastExitCode -ne 0) {
-      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-      Add-AppveyorMessage "FAIL: Unit tests. See test results for more information."
-     } else {
-      Add-AppveyorMessage "PASS: Unit tests."
-     }
-     Push-AppveyorArtifact $unitTestsXml
-     $wc = New-Object 'System.Net.WebClient'
-     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $unitTestsXml)
+$outDir = (Resolve-Path .\testOutput\unit\)
+$unitTestsXml = "$outDir\unitTests.xml"
+.\rununittests.bat --with-xunit --xunit-file="$unitTestsXml"
+if($LastExitCode -ne 0) {
+	Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+	Add-AppveyorMessage "FAIL: Unit tests. See test results for more information."
+} else {
+	Add-AppveyorMessage "PASS: Unit tests."
+}
+Push-AppveyorArtifact $unitTestsXml
+$wc = New-Object 'System.Net.WebClient'
+$wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $unitTestsXml)

--- a/appveyor/scripts/tests/unitTests.ps1
+++ b/appveyor/scripts/tests/unitTests.ps1
@@ -1,0 +1,12 @@
+     $outDir = (Resolve-Path .\testOutput\unit\)
+     $unitTestsXml = "$outDir\unitTests.xml"
+     .\rununittests.bat --with-xunit --xunit-file="$unitTestsXml"
+     if($LastExitCode -ne 0) {
+      Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
+      Add-AppveyorMessage "FAIL: Unit tests. See test results for more information."
+     } else {
+      Add-AppveyorMessage "PASS: Unit tests."
+     }
+     Push-AppveyorArtifact $unitTestsXml
+     $wc = New-Object 'System.Net.WebClient'
+     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $unitTestsXml)

--- a/appveyor/scripts/uploadArtifacts.ps1
+++ b/appveyor/scripts/uploadArtifacts.ps1
@@ -1,0 +1,10 @@
+    # Upload artifacts, preserving directory structure.
+    $uploadFromFolder = "output\"
+    if( Test-Path $uploadFromFolder ){
+      $root = Resolve-Path .\
+      $output = Resolve-Path $uploadFromFolder
+      $paths = [IO.Directory]::GetFiles($output.Path, '*.*', 'AllDirectories')
+      $paths | % {
+        Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)
+      }
+    }

--- a/appveyor/scripts/uploadArtifacts.ps1
+++ b/appveyor/scripts/uploadArtifacts.ps1
@@ -1,10 +1,11 @@
-    # Upload artifacts, preserving directory structure.
-    $uploadFromFolder = "output\"
-    if( Test-Path $uploadFromFolder ){
-      $root = Resolve-Path .\
-      $output = Resolve-Path $uploadFromFolder
-      $paths = [IO.Directory]::GetFiles($output.Path, '*.*', 'AllDirectories')
-      $paths | % {
-        Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)
-      }
-    }
+$ErrorActionPreference = "Stop";
+# Upload artifacts, preserving directory structure.
+$uploadFromFolder = "output\"
+if( Test-Path $uploadFromFolder ){
+	$root = Resolve-Path .\
+	$output = Resolve-Path $uploadFromFolder
+	$paths = [IO.Directory]::GetFiles($output.Path, '*.*', 'AllDirectories')
+	$paths | % {
+		Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1)
+	}
+}


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

If a developer wishes to use multiple appveyor.yml files, there would be a lot of code duplication. In order to make changes to the AppVeyor build process(es), inline powershell scripts must be edited. Inline powershell scripts are harder to lint and parse than individual files within IDEs. 

### Description of how this pull request fixes the issue:

Simplifies the `appveyor.yml` file by putting the powershell scripts into separate files. 

Note to reviewers: I would recommend reading through these changes, and then compare them to the individual commits and README. The git bash script is a tool you can use to review the final changes or specific commits. I've noted some proposed changes of behaviour, but otherwise original behaviour is intended.

Changes: 
- Moved comments to `appveyor\README.md` and created an outline of AppVeyor proccess in the `appveyor\README.md`
- Move inline ps into script files
  - adds `$ErrorActionPreference = "Stop";` to the start of each except our test scripts which are allowed to fail
  - confirm with the following (git) bash script, run from the project root. This generates diff files optimised for review between masters appveyor.yml and our powershell scripts on `HEAD`. To see the diff at a specific commit, check it out, as the files specified by `ls` must be checked out locally.
  ```sh
  # the git diff argument -W ensures whole functions are preserved in the diff, to aid reviewing and give context
  # the git diff arguments -wb ignore all trailing and leading whitespace changes. this is ignored due to
  # indentation changes.
  #
  # perl (as it supports advanced regex - PCRE) replaces our large blocks of removed code with a snippet
  # the perl preserves the first, second, second last, and last lines of blocks of removed code longer than
  # 4 lines. This makes it easier to diff between the relevant functions and preserves context (such as the
  # appveyor.yml build phase we are in).
  export subLine='\n-[^\n]*';  # subtracted line regex
  export perlSed="s/($subLine)($subLine)(?:$subLine)+($subLine)($subLine)/\1\2\n-...\3\4/g";
  for file in $(ls appveyor/scripts/*.ps1 appveyor/scripts/tests/*.ps1)
  do
  git diff -Wwb master:appveyor.yml HEAD:$file | perl -0777 -pe $perlSed > $file-appveyor.yml-hide-removed.diff
  done
  ```
- as the repo isn't cloned until after the `init` phase, `setBuildVersionVars.ps1` was moved until after that, into the `install` build phase
  - this means we don't update the appveyor build number until after a successful clone
- moved the translation comments check to the `test_script` build phase
- moved some inline cmd to ps and cleaned up appveyor.yml
- removed unnecessary exit commands
  - as any exit code above 0 (eg terminating error) will cause AppVeyor to exit and the build to fail - [Proof: see this failed build](https://github.com/nvaccess/nvda/commit/72cdb74adf3324ed7bf14ddc5cd4f3191753300f)
- removed markdown from the build link message as AppVeyor and other applications don't support it - only GitHub

### Testing strategy:

- Ensure each part and type of build occurs successfully. 
- See review tools to ensure no unintended changes of behaviour: especially `decryptFilesForSigning.ps1` as this acts upon secure files when on non PR builds. 
- Confirm intended changes of behaviour
- Check build artifacts are there and the same as other PR builds (and eventual master builds). 

### Known issues with pull request:

None needed

### Change log entries:

None needed

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
