### PR TITLE
Input Gesture Dialog fix for when there is no filtered Input Gestures

### DIFF
--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -482,7 +482,15 @@ class _GesturesTree(VirtualTree, wx.TreeCtrl):
 
 	def getSelectedItemData(self) -> Optional[_VmSelection]:
 		selection = self.GetSelection()
-		selIdx: Tuple[int, ...] = self.GetIndexOfItem(selection)
+		try:
+			selIdx: Tuple[int, ...] = self.GetIndexOfItem(selection)
+		except AssertionError:
+			# If item.IsOK() fails on this item or any parents indexed, an assertion error is thrown. (#12673)
+			log.debugWarning(
+				"",
+				exc_info=True,
+			)
+			return None
 		# ensure that the length of tuple is 3, missing elements replaced with None
 		nonesForMissingElements = ((None, ) * (3 - len(selIdx)))
 		selIdx: Tuple[int, Optional[int], Optional[int]] = selIdx + nonesForMissingElements

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,6 +39,7 @@ This can be toggled in the Preferences dialog or with a new (unassigned) command
 - NVDA exits safely when a new process is started. (#12605)
 - Reselecting the Handy Tech braille display driver from the Select Braille Display dialog no longer causes errors. (#12618)
 - Windows version 10.0.22000 or later is recognized as Windows 11, not Windows 10. (#12626)
+- If no results are shown when filtering input gestures, the input gesture configuration dialog continues to work as expected. (#12673)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12673 

### Summary of the issue:

The input gestures GUI did not handle the case where there was no filtered input gestures available, such as filtering the gestures for a string like "zzzzzzzzz". This results in multiple input gesture dialogs being able to be opened at once.

This wx assertion error was also thrown while testing a preliminary fix for this.

```python
DEBUG - gui.inputGestures._GesturesTree.getData (12:48:13.699) - MainThread (8444):
No filtered gestures available.
DEBUG - gui.inputGestures._GesturesTree.getData (12:48:13.702) - MainThread (8444):
No filtered gestures available.
ERROR - unhandled exception (12:48:13.702) - MainThread (8444):
Traceback (most recent call last):
  File "gui\inputGestures.py", line 642, in onTreeSelect
    self._refreshButtonState()
  File "gui\inputGestures.py", line 645, in _refreshButtonState
    selectedItems = self.tree.getSelectedItemData()
  File "gui\inputGestures.py", line 485, in getSelectedItemData
    selIdx: Tuple[int, ...] = self.GetIndexOfItem(selection)
  File "C:\nvda\.venv\lib\site-packages\wx\lib\mixins\treemixin.py", line 250, in GetIndexOfItem
    parent = self.GetItemParent(item)
wx._core.wxAssertionError: C++ assertion ""item.IsOk()"" failed at ..\..\src\msw\treectrl.cpp(1369) in wxTreeCtrl::GetItemParent(): invalid tree item
```

### Description of how this pull request fixes the issue:

Add checks for when the filtered gesture list is empty.

### Testing strategy:

Manual testing using the example from #12673

Unit testing this is difficult due to the need to spoof the wx.App

System testing this specific bug seems overkill, due to almost no user impact, however a smoke test for the input gestures dialog may be valuable.

### Known issues with pull request:
None

### Change log entries:
Bug fixes

```
- If no results are shown when filtering input gestures, the input gesture configuration dialog continues to work as expected. (#12673)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
