### PR TITLE
Change log for beta: little fixes

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -32,7 +32,7 @@ This can be toggled in the Preferences dialog or with a new (unassigned) command
   - Diff Match Patch now enabled by default. (#12485)
   -
 - The braille input works properly with the following contracted tables: Arabic grade 2, Spanish grade 2, Urdu grade 2, Chinese (China, Mandarin) grade 2. (#12541)
-- The COM Registration Fixing Tool now resolves more issues, especially on 64 bit Windows. (#1256)
+- The COM Registration Fixing Tool now resolves more issues, especially on 64 bit Windows. (#12560)
 - Improvements to button handling for the Seika Notetaker braille device from Nippon Telesoft. (#12598)
 - Improvements to announcing the Windows emoji panel and clipboard history. (#11485)
 - Updated the Bengali alphabet character descriptions. (#12502)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,9 @@ What's New in NVDA
 This can be toggled in the Preferences dialog or with a new (unassigned) command. (#11779)
 - Espeak-ng has been updated to 1.51-dev commit ``ab11439b18238b7a08b965d1d5a6ef31cbb05cbb``. (#12449, #12202, #12280, #12568)
 - If article is enabled in the user preferences for document formatting, NVDA announces "article" after the content. (#11103)
+- Updated liblouis braille translator to [3.18.0 https://github.com/liblouis/liblouis/releases/tag/v3.18.0]. (#12526)
+  - New braille tables: Bulgarian grade 1, Burmese grade 1, Burmese grade 2, Kazakh grade 1, Khmer grade 1, Northern Kurdish grade 0, Sepedi grade 1, Sepedi grade 2, Sesotho grade 1, Sesotho grade 2, Setswana grade 1, Setswana grade 2, Tatar grade 1, Vietnamese grade 0, Vietnamese grade 2, Southern Vietnamese grade 1, Xhosa grade 1, Xhosa grade 2, Yakut grade 1, Zulu grade 1, Zulu grade 2
+  -
 -
 
 
@@ -27,9 +30,6 @@ This can be toggled in the Preferences dialog or with a new (unassigned) command
 - In Windows 10 Calculator, NVDA will announce calculator expressions on a braille display. (#12268)
 - In terminal programs on Windows 10 version 1607 and later, when inserting or deleting characters in the middle of a line, the characters to the right of the caret are no longer read out. (#3200)
   - Diff Match Patch now enabled by default. (#12485)
-  -
-- Updated liblouis braille translator to [3.18.0 https://github.com/liblouis/liblouis/releases/tag/v3.18.0]. (#12526)
-  - New braille tables: Bulgarian grade 1, Burmese grade 1, Burmese grade 2, Kazakh grade 1, Khmer grade 1, Northern Kurdish grade 0, Sepedi grade 1, Sepedi grade 2, Sesotho grade 1, Sesotho grade 2, Setswana grade 1, Setswana grade 2, Tatar grade 1, Vietnamese grade 0, Vietnamese grade 2, Southern Vietnamese grade 1, Xhosa grade 1, Xhosa grade 2, Yakut grade 1, Zulu grade 1, Zulu grade 2
   -
 - The braille input works properly with the following contracted tables: Arabic grade 2, Spanish grade 2, Urdu grade 2, Chinese (China, Mandarin) grade 2. (#12541)
 - The COM Registration Fixing Tool now resolves more issues, especially on 64 bit Windows. (#1256)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

Some issues have been found in the change log for NVDA 2021.2:
1. The following item of the change log landed in the wrong section (bugfix instead of changes)in spite of what was specified in the PR:
```
- Updated liblouis braille translator to [3.18.0 https://github.com/liblouis/liblouis/releases/tag/v3.18.0]. (#12526)
  - New braille tables: Bulgarian grade 1, Burmese grade 1, Burmese grade 2, Kazakh grade 1, Khmer grade 1, Northern Kurdish grade 0, Sepedi grade 1, Sepedi grade 2, Sesotho grade 1, Sesotho grade 2, Setswana grade 1, Setswana grade 2, Tatar grade 1, Vietnamese grade 0, Vietnamese grade 2, Southern Vietnamese grade 1, Xhosa grade 1, Xhosa grade 2, Yakut grade 1, Zulu grade 1, Zulu grade 2
  -
```
2. A wrong reference to #1256 has been written instead of #12560 for the following entry:
   `The COM Registration Fixing Tool now resolves more issues, especially on 64 bit Windows. (`

### Description of how this pull request fixes the issue:

1. Moved this item in the change log.
2. Fixed the PR's reference.

### Testing strategy:
Change log to be checked when the build is done.

### Known issues with pull request:
None

### Change log entries:
None
### Code Review Checklist:


- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
