### PR TITLE
remove usages of controlTypes.stateLabels and negativeStateLabels

### DIFF
--- a/source/appModules/msimn.py
+++ b/source/appModules/msimn.py
@@ -119,9 +119,9 @@ class MessageListItem(sysListView32.ListItem):
 		nameList=[]
 		imageState=watchdog.cancellableSendMessage(self.windowHandle,sysListView32.LVM_GETITEMSTATE,self.IAccessibleChildID-1,sysListView32.LVIS_STATEIMAGEMASK)>>12
 		if imageState==5:
-			nameList.append(controlTypes.stateLabels[controlTypes.State.COLLAPSED])
+			nameList.append(controlTypes.State.COLLAPSED.displayString)
 		elif imageState==6:
-			nameList.append(controlTypes.stateLabels[controlTypes.State.EXPANDED])
+			nameList.append(controlTypes.State.EXPANDED.displayString)
 		if self.isUnread:
 			# Translators: Displayed in outlook or live mail to indicate an email is unread
 			nameList.append(_("unread"))

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -439,9 +439,9 @@ class UIAGridRow(RowWithFakeNavigation,UIA):
 	def _get_name(self):
 		textList=[]
 		if controlTypes.State.EXPANDED in self.states:
-			textList.append(controlTypes.stateLabels[controlTypes.State.EXPANDED])
+			textList.append(controlTypes.State.EXPANDED.displayString)
 		elif controlTypes.State.COLLAPSED in self.states:
-			textList.append(controlTypes.stateLabels[controlTypes.State.COLLAPSED])
+			textList.append(controlTypes.State.COLLAPSED.displayString)
 		selection=None
 		if self.appModule.nativeOm:
 			try:

--- a/source/appModules/thunderbird.py
+++ b/source/appModules/thunderbird.py
@@ -22,7 +22,7 @@ class AppModule(appModuleHandler.AppModule):
 				except:
 					# Fall back to reading the entire status bar.
 					statusText = api.getStatusBarText(statusBar)
-				speech.speakMessage(controlTypes.stateLabels[controlTypes.State.BUSY])
+				speech.speakMessage(controlTypes.State.BUSY.displayString)
 				speech.speakMessage(statusText)
 				return
 		nextHandler()

--- a/source/appModules/totalcmd.py
+++ b/source/appModules/totalcmd.py
@@ -42,7 +42,7 @@ class TCList(IAccessible):
 		if self.name:
 			speakList=[]
 			if controlTypes.State.SELECTED in self.states:
-				speakList.append(controlTypes.stateLabels[controlTypes.State.SELECTED])
+				speakList.append(controlTypes.State.SELECTED.displayString)
 			speakList.append(self.name.split("\\")[-1])
 			speech.speakMessage(" ".join(speakList))
 		else:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1288,7 +1288,7 @@ def getTextInfoSpeech(  # noqa: C901
 				# We entered the most outer clickable, so announce it, if we won't be announcing anything else interesting for this field
 				presCat=field.getPresentationCategory(newControlFieldStack[0:count],formatConfig,reason)
 				if not presCat or presCat is field.PRESCAT_LAYOUT:
-					speechSequence.append(controlTypes.stateLabels[controlTypes.State.CLICKABLE])
+					speechSequence.append(controlTypes.State.CLICKABLE.displayString)
 					shouldConsiderTextInfoBlank = False
 				inClickable=True
 		fieldSequence = info.getControlFieldSpeech(
@@ -1392,7 +1392,7 @@ def getTextInfoSpeech(  # noqa: C901
 						# Announce it if there is nothing else interesting about the field, but not if the user turned it off. 
 						presCat=command.field.getPresentationCategory(newControlFieldStack[0:],formatConfig,reason)
 						if not presCat or presCat is command.field.PRESCAT_LAYOUT:
-							fieldSequence.append(controlTypes.stateLabels[controlTypes.State.CLICKABLE])
+							fieldSequence.append(controlTypes.State.CLICKABLE.displayString)
 						inClickable=True
 				fieldSequence.extend(info.getControlFieldSpeech(
 					command.field,

--- a/tests/unit/test_controlTypes.py
+++ b/tests/unit/test_controlTypes.py
@@ -20,7 +20,7 @@ class TestLabels(unittest.TestCase):
 			if name.startswith("ROLE_"):
 				self.assertIsNotNone(controlTypes.roleLabels.get(const),msg="{name} has no label".format(name=name))
 
-	def test_roleLabels(self):
+	def test_role_displayString(self):
 		"""Test to check whether every role has its own display string"""
 		for role in controlTypes.Role:
 			role.displayString
@@ -32,7 +32,7 @@ class TestLabels(unittest.TestCase):
 			if name.startswith("STATE_"):
 				self.assertIsNotNone(controlTypes.stateLabels.get(const),msg="{name} has no label".format(name=name))
 
-	def test_stateLabels(self):
+	def test_state_displayString(self):
 		"""Test to check whether every state has its own display string and negative display string"""
 		for state in controlTypes.State:
 			state.displayString
@@ -93,7 +93,7 @@ class TestStateOrder(unittest.TestCase):
 				obj.states,
 				None
 			),
-			[controlTypes.stateLabels[controlTypes.State.CHECKED]]
+			[controlTypes.State.CHECKED.displayString]
 		)
 
 	def test_negativeMergedStatesOutput(self):
@@ -113,5 +113,5 @@ class TestStateOrder(unittest.TestCase):
 				obj.states,
 				None
 			),
-			[controlTypes.negativeStateLabels[controlTypes.State.CHECKED]]
+			[controlTypes.State.CHECKED.negativeDisplayString]
 		)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Part of #12549

### Summary of the issue:

 `controlTypes.stateLabels` has been deprecated, usages such as `controlTypes.stateLabels[controlTypes.State.*]` should be replaced to their equivalent `controlTypes.State.*.displayString`

### Description of how this pull request fixes the issue:

Use `displayString` and `negativeDisplayString` instead of `stateLabels` and `negativeStateLabels`.

### Testing strategy:

Search the NVDA repo for "stateLabels" and "negativeStateLabels".

Unit tests exist in `test_controlTypes.TestLabels` (and have been renamed appropriately).

### Known issues with pull request:

None

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
