### PR TITLE
Ensure documents always scroll to exact browse mode position

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -122,6 +122,12 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	detectFormattingAfterCursorMaybeSlow=False
 
+	def scrollIntoView(self):
+		self.obj.IAccessibleTextObject.scrollSubstringTo(
+			self._startOffset, self._endOffset,
+			IA2.IA2_SCROLL_TYPE_TOP_LEFT
+		)
+
 	def _get_encoding(self):
 		return super().encoding
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -45,6 +45,9 @@ import winVersion
 
 class UIATextInfo(textInfos.TextInfo):
 
+	def scrollIntoView(self):
+		self._rangeObj.scrollIntoView(True)
+
 	_cache_controlFieldNVDAObjectClass=True
 	def _get_controlFieldNVDAObjectClass(self):
 		"""

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -888,6 +888,15 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 			field['line-prefix']=mapPUAToUnicode.get(bullet,bullet)
 		return field
 
+	def scrollIntoView(self):
+		try:
+			self.obj.WinwordWindowObject.ScrollIntoView(self._rangeObj, True)
+		except COMError:
+			log.exception("Can't scroll")
+			pass
+
+
+
 	def expand(self,unit):
 		if unit==textInfos.UNIT_LINE: 
 			try:

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -892,10 +892,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		try:
 			self.obj.WinwordWindowObject.ScrollIntoView(self._rangeObj, True)
 		except COMError:
-			log.exception("Can't scroll")
-			pass
-
-
+			log.debugWarning("Can't scroll", exc_info=True)
 
 	def expand(self,unit):
 		if unit==textInfos.UNIT_LINE: 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1237,6 +1237,7 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 			return self.obj.rootNVDAObject
 		return item.obj
 
+
 class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation,cursorManager.CursorManager,BrowseModeTreeInterceptor,treeInterceptorHandler.DocumentTreeInterceptor):
 
 	programmaticScrollMayFireEvent = False
@@ -1354,13 +1355,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		else:
 			self._lastCaretMoveWasFocus = False
 			focusObj=info.focusableNVDAObjectAtStart
-			obj=info.NVDAObjectAtStart
-			if not obj:
-				log.debugWarning("Invalid NVDAObjectAtStart")
-				return
-			if obj==self.rootNVDAObject:
-				return
-			obj.scrollIntoView()
+			info.scrollIntoView()
 			if self.programmaticScrollMayFireEvent:
 				self._lastProgrammaticScrollTime = time.time()
 		if focusObj:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -640,6 +640,13 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
+	def scrollIntoView(self):
+		"""
+		Scrolls the window to ensure that this text range is visible.
+		"""
+		raise NotImplementedError
+
+
 RE_EOL = re.compile("\r\n|[\n\r]")
 def convertToCrlf(text):
 	"""Convert a string so that it contains only CRLF line endings.

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -186,6 +186,9 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def _set__rangeObj(self,r):
 		self.innerTextInfo._rangeObj=r
 
+	def scrollIntoView(self):
+		self.innerTextInfo.scrollIntoView()
+
 	def _get_locationText(self):
 		return self.innerTextInfo.locationText
 

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -394,6 +394,17 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		obj = self.obj.getNVDAObjectFromIdentifier(docHandle, nodeId)
 		return obj.mathMl
 
+	def scrollIntoView(self):
+		# Scroll the deepest object at this point into view.
+		obj = self.NVDAObjectAtStart
+		if not obj:
+			return
+		if obj == self.obj.rootNVDAObject:
+			# However never scroll to the  document itself
+			return
+		obj.scrollIntoView()
+
+
 class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	TextInfo=VirtualBufferTextInfo

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -398,6 +398,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		# Scroll the deepest object at this point into view.
 		obj = self.NVDAObjectAtStart
 		if not obj:
+			log.debugWarning("Invalid NVDAObjectAtStart")
 			return
 		if obj == self.obj.rootNVDAObject:
 			# However never scroll to the  document itself

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -37,6 +37,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - NVDA no longer sets invalid Python locales. (#12753)
 - If a disabled addon is uninstalled and then re-installed it is re-enabled. (#12792)
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
+- Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #9611

### Summary of the issue:
When reading / navigating with browse mode in Microsoft Word via UI Automation, the document does not always scroll so that the current browse mode position is visible on screen, nor does the focus mode caret position stay in sync with the browse mode caret, especially when moving across pages in browse mode.
Browse mode currently only knows how to scroll to objects in the document, not specific text range positions. Thus, it is only able to scroll to lists, tables and graphics, and not any arbitrary text.
Also, setting the caret in Microsoft Word to a range that is on a page that is currently off screen seems to fail and or set the caret to a random point on the current page.

### Description of how this pull request fixes the issue:
* Add a scrollIntoView method on `textInfos.TextInfo` which should croll the document containing that range such that the range is visible on screen. The base implementation has no implementation and does nothing.
* Implement ScrollIntoView for IAccessible2 textInfos, UIA textInfos, Microsoft Word object model textInfos, and virtualBuffer textInfos. The VirtualBuffer textInfo implementation comes straight from the old BrowseMode logic which is to call ScrollIntoView on the deepest object at the position in the document.
* Change BrowseModeDocument's `_set_selection` to call ScrollIntoView on the given textInfo, rather than the deepest object at the position of that textInfo. This is much more accurate and will ensure that any arbitrary textRange is scrolled to. It is specifically this change, plus the implementation of ScrollIntoView for UIA TextInfo that solves the Microsoft  Word with Browse mode via UI Automation scrolling issue.

### Testing strategy:
Try build: https://ci.appveyor.com/api/buildjobs/bsjf2a8c6t9879wf/artifacts/output%2Fnvda_snapshot_try-i9611-23673%2C38a7b5ac.exe
@Qchristensen  has confirmed this pr fixes #9611 and  that it does not cause regressions in any other browse mode implementation (Firefox, Chrome etc).

### Known issues with pull request:
None known.

### Change log entries:
Bug fixes:
* Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [ ] Manual testing.
- [ ] User Documentation.
- [ ] Change log entry.
- [ ] Context sensitive help for GUI changes.
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
