### PR TITLE
Minor fixes in the User Guide and a GUI label regarding annotations options group

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2664,7 +2664,7 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a checkbox in the
 		#  Advanced settings panel.
-		label = _("Report aria-description always:")
+		label = _("Report aria-description always")
 		self.ariaDescCheckBox: wx.CheckBox = AnnotationsGroup.addItem(
 			wx.CheckBox(AnnotationsBox, label=label)
 		)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1857,8 +1857,8 @@ The combo box has the following options:
 - No: Don't use UIA, even if NVDA is unable to inject in process. This may be useful for developers debugging issues with IA2 and want to ensure that NVDA does not fall back to UIA.
 -
 
-==== Enable Experimental ARIA annotations support ====[Annotations]
-Used to enable features which add experimental support for ARIA annotations.
+==== Annotations ====[Annotations]
+This group of options is used to enable features which add experimental support for ARIA annotations.
 Some of these features may be incomplete.
 The following options exist: 
 - "Report details in browse mode": enables reporting if an object has details in browse mode.


### PR DESCRIPTION
### Link to issue number:

None.
Minor fixes of issues introduced by #12409 and #12500.
See @k-kolev1985  message in [this thread](https://groups.io/g/nvda-translations/topic/85079744#2663) on NVDA translation mailing-list for the initial reporting.

### Summary of the issue:

1. An option group is named "Annotations" in the Advanced settings panel. But the corresponding paragraph in the User Guide is still named with the old name "Enable Experimental ARIA annotations"
2. In advanced settings panel the option "Report aria-description always:" has a typo: an extra colon character.

### Description of how this pull request fixes the issue:
1. I have made the User Guide paragraph title match the option group it is describing. While at it, I have also modified the first sentence of the paragraph to make it a complete grammatically correct sentence; and it makes clearer the fact that this paragraph describes a group of option while the neighbouring paragraphs describle single options.

### Testing strategy:
* Checked the typo running from cource
* Checked the generated user guide from appVeyor
* Checked that context help still works in this group of options

### Known issues with pull request:
Issue 2. is present in NVDA 2021.2beta1. However, since we are already in the translation freeze, I fear we cannot submit PR's affecting the User Guide targetting the beta branch.
Let me know if I am mistaken; in this case, I may open a separate PR for point 2. against targetting beta branch.
If on the contrary you confirm me that we cannot add User Guide changes in the beta branch, I may send an e-mail to the translators so that they use the matching group name in their translation. Thus the English User Guide may have the mistake but not the translated ones.

### Change log entries:

Not needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
