### PR TITLE
UI Automation in Windows Console: use UIATextInfo in FORMATTED consoles

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -19,6 +19,7 @@ from ..window import Window
 
 
 class ConsoleUIATextInfo(UIATextInfo):
+	"A TextInfo implementation for consoles with an IMPROVED, but not FORMATTED, API level."
 	def __init__(self, obj, position, _rangeObj=None):
 		collapseToEnd = None
 		# We want to limit  textInfos to just the visible part of the console.
@@ -376,11 +377,12 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 		ConsoleUIATextInfo bounds review to the visible text.
 		ConsoleUIATextInfoWorkaroundEndInclusive fixes expand/collapse and implements
 		word movement."""
-		return (
-			ConsoleUIATextInfo
-			if self.apiLevel >= WinConsoleAPILevel.IMPROVED
-			else ConsoleUIATextInfoWorkaroundEndInclusive
-		)
+		if self.apiLevel >= WinConsoleAPILevel.FORMATTED:
+			return UIATextInfo  # No TextInfo workarounds needed
+		elif self.apiLevel >= WinConsoleAPILevel.IMPROVED:
+			return ConsoleUIATextInfo
+		else:
+			return ConsoleUIATextInfoWorkaroundEndInclusive
 
 	def _get_devInfo(self):
 		info = super().devInfo
@@ -408,5 +410,4 @@ def findExtraOverlayClasses(obj, clsList):
 
 
 class WinTerminalUIA(EnhancedTermTypedCharSupport):
-	def _get_TextInfo(self):
-		return ConsoleUIATextInfo
+	pass


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #12130.
Might help #11172.
Supersedes #11495 and #12425.

### Summary of the issue:
Before recent upstream work, NVDA needed a custom `TextInfo` implementation including workarounds for the console. Notably, it was necessary to restrict the text range to visible content, as the console contained thousands of empty lines which both slowed down diffing and disorientated the user. This is no longer necessary as the console's UIA text range now ends at the last actual character (i.e. no more extraneous empty lines).

This bounding to the visible ranges can sometimes lead to choppy speech output, as full screen refreshes (such as in pagers or full-screen editors) cause text discontinuity, resulting in the diff algorithms losing context about which parts of the text are new. It breaks precedent from the rest of NVDA: in Word or web documents, for instance, the review cursor is not bounded to the visible text and the entire document can be freely explored. Despite the documentation of the scrolling commands in the user guide, the need to scroll consoles in particular, in strict contrast to the behaviour in other applications, has caused user confusion (microsoft/terminal#6453 and private correspondance with various users) and the commands [don't work consistently](https://nvda.groups.io/g/nvda/topic/69238539) in any case. In https://github.com/microsoft/terminal/issues/6453#issuecomment-674361602 it was pointed out that consoles can have text that appears below the visible content, which is currently inaccessible to NVDA due to bounding.

### Description of how this pull request fixes the issue:
Switches consoles where `apiLevel` is `FORMATTED` to use the default `TextInfo` implementation (i.e. no customization at the UIA text range level). Also use `UIATextInfo` in Windows Terminal as it never contained thousands of empty lines, making the overrides unnecessary there.

### Testing strategy:
With NVDA developer info (NVDA+f1), verified that:
* In a `FORMATTED` console: `UIATextInfo` is used.
* In an `IMPROVED` console: `ConsoleUIATextInfo` is used.
* In an `END_INCLUSIVE` console: `ConsoleUIATextInfoWorkaroundEndInclusive` is used.
* In Windows Terminal: `UIATextInfo` is used.

Also manually verified that new and old UIA console work as expected.

### Known issues with pull request:
None.

### Change log entries:
None (will become user visible with #10964).

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual tests.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
