### PR TITLE
Set focus on existing dialog rather than raise an error if the dialog  when launching a dialog which is already open

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -145,10 +145,8 @@ class MainFrame(wx.Frame):
 		self.prePopup()
 		try:
 			dialog(self, *args, **kwargs).Show()
-		except SettingsDialog.MultiInstanceError:
-			# Translators: Message shown when attempting to open another NVDA settings dialog when one is already open
-			# (example: when trying to open keyboard settings when general settings dialog is open).
-			messageBox(_("An NVDA settings dialog is already open. Please close it first."),_("Error"),style=wx.OK | wx.ICON_ERROR)
+		except SettingsDialog.MultiInstanceErrorWithDialog as errorWithDialog:
+			errorWithDialog.dialog.SetFocus()
 		except MultiCategorySettingsDialog.CategoryUnavailableError:
 			# Translators: Message shown when trying to open an unavailable category of a multi category settings dialog
 			# (example: when trying to open touch interaction settings on an unsupported system).

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -85,6 +85,13 @@ class SettingsDialog(
 
 	class MultiInstanceError(RuntimeError): pass
 
+	class MultiInstanceErrorWithDialog(MultiInstanceError):
+		dialog: 'SettingsDialog'
+
+		def __init__(self, dialog: 'SettingsDialog', *args: object) -> None:
+			self.dialog = dialog
+			super().__init__(*args)
+
 	class DialogState(IntEnum):
 		CREATED = 0
 		DESTROYED = 1
@@ -110,7 +117,10 @@ class SettingsDialog(
 				"State of _instances {!r}".format(multiInstanceAllowed, instancesState)
 			)
 		if state is cls.DialogState.CREATED and not multiInstanceAllowed:
-			raise SettingsDialog.MultiInstanceError("Only one instance of SettingsDialog can exist at a time")
+			raise SettingsDialog.MultiInstanceErrorWithDialog(
+				firstMatchingInstance,
+				"Only one instance of SettingsDialog can exist at a time",
+			)
 		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
 			# the dialog has been destroyed by wx, but the instance is still available. This indicates there is something
 			# keeping it alive.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,7 @@ What's New in NVDA
 - If OneCore voices consistently fail to speak, revert to eSpeak as a synthesizer. (#11544)
 - When reading status bar with ``NVDA+end``, the review cursor is no longer moved to its location.
 If you need this functionality please assign a gesture to the appropriate script in the Object Navigation category in the Input Gestures dialog. (#8600)
+- When opening a settings dialog which is already open, NVDA sets focus on the existing dialog rather than raise an error. (#5383)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #5383

### Summary of the issue:
NVDA raises an error when launching a dialog, when the dialog is already open. This is unfriendly to the user, and should instead focus the open dialog.

Example:
1. Press `NVDA+n` to open the NVDA menu
1. Launch the settings dialog by pressing `p` then `s`
1. Change a setting, so that you can confirm a new instance isn't created
1. Minimise the settings dialog window
1. Press `NVDA+n` to open the NVDA menu
1. Launch the settings dialog by pressing `p` then `s`
1. An error message is raised

### Description of how this pull request fixes the issue:

Set focus on existing dialog rather than raise an error if the dialog when launching a dialog which is already open.

### Testing strategy:

Manual testing:
1. Press `NVDA+n` to open the NVDA menu
1. Launch the settings dialog by pressing `p` then `s`
1. Change a setting, so that you can confirm a new instance isn't created
1. Minimise the settings dialog window
1. Press `NVDA+n` to open the NVDA menu
1. Launch the settings dialog by pressing `p` then `s`
1. Confirm the same settings dialog from before is now focused, a new instance was not created, and the error message dialog isn't opened.

### System testing

System testing could be added here, but for such a specific feature it seems unworthy, the reviewer may disagree.

### Known issues with pull request:

### Change log entries:
Changes
```
- When opening a settings dialog which is already open, NVDA sets focus on the existing dialog rather than raise an error. (#5383)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
