### PR TITLE
Fix auto update

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -133,8 +133,12 @@ def restartUnsafely():
 	- Remove icons (systray)
 	- Saving settings
 	"""
-
+	log.info("Restarting unsafely")
 	import subprocess
+	# Unlike a normal restart, see L{restart}:
+	# - if addons are disabled, leave them disabled
+	# - if debug logging is set, leave it set.
+	# The new instance should operate in the same way (as much as possible) as the old instance.
 	for paramToRemove in ("--ease-of-access"):
 		try:
 			sys.argv.remove(paramToRemove)

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -112,10 +112,7 @@ def doInstall(
 
 	newNVDA = None
 	if startAfterInstall:
-		newNVDA = core.NewNVDAInstance(
-			filePath=os.path.join(installer.defaultInstallPath, 'nvda.exe'),
-			parameters=f"--log-level={log.level}"
-		)
+		newNVDA = core.NewNVDAInstance(os.path.join(installer.defaultInstallPath, 'nvda.exe'))
 	if not core.triggerNVDAExit(newNVDA):
 		log.error("NVDA already in process of exiting, this indicates a logic error.")
 
@@ -471,9 +468,6 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 	if silent or startAfterCreate:
 		newNVDA = None
 		if startAfterCreate:
-			newNVDA = core.NewNVDAInstance(
-				filePath=os.path.join(portableDirectory, 'nvda.exe'),
-				parameters=f"--log-level={log.level}"
-			)
+			newNVDA = core.NewNVDAInstance(os.path.join(portableDirectory, 'nvda.exe'))
 		if not core.triggerNVDAExit(newNVDA):
 			log.error("NVDA already in process of exiting, this indicates a logic error.")

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -112,7 +112,9 @@ def doInstall(
 
 	newNVDA = None
 	if startAfterInstall:
-		newNVDA = core.NewNVDAInstance(os.path.join(installer.defaultInstallPath, 'nvda.exe'))
+		newNVDA = core.NewNVDAInstance(
+			filePath=os.path.join(installer.defaultInstallPath, 'nvda.exe'),
+		)
 	if not core.triggerNVDAExit(newNVDA):
 		log.error("NVDA already in process of exiting, this indicates a logic error.")
 
@@ -468,6 +470,8 @@ def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAf
 	if silent or startAfterCreate:
 		newNVDA = None
 		if startAfterCreate:
-			newNVDA = core.NewNVDAInstance(os.path.join(portableDirectory, 'nvda.exe'))
+			newNVDA = core.NewNVDAInstance(
+				filePath=os.path.join(portableDirectory, 'nvda.exe'),
+			)
 		if not core.triggerNVDAExit(newNVDA):
 			log.error("NVDA already in process of exiting, this indicates a logic error.")

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -220,7 +220,6 @@ def _executeUpdate(destPath):
 			)
 		else:
 			executeParams = u"--launcher"
-	executeParams += f"--log-level={log.level}"
 	# #4475: ensure that the new process shows its first window, by providing SW_SHOWNORMAL
 	if not core.triggerNVDAExit(core.NewNVDAInstance(destPath, executeParams)):
 		log.error("NVDA already in process of exiting, this indicates a logic error.")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#12574

### Summary of the issue:

There were several issues introduced when trying to maintain the logging level between NVDA processes during a restart:
- a missing space before "--log-level=" in updateCheck.py caused automatic updates to fail.
- explicitly setting the log level prevents the log level from being manually set in the General settings panel. 

### Description of how this pull request fixes the issue:
To address this, reverting commit: 76b2aeaa "Maintain logging level on restart"

The change to maintain the logging level between restarts needs to be considered more carefully. See usages of `logHandler.isLogLevelForced()`. This can be postponed to 2021.2.


### Testing strategy:
Automatic upgrading FROM a source copy to another source copy built locally is difficult.
- You'll need: 
  - "Upgrade From" launcher
  - "Upgrade To" launcher
  - A version such as beta3 installed that normally provides automatic updates and has an update available.
- With beta3 installed check for updates, and choose to "install later".
- Open the user config directory, copy `updateCheckState.pickle` and the `updates` folder to a new folder on your desktop, then prepare this folder with the launcher built from source:
  - Take note of the file name for the executable in this folder EG `nvda_update_l4ri0_o5.exe`
  - Rename you "Upgrade to" launcher build to this name EG `nvda_update_l4ri0_o5.exe`
  - Copy it to the `updates` folder (overwriting the existing file).
- Installer your "Upgrade from" launcher and leave it running.
- Open the python console and paste the following:
    ```python
    import _buildVersion
    import buildVersion
    import versionInfo
    versionInfo.updateVersionType = buildVersion.updateVersionType =  _buildVersion.updateVersionType = 'beta'
    import updateCheck
    updateCheck.initialize()
    import gui
    gui.updateCheck = updateCheck
    ```
- choose "update later"
- From the NVDA menu select "Install pending update"


### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
