### PR TITLE
Fix how the Seika Notetaker Driver processes data

### DIFF
--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -163,14 +163,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		cmd = stream.read(3)  # Note, first and third bytes are discarded
 		newByte: bytes = cmd[1:2]  # use range to return bytes
 		self._hidBuffer += newByte
-		hasCommandBeenCollected = self._command is None
-		hasArgLenBeenCollected = self._argsLen is None
+		hasCommandBeenCollected = self._command is not None
+		hasArgLenBeenCollected = self._argsLen is not None
 		if (  # still collecting command bytes
 			not hasCommandBeenCollected
 			and len(self._hidBuffer) == COMMAND_LEN
 		):
 			self._command = self._hidBuffer  # command found reset and wait for args length
-			self._hidBuffer = None
+			self._hidBuffer = b""
 		elif (  # next byte gives the command + args length
 			hasCommandBeenCollected
 			and not hasArgLenBeenCollected  # argsLen has not

--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -23,6 +23,8 @@ class TestSeikaNotetakerDriver(unittest.TestCase):
 		sampleArgument = b"test"
 		sampleArgLen = bytes([len(sampleArgument)])
 		sampleMessage = sampleCommand + sampleArgLen + sampleArgument + b"\0\0\0"
+		PRE_CANARY = bytes([2])  # start of text character
+		POST_CANARY = bytes([3])  # end of text character
 
 		class FakeSeikaNotetakerDriver(SeikaNotetakerDriver):
 			def __init__(self):
@@ -41,7 +43,7 @@ class TestSeikaNotetakerDriver(unittest.TestCase):
 		seikaTestDriver = FakeSeikaNotetakerDriver()
 		for byteToSend in sampleMessage:
 			# the middle byte is the only one used, padded by a byte on either side.
-			seikaTestDriver._onReceive(b"\0" + bytes([byteToSend]) + b"\0")
+			seikaTestDriver._onReceive(PRE_CANARY + bytes([byteToSend]) + POST_CANARY)
 
 		self.assertEqual(sampleCommand, seikaTestDriver._finalCommand)
 		self.assertEqual(sampleArgLen + sampleArgument, seikaTestDriver._finalArg)

--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -6,8 +6,43 @@
 """Unit tests for braille display drivers.
 """
 
+from brailleDisplayDrivers.seikantk import BrailleDisplayDriver as SeikaNotetakerDriver, SEIKA_INFO
+
 import unittest
 import braille
+
+
+class TestSeikaNotetakerDriver(unittest.TestCase):
+	def test_onReceive(self):
+		sampleCommand = SEIKA_INFO
+		sampleArgument = b"test"
+		sampleArgLen = bytes([len(sampleArgument)])
+		sampleMessage = sampleCommand + sampleArgLen + sampleArgument + b"\0\0\0"
+		paddedMessage = b"\0" + sampleMessage + b"\0"
+
+		class FakeSeikaNotetakerDriver(SeikaNotetakerDriver):
+			def __init__(self):
+				"""Sets the variables necessary to test _onReceive without a braille device
+				"""
+				self._hidBuffer = b""
+				self._command = None
+				self._argsLen = None
+
+			def _processCommand(self, command, arg):
+				"""Intercept processCommand to confirm _onReceive processes a message correctly.
+				"""
+				self._finalCommand = command
+				self._finalArg = arg
+		
+		seikaTestDriver = FakeSeikaNotetakerDriver()
+		for i in range(len(sampleMessage)):
+			# the middle byte is the only one used, padded by 2 other bits
+			# paddedMessage[i:i + 2] == [sampleMessage[i-1], sampleMessage[i], sampleMessage[i+1]]
+			seikaTestDriver._onReceive(paddedMessage[i:i + 2])
+
+		self.assertEqual(sampleCommand, seikaTestDriver._finalCommand)
+		self.assertEqual(sampleArgLen + sampleArgument, seikaTestDriver._finalArg)
+
 
 class TestGestureMap(unittest.TestCase):
 	"""Tests the integrity of braille display driver gesture maps."""

--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -14,6 +14,11 @@ import braille
 
 class TestSeikaNotetakerDriver(unittest.TestCase):
 	def test_onReceive(self):
+		""" Tests how the Seika Notetaker driver handles receiving data via `_onReceive`.
+		Simulates sending a sample message from the device, which should result in our driver processing a
+		command via `_processCommand`. Without knowing the specifications of the device, this simulation may
+		be inaccurate or uncomprehensive.
+		"""
 		sampleCommand = SEIKA_INFO
 		sampleArgument = b"test"
 		sampleArgLen = bytes([len(sampleArgument)])
@@ -22,7 +27,7 @@ class TestSeikaNotetakerDriver(unittest.TestCase):
 
 		class FakeSeikaNotetakerDriver(SeikaNotetakerDriver):
 			def __init__(self):
-				"""Sets the variables necessary to test _onReceive without a braille device
+				"""Sets the variables necessary to test _onReceive without a braille device connected.
 				"""
 				self._hidBuffer = b""
 				self._command = None
@@ -36,7 +41,7 @@ class TestSeikaNotetakerDriver(unittest.TestCase):
 		
 		seikaTestDriver = FakeSeikaNotetakerDriver()
 		for i in range(len(sampleMessage)):
-			# the middle byte is the only one used, padded by 2 other bits
+			# the middle byte is the only one used, padded by a byte on either side.
 			# paddedMessage[i:i + 2] == [sampleMessage[i-1], sampleMessage[i], sampleMessage[i+1]]
 			seikaTestDriver._onReceive(paddedMessage[i:i + 2])
 

--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -23,7 +23,6 @@ class TestSeikaNotetakerDriver(unittest.TestCase):
 		sampleArgument = b"test"
 		sampleArgLen = bytes([len(sampleArgument)])
 		sampleMessage = sampleCommand + sampleArgLen + sampleArgument + b"\0\0\0"
-		paddedMessage = b"\0" + sampleMessage + b"\0"
 
 		class FakeSeikaNotetakerDriver(SeikaNotetakerDriver):
 			def __init__(self):
@@ -40,10 +39,9 @@ class TestSeikaNotetakerDriver(unittest.TestCase):
 				self._finalArg = arg
 		
 		seikaTestDriver = FakeSeikaNotetakerDriver()
-		for i in range(len(sampleMessage)):
+		for byteToSend in sampleMessage:
 			# the middle byte is the only one used, padded by a byte on either side.
-			# paddedMessage[i:i + 2] == [sampleMessage[i-1], sampleMessage[i], sampleMessage[i+1]]
-			seikaTestDriver._onReceive(paddedMessage[i:i + 2])
+			seikaTestDriver._onReceive(b"\0" + bytes([byteToSend]) + b"\0")
 
 		self.assertEqual(sampleCommand, seikaTestDriver._finalCommand)
 		self.assertEqual(sampleArgLen + sampleArgument, seikaTestDriver._finalArg)


### PR DESCRIPTION
### Link to issue number:

Discussed/raised here: https://github.com/nvaccess/nvda/pull/11514#issuecomment-859437183

### Summary of the issue:

Seika Notetaker braille device still does not load in NVDA. 

### Description of how this pull request fixes the issue:

Fixes several minor logic errors in `_onReceive`

### Testing strategy:

Unit tests have been added for this function. To run the unit tests on @moyanming's latest commit on the driver `84af837`, the following patch can be done.

git checkout 84af837 source/brailleDisplayDrivers/seikantk.py
git apply test-original-onReceive.diff

Where this is `test-original-onReceive.diff`
```diff
diff --git a/source/brailleDisplayDrivers/seikantk.py b/source/brailleDisplayDrivers/seikantk.py
index c8a25dcb1..892e2627f 100644
--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -143,7 +143,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			arg = self._hidBuffer[3:self.cmdlen + 4]
 			self.status = 0
 			self._hidBuffer = b""
-			
+			self._processCommand(command, arg)
+
+	def _processCommand(self, command, arg):
 			if command == SEIKA_INFO:
 				self._handInfo(arg)
 			elif command == SEIKA_ROUTING:
diff --git a/tests/unit/test_brailleDisplayDrivers.py b/tests/unit/test_brailleDisplayDrivers.py
index 017f6a6ed..9303ebc97 100644
--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -27,6 +27,7 @@ class TestSeikaNotetaker(unittest.TestCase):
 				self._hidBuffer = b""
 				self._command = None
 				self._argsLen = None
+				self.status = 0
 
 			def _processCommand(self, command, arg):
 				"""Intercept processCommand to confirm _onReceive processes a message correctly.
```

### Known issues with pull request:

Other unknown issues may still exist with Seika Notetaker Driver

### Change log entries:

If merged to beta: none
If merged to alpha: Bug fixes

Fix registration for Seika Notetaker device

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [ ] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
