### PR TITLE
Check that a remote update exists even if a pending update is cached

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -6,6 +6,7 @@
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.
 """
+from typing import Dict, Optional, Tuple
 import garbageHandler
 import globalVars
 import config
@@ -94,13 +95,12 @@ def getQualifiedDriverClassNameForStats(cls):
 		return "%s (external)"%name
 	return "%s (core)"%name
 
-def checkForUpdate(auto=False):
+
+def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 	"""Check for an updated version of NVDA.
 	This will block, so it generally shouldn't be called from the main thread.
 	@param auto: Whether this is an automatic check for updates.
-	@type auto: bool
 	@return: Information about the update or C{None} if there is no update.
-	@rtype: dict
 	@raise RuntimeError: If there is an error checking for an update.
 	"""
 	allowUsageStats=config.conf["update"]['allowUsageStats']
@@ -169,9 +169,8 @@ def _setStateToNone(_state):
 	_state["pendingUpdateBackCompatToAPIVersion"] = (0,0,0)
 
 
-def getPendingUpdate():
+def getPendingUpdate() -> Optional[Tuple]:
 	"""Returns a tuple of the path to and version of the pending update, if any. Returns C{None} otherwise.
-	@rtype: tuple
 	"""
 	try:
 		pendingUpdateFile=state["pendingUpdateFile"]
@@ -190,11 +189,12 @@ def getPendingUpdate():
 			_setStateToNone(state)
 	return None
 
-def isPendingUpdate():
+
+def isPendingUpdate() -> bool:
 	"""Returns whether there is a pending update.
-	@rtype: bool
 	"""
-	return bool(getPendingUpdate())
+	return getPendingUpdate() is not None
+
 
 def executePendingUpdate():
 	updateTuple = getPendingUpdate()
@@ -276,7 +276,7 @@ class UpdateChecker(garbageHandler.TrackedObject):
 			_("Error"),
 			wx.OK | wx.ICON_ERROR)
 
-	def _result(self, info):
+	def _result(self, info: Optional[Dict]) -> None:
 		wx.CallAfter(self._progressDialog.done)
 		self._progressDialog = None
 		wx.CallAfter(UpdateResultDialog, gui.mainFrame, info, False)
@@ -331,7 +331,7 @@ class UpdateResultDialog(
 ):
 	helpId = "GeneralSettingsCheckForUpdates"
 
-	def __init__(self, parent, updateInfo, auto):
+	def __init__(self, parent, updateInfo: Optional[Dict], auto: bool) -> None:
 		# Translators: The title of the dialog informing the user about an NVDA update.
 		super().__init__(parent, title=_("NVDA Update"))
 
@@ -339,12 +339,14 @@ class UpdateResultDialog(
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
+		remoteUpdateExists = updateInfo is not None
 		pendingUpdateDetails = getPendingUpdate()
-		canOfferPendingUpdate = isPendingUpdate() and pendingUpdateDetails[1] == updateInfo["version"]
+		remoteUpdateMatchesPending = pendingUpdateDetails[1] == updateInfo["version"]
+		canOfferPendingUpdate = isPendingUpdate() and remoteUpdateExists and remoteUpdateMatchesPending
 
 		text = sHelper.addItem(wx.StaticText(self))
 		bHelper = guiHelper.ButtonHelper(wx.HORIZONTAL)
-		if not updateInfo:
+		if not remoteUpdateExists:
 			# Translators: A message indicating that no update to NVDA is available.
 			message = _("No update available.")
 		elif canOfferPendingUpdate:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -341,8 +341,11 @@ class UpdateResultDialog(
 
 		remoteUpdateExists = updateInfo is not None
 		pendingUpdateDetails = getPendingUpdate()
-		remoteUpdateMatchesPending = pendingUpdateDetails[1] == updateInfo["version"]
-		canOfferPendingUpdate = isPendingUpdate() and remoteUpdateExists and remoteUpdateMatchesPending
+		canOfferPendingUpdate = (
+			isPendingUpdate()
+			and remoteUpdateExists
+			and pendingUpdateDetails[1] == updateInfo["version"]
+		)
 
 		text = sHelper.addItem(wx.StaticText(self))
 		bHelper = guiHelper.ButtonHelper(wx.HORIZONTAL)


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

The following was reported in a user group. When running "checkForUpdate" from beta5, someone encountered the following bug and log.

```python
IO - speech.speech.speak (11:22:14.827) - MainThread (3288):
Speaking [LangChangeCommand ('en_GB'), 'Checking for Update', 'dialog', 'Checking for update', CancellableSpeech (still valid)]
IO - tones.beep (11:22:15.231) - MainThread (3288):
Beep at pitch 1760, for 40 ms, left volume 50, right volume 50
DEBUG - gui.contextHelp.bindHelpEvent (11:22:15.232) - MainThread (3288):
Did context help binding for UpdateResultDialog
ERROR - unhandled exception (11:22:15.232) - MainThread (3288):
Traceback (most recent call last):
 File "wx\core.pyc", line 3407, in <lambda>
 File "updateCheck.pyc", line 343, in __init__
TypeError: 'NoneType' object is not subscriptable
```

It seems that if a pending update is cached, even if there is no remote update, we attempt to compare the versions. This seems like an uncommon bug, possibly brought to surface by the earlier beta updates failing.

### Description of how this pull request fixes the issue:

Added a trail of typing to confirm the possibility of a state where there is a pending update cached and no remote update. Added a check to ensure that both of these exist before comparing their versions.

### Testing strategy:

As with any updating issue, this must be confirmed on alpha. 

### Known issues with pull request:

I am not certain that this is the cause of the issue, and without more information from the user it is hard to be certain as I was unable to reproduce this without spoofing a cached update.

### Change log entries:

None needed as it seems to be a rare, new and minimally obtrusive bug.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
