### PR TITLE
Fix for some grade 2 braille tables that are not declared as contracted

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -104,7 +104,7 @@ addTable("ar-ar-comp8.utb", _("Arabic 8 dot computer braille"))
 addTable("ar-ar-g1.utb", _("Arabic grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ar-ar-g2.ctb", _("Arabic grade 2"))
+addTable("ar-ar-g2.ctb", _("Arabic grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("as-in-g1.utb", _("Assamese grade 1"))
@@ -224,7 +224,7 @@ addTable("Es-Es-G0.utb", _("Spanish 8 dot computer braille"))
 addTable("es-g1.ctb", _("Spanish grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("es-g2.ctb", _("Spanish grade 2"))
+addTable("es-g2.ctb", _("Spanish grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("et-g0.utb", _("Estonian grade 0"))
@@ -482,7 +482,7 @@ addTable("uk-comp.utb", _("Ukrainian computer braille"))
 addTable("ur-pk-g1.utb", _("Urdu grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ur-pk-g2.ctb", _("Urdu grade 2"))
+addTable("ur-pk-g2.ctb", _("Urdu grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("uz-g1.utb", _("Uzbek grade 1"))
@@ -512,7 +512,7 @@ addTable("xh-za-g2.ctb", _("Xhosa grade 2"), contracted=True)
 addTable("zhcn-g1.ctb", _("Chinese (China, Mandarin) grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("zhcn-g2.ctb", _("Chinese (China, Mandarin) grade 2"))
+addTable("zhcn-g2.ctb", _("Chinese (China, Mandarin) grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,7 @@ What's New in NVDA
 - Updated liblouis braille translator to [3.18.0 https://github.com/liblouis/liblouis/releases/tag/v3.18.0]. (#12526)
   - New braille tables: Bulgarian grade 1, Burmese grade 1, Burmese grade 2, Kazakh grade 1, Khmer grade 1, Northern Kurdish grade 0, Sepedi grade 1, Sepedi grade 2, Sesotho grade 1, Sesotho grade 2, Setswana grade 1, Setswana grade 2, Tatar grade 1, Vietnamese grade 0, Vietnamese grade 2, Southern Vietnamese grade 1, Xhosa grade 1, Xhosa grade 2, Yakut grade 1, Zulu grade 1, Zulu grade 2
   -
+- The braille input works properly with the following contracted tables: Arabic grade 2, Spanish grade 2, Urdu grade 2, Chinese (China, Mandarin) grade 2. (#12541)
 -
 
 


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Follow up https://github.com/nvaccess/nvda/pull/12526#issuecomment-856474184

### Summary of the issue:
There are some grade 2 braille tables that are not declared as contracted. As a result the braille input does not work well with these tables.

### Description of how this pull request fixes the issue:
Just adds `contracted=True` to the corresponding tables.

### Testing strategy:
Ran from sources, set "Spanish grade 2" as input braille table and tried several inputs.

### Known issues with pull request:
None

### Change log entries:
Section: Bug fixes
`- The braille input works properly with the following contracted tables: Arabic grade 2, Spanish grade 2, Urdu grade 2, Chinese (China, Mandarin) grade 2. (#12541)`

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [X] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
