### PR TITLE
Update .gitattributes to prefer LF

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+# Documentation: https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+# Usage: git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+
 # Normalize line endings in t2t files
 e6a639bfe237ff7f98c4cbec2094a34ac4b879db
 # Migrate t2t to markdown

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,84 @@
 # Every person expected to commit po files should change their personal config file as described here:
 # https://mail.gnome.org/archives/kupfer-list/2010-June/msg00002.html
 *.po filter=cleanpo
+
+eol=lf
+*	text=auto
+
+# Files which should not be renormalized
+*.dic   -text
+*.po    -text
+
+# Git files
+.gitignore       text
+.gitattributes   text
+CODEOWNERS       text
+
+# Documentation files
+*.md     text
+*.txt    text
+
+# Scripts
+*.ps1    text
+*.bat    text
+*.nsi    text
+
+# Config files
+*.ini    text
+*.yml    text
+*.robot  text
+*.subst  text
+Doxyfile     text
+Makefile     text
+
+# Other files
+*.def text
+*.css text
+*.svg text
+
+# Source files
+# ============
+# Python Sources
+*.py     text diff=python
+*.pyw    text diff=python
+*_sconscript  text diff=python
+sconscript    text diff=python
+sconstruct    text diff=python
+# C++ Sources
+*.c     text diff=c
+*.cpp   text diff=cpp
+*.h     text diff=c
+*.idl   text diff=c
+*.acf   text diff=c
+
+# Binary files
+# ============
+# Python binary files
+# *.db     binary
+# *.p      binary
+# *.pkl    binary
+# *.pickle binary
+# *.pyc    binary
+# *.pyd    binary
+# *.pyo    binary
+# # Compiled C++ Object files
+# *.slo   binary
+# *.lo    binary
+# *.o     binary
+# *.obj   binary
+# # Precompiled C++ Headers
+# *.gch   binary
+# *.pch   binary
+# # Compiled C++ Dynamic libraries
+# *.so    binary
+# *.dylib binary
+# *.dll   binary
+# # Compiled C++ Static libraries
+# *.lai   binary
+# *.la    binary
+# *.a     binary
+# *.lib   binary
+# # C++ Executables
+# *.exe   binary
+# *.out   binary
+# *.app   binary

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -3,17 +3,20 @@
 Python code style is enforced with the flake8 linter, see [`tests/lint/readme.md`](https://github.com/nvaccess/nvda/tree/master/tests/lint/readme.md) for more information.
 
 ### Encoding
+
 * Where Python files contain non-ASCII characters, they should be encoded in UTF-8.
-    * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of the translation tools we use (`xgettext`).
-    Instead, include this as the first line of the file, only if the file contains non-ASCII characters:
-        ```py
-        # -*- coding: UTF-8 -*-
-        ```
-    * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`.
+  * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of the translation tools we use (`xgettext`).
+  Instead, include this as the first line of the file, only if the file contains non-ASCII characters:
+
+  ```py
+  # -*- coding: UTF-8 -*-
+  ```
+
+  * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`.
     This is particularly relevant for braille display drivers.
     This is due to a `gettext` bug; see [comment on #2592](https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911).
-* New files should contain `LF` line endings, however NVDA currently uses a mix of LF and CRLF line endings.
-See issue [#12387](https://github.com/nvaccess/nvda/issues/12387).
+* Most files should be committed with `LF` line endings.
+Files can be checked out locally using CRLF if needed for Windows development using [git](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 
 ### Indentation
 * Indentation must be done with tabs (one per level), not spaces.

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -15,7 +15,7 @@ Python code style is enforced with the flake8 linter, see [`tests/lint/readme.md
   * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`.
     This is particularly relevant for braille display drivers.
     This is due to a `gettext` bug; see [comment on #2592](https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911).
-* Most files should be committed with `LF` line endings.
+* Text files should be committed with `LF` line endings.
 Files can be checked out locally using CRLF if needed for Windows development using [git](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 
 ### Indentation


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Part of #12387

### Summary of the issue:

The NVDA code base uses a mix of CRLF and LF style line endings, with the preference being CRLF.
LF style endings have been introduced prior to lint checking, and can causes issues when moving code or making changes. 
Many IDEs will normalize the line endings when editing files, causing larger than intended diffs of files with mixed line endings.
Instead, we should normalize all line endings of text files to LF and ensure that all files are committed with LF line endings.

Specific files should be excluded from normalization such as:
  * files used by translators, as we are uncertain of the side-effects here
  * binary files
  
git allows independent configurations between line endings used when a developer checkouts out code locally, and when code is committed to a repository.
IDEs are often better suited for different line endings, with LF line endings becoming more and more standardised. 
However, NVDA is Windows based development, where CRLF line ending usage is commonly default or compulsory.
Developers can checkout code locally, using whatever line endings they prefer or their IDE requires, using `git config.core autocrlf`. 

We can configure what line endings we commit to the repository with `.gitattributes`.
This is set on a repository level.
As what line endings we commit with is agnostic to what is checked out, the decision is based on what works best for the repository.
Unix style line endings usage and support continues to increase on Windows and LF files.
LF tends to be better supported by Unix style developer tools such as git.
LF uses less data than CRLF.

Additional information: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

### Description of how this pull request fixes the issue:

Fixing this is a 3 step process, this PR emulates the 3 steps, but only one commit should be merged at a time.

1. The first commit  updates .gitattributes so that any new files committed will use LF style endings where appropriate.
2. Then, no PRs should be merged until a commit which normalizes the line endings is committed to master.
   Otherwise, new PRs will have large diffs due to line ending changes.
   ```sh
   git pull origin/master # to get .gitattributes
   git add --renormalize .
   git commit -m "fix line endings"
   ```
3. Then, the third commit can be committed. This updates the `.git-blame-ignore-revs` file so that the normalization commit can be ignored by developers using `git blame`.

Specifically this PR:

* Updates [`.gitattributes` file](https://git-scm.com/docs/gitattributes#_end_of_line_conversion), with `eol=lf` and normalization patterns for each file type NVDA uses:
  * `-text` or `binary` for no normalization
  * `text` to change line endings to `lf` when committing code.
* Ensures `git add --renormalize .` sets the correct line endings for the entire project.
* Updates documentation
  
### Testing strategy:

Setup `normalize-line-endings` as follows to perform this testing.
```sh
git checkout normalize-line-endings
git reset origin/normalize-line-endings --hard
git add --renormalize .
git commit -m "fix line endings"
```
Update `.git-blame-ignore-revs` with the latest commit.

#### Compare the diff while ignoring eol line changes
```sh
git diff --ignore-cr-at-eol origin/master normalize-line-endings
```

#### Check the blame of a file from this branch and confirm the line ending changes show up in the blame.
Then check the blame of a file:
```sh
git blame source/core.py normalize-line-endings
```

#### Test that `.git-blame-ignore-revs` works and ignores the line ending changes.
```sh
git blame --ignore-revs-file .git-blame-ignore-revssource/core.py normalize-line-endings
```

#### Test that setting `.git-blame-ignore-revs` works.
This should be recommended to devs.
```sh
git config --local blame.ignoreRevsFile .git-blame-ignore-revs
# should ignore revs
git blame source/core.py normalize-line-endings
# should not ignore revs
git blame --ignore-revs-file "" source/core.py normalize-line-endings
```

#### Test that committing a text file, not used by the translation system, with CRLF line endings is not possible.
This can be done by adding or changing a file.

#### Test that the resulting translation .pot files generated do not change after nomalization.
```cmd
git checkout master
scons pot
git checkout normalize-line-endings
scons pot
```
Note: Not git diff, as these files are ignored. Update the commits within the file names if required.
```sh
diff output/nvda_snapshot_source-master-6b4cf45.pot output/nvda_snapshot_source-normalize-line-endings-31dee0a.pot
```

`cat -A` displays `CR` as `^M`. This will ensure the diff tool picks up on any CRLF changes.
```sh
cat -A output/nvda_snapshot_source-master-6b4cf45.pot > master-with-explicit-line-endings.pot
cat -A output/nvda_snapshot_source-normalize-line-endings-31dee0a.pot > normalized-with-explicit-line-endings.pot
diff master-with-explicit-line-endings.pot normalized-with-explicit-line-endings.pot
```

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed usage guidelines for the `git-blame-ignore-revs` feature.
  - Updated `codingStandards.md` with new file encoding and line ending practices, naming conventions, and docstring format specifications.

- **Chores**
  - Modified `.gitattributes` to set `eol=lf`, define text attributes for various file types, and specify files exempt from renormalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->