### PR TITLE
Remove low contrast styling from documentation (backport of #12674)

### DIFF
--- a/user_docs/styles.css
+++ b/user_docs/styles.css
@@ -42,9 +42,9 @@ th {
 /* code / pre */
 code,
 pre {
-  background: #f5f7f9;
+  background: #f6f8fa;
   border-bottom: 1px solid #d8dee9;
-  color: #a7adba;
+  color: #33104e;
 }
 
 code {


### PR DESCRIPTION
Increase the contrast ratio of code blocks from 2.09 to 15.05

Backport of #12674 

Summary of the issue:
Code blocks on pages such as the developer guide are hard to read due to low contrast.

Description of how this pull request fixes the issue:
Increase the contrast ratio of code blocks from 2.09 to 15.05
A ratio of at least 7 considerably improves accessibility