### PR TITLE
Prevent table heading text being announced twice

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -327,6 +327,10 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 			# Get the text for the header cells.
 			textList = []
 			for docHandle, ID in cellIdentifiers:
+				if attrs.get("controlIdentifier_docHandle") == docHandle and attrs.get("controlIdentifier_ID") == ID:
+					# This is a self-reference to a column or row header
+					# Do not double up the cell header name. This is happening in Chrome.
+					continue
 				try:
 					start, end = self._getOffsetsFromFieldIdentifier(int(docHandle), int(ID))
 				except (LookupError, ValueError):

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -603,3 +603,49 @@ def test_ariaDescription_sayAll():
 			"After Test Case Marker"
 		])
 	)
+
+
+def test_i10840():
+	"""
+	The name of table header cells should only be conveyed once when navigating directly to them in browse mode
+	Chrome self-references a header cell as its own header, which used to cause the name to be announced twice
+	"""
+	_chrome.prepareChrome(
+		f"""
+			<table>
+				<thead>
+					<tr>
+						<th>Month</th>
+						<th>items</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>January</td>
+						<td>100</td>
+					</tr>
+					<tr>
+						<td>February</td>
+						<td>80</td>
+					</tr>
+				</tbody>
+				<tfoot>
+					<tr>
+						<td>Sum</td>
+						<td>180</td>
+					</tr>
+				</tfoot>
+				</table>
+		"""
+	)
+	# Jump to the table
+	actualSpeech = _chrome.getSpeechAfterKey("t")
+	_asserts.strings_match(
+		actualSpeech,
+		"table  with 4 rows and 2 columns  row 1  column 1  Month"
+	)
+	nextActualSpeech = _chrome.getSpeechAfterKey("control+alt+rightArrow")
+	_asserts.strings_match(
+		nextActualSpeech,
+		"column 2  items"
+	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -316,7 +316,7 @@ def test_ariaTreeGrid_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"row 1  Subject  column 1  Subject"
+		"row 1  column 1  Subject"
 	)
 	# Navigate to row 2 column 1 with NVDA table navigation command
 	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
@@ -461,7 +461,7 @@ def test_tableInStyleDisplayTable():
 	actualSpeech = _chrome.getSpeechAfterKey("t")
 	_asserts.strings_match(
 		actualSpeech,
-		"table  with 2 rows and 2 columns  row 1  First heading  column 1  First heading"
+		"table  with 2 rows and 2 columns  row 1  column 1  First heading"
 	)
 	nextActualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
 	_asserts.strings_match(

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -69,3 +69,6 @@ ARIA description Browse Mode
 ARIA description Say All
 	[Documentation]	Say all, contents includes aria-description
 	test_ariaDescription_sayAll
+i10840
+	[Documentation]	The name of table header cells should only be conveyed once when navigating directly to them in browse mode (chrome self-references a header cell as its own header, which used to cause the name to be announced twice)
+	test_i10840

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ What's New in NVDA
 - NVDA no longer fails to translate braille input when multiple characters are typed that consist of multiple braille patterns (e.g. (1) in UEB). (#12667)
 - It is once again possible to check for NVDA updates on certain systems; e.g. clean Windows installs. (#12729)
 - NVDA correctly announces blank table cells in Microsoft Word when using UI automation. (#11043)
+- When reading a header cell of a table in Chrome, fix the column name being announced twice. (#10840)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes https://github.com/nvaccess/nvda/issues/10840

### Summary of the issue:

NVDA+Chromium browsers are announcing the name of table header cells twice when navigating directly to the header cell.

For example, NVDA was announcing a header like this "row 1 Subject column 1 Subject" where the name is announced twice.

### Description of how this pull request fixes the issue:

Chrome is referencing cell headers as their own header, which is causing the name of the header to be announced twice when navigating to it directly.

This change checks if the header is referring to itself before adding the name of the header for the cell to the speech. output. If it is a self-reference, the name is not added to the speech output.

I'm confident that this PR fixes the issue, but I'm not as confident that this is the best fix. Feedback is more than welcome!

Now "row 1 Subject column 1 Subject" is announced as "row 1 column 1 Subject".

Since this is due to how Chrome is surfacing the header, it could be considered a bug in Chromium instead of NVDA. Why fix it here? Because it is low effort and makes NVDA more resilient if other browsers end up surfacing headers in a similar way in the future. Also, other screen readers such as JAWS handle this scenario well and don't announce the header name twice.

### Testing strategy:

I added a system test for this case as part of this PR. I also manually tested several tables found in the wild in chrome and firefox.

### Known issues with pull request:

### Change log entries:
Bug fixes

```
- When reading a header cell of a table in Chrome, fix the column name being announced twice. (#10840)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
