### PR TITLE
Check system tests for crashes, add test for auxiliary thread crashes

### DIFF
--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -13,6 +13,7 @@ This is in contrast with the `SystemTestSpy/speechSpy*.py files,
 which provide library functions related to monitoring NVDA and asserting NVDA output.
 """
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
+from datetime import datetime as _datetime
 from os.path import (
 	join as _pJoin,
 	abspath as _abspath,
@@ -21,7 +22,7 @@ from os.path import (
 	splitext as _splitext,
 )
 import tempfile as _tempFile
-from typing import Optional
+from typing import Optional as _Optional
 from urllib.parse import quote as _quoteStr
 
 from robotremoteserver import (
@@ -76,7 +77,7 @@ class _NvdaLocationData:
 			"nvdaTestRunLogs"
 		)
 
-	def getPy2exeBootLogPath(self) -> Optional[str]:
+	def getPy2exeBootLogPath(self) -> _Optional[str]:
 		if self.whichNVDA == "installed":
 			executablePath = _locations.findInstalledNVDAPath()
 			# py2exe names this log file after the executable, see py2exe/boot_common.py
@@ -84,7 +85,7 @@ class _NvdaLocationData:
 		elif self.whichNVDA == "source":
 			return None  # Py2exe not used for source.
 
-	def findInstalledNVDAPath(self) -> Optional[str]:
+	def findInstalledNVDAPath(self) -> _Optional[str]:
 		NVDAFilePath = _pJoin(_expandvars('%PROGRAMFILES%'), 'nvda', 'nvda.exe')
 		legacyNVDAFilePath = _pJoin(_expandvars('%PROGRAMFILES%'), 'NVDA', 'nvda.exe')
 		exeErrorMsg = f"Unable to find installed NVDA exe. Paths tried: {NVDAFilePath}, {legacyNVDAFilePath}"
@@ -118,8 +119,9 @@ class NvdaLib:
 	- NvdaLib.nvdaSpy is a library instance for getting speech and other information out of NVDA
 	"""
 	def __init__(self):
-		self.nvdaSpy = None  #: Optional[SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib]
-		self.nvdaHandle: Optional[int] = None
+		self.nvdaSpy = None  #: _Optional[SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib]
+		self.nvdaHandle: _Optional[int] = None
+		self.lastNVDAStart: _Optional[_datetime] = None
 
 	@staticmethod
 	def _createTestIdFileName(name):
@@ -130,7 +132,7 @@ class NvdaLib:
 		return outputFileName
 
 	@staticmethod
-	def setup_nvda_profile(configFileName, gesturesFileName: Optional[str] = None):
+	def setup_nvda_profile(configFileName, gesturesFileName: _Optional[str] = None):
 		configManager.setupProfile(
 			_locations.repoRoot,
 			configFileName,
@@ -255,6 +257,7 @@ class NvdaLib:
 		return remoteLib
 
 	def start_NVDAInstaller(self, settingsFileName):
+		self.lastNVDAStart = _datetime.utcnow()
 		builtIn.log(f"Starting NVDA with config: {settingsFileName}")
 		self.setup_nvda_profile(settingsFileName)
 		nvdaProcessHandle = self._startNVDAInstallerProcess()
@@ -264,7 +267,8 @@ class NvdaLib:
 		self.nvdaSpy.wait_for_NVDA_startup_to_complete()
 		return nvdaProcessHandle
 
-	def start_NVDA(self, settingsFileName: str, gesturesFileName: Optional[str] = None):
+	def start_NVDA(self, settingsFileName: str, gesturesFileName: _Optional[str] = None):
+		self.lastNVDAStart = _datetime.utcnow()
 		builtIn.log(f"Starting NVDA with config: {settingsFileName}")
 		self.setup_nvda_profile(settingsFileName, gesturesFileName)
 		nvdaProcessHandle = self._startNVDAProcess()
@@ -307,6 +311,15 @@ class NvdaLib:
 		"""
 		return _pJoin(_locations.preservedLogsDir, self._createTestIdFileName(fileName))
 
+	def _quitNVDAProcessCleanup(self):
+		self.save_NVDA_log()
+		self.save_py2exe_boot_log()
+		crashDmpPath = self.save_crash_dump_if_exists()
+		# remove the spy so that if nvda is run manually against this config it does not interfere.
+		self.teardown_nvda_profile()
+		if crashDmpPath is not None:
+			raise AssertionError(f"NVDA crashed during this test. Crash dump saved to: {crashDmpPath}")
+
 	def quit_NVDA(self):
 		builtIn.log("Stopping nvdaSpy server: {}".format(self._spyServerURI))
 		try:
@@ -319,10 +332,7 @@ class NvdaLib:
 		except Exception:
 			raise
 		finally:
-			self.save_NVDA_log()
-			self.save_py2exe_boot_log()
-			# remove the spy so that if nvda is run manually against this config it does not interfere.
-			self.teardown_nvda_profile()
+			self._quitNVDAProcessCleanup()
 
 	def quit_NVDAInstaller(self):
 		builtIn.log("Stopping nvdaSpy server: {}".format(self._spyServerURI))
@@ -335,11 +345,39 @@ class NvdaLib:
 		except Exception:
 			raise
 		finally:
-			self.save_NVDA_log()
-			self.save_py2exe_boot_log()
-			# remove the spy so that if nvda is run manually against this config it does not interfere.
-			self.teardown_nvda_profile()
+			self._quitNVDAProcessCleanup()
 
+	@staticmethod
+	def check_for_crash_dump(
+			since: _Optional[_datetime],
+			overridePath: _Optional[str] = None,
+	) -> _Optional[str]:
+		"""
+		Checks if a crash.dmp exits and returns the crash dmp path if so
+		"""
+		crashPath = overridePath or _pJoin(_locations.logPath, "..", "nvda_crash.dmp")
+		try:
+			opSys.file_should_not_exist(crashPath)
+		except Exception:
+			crashTime = opSys.get_modified_time(crashPath, format="epoch")
+			crashTime = _datetime.fromtimestamp(crashTime)
+			since = since.replace(microsecond=0)  # get_modified_time only reports seconds, not microseconds
+			if crashTime >= since:
+				return crashPath
+
+	def save_crash_dump_if_exists(self, deleteCachedAfter: bool = True) -> _Optional[str]:
+		crashPath = self.check_for_crash_dump(self.lastNVDAStart)
+		if crashPath is None:
+			return None
+		saveToPath = self.create_preserved_test_output_filename("nvda_crash.dmp")
+		opSys.copy_file(
+			crashPath,
+			saveToPath
+		)
+		if deleteCachedAfter:
+			opSys.remove_file(crashPath)
+			opSys.wait_until_removed(crashPath)
+		return saveToPath
 
 
 def getSpyLib():

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -71,6 +71,14 @@ class NVDASpyLib:
 		from queueHandler import queueFunction, eventQueue
 		queueFunction(eventQueue, _crashNVDA)
 
+	def queueNVDABrailleThreadCrash(self):
+		from braille import _BgThread
+		_BgThread.queueApc(ctypes.windll.Kernel32.DebugBreak)
+
+	def queueNVDAUIAHandlerThreadCrash(self):
+		from UIAHandler import handler
+		handler.MTAThreadQueue.put(_crashNVDA)
+
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
 		self._isNvdaStartupComplete = True

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -138,3 +138,27 @@ def NVDA_restarts_on_crash():
 	_process.process_should_be_stopped(_nvdaProcessAlias)
 	waitUntilWindowFocused("Welcome to NVDA")
 	# TODO: check for crash.dmp
+
+
+def NVDA_restarts_on_braille_crash():
+	"""Ensure NVDA restarts on crash."""
+	spy = _nvdaLib.getSpyLib()
+	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present
+	spy.emulateKeyPress("enter")  # close the dialog so we can check for it after the crash
+	spy.queueNVDABrailleThreadCrash()
+	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
+	_process.process_should_be_stopped(_nvdaProcessAlias)
+	waitUntilWindowFocused("Welcome to NVDA")
+	# TODO: check for crash.dmp
+
+
+def NVDA_restarts_on_UIAHandler_crash():
+	"""Ensure NVDA restarts on crash."""
+	spy = _nvdaLib.getSpyLib()
+	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present
+	spy.emulateKeyPress("enter")  # close the dialog so we can check for it after the crash
+	spy.queueNVDAUIAHandlerThreadCrash()
+	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
+	_process.process_should_be_stopped(_nvdaProcessAlias)
+	waitUntilWindowFocused("Welcome to NVDA")
+	# TODO: check for crash.dmp

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -6,16 +6,20 @@
 """Logic for startupShutdownNVDA tests.
 """
 
+from datetime import datetime as _datetime
+from typing import Callable as _Callable
 from robot.libraries.BuiltIn import BuiltIn
 # relative import not used for 'systemTestUtils' because the folder is added to the path for 'libraries'
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
 from SystemTestSpy import (
 	_getLib,
+	_blockUntilConditionMet,
 )
 from SystemTestSpy.windows import waitUntilWindowFocused
 
 # Imported for type information
 from robot.libraries.Process import Process as _ProcessLib
+from robot.libraries.OperatingSystem import OperatingSystem as _OpSysLib
 
 from AssertsLib import AssertsLib as _AssertsLib
 
@@ -23,6 +27,8 @@ import NvdaLib as _nvdaLib
 from NvdaLib import NvdaLib as _nvdaRobotLib
 _nvdaProcessAlias = _nvdaRobotLib.nvdaProcessAlias
 
+_nvdaRobot: _nvdaRobotLib = _getLib("NvdaLib")
+_opSys: _OpSysLib = _getLib('OperatingSystem')
 _builtIn: BuiltIn = BuiltIn()
 _process: _ProcessLib = _getLib("Process")
 _asserts: _AssertsLib = _getLib("AssertsLib")
@@ -128,37 +134,52 @@ def NVDA_restarts():
 	waitUntilWindowFocused("Welcome to NVDA")
 
 
-def NVDA_restarts_on_crash():
-	"""Ensure NVDA restarts on crash."""
+def _attemptFileRemove(filePath: str) -> bool:
+	try:
+		_opSys.remove_file(filePath)
+		return True
+	except PermissionError:
+		return False
+
+
+def _ensureRestartWithCrashDump(crashFunction: _Callable[[], None]):
+	startTime = _datetime.utcnow()
 	spy = _nvdaLib.getSpyLib()
 	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present
 	spy.emulateKeyPress("enter")  # close the dialog so we can check for it after the crash
-	spy.queueNVDAMainThreadCrash()
+	crashFunction()
 	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
 	_process.process_should_be_stopped(_nvdaProcessAlias)
+	crashOccurred, crashPath = _blockUntilConditionMet(
+		getValue=lambda: _nvdaRobot.check_for_crash_dump(startTime),
+		giveUpAfterSeconds=3,
+	)
+	if not crashOccurred:
+		raise AssertionError("A crash.dmp file has not been generated after a crash")
 	waitUntilWindowFocused("Welcome to NVDA")
-	# TODO: check for crash.dmp
+	# prevent test failure by removing the crash dump file
+	crashFileDeleted, _crashFileExists = _blockUntilConditionMet(
+		getValue=lambda: _attemptFileRemove(crashPath),
+		giveUpAfterSeconds=3,
+	)
+	_opSys.wait_until_removed(crashPath)
+	if not crashFileDeleted:
+		raise AssertionError("crash.dmp file could not be deleted")
+
+
+def NVDA_restarts_on_crash():
+	"""Ensure NVDA restarts on crash."""
+	spy = _nvdaLib.getSpyLib()
+	_ensureRestartWithCrashDump(spy.queueNVDAMainThreadCrash)
 
 
 def NVDA_restarts_on_braille_crash():
 	"""Ensure NVDA restarts on crash."""
 	spy = _nvdaLib.getSpyLib()
-	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present
-	spy.emulateKeyPress("enter")  # close the dialog so we can check for it after the crash
-	spy.queueNVDABrailleThreadCrash()
-	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
-	_process.process_should_be_stopped(_nvdaProcessAlias)
-	waitUntilWindowFocused("Welcome to NVDA")
-	# TODO: check for crash.dmp
+	_ensureRestartWithCrashDump(spy.queueNVDABrailleThreadCrash)
 
 
 def NVDA_restarts_on_UIAHandler_crash():
 	"""Ensure NVDA restarts on crash."""
 	spy = _nvdaLib.getSpyLib()
-	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present
-	spy.emulateKeyPress("enter")  # close the dialog so we can check for it after the crash
-	spy.queueNVDAUIAHandlerThreadCrash()
-	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
-	_process.process_should_be_stopped(_nvdaProcessAlias)
-	waitUntilWindowFocused("Welcome to NVDA")
-	# TODO: check for crash.dmp
+	_ensureRestartWithCrashDump(spy.queueNVDAUIAHandlerThreadCrash)

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -46,3 +46,11 @@ Restarts
 Restarts on crash
 	[Documentation]	Ensure NVDA restarts on crash.
 	NVDA restarts on crash
+
+Restarts on braille crash
+	[Documentation]	Ensure NVDA restarts on a crash on the braille thread.
+	NVDA restarts on braille crash
+
+Restarts on UIAHandler crash
+	[Documentation]	Ensure NVDA restarts on crash on the UIAHandler thread.
+	NVDA restarts on UIAHandler crash


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

System tests may pass even if a crash occurs during them. 

Similar to #12604, it is important to ensure NVDA can restart when an auxiliary thread crashes.

### Description of how this pull request fixes the issue:

This adds a check for a crash dump file when we save the NVDA log, tests will fail if a crash has occurred during the test. Crash dump files will be saved like log files.

Adds system tests to simulate the UIAHandler and braille thread crashing.

### Testing strategy:

Run system tests locally and via appveyor

### Known issues with pull request:

None

### Change log entries:

None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
