### PR TITLE
Fix tracking of keyboard modifiers when watchdog is attempting recovery

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -651,8 +651,9 @@ def main():
 	import inputCore
 	inputCore.initialize()
 	import keyboardHandler
+	import watchdog
 	log.debug("Initializing keyboard handler")
-	keyboardHandler.initialize()
+	keyboardHandler.initialize(watchdog.WatchdogObserver())
 	import mouseHandler
 	log.debug("initializing mouse handler")
 	mouseHandler.initialize()
@@ -692,7 +693,6 @@ def main():
 	# Queue the handling of initial focus,
 	# as API handlers might need to be pumped to get the first focus event.
 	queueHandler.queueFunction(queueHandler.eventQueue, _setInitialFocus)
-	import watchdog
 	import baseObject
 
 	# Doing this here is a bit ugly, but we don't want these modules imported

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -195,7 +195,7 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 			currentModifiers.discard(stickyNVDAModifier)
 			stickyNVDAModifier = None
 
-		if _watchdogObserver._get_isAttemptingRecovery():
+		if _watchdogObserver.isAttemptingRecovery:
 			# When attempting recovery only process modifiers, but do not execute gesture.
 			return True
 
@@ -212,7 +212,7 @@ def internal_keyDownEvent(vkCode,scanCode,extended,injected):
 	except:
 		log.error("internal_keyDownEvent", exc_info=True)
 	finally:
-		if _watchdogObserver._get_isAttemptingRecovery():
+		if _watchdogObserver.isAttemptingRecovery:
 			return True
 		# #6017: handle typed characters in Win10 RS2 and above where we can't detect typed characters in-process 
 		# This code must be in the 'finally' block as code above returns in several places yet we still want to execute this particular code.
@@ -282,7 +282,7 @@ def internal_keyUpEvent(vkCode,scanCode,extended,injected):
 #Register internal key press event with  operating system
 
 
-def initialize(watchdogObserver=None):
+def initialize(watchdogObserver):
 	"""Initialises keyboard support."""
 	global _watchdogObserver
 	_watchdogObserver = watchdogObserver

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -11,6 +11,8 @@ import ctypes
 import sys
 import time
 import re
+import typing
+
 import wx
 import winVersion
 import winUser
@@ -29,7 +31,11 @@ import tones
 import core
 from contextlib import contextmanager
 import threading
-_watchdogObserver = None
+
+if typing.TYPE_CHECKING:
+	from watchdog import WatchdogObserver
+
+_watchdogObserver: typing.Optional["WatchdogObserver"] = None
 ignoreInjected=False
 
 # Fake vk codes.
@@ -282,7 +288,7 @@ def internal_keyUpEvent(vkCode,scanCode,extended,injected):
 #Register internal key press event with  operating system
 
 
-def initialize(watchdogObserver):
+def initialize(watchdogObserver: "WatchdogObserver"):
 	"""Initialises keyboard support."""
 	global _watchdogObserver
 	_watchdogObserver = watchdogObserver

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -39,7 +39,7 @@ safeWindowClassSet=set([
 ])
 
 isRunning=False
-isAttemptingRecovery = False
+isAttemptingRecovery: bool = False
 _coreIsAsleep = False
 
 _coreDeadTimer = windll.kernel32.CreateWaitableTimerW(None, True, None)
@@ -374,6 +374,6 @@ def cancellableSendMessage(hwnd, msg, wParam, lParam, flags=0, timeout=60000):
 
 class WatchdogObserver:
 	@property
-	def isAttemptingRecovery(self):
+	def isAttemptingRecovery(self) -> bool:
 		global isAttemptingRecovery
 		return isAttemptingRecovery

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -370,3 +370,9 @@ def cancellableSendMessage(hwnd, msg, wParam, lParam, flags=0, timeout=60000):
 	result = ctypes.wintypes.DWORD()
 	NVDAHelper.localLib.cancellableSendMessageTimeout(hwnd, msg, wParam, lParam, flags, timeout, ctypes.byref(result))
 	return result.value
+
+
+class WatchdogObserver:
+	def _get_isAttemptingRecovery(self):
+		global isAttemptingRecovery
+		return isAttemptingRecovery

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -373,6 +373,7 @@ def cancellableSendMessage(hwnd, msg, wParam, lParam, flags=0, timeout=60000):
 
 
 class WatchdogObserver:
-	def _get_isAttemptingRecovery(self):
+	@property
+	def isAttemptingRecovery(self):
 		global isAttemptingRecovery
 		return isAttemptingRecovery

--- a/source/winInputHook.py
+++ b/source/winInputHook.py
@@ -44,7 +44,7 @@ mouseCallback=None
 
 @WINFUNCTYPE(c_long,c_int,WPARAM,LPARAM)
 def keyboardHook(code,wParam,lParam):
-	if watchdog.isAttemptingRecovery or code!=HC_ACTION:
+	if code != HC_ACTION:
 		return windll.user32.CallNextHookEx(0,code,wParam,lParam)
 	kbd=KBDLLHOOKSTRUCT.from_address(lParam)
 	if keyUpCallback and kbd.flags&LLKHF_UP:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes: #12609

### Summary of the issue:
NVDA doesn't correctly track state of keyboard modifiers (such as Control, or Insert) in some cases, e.g. when watchdog is recovering.

### Description of how this pull request fixes the issue:
In `winInputHook.py` , in `def keyboardHook()`, currently there is a condition:
```
if watchdog.isAttemptingRecovery or code!=HC_ACTION:
return windll.user32.CallNextHookEx(0,code,wParam,lParam)
```
So when `watchdog.isAttemptingRecovery` is `True`, then this function returns early and doesn't process any keyboard events, including events related to keyboard modifiers. As a result, when a user happens to press modifier while watchdog is recovering, NVDA won't process this, thus getting out of sync with current keyboard state.
In this PR I propose to check whether current keyboard event is related to keyboard modifiers, and         when it is related, then process it even when watchdog is recovering.
Please note, I reduplicate the list of keyboard modifiers in `winInputHook.py`, since importing the same list from `keyboardHandler.py` makes NVDA to crash on startup, probably due to circular import.

### Testing strategy:
Performed thorough manual testing on locally built version. This PR was applied on top of 2021.1beta1.
I have been running my custom build for about a month and couldn't reproduce the problem even once. For comparison, without this PR< the problem would reproduce several times a day during my normal work process.
I also had `tones.beep()` inserted in multiple versions to verify my hypothesis, and it proved true that when Notepad++ window is stuck on network write, then indeed watchdog enters recovery mode very often, and also while this happens if user happens to press or release any modifiers, then I also verified, that this event is indeed being ignored in current master version.
### Known issues with pull request:
None observed.
### Change log entries:
Bug fixes:
Fixing tracking state of keyboard modifiers (such as Control, or Insert) when watchdog is recovering.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests (something unrelated fails regarding to Bulgarian braille table - but master fails too)
- [ ] System (end to end) tests - doesn't apply
- [x] Manual testing.
- [ ] User Documentation - doesn't apply
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes - doesn't apply
- [ ] UX of all users considered - doesn't apply.
