### PR TITLE
Announce article after content

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -42,6 +42,7 @@ from .types import (
 	_flattenNestedSequences
 )
 from typing import (
+	Iterable,
 	Optional,
 	Dict,
 	List,
@@ -1692,6 +1693,39 @@ def getPropertiesSpeech(  # noqa: C901
 	return textList
 
 
+def _shouldSpeakContentFirst(
+		reason: OutputReason,
+		role: int,
+		presCat: str,
+		attrs: textInfos.ControlField,
+		tableID: Any,
+		states: Iterable[int],
+) -> bool:
+	"""
+	Determines whether or not to speak the content before the controlField information.
+	Helper function for getControlFieldSpeech.
+	"""
+	_neverSpeakContentFirstRoles = (
+		controlTypes.ROLE_EDITABLETEXT,
+		controlTypes.ROLE_COMBOBOX,
+		controlTypes.ROLE_TREEVIEW,
+		controlTypes.ROLE_LIST,
+		controlTypes.ROLE_LANDMARK,
+		controlTypes.ROLE_REGION,
+	)
+	return (
+		reason == OutputReason.FOCUS
+		and (
+			# the category is not a container, unless it's an article (#11103)
+			presCat != attrs.PRESCAT_CONTAINER
+			or role == controlTypes.ROLE_ARTICLE
+		)
+		and not (role in _neverSpeakContentFirstRoles)
+		and not tableID
+		and controlTypes.STATE_EDITABLE not in states
+	)
+
+
 # C901 'getControlFieldSpeech' is too complex
 # Note: when working on getControlFieldSpeech, look for opportunities to simplify
 # and move logic out into smaller helper functions.
@@ -1788,24 +1822,7 @@ def getControlFieldSpeech(  # noqa: C901
 
 	# Determine the order of speech.
 	# speakContentFirst: Speak the content before the control field info.
-	speakContentFirst = (
-		reason == OutputReason.FOCUS
-		and (
-			# the category is not a container, unless it's an article (#11103)
-			presCat != attrs.PRESCAT_CONTAINER
-			or role == controlTypes.ROLE_ARTICLE
-		)
-		and role not in (
-			controlTypes.ROLE_EDITABLETEXT,
-			controlTypes.ROLE_COMBOBOX,
-			controlTypes.ROLE_TREEVIEW,
-			controlTypes.ROLE_LIST,
-			controlTypes.ROLE_LANDMARK,
-			controlTypes.ROLE_REGION,
-		)
-		and not tableID
-		and controlTypes.STATE_EDITABLE not in states
-	)
+	speakContentFirst = _shouldSpeakContentFirst(reason, role, presCat, attrs, tableID, states)
 	# speakStatesFirst: Speak the states before the role.
 	speakStatesFirst=role==controlTypes.ROLE_LINK
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1790,7 +1790,11 @@ def getControlFieldSpeech(  # noqa: C901
 	# speakContentFirst: Speak the content before the control field info.
 	speakContentFirst = (
 		reason == OutputReason.FOCUS
-		and presCat != attrs.PRESCAT_CONTAINER
+		and (
+			# the category is not a container, unless it's an article (#11103)
+			presCat != attrs.PRESCAT_CONTAINER
+			or role == controlTypes.ROLE_ARTICLE
+		)
 		and role not in (
 			controlTypes.ROLE_EDITABLETEXT,
 			controlTypes.ROLE_COMBOBOX,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,6 +15,7 @@ What's New in NVDA
 
 == Changes ==
 - Espeak-ng has been updated to 1.51-dev commit `ab11439b18238b7a08b965d1d5a6ef31cbb05cbb`. (#12449, #12202, #12280, #12568)
+- If article is enabled in the user preferences for document formatting, NVDA announces "article" after the content. (#11103)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes #11103

### Summary of the issue:

When using quick keys to navigate articles on a web page, the article text/label should be announced first and then "article" should be announced after it in order to streamline the browsing process.

### Description of how this pull request fixes the issue:

As discussed here - https://github.com/nvaccess/nvda/pull/12277#pullrequestreview-639522337
`ROLE_ARTICLE` is determined to be a `PRESCAT_CONTAINER` via `getPresentationCategory` if `reportArticles` is enabled.  The condition in determining `speakContentFirst`, `presCat != attrs.PRESCAT_CONTAINER` has been replaced with `presCat != attrs.PRESCAT_CONTAINER or role == controlTypes.ROLE_ARTICLE`. 

The logic to determine `speakContentFirst` has been moved to a helper function as it is documented that we need to reduce the complexity of `getControlFieldSpeech`. 

### Testing strategy:

Manually tried it out on web pages. Example websites can be found on this issue #9227

Unit testing seems unhelpful for the new helper function, however system tests for reading articles might be helpful if reviewers think so. 

### Known issues with pull request:

None

### Change log entries:

Changes
`- If article is enabled in the user preferences for document formatting, NVDA announces "article" after the content. (#11103)`

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
