### PR TITLE
Repaired the COM Registration Fixing Tool so it is effective on 64bit Windows

### DIFF
--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -45,7 +45,7 @@ def applyRegistryPatch(fileName,wow64=False):
 	"""
 	if not os.path.isfile(fileName):
 		raise FileNotFoundError(f"Cannot apply registry patch, {fileName} not found.")
-	regedit=os.path.join(sysWow64 if wow64 else systemRoot,'regedit.exe')
+	regedit = os.path.join(sysWow64 if wow64 else systemRoot + "\\Sysnative", "regedt32.exe")
 	try:
 		subprocess.check_call([regedit,'/s',fileName])
 	except subprocess.CalledProcessError as e:


### PR DESCRIPTION

### Link to issue number:

Closes #9039 

### Summary of the issue:

The COM Registration Fixing Tool has never worked on 64bit Windows, as a result of path confusion caused by the use of SysWOW64, and the inability to use the regedit.exe name for the registry editor (fails silently).

### Description of how this pull request fixes the issue:

Renamed regedit.exe to regedt32.exe in the subprocess call.
Added Sysnative to the path for 32bit calls, per discussions linked from #9039.

### Testing strategy:

Followed the STR in [#9039  (comment)](https://github.com/nvaccess/nvda/issues/9039#issuecomment-857356117).

* With current Alpha, could not restore the registry, as described in that STR.
* With these modifications, the registry key was restored, indicating that the reg patch successfully applied.

### Known issues with pull request:

I would like this to be tested by someone with 32bit Windows. I have no such capacity locally.

### Change log entries:
Bug fixes
The COM Registration Fixing Tool now works for 64bit Windows systems.

### Code Review Checklist:

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [ ] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
