### PR TITLE
Ensure that NVDA  sets Python locale to a valid Windows locale when initializing language.

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -348,7 +348,7 @@ class CalendarView(IAccessible):
 		separatorBuf = ctypes.create_unicode_buffer(bufLength)
 		if ctypes.windll.kernel32.GetLocaleInfoW(
 			languageHandler.LOCALE_USER_DEFAULT,
-			languageHandler.LOCALE_SLIST,
+			languageHandler.LOCALE.SLIST,
 			separatorBuf,
 			bufLength
 		) == 0:

--- a/source/core.py
+++ b/source/core.py
@@ -467,11 +467,16 @@ def main():
 			log.debugWarning(message,codepath="WX Widgets",stack_info=True)
 
 		def InitLocale(self):
-			# Backport of `InitLocale` from wx Python 4.1.2 as the current version tries to set a Python
-			# locale to an nonexistent one when creating an instance of `wx.App`.
-			# This causes a crash when running under a particular version of Universal CRT (#12160)
-			import locale
-			locale.setlocale(locale.LC_ALL, "C")
+			"""Custom implementation of `InitLocale` which ensures that wxPython does not change the locale.
+			The current wx implementation (as of wxPython 4.1.1) sets Python locale to an invalid one
+			which triggers Python issue 36792 (#12160).
+			The new implementation (wxPython 4.1.2) sets locale to "C" (basic Unicode locale).
+			While this is not wrong as such NVDA manages locale themselves using `languageHandler`
+			and it is better to remove wx from the equation so this method is a No-op.
+			This code may need to be revisited when we update Python / wxPython.
+			"""
+			pass
+
 
 	app = App(redirect=False)
 	# We support queryEndSession events, but in general don't do anything for them.

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -28,6 +28,8 @@ LOCALE_SENGLISHLANGUAGENAME = 0x00001001
 LOCALE_SENGLISHCOUNTRYNAME = 0x00001002
 LOCALE_IDEFAULTANSICODEPAGE = 0x00001004
 
+# A constant returned when asking Windows for a default code page for a given locale
+# and its code page is the default code page for non Unicode programs set in Windows.
 CP_ACP = "0"
 
 #: Returned from L{localeNameToWindowsLCID} when the locale name cannot be mapped to a locale identifier.

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -390,35 +390,32 @@ def setLocale(localeName: str) -> None:
 		log.debugWarning(f"Locale {localeName} not supported by Windows")
 	if localeString and _setPythonLocale(localeString):
 		return
-	else:
-		# The full form langName_country either cannot be retrieved from Windows
-		# or Python cannot be set to that locale.
-		# Try just with the language name.
-		if "_" in localeName:
-			localeName = localeName.split("_")[0]
-			try:
-				localeString = localeStringFromLocaleCode(localeName)
-				log.debug(f"Win32 locale string from locale code is {localeString}")
-			except ValueError:
-				log.debugWarning(f"Locale {localeName} not supported by Windows")
+	# The full form langName_country either cannot be retrieved from Windows
+	# or Python cannot be set to that locale.
+	# Try just with the language name.
+	if "_" in localeName:
+		localeName = localeName.split("_")[0]
+		try:
+			localeString = localeStringFromLocaleCode(localeName)
+			log.debug(f"Win32 locale string from locale code is {localeString}")
+		except ValueError:
+			log.debugWarning(f"Locale {localeName} not supported by Windows")
 	if localeString and _setPythonLocale(localeString):
 		return
+	# As a final fallback try setting locale just to the English name of the given language.
+	localeFromLang = englishLanguageNameFromNVDALocale(localeName)
+	if localeFromLang and _setPythonLocale(localeFromLang):
+		return
+	# Either Windows does not know the locale, or Python is unable to handle it.
+	# reset to default locale
+	if originalLocaleName == curLang:
+		# reset to system locale default if we can't set the current lang's locale
+		locale.setlocale(locale.LC_ALL, "")
+		log.debugWarning(f"set python locale to system default")
 	else:
