### PR TITLE
Split script for reading status bar into  two - one for reading and one for moving review cursor into its location

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1943,7 +1943,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for command which spells content of the status bar.
-			"spells the current application status bar."
+			"Spells the current application status bar."
 		),
 		category=SCRCAT_FOCUS,
 	)
@@ -1960,7 +1960,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for command which copies status bar content to the clipboard.
-			"copies content of the status bar  of current application to the clipboard."
+			"Copies content of the status bar  of current application to the clipboard."
 		),
 		category=SCRCAT_FOCUS,
 	)
@@ -1970,7 +1970,7 @@ class GlobalCommands(ScriptableObject):
 			return
 		if not text.strip():
 			# Translators: Reported when user attempts to copy content of the empty status line.
-			ui.message(_("unable to copy status bar content to clipboard"))
+			ui.message(_("Unable to copy status bar content to clipboard"))
 		else:
 			api.copyToClip(text, notify=True)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,8 @@ What's New in NVDA
 - Espeak-ng has been updated to 1.51-dev commit ``74068b91bcd578bd7030a7a6cde2085114b79b44``. (#12665)
 - NVDA will default to eSpeak if no installed OneCore voices support the NVDA preferred language. (#10451)
 - If OneCore voices consistently fail to speak, revert to eSpeak as a synthesizer. (#11544)
+- When reading status bar with ``NVDA+end``, the review cursor is no longer moved to its location.
+If you need this functionality please assign a gesture to the appropriate script in the Object Navigation category in the Input Gestures dialog. (#8600)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -381,7 +381,7 @@ To navigate by object, use the following commands:
 | Activate current navigator object | NVDA+numpadEnter | NVDA+enter | double-tap | Activates the current navigator object (similar to clicking with the mouse or pressing space when it has the system focus) |
 | Move System focus or caret to current review position | NVDA+shift+numpadMinus | NVDA+shift+backspace | none | pressed once Moves the System focus to the current navigator object, pressed twice moves the system caret to the position of the review cursor |
 | Report review cursor location | NVDA+numpadDelete | NVDA+delete | none | Reports information about the location of the text or object at the review cursor. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail. |
-| Move review cursor to status bar  | none | none | none | Reports the Status Bar if NVDA finds one. It also moves the navigator object to this location. |
+| Move review cursor to status bar | none | none | none | Reports the Status Bar if NVDA finds one. It also moves the navigator object to this location. |
 %kc:endInclude
 
 Note: numpad keys require the Num Lock to be turned off to work properly.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -315,7 +315,7 @@ There are some key commands that are useful when moving with the System focus:
 | Report current focus | NVDA+tab | NVDA+tab | announces the current object or control that has the System focus. Pressing twice will spell the information |
 | Report title | NVDA+t | NVDA+t | Reports the title of the currently active window. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
 | Read active window | NVDA+b | NVDA+b | reads all the controls in the currently active window (useful for dialogs) |
-| Report Status Bar | NVDA+end | NVDA+shift+end | Reports the Status Bar if NVDA finds one. It also moves the navigator object to this location. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
+| Report Status Bar | NVDA+end | NVDA+shift+end | Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
 %kc:endInclude
 
 ++ Navigating with the System Caret ++[SystemCaret]
@@ -381,6 +381,7 @@ To navigate by object, use the following commands:
 | Activate current navigator object | NVDA+numpadEnter | NVDA+enter | double-tap | Activates the current navigator object (similar to clicking with the mouse or pressing space when it has the system focus) |
 | Move System focus or caret to current review position | NVDA+shift+numpadMinus | NVDA+shift+backspace | none | pressed once Moves the System focus to the current navigator object, pressed twice moves the system caret to the position of the review cursor |
 | Report review cursor location | NVDA+numpadDelete | NVDA+delete | none | Reports information about the location of the text or object at the review cursor. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail. |
+| Move review cursor to status bar  | none | none | none | Reports the Status Bar if NVDA finds one. It also moves the navigator object to this location. |
 %kc:endInclude
 
 Note: numpad keys require the Num Lock to be turned off to work properly.


### PR DESCRIPTION
### Link to issue number:
Closes #8600
Implements part of #7314

### Summary of the issue:
Currently when  reading status bar with NVDA+END review cursor is unconditionally moved to its location. This is inconsistent with all other commands for retrieving information and aside from that is extremely annoying for people working with review cursor now following the caret (I've been in a situation in which I've left review cursor somewhere either because I wanted to monitor a given object for changes, or because I was following some documentation with review cursor in a separate window and wanted to avoid unnecessary alt tabbing and lost my review position because I had to check something on a status bar countless times).

### Description of how this pull request fixes the issue:
Review cursor is no longer moved to the location of the status bar. There is a separate script (no gesture assigned by default) which moves review cursor there. As described in #7314 I took this opportunity to split script for reading status bar into a separate ones for reading, spelling and copying.
### Testing strategy:
With NVDA+end made sure that first press still reads, second spells and third copies. Made sure that after each of these operations review cursor has not been moved. Tested each of the newly introduced scripts made sure they work. Compiled user guide - ensured it renders as expected.
### Known issues with pull request:
None known
### Change log entries:
Changes:
- When reading status bar with NVDA+end review cursor is no longer moved to its location - if you need this functionality please assign a gesture to the appropriate script in the Object Navigation category in the Input gestures dialog.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
