### PR TITLE
UI Automation in Windows Console: remove STABILIZE_DELAY

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -333,9 +333,6 @@ class consoleUIAWindow(Window):
 class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 	#: Disable the name as it won't be localized
 	name = ""
-	#: Only process text changes every 30 ms, in case the console is getting
-	#: a lot of text.
-	STABILIZE_DELAY = 0.03
 
 	def _get_apiLevel(self) -> WinConsoleAPILevel:
 		"""


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
During initial development of UIA in consoles, I added the `STABILIZE_DELAY` present in the legacy console support for consistency across implementations. However, the delay seems to offer no practical benefit to UIA and appears to contribute to lag.

### Description of how this pull request fixes the issue:
Removed `STABILIZE_DELAY` from the UIA console. Legacy console users (i.e. the current default experience) are completely unaffected.

### Testing strategy:
Running without `STABILIZE_DELAY` locally for a while, and also sent a test build to @tspivey who confirms that this (along with changes to follow) have significantly reduced a lag he was experiencing.

### Known issues with pull request:
None.

### Change log entries:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
