### PR TITLE
appModules/SearchUI: add 'searchhost' as an alias of Search UI app module in Windows 11

### DIFF
--- a/source/appModules/searchhost.py
+++ b/source/appModules/searchhost.py
@@ -1,0 +1,10 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2021 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Windows Search app module for Windows 11 (build 22000) and later.
+"""
+
+# Flake8/F403: this is an alias for SearchUI app module.
+from .searchui import * # NOQA

--- a/source/appModules/searchhost.py
+++ b/source/appModules/searchhost.py
@@ -6,5 +6,5 @@
 """Windows Search app module for Windows 11 (build 22000) and later.
 """
 
-# Flake8/F403: this is an alias for SearchUI app module.
-from .searchui import * # NOQA
+from .searchui import AppModule, StartMenuSearchField
+__all__ = ["AppModule", "StartMenuSearchField"]

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,7 +10,7 @@ What's New in NVDA
   - adds a command to read a summary of details of an object with aria-details. (#12364)
   - adds an option in advanced to report if an object has details in browse mode. (#12439) 
   -
-- In Windows 10 Version 1909, NVDA will announce suggestion count when performing searches in File Explorer. (#10231)
+- In Windows 10 Version 1909 and later (including Windows 11), NVDA will announce suggestion count when performing searches in File Explorer. (#10341, #12628)
 -
 
 


### PR DESCRIPTION
Hi,

Another part of #12585:

### Link to issue number:
Expands #10341 

### Summary of the issue:
Windows Search executable was renamed to searchhost.exe in Windows 11, affecting suggestion count announcement.

### Description of how this pull request fixes the issue:
Add an alias app module named "searchhost.py" to support suggestions count announcement in Windows 11.

### Testing strategy:
Manual testing:

1. In Windows 11 preview, open File Explorer (Windows+E).
2. Press F3 to open search interface.
3. Type something. NVDA should announce suggestion count.

### Known issues with pull request:
None

### Change log entries:
Tweaking #10341 to say:

New features:
In Windows 10 Version 1909 and later (including Windows 11), NVDA will announce suggestion count when performing searches in File Explorer. (#10341, #12628)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
