### PR TITLE
Catch `AttributeError` when fetching parent of  an no longer existing object when navigating quickly in Windows Explorer

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -389,13 +389,18 @@ class AppModule(appModuleHandler.AppModule):
 			return
 
 		if windowClass == "DirectUIHWND" and role == controlTypes.Role.LIST:
-			if obj.parent and obj.parent.parent:
-				parent = obj.parent.parent.parent
-				if parent is not None and parent.windowClassName == "Desktop Search Open View":
-					# List containing search results in Windows 7 start menu.
-					# Its name is not useful so discard it.
-					obj.name = None
-					return
+			# Is this a list containing search results in Windows 7 start menu?
+			isWin7SearchResultsList = False
+			try:
+				if obj.parent and obj.parent.parent:
+					parent = obj.parent.parent.parent
+					isWin7SearchResultsList = parent is not None and parent.windowClassName == "Desktop Search Open View"
+			except AttributeError:
+				isWin7SearchResultsList = False
+			if isWin7SearchResultsList:
+				# Namae of this list is not useful and should be  discarded.
+				obj.name = None
+				return
 
 	def event_gainFocus(self, obj, nextHandler):
 		wClass = obj.windowClassName


### PR DESCRIPTION

### Link to issue number:
None - fix-up of #10257

### Summary of the issue:
PR #10257 introduced code which removes  pointless name of list which contains search results in Windows 7 start menu. To determine if we're dealing with a correct control however it is necessary to travel a lot of object ancestry. This causes the following error when navigating quickly in Windows Explorer:
```
ERROR - NVDAObjects.__call__ (22:47:08.606) - Dummy-1 (6416):
Exception in event_NVDAObject_init for <'explorer' (appName 'explorer', process ID 2552) at address 3cc63d0>
Traceback (most recent call last):
  File "NVDAObjects\__init__.pyc", line 157, in __call__
  File "appModules\explorer.pyc", line 393, in event_NVDAObject_init
AttributeError: 'NoneType' object has no attribute 'parent'

```


### Description of how this pull request fixes the issue:
Since this occurs for objects which are dead I've just started catching `AttributeError` in this block of code.
### Testing strategy:
- Navigated in Windows Explorer for several hours - made sure that no error sound plays
- Made sure that #2020 is not reintroduced.
 
### Known issues with pull request:
None known
### Change log entries:
None needed- error sounds are not enabled in releases and aside from annoying error sound for time to time this error had no adverse side effects.

### Code Review Checklist:

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
