### PR TITLE
Speak Symbols When moving by word

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -31,6 +31,13 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [speech]
 	# The synthesizer to use
 	synth = string(default=auto)
+	# symbolLevel values:
+	#  NONE = 0
+	#  SOME = 100
+	#  MOST = 200
+	#  ALL = 300
+	#  CHAR = 1000
+	#  UNCHANGED = -1
 	symbolLevel = integer(default=100)
 	trustVoiceLanguage = boolean(default=true)
 	includeCLDR = boolean(default=True)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -38,7 +38,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	#  ALL = 300
 	#  CHAR = 1000
 	#  UNCHANGED = -1
-	symbolLevel = integer(default=100)
+	symbolLevel = integer(default=100) # default: SOME
 	# Speak all symbols when reviewing by word, uses editor specific implementation if false
 	symbolLevelWordAll = boolean(default=true)
 	trustVoiceLanguage = boolean(default=true)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -39,6 +39,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	#  CHAR = 1000
 	#  UNCHANGED = -1
 	symbolLevel = integer(default=100)
+	# Speak all symbols when reviewing by word, uses editor specific implementation if false
+	symbolLevelWordAll = boolean(default=true)
 	trustVoiceLanguage = boolean(default=true)
 	includeCLDR = boolean(default=True)
 	beepSpeechModePitch = integer(default=10000,min=50,max=11025)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -25,6 +25,7 @@ import api
 import textInfos
 import speech
 from speech import sayAll
+from speech.speech import UserInterface
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 import globalVars
 from logHandler import log
@@ -998,14 +999,14 @@ class GlobalCommands(ScriptableObject):
 	def script_reviewMode_next(self,gesture):
 		label=review.nextMode()
 		if label:
-			ui.reviewMessage(label)
+			ui.reviewMessage(UserInterface(label))
 			pos=api.getReviewPosition().copy()
 			pos.expand(textInfos.UNIT_LINE)
 			braille.handler.setTether(braille.handler.TETHER_REVIEW, auto=True)
 			speech.speakTextInfo(pos)
 		else:
 			# Translators: reported when there are no other available review modes for this object 
