### PR TITLE
Fix some undefined names in NVDAObjects

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -9,6 +9,7 @@ from comtypes.hresult import S_OK, S_FALSE
 import ctypes
 import os
 import re
+import sys
 import itertools
 import importlib
 from comInterfaces.tom import ITextDocument
@@ -1302,7 +1303,7 @@ the NVDAObject for IAccessible
 		# For our purposes, we can treat both S_OK and S_FALSE as success.
 		if res!=S_OK and res!=S_FALSE:
 			raise COMError(res,None,None)
-		return numItemsFetched.value if numItemsFetched.value<=maxCount else sys.maxsize
+		return numItemsFetched.value if numItemsFetched.value <= maxCount else sys.maxsize
 
 	def getSelectedItemsCount(self,maxCount):
 		# To fetch the number of selected items, we first try MSAA's accSelection, but if that fails in any way, we fall back to using IAccessibleTable2's nSelectedCells, if we are on an IAccessible2 table.

--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -954,10 +954,17 @@ class OfficeChartElementLegendKey( OfficeChartElementBase):
 			# See https://support.office.com/en-us/article/Excel-Glossary-53b6ce43-1a9f-4ac2-a33c-d6f64ea2d1fc?CorrelationId=44f003e6-453a-4b14-a9a6-3fb5287109c7&ui=en-US&rs=en-US&ad=US
 			return _( "Legend key for Series {seriesName} {seriesIndex} of {seriesCount}").format( seriesName = self.officeChartObject.SeriesCollection(arg1).Name , seriesIndex = arg1 , seriesCount = self.officeChartObject.SeriesCollection().Count )
 
+
 class OfficeChartElementDataTable( OfficeChartElementBase):
 
 	def __init__(self, windowHandle=None , officeChartObject=None   , elementID=None  , arg1=None , arg2=None ):
-		super( OfficeChartDataTable , self ).__init__( windowHandle=windowHandle , officeChartObject=officeChartObject , elementID=elementID , arg1=arg1 , arg2=arg2 )
+		super().__init__(
+			windowHandle=windowHandle,
+			officeChartObject=officeChartObject,
+			elementID=elementID,
+			arg1=arg1,
+			arg2=arg2
+		)
 
 	def _getChartElementText(self, ElementID ,arg1,arg2 , reportExtraInfo=False ):
 		#Translators: Data Table will be spoken when chart element Data Table is selected

--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -1,12 +1,9 @@
-# -*- coding: UTF-8 -*-
-#NVDAObjects/window/_msOfficeChartConstants.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2014-2017 NV Access Limited, NVDA India
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2014-2021 NV Access Limited, NVDA India, dineshkaushal
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import eventHandler
-import time
 import ui
 from . import Window
 import ctypes
@@ -16,6 +13,9 @@ import colors
 import inputCore
 import re
 from logHandler import log
+import browseMode
+from scriptHandler import script
+
 
 #This file contains chart constants common to Chart Object for Microsoft Office.
 
@@ -572,14 +572,23 @@ class OfficeChart(OfficeChartElementList):
 			text +=_("No Series defined.")
 		return text
 
-	def script_activatePosition(self,gesture):
+	@script(
+		description=_(
+			# Translators: Input help mode message for toggle focus and browse mode command
+			# in web browsing and other situations.
+			"Toggles between browse mode and focus mode."
+			" When in focus mode, keys will pass straight through to the application, "
+			"allowing you to interact directly with a control. "
+			"When in browse mode, you can navigate the document with the cursor, quick navigation keys, etc."
+		),
+		category=inputCore.SCRCAT_BROWSEMODE,
+		gestures=("kb:enter", "kb(desktop):numpadEnter", "kb:space")
+	)
+	def script_activatePosition(self, gesture):
 		# Toggle browse mode pass-through.
 		self.passThrough = True
 		self.ignoreTreeInterceptorPassThrough=False
 		browseMode.reportPassThrough(self)
-	# Translators: Input help mode message for toggle focus and browse mode command in web browsing and other situations.
-	script_activatePosition.__doc__=_("Toggles between browse mode and focus mode. When in focus mode, keys will pass straight through to the application, allowing you to interact directly with a control. When in browse mode, you can navigate the document with the cursor, quick navigation keys, etc.")
-	script_activatePosition.category=inputCore.SCRCAT_BROWSEMODE
 
 	def script_disablePassThrough(self, gesture):
 		log.debugWarning("script_disablePassThrough")
@@ -589,9 +598,6 @@ class OfficeChart(OfficeChartElementList):
 	__gestures = {
 				"kb:upArrow":"previousElement",
 				"kb:downArrow":"nextElement",
-				"kb:enter": "activatePosition",
-				"kb(desktop):numpadEnter":"activatePosition",
-				"kb:space": "activatePosition",
 				"kb:escape": "disablePassThrough",
 	}
 


### PR DESCRIPTION

### Link to issue number:
None - noticed when looking ad a failed lint in Pr #12649 
### Summary of the issue:
Linter complains about some names being undefined in `NVDAObjects` package. In particular:
- Missing import of `sys` in main IAccessible` module.
- Missing import of `browseMode` in _msOfficeChart
- Wrong name of the class in the call to `super` in the same file.

### Description of how this pull request fixes the issue:
Added missing imports and fixed the `super` call by using Python 3 `super`
### Testing strategy:
Ensured that  Linter shows no undefined names warning for these files

### Known issues with pull request:
None known
### Change log entries:
None needed IMHO - these issues were there for a very long time and since no one noticed them in the normal usage these code path's are probably very rarely used.

### Code Review Checklist:

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
