### PR TITLE
Handle menu start events processed after the menu item

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -5,6 +5,7 @@
 
 import re
 import struct
+from typing import Optional, Tuple
 import weakref
 from ctypes import (
 	wintypes,
@@ -422,22 +423,22 @@ def accNavigate(pacc, childID, direction):
 		return None
 
 
-def winEventToNVDAEvent(eventID, window, objectID, childID, useCache=True):
-	"""Tries to convert a win event ID to an NVDA event name, and instanciate or fetch an NVDAObject for
+def winEventToNVDAEvent(
+		eventID: int,
+		window: int,
+		objectID: int,
+		childID: int,
+		useCache: bool = True
+) -> Optional[Tuple[str, NVDAObjects.IAccessible.IAccessible]]:
+	"""Tries to convert a win event ID to an NVDA event name, and instantiate or fetch an NVDAObject for
 	 the win event parameters.
 	@param eventID: the win event ID (type)
-	@type eventID: integer
 	@param window: the win event's window handle
-	@type window: integer
 	@param objectID: the win event's object ID
-	@type objectID: integer
 	@param childID: the win event's childID
-	@type childID: the win event's childID
 	@param useCache: C{True} to use the L{liveNVDAObjectTable} cache when
 	 retrieving an NVDAObject, C{False} if the cache should not be used.
-	@type useCache: boolean
 	@returns: the NVDA event name and the NVDAObject the event is for
-	@rtype: tuple of string and L{NVDAObjects.IAccessible.IAccessible}
 	"""
 	if isMSAADebugLoggingEnabled():
 		log.debug(

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -423,7 +423,10 @@ def accNavigate(pacc, childID, direction):
 		return None
 
 
-def winEventToNVDAEvent(
+# C901 'winEventToNVDAEvent' is too complex
+# Note: when working on winEventToNVDAEvent, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def winEventToNVDAEvent(  # noqa: C901
 		eventID: int,
 		window: int,
 		objectID: int,

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -535,10 +535,12 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		# Translators: Reports navigator object's dimensions (example output: object edges positioned 20 per cent from left edge of screen, 10 per cent from top edge of screen, width is 40 per cent of screen, height is 50 per cent of screen).
 		return _("Object edges positioned {left:.1f} per cent from left edge of screen, {top:.1f} per cent from top edge of screen, width is {width:.1f} per cent of screen, height is {height:.1f} per cent of screen").format(left=percentFromLeft,top=percentFromTop,width=percentWidth,height=percentHeight)
 
-	def _get_parent(self):
+	#: Typing information for auto-property: _get_parent
+	parent: typing.Optional['NVDAObject']
+
+	def _get_parent(self) -> typing.Optional['NVDAObject']:
 		"""Retrieves this object's parent (the object that contains this object).
 		@return: the parent object if it exists else None.
-		@rtype: L{NVDAObject} or None
 		"""
 		return None
 

--- a/source/api.py
+++ b/source/api.py
@@ -27,12 +27,11 @@ from typing import Any, Optional
 
 #User functions
 
-def getFocusObject():
+def getFocusObject() -> NVDAObjects.NVDAObject:
 	"""
-Gets the current object with focus.
-@returns: the object with focus
-@rtype: L{NVDAObjects.NVDAObject}
-"""
+	Gets the current object with focus.
+	@returns: the object with focus
+	"""
 	return globalVars.focusObject
 
 def getForegroundObject():

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -21,6 +21,8 @@ import globalPluginHandler
 import config
 import winUser
 import extensionPoints
+import oleacc
+
 
 #Some dicts to store event counts by name and or obj
 _pendingEventCountsByName={}
@@ -175,22 +177,25 @@ class FocusLossCancellableSpeechCommand(_CancellableSpeechCommand):
 		elif not hasattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME):
 			setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, False)
 
-	def _checkIfValid(self):
+	def _checkIfValid(self) -> bool:
 		stillValid = (
 			self.isLastFocusObj()
 			or not self.previouslyHadFocus()
 			or self.isAncestorOfCurrentFocus()
 			# Ensure titles for dialogs gaining focus are reported, EG NVDA Find dialog
 			or self.isForegroundObject()
+			# Ensure menu items are reported when focus is gained to the menu start (see #12624).
+			or self.isMenuItemOfCurrentFocus()
 		)
 		return stillValid
 
