### PR TITLE
Check screen is black after activating screen curtain

### DIFF
--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -306,8 +306,10 @@ def isScreenFullyBlack() -> bool:
 	- there is only one colour used in the image
 	- the first pixel of the screen capture is black
 
-	Having to iterate over a large bitmap image in python is slow (~4s depending on machine, number of pixels).
-	Using this method to calculate a histogram in native code takes ~0.4s comparably.
+	Iterating over a large bitmap image in python is slow (~4s depending on machine, number of pixels).
+	Due to no native support for calculating the number of black pixels, the screenBitmap module is avoided.
+	wxWidgets has native support for calculating the usage of colours within an image.
+	Using this method to calculate a colour usage histogram in native code takes ~0.4s comparably.
 	"""
 	screen = wx.ScreenDC()
 	screenSize = screen.GetSize()
@@ -319,7 +321,7 @@ def isScreenFullyBlack() -> bool:
 	# https://docs.wxwidgets.org/3.0/classwx_image.html#a7c9d557cd7ad577ed76e4337b1fd843a
 	hist = wx.ImageHistogram()
 	numberOfColours = img.ComputeHistogram(hist)
-	# Due to wxImageHistogram not fully supported in wxPython, the histogram is not subscriptable,
+	# Due to wxImageHistogram not being fully supported in wxPython, the histogram is not subscriptable,
 	# and thus the key value cannot be accessed for colours.
 	# https://github.com/wxWidgets/Phoenix/issues/1991
 	# This function could be improved in the future using the following logic:

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -305,6 +305,9 @@ def isScreenFullyBlack() -> bool:
 	Uses wx to check that the screen is currently fully black by taking a screen capture and checking:
 	- there is only one colour used in the image
 	- the first pixel of the screen capture is black
+
+	Having to iterate over a large bitmap image in python is slow (~4s depending on machine, number of pixels).
+	Using this method to calculate a histogram in native code takes ~0.4s comparably.
 	"""
 	screen = wx.ScreenDC()
 	screenSize = screen.GetSize()

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -333,7 +333,7 @@ def isScreenFullyBlack() -> bool:
 	return numberOfColours == 1 and firstPixelIsBlack
 
 
-class ScreenCurtainFail(RuntimeError):
+class ScreenCurtainInitializationError(RuntimeError):
 	pass
 
 
@@ -370,7 +370,7 @@ class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 			Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 			Magnification.MagShowSystemCursor(False)
 			if not isScreenFullyBlack():
-				raise ScreenCurtainFail("Screen curtain not activated properly")
+				raise ScreenCurtainInitializationError("Screen curtain not activated properly")
 		except Exception as e:
 			try:
 				Magnification.MagShowSystemCursor(True)

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -300,6 +300,43 @@ class ScreenCurtainGuiPanel(
 			return res == wx.YES
 
 
+def isScreenFullyBlack() -> bool:
+	"""
+	Uses wx to check that the screen is currently fully black by taking a screen capture and checking:
+	- there is only one colour used in the image
+	- the first pixel of the screen capture is black
+	"""
+	screen = wx.ScreenDC()
+	screenSize = screen.GetSize()
+	bmp: wx.Bitmap = wx.Bitmap(screenSize[0], screenSize[1])
+	mem = wx.MemoryDC(bmp)
+	mem.Blit(0, 0, screenSize[0], screenSize[1], screen, 0, 0)  # copy screen over to bmp
+	del mem  # Release bitmap
+	img: wx.Image = bmp.ConvertToImage()
+	# https://docs.wxwidgets.org/3.0/classwx_image.html#a7c9d557cd7ad577ed76e4337b1fd843a
+	hist = wx.ImageHistogram()
+	numberOfColours = img.ComputeHistogram(hist)
+	# Due to wxImageHistogram not fully supported in wxPython, the histogram is not subscriptable,
+	# and thus the key value cannot be accessed for colours.
+	# https://github.com/wxWidgets/Phoenix/issues/1991
+	# This function could be improved in the future using the following logic:
+	# numberOfBlackPixelsKey = hist.MakeKey(255, 255, 255)
+	# numberOfBlackPixels = hist[numberOfBlackPixelsKey]
+	# numberOfDisplayPixels = screenSize[0] * screenSize[1]
+	# log.debug(f"""Screen Capture:
+	#  - number of colours: {numberOfColours}
+	#  - number of black pixels: {numberOfBlackPixels}
+	#  - number of total pixels: {numberOfDisplayPixels}
+	# """)
+	# return numberOfColours == 1 and numberOfBlackPixels == numberOfDisplayPixels
+	firstPixelIsBlack = img.GetRed(0, 0) == 0 and img.GetBlue(0, 0) == 0 and img.GetGreen(0, 0) == 0
+	return numberOfColours == 1 and firstPixelIsBlack
+
+
+class ScreenCurtainFail(RuntimeError):
+	pass
+
+
 class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 	_settings = ScreenCurtainSettings()
 
@@ -332,7 +369,13 @@ class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 		try:
 			Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 			Magnification.MagShowSystemCursor(False)
+			if not isScreenFullyBlack():
+				raise ScreenCurtainFail("Screen curtain not activated properly")
 		except Exception as e:
+			try:
+				Magnification.MagShowSystemCursor(True)
+			except Exception:
+				log.error(f"Could not restore cursor after screen curtain failure.", exc_info=True)
 			Magnification.MagUninitialize()
 			raise e
 		if self.getSettings().playToggleSounds:


### PR DESCRIPTION
### Link to issue number:

Fixes #12708

### Summary of the issue:

There is a security risk if the screen curtain fails silently. The Magnification API used by Screen Curtain does not officially support WOW64 applications like NVDA. As this is a risk with untested Windows versions, an external check would be helpful to minimise silent failures of the screen curtain.

### Description of how this pull request fixes the issue:

Capture the screen and check it is fully black after initialising screen curtain.

wxWidgets uses [winGDI methods](https://docs.microsoft.com/en-us/windows/win32/gdi/windows-gdi), winGDI is a low level, stable API, as compared to the Magnification API:
>"The Microsoft Windows graphics device interface (GDI) enables applications to use graphics and formatted text on both the video display and the printer. Windows-based applications do not access the graphics hardware directly. Instead, GDI interacts with device drivers on behalf of applications."

[wxScreenDC](https://wxpython.org/Phoenix/docs/html/wx.ScreenDC.html?highlight=screendc#wx.ScreenDC) captures all monitors. 

### Testing strategy:

Manual confirmation from a sighted developer is required. 

1. Test the screen curtain activates properly
1. In the NVDA python console, change the black transformation matrix so it will fail to initialise the screen curtain properly.
1. Test that the screen curtain doesn't start and a warning is provided to the user.

Example for Win 10:
```python
from visionEnhancementProviders import screenCurtain
screenCurtain.TRANSFORM_BLACK.transform[1][1] = 1  # retain the green channel
```

Example for Win 11 (preview):
```python
from visionEnhancementProviders import screenCurtain
screenCurtain.TRANSFORM_BLACK.transform[3][3] = 0  # change the opacity to 0
```

### Known issues with pull request:

None

### Change log entries:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
