### PR TITLE
Handle generic menu popup start events processed after the menu item

### DIFF
--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -226,15 +226,12 @@ class FocusLossCancellableSpeechCommand(_CancellableSpeechCommand):
 		The object tree in this case (menu item > submenu (not keyboard focusable) > submenu item).
 		The focus event order after activating the menu item's sub menu is (submenu item, submenu).
 		"""
-		from NVDAObjects import IAccessible
 		lastFocus = api.getFocusObject()
 		_isMenuItemOfCurrentFocus = (
 			self._obj.parent
-			and isinstance(self._obj, IAccessible.IAccessible)
-			and isinstance(lastFocus, IAccessible.IAccessible)
-			and self._obj.IAccessibleRole == oleacc.ROLE_SYSTEM_MENUITEM
-			and lastFocus.IAccessibleRole == oleacc.ROLE_SYSTEM_MENUPOPUP
 			and self._obj.parent == lastFocus
+			and self._obj.role == controlTypes.Role.MENUITEM
+			and lastFocus.role == controlTypes.Role.POPUPMENU
 		)
 		if _isMenuItemOfCurrentFocus:
 			# Change this to log.error for easy debugging


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12624, follow up on #12709

### Summary of the issue:

As discussed in #12709

>When opening a submenu in certain applications (like Thunderbird 78.12),
NVDA can process a menu start event after the first item in the menu is focused.
The menu start event causes a focus event on the menu, taking NVDA's focus from the menu item.
Additionally, the "menu" parent of the submenu item is not keyboard focusable, and is separate from
the menu item which triggered the submenu.
The object tree in this case (menu item > submenu (not keyboard focusable) > submenu item).
The focus event order after activating the menu item's sub menu is (submenu item, submenu).

Additionally, this problem occurs for UIA controls (in `Outlook 2016 version 16.0.5182.1000`), not just IAccessible2. 

### Description of how this pull request fixes the issue:

makes isMenuItemOfCurrentFocus generic, using NVDA roles rather than IAccessible2 roles. 

### Testing strategy:

- [x] Confirm that the issue is still fixed for Thunderbird
- [ ] Confirm the issue is fixed for `Outlook 2016 version 16.0.5182.1000`

Manual testing steps (note that this does not always occur and is hard to consistently reproduce):

1. Enable debug logging
2. With a context menu (activate one on an email, for example)
3. navigate to a menu item with a submenu.
4. Activate it.
5. Examine the logs for an event (submenu item, submenu) - eg the speech is announced in this order in the logs, as are the events if event debugging is enabled.
6. On this PR: Confirm that this case has extensive logging when it occurs. When this event occurs confirm that the menu item is spoken, followed by the submenu. If you want to hear a beep on this event, change the logging to an error beep.
7. On 2021.1: Confirm that only menu item is spoken, as the seubmenu item is cancelled.

### Known issues with pull request:

This may be an overzealous check. Speech in similar contexts that should be cancelled may continue to be spoken.
As such, debug logs are added to make handling new cases easier until the root problem of event processing is addressed.

### Change log entries:

Bug fixes

```
- Fixed bug where the first menu item is not announced in a submenu in some contexts. (#12624)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [ ] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