-	def _getDevInfo(self):
+	def _getDevInfo(self) -> str:
 		return (
 			f"isLast: {self.isLastFocusObj()}"
 			f", previouslyHad: {self.previouslyHadFocus()}"
 			f", isAncestorOfCurrentFocus: {self.isAncestorOfCurrentFocus()}"
 			f", is foreground obj {self.isForegroundObject()}"
+			f", isMenuItemOfCurrentFocus: {self.isMenuItemOfCurrentFocus()}"
 		)
 
 	def isLastFocusObj(self):
@@ -207,6 +212,39 @@ class FocusLossCancellableSpeechCommand(_CancellableSpeechCommand):
 	def isForegroundObject(self):
 		foreground = api.getForegroundObject()
 		return self._obj is foreground or self._obj == foreground
+
+	def isMenuItemOfCurrentFocus(self) -> bool:
+		"""
+		Checks if the current object is a menu item of the current focus.
+		The only known case where this returns True is the following (see #12624):
+		
+		When opening a submenu in certain applications (like Thunderbird 78.12),
+		NVDA can process a menu start event after the first item in the menu is focused.
+		The menu start event causes a focus event on the menu, taking NVDA's focus from the menu item.
+		Additionally, the "menu" parent of the submenu item is not keyboard focusable, and is separate from
+		the menu item which triggered the submenu.
+		The object tree in this case (menu item > submenu (not keyboard focusable) > submenu item).
+		The focus event order after activating the menu item's sub menu is (submenu item, submenu).
+		"""
+		from NVDAObjects import IAccessible
+		lastFocus = api.getFocusObject()
+		_isMenuItemOfCurrentFocus = (
+			self._obj.parent
+			and isinstance(self._obj, IAccessible.IAccessible)
+			and isinstance(lastFocus, IAccessible.IAccessible)
+			and self._obj.IAccessibleRole == oleacc.ROLE_SYSTEM_MENUITEM
+			and lastFocus.IAccessibleRole == oleacc.ROLE_SYSTEM_MENUPOPUP
+			and self._obj.parent == lastFocus
+		)
+		if _isMenuItemOfCurrentFocus:
+			# Change this to log.error for easy debugging
+			log.debugWarning(
+				"This parent menu was not announced properly, "
+				"and should have been focused before the submenu item.\n"
+				f"Object info: {self._obj.devInfo}\n"
+				f"Object parent info: {self._obj.parent.devInfo}\n"
+			)
+		return _isMenuItemOfCurrentFocus
 
 
 def _getFocusLossCancellableSpeechCommand(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,7 @@ To ensure security, confirm that screen curtain works properly with new or exper
 - Windows version 10.0.22000 or later is recognized as Windows 11, not Windows 10. (#12626)
 - Screen curtain support has been fixed and tested for Windows versions up until 10.0.22000. (#12684)
 - If no results are shown when filtering input gestures, the input gesture configuration dialog continues to work as expected. (#12673)
+- Fixed a bug where the first menu item of a submenu is not announced in some contexts. (#12624)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12624 

### Summary of the issue:

When opening a submenu in certain applications (like Thunderbird 78.12),
NVDA can process a menu start event after the first item in the menu is focused.
The menu start event causes a focus event on the menu, taking NVDA's focus from the menu item.
Additionally, the "menu" parent of the submenu item is not keyboard focusable, and is separate from
the menu item which triggered the submenu.
The object tree in this case (menu item > submenu (not keyboard focusable) > submenu item).
The focus event order after activating the menu item's sub menu is (submenu item, submenu).

### Description of how this pull request fixes the issue:

Before cancelling speech, check that the focus is now on the parent menu.

### Testing strategy:

Manual testing (note that this does not always occur and is hard to consistently reproduce):
1. Enable debug logging
1. With a Thunderbird 78.12 context menu (activate one on an email, for example)
1. navigate to a menu item with a submenu. 
1. Activate it.
1. Examine the logs for an event (submenu item, submenu) - eg the speech is announced in this order in the logs, as are the events if event debugging is enabled.
On this PR: Confirm that this case has extensive logging when it occurs. When this event occurs confirm that the menu item is spoken, followed by the submenu. If you want to hear a beep on this event, change the logging to an error beep.
On 2021.1: Confirm that only menu item is spoken, as the seubmenu item is cancelled.


### Known issues with pull request:

This may be an overzealous check. Speech in similar contexts that should be cancelled may continue to be spoken.
As such, debug logs are added to make handling new cases easier until the root problem of event processing is addressed.

### Change log entries:
Bug Fixes

```
- Fixed bug where the first menu item is not announced in a submenu in some contexts. (#12624)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
