### PR TITLE
Improve error handling for appveyor build scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
 install:
  - ps: appveyor\scripts\setBuildVersionVars.ps1
  - ps: appveyor\scripts\decryptFilesForSigning.ps1
- - py -m pip install --upgrade pip
+ - py -m pip install --upgrade --no-warn-script-location pip
  - git submodule update --init
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ environment:
 install:
  - ps: appveyor\scripts\setBuildVersionVars.ps1
  - ps: appveyor\scripts\decryptFilesForSigning.ps1
+ - py -m pip pip install --upgrade pip
  - git submodule update --init
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
 install:
  - ps: appveyor\scripts\setBuildVersionVars.ps1
  - ps: appveyor\scripts\decryptFilesForSigning.ps1
- - py -m pip pip install --upgrade pip
+ - py -m pip install --upgrade pip
  - git submodule update --init
 
 build_script:

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -28,10 +28,10 @@ if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 
 	# Upload symbols to Mozilla.
 	py -m pip install --no-warn-script-location requests
-	py appveyor\mozillaSyms.py
-	if($LastExitCode -ne 0) {
-		$errorCode=$LastExitCode
-		echo "Unable to upload symbols to Mozilla"
+	Try {
+		py appveyor\mozillaSyms.py
+	}
+	Catch {
 		Add-AppveyorMessage "Unable to upload symbols to Mozilla"
 	}
 }

--- a/appveyor/scripts/installNVDA.ps1
+++ b/appveyor/scripts/installNVDA.ps1
@@ -1,4 +1,3 @@
-$ErrorActionPreference = "Stop";
 $errorCode=0
 $nvdaLauncherFile=".\output\nvda"
 if(!$env:release) {


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

[This alpha build also failed](https://ci.appveyor.com/project/NVAccess/nvda/builds/39838466). Caused by #12540 

### Description of how this pull request fixes the issue:

Updates pip (a pip warning is causing deployScript to fail). Adds a try/catch around where we expected an error that we didn't want to exit for. Let the existing exit procedure for installNVDA.ps1 handle itself.

### Testing strategy:

Merge PR

### Known issues with pull request:

A followup PR should be done to document any changes on success

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [ ] Manual testing.
- [ ] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
