### PR TITLE
Set the config using the integer value of a SymbolLevel enum member

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -127,7 +127,7 @@ def getCharacterDescription(locale,character):
 
 
 # Speech symbol levels
-class SYMLVL(IntEnum):
+class SymbolLevel(IntEnum):
 	NONE = 0
 	SOME = 100
 	MOST = 200
@@ -137,28 +137,28 @@ class SYMLVL(IntEnum):
 
 
 # The following SYMLVL_ constants are deprecated in #11856 but remain to maintain backwards compatibility.
-# Remove these in 2022.1 and replace instances using them with the SYMLVL IntEnum.
+# Remove these in 2022.1 and replace instances using them with the SymbolLevel IntEnum.
 if version_year < 2022:
-	SYMLVL_NONE = SYMLVL.NONE
-	SYMLVL_SOME = SYMLVL.SOME
-	SYMLVL_MOST = SYMLVL.MOST
-	SYMLVL_ALL = SYMLVL.ALL
-	SYMLVL_CHAR = SYMLVL.CHAR
+	SYMLVL_NONE = SymbolLevel.NONE
+	SYMLVL_SOME = SymbolLevel.SOME
+	SYMLVL_MOST = SymbolLevel.MOST
+	SYMLVL_ALL = SymbolLevel.ALL
+	SYMLVL_CHAR = SymbolLevel.CHAR
 
 SPEECH_SYMBOL_LEVEL_LABELS = {
 	# Translators: The level at which the given symbol will be spoken.
-	SYMLVL.NONE: pgettext("symbolLevel", "none"),
+	SymbolLevel.NONE: pgettext("symbolLevel", "none"),
 	# Translators: The level at which the given symbol will be spoken.
-	SYMLVL.SOME: pgettext("symbolLevel", "some"),
+	SymbolLevel.SOME: pgettext("symbolLevel", "some"),
 	# Translators: The level at which the given symbol will be spoken.
-	SYMLVL.MOST: pgettext("symbolLevel", "most"),
+	SymbolLevel.MOST: pgettext("symbolLevel", "most"),
 	# Translators: The level at which the given symbol will be spoken.
-	SYMLVL.ALL: pgettext("symbolLevel", "all"),
+	SymbolLevel.ALL: pgettext("symbolLevel", "all"),
 	# Translators: The level at which the given symbol will be spoken.
-	SYMLVL.CHAR: pgettext("symbolLevel", "character"),
+	SymbolLevel.CHAR: pgettext("symbolLevel", "character"),
 }
-CONFIGURABLE_SPEECH_SYMBOL_LEVELS = (SYMLVL.NONE, SYMLVL.SOME, SYMLVL.MOST, SYMLVL.ALL)
-SPEECH_SYMBOL_LEVELS = CONFIGURABLE_SPEECH_SYMBOL_LEVELS + (SYMLVL.CHAR,)
+CONFIGURABLE_SPEECH_SYMBOL_LEVELS = (SymbolLevel.NONE, SymbolLevel.SOME, SymbolLevel.MOST, SymbolLevel.ALL)
+SPEECH_SYMBOL_LEVELS = CONFIGURABLE_SPEECH_SYMBOL_LEVELS + (SymbolLevel.CHAR,)
 
 # Speech symbol preserve modes
 SYMPRES_NEVER = 0
