### PR TITLE
Fix Aria description tests

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -514,14 +514,7 @@ def test_ariaDescription_focusMode():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	# description-from hasn't reached Chrome stable yet.
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
-	_builtIn.run_keyword_and_expect_error(
-		# expected_error
-		"Actual speech != Expected speech:"
-		" Here is a sentence that is being edited by someone else."
-		"  Multiple can edit this. != *",
-		# keyword
-		"strings_match",
-		# args
+	_asserts.strings_match(
 		actualSpeech,
 		f"{annotation}  Here is a sentence that is being edited by someone else."
 		"  Multiple authors can edit this."

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -593,8 +593,7 @@ def test_ariaDescription_sayAll():
 		"\n".join([
 			"Test page load complete",
 			"edit  multi line  This is a line with no annotation",
-			f"{annotation}  Here is a sentence that is being edited by someone else.",
-			"Multiple can edit this.",
+			f"{annotation}  Here is a sentence that is being edited by someone else.  Multiple can edit this.",
 			"An element with a role, "  # no comma, concat these two long strings.
 			f"follow  {linkRole}  {linkDescription}  {linkName}  website",
 			# 'title' attribute for link ("conduct a search") should not be announced.

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -517,7 +517,7 @@ def test_ariaDescription_focusMode():
 	_asserts.strings_match(
 		actualSpeech,
 		f"{annotation}  Here is a sentence that is being edited by someone else."
-		"  Multiple authors can edit this."
+		f"  Multiple can edit this."
 	)
 
 	linkRole = "link"
@@ -555,7 +555,7 @@ def test_ariaDescription_browseMode():
 	_asserts.strings_match(
 		actualSpeech,
 		f"{annotation}  Here is a sentence that is being edited by someone else."
-		"  Multiple authors can edit this."
+		"  Multiple can edit this."
 	)
 
 	linkRole = "link"
@@ -594,7 +594,7 @@ def test_ariaDescription_sayAll():
 			"Test page load complete",
 			"edit  multi line  This is a line with no annotation",
 			f"{annotation}  Here is a sentence that is being edited by someone else.",
-			"Multiple authors can edit this.",
+			"Multiple can edit this.",
 			"An element with a role, "  # no comma, concat these two long strings.
 			f"follow  {linkRole}  {linkDescription}  {linkName}  website",
 			# 'title' attribute for link ("conduct a search") should not be announced.

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -532,14 +532,7 @@ def test_ariaDescription_focusMode():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	# description-from hasn't reached Chrome stable yet.
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
-	_builtIn.run_keyword_and_expect_error(
-		# expected_error
-		"Actual speech != Expected speech:"
-		f" An element with a role, follow  {linkRole}  {linkName}  website"
-		" != *",
-		# keyword
-		"strings_match",
-		# args
+	_asserts.strings_match(
 		actualSpeech,
 		f"An element with a role, follow  {linkRole}  {linkDescription}  {linkName}  website"
 	)
@@ -566,14 +559,7 @@ def test_ariaDescription_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	# description-from hasn't reached Chrome stable yet.
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
-	_builtIn.run_keyword_and_expect_error(
-		# expected_error
-		"Actual speech != Expected speech:"
-		" Here is a sentence that is being edited by someone else."
-		"  Multiple can edit this. != *",
-		# keyword
-		"strings_match",
-		# args
+	_asserts.strings_match(
 		actualSpeech,
 		f"{annotation}  Here is a sentence that is being edited by someone else."
 		"  Multiple authors can edit this."
@@ -584,14 +570,7 @@ def test_ariaDescription_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	# description-from hasn't reached Chrome stable yet.
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
-	_builtIn.run_keyword_and_expect_error(
-		# expected_error
-		"Actual speech != Expected speech:"
-		f" An element with a role, follow  {linkRole}  {linkName}  website"
-		" != *",
-		# keyword
-		"strings_match",
-		# args
+	_asserts.strings_match(
 		actualSpeech,
 		f"An element with a role, follow  {linkRole}  {linkDescription}  {linkName}  website"
 	)
@@ -616,13 +595,7 @@ def test_ariaDescription_sayAll():
 
 	# description-from hasn't reached Chrome stable yet.
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
-	_builtIn.run_keyword_and_expect_error(
-		# asserting multiline error messages doesn't seem to work, instead just Glob the details
-		# of the error message:
-		"Multiline strings are different:*",
-		# keyword
-		"strings_match",
-		# args
+	_asserts.strings_match(
 		actualSpeech,
 		"\n".join([
 			"Test page load complete",


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
[Appveyor 2019 image has been updated](https://www.appveyor.com/updates/) to include Chrome 92.0.4515.131
Now the [expected failures aren't as expected](https://ci.appveyor.com/project/NVAccess/nvda/builds/40274205/tests).

### Description of how this pull request fixes the issue:
Expect the aria-description text to be spoken

### Testing strategy:
Run system tests on appveyor

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:
- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
