### PR TITLE
Emergency fix for #12523: import Hid class in hwIo package

### DIFF
--- a/source/hwIo/__init__.py
+++ b/source/hwIo/__init__.py
@@ -19,3 +19,4 @@ from .base import (  # noqa: F401
 	intToByte,
 	getByte
 )
+from .hid import Hid  # noqa: F401


### PR DESCRIPTION
### Link to issue number:
#12523

### Summary of the issue:
#12523 stores the Hid class in its own submodule of hwIo, thereby breaking drivers relying on Hid as well as backwards compatibility.

### Description of how this pull request fixes the issue:
Import Hid in hwIo package

### Testing strategy:
Tested that the handy tech Braille driver works again

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
