### PR TITLE
Increase timeout for focusing chrome

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -142,8 +142,8 @@ class ChromeLib:
 		"""
 		success, _success = _blockUntilConditionMet(
 			getValue=lambda: SetForegroundWindow(startsWithTestCaseTitle, builtIn.log),
-			giveUpAfterSeconds=3,
-			intervalBetweenSeconds=0.5
+			giveUpAfterSeconds=5,
+			intervalBetweenSeconds=0.2
 		)
 		if success:
 			return


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

Builds currently randomly fail due to being unable to focus chrome. I think this is due to the timeout being too early because:

- this only occurs on a single test: `"Robot.chromeTests.checkbox labelled by inner element"`
- Sometimes when the logging code happens to describe the fail of focus, chrome ends up being focused. [Example](https://ci.appveyor.com/project/NVAccess/nvda/builds/39573258/tests): 
```python
Unable to focus Chrome.
Foreground Window: NVDA Browser Test Case (1950076191) - Google Chrome.
Open Windows: ['NVDA Browser Test Case (1950076191) - Google Chrome', 'AppVeyor Build Agent', 'Program Manager']
```

### Description of how this pull request fixes the issue:

Increases the time and poll rate of the focusChome attempt

### Testing strategy:

This PR builds, random build failures decrease.

### Known issues with pull request:

The log for focus events may become noisy with so much polling

### Change log entries:

None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