-		# As a final fallback try setting locale just to the English name of the given language.
-		localeFromLang = englishLanguageNameFromNVDALocale(localeName)
-		if localeFromLang and _setPythonLocale(localeFromLang):
-			return
-		else:
-			# Either Windows does not know the locale, or Python is unable to handle it.
-			# reset to default locale
-			if originalLocaleName == curLang:
-				# reset to system locale default if we can't set the current lang's locale
-				locale.setlocale(locale.LC_ALL, "")
-				log.debugWarning(f"set python locale to system default")
-			else:
-				log.debugWarning(f"setting python locale to the current language {curLang}")
-				# fallback and try to reset the locale to the current lang
-				setLocale(curLang)
+		log.debugWarning(f"setting python locale to the current language {curLang}")
+		# fallback and try to reset the locale to the current lang
+		setLocale(curLang)
 
 
 def getLanguage() -> str:

--- a/source/localesData.py
+++ b/source/localesData.py
@@ -1,0 +1,29 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2012-2021 NV Access Limited, Joseph Lee, Łukasz Golonka
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+
+"""Contains informations about various languages supported by NVDA.
+As there are localizable strings at module level,
+this can only be imported once localization is set up via `languageHandler.initialize`.
+"""
+
+
+from typing import Dict
+
+
+# Maps names of languages supported by NVDA to their translated names
+# for langs  for which Windows does not contain a translated description.
+LANG_NAMES_TO_LOCALIZED_DESCS: Dict[str, str] = {
+	# Translators: The name of a language supported by NVDA.
+	"an": pgettext("languageName", "Aragonese"),
+	# Translators: The name of a language supported by NVDA.
+	"ckb": pgettext("languageName", "Central Kurdish"),
+	# Translators: The name of a language supported by NVDA.
+	"kmr": pgettext("languageName", "Northern Kurdish"),
+	# Translators: The name of a language supported by NVDA.
+	"my": pgettext("languageName", "Burmese"),
+	# Translators: The name of a language supported by NVDA.
+	"so": pgettext("languageName", "Somali"),
+}

--- a/source/localesData.py
+++ b/source/localesData.py
@@ -4,7 +4,7 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 
-"""Contains informations about various languages supported by NVDA.
+"""Contains information about various languages supported by NVDA.
 As there are localizable strings at module level,
 this can only be imported once localization is set up via `languageHandler.initialize`.
 """
@@ -14,7 +14,7 @@ from typing import Dict
 
 
 # Maps names of languages supported by NVDA to their translated names
-# for langs  for which Windows does not contain a translated description.
+# for langs for which Windows does not contain a translated description.
 LANG_NAMES_TO_LOCALIZED_DESCS: Dict[str, str] = {
 	# Translators: The name of a language supported by NVDA.
 	"an": pgettext("languageName", "Aragonese"),

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -291,7 +291,7 @@ class Formatter(logging.Formatter):
 	def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
 		"""Custom implementation of `formatTime` which avoids `time.localtime`
 		since it causes a crash under some versions of Universal CRT when Python locale
