### PR TITLE
UI Automation in Windows Console: Revert "downgrade E_FAIL when comparing selection changes to debugWarning"

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -373,18 +373,6 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 			else ConsoleUIATextInfoWorkaroundEndInclusive
 		)
 
-	def detectPossibleSelectionChange(self):
-		try:
-			return super().detectPossibleSelectionChange()
-		except COMError:
-			# microsoft/terminal#5399: when attempting to compare text ranges
-			# from the standard and alt mode buffers, E_FAIL is returned.
-			# Downgrade this to a debugWarning.
-			log.debugWarning((
-				"Exception raised when comparing selections, "
-				"probably due to a switch to/from the alt buffer."
-			), exc_info=True)
-
 
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
microsoft/terminal#5406

Reverts #11039.

### Summary of the issue:
With the resolution of microsoft/terminal#5406, conhost now handles normal and alt buffer ranges correctly. NVDA currently filters out exceptions on `detectPossibleSelectionChange`, but we're no longer expecting any here, so these should be properly reported as errors.

### Description of how this pull request fixes the issue:
Remove special exception handling in `detectPossibleSelectionChange`.

### Testing strategy:
Tested that console works correctly.

### Known issues with pull request:
None.

### Change log entries:
None (only affected unreleased development builds)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
