### PR TITLE
allow warnings or errors when decrypting on appveyor

### DIFF
--- a/appveyor/scripts/decryptFilesForSigning.ps1
+++ b/appveyor/scripts/decryptFilesForSigning.ps1
@@ -1,4 +1,3 @@
-$ErrorActionPreference = "Stop";
 if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
 	openssl enc -d -md sha256 -aes-256-cbc -pbkdf2 -salt -pass pass:$env:secure_authenticode_pass -in appveyor\authenticode.pfx.enc -out appveyor\authenticode.pfx
 	if($LastExitCode -ne 0) {


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

[This alpha build](https://ci.appveyor.com/project/NVAccess/nvda/builds/39837195) failed due to #12540 being merged to master. 

### Description of how this pull request fixes the issue:

Allowed warnings and errors in `appveyor/scripts/decryptFilesForSigning.ps1` as these are handled using `$host.SetShouldExit`

### Testing strategy:

Merge this PR

### Known issues with pull request:

None

### Change log entries:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