-			ui.reviewMessage(_("No next review mode"))
+			ui.reviewMessage(UserInterface(_("No next review mode")))
 
 	@script(
 		description=_(
@@ -1017,16 +1018,16 @@ class GlobalCommands(ScriptableObject):
 		gestures=("kb:NVDA+numpad1", "kb(laptop):NVDA+pageDown", "ts(object):2finger_flickDown")
 	)
 	def script_reviewMode_previous(self,gesture):
-		label=review.nextMode(prev=True)
+		label = review.nextMode(prev=True)
 		if label:
-			ui.reviewMessage(label)
+			ui.reviewMessage(UserInterface(label))
 			pos=api.getReviewPosition().copy()
 			pos.expand(textInfos.UNIT_LINE)
 			braille.handler.setTether(braille.handler.TETHER_REVIEW, auto=True)
 			speech.speakTextInfo(pos)
 		else:
 			# Translators: reported when there are no other available review modes for this object 
-			ui.reviewMessage(_("No previous review mode"))
+			ui.reviewMessage(UserInterface(_("No previous review mode")))
 
 	@script(
 		# Translators: Input help mode message for toggle simple review mode command.
@@ -1059,7 +1060,7 @@ class GlobalCommands(ScriptableObject):
 		if not isinstance(curObject,NVDAObject):
 			# Translators: Reported when the user tries to perform a command related to the navigator object
 			# but there is no current navigator object.
-			ui.reviewMessage(_("No navigator object"))
+			ui.reviewMessage(UserInterface(_("No navigator object")))
 			return
 		if scriptHandler.getLastScriptRepeatCount()>=1:
 			if curObject.TextInfo!=NVDAObjectTextInfo:
@@ -1241,7 +1242,7 @@ class GlobalCommands(ScriptableObject):
 		if not isinstance(curObject,NVDAObject):
 			# Translators: Reported when the user tries to perform a command related to the navigator object
 			# but there is no current navigator object.
-			ui.reviewMessage(_("No navigator object"))
+			ui.reviewMessage(UserInterface(_("No navigator object")))
 			return
 		simpleReviewMode=config.conf["reviewCursor"]["simpleReviewMode"]
 		curObject=curObject.simpleParent if simpleReviewMode else curObject.parent
@@ -1250,7 +1251,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(curObject, reason=controlTypes.OutputReason.FOCUS)
 		else:
 			# Translators: Reported when there is no containing (parent) object such as when focused on desktop.
-			ui.reviewMessage(_("No containing object"))
+			ui.reviewMessage(UserInterface(_("No containing object")))
 
 	@script(
 		# Translators: Input help mode message for move to next object command.
@@ -1263,7 +1264,7 @@ class GlobalCommands(ScriptableObject):
 		if not isinstance(curObject,NVDAObject):
 			# Translators: Reported when the user tries to perform a command related to the navigator object
 			# but there is no current navigator object.
-			ui.reviewMessage(_("No navigator object"))
+			ui.reviewMessage(UserInterface(_("No navigator object")))
 			return
 		simpleReviewMode=config.conf["reviewCursor"]["simpleReviewMode"]
 		curObject=curObject.simpleNext if simpleReviewMode else curObject.next
@@ -1272,7 +1273,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(curObject, reason=controlTypes.OutputReason.FOCUS)
 		else:
 			# Translators: Reported when there is no next object (current object is the last object).
-			ui.reviewMessage(_("No next"))
+			ui.reviewMessage(UserInterface(_("No next")))
 
 	@script(
 		# Translators: Input help mode message for move to previous object command.
@@ -1285,7 +1286,7 @@ class GlobalCommands(ScriptableObject):
 		if not isinstance(curObject,NVDAObject):
 			# Translators: Reported when the user tries to perform a command related to the navigator object
 			# but there is no current navigator object.
-			ui.reviewMessage(_("No navigator object"))
+			ui.reviewMessage(UserInterface(_("No navigator object")))
 			return
 		simpleReviewMode=config.conf["reviewCursor"]["simpleReviewMode"]
 		curObject=curObject.simplePrevious if simpleReviewMode else curObject.previous
@@ -1294,7 +1295,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(curObject, reason=controlTypes.OutputReason.FOCUS)
 		else:
 			# Translators: Reported when there is no previous object (current object is the first object).
-			ui.reviewMessage(_("No previous"))
+			ui.reviewMessage(UserInterface(_("No previous")))
 
 	@script(
 		# Translators: Input help mode message for move to first child object command.
@@ -1307,7 +1308,7 @@ class GlobalCommands(ScriptableObject):
 		if not isinstance(curObject,NVDAObject):
 			# Translators: Reported when the user tries to perform a command related to the navigator object
 			# but there is no current navigator object.
-			ui.reviewMessage(_("No navigator object"))
+			ui.reviewMessage(UserInterface(_("No navigator object")))
 			return
 		simpleReviewMode=config.conf["reviewCursor"]["simpleReviewMode"]
 		curObject=curObject.simpleFirstChild if simpleReviewMode else curObject.firstChild
@@ -1316,7 +1317,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(curObject, reason=controlTypes.OutputReason.FOCUS)
 		else:
 			# Translators: Reported when there is no contained (first child) object such as inside a document.
-			ui.reviewMessage(_("No objects inside"))
+			ui.reviewMessage(UserInterface(_("No objects inside")))
 
 	@script(
 		description=_(
@@ -1384,7 +1385,7 @@ class GlobalCommands(ScriptableObject):
 		res=info.move(textInfos.UNIT_LINE,-1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the top line of the current navigator object.
-			ui.reviewMessage(_("Top"))
+			ui.reviewMessage(UserInterface(_("Top")))
 		else:
 			api.setReviewPosition(info)
 		info.expand(textInfos.UNIT_LINE)
@@ -1431,7 +1432,7 @@ class GlobalCommands(ScriptableObject):
 		# i.e. the new line starts after the original review cursor position.
 		if res == 0 or newLine.start <= origInfo.start:
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
-			ui.reviewMessage(_("Bottom"))
+			ui.reviewMessage(UserInterface(_("Bottom")))
 		else:
 			api.setReviewPosition(info)
 		speech.speakTextInfo(newLine, unit=textInfos.UNIT_LINE, reason=controlTypes.OutputReason.CARET)
@@ -1461,7 +1462,7 @@ class GlobalCommands(ScriptableObject):
 		res=info.move(textInfos.UNIT_WORD,-1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the top line of the current navigator object.
-			ui.reviewMessage(_("Top"))
+			ui.reviewMessage(UserInterface(_("Top")))
 		else:
 			api.setReviewPosition(info)
 		info.expand(textInfos.UNIT_WORD)
@@ -1507,7 +1508,7 @@ class GlobalCommands(ScriptableObject):
 		# i.e. the new word starts after the original review cursor position.
 		if res == 0 or newWord.start <= origInfo.start:
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
-			ui.reviewMessage(_("Bottom"))
+			ui.reviewMessage(UserInterface(_("Bottom")))
 		else:
 			api.setReviewPosition(info)
 		speech.speakTextInfo(newWord, unit=textInfos.UNIT_WORD, reason=controlTypes.OutputReason.CARET)
@@ -1546,7 +1547,7 @@ class GlobalCommands(ScriptableObject):
 		res=charInfo.move(textInfos.UNIT_CHARACTER,-1)
 		if res==0 or charInfo.compareEndPoints(lineInfo,"startToStart")<0:
 			# Translators: a message reported when review cursor is at the leftmost character of the current navigator object's text.
-			ui.reviewMessage(_("Left"))
+			ui.reviewMessage(UserInterface(_("Left")))
 			reviewInfo=api.getReviewPosition().copy()
 			reviewInfo.expand(textInfos.UNIT_CHARACTER)
 			speech.speakTextInfo(reviewInfo, unit=textInfos.UNIT_CHARACTER, reason=controlTypes.OutputReason.CARET)
@@ -1604,7 +1605,7 @@ class GlobalCommands(ScriptableObject):
 		res=charInfo.move(textInfos.UNIT_CHARACTER,1)
 		if res==0 or charInfo.compareEndPoints(lineInfo,"endToEnd")>=0:
 			# Translators: a message reported when review cursor is at the rightmost character of the current navigator object's text.
-			ui.reviewMessage(_("Right"))
+			ui.reviewMessage(UserInterface(_("Right")))
 			reviewInfo=api.getReviewPosition().copy()
 			reviewInfo.expand(textInfos.UNIT_CHARACTER)
 			speech.speakTextInfo(reviewInfo, unit=textInfos.UNIT_CHARACTER, reason=controlTypes.OutputReason.CARET)
@@ -2904,7 +2905,7 @@ class GlobalCommands(ScriptableObject):
 		pos = api.getReviewPosition()
 		if not getattr(pos.obj, "_copyStartMarker", None):
 			# Translators: Presented when attempting to move to the start marker for copy but none has been set.
-			ui.reviewMessage(_("No start marker set"))
+			ui.reviewMessage(UserInterface(_("No start marker set")))
 			return
 		startMarker = pos.obj._copyStartMarker.copy()
 		api.setReviewPosition(startMarker)
@@ -3252,7 +3253,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(newObject, reason=controlTypes.OutputReason.FOCUS)
 		else:
 			# Translators: a message when there is no next object when navigating
-			ui.reviewMessage(_("No next"))
+			ui.reviewMessage(UserInterface(_("No next")))
 
 	@script(
 		# Translators: Input help mode message for a touchscreen gesture.
@@ -3273,7 +3274,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(newObject, reason=controlTypes.OutputReason.FOCUS)
 		else:
 			# Translators: a message when there is no previous object when navigating
-			ui.reviewMessage(_("No previous"))
+			ui.reviewMessage(UserInterface(_("No previous")))
 
 	@script(
 		# Translators: Describes a command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -927,6 +927,27 @@ class GlobalCommands(ScriptableObject):
 		ui.message(_("Symbol level %s") % name)
 
 	@script(
+		# Translators: Input help mode message for a command.
+		description=_("Toggle the announcement of all punctuation and symbols when reviewing by word"),
+		category=SCRCAT_SPEECH
+	)
+	def script_toggleSpeechSymbolLevelWordAll(self, gesture):
+		symbolLevelWordAll = config.conf["speech"]["symbolLevelWordAll"]
+		if symbolLevelWordAll:
+			# Translators: Used to report the new state of a setting which is toggled via a command.
+			reportedState = pgettext("command toggle", "off")
+		else:
+			# Translators: Used to report the new state of a setting which is toggled via a command.
+			reportedState = pgettext("command toggle", "on")
+		config.conf["speech"]["symbolLevelWordAll"] = not symbolLevelWordAll
+		ui.message(
+			# Translators: Reported when toggling a speech setting
+			_("Speak all punctuation and symbols when reviewing by word: {state}").format(
+				state=reportedState
+			)
+		)
+
+	@script(
 		# Translators: Input help mode message for move mouse to navigator object command.
 		description=_("Moves the mouse pointer to the current navigator object"),
 		category=SCRCAT_MOUSE,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1529,6 +1529,16 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 			characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS.index(curLevel)
 		)
 
+		self.symbolLevelWordAll = settingsSizerHelper.addItem(
+			wx.CheckBox(
+				self,
+				# Translators: The label for a setting in the Speech category
+				label=_("Speak all punctuation and symbols when reviewing by &word"),
+			)
+		)
+		self.bindHelpEvent("SpeechSettingsSymbolLevelWord", self.symbolLevelWordAll)
+		self.symbolLevelWordAll.SetValue(config.conf["speech"]["symbolLevelWordAll"])
+
 		# Translators: This is the label for a checkbox in the
 		# voice settings panel (if checked, text will be read using the voice for the language of the text).
 		trustVoiceLanguageText = _("Trust voice's language when processing characters and symbols")
@@ -1619,6 +1629,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		config.conf["speech"]["symbolLevel"] = characterProcessing.CONFIGURABLE_SPEECH_SYMBOL_LEVELS[
 			self.symbolLevelList.GetSelection()
 		].value
+		config.conf["speech"]["symbolLevelWordAll"] = self.symbolLevelWordAll.IsChecked()
 		config.conf["speech"]["trustVoiceLanguage"] = self.trustVoiceLanguageCheckbox.IsChecked()
 		currentIncludeCLDR = config.conf["speech"]["includeCLDR"]
 		config.conf["speech"]["includeCLDR"] = newIncludeCldr = self.includeCLDRCheckbox.IsChecked()

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -12,6 +12,9 @@ import builtins
 import os
 import sys
 import ctypes
+
+import weakref
+
 import locale
 import gettext
 import enum
@@ -41,6 +44,9 @@ CP_ACP = "0"
 LCID_NONE = 0 # 0 used instead of None for backwards compatibility.
 
 LANGS_WITHOUT_TRANSLATIONS: FrozenSet[str] = frozenset(("en",))
+installedTranslation: Optional[weakref.ReferenceType] = None
+"""Saved copy of the installed translation for ease of wrapping.
+"""
 
 
 class LOCALE(enum.IntEnum):
@@ -371,6 +377,9 @@ def setLanguage(lang: str) -> None:
 	setLocale(getLanguage())
 	# Install our pgettext function.
 	builtins.pgettext = makePgettext(trans)
+
+	global installedTranslation
+	installedTranslation = weakref.ref(trans)
 
 
 def localeStringFromLocaleCode(localeCode: str) -> str:

--- a/source/review.py
+++ b/source/review.py
@@ -4,6 +4,8 @@
 #Copyright (C) 2013 Michael Curran <mick@nvaccess.org>
 
 from collections import OrderedDict
+from typing import Optional, Union
+
 import api
 import winUser
 from logHandler import log
@@ -102,13 +104,13 @@ def getCurrentMode():
 	"""Fetches the ID of the current mode"""
 	return modes[_currentMode][0]
 
-def setCurrentMode(mode,updateReviewPosition=True):
+
+def setCurrentMode(mode: Union[int, str], updateReviewPosition: bool = True) -> str:
 	"""
 	Sets the current review mode to the given mode ID or index and updates the review position.
 	@param mode: either a 0-based index into the modes list, or one of the mode IDs (first item of a tuple in the modes list).
-	@type mode: int or string
-	@return: a presentable label for the new current mode (suitable for speaking or brailleing)
-	@rtype: string
+	@param updateReviewPosition: Should the review position be updated?
+	@return: a presentable label for the new current mode (suitable for speech or braille)
 	"""
 	global _currentMode
 	if isinstance(mode,int):
@@ -127,13 +129,13 @@ def setCurrentMode(mode,updateReviewPosition=True):
 		if updateReviewPosition: api.setReviewPosition(pos[0],clearNavigatorObject=False)
 		return label
 
-def nextMode(prev=False,startMode=None):
+
+def nextMode(prev: bool = False, startMode: Optional[int] = None) -> str:
 	"""
 	Sets the current review mode to the next available  mode and updates the review position. 
 	@param prev: if true then switch to the previous mode. If false, switch to the next mode.
-	@type prev: bool
-	@return: a presentable label for the new current mode (suitable for speaking or brailleing)
-	@rtype: string
+	@param startMode: Used to reset the cycle.
+	@return: a presentable label for the new current mode (suitable for speech or braille)
 	"""
 	if startMode is None:
 		startMode=_currentMode

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2020 NV Access Limited
+# Copyright (C) 2019-2021 NV Access Limited
 
 """
 Commands that can be embedded in a speech sequence for changing synth parameters, playing sounds or running
@@ -14,7 +14,7 @@ from typing import Optional, Callable
 
 import config
 from synthDriverHandler import getSynth
-from logHandler import log
+
 
 class SpeechCommand(object):
 	"""The base class for objects that can be inserted between strings of text to perform actions,
@@ -23,6 +23,35 @@ class SpeechCommand(object):
 	Note: Some of these commands are processed by NVDA and are not directly passed to synth drivers.
 	synth drivers will only receive commands derived from L{SynthCommand}.
 	"""
+	pass
+
+
+class Atomic(SpeechCommand):
+	""" Text that should not be subdivided further. Typically this text is not replaced.
+	"""
+	def __init__(self, text: str):
+		"""
+		@param text: The text to speak.
+		"""
+		self._text = text
+
+	@property
+	def text(self) -> str:
+		return self._text
+
+	def __repr__(self):
+		return f"{self.__class__.__name__} ({self.text})"
+
+
+class Symbol(Atomic):
+	""" Replacement text to represent a symbol.
+	"""
+	pass
+
+
+class UserInterface(Atomic):
+	""" Speech commands for NVDA's speech UI"""
+	pass
 
 
 class _CancellableSpeechCommand(SpeechCommand):

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -26,18 +26,14 @@ class SpeechCommand(object):
 	pass
 
 
-class Atomic(SpeechCommand):
+class Atomic(str, SpeechCommand):
 	""" Text that should not be subdivided further. Typically this text is not replaced.
+	Usage a = Atomic("don't break up this string")
 	"""
-	def __init__(self, text: str):
-		"""
-		@param text: The text to speak.
-		"""
-		self._text = text
 
 	@property
 	def text(self) -> str:
-		return self._text
+		return str(self)
 
 	def __repr__(self):
 		return f"{self.__class__.__name__} ({self.text})"

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -29,6 +29,8 @@ class SpeechCommand(object):
 class Atomic(str, SpeechCommand):
 	""" Text that should not be subdivided further. Typically this text is not replaced.
 	Usage a = Atomic("don't break up this string")
+	@note: Potential design flaw, inheriting from str makes it very easy to slice an object, loosing its initial
+	class type. Eg type(Atomic("hello") + " world") == str
 	"""
 
 	@property

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -19,6 +19,7 @@ from .commands import (
 	ConfigProfileTriggerCommand,
 	IndexCommand,
 	_CancellableSpeechCommand,
+	Atomic,
 )
 
 from .priorities import Spri, SPEECH_PRIORITIES
@@ -372,6 +373,8 @@ class SpeechManager(object):
 				continue
 			if isinstance(command, SynthParamCommand):
 				paramTracker.update(command)
+			if isinstance(command, Atomic):
+				command = command.text
 			outSeq.append(command)
 		# Add the last sequence and make sure the sequence ends the utterance.
 		self._ensureEndUtterance(outSeq, outSeqs, paramsToReplay, paramTracker)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -32,6 +32,9 @@ from .commands import (
 	BeepCommand,
 	EndUtteranceCommand,
 	CharacterModeCommand,
+	Atomic,
+	UserInterface,
+	Symbol,
 )
 
 from . import types
@@ -279,10 +282,10 @@ def _getSpellingCharAddCapNotification(
 	if beepForCapitals:
 		yield BeepCommand(2000, 50)
 	if capMsgBefore:
-		yield capMsgBefore
-	yield speakCharAs
+		yield UserInterface(capMsgBefore)
+	yield Symbol(speakCharAs)
 	if capMsgAfter:
-		yield capMsgAfter
+		yield UserInterface(capMsgAfter)
 	if capPitchChange:
 		yield PitchCommand()
 
@@ -302,13 +305,13 @@ def _getSpellingSpeechWithoutCharMode(
 
 	if not text:
 		# Translators: This is spoken when NVDA moves to an empty line.
-		yield _("blank")
+		yield UserInterface(_("blank"))
 		return
 	if not text.isspace():
 		text=text.rstrip()
 
 	textLength=len(text)
-	count = 0
+
 	localeHasConjuncts = True if locale.split('_',1)[0] in LANGS_WITH_CONJUNCT_CHARS else False
 	charDescList = getCharDescListFromText(text,locale) if localeHasConjuncts else text
 	for item in charDescList:
@@ -320,7 +323,7 @@ def _getSpellingSpeechWithoutCharMode(
 			# item is just a character.
 			speakCharAs = item
 			if useCharacterDescriptions:
-				charDesc=characterProcessing.getCharacterDescription(locale,speakCharAs.lower())
+				charDesc = characterProcessing.getCharacterDescription(locale, speakCharAs.lower())
 		uppercase=speakCharAs.isupper()
 		if useCharacterDescriptions and charDesc:
 			IDEOGRAPHIC_COMMA = u"\u3001"
@@ -836,7 +839,7 @@ def speak(  # noqa: C901
 			curLanguage=item.lang
 			if not curLanguage or (not autoDialectSwitching and curLanguage.split('_')[0]==defaultLanguageRoot):
 				curLanguage=defaultLanguage
-		elif isinstance(item,str):
+		elif isinstance(item, (str, Atomic)):
 			if not item: continue
 			if autoLanguageSwitching and curLanguage!=prevLanguage:
 				speechSequence.append(LangChangeCommand(curLanguage))

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2522,28 +2522,28 @@ def getFormatFieldSpeech(  # noqa: C901
 		oldInvalidSpelling=attrsCache.get("invalid-spelling") if attrsCache is not None else None
 		if (invalidSpelling or oldInvalidSpelling is not None) and invalidSpelling!=oldInvalidSpelling:
 			if invalidSpelling:
-				# Translators: Reported when text contains a spelling error.
-				text=_("spelling error")
+				textList.append(UserInterface(_(
+					# Translators: Reported when text contains a spelling error.
+					"spelling error"
+				)))
 			elif extraDetail:
-				# Translators: Reported when moving out of text containing a spelling error.
-				text=_("out of spelling error")
-			else:
-				text=""
-			if text:
-				textList.append(text)
+				textList.append(UserInterface(_(
+					# Translators: Reported when moving out of text containing a spelling error.
+					"out of spelling error"
+				)))
 		invalidGrammar=attrs.get("invalid-grammar")
 		oldInvalidGrammar=attrsCache.get("invalid-grammar") if attrsCache is not None else None
 		if (invalidGrammar or oldInvalidGrammar is not None) and invalidGrammar!=oldInvalidGrammar:
 			if invalidGrammar:
-				# Translators: Reported when text contains a grammar error.
-				text=_("grammar error")
+				textList.append(UserInterface(_(
+					# Translators: Reported when text contains a grammar error.
+					"grammar error"
+				)))
 			elif extraDetail:
-				# Translators: Reported when moving out of text containing a grammar error.
-				text=_("out of grammar error")
-			else:
-				text=""
-			if text:
-				textList.append(text)
+				textList.append(UserInterface(_(
+					# Translators: Reported when moving out of text containing a grammar error.
+					"out of grammar error"
+				)))
 	# The line-prefix formatField attribute contains the text for a bullet or number for a list item, when the bullet or number does not appear in the actual text content.
 	# Normally this attribute could be repeated across formatFields within a list item and therefore is not safe to speak when the unit is word or character.
 	# However, some implementations (such as MS Word with UIA) do limit its useage to the very first formatField of the list item.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -865,13 +865,16 @@ def speak(  # noqa: C901
 		if autoLanguageSwitching and isinstance(item,LangChangeCommand):
 			curLanguage=item.lang
 		if isinstance(item, str) and not isinstance(item, Atomic):
-			speechSequence[index]=processText(curLanguage,item,symbolLevel)
+			speechSequence[index] = processText(curLanguage, item, symbolLevel)
 			if not inCharacterMode:
-				speechSequence[index]+=CHUNK_SEPARATOR
-		if isinstance(item, Symbol):
-			speechSequence[index] = Symbol(
-				processText(curLanguage, item.text, characterProcessing.SymbolLevel.NONE)
-			)
+				speechSequence[index] += CHUNK_SEPARATOR
+		elif isinstance(item, Atomic):
+			text = item.text  # convert the Atomic back to str
+			text = processText(curLanguage, text, characterProcessing.SymbolLevel.NONE)
+			if not inCharacterMode:
+				text += CHUNK_SEPARATOR
+			speechSequence[index] = text
+
 	_manager.speak(speechSequence, priority)
 
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -868,6 +868,10 @@ def speak(  # noqa: C901
 			speechSequence[index]=processText(curLanguage,item,symbolLevel)
 			if not inCharacterMode:
 				speechSequence[index]+=CHUNK_SEPARATOR
+		if isinstance(item, Symbol):
+			speechSequence[index] = Symbol(
+				processText(curLanguage, item.text, characterProcessing.SymbolLevel.NONE)
+			)
 	_manager.speak(speechSequence, priority)
 
 
@@ -1355,7 +1359,7 @@ def getTextInfoSpeech(  # noqa: C901
 	if onlyInitialFields or (
 		isWordOrCharUnit
 		and len(textWithFields) > 0
-		and len(textWithFields[0]) == 1
+		and len(textWithFields[0].strip() if not textWithFields[0].isspace() else textWithFields[0]) == 1
 		and all(isControlEndFieldCommand(x) for x in itertools.islice(textWithFields, 1, None))
 	):
 		if not onlyCache:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -244,7 +244,7 @@ def _getSpellingSpeechAddCharMode(
 	"""
 	charMode = False
 	for item in seq:
-		if isinstance(item, str):
+		if isinstance(item, str) and not isinstance(item, Atomic):
 			if len(item) == 1:
 				if not charMode:
 					yield CharacterModeCommand(True)
@@ -864,7 +864,7 @@ def speak(  # noqa: C901
 			inCharacterMode=item.state
 		if autoLanguageSwitching and isinstance(item,LangChangeCommand):
 			curLanguage=item.lang
-		if isinstance(item,str):
+		if isinstance(item, str) and not isinstance(item, Atomic):
 			speechSequence[index]=processText(curLanguage,item,symbolLevel)
 			if not inCharacterMode:
 				speechSequence[index]+=CHUNK_SEPARATOR

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1355,11 +1355,12 @@ def getTextInfoSpeech(  # noqa: C901
 	def isControlEndFieldCommand(x):
 		return isinstance(x, textInfos.FieldCommand) and x.command == "controlEnd"
 
-	isWordOrCharUnit = unit in (textInfos.UNIT_CHARACTER, textInfos.UNIT_WORD)
+	# Moving by character, ensure character is spelled out. Particularly important for newline
+	# (carriage return and line feed) characters.
 	if onlyInitialFields or (
-		isWordOrCharUnit
+		unit == textInfos.UNIT_CHARACTER
 		and len(textWithFields) > 0
-		and len(textWithFields[0].strip() if not textWithFields[0].isspace() else textWithFields[0]) == 1
+		and len(textWithFields[0]) == 1
 		and all(isControlEndFieldCommand(x) for x in itertools.islice(textWithFields, 1, None))
 	):
 		if not onlyCache:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -364,8 +364,10 @@ def getSpellingSpeech(
 	yield from seq
 
 
-def getCharDescListFromText(text,locale):
-	"""This method prepares a list, which contains character and its description for all characters the text is made up of, by checking the presence of character descriptions in characterDescriptions.dic of that locale for all possible combination of consecutive characters in the text.
+def getCharDescListFromText(text: str, locale: str) -> List[Tuple[str, List[str]]]:
+	"""This method prepares a list, which contains character and its description for all characters the text is
+	made up of, by checking the presence of character descriptions in characterDescriptions.dic of that locale
+	for all possible combination of consecutive characters in the text.
 	This is done to take care of conjunct characters present in several languages such as Hindi, Urdu, etc.
 	"""
 	charDescList = []

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1147,8 +1147,14 @@ def speakTextInfo(
 	)
 
 	speechGen = GeneratorWithReturn(speechGen)
+	symbolLevel: Optional[characterProcessing.SymbolLevel] = None
+	if unit == textInfos.UNIT_CHARACTER:
+		symbolLevel = characterProcessing.SymbolLevel.ALL
+	elif unit == textInfos.UNIT_WORD:
+		if config.conf["speech"]["symbolLevelWordAll"]:
+			symbolLevel = characterProcessing.SymbolLevel.ALL
 	for seq in speechGen:
-		speak(seq, priority=priority)
+		speak(seq, symbolLevel=symbolLevel, priority=priority)
 	return speechGen.returnValue
 
 
@@ -1344,7 +1350,7 @@ def getTextInfoSpeech(  # noqa: C901
 	if onlyInitialFields or (
 		isWordOrCharUnit
 		and len(textWithFields) > 0
-		and len(textWithFields[0].strip() if not textWithFields[0].isspace() else textWithFields[0]) == 1
+		and len(textWithFields[0]) == 1
 		and all(isControlEndFieldCommand(x) for x in itertools.islice(textWithFields, 1, None))
 	):
 		if not onlyCache:

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -15,6 +15,9 @@ import gui.contextHelp
 # We have to manually add a wx.Panel to get correct tab ordering behaviour.
 # wx.Dialog causes a crash on destruction when multiple were created at the same time (brailleViewer
 # may start at the same time)
+from speech.commands import Atomic
+
+
 class SpeechViewerFrame(
 		gui.contextHelp.ContextHelpMixin,
 		wx.Frame  # wxPython does not seem to call base class initializer, put last in MRO
@@ -164,6 +167,8 @@ def appendSpeechSequence(sequence: SpeechSequence) -> None:
 	if _guiFrame.FindFocus() == _guiFrame.textCtrl:
 		return
 
+	# convert text wrapper commands to str
+	sequence = (item.text if isinstance(item, Atomic) else item for item in sequence)
 	# to make the speech easier to read, we must separate the items.
 	text = SPEECH_ITEM_SEPARATOR.join(
 		speech for speech in sequence if isinstance(speech, str)

--- a/source/ui.py
+++ b/source/ui.py
@@ -12,6 +12,7 @@ See L{gui} for the graphical user interface.
 
 import os
 import sys
+import typing
 from ctypes import windll, byref, POINTER, addressof
 from comtypes import IUnknown
 from comtypes import automation 
@@ -73,7 +74,7 @@ def browseableMessage(message,title=None,isHtml=False):
 
 
 def message(
-		text: str,
+		text: typing.Union[str, speech.speech.Atomic],
 		speechPriority: Optional[speech.Spri] = None,
 		brailleText: Optional[str] = None,
 ):
@@ -87,7 +88,10 @@ def message(
 	braille.handler.message(brailleText if brailleText is not None else text)
 
 
-def reviewMessage(text: str, speechPriority: Optional[speech.Spri] = None):
+def reviewMessage(
+		text: typing.Union[str, speech.speech.Atomic],
+		speechPriority: Optional[speech.Spri] = None
+):
 	"""Present a message from review or object navigation to the user.
 	The message will always be presented in speech, and also in braille if it is tethered to review or when auto tethering is on.
 	@param text: The text of the message.

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -28,6 +28,7 @@ from typing import (
 )
 from urllib.parse import quote as _quoteStr
 
+import typing
 from robotremoteserver import (
 	test_remote_server as _testRemoteServer,
 	stop_remote_server as _stopRemoteServer,
@@ -38,6 +39,9 @@ from SystemTestSpy import (
 	_nvdaSpyAlias,
 	configManager
 )
+
+if typing.TYPE_CHECKING:
+	from SystemTestSpy.speechSpyGlobalPlugin import NVDASpyLib
 
 # Imported for type information
 from robot.libraries.BuiltIn import BuiltIn
@@ -383,11 +387,10 @@ class NvdaLib:
 		return saveToPath
 
 
-def getSpyLib():
+def getSpyLib() -> "NVDASpyLib":
 	""" Gets the spy library instance. This has been augmented with methods for all supported keywords.
 	Requires NvdaLib and nvdaSpy (remote library - see speechSpyGlobalPlugin) to be initialised.
 	On failure check order of keywords in Robot log and NVDA log for failures.
-	@rtype: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
 	@return: Remote NVDA spy Robot Framework library.
 	"""
 	nvdaLib = _getLib("NvdaLib")

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -8,6 +8,7 @@ It allows tests to get information out of NVDA.
 It is copied into the (system test specific) NVDA profile directory. It becomes the '__init__.py' file as part
 of a package.
 """
+import gettext
 import typing
 from typing import Optional
 
@@ -116,6 +117,41 @@ class NVDASpyLib:
 			penultimateConf = penultimateConf[key]
 		ultimateKey = keyPath[-1]
 		penultimateConf[ultimateKey] = val
+
+	fakeTranslations: typing.Optional[gettext.NullTranslations] = None
+
+	def override_translationString(self, invariantString: str, replacementString: str):
+		import languageHandler
+		if not self.fakeTranslations:
+			class Translation_Fake(gettext.NullTranslations):
+				originalTranslationFunction: Optional
+				translationResults: typing.Dict[str, str]
+
+				def __init__(
+						self,
+						originalTranslationFunction: Optional
+				):
+					self.originalTranslationFunction = originalTranslationFunction
+					self.translationResults = {}
+					super().__init__()
+					self.install()
+
+				def gettext(self, msg: str) -> str:
+					if msg in self.translationResults:
+						return self.translationResults[msg]
+					if self.originalTranslationFunction:
+						return self.originalTranslationFunction.gettext(msg)
+					return msg
+
+				def restore(self) -> None:
+					self.translationResults.clear()
+					if self.originalTranslationFunction:
+						self.originalTranslationFunction.install()
+
+			self.fakeTranslations = Translation_Fake(
+				languageHandler.installedTranslation() if languageHandler.installedTranslation else None
+			)
+		self.fakeTranslations.translationResults[invariantString] = replacementString
 
 	def queueNVDAMainThreadCrash(self):
 		from queueHandler import queueFunction, eventQueue

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -313,13 +313,8 @@ def test_symbolInSpeechUI():
 	actual = _pressKeyAndCollectSpeech(Move.CHAR.value, numberOfTimes=1)
 	_builtIn.should_be_equal(
 		actual,
-		# Illustrates a bug in NVDA. The internal speech UI is processed substituting symbols.
-		# This can be a major issue in languages other than English.
-		[
-			# 'tick' is a bug
-			"shouldn tick t sub tick symbol"  # intentionally concatenate strings
-			"\nblank",
-		],
+		# 'tick' would be a bug
+		[f"{expected}\nblank", ],
 		msg="actual vs expected. NVDA speech UI substitutes symbols",
 	)
 

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -107,27 +107,6 @@ def test_moveByWord():
 	_doTest(
 		navKey=Move.WORD,
 		reportedAfterLast=EndSpeech.BOTTOM,
-		symbolLevel=SymLevel.ALL,
-		expectedSpeech=[
-			'Say',
-			'left paren(quietly right paren)',  # parenthesis are named
-			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
-			'don tick t',  # mid-word symbol
-			'right dash pointing arrow', 't dash shirt',
-			# end of first line
-			'blank',  # single space and newline
-			'tab',  # tab and newline
-			'blank',  # 4 spaces and newline
-			'right dash pointing arrow',  # no space before or after symbol
-			't dash shirt',  # no space before or after symbol
-			't dash shirt',  # no character before or after symbol (no newline)
-			'blank'  # end of doc
-		]
-	)
-	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
-	_doTest(
-		navKey=Move.WORD,
-		reportedAfterLast=EndSpeech.BOTTOM,
 		symbolLevel=SymLevel.NONE,
 		expectedSpeech=[
 			'Say',
@@ -145,28 +124,32 @@ def test_moveByWord():
 		],
 	)
 
+	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
+
+	_doTest(
+		navKey=Move.WORD,
+		reportedAfterLast=EndSpeech.BOTTOM,
+		symbolLevel=SymLevel.ALL,
+		expectedSpeech=[
+			'Say',
+			'left paren(quietly right paren)',  # parenthesis are named
+			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
+			'don tick t',  # mid-word symbol
+			'right dash pointing arrow', 't dash shirt',
+			# end of first line
+			'blank',  # single space and newline
+			'tab',  # tab and newline
+			'blank',  # 4 spaces and newline
+			'right dash pointing arrow',  # no space before or after symbol
+			't dash shirt',  # no space before or after symbol
+			't dash shirt',  # no character before or after symbol (no newline)
+			'blank'  # end of doc
+		]
+	)
+
 
 def test_moveByLine():
 	_notepad.prepareNotepad(_getMoveByLineTestSample())
-	_doTest(
-		navKey=Move.LINE,
-		symbolLevel=SymLevel.ALL,
-		reportedAfterLast=EndSpeech.BOTTOM,
-		expectedSpeech=[
-			'Say',
-			'left paren(quietly right paren)',
-			'quote Hello comma,', 'Jim quote  dot.',
-			'don tick t',
-			'right-pointing arrow', 't-shirt',  # symbols each on a line
-			'right-pointing arrow', 't-shirt',  # symbols and a space each on a line
-			'right-pointing arrow  t-shirt',  # symbols joined no space
-			'blank',  # single space
-			'tab',  # single tab
-			'blank',  # 4 spaces
-			'blank',  # end of doc
-		],
-	)
-	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
 	_doTest(
 		navKey=Move.LINE,
 		reportedAfterLast=EndSpeech.BOTTOM,
@@ -185,37 +168,49 @@ def test_moveByLine():
 		]
 	)
 
+	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
+
+	_doTest(
+		navKey=Move.LINE,
+		symbolLevel=SymLevel.ALL,
+		reportedAfterLast=EndSpeech.BOTTOM,
+		expectedSpeech=[
+			'Say',
+			'left paren(quietly right paren)',
+			'quote Hello comma,', 'Jim quote  dot.',
+			'don tick t',
+			'right-pointing arrow', 't-shirt',  # symbols each on a line
+			'right-pointing arrow', 't-shirt',  # symbols and a space each on a line
+			'right-pointing arrow  t-shirt',  # symbols joined no space
+			'blank',  # single space
+			'tab',  # single tab
+			'blank',  # 4 spaces
+			'blank',  # end of doc
+		],
+	)
+
 
 def test_moveByChar():
 	_notepad.prepareNotepad(_getMoveByCharTestSample())
 	# Symbol level should not affect move by character
 	# use the same expected speech with symbol level none and all.
-	symLevelNoneExpected = [
-		'S', 'space',
-		'left paren', 'right paren',
-		'quote', 'tick',
-		'e', 'comma',
-		'right pointing arrow', 't shirt',
-		'tab',
-		'carriage return',  # on Windows/notepad newline is \r\n
-		'line feed',  # on Windows/notepad newline is \r\n
-	]
 	# Bug: With symbol level ALL text due to a symbol substitution has further substitutions applied:
 	# IE: "t-shirt" either becomes "t shirt" or "t dash shirt" dependent on symbol level.
-	exceptions = {
-		'right pointing arrow': 'right dash pointing arrow',
-		't shirt': 't dash shirt',
-	}
-	symLevelAllExpected = [
-		e if e not in exceptions.keys() else exceptions[e]
-		for e in symLevelNoneExpected
-	]
 
 	_doTest(
 		navKey=Move.CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
 		symbolLevel=SymLevel.NONE,
-		expectedSpeech=symLevelNoneExpected,
+		expectedSpeech=[
+			'S', 'space',
+			'left paren', 'right paren',
+			'quote', 'tick',
+			'e', 'comma',
+			'right pointing arrow', 't shirt',   # note no dash, sym level All has
+			'tab',
+			'carriage return',  # on Windows/notepad newline is \r\n
+			'line feed',  # on Windows/notepad newline is \r\n
+		],
 	)
 
 	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position.
@@ -224,7 +219,16 @@ def test_moveByChar():
 		navKey=Move.CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
 		symbolLevel=SymLevel.ALL,
-		expectedSpeech=symLevelAllExpected,
+		expectedSpeech=[
+			'S', 'space',
+			'left paren', 'right paren',
+			'quote', 'tick',
+			'e', 'comma',
+			'right dash pointing arrow', 't dash shirt',  # note has dash, sym level None doesn't
+			'tab',
+			'carriage return',  # on Windows/notepad newline is \r\n
+			'line feed',  # on Windows/notepad newline is \r\n
+		],
 	)
 
 

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -114,15 +114,15 @@ def test_moveByWord():
 			# symbols shouldn't be named:
 			'(quietly)', 'Hello,', 'Jim', '.',
 			"don't",  # mid-word symbol, tick shouldn't be substituted at level NONE
-			'right pointing arrow', 't shirt',
+			'', 't-shirt',  # right arrow is missing
 			# end of first line
 			'blank',  # single space and newline
 			'',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right pointing arrow',  # right arrow is not spoken!
-			't shirt',  # no space before or after symbol
+			'',  # right arrow is not spoken!
+			't-shirt',  # no space before or after symbol
 			# note different result with no space character
-			't shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank',  # end of doc
 		],
 	)
@@ -138,15 +138,15 @@ def test_moveByWord():
 			'left paren(quietly right paren)',  # parenthesis are named
 			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
 			'don tick t',  # mid-word symbol
-			'right pointing arrow', 't shirt',
+			'right-pointing arrow', 't-shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right pointing arrow',  # no space before or after symbol
+			'right-pointing arrow',  # no space before or after symbol
 			# note different result with no space character
-			't shirt',  # no space before or after symbol
-			't shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no space before or after symbol
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank'  # end of doc
 		]
 	)
@@ -168,15 +168,15 @@ def test_moveByWord_speakAllSymbols():
 			# symbols should be named, symbol level overridden, now ALL
 			'left paren(quietly right paren)', 'quote Hello comma,', 'Jim', 'quote  dot.',
 			"don tick t",  # mid-word symbol, tick should be substituted
-			'right pointing arrow', 't shirt',
+			'right-pointing arrow', 't-shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right pointing arrow',
-			't shirt',  # no space before or after symbol
+			'right-pointing arrow',
+			't-shirt',  # no space before or after symbol
 			# note different result with no space character
-			't shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank',  # end of doc
 		],
 	)
@@ -192,15 +192,15 @@ def test_moveByWord_speakAllSymbols():
 			# symbols should be named, symbol level overridden, now ALL
 			'left paren(quietly right paren)', 'quote Hello comma,', 'Jim', 'quote  dot.',
 			"don tick t",  # mid-word symbol, tick should be substituted
-			'right pointing arrow', 't shirt',
+			'right-pointing arrow', 't-shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right pointing arrow',
-			't shirt',  # no space before or after symbol
+			'right-pointing arrow',
+			't-shirt',  # no space before or after symbol
 			# note different result with no space character
-			't shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank'  # end of doc
 		]
 	)

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -122,7 +122,7 @@ def test_moveByWord():
 			'',  # right arrow is not spoken!
 			't-shirt',  # no space before or after symbol
 			# note different result with no space character
-			't shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank',  # end of doc
 		],
 	)
@@ -146,7 +146,7 @@ def test_moveByWord():
 			'right-pointing arrow',  # no space before or after symbol
 			# note different result with no space character
 			't-shirt',  # no space before or after symbol
-			't dash shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank'  # end of doc
 		]
 	)
@@ -176,7 +176,7 @@ def test_moveByWord_speakAllSymbols():
 			'right-pointing arrow',
 			't-shirt',  # no space before or after symbol
 			# note different result with no space character
-			't dash shirt',  # no character before or after symbol (no newline)
+			't-shirt',  # no character before or after symbol (no newline)
 			'blank',  # end of doc
 		],
 	)
@@ -200,8 +200,8 @@ def test_moveByWord_speakAllSymbols():
 			'right-pointing arrow',
 			't-shirt',  # no space before or after symbol
 			# note different result with no space character
-			't dash shirt',  # no character before or after symbol (no newline)
-			'blank',  # end of doc
+			't-shirt',  # no character before or after symbol (no newline)
+			'blank'  # end of doc
 		]
 	)
 
@@ -266,7 +266,7 @@ def test_moveByChar():
 			'left paren', 'right paren',
 			'quote', 'tick',
 			'e', 'comma',
-			'right dash pointing arrow', 't dash shirt',   # Should be no 'dash', only if sym level All
+			'right-pointing arrow', 't-shirt',   # Should be no 'dash', only if sym level All
 			'tab',
 			'carriage return',  # on Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n
@@ -284,7 +284,7 @@ def test_moveByChar():
 			'left paren', 'right paren',
 			'quote', 'tick',
 			'e', 'comma',
-			'right dash pointing arrow', 't dash shirt',  # Note 'dash', not if sym level None
+			'right-pointing arrow', 't-shirt',  # Note 'dash', not if sym level None
 			'tab',
 			'carriage return',  # on Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -114,15 +114,15 @@ def test_moveByWord():
 			# symbols shouldn't be named:
 			'(quietly)', 'Hello,', 'Jim', '.',
 			"don't",  # mid-word symbol, tick shouldn't be substituted at level NONE
-			'', 't-shirt',  # right arrow is not spoken!
+			'right pointing arrow', 't shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'',  # right arrow is not spoken!
-			't-shirt',  # no space before or after symbol
+			'right pointing arrow',  # right arrow is not spoken!
+			't shirt',  # no space before or after symbol
 			# note different result with no space character
-			't-shirt',  # no character before or after symbol (no newline)
+			't shirt',  # no character before or after symbol (no newline)
 			'blank',  # end of doc
 		],
 	)
@@ -138,15 +138,15 @@ def test_moveByWord():
 			'left paren(quietly right paren)',  # parenthesis are named
 			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
 			'don tick t',  # mid-word symbol
-			'right-pointing arrow', 't-shirt',
+			'right pointing arrow', 't shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right-pointing arrow',  # no space before or after symbol
+			'right pointing arrow',  # no space before or after symbol
 			# note different result with no space character
-			't-shirt',  # no space before or after symbol
-			't-shirt',  # no character before or after symbol (no newline)
+			't shirt',  # no space before or after symbol
+			't shirt',  # no character before or after symbol (no newline)
 			'blank'  # end of doc
 		]
 	)
@@ -168,15 +168,15 @@ def test_moveByWord_speakAllSymbols():
 			# symbols should be named, symbol level overridden, now ALL
 			'left paren(quietly right paren)', 'quote Hello comma,', 'Jim', 'quote  dot.',
 			"don tick t",  # mid-word symbol, tick should be substituted
-			'right-pointing arrow', 't-shirt',
+			'right pointing arrow', 't shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right-pointing arrow',
-			't-shirt',  # no space before or after symbol
+			'right pointing arrow',
+			't shirt',  # no space before or after symbol
 			# note different result with no space character
-			't-shirt',  # no character before or after symbol (no newline)
+			't shirt',  # no character before or after symbol (no newline)
 			'blank',  # end of doc
 		],
 	)
