### PR TITLE
Add system test for desktop shortcut

### DIFF
--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -79,9 +79,9 @@ def GetForegroundWindowTitle() -> str:
 	return _GetWindowTitle(hwnd)
 
 
-def waitUntilWindowFocused(targetWindowTitle: str):
+def waitUntilWindowFocused(targetWindowTitle: str, timeoutSecs: int = 5):
 	_blockUntilConditionMet(
 		getValue=lambda: GetForegroundWindowTitle() == targetWindowTitle,
-		giveUpAfterSeconds=5,
+		giveUpAfterSeconds=timeoutSecs,
 		errorMessage=f"Timed out waiting {targetWindowTitle} to focus",
 	)

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -92,6 +92,13 @@ def quits_from_keyboard():
 	_process.process_should_be_stopped(_nvdaProcessAlias)
 
 
+def test_desktop_shortcut():
+	spy = _nvdaLib.getSpyLib()
+	spy.emulateKeyPress("control+alt+n")
+	# Takes some time to exit a running process and start a new one
+	waitUntilWindowFocused("Welcome to NVDA", timeoutSecs=7)
+
+
 def read_welcome_dialog():
 	spy = _nvdaLib.getSpyLib()
 	welcomeTitleIndex = spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present.

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -26,6 +26,12 @@ Starts
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
 	NVDA_Starts	# run test
 
+Starts from desktop shortcut
+	[Documentation]	Ensure that NVDA can start from desktop shortcut
+	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
+	Pass Execution If	"${whichNVDA}"!="installed"	Desktop shortcut only exists on installed copies
+	test desktop shortcut
+
 Quits from keyboard
 	[Documentation]	Starts NVDA and ensures that it can be quit using the keyboard
 	quits_from_keyboard	# run test


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

The desktop shortcut, and the input gesture to activate it, do not have system tests

### Description of how this pull request fixes the issue:

Use the input gesture to test the desktop shortcut.

The documentation at #12645 should be updated to include this test once merged.

### Testing strategy:

Run locally against my 2021.2 beta installation: `runsystemtests.bat -t "Starts from desktop shortcut" -v whichNVDA:installed`
Confirmed that the test skips when running from source, eg: `runsystemtests.bat -t "Starts from desktop shortcut"`

Tests are to run on AppVeyor

### Known issues with pull request:

None

### Change log entries:

None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
