### PR TITLE
Modern Settings app: import progress bar class from UIA objects mix-in

### DIFF
--- a/source/appModules/systemsettings.py
+++ b/source/appModules/systemsettings.py
@@ -6,8 +6,7 @@
 """App module for Settings app on Windows 10 and later (aka Immersive Control Panel)."""
 
 import appModuleHandler
-from NVDAObjects.UIA import UIA
-from NVDAObjects.behaviors import ProgressBar
+from NVDAObjects.UIA import UIA, ProgressBar
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/systemsettings.py
+++ b/source/appModules/systemsettings.py
@@ -1,10 +1,9 @@
-# appModules/systemsettings.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2019 NV Access Limited, Joseph Lee
+# Copyright (C) 2019-2021 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-"""App module for Windows 10 Settings app (aka Immersive Control Panel)."""
+"""App module for Settings app on Windows 10 and later (aka Immersive Control Panel)."""
 
 import appModuleHandler
 from NVDAObjects.UIA import UIA


### PR DESCRIPTION

### Link to issue number:
Closes #12783 

### Summary of the issue:
Progress bar class is imported from behaviors, whereas UIA objects mix-in now includes a dedicated progress bar overlay class. Without this change, volume meter (Setings/System/Sound) plays progress bar beeps.

### Description of how this pull request fixes the issue:
Changes:
From:
from NVDAObjects.behaviors import ProgressBar
To:
from NVDAObjects.UIA import UIA, ProgressBar

### Testing strategy:
Manual testing required:

1. Run NVDA alpha 23630 or 2021.1 beta 1.
2. Open Settings/System/Sound and notice that progress bar beeps are not heard.
3. Run alpha.23637.
4. Open Settings/System/Sound and notice that progress bar beeps are hard.
5. Apply this PR, and notice that progress bar beeps are not heard for volume meter.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers

### Additional notes:
Also performed basic lint and updated copyright header and general intro comment.

Thanks.