@@ -192,15 +192,15 @@ def test_moveByWord_speakAllSymbols():
 			# symbols should be named, symbol level overridden, now ALL
 			'left paren(quietly right paren)', 'quote Hello comma,', 'Jim', 'quote  dot.',
 			"don tick t",  # mid-word symbol, tick should be substituted
-			'right-pointing arrow', 't-shirt',
+			'right pointing arrow', 't shirt',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right-pointing arrow',
-			't-shirt',  # no space before or after symbol
+			'right pointing arrow',
+			't shirt',  # no space before or after symbol
 			# note different result with no space character
-			't-shirt',  # no character before or after symbol (no newline)
+			't shirt',  # no character before or after symbol (no newline)
 			'blank'  # end of doc
 		]
 	)
@@ -266,7 +266,7 @@ def test_moveByChar():
 			'left paren', 'right paren',
 			'quote', 'tick',
 			'e', 'comma',
-			'right-pointing arrow', 't-shirt',   # Should be no 'dash', only if sym level All
+			'right pointing arrow', 't shirt',   # Should be no word 'dash'
 			'tab',
 			'carriage return',  # on Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n
@@ -284,7 +284,7 @@ def test_moveByChar():
 			'left paren', 'right paren',
 			'quote', 'tick',
 			'e', 'comma',
