### PR TITLE
Fix rare recursion error in the winVersion module

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -43,9 +43,6 @@ def _getRunningVersionNameFromWinReg() -> str:
 	"""Returns the Windows release name defined in Windows Registry.
 	This is applicable on Windows 10 Version 1511 (build 10586) and later.
 	"""
-	# Release name is recorded in Windows Registry from Windows 10 Version 1511 (build 10586) onwards.
-	if getWinVer() < WIN10_1511:
-		raise RuntimeError("Release name is not recorded in Windows Registry on this version of Windows")
 	# Cache the version in use on the system.
 	with winreg.OpenKey(
 		winreg.HKEY_LOCAL_MACHINE, r"Software\Microsoft\Windows NT\CurrentVersion"
@@ -58,7 +55,9 @@ def _getRunningVersionNameFromWinReg() -> str:
 			try:
 				releaseId = winreg.QueryValueEx(currentVersion, "ReleaseID")[0]
 			except OSError:
-				releaseId = ""
+				raise RuntimeError(
+					"Release name is not recorded in Windows Registry on this version of Windows"
+				) from None
 	return releaseId
 
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -157,6 +157,7 @@ WINSERVER_2022 = WinVersion(major=10, minor=0, build=20348)
 WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
 
 
+@functools.lru_cache(maxsize=1)
 def getWinVer():
 	"""Returns a record of current Windows version NVDA is running on.
 	"""


### PR DESCRIPTION
Opened against beta since this PR fixes regression which should be fixed before 2021.2
### Link to issue number:
Fixes #12666 
Fix-up of #12544

### Summary of the issue:
In some rare cases `winVersion.getWinVer` can cause recursion errors since it calls `winVersion._getRunningVersionNameFromWinReg` which in turn executes `winVersion.getWinVer` to check if the currently running version of Windows contains release info in the registry.
A sample of the log posted in #12666  is as follows:
```
File "threading.pyc", line 890, in _bootstrap
  File "threading.pyc", line 926, in _bootstrap_inner
  File "threading.pyc", line 870, in run
  File "winInputHook.pyc", line 79, in hookThreadFunc
  File "winInputHook.pyc", line 54, in keyboardHook
  File "keyboardHandler.pyc", line 227, in internal_keyDownEvent
  File "keyboardHandler.pyc", line 116, in shouldUseToUnicodeEx
  File "winVersion.pyc", line 176, in getWinVer
  File "winVersion.pyc", line 47, in _getRunningVersionNameFromWinReg
  File "winVersion.pyc", line 176, in getWinVer

File "winVersion.pyc", line 176, in getWinVer
  File "winVersion.pyc", line 47, in _getRunningVersionNameFromWinReg
  File "winVersion.pyc", line 176, in getWinVer
  File "winVersion.pyc", line 47, in _getRunningVersionNameFromWinReg
  File "winVersion.pyc", line 164, in getWinVer
  File "garbageHandler.pyc", line 48, in _collectionCallback
Traceback (most recent call last):
  File "garbageHandler.pyc", line 46, in _collectionCallback
  File "garbageHandler.pyc", line 53, in _collectionCallback_helper
RecursionError: maximum recursion depth exceeded in comparison
```


### Description of how this pull request fixes the issue:
Rather than checking if the current version of Windows contains release info in the registry by comparing it to the lowest  version for which this is supported I'm just checking if the necessary info exists in the registry and if not appropriate exceptions are raised.
To avoid pointless registry accesses result of `getWinVer` is cached - version of Windows on which NVDA is running is not going to change during its lifetime.
### Testing strategy:
Started NVDA ensured it works in general.
### Known issues with pull request:
None known
### Change log entries:
None necessary - unreleased regression.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
