### PR TITLE
Recognize build 22000 as Windows 11

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -159,8 +159,17 @@ def getWinVer():
 	"""
 	winVer = sys.getwindowsversion()
 	# #12509: on Windows 10, fetch whatever Windows Registry says for the current build.
+	# #12626: note that not all Windows 10 releases are labeled "Windows 10"
+	# (build 22000 is Windows 11 despite major.minor being 10.0).
 	try:
-		releaseName = f"Windows 10 {_getRunningVersionNameFromWinReg()}"
+		if WinVersion(
+			major=winVer.major,
+			minor=winVer.minor,
+			build=winVer.build
+		) >= WIN11:
+			releaseName = f"Windows 11 {_getRunningVersionNameFromWinReg()}"
+		else:
+			releaseName = f"Windows 10 {_getRunningVersionNameFromWinReg()}"
 	except RuntimeError:
 		releaseName = None
 	return WinVersion(

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -32,7 +32,7 @@ _BUILDS_TO_RELEASE_NAMES = {
 	19041: "Windows 10 2004",
 	19042: "Windows 10 20H2",
 	19043: "Windows 10 21H1",
-	22000: "Windows 11 21H2"
+	22000: "Windows 11 21H2",
 }
 
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -31,7 +31,8 @@ _BUILDS_TO_RELEASE_NAMES = {
 	18363: "Windows 10 1909",
 	19041: "Windows 10 2004",
 	19042: "Windows 10 20H2",
-	19043: "Windows 10 21H1"
+	19043: "Windows 10 21H1",
+	22000: "Windows 11 21H2"
 }
 
 
@@ -150,6 +151,7 @@ WIN10_1909 = WinVersion(major=10, minor=0, build=18363)
 WIN10_2004 = WinVersion(major=10, minor=0, build=19041)
 WIN10_20H2 = WinVersion(major=10, minor=0, build=19042)
 WIN10_21H1 = WinVersion(major=10, minor=0, build=19043)
+WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
 
 
 def getWinVer():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -36,6 +36,7 @@ This can be toggled in the Preferences dialog or with a new (unassigned) command
 - Improvements to announcing the Windows emoji panel and clipboard history. (#11485)
 - Updated the Bengali alphabet character descriptions. (#12502)
 - NVDA exits safely when a new process is started. (#12605)
+- Windows version 10.0.22000 or later is recognized as Windows 11, not Windows 10. (#12626)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #12626

### Summary of the issue:
Windows 11 build 22000 is presented as "Windows 10" by NVDA.

### Description of how this pull request fixes the issue:
Recognize build 22000 as Windows 11:

1. Define two Windows 11 constants: winVersion.WIN11 and winVersion.WIN11_21H2, similar to how initial Windows 10 release constant was defined.
2. Edit winVersion.getWinVer function by comparing minimal WinVersion class (major, minor, build) to Windows 11 constant and settings release name to "Windows 11" if this is a Windows 11 build.

### Testing strategy:
Manual testing:

Install Windows 11 Insider Preview (build 22000) and:

1. Make sure Windows says "Windows 11" (open Start, type "winver", press Enter, then examine "About Windows" dialog).
2. Verify that NVDA log reports "Windows version: Windows 11 21H2".
3. From Python Console, try winVersion.getWinVer() >= winVersion.WIN11 (Tru on Windows 11, False otherwise).

### Known issues with pull request:
None

### Change log entries:
Changes for developers (or perhaps a bug fix/changes):
Windows version 10.0.22000 or later is recognized as Windows 11, not Windows 10. (#12626)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers

Thanks.