-			'right-pointing arrow', 't-shirt',  # Note 'dash', not if sym level None
+			'right pointing arrow', 't shirt',  # Note no word 'dash', or dash single dash character
 			'tab',
 			'carriage return',  # on Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -6,6 +6,8 @@
 """Logic for reading text using NVDA in the notepad text editor.
 """
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
+import typing as _typing
+
 from SystemTestSpy import (
 	_getLib,
 )
@@ -14,49 +16,192 @@ from SystemTestSpy import (
 from NotepadLib import NotepadLib as _NotepadLib
 from AssertsLib import AssertsLib as _AssertsLib
 import NvdaLib as _NvdaLib
+from robot.libraries.BuiltIn import BuiltIn
 
+_builtIn: BuiltIn = BuiltIn()
 _notepad: _NotepadLib = _getLib("NotepadLib")
 _asserts: _AssertsLib = _getLib("AssertsLib")
+
+navToNextCharKey = "numpad3"
+navToNextWordKey = "numpad6"
+navToNextLineKey = "numpad9"
+
+
+def _pressKeyAndCollectSpeech(key: str, numberOfTimes: int) -> _typing.List[str]:
+	actual = []
+	for _ in range(numberOfTimes):
+		spoken = _NvdaLib.getSpeechAfterKey(key)
+		# collect all output before asserting to show full picture of behavior
+		actual.append(spoken)
+	return actual
+
+
+def _doMoveByWordTest(expected: _typing.List[str]):
+	_moveByWordData = (
+		'Say (quietly) "Hello, Jim ". ➔ 👕 \n'
+		' \n'  # single space
+		'\t\n'
+		'    \n'  # 4 spaces
+		'➔\n'
+		'👕\n'  # no space after symbol
+		'👕'  # no character (no newline) after symbol
+	)
+	_notepad.prepareNotepad(f"Test: {_moveByWordData}")
+	actual = _pressKeyAndCollectSpeech(navToNextWordKey, numberOfTimes=len(expected))
+	_builtIn.should_be_equal(actual, expected)
+	# ensure all words tested
+	actual = _pressKeyAndCollectSpeech(navToNextWordKey, 1)
+	_builtIn.should_be_equal(actual, [f"Bottom\n{expected[-1]}", ])
 
 
 def test_moveByWord_symbolLevelWord():
 	"""Disabled due to revert of PR #11856 is: "Speak all symbols when moving by words (#11779)
 	"""
-	# unlike other symbols used, symbols.dic doesn't preserve quote symbols with SYMPRES_ALWAYS
-	_wordsToExpected = {
-		'Say': 'Say',
-		'(quietly)': 'left paren(quietly right paren)',
-		'"Hello,': 'quote Hello comma,',
-		'Jim".': 'Jim quote  dot.',
-		'➔': 'right-pointing arrow',  # Speech for symbols shouldn't change
-		'👕': 't-shirt',  # Speech for symbols shouldn't change
-	}
-
 	spy = _NvdaLib.getSpyLib()
 	spy.set_configValue(["speech", "symbolLevelWordAll"], True)
 
-	textStr = ' '.join(_wordsToExpected.keys())
-	_notepad.prepareNotepad(f"Test: {textStr}")
-	for expectedWord in _wordsToExpected.values():
-		wordSpoken = _NvdaLib.getSpeechAfterKey("numpad6")  # navigate to next word
-		_asserts.strings_match(wordSpoken, expectedWord)
+	# unlike other symbols used, symbols.dic doesn't preserve quote symbols with SYMPRES_ALWAYS
+	_doMoveByWordTest(expected=[
+		'Say',
+		'(quietly)',
+		'Hello,',
+		'Jim',
+		'.',
+		'right pointing arrow',  # has space before and after symbol
+		't shirt',  # has space before and after symbol
+		# end of first line
+		'blank',  # single space and newline
+		'',  # tab and newline
+		'blank',  # 4 spaces and newline
+		'right pointing arrow',  # no space before or after symbol
+		't shirt',  # no space before or after symbol
+		't shirt',  # no character before or after symbol (no newline)
+		'blank',  # end of doc
+	])
 
 
 def test_moveByWord():
-	_wordsToExpected = {
-		'Say': 'Say',
-		'(quietly)': '(quietly)',
-		'"Hello,': 'Hello,',
-		'Jim".': 'Jim .',
-		'➔': 'right pointing arrow',
-		'👕': 't shirt',
-	}
-
 	spy = _NvdaLib.getSpyLib()
 	spy.set_configValue(["speech", "symbolLevelWordAll"], False)
 
-	textStr = ' '.join(_wordsToExpected.keys())
-	_notepad.prepareNotepad(f"Test: {textStr}")
-	for expectedWord in _wordsToExpected.values():
-		wordSpoken = _NvdaLib.getSpeechAfterKey("numpad6")  # navigate to next word
-		_asserts.strings_match(wordSpoken, expectedWord)
+	_doMoveByWordTest(expected=[
+		'Say',
+		'(quietly)',
+		'Hello,',
+		'Jim',
+		'.',
+		'right pointing arrow',  # has space before and after symbol
+		't shirt',  # has space before and after symbol
+		# end of first line
+		'blank',  # single space and newline
+		'',  # tab and newline
+		'blank',  # 4 spaces and newline
+		'right pointing arrow',  # no space before or after symbol
+		't shirt',  # no space before or after symbol
+		't shirt',  # no character before or after symbol (no newline)
+		'blank',  # end of doc
+	])
+
+
+def _doMoveByLineTest():
+	testData = [
+		'Say',
+		'(quietly)',
+		'"Hello,',
+		'Jim".',
+		'➔',
+		'👕',
+		'➔ ',
+		'👕 ',
+		'➔👕',
+		' ',
+		'\t',
+		'    ',
+		'',
+	]
+
+	expected = [
+		'Say',
+		'(quietly)',
+		'Hello,',
+		'Jim .',
+		'right-pointing arrow',
+		't-shirt',
+		'right-pointing arrow',
+		't-shirt',
+		'right-pointing arrow  t-shirt',
+		'blank',  # single space
+		'',  # tab
+		'blank',  # four spaces
+		'blank',  # end of doc
+	]
+
+	textStr = '\n'.join(testData)
+
+	_notepad.prepareNotepad(f"Test:\n{textStr}")  # initial new line which isn't spoken
+	actual = _pressKeyAndCollectSpeech(navToNextLineKey, numberOfTimes=len(expected))
+	_builtIn.should_be_equal(actual, expected)
+	# ensure all lines tested
+	actual = _pressKeyAndCollectSpeech(navToNextLineKey, 1)
+	_builtIn.should_be_equal(actual, [f"Bottom\n{expected[-1]}", ])
+
+
+def test_moveByLine():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], False)
+	_doMoveByLineTest()
+
+
+def test_moveByLine_symbolLevelWord():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], True)
+	_doMoveByLineTest()
+
+
+def _doMoveByCharTest(expected: _typing.List[str]):
+	_text = 'S ()e,➔👕\t\na'  # note, 'a' is on next line and won't be spoken
+
+	_notepad.prepareNotepad(f" {_text}")
+	actual = _pressKeyAndCollectSpeech(navToNextCharKey, numberOfTimes=len(expected))
+	_builtIn.should_be_equal(actual, expected)
+	# ensure all chars tested
+	actual = _pressKeyAndCollectSpeech(navToNextCharKey, 1)
+	_builtIn.should_be_equal(actual, [f"Right\n{expected[-1]}", ])
+
+
+def test_moveByChar():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], False)
+
+	_doMoveByCharTest(expected=[
+		'S',
+		'space',
+		'left paren',
+		'right paren',
+		'e',
+		'comma',
+		'right pointing arrow',
+		't shirt',
+		'tab',
+		'carriage return',  # on Windows/notepad newline is \r\n
+		'line feed',  # on Windows/notepad newline is \r\n
+	])
+
+
+def test_moveByChar_symbolLevelWord():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], True)
+
+	_doMoveByCharTest([
+		'S',
+		'space',
+		'left paren',
+		'right paren',
+		'e',
+		'comma',
+		'right pointing arrow',
+		't shirt',
+		'tab',
+		'carriage return',  # on Windows/notepad newline is \r\n
+		'line feed',  # on Windows/notepad newline is \r\n
+	])

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -27,19 +27,6 @@ default setup
 	start NVDA	standard-dontShowWelcomeDialog.ini
 
 *** Test Cases ***
