### PR TITLE
Descend into children for dialog text for option pane (Fixes #11687)

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -89,15 +89,15 @@ class Dialog(NVDAObject):
 				continue
 			#For particular objects, we want to descend in to them and get their children's message text
 			if childRole in (
-					controlTypes.Role.PROPERTYPAGE,
-					controlTypes.Role.PANE,
-					controlTypes.Role.PANEL,
-					controlTypes.Role.WINDOW,
-					controlTypes.Role.GROUPING,
-					controlTypes.Role.PARAGRAPH,
-					controlTypes.Role.SECTION,
-					controlTypes.Role.TEXTFRAME,
-					controlTypes.Role.UNKNOWN
+				controlTypes.Role.PROPERTYPAGE,
+				controlTypes.Role.PANE,
+				controlTypes.Role.PANEL,
+				controlTypes.Role.WINDOW,
+				controlTypes.Role.GROUPING,
+				controlTypes.Role.PARAGRAPH,
+				controlTypes.Role.SECTION,
+				controlTypes.Role.TEXTFRAME,
+				controlTypes.Role.UNKNOWN
 			):
 				#Grab text from descendants, but not for a child which inherits from Dialog and has focusable descendants
 				#Stops double reporting when focus is in a property page in a dialog

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -89,6 +89,7 @@ class Dialog(NVDAObject):
 				continue
 			#For particular objects, we want to descend in to them and get their children's message text
 			if childRole in (
+				controlTypes.ROLE_OPTIONPANE,
 				controlTypes.Role.PROPERTYPAGE,
 				controlTypes.Role.PANE,
 				controlTypes.Role.PANEL,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -41,6 +41,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - If a disabled addon is uninstalled and then re-installed it is re-enabled. (#12792)
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA no longer redundantly announces when a single cell is selected. (#12530)
+- More dialog text is automatically read in LibreOffice Writer, such as in confirmation dialogs. (#11687)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #11687

### Summary of the issue:

Text in LibreOffice message dialogs is not announced by NVDA.

### Description of how this pull request fixes the issue:

This commit makes sure that the children of objects of role 'controlTypes.Role.OPTIONPANE' are taken into account when determining the text to announce for a dialog, as is done for objects of role 'controlTypes.Role.PANE'.

For LibreOffice (message) dialogs, the dialog text are objects of role 'controlTypes.Role.STATICTEXT'  that are children of an object of type 'controlTypes.Role.OPTIONPANE'.
Those were previously not considered when determining the dialog text to announce. This change ensures that they are now and that the actual dialog text is thus announced by NVDA, just as is done (and has been the case) for objects of role 'controlTypes.Role.PANE'.

Note: In addition to this change in NVDA, it also requires
the following commit recently committed to LibreOffice [1]
(which will be contained in LibreOffice 7.3):

    commit e29f80efc826fdc8a8e4b7cbdd3becf2f074cce4
    Author: Michael Weghorn <m.weghorn@posteo.de>
    Date:   Wed Sep 1 16:25:01 2021 +0200

        tdf#135588 wina11y: Map AccessibleRole::STATIC to ROLE_SYSTEM_STATICTEXT

Its commit message has some more background information.

[1] https://git.libreoffice.org/core/+/e29f80efc826fdc8a8e4b7cbdd3becf2f074cce4%5E%21

### Testing strategy:

* download and set up a recent LibreOffice daily build from https://dev-builds.libreoffice.org/daily/master/current.html (needs to be from 2021-09-02 or newer, since the above mentioned LibreOffice commit is needed as well)
* start NVDA and LibreOffice Writer
* type some text
* press the "Close" button in LibreOffice
* check that the Text in the "Save document?" dialog is announced completely
* kill the LibreOffice process using Task manager
* start LibreOffice again
* follow description in #11687 and ensure that the text in the document recovery dialog is announced

### Known issues with pull request:

none

### Change log entries:
*Changes*
Dialog text from an object of role 'OPTIONPANE' is now retrieved by descending into the objects children. (#11687)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual testing.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
