### PR TITLE
updateCheck: Fix fetching of server certificate  for Python 3

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -138,7 +138,7 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 	try:
 		res = urllib.request.urlopen(url)
 	except IOError as e:
-		if isinstance(e.strerror, ssl.SSLError) and e.strerror.reason == "CERTIFICATE_VERIFY_FAILED":
+		if isinstance(e.reason, ssl.SSLCertVerificationError) and e.reason.reason == "CERTIFICATE_VERIFY_FAILED":
 			# #4803: Windows fetches trusted root certificates on demand.
 			# Python doesn't trigger this fetch (PythonIssue:20916), so try it ourselves
 			_updateWindowsRootCertificates()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,6 +23,7 @@ What's New in NVDA
 
 == Bug Fixes ==
 - Tracking keyboard modifiers (such as Control, or Insert) is more robust when watchdog is recovering. (#12609)
+- It is once again possible to check for NVDA updates on certain systems; e.g. clean Windows installs. (#12729)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When checking for updates to NVDA and certificate of NV Access's server is not installed on the system (this most commonly happens for clean Windows installs) we need to fetch it manually as Python does not do this for us. To do this we're catching errors during connection to the server and then inspecting raised exception to determine if it has been  caused by missing certificate and if so we're asking Windows to fetch it for us. This does not work in Python3 however as the structure of the exception from `SSL` has changed.
### Description of how this pull request fixes the issue:
1. Since `strerror` of SSL exceptions is empty in Python 3 we need to inspect its `reason` to get to the cause of the failure.
2. When the exception is caused by lack of certificate in Python 3 it is represented by `ssl.SSLCertVerificationError` not a less specific `SSLError`
### Testing strategy:
I've created two launchers of NVDA as follows: `scons launcher version-2020.3 updateVersionType=stable` the first one from master, the second from the code from this PR. On the clean Windows 10 VM made sure that the build from the current master fails to check for updates whereas the one with the fix from this PR can successfully check for update and download it.

### Known issues with pull request:
None known
### Change log entries:
Bug fixes
- It is once again possible to check for NVDA updates on certain systems; e.g. clean Windows installs.

### Code Review Checklist:

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