-moveByWord with symbolLevelWord
-	# Disabled due to revert of PR #11856 is: "Speak all symbols when moving by words (#11779)
-	[Tags]	excluded_from_build
-	[Documentation]	Ensure all symbols are read when navigating by word.
-	test_moveByWord_symbolLevelWord
-moveByLine with symbolLevelWord
-	[Documentation]	Ensure all symbols are read when navigating by line.
-	[Tags]	excluded_from_build
-	test_moveByLine_symbolLevelWord
-moveByCharacter with symbolLevelWord
-	[Documentation]	Ensure all symbols are read when navigating by character.
-	[Tags]	excluded_from_build
-	test_moveByChar_symbolLevelWord
 
 moveByWord
 	[Documentation]	Ensure symbols announced as expected when navigating by word (numpad 6).

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -41,3 +41,7 @@ moveByLine
 moveByCharacter
 	[Documentation]	Ensure symbols announced as expected when navigating by character (numpad 3).
 	test_moveByChar
+
+moveByWordWithSpeakAllSymbols
+	[Documentation]	With speak all symbols for move by word, check symbols reported with word nav (numpad 6).
+	test_moveByWord_speakAllSymbols

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -28,6 +28,10 @@ default setup
 
 *** Test Cases ***
 
+symbolInSpeechUI
+	[Documentation]	Ensure symbols aren't substituted within NVDA speech UI.
+	test_symbolInSpeechUI
+
 moveByWord
 	[Documentation]	Ensure symbols announced as expected when navigating by word (numpad 6).
 	test_moveByWord

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -19,7 +19,7 @@ Test Teardown	default teardown
 default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
