### PR TITLE
Correctly read blank cells in MS Word with NVDA's UIA for MS Word option enabled

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -23,6 +23,9 @@ from scriptHandler import script
 
 """Support for Microsoft Word via UI Automation."""
 
+#: the non-printable unicode character that represents the end of cell or end of row mark in Microsoft Word
+END_OF_ROW_MARK = '\x07'
+
 class ElementsListDialog(browseMode.ElementsListDialog):
 
 	ELEMENT_TYPES=(browseMode.ElementsListDialog.ELEMENT_TYPES[0],browseMode.ElementsListDialog.ELEMENT_TYPES[1],
@@ -183,7 +186,7 @@ class WordDocumentTextInfo(UIATextInfo):
 			# Really better as carage returns
 			t=t.replace('\v','\r')
 			# Remove end-of-row markers from the text - they are not useful
-			t=t.replace('\x07','')
+			t = t.replace(END_OF_ROW_MARK, '')
 		return t
 
 	def _isEndOfRow(self):
@@ -218,7 +221,7 @@ class WordDocumentTextInfo(UIATextInfo):
 		fields = None
 		if not self.isCollapsed:
 			rawText = self._rangeObj.GetText(2)
-			if not rawText or rawText == '\x07':
+			if not rawText or rawText == END_OF_ROW_MARK:
 				r = self.copy()
 				r.end = r.start
 				fields = super(WordDocumentTextInfo, r).getTextWithFields(formatConfig=formatConfig)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -219,6 +219,16 @@ class WordDocumentTextInfo(UIATextInfo):
 
 	def getTextWithFields(self,formatConfig=None):
 		fields = None
+		# #11043: when a non-collapsed text range is positioned within a blank table cell
+		# MS Word does not return the table  cell as an enclosing element,
+		# Thus NVDa thinks the range is not inside the cell.
+		# This can be detected by asking for the first 2 characters of the range's text,
+		# Which will either be an empty string, or the single end-of-row mark.
+		# Anything else means it is not on an empty table cell,
+		# or the range really does span more than the cell itself.
+		# If this situation is detected,
+		# copy and collapse the range, and fetch the content from that instead,
+		# As a collapsed range on an empty cell does correctly return the table cell as its first enclosing element.
 		if not self.isCollapsed:
 			rawText = self._rangeObj.GetText(2)
 			if not rawText or rawText == END_OF_ROW_MARK:
@@ -226,7 +236,7 @@ class WordDocumentTextInfo(UIATextInfo):
 				r.end = r.start
 				fields = super(WordDocumentTextInfo, r).getTextWithFields(formatConfig=formatConfig)
 		if fields is None:
-			fields = super(WordDocumentTextInfo, self).getTextWithFields(formatConfig=formatConfig)
+			fields = super().getTextWithFields(formatConfig=formatConfig)
 		if len(fields)==0: 
 			# Nothing to do... was probably a collapsed range.
 			return fields

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -215,10 +215,15 @@ class WordDocumentTextInfo(UIATextInfo):
 				self.setEndPoint(docInfo,"endToEnd")
 
 	def getTextWithFields(self,formatConfig=None):
-		if self.isCollapsed:
-			# #7652: We cannot fetch fields on collapsed ranges otherwise we end up with repeating controlFields in braille (such as list list list). 
-			return []
-		fields=super(WordDocumentTextInfo,self).getTextWithFields(formatConfig=formatConfig)
+		fields = None
+		if not self.isCollapsed:
+			rawText = self._rangeObj.GetText(2)
+			if not rawText or rawText == '\x07':
+				r = self.copy()
+				r.end = r.start
+				fields = super(WordDocumentTextInfo, r).getTextWithFields(formatConfig=formatConfig)
+		if fields is None:
+			fields = super(WordDocumentTextInfo, self).getTextWithFields(formatConfig=formatConfig)
 		if len(fields)==0: 
 			# Nothing to do... was probably a collapsed range.
 			return fields

--- a/source/braille.py
+++ b/source/braille.py
@@ -880,7 +880,13 @@ class TextInfoRegion(Region):
 		formatFieldAttributesCache = getattr(info.obj, "_brailleFormatFieldAttributesCache", {})
 		# When true, we are inside a clickable field, and should therefore not report any more new clickable fields
 		inClickable=False
-		for command in info.getTextWithFields(formatConfig=formatConfig):
+		# Collapsed ranges should never produce text and fields,
+		# But later on we may still need to draw the cursor at this position.
+		if not info.isCollapsed:
+			commands = info.getTextWithFields(formatConfig=formatConfig)
+		else:
+			commands = []
+		for command in commands:
 			if isinstance(command, str):
 				# Text should break a run of clickables
 				inClickable=False

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,7 @@ What's New in NVDA
 == Bug Fixes ==
 - Tracking keyboard modifiers (such as Control, or Insert) is more robust when watchdog is recovering. (#12609)
 - It is once again possible to check for NVDA updates on certain systems; e.g. clean Windows installs. (#12729)
+- NVDA correctly announces blank table cells in Microsoft Word when using UI automation. (#11043)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #11043
Fixes #11457
Fixes #12490 

### Summary of the issue:
When using UIA to access Microsoft word documents with NVDA, NVDA failed to announce row and column numbers when arrowing onto blank table cells. Also, navigating a table with the control+alt+arrow keys and landing on blank cells would sometimes announce leaving the table.

This was caused by the fact that when expanding a IUIAutomationTextRange in a blank table cell to any text unit, the range will cover the end-of-cell marker, and therefore span more than the cell itself, thus it looks like the range is not entirely inside the cell.

### Description of how this pull request fixes the issue:
Work around this MS Word bug by detecting when in this situation: the range is not collapsed, yet the text in the range is either empty or the end-of-cell marker. And if so, Use a copy of the range, that is collapsed to the start (entirely inside the cell) to fetch the text and fields.

This pr also makes a change to Braille, so that when building a line of rich text in braille, a TextInfo's getTextWithFields method is only called if the textInfo is not collapsed. this stops repeating of fields for collapsed ranges, which was sometimes seen in Microsoft Word with UIA enabled.

### Testing strategy:
* Navigated a Word document containing tables, lists, headings, images, comments, foot notes and end notes, ensuring that noting has changed in speech or braille. Test document: 
[Test document.docx](https://github.com/nvaccess/nvda/files/6978986/Test.document.docx)

* Create a new document in MS Word, insert a blank table, and use, arrows, tab and control+alt+arrows to move between the blank cells ensuring that row and column info is reported in both speech and braille.

### Known issues with pull request:
None known.

### Change log entries:
Bug fixes
- NVDA correctly announces blank table cells in Microsoft Word when using UI automation.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
