### PR TITLE
Ensure that clipboard manager does not steal focus when starting  MS Office programs

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -40,6 +40,11 @@ import eventHandler
 from NVDAObjects.behaviors import ProgressBar, Dialog, EditableTextWithAutoSelectDetection, FocusableUnfocusableContainer, ToolTip, Notification
 from locationHelper import RectLTWH
 
+
+# Custom object ID used for clipboard pane in some versions of MS Office
+MSO_COLLECT_AND_PASTE_OBJECT_ID = 21
+
+
 def getNVDAObjectFromEvent(hwnd,objectID,childID):
 	try:
 		accHandle=IAccessibleHandler.accessibleObjectFromEvent(hwnd,objectID,childID)
@@ -499,7 +504,10 @@ the NVDAObject for IAccessible
 		elif windowClassName.startswith('Mozilla'):
 			from . import mozilla
 			mozilla.findExtraOverlayClasses(self, clsList)
-		elif self.event_objectID in (None,winUser.OBJID_CLIENT) and windowClassName.startswith('bosa_sdm'):
+		elif(
+			self.event_objectID in (None, winUser.OBJID_CLIENT, MSO_COLLECT_AND_PASTE_OBJECT_ID)
+			and windowClassName.startswith('bosa_sdm')
+		):
 			if role==oleacc.ROLE_SYSTEM_GRAPHIC and controlTypes.State.FOCUSED in self.states:
 				from .msOffice import SDMSymbols
 				clsList.append(SDMSymbols)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,6 +12,7 @@ What's New in NVDA
 -
 
 == Bug Fixes ==
+- Clipboard manager pane should no longer incorrectly steal focus when opening some Office programs. (#12736)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None, related to #4199, Originally reported on one of the Polish mailing  lists (I cannot link to the conversation archives cannot be accessed for non subscribers)

### Summary of the issue:
As described in #4199 when starting Office programs Word, Excel clipboard manager can sometimes steal accessibility focus making it impossible to interact with the document / spreadsheet.
Most cases were fixed but it seems one has been missed - focus lands on something called Collect  and Paste 2.0 ,making interaction with the actual document difficult.

### Description of how this pull request fixes the issue:
Since the "Collect and paste" has a custom eventObjectID `SDM~has not been applied to it causing focus to be incorrect. This custom ID has been added to the list of objects for which `SDM~applies.
### Testing strategy:
Started Excel from the run box - made sure that focus lands on the actual spreadsheet whereas previously it didn't.

### Known issues with pull request:
None known
### Change log entries:
Bug fixes
 - Clipboard manager pane should no longer incorrectly steal focus when opening some Office programs

### Code Review Checklist:


- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