-	Run Keyword If Test Failed	dump_speech_to_log
+	dump_speech_to_log
 	exit notepad
 	quit NVDA
 
@@ -32,6 +32,21 @@ moveByWord with symbolLevelWord
 	[Tags]	excluded_from_build
 	[Documentation]	Ensure all symbols are read when navigating by word.
 	test_moveByWord_symbolLevelWord
+moveByLine with symbolLevelWord
+	[Documentation]	Ensure all symbols are read when navigating by line.
+	[Tags]	excluded_from_build
+	test_moveByLine_symbolLevelWord
+moveByCharacter with symbolLevelWord
+	[Documentation]	Ensure all symbols are read when navigating by character.
+	[Tags]	excluded_from_build
+	test_moveByChar_symbolLevelWord
+
 moveByWord
-	[Documentation]	Ensure symbols announced as expected when navigating by word.
+	[Documentation]	Ensure symbols announced as expected when navigating by word (numpad 6).
 	test_moveByWord
+moveByLine
+	[Documentation]	Ensure symbols announced as expected when navigating by line (numpad 9).
+	test_moveByLine
+moveByCharacter
+	[Documentation]	Ensure symbols announced as expected when navigating by character (numpad 3).
+	test_moveByChar

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -19,7 +19,7 @@ from speech.commands import (
 	CharacterModeCommand,
 	PitchCommand,
 	BeepCommand,
-	LangChangeCommand
+	LangChangeCommand, UserInterface, Symbol,
 )
 
 