-		is set to a Unicode one ( #12160, Python issue 36792)
+		is set to a Unicode one (#12160, Python issue 36792)
 		"""
 		timeAsFileTime = winKernel.time_tToFileTime(record.created)
 		timeAsSystemTime = winKernel.SYSTEMTIME()

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -290,7 +290,8 @@ class Formatter(logging.Formatter):
 
 	def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
 		"""Custom implementation of `formatTime` which avoids `time.localtime`
-		since it causes a crash under some versions of Universal CRT ( #12160, Python issue 36792)
+		since it causes a crash under some versions of Universal CRT when Python locale
+		is set to a Unicode one ( #12160, Python issue 36792)
 		"""
 		timeAsFileTime = winKernel.time_tToFileTime(record.created)
 		timeAsSystemTime = winKernel.SYSTEMTIME()

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -288,18 +288,6 @@ class Formatter(logging.Formatter):
 	def formatException(self, ex):
 		return stripBasePathFromTracebackText(super(Formatter, self).formatException(ex))
 
-	def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
-		"""Custom implementation of `formatTime` which avoids `time.localtime`
-		since it causes a crash under some versions of Universal CRT ( #12160, Python issue 36792)
-		"""
-		timeAsFileTime = winKernel.time_tToFileTime(record.created)
-		timeAsSystemTime = winKernel.SYSTEMTIME()
-		winKernel.FileTimeToSystemTime(timeAsFileTime, timeAsSystemTime)
-		timeAsLocalTime = winKernel.SYSTEMTIME()
-		winKernel.SystemTimeToTzSpecificLocalTime(None, timeAsSystemTime, timeAsLocalTime)
-		res = f"{timeAsLocalTime.wHour:02d}:{timeAsLocalTime.wMinute:02d}:{timeAsLocalTime.wSecond:02d}"
-		return self.default_msec_format % (res, record.msecs)
-
 
 class StreamRedirector(object):
 	"""Redirects an output stream to a logger.

--- a/tests/unit/test_languageHandler.py
+++ b/tests/unit/test_languageHandler.py
@@ -45,6 +45,70 @@ class TestLocaleNameToWindowsLCID(unittest.TestCase):
 		self.assertEqual(lcid, LCID_NONE)
 
 
+class Test_Normalization(unittest.TestCase):
+
+	def test_isNormalizedWin32LocaleNormalizedLocale(self):
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("en"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("ro"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("so"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("ckb"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("de-CH"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("pl-PL"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("de-DE_phoneb"))
+		self.assertTrue(languageHandler.isNormalizedWin32Locale("mn-Mong-CN"))
+
+	def test_isNormalizedWin32LocaleInvalidLocales(self):
+		self.assertFalse(languageHandler.isNormalizedWin32Locale("pl_PL"))
+		self.assertFalse(languageHandler.isNormalizedWin32Locale("de_CH"))
+		self.assertFalse(languageHandler.isNormalizedWin32Locale("ru_RU"))
+
+	def test_localeNormalizationForWin32(self):
+		self.assertEqual(languageHandler.normalizeLocaleForWin32("en"), "en")
+		self.assertEqual(languageHandler.normalizeLocaleForWin32("en-US"), "en-US")
+		self.assertEqual(languageHandler.normalizeLocaleForWin32("en_US"), "en-US")
+		self.assertEqual(languageHandler.normalizeLocaleForWin32("de-DE_phoneb"), "de-DE_phoneb")
+		self.assertEqual(languageHandler.normalizeLocaleForWin32("de_DE_phoneb"), "de-DE_phoneb")
+
+
+class Test_GetLocaleInfoEx_Wrappers(unittest.TestCase):
+	"""Set of tests for wrappers around `GetLocaleInfoEx` from `languageHandler`"""
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self._ansiCP = str(ctypes.windll.kernel32.GetACP())
+
+	def test_ValidEnglishLangNamesAreReturned(self):
+		"""Smoke tests `languageHandler.englishLanguageNameFromNVDALocale` with some known locale names"""
+		self.assertEqual(languageHandler.englishLanguageNameFromNVDALocale("en"), "English")
+		self.assertEqual(languageHandler.englishLanguageNameFromNVDALocale("de"), "German")
+		self.assertEqual(languageHandler.englishLanguageNameFromNVDALocale("ne"), "Nepali")
+		self.assertEqual(languageHandler.englishLanguageNameFromNVDALocale("pt-BR"), "Portuguese")
+		self.assertEqual(languageHandler.englishLanguageNameFromNVDALocale("de_CH"), "German")
+
+	def test_ValidEnglishCountryNamesAreReturned(self):
+		"""Smoke tests `languageHandler.englishCountryNameFromNVDALocale` with some known locale names"""
+		self.assertEqual(languageHandler.englishCountryNameFromNVDALocale("en"), "United States")
+		self.assertEqual(languageHandler.englishCountryNameFromNVDALocale("de"), "Germany")
+		self.assertEqual(languageHandler.englishCountryNameFromNVDALocale("ne"), "Nepal")
+		self.assertEqual(languageHandler.englishCountryNameFromNVDALocale("pt-BR"), "Brazil")
+		self.assertEqual(languageHandler.englishCountryNameFromNVDALocale("pt-PT"), "Portugal")
+		self.assertEqual(languageHandler.englishCountryNameFromNVDALocale("de_CH"), "Switzerland")
+
+	def test_validAnsiCodePagesAreReturned(self):
+		"""Smoke tests `languageHandler.ansiCodePageFromNVDALocale` with some known 
+		not Unicode only locale names"""
+		self.assertEqual(languageHandler.ansiCodePageFromNVDALocale("en"), "1252")
+		self.assertEqual(languageHandler.ansiCodePageFromNVDALocale("pl_PL"), "1250")
+		self.assertEqual(languageHandler.ansiCodePageFromNVDALocale("ja_JP"), "932")
+		self.assertEqual(languageHandler.ansiCodePageFromNVDALocale("de-CH"), "1252")
+
+	def test_validAnsiCodePagesAreReturnedUnicodeOnlyLocales(self):
+		"""Smoke tests `languageHandler.ansiCodePageFromNVDALocale` with some known
+		Unicode only locale names"""
+		self.assertEqual(languageHandler.ansiCodePageFromNVDALocale("hi"), self._ansiCP)
+		self.assertEqual(languageHandler.ansiCodePageFromNVDALocale("Ne"), self._ansiCP)
+
+
 class Test_languageHandler_setLocale(unittest.TestCase):
 	"""Tests for the function languageHandler.setLocale"""
 

--- a/tests/unit/test_languageHandler.py
+++ b/tests/unit/test_languageHandler.py
@@ -202,12 +202,13 @@ class Test_languageHandler_setLocale(unittest.TestCase):
 				languageHandler.setLocale(localeName)
 				current_locale = locale.setlocale(locale.LC_ALL)
 				# check that the language codes are correctly set for python
-				# They can be set to the exact locale that was requested, or to the locale gotten
-				# from the language name if language_country cannot be set.
+				# They can be set to the exact locale that was requested, to the locale gotten
+				# from the language name if language_country cannot be set
+				# or just to English name of the language.
 				lang_country = languageHandler.localeStringFromLocaleCode(localeName)
 				possibleVariants = {lang_country}
 				if "65001" in lang_country:
-					# Python replaces Unicode Windows code page with 'utf8'
+					# Python normalizes Unicode Windows code page to 'utf8'
 					possibleVariants.add(lang_country.replace("65001", "utf8"))
 				if "_" in lang_country:
 					possibleVariants.add(languageHandler.localeStringFromLocaleCode(localeName.split("_")[0]))
@@ -222,6 +223,11 @@ class Test_languageHandler_setLocale(unittest.TestCase):
 		"""
 		We don't know whether python supports a specific windows locale so just ensure locale isn't
 		broken after testing these values.
+		Even though we cannot use `locale.getlocale` when checking if the correct locale has been set
+		in all other tests since it normalizes locale making it impossible to do comparisons
+		it is important that whatever is being set can be retrieved with `getlocale`
+		since some parts of Python standard library such as `time.strptime` relies on `getlocale`
+		being able to return current locale.
 		"""
 		for localeName in WINDOWS_LANGS:
 			with self.subTest(localeName=localeName):
@@ -291,12 +297,13 @@ class Test_LanguageHandler_SetLanguage(unittest.TestCase):
 					self.assertEqual(self._defaultPythonLocale, python_locale)
 				else:
 					# check that the language codes are correctly set for python
-					# They can be set to the exact locale that was requested, or to the locale gotten
-					# from the language name if language_country cannot be set.
+					# They can be set to the exact locale that was requested, to the locale gotten
+					# from the language name if language_country cannot be set
+					# or just to English name of the language.
 					lang_country = languageHandler.localeStringFromLocaleCode(localeName)
 					possibleVariants = {lang_country}
 					if "65001" in lang_country:
-						# Python replaces Unicode Windows code page with 'utf8'
+						# Python normalizes Unicode Windows code page to 'utf8'
 						possibleVariants.add(lang_country.replace("65001", "utf8"))
 					if "_" in lang_country:
 						possibleVariants.add(languageHandler.localeStringFromLocaleCode(localeName.split("_")[0]))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,6 +29,7 @@ What's New in NVDA
 - When reading a header cell of a table in Chrome, fix the column name being announced twice. (#10840)
 - NVDA no longer reports a numerical value for UIA sliders that have a textual representation of their value defined. (UIA ValuePattern is now preferred over RangeValuePattern). (#12724)
 - NVDA no longer treats the value of UIA sliders as always percentage based.
+- NVDA no longer sets invalid Python locales. (#12753)
 -
 
 
@@ -39,6 +40,8 @@ To match the production build environment, update Visual Studio to keep in sync 
   - Instead use ``apiLevel`` (see the comments at ``_UIAConstants.WinConsoleAPILevel`` for details).
   -
 - Transparency of text background color sourced from GDI applications (via the display model), is now exposed for add-ons or appModules. (#12658)
+- ``LOCALE_SLANGUAGE``, ``LOCALE_SLIST`` and ``LOCALE_SLANGDISPLAYNAME`` are moved to the ``LOCALE`` enum in languageHandler.
+They are still available at the module level but are deprecated and to be removed in NVDA 2022.1. (#12753)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fix-up of #12214
Follow up to #12250
Fixes root cause of #12160
### Summary of the issue:
After NVDA sets its interface language it also attempts to set Python locale to the current language. Before PR #12214  we were just passing the current language code to `locale.setlocale` and catching all possible exceptions. Unfortunately Python `setlocale` is pretty useless on Windows as it tries to normalize the locale name according to the Unix standards (see [Python issue 37945](https://bugs.python.org/issue37945). When we were using wxPython older than 4.1 this was generally not an issue (except for some specific locales under a particular configurations  such as one described in #12160 ) since wxPython was setting locale to a valid one so the problem remained unnoticed. This broke with wxPython 4.1 and the fix was attempted in #12214 but it still was setting Python locale to Unix locales. This is causing two problems:
- We are Windows only so it is important to set locales to something reasonable
- If the locale that is unknown to Windows is set some versions of CRT assumes that the code page of such locale is Utf8 which causes a crash when using `time.localtime` (that was the underlying cause of #12160)

### Description of how this pull request fixes the issue:
Since Python `locale.setlocale` and `locale.getlocale` cannot be trusted on Windows the approach I took avoids all the normalization they offer by creating a valid Windows locale string using [`getLocaleInfoEx`](https://docs.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getlocaleinfoex) in a form which Python no longer normalizes. This string is then passed to `locale.setlocale`. The new functionality has pretty solid unit test coverage, previous unit tests for `languageHandler` are also updated to account for these changes. As suggested during the review this PR also consolidates all NLS constants we use when retrieving various locale related information from Windows into an enum in `languageHandler`. The  old constants are  deprecated and would no longer be available in 2022.1.
Specific fix for #12160 from #12250 cannot be removed because even though we're setting only complete locales i.e. with a code page and for languages such as Russian or German_Switzerland this crash would no longer occur NVDA supports some locales such as Hindi  for which code page is indeed Utf8 and they would still cause a crash.
### Testing strategy:
Manual testing:
On Windows 7, Server 2012, Windows 10 1809 (on which I was previously able to reproduce #12160 ) and latest preview of Windows 11 started NVDA with both specific language set in preferences and with the language set to default. Made sure that when 'user default' is selected appropriate language is chosen and locale (as retrieved by `locale.setlocale(locale.LC_ALL)`) is set into a locale of a form `englishLanguageName_englishCountryName.ANSICodePage`. Repeated these  tests with some languages known to cause troubles in the past:
- Aragonese - locale set to Windows locale
- German_Switzerland and Hindi - made sure that #12160  has not been reintroduced

Executed unit tests on all above mentioned versions of Windows made sure they pass.
### Known issues with pull request:
None known
### Change log entries:
Bug fixes:
- NVDA no longer sets invalid Python locales

Changes for developers:
- `LOCALE_SLANGUAGE`, `LOCALE_SLIST` and LOCALE_SLANGDISPLAYNAME are moved to the `LOCALE` enum in `languageHandler`. They are still available at the module level but deprecated and would be removed in NVDA 2022.1
### Code Review Checklist:


- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
