### PR TITLE
Suppress reporting of tables when reading emails in Outlook using UIA

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -177,6 +177,15 @@ class WordDocumentTextInfo(UIATextInfo):
 				or field.pop('name', None)
 				or obj.name
 			)
+		# #11430: Read-only tables, such as in the Outlook message viewer
+		# should be treated as layout tables
+		# If they only contain 1 column or 1 row.
+		if (
+			obj.appModule.appName == 'outlook'
+			and obj.role == controlTypes.Role.TABLE
+			and controlTypes.State.READONLY in obj.states
+		):
+			field['table-layout'] = True
 		return field
 
 	def _getTextFromUIARange(self, textRange):

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -178,8 +178,7 @@ class WordDocumentTextInfo(UIATextInfo):
 				or obj.name
 			)
 		# #11430: Read-only tables, such as in the Outlook message viewer
-		# should be treated as layout tables
-		# If they only contain 1 column or 1 row.
+		# should be treated as layout tables.
 		if (
 			obj.appModule.appName == 'outlook'
 			and obj.role == controlTypes.Role.TABLE

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -35,6 +35,9 @@ If you need this functionality please assign a gesture to the appropriate script
 - NVDA no longer treats the value of UIA sliders as always percentage based.
 - Reporting the location of a cell in Microsoft Excel when accessed via UI Automation again works correctly on Windows 11. (#12782)
 - NVDA no longer sets invalid Python locales. (#12753)
+- When reading emails in Outlook  via UI Automation, reporting of tables is now suppressed by default. (#11430)
+ - If the user needs to temporarily have tables reported when reading an email, the Include Layout Tables option in Browse Mode settings can be turned on.
+ -
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #11430

### Summary of the issue:
Microsoft Outlook uses a Microsoft word document control to present emails when both reading and composing. NVDA is in the process of switching to using UI Automation to access Microsoft Word document controls due to major performance advantages, and also due to Microsoft no longer maintaining the Office object model.
However, in the UI automation implementation exposed by MS Word document controls, it is impossible to identify the difference between a data table and a layout table. Thus, NVDa reports all layout tables when reading, which is extremely annoying, as the majority of HTML emails use many nested layout tables.

### Description of how this pull request fixes the issue:
Tables are now classed as layout tables in MS Word document controls if the app is Outlook, and the table is read-only (Outlook is in message reading view).
Being marked as a layout table means that by default the table will not be reported, however the user can still turn on the Include Layout Tables option in NVDA's browse mode settings temporarily if there is a genuine data table they need to have reported.
 
### Testing strategy:
With use UIA in MS Word controls enabled in NVDA's advanced settings:
* Create a table in Microsoft Word and ensure that NVDA still reports it (number of rows / columns, cell's row and column number etc).
* Create a table in Microsoft Outlook composition view and ensure that NVDA still reports it (number of rows / columns, cell's row and column number etc).
* Open an HTML email in Outlook that has layout tables, and ensure that the table is not reported when moving into and through the table's content with the arrow keys.

### Known issues with pull request:
All table reporting will be suppressed when reading emails in Outlook, even data tables. However, waying up the extreme annoyance of having layout tables read verses not reporting some very rare data tables (where the user can manually still enforce reporting by turning on includeLayoutTables) I think this is okay.
Though it would be much better if Outlook exposed layout tables in an identifiable way, such as not supporting the UI Automation Table Pattern for layout tables.

### Change log entries:
Bug fixes:
* When reading emails in Outlook and NVDA is accessing the message with UI Automation, reporting of tables is now suppressed by default.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
