### PR TITLE
Start logging earlier and keep more log files

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -6,6 +6,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
+import config
+
 """NVDA core"""
 
 RPC_E_CALL_CANCELED = -2147418110
@@ -396,6 +398,17 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	brailleViewer.destroyBrailleViewer()
 
 
+def _startLogCleanupThread(conf: config.ConfigManager):
+	# todo: this needs to be replaced with:
+	#  - start a thread
+	#  - thread will sort log files by file name
+	#  - keep the first N (defined in conf)
+	#  - delete all older log files
+	#  - end thread
+	# logHandler._backupOldLog(os.path.dirname(globalVars.appArgs.logFileName))
+	pass
+
+
 def main():
 	"""NVDA's core main loop.
 	This initializes all modules such as audio, IAccessible, keyboard, mouse, and GUI.
@@ -742,6 +755,7 @@ def main():
 	# and initial focus has been reported.
 	def _doPostNvdaStartupAction():
 		log.debug("Notify of postNvdaStartup action")
+		_startLogCleanupThread(config.conf)
 		postNvdaStartup.notify()
 
 	queueHandler.queueFunction(queueHandler.eventQueue, _doPostNvdaStartupAction)

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -1,35 +1,45 @@
-#globalVars.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-"""global variables module
-@var foregroundObject: holds the current foreground object. The object for the last foreground event received.
-@type foregroundObject: L{NVDAObjects.NVDAObject}
-  @var focusObject: holds the current focus object
-@type focusObject: L{NVDAObjects.NVDAObject}
-@var mouseObject: holds the object that is at the position of the mouse pointer
-@type mouseObject: L{NVDAObjects.NVDAObject}
-@var mouseOldX: the last x coordinate of the mouse pointer before its current position
-@type oldMouseX: int
-@var mouseOldY: the last y coordinate of the mouse pointer before its current position
-@type oldMouseY: int
-  @var navigatorObject: holds the current navigator object
-@type navigatorObject: L{NVDAObjects.NVDAObject}
-@var navigatorTracksFocus: if true, the navigator object will follow the focus as it changes
-@type navigatorTracksFocus: boolean
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2021 NV Access Limited, Leonard de Ruijter, pvagner
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Global variables module
 """
- 
+import typing
+from typing import(
+	Optional,
+)
+
+if typing.TYPE_CHECKING:
+	import NVDAObjects
+
+#: The directory that contains 'nvda.pyw'
+appDir = Optional[str]
+
 startTime=0
 desktopObject=None
-foregroundObject=None
-focusObject=None
+
+#: Holds the current foreground object. The object for the last foreground event received.
+foregroundObject: Optional["NVDAObjects.NVDAObject"] = None
+
+#: Holds the current focus object
+focusObject: Optional["NVDAObjects.NVDAObject"] = None
+
 focusAncestors=[]
 focusDifferenceLevel=None
-mouseObject=None
-mouseOldX=None
-mouseOldY=None
-navigatorObject=None
+
+#: Holds the object that is at the position of the mouse pointer
+mouseObject: Optional["NVDAObjects.NVDAObject"] = None
+
+#: The last x coordinate of the mouse pointer before its current position
+mouseOldX: Optional[int] = None
+
+#: The last y coordinate of the mouse pointer before its current position
+mouseOldY: Optional[int] = None
+
+#: Holds the current navigator object
+navigatorObject: Optional["NVDAObjects.NVDAObject"] = None
+
 reviewPosition=None
 reviewPositionObj=None
 lastProgressValue=0


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

### Summary of the issue:
While investigating several of the restarting bugs, it was useful to have earlier logging.
It became clear that there are several more NVDA processes being started when only one is expected (due to ease-of-access).
Under this new approach, these processes are all in contention for the log file name. 

### Description of how this pull request fixes the issue:
- Start logging earlier in NVDA startup.
- Keep more log files, in an nvdalogs folder, use startup date-time as basis for name.
- [ ] Ensure no race condition.
- [ ] Limit total log files collected.

### Testing strategy:

### Known issues with pull request:

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual testing.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
