### PR TITLE
Revert "Remove ignoreEditableText param"

### DIFF
--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -346,8 +346,8 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 		log.debug("Setting selection to (%d, %d)" % (sel._startOffset, sel._endOffset))
 		sel.updateSelection()
 
-	def _getControlFieldForObject(self, obj):
-		field = super(BookPageViewTextInfo, self)._getControlFieldForObject(obj)
+	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
+		field = super(BookPageViewTextInfo, self)._getControlFieldForObject(obj, ignoreEditableText=ignoreEditableText)
 		if field and field["role"] == controlTypes.Role.MATH:
 			try:
 				field["mathMl"] = obj.mathMl

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -142,7 +142,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 			return None
 		role = obj.role
 		states = obj.states
-		if role == controlTypes.Role.LINK and controlTypes.STATE_LINKED not in states:
+		if role == controlTypes.Role.LINK and controlTypes.State.LINKED not in states:
 			# Named link destination, not a link that can be activated.
 			return None
 		field = textInfos.ControlField()

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -136,9 +136,15 @@ class CompoundTextInfo(textInfos.TextInfo):
 			and controlTypes.State.LINKED not in obj.states
 		)
 
-	def _getControlFieldForObject(self, obj: NVDAObject):
+	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
+		if ignoreEditableText and self._isObjectEditableText(obj):
+			# This is basically just a text node.
+			return None
 		role = obj.role
 		states = obj.states
+		if role == controlTypes.Role.LINK and controlTypes.STATE_LINKED not in states:
+			# Named link destination, not a link that can be activated.
+			return None
 		field = textInfos.ControlField()
 		field["role"] = role
 		field['roleText'] = obj.roleText
@@ -271,11 +277,8 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 		rootObj = self.obj.rootNVDAObject
 		obj = self._startObj
 		while obj and obj != rootObj:
-			if not (
-				self._isObjectEditableText(obj)
-				or self._isNamedlinkDestination(obj)
-			):
-				field = self._getControlFieldForObject(obj)
+			field = self._getControlFieldForObject(obj)
+			if field:
 				fields.insert(0, textInfos.FieldCommand("controlStart", field))
 			obj = obj.parent
 
@@ -287,23 +290,16 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 						embedIndex = self._getFirstEmbedIndex(ti)
 					else:
 						embedIndex += 1
-					childObject: NVDAObject = ti.obj.getChild(embedIndex)
-					if not (
-						# Don't check for self._isObjectEditableText
-						# Only for named link destinations.
-						self._isNamedlinkDestination(obj)
-					):
-						controlField = self._getControlFieldForObject(childObject)
-						controlField["content"] = childObject.name
-						fields.extend((
-							textInfos.FieldCommand("controlStart", controlField),
-							textUtils.OBJ_REPLACEMENT_CHAR,
-							textInfos.FieldCommand("controlEnd", None),
-						))
-				else:  # str or fieldCommand
-					if not isinstance(textWithEmbeddedObjectsItem, (str, textInfos.FieldCommand)):
-						log.error(f"Unexpected type: {textWithEmbeddedObjectsItem!r}")
-					fields.append(textWithEmbeddedObjectsItem)
+					field = ti.obj.getChild(embedIndex)
+					controlField = self._getControlFieldForObject(field, ignoreEditableText=False)
+					controlField["content"] = field.name
+					fields.extend((
+						textInfos.FieldCommand("controlStart", controlField),
+						textUtils.OBJ_REPLACEMENT_CHAR,
+						textInfos.FieldCommand("controlEnd", None)
+					))
+				else:
+					fields.append(field)
 		return fields
 
 	def _findNextContent(self, origin, moveBack=False):


### PR DESCRIPTION
This reverts commit 6262596d093dc0176a300a6cd29e485f94bc04fc.

In issue #12746 it was reported that moving by paragraph in Google Docs in Google Chrome would sometimes result in NVDA saying "blank" for certain paragraphs.
Similarly although not noted in an issue yet, Some lines in Thunderbird message composition windows would also say blank.

These regressions were found to be caused by the merging of pr #12500

Further investigation found that the specific commit in the pr that caused this was 6262596d093dc0176a300a6cd29e485f94bc04fc  

I'm not entirely sure on why this commit causes the regression, however my understanding is that this commit was only to improve readability / understanding of logic along the way and that the actual feature introduced by the pr had no dependency on this commit as such.

Thus, this pr reverts that single commit, and therefore fixes #12746.

Perhaps the logic of this commit can be better investigated at a later stage, but for now it is better to return to what we know works.

 