@@ -125,7 +125,7 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 	
 	def test_noNotifications(self):
 		expected = repr([
-			'A',
+			Symbol('A'),
 		])
 		output = _getSpellingCharAddCapNotification(
 			speakCharAs='A',
@@ -138,7 +138,7 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 	def test_pitchNotifications(self):
 		expected = repr([
 			PitchCommand(offset=30),
-			'A',
+			Symbol('A'),
 			PitchCommand()
 		])
 		output = _getSpellingCharAddCapNotification(
@@ -152,7 +152,7 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 	def test_beepNotifications(self):
 		expected = repr([
 			BeepCommand(2000, 50, left=50, right=50),
-			'A',
+			Symbol('A'),
 		])
 		output = _getSpellingCharAddCapNotification(
 			speakCharAs='A',
@@ -164,8 +164,8 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 
 	def test_capNotifications(self):
 		expected = repr([
-			'cap ',
-			'A',
+			UserInterface('cap '),
+			Symbol('A'),
 		])
 		output = _getSpellingCharAddCapNotification(
 			speakCharAs='A',
@@ -177,7 +177,7 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 
 	def test_capNotificationsWithPlaceHolderBefore(self):
 		self.translationsFake.translationResults["cap %s"] = "%s cap"
-		expected = repr(['A', ' cap', ])  # for English this would be "cap A"
+		expected = repr([Symbol('A'), UserInterface(' cap'), ])  # for English this would be "cap A"
 		output = _getSpellingCharAddCapNotification(
 			speakCharAs='A',
 			sayCapForCapitals=True,
@@ -190,8 +190,8 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 		expected = repr([
 			PitchCommand(offset=30),
 			BeepCommand(2000, 50, left=50, right=50),
-			'cap ',
-			'A',
+			UserInterface('cap '),
+			Symbol('A'),
 			PitchCommand()
 		])
 		output = _getSpellingCharAddCapNotification(
@@ -216,11 +216,11 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 	
 	def test_simpleSpelling(self):
 		expected = repr([
-			'a',
+			Symbol('a'),
 			EndUtteranceCommand(),
-			'b',
+			Symbol('b'),
 			EndUtteranceCommand(),
-			'c',
+			Symbol('c'),
 			EndUtteranceCommand(),
 		])
 		output = _getSpellingSpeechWithoutCharMode(
@@ -237,8 +237,8 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 		expected = repr([
 			PitchCommand(offset=30),
 			BeepCommand(2000, 50, left=50, right=50),
-			'cap ',
-			'A',
+			UserInterface('cap '),
+			Symbol('A'),
 			PitchCommand(),
 			EndUtteranceCommand(),
 		])
@@ -254,7 +254,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 	
 	def test_characterMode(self):
 		expected = repr([
-			'Alfa',
+			Symbol('Alfa'),
 			EndUtteranceCommand(),
 		])
 		output = _getSpellingSpeechWithoutCharMode(
@@ -269,7 +269,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 
 	def test_blank(self):
 		expected = repr([
-			'blank',
+			UserInterface('blank'),
 		])
 		output = _getSpellingSpeechWithoutCharMode(
 			text='',
@@ -283,9 +283,9 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 
 	def test_onlySpaces(self):
 		expected = repr([
-			'space',
+			Symbol('space'),
 			EndUtteranceCommand(),
-			'tab',
+			Symbol('tab'),
 			EndUtteranceCommand(),
 		])
 		output = _getSpellingSpeechWithoutCharMode(
@@ -300,7 +300,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 
 	def test_trimRightSpace(self):
 		expected = repr([
-			'a',
+			Symbol('a'),
 			EndUtteranceCommand(),
 		])
 		output = _getSpellingSpeechWithoutCharMode(
@@ -315,7 +315,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 
 	def test_symbol(self):
 		expected = repr([
-			'bang',
+			Symbol('bang'),
 			EndUtteranceCommand(),
 		])
 		output = _getSpellingSpeechWithoutCharMode(
@@ -332,7 +332,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 		config.conf['speech']['autoLanguageSwitching'] = True
 		expected = repr([
 			LangChangeCommand('fr_FR'),
-			'a',
+			Symbol('a'),
 			EndUtteranceCommand(),
 		])
 		output = _getSpellingSpeechWithoutCharMode(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -34,6 +34,8 @@ What's New in NVDA
 - ``NVDA+Numpad Delete`` reports the location of the caret or focused object by default. (#13060)
 - ``NVDA+Shift+Numpad Delete`` reports the location of the review cursor. (#13060)
 - Added default bindings for toggling modifier keys to Freedom Scientific displays (#13152)
+- By default, every symbol is now spoken when navigating by word.
+This can be toggled in the Preferences dialog or with a new (unassigned) command. (#11779)
 -
 
 == Bug Fixes ==
@@ -111,6 +113,9 @@ This can dramatically decrease build times on multi core systems. (#13226)
 - ``config.RUN_REGKEY``, ``config.NVDA_REGKEY`` are deprecated, please use ``config.RegistryKey.RUN``, ``config.RegistryKey.NVDA`` instead. These will be removed in 2023. (#13242)
 - ``easeOfAccess.ROOT_KEY``, ``easeOfAccess.APP_KEY_PATH`` are deprecated, please use``easeOfAccess.RegistryKey.ROOT``, ``easeOfAccess.RegistryKey.APP`` instead. These will be removed in 2023. (#13242)
 - ``easeOfAccess.APP_KEY_NAME`` has been deprecated, to be removed in 2023. (#13242)
+- New 'Atomic' speech commands have been introduced. (#12710)
+  - 'Symbol' speech command, encapsulates symbol descriptions.
+  - `UserInterface` speech command, encapsulates NVDA's user interface messages.
 -
 
 
@@ -171,8 +176,6 @@ If you need this functionality please assign a gesture to the appropriate script
   -
 - Instead of "marked content" or "mrkd", "highlight" or "hlght" will be announced for speech and braille respectively. (#12892)
 - NVDA will no longer attempt to exit when dialogs are awaiting a required action (eg Confirm/Cancel). (#12984)
-- By default, every symbol is now spoken when navigating by word.
-This can be toggled in the Preferences dialog or with a new (unassigned) command. (#11779)
 -
 
 
@@ -218,9 +221,6 @@ To match the production build environment, update Visual Studio to keep in sync 
 They are still available at the module level but are deprecated and to be removed in NVDA 2022.1. (#12753)
 - The usage of functions ``addonHandler.loadState`` and ``addonHandler.saveState`` should be replaced with their equivalents ``addonHandler.state.save`` and ``addonHandler.state.load`` before 2022.1. (#12792)
 - Braille output can now be checked in system tests. (#12917)
-- New 'Atomic' speech commands have been introduced. (#12710)
-  - 'Symbol' speech command, encapsulates symbol descriptions.
-  - `UserInterface` speech command, encapsulates NVDA's user interface messages.
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -218,6 +218,9 @@ To match the production build environment, update Visual Studio to keep in sync 
 They are still available at the module level but are deprecated and to be removed in NVDA 2022.1. (#12753)
 - The usage of functions ``addonHandler.loadState`` and ``addonHandler.saveState`` should be replaced with their equivalents ``addonHandler.state.save`` and ``addonHandler.state.load`` before 2022.1. (#12792)
 - Braille output can now be checked in system tests. (#12917)
+- New 'Atomic' speech commands have been introduced. (#12710)
+  - 'Symbol' speech command, encapsulates symbol descriptions.
+  - `UserInterface` speech command, encapsulates NVDA's user interface messages.
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -171,6 +171,8 @@ If you need this functionality please assign a gesture to the appropriate script
   -
 - Instead of "marked content" or "mrkd", "highlight" or "hlght" will be announced for speech and braille respectively. (#12892)
 - NVDA will no longer attempt to exit when dialogs are awaiting a required action (eg Confirm/Cancel). (#12984)
+- By default, every symbol is now spoken when navigating by word.
+This can be toggled in the Preferences dialog or with a new (unassigned) command. (#11779)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1212,6 +1212,12 @@ This allows you to choose the amount of punctuation and other symbols that shoul
 For example, when set to all, all symbols will be spoken as words.
 This option applies to all synthesizers, not just the currently active synthesizer.
 
+==== Speak all punctuation and symbols when reviewing by word ====[SpeechSettingsSymbolLevelWord]
+
+When reviewing text by word, it is often desirable to get more details than when reading a whole sentence.
+When checked (by default), NVDA speaks the name of all punctuation and other symbols when reviewing by word, as if the above level was set to "all".
+Note: In any case, when reviewing text by character, NVDA always reports the name of punctuation and other symbols.
+
 ==== Trust voice's language when processing characters and symbols ====[SpeechSettingsTrust]
 On by default, this option tells NVDA if the current voice's language can be trusted when processing symbols and characters.
 If you find that NVDA is reading punctuation in the wrong language for a particular synthesizer or voice, you may wish to turn this off to force NVDA to use its global language setting instead.


### PR DESCRIPTION
### Closed reason.
This requires an API breaking change, time ran out prior to the 2022.1 release while resolving usage and design concerns.
- There are many translated strings in NVDA (approx. 2300). It will take a while to consider them, and wrap with a type.
- The full set of types required is not known, what about strings with placeholders. The placeholder text may need to be considered for symbol substitution, but not the surrounding text. Consider the contrived example: `_("The column's name is %s")`. The apostrophe should not be announced as `tick`, but if the the column name should be processed eg for column name `don't`: `"The column's name is don tick t"`
- The commands inherit from `str` to ensure that they can be used in the same way is prior items in the speech sequence, however this also means it is easy for a logic error to drop the extra information provided by a class.

### Link to issue number:
https://github.com/nvaccess/nvda/pull/12695
Fixes: #10855
Fixes #11779

### Summary of the issue:
NV Access took open this abandoned PR:
Recent history: PR #12695 reverted PR #11856 fixing a regression described in issue #12653.

Navigation by word is inconsistent among different editors.
This might lead to different symbol announcements, or opening and closing symbols not announced consistently.

### Description of how this pull request fixes the issue:
- New config "symbolLevelWordAll" enabling symbol level ALL when navigating by word.
- When navigating by character, use symbol level all.
- When describing a symbol a new speech command is used to wrap the replacement.
  This propagates the initial intention and semantics of the speech sequence item.

Intentionally changes behavior for symbol text sent to synth when moving by word. This now matches the behavior for moving by line. The hyphen character in symbols like "t-shirt" and "right-pointing arrow" are sent to the synthesizer.

Note, commits have been carefully authored to show the progression of changes, however there are two commits that can be ignored, which only tidy related code:
- Clarify symbol level default
- add type information

The notepad tests have been confirmed to pass for all commits, looking at the changes to these tests will demonstrate the changes in behavior with that commit.

### Testing strategy:
- System tests
- Manual testing

### Known issues with pull request:
None

### Change log entries:
Already included in PR, see diff.

### Code Review Checklist:

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
