### PR TITLE
Update espeak to ab11439b18

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -110,6 +110,7 @@ env.Append(
 		'#nvdaHelper/espeak',  # ensure that nvdaHelper/espeak/config.h is found first.
 		espeakIncludeDir,
 		espeakIncludeDir.Dir('compat'),
+		espeakSrcDir.Dir('speechPlayer/include'),
 		sonicSrcDir,
 		espeakSrcDir.Dir('ucd-tools/src/include')
 	])
@@ -154,6 +155,7 @@ espeakDictionaryCompileList: typing.Dict[
 	"bs_dict": ("bs", ["bs_list", "bs_rules", ]),
 	"ca_dict": ("ca", ["ca_list", "ca_rules", ]),
 	"chr_dict": ("chr", ["chr_list", "chr_rules", ]),
+	"cmn_dict": ("cmn", ["cmn_listx", "cmn_list", "cmn_rules"]),
 	"cs_dict": ("cs", ["cs_list", "cs_rules", ]),
 	"cv_dict": ("cv", ["cv_list", "cv_rules", ]),
 	"cy_dict": ("cy", ["cy_list", "cy_rules", ]),
@@ -181,8 +183,9 @@ espeakDictionaryCompileList: typing.Dict[
 	"ht_dict": ("ht", ["ht_list", "ht_rules", ]),
 	"hu_dict": ("hu", ["hu_list", "hu_rules", ]),
 	"hy_dict": ("hy", ["hy_list", "hy_rules", ]),
-	"ia_dict": ("ia", ["ia_list", "ia_rules"]),
+	"ia_dict": ("ia", ["ia_listx", "ia_list", "ia_rules"]),
 	"id_dict": ("id", ["id_list", "id_rules", ]),
+	"io_dict": ("io", ["io_list", "io_rules", ]),
 	"is_dict": ("is", ["is_list", "is_rules", ]),
 	"it_dict": ("it", ["it_listx", "it_list", "it_rules"]),
 	"ja_dict": ("ja", ["ja_list", "ja_rules", ]),
@@ -215,9 +218,11 @@ espeakDictionaryCompileList: typing.Dict[
 	"or_dict": ("or", ["or_list", "or_rules", ]),
 	"pap_dict": ("pap", ["pap_list", "pap_rules", ]),
 	"pa_dict": ("pa", ["pa_list", "pa_rules", ]),
+	"piqd_dict": ("piqd", ["piqd_list", "piqd_rules", ]),
 	"pl_dict": ("pl", ["pl_list", "pl_rules", ]),
 	"pt_dict": ("pt", ["pt_list", "pt_rules", ]),
 	"py_dict": ("py", ["py_list", "py_rules", ]),
+	"qdb_dict": ("qdb", ["qdb_list", "qdb_rules", ]),
 	"quc_dict": ("quc", ["quc_list", "quc_rules", ]),
 	"qu_dict": ("qu", ["qu_list", "qu_rules", ]),
 	"ro_dict": ("ro", ["ro_list", "ro_rules", ]),
@@ -227,6 +232,7 @@ espeakDictionaryCompileList: typing.Dict[
 	"si_dict": ("si", ["si_list", "si_rules", ]),
 	"sk_dict": ("sk", ["sk_list", "sk_rules", ]),
 	"sl_dict": ("sl", ["sl_list", "sl_rules", ]),
+	"smj_dict": ("smj", ["smj_list", "smj_rules", ]),
 	"sq_dict": ("sq", ["sq_list", "sq_rules", ]),
 	"sr_dict": ("sr", ["sr_list", "sr_rules", ]),
 	"sv_dict": ("sv", ["sv_list", "sv_rules", ]),
@@ -243,8 +249,7 @@ espeakDictionaryCompileList: typing.Dict[
 	"ur_dict": ("ur", ["ur_list", "ur_rules", ]),
 	"uz_dict": ("uz", ["uz_list", "uz_rules", ]),
 	"vi_dict": ("vi", ["vi_list", "vi_rules", ]),
-	"zh_dict": ("cmn", ["zh_list", "zh_listx", "zh_rules"]),
-	"zhy_dict": ("yue", ["zhy_list", "zhy_listx", "zhy_rules"]),
+	"yue_dict": ("yue", ["yue_list", "yue_listx", "yue_rules"]),
 }
 
 def espeak_compileDict_buildAction(
@@ -359,6 +364,7 @@ espeakLib=env.SharedLibrary(
 		"phonemelist.c",
 		"readclause.c",
 		"setlengths.c",
+		"soundIcon.c",
 		"spect.c",
 		"speech.c",
 		"ssml.c",
@@ -370,6 +376,14 @@ espeakLib=env.SharedLibrary(
 		"voices.c",
 		"wavegen.c",
 		sonicLib,
+		# espeak OPT_SPEECHPLAYER block
+		"sPlayer.c",
+		"../speechPlayer/src/frame.cpp",
+		"../speechPlayer/src/speechPlayer.cpp",
+		"../speechPlayer/src/speechWaveGenerator.cpp",
+		#"../speak-ng.cpp",
+		# if not OPT_SPEECHPLAYER
+		# "../speak-ng.c",
 		# espeak does not need to handle its own audio output so dont include:
 		# pcaudiolib\src\audio.c
 		# pcaudiolib\src\windows.c

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit aafd2e720
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit f6d092a9c
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.18.0

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit f6d092a9c
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit ab11439b18238b7
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.18.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -62,6 +62,7 @@ Note:
 - 'Attempt to cancel speech for expired focus events' option in the advanced settings panel now enabled by default. (#10885)
   - This behaviour can be disabled by setting this option to "No".
   - Web applications (E.G. Gmail) no longer speak outdated information when moving focus rapidly.
+- Espeak-ng has been updated to 1.51-dev commit f6d092a9c13d864ede78c493f64a7d32cde41f09. (#12449, #12202, #12280)
 - Updated liblouis braille translator to [3.17.0 https://github.com/liblouis/liblouis/releases/tag/v3.17.0]. (#12137)
   - New braille tables: Belarusian literary braille, Belarusian computer braille, Urdu grade 1, Urdu grade 2.
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,6 +14,8 @@ What's New in NVDA
 
 
 == Changes ==
+- Espeak-ng has been updated to 1.51-dev commit `ab11439b18238b7a08b965d1d5a6ef31cbb05cbb`. (#12449, #12202, #12280, #12568)
+-
 
 
 == Bug Fixes ==
@@ -62,7 +64,6 @@ Note:
 - 'Attempt to cancel speech for expired focus events' option in the advanced settings panel now enabled by default. (#10885)
   - This behaviour can be disabled by setting this option to "No".
   - Web applications (E.G. Gmail) no longer speak outdated information when moving focus rapidly.
-- Espeak-ng has been updated to 1.51-dev commit f6d092a9c13d864ede78c493f64a7d32cde41f09. (#12449, #12202, #12280)
 - Updated liblouis braille translator to [3.17.0 https://github.com/liblouis/liblouis/releases/tag/v3.17.0]. (#12137)
   - New braille tables: Belarusian literary braille, Belarusian computer braille, Urdu grade 1, Urdu grade 2.
 - Support for Adobe Flash content has been removed from NVDA due to the use of Flash being actively discouraged by Adobe. (#11131)


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

It is helpful to run the latest version of espeak. 

### Description of how this pull request fixes the issue:

- Reverts #12495 
- updates espeak to the latest commit. The strategy to updating was to follow [the updating espeak readme](https://github.com/nvaccess/nvda/blob/master/include/espeak.md).

### Testing strategy:

- note that there has been no changes since the commit that was reverted to the build process (f6d092a9c13d864ede78c493f64a7d32cde41f09).
```sh
git diff f6d092a9c13d864ede78c493f64a7d32cde41f09 ab11439b18238b7a08b965d1d5a6ef31cbb05cbb Makefile.am
git diff f6d092a9c13d864ede78c493f64a7d32cde41f09 ab11439b18238b7a08b965d1d5a6ef31cbb05cbb --stat
```
- NVDA builds, ensure espeak continues to work as expected


### Known issues with pull request:

May reintroduce #12465. If this is the case, espeak-ng/espeak-ng#950 will need to be updated. This may remain an issue when updating espeak in future.

> As a short term solution I'll do a revert. However, since there is no test case that works for me and @valdisvi the bug might be reintroduced by accident later. [[revert commit](https://github.com/espeak-ng/espeak-ng/commit/4d0a4df86b279a0bde950db348c11133d4cc33f7)]

_Originally posted by @jaacoppi in https://github.com/espeak-ng/espeak-ng/issues/950#issuecomment-855996688_



### Change log entries:

See changes.t2t diff

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
