### PR TITLE
Recognize more Windows 21H2 builds

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -24,7 +24,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.18990.0" 
-			MaxVersionTested="10.0.19043.0" 
+			MaxVersionTested="10.0.19044.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -32,6 +32,8 @@ _BUILDS_TO_RELEASE_NAMES = {
 	19041: "Windows 10 2004",
 	19042: "Windows 10 20H2",
 	19043: "Windows 10 21H1",
+	19044: "Windows 10 21H2",
+	20348: "Windows Server 2022",
 	22000: "Windows 11 21H2",
 }
 
@@ -151,6 +153,8 @@ WIN10_1909 = WinVersion(major=10, minor=0, build=18363)
 WIN10_2004 = WinVersion(major=10, minor=0, build=19041)
 WIN10_20H2 = WinVersion(major=10, minor=0, build=19042)
 WIN10_21H1 = WinVersion(major=10, minor=0, build=19043)
+WIN10_21H2 = WinVersion(major=10, minor=0, build=19044)
+WINSERVER_2022 = WinVersion(major=10, minor=0, build=20348)
 WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
 
 


### PR DESCRIPTION

### Link to issue number:
Closes #12654 

### Summary of the issue:
Windows 21H2 are three releases: Windows 11, Windows 10 client, and Windows Server 2022.

### Description of how this pull request fixes the issue:
Recognizes the following 21H2 builds:

* 19044: client
* 20348: Server 2022

### Testing strategy:
Manual testing: from a system running Server 2022 or build 19044, open Python Console and make sure winVersion.getWinVer().releaseName says "Windows Server 2022" (build 20348) or Windows 10 21H2 (build 19044).

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
