### PR TITLE
Fallback to eSpeak if OneCore voices are not installed

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -1,6 +1,5 @@
-# languageHandler.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2018 NV access Limited, Joseph Lee
+# Copyright (C) 2007-2021 NV access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -16,6 +15,7 @@ import locale
 import gettext
 import globalVars
 from logHandler import log
+from typing import Optional
 
 #a few Windows locale constants
 LOCALE_SLANGUAGE=0x2
@@ -291,7 +291,8 @@ def setLocale(localeName: str) -> None:
 def getLanguage() -> str:
 	return curLang
 
-def normalizeLanguage(lang):
+
+def normalizeLanguage(lang) -> Optional[str]:
 	"""
 	Normalizes a  language-dialect string  in to a standard form we can deal with.
 	Converts  any dash to underline, and makes sure that language is lowercase and dialect is upercase.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -182,7 +182,7 @@ def speakMessage(
 		speak(seq, symbolLevel=None, priority=priority)
 
 
-def getCurrentLanguage():
+def getCurrentLanguage() -> str:
 	synth = getSynth()
 	language=None
 	if  synth:

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -460,14 +460,14 @@ def setSynth(name, isFallback=False):
 	
 	if _curSynth and _curSynth.name == "oneCore" and not _curSynth.availableVoices:
 		# This synth cannot be used without available voices
-		log.info(f"No available voices for synthDriver {name}")
+		log.info(f"No available voices for synthDriver {_curSynth.name}")
 		_curSynth = None
 	
 	if _curSynth is not None:
 		_audioOutputDevice = config.conf["speech"]["outputDevice"]
 		if not isFallback:
 			config.conf["speech"]["synth"] = name
-		log.info(f"Loaded synthDriver {name}")
+		log.info(f"Loaded synthDriver {_curSynth.name}")
 		return True
 	# As there was an error loading this synth:
 	elif prevSynthName:

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -458,7 +458,7 @@ def setSynth(name, isFallback=False):
 	except:  # noqa: E722 # Legacy bare except
 		log.error(f"setSynth failed for {name}", exc_info=True)
 	
-	if _curSynth and not _curSynth.availableVoices:
+	if _curSynth and _curSynth.name == "oneCore" and not _curSynth.availableVoices:
 		# This synth cannot be used without available voices
 		log.info(f"No available voices for synthDriver {name}")
 		_curSynth = None

--- a/source/synthDrivers/silence.py
+++ b/source/synthDrivers/silence.py
@@ -4,6 +4,7 @@
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
+from collections import OrderedDict
 import synthDriverHandler
 from speech.commands import IndexCommand
 
@@ -18,7 +19,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 	def check(cls):
 		return True
 
-	supportedSettings=[]
+	supportedSettings = frozenset()
+	_availableVoices = OrderedDict({name: synthDriverHandler.VoiceInfo(name, description)})
 
 	def speak(self, speechSequence):
 		self.lastIndex = None
@@ -28,3 +30,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
 	def cancel(self):
 		self.lastIndex = None
+
+	def _get_voice(self):
+		return self.name


### PR DESCRIPTION
### Link to issue number:

Fixes #10451

### Summary of the issue:

If a device has no OneCore voices installed, speech fails by default when starting a new NVDA copy.

### Description of how this pull request fixes the issue:

Consider OneCore as unusable if there are no available voices

### Testing strategy:

- [ ] Manual confirmation that this issue still exists on the latest alpha build
- [ ] Manual confirmation that the PR build fixes this issue on devices without any OneCore voices installed
- [x] Manual confirmation that all NVDA synths still work

### Known issues with pull request:

#11544 is still a current issue

### Change log entries:

Bug fixes
```
- NVDA will default to eSpeak if no OneCore voices are installed on the device. (#10451)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [ ] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
