### PR TITLE
Make unit tests for oneCore pass  under the versions of Windows where oneCore is not supported

### DIFF
--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -94,31 +94,25 @@ class test_synthDriverHandler(unittest.TestCase):
 			self.assertEqual(synthName, synthDriverHandler.getSynth().name)
 			self.assertEqual(FAKE_DEFAULT_LANG, config.conf["speech"]["synth"])
 
+	@unittest.skipUnless(OneCoreSynthDriver.check(), "Requires oneCore being supported under current OS")
 	def test_setSynth_auto_usesOneCore_ifSupportsDefaultLanguage(self):
 		"""
-		Ensures that if oneCore supports the current language, setSynth("auto") uses "oneCore" on versions
-		of Windows where oneCore is the default - else eSpeak is used regardless of the language  support.
+		Ensures that if oneCore supports the current language, setSynth("auto") uses "oneCore".
 		"""
 		# test setup ensures curLang is supported for oneCore
 		synthDriverHandler.setSynth(None)  # reset the synth so there is no fallback
 		synthDriverHandler.setSynth("auto")
-		if OneCoreSynthDriver.check():
-			self.assertEqual(synthDriverHandler.getSynth().name, "oneCore")
-		else:
-			self.assertEqual(synthDriverHandler.getSynth().name, "espeak")
+		self.assertEqual(synthDriverHandler.getSynth().name, "oneCore")
 
+	@unittest.skipUnless(OneCoreSynthDriver.check(), "Requires oneCore being supported under current OS")
 	def test_setSynth_auto_fallback_ifOneCoreDoesntSupportDefaultLanguage(self):
 		"""
-		Ensures that if oneCore is supported under the currently running version of Windows
-		yet it doesn't support the current language, setSynth("auto") falls back to the
+		Ensures that if oneCore doesn't support the current language, setSynth("auto") falls back to the
 		current synth, or espeak if there is no current synth.
 		"""
 		languageHandler.curLang = "bar"  # set the lang so it is not supported
 		synthDriverHandler.setSynth("auto")
-		if OneCoreSynthDriver.check():  # OneCore failed to initialize so current synth unchanged
-			self.assertEqual(synthDriverHandler.getSynth().name, FAKE_DEFAULT_SYNTH_NAME)
-		else:  # OneCore unsupported - there are  no checks for the current language being supported by eSpeak
-			self.assertEqual(synthDriverHandler.getSynth().name, "espeak")
+		self.assertEqual(synthDriverHandler.getSynth().name, FAKE_DEFAULT_SYNTH_NAME)
 		synthDriverHandler.setSynth(None)  # reset the synth so there is no fallback
 		synthDriverHandler.setSynth("auto")
 		self.assertEqual(synthDriverHandler.getSynth().name, "espeak")


### PR DESCRIPTION
### Link to issue number:
Fixes unit tests introduced in #12647
### Summary of the issue:
Some unit tests introduced as part of #12647 were failing under versions of Windows where oneCore was unsupported. The output was as follows:
```
FAIL: Ensures that if oneCore doesn't support the current language, setSynth("auto") falls back to the
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\my_repos\nvda\tests\unit\test_synthDriverHandler.py", line 113, in test_setSynth_auto_fallback_ifOneCoreDoesntSupportDefaultLangauge
    self.assertEqual(synthDriverHandler.getSynth().name, FAKE_DEFAULT_SYNTH_NAME)
AssertionError: 'espeak' != 'defaultSynth'
- espeak
+ defaultSynth


======================================================================
FAIL: Ensures that if oneCore supports the current language, setSynth("auto") uses "oneCore".
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\my_repos\nvda\tests\unit\test_synthDriverHandler.py", line 104, in test_setSynth_auto_usesOneCore_ifSupportsDefaultLangauge
    self.assertEqual(synthDriverHandler.getSynth().name, "oneCore")
AssertionError: 'espeak' != 'oneCore'
- espeak
+ oneCore
```


### Description of how this pull request fixes the issue:
Tests which require oneCore being supported are being skipped on versions of Windows on which oneCore is not supported.
### Testing strategy:
Unit tests passes locally whereas previously they didn't. I'll inspect log on AppVeyor to ensure they still pass on a version of Windows where oneCore is supported.
### Known issues with pull request:
None known.
### Change log entries:
None needed

### Code Review Checklist:



- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
