### PR TITLE
nvda_slave should log at debug and parent NVDA can filter

### DIFF
--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 	# Initialize remote logging back to NVDA
 	logHandler.initialize(True)
 	# Log at the most detailed level, and NVDA will filter it using its own level setting.
-	logHandler.log.setLevel(1)
+	logHandler.log.setLevel(logHandler.log.DEBUG)
 	import languageHandler
 	languageHandler.setLanguage("Windows")
 	main()

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -131,8 +131,10 @@ def main():
 		sys.exit(1)
 
 if __name__ == "__main__":
+	# Initialize remote logging back to NVDA 
 	logHandler.initialize(True)
-	logHandler.log.setLevel(0)
+	# Log at the most detailed level, and NVDA will filter it using its own level setting.
+	logHandler.log.setLevel(1)
 	import languageHandler
 	languageHandler.setLanguage("Windows")
 	main()

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -131,7 +131,7 @@ def main():
 		sys.exit(1)
 
 if __name__ == "__main__":
-	# Initialize remote logging back to NVDA 
+	# Initialize remote logging back to NVDA
 	logHandler.initialize(True)
 	# Log at the most detailed level, and NVDA will filter it using its own level setting.
 	logHandler.log.setLevel(1)


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
For some time now, nvda_slave has not been logging back to NVDA, even if NVDA was set to log level debug. E.g. the nvda_install.log appveyor artifact does not contain any installer messages. Similarly, the COM registration fixing tool also looks like it logs nothing unless there is a specific error.

When nvda_slave initializes logging, it sets the level of loghandler.log to 0. I'm guessing that we chose 0 as it was thought to be the lowest (most detailed) level (I.e. greater than debug (10)). However, 0 seems to have a special meaning of NOTSET, and therefore messages honor the first ancestor that is not set to NOTSET, which is the root logger, which is probably set to warning by default. Thus, all the debug messages are being dropped and not being sent back to NVDA, even if NVDA's own log level was debug.

### Description of how this pull request fixes the issue:
In nvda_slave: initialize logging with a specific level of DEBUG (10), the most detailed level.

### Testing strategy:
Generated a try build of this commit. Verified that nvda_install.log contains all debug messages from the installer, including the COM registration messages.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