@@ -269,11 +269,11 @@ class SpeechSymbols(object):
 	}
 	IDENTIFIER_ESCAPES_OUTPUT = {v: k for k, v in IDENTIFIER_ESCAPES_INPUT.items()}
 	LEVEL_INPUT = {
-		"none": SYMLVL.NONE,
-		"some": SYMLVL.SOME,
-		"most": SYMLVL.MOST,
-		"all": SYMLVL.ALL,
-		"char": SYMLVL.CHAR,
+		"none": SymbolLevel.NONE,
+		"some": SymbolLevel.SOME,
+		"most": SymbolLevel.MOST,
+		"all": SymbolLevel.ALL,
+		"char": SymbolLevel.CHAR,
 	}
 	LEVEL_OUTPUT = {v:k for k, v in LEVEL_INPUT.items()}
 	PRESERVE_INPUT = {
@@ -499,7 +499,7 @@ class SpeechSymbolProcessor(object):
 					pass
 				continue
 			if symbol.level is None:
-				symbol.level = SYMLVL.ALL
+				symbol.level = SymbolLevel.ALL
 			if symbol.preserve is None:
 				symbol.preserve = SYMPRES_NEVER
 			if symbol.displayName is None:
@@ -676,7 +676,7 @@ class SpeechSymbolProcessor(object):
 _localeSpeechSymbolProcessors = LocaleDataMap(SpeechSymbolProcessor)
 
 
-def processSpeechSymbols(locale: str, text: str, level: SYMLVL):
+def processSpeechSymbols(locale: str, text: str, level: SymbolLevel):
 	"""Process some text, converting symbols according to desired pronunciation.
 	@param locale: The locale of the text.
 	@param text: The text to process.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -889,7 +889,7 @@ class GlobalCommands(ScriptableObject):
 		else:
 			level = characterProcessing.SYMLVL_NONE
 		name = characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS[level]
-		config.conf["speech"]["symbolLevel"] = level
+		config.conf["speech"]["symbolLevel"] = level.value
 		# Translators: Reported when the user cycles through speech symbol levels
 		# which determine what symbols are spoken.
 		# %s will be replaced with the symbol level; e.g. none, some, most and all.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1592,7 +1592,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		config.conf["speech"]["autoDialectSwitching"] = self.autoDialectSwitchingCheckbox.IsChecked()
 		config.conf["speech"]["symbolLevel"] = characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS[
 			self.symbolLevelList.GetSelection()
-		]
+		].value
 		config.conf["speech"]["symbolLevelWordAll"] = self.symbolLevelWordAll.IsChecked()
 		config.conf["speech"]["trustVoiceLanguage"] = self.trustVoiceLanguageCheckbox.IsChecked()
 		currentIncludeCLDR = config.conf["speech"]["includeCLDR"]

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1126,12 +1126,12 @@ def speakTextInfo(
 	)
 
 	speechGen = GeneratorWithReturn(speechGen)
-	symbolLevel: Optional[characterProcessing.SYMLVL] = None
+	symbolLevel: Optional[characterProcessing.SymbolLevel] = None
 	if unit == textInfos.UNIT_CHARACTER:
-		symbolLevel = characterProcessing.SYMLVL.ALL
+		symbolLevel = characterProcessing.SymbolLevel.ALL
 	elif unit == textInfos.UNIT_WORD:
 		if config.conf["speech"]["symbolLevelWordAll"]:
-			symbolLevel = characterProcessing.SYMLVL.ALL
+			symbolLevel = characterProcessing.SymbolLevel.ALL
 	for seq in speechGen:
 		speak(seq, symbolLevel=symbolLevel, priority=priority)
 	return speechGen.returnValue

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,7 +42,7 @@ This can be toggled in the Preferences dialog or with a new (unassigned) command
 
 
 == Changes for Developers ==
-- ``characterProcessing.SYMLVL_*`` constants should be replaced using their equivalent ``SymbolLevel.*`` before 2022.1. (#11856)
+- ``characterProcessing.SYMLVL_*`` constants should be replaced using their equivalent ``SymbolLevel.*`` before 2022.1. (#11856, #12636)
 - ``controlTypes`` has been split up into various submodules, symbols marked for deprecation must be replaced before 2022.1. (#12510)
   - ``ROLE_*`` and ``STATE_*`` constants should be replaced to their equivalent ``Role.*`` and ``State.*``.
   - ``roleLabels``, ``stateLabels`` and ``negativeStateLabels`` have been deprecated, usages such as ``roleLabels[ROLE_*]`` should be replaced to their equivalent ``Role.*.displayString`` or ``State.*.negativeDisplayString``.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,7 +42,7 @@ This can be toggled in the Preferences dialog or with a new (unassigned) command
 
 
 == Changes for Developers ==
-- ``characterProcessing.SYMLVL_*`` constants should be replaced using their equivalent ``SYMLVL.*`` before 2022.1. (#11856)
+- ``characterProcessing.SYMLVL_*`` constants should be replaced using their equivalent ``SymbolLevel.*`` before 2022.1. (#11856)
 - ``controlTypes`` has been split up into various submodules, symbols marked for deprecation must be replaced before 2022.1. (#12510)
   - ``ROLE_*`` and ``STATE_*`` constants should be replaced to their equivalent ``Role.*`` and ``State.*``.
   - ``roleLabels``, ``stateLabels`` and ``negativeStateLabels`` have been deprecated, usages such as ``roleLabels[ROLE_*]`` should be replaced to their equivalent ``Role.*.displayString`` or ``State.*.negativeDisplayString``.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12630, caused by #11856

### Summary of the issue:

SYMLVL_* constants were moved to an IntEnum. When updating the config for symbolLevel, the type being set is Enum, as opposed to int. Additionally, the enum does not conform to our naming standards https://github.com/nvaccess/nvda/blob/master/devDocs/codingStandards.md#identifier-names.

### Description of how this pull request fixes the issue:

Sets the config using the value of the enum member. Renames `SYMLVL` to `SymbolLevel`. 

### Testing strategy:

Manual testing of the config using the steps in #12630. Set the symbolLevel via NVDA settings and quick keys and ensure the config can be used on restart. 

System testing for setting the NVDA config could be added in the future.

### Known issues with pull request:

None

### Change log entries:

None needed, just fixed the earlier developer changes message for #11856

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
