### PR TITLE
No longer append clang directories to path in SCons environment when building liblouis and update readme about Visual Studio

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -53,7 +53,6 @@ if len(clangDirs) == 0:
 		"Could not find the Clang compiler. "
 		"Perhaps the C++ Clang tools for Windows component in visual Studio is not installed"
 	) 
-env['ENV']['PATH'] += "".join(f";{d}" for d in clangDirs)
 env['CC'] = 'clang-cl'
 
 # Don't analyze the code as not our project

--- a/readme.md
+++ b/readme.md
@@ -57,13 +57,13 @@ The following dependencies need to be installed on your system:
 
 * [Python](https://www.python.org/), version 3.7, 32 bit
 	* Use latest minor version if possible.
-* Microsoft Visual Studio 2019 Community, Version 16.3 or later:
+* Microsoft Visual Studio 2019 Community, Version 16.11:
 	* Download from https://visualstudio.microsoft.com/vs/
 	* When installing Visual Studio, you need to enable the following:
-		* On the Workloads tab
-			* in the Windows group:
+		* In the list  on the Workloads tab
+			* in the Windows grouping:
 				* Desktop development with C++
-			* Then in the Installation details section, under Desktop for C++, Optional grouping, ensure the following are selected:
+			* Then in the Installation details tree view, under Desktop for C++, Optional, ensure the following are selected:
 				* MSVC v142 - VS 2019 C++ x64/x86 build tools
 				* Windows 10 SDK (10.0.19041.0)
 				* C++ ATL for v142 build tools (x86 & x64)

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ The following dependencies need to be installed on your system:
 * [Python](https://www.python.org/), version 3.7, 32 bit
 	* Use latest minor version if possible.
 * Microsoft Visual Studio 2019:
-        * To replicate the production build environment, use the [version of Visual Studio that AppVeyor is using](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019). 
+	* To replicate the production build environment, use the [version of Visual Studio that AppVeyor is using](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019). 
 	* Download from https://visualstudio.microsoft.com/downloads/
 		* When you do not use the Visual Studio IDE itself, you can download the build tools under the Tools for Visual Studio 2019 expandable heading
 		* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download the community version under the Visual Studio 2019 expandable heading

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,8 @@ The following dependencies need to be installed on your system:
 
 * [Python](https://www.python.org/), version 3.7, 32 bit
 	* Use latest minor version if possible.
-* Microsoft Visual Studio 2019, Version 16.11:
+* Microsoft Visual Studio 2019:
+        * To replicate the production build environment, use the [version of Visual Studio that AppVeyor is using](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019). 
 	* Download from https://visualstudio.microsoft.com/downloads/
 		* When you do not use the Visual Studio IDE itself, you can download the build tools under the Tools for Visual Studio 2019 expandable heading
 		* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download the community version under the Visual Studio 2019 expandable heading

--- a/readme.md
+++ b/readme.md
@@ -57,8 +57,10 @@ The following dependencies need to be installed on your system:
 
 * [Python](https://www.python.org/), version 3.7, 32 bit
 	* Use latest minor version if possible.
-* Microsoft Visual Studio 2019 Community, Version 16.11:
-	* Download from https://visualstudio.microsoft.com/vs/
+* Microsoft Visual Studio 2019, Version 16.11:
+	* Download from https://visualstudio.microsoft.com/downloads/
+		* When you do not use the Visual Studio IDE itself, you can download the build tools under the Tools for Visual Studio 2019 expandable heading
+		* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download the community version under the Visual Studio 2019 expandable heading
 	* When installing Visual Studio, you need to enable the following:
 		* In the list  on the Workloads tab
 			* in the Windows grouping:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,8 @@ What's New in NVDA
 
 
 == Changes for Developers ==
+- Building NVDA now requires Visual Studio 2019 16.10.4 or later.
+To match the production build environment, update Visual Studio to keep in sync with the [current version AppVeyor is using https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019]. (#12728)
 - ``NVDAObjects.UIA.winConsoleUIA.WinConsoleUIA.isImprovedTextRangeAvailable`` has been deprecated for removal in 2022.1. (#12660)
   - Instead use ``apiLevel`` (see the comments at ``_UIAConstants.WinConsoleAPILevel`` for details).
   -


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In the past, we had to explicitly dig up the dirs where clang was installed inside Visual Studio. It looks like since then, Microsoft added LLVM to the path of the Visual Studio tools command prompt, which constructor batch file is used by SCons.

### Description of how this pull request fixes the issue:
No longer add Clang to the path. Note that we still check its installation.

I also updated the readme according to the new design of the Visual Studio installer, thereby changing the following:

1. As a minimum, version 16.11 is recommended which is the most recent version of Visual Studio 2019. This is not yet available on appveyor at the time of writing, but version 16.10 will only be supported for three months or so. I assume Appveyor will switch to 16.11 asap.
2. The installer has a new design with list/tree view instead of a bunch of groupings you have to tab through.
3. I appended a note about the build tools for those who don't require the IDE. This works like a charm and saves some unnecessary space on ones hard drive.

### Testing strategy:
Tested that NVDA builds with Visual Studio build tools 16.11

### Known issues with pull request:
None known

### Change log entries:
Changes for developers:
- Building NVDA now requires Visual Studio 2019 16.10 or later. To build NVDA successfully, update Visual Studio to keep in sync with the [current AppVeyor build version https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019]. (#12728)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
