### PR TITLE
Optionally detect caret movement with events in terminal applications

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -362,7 +362,7 @@ class Terminal(LiveText, EditableText):
 	def _get_caretMovementDetectionUsesEvents(self):
 		"""Using caret events in consoles sometimes causes the last character of the
 		prompt to be read when quickly deleting text."""
-		return False
+		return config.conf["terminals"]["caretMovementShouldUseEvents"] == "always"
 
 
 class EnhancedTermTypedCharSupport(Terminal):

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -236,6 +236,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	speakPasswords = boolean(default=false)
 	keyboardSupportInLegacy = boolean(default=True)
 	diffAlgo = option("auto", "dmp", "difflib", default="auto")
+	caretMovementShouldUseEvents = option("auto", "always", "never", default="auto")
 
 [update]
 	autoCheck = boolean(default=true)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2763,6 +2763,17 @@ class AdvancedPanelControls(
 			self._getDefaultValue(["terminals", "diffAlgo"])
 		)
 
+		# Translators: This is the label for a checkbox in the
+		#  Advanced settings panel.
+		label = _("Use events to detect caret &movement (may improve performance)")
+		self.caretEventsInConsolesCheckBox = terminalsGroup.addItem(wx.CheckBox(terminalsBox, label=label))
+		self.bindHelpEvent("CaretEventsInConsoles", self.caretEventsInConsolesCheckBox)
+		caretEventsDevMap = True if config.conf['terminals']['caretMovementShouldUseEvents'] == 'always' else False
+		self.caretEventsInConsolesCheckBox.SetValue(caretEventsDevMap)
+		self.caretEventsInConsolesCheckBox.defaultValue = self._getDefaultValue(
+			["terminals", "caretMovementShouldUseEvents"]
+		)
+
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
 		label = _("Speech")
@@ -2916,6 +2927,9 @@ class AdvancedPanelControls(
 			and self.UIAInChromiumCombo.GetSelection() == self.UIAInChromiumCombo.defaultValue
 			and self.keyboardSupportInLegacyCheckBox.IsChecked() == self.keyboardSupportInLegacyCheckBox.defaultValue
 			and self.diffAlgoCombo.GetSelection() == self.diffAlgoCombo.defaultValue
+			and self.caretEventsInConsolesCheckBox.IsChecked() == (
+				self.caretEventsInConsolesCheckBox.defaultValue == 'always'
+			)
 			and self.caretMoveTimeoutSpinControl.GetValue() == self.caretMoveTimeoutSpinControl.defaultValue
 			and self.reportTransparentColorCheckBox.GetValue() == self.reportTransparentColorCheckBox.defaultValue
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
@@ -2935,6 +2949,7 @@ class AdvancedPanelControls(
 		self.cancelExpiredFocusSpeechCombo.SetSelection(self.cancelExpiredFocusSpeechCombo.defaultValue)
 		self.keyboardSupportInLegacyCheckBox.SetValue(self.keyboardSupportInLegacyCheckBox.defaultValue)
 		self.diffAlgoCombo.SetSelection(self.diffAlgoCombo.defaultValue == 'auto')
+		self.caretEventsInConsolesCheckBox.SetValue(self.caretEventsInConsolesCheckBox.defaultValue == 'always')
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.annotationsDetailsCheckBox.SetValue(self.annotationsDetailsCheckBox.defaultValue)
 		self.ariaDescCheckBox.SetValue(self.ariaDescCheckBox.defaultValue)
@@ -2960,6 +2975,10 @@ class AdvancedPanelControls(
 		config.conf['terminals']['diffAlgo'] = (
 			self.diffAlgoVals[diffAlgoChoice]
 		)
+		if self.caretEventsInConsolesCheckBox.IsChecked():
+			config.conf['terminals']['caretMovementShouldUseEvents'] = "always"
+		else:
+			config.conf['terminals']['caretMovementShouldUseEvents'] = "auto"
 		config.conf["editableText"]["caretMoveTimeoutMs"]=self.caretMoveTimeoutSpinControl.GetValue()
 		config.conf["documentFormatting"]["reportTransparentColor"] = (
 			self.reportTransparentColorCheckBox.IsChecked()

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1905,6 +1905,11 @@ Additionally, it may be available in other terminals on earlier Windows releases
 It is identical to NVDA's behaviour in versions 2020.4 and earlier.
 -
 
+==== Use events to detect caret movement ====[CaretEventsInConsoles]
+This option enables an alternative, experimental method of detecting movement of the text caret in terminals.
+It may improve performance in some scenarios, especially in newer version of the Windows Console and Windows Terminal.
+However, reporting of deleted characters may be less accurate, especially when text is quickly deleted.
+
 ==== Attempt to cancel speech for expired focus events ====[CancelExpiredFocusSpeech]
 This option enables behaviour which attempts to cancel speech for expired focus events.
 In particular moving quickly through messages in Gmail with Chrome can cause NVDA to speak outdated information.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Using events to detect caret movement increases responsiveness in some scenarios, but we intermitantly get unreliable results when backspacing quickly (see microsoft/terminal#10820).

### Description of how this pull request fixes the issue:
Add a feature flag to enable `caretMovementDetectionUsesEvents` in terminals. The setting is currently ternary to avoid the need for a config spec upgrade should automatic enablement later be added in some apps.

In a follow-up PR, the checkbox may be changed to a combobox (similar to the approach in #10964).

### Testing strategy:
Tested that caret events are used when the feature flag is enabled, and not used when the flag is disabled in Windows Terminal and both UIA and legacy conhost.

### Known issues with pull request:
None.

### Change log entries:
== Changes for Developers ==
- Added an advanced setting to enable caret movement detection in terminal applications for testing purposes.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
