### PR TITLE
Handle VT_R8 (double) arrays in COM VARIANTS

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -30,6 +30,7 @@ What's New in NVDA
 - When reading a header cell of a table in Chrome, fix the column name being announced twice. (#10840)
 - NVDA no longer reports a numerical value for UIA sliders that have a textual representation of their value defined. (UIA ValuePattern is now preferred over RangeValuePattern). (#12724)
 - NVDA no longer treats the value of UIA sliders as always percentage based.
+- Reporting the location of a cell in Microsoft Excel when accessed via UI Automation again works correctly on Windows 11. (#12782)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Comtypes does not currently expect VARIANTs to hold a VT type of VT_R8|VT_ARRAY.
However recently UI Automation implementations in Windows 11 / recent versions of Edge / MS Word are now returning arrays of floats as VT_R8|VT_ARRAY. I think this used to be VT_R4|VT_ARRAY.

When this occurs, we see tracebacks in NVDA such as:
```
ERROR - scriptHandler.executeScript (08:31:21.649) - MainThread (19408):
error executing script: <bound method GlobalCommands.script_navigatorObject_currentDimensions of <globalCommands.GlobalCommands object at 0x159E2650>> with gesture 'NVDA+numpad delete'
Traceback (most recent call last):
  File "scriptHandler.py", line 208, in executeScript
    script(gesture)
  File "globalCommands.py", line 1082, in script_navigatorObject_currentDimensions
    locationText=api.getNavigatorObject().locationText
  File "baseObject.py", line 42, in __get__
    return instance._getPropertyViaCache(self.fget)
  File "baseObject.py", line 146, in _getPropertyViaCache
    val=getterMethod(self)
  File "NVDAObjects\__init__.py", line 537, in _get_locationText
    location=self.location
  File "baseObject.py", line 42, in __get__
    return instance._getPropertyViaCache(self.fget)
  File "baseObject.py", line 146, in _getPropertyViaCache
    val=getterMethod(self)
  File "NVDAObjects\UIA\__init__.py", line 1719, in _get_location
    r=self._getUIACacheablePropertyValue(UIAHandler.UIA_BoundingRectanglePropertyId)
  File "NVDAObjects\UIA\__init__.py", line 842, in _getUIACacheablePropertyValue
    value=self.UIAElement.getCurrentPropertyValueEx(ID,ignoreDefault)
  File "monkeyPatches\comtypesMonkeyPatches.py", line 27, in __call__
    return super().__call__(*args,**kwargs)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\comtypes\automation.py", line 510, in __ctypes_from_outparam__
    result = self.value
  File "monkeyPatches\comtypesMonkeyPatches.py", line 125, in newVARIANT_value_fget
    return self._get_value(dynamic=True)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\comtypes\automation.py", line 458, in _get_value
    typ = _vartype_to_ctype[self.vt & ~VT_ARRAY]
KeyError: 5
```
Where 5 is the value of VT_R8.

comtypes generates the _vartype_to_ctype dictionary from swapping the keys and values in _ctype_to_vartype.
Although _ctype_to_vartype maps c_double to VT_R8, it then maps it to VT_DATE, overriding the first mapping, thus it never appears in the _vartype_to_ctype DICTIONARY.
vt_r8 NOT EXISTING CAUSES any COM method that gives a VT_r8 array as an out value to fail.
For example, the cellSize UIA custom property in Excel.

### Description of how this pull request fixes the issue:
Provide a monkeypatch for comtypes that correctly maps VT_R8 to c_double.

### Testing strategy:
* Enable the Use UIA in Excel advanced setting in NVDA. Open a new spreadsheet in Excel. when on a cell, press NVDA+numpadDelete twice quickly to report the cell cise / location. Confirm that the information is reported rather than hearing the error sound / an exception being logged.
* Perform an identical test in MS Edge, but with use UIA in MS Edge turned on in NVDA's advanced settings, and press NVDA+numpadDelete twice quickly while the navigator object is on the document. Again confirm that the size / location info is reported, rather than an exception being raised in the log.

### Known issues with pull request:
None.

### Change log entries:
Bug fixes:
* Reporting the location of a cell in Microsoft Excel when accessed via UI Automation again works correctly on Windows 11.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
