### PR TITLE
Normalize review by collapsing before expanding

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1285,8 +1285,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_review_previousLine(self,gesture):
 		info=api.getReviewPosition().copy()
-		info.expand(textInfos.UNIT_LINE)
 		info.collapse()
+		info.expand(textInfos.UNIT_LINE)
 		res=info.move(textInfos.UNIT_LINE,-1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the top line of the current navigator object.
@@ -1326,8 +1326,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_review_nextLine(self,gesture):
 		info=api.getReviewPosition().copy()
-		info.expand(textInfos.UNIT_LINE)
 		info.collapse()
+		info.expand(textInfos.UNIT_LINE)
 		res=info.move(textInfos.UNIT_LINE,1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
@@ -1357,8 +1357,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_review_previousWord(self,gesture):
 		info=api.getReviewPosition().copy()
-		info.expand(textInfos.UNIT_WORD)
 		info.collapse()
+		info.expand(textInfos.UNIT_WORD)
 		res=info.move(textInfos.UNIT_WORD,-1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the top line of the current navigator object.
@@ -1397,8 +1397,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_review_nextWord(self,gesture):
 		info=api.getReviewPosition().copy()
-		info.expand(textInfos.UNIT_WORD)
 		info.collapse()
+		info.expand(textInfos.UNIT_WORD)
 		res=info.move(textInfos.UNIT_WORD,1)
 		if res==0:
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #12808.

### Summary of the issue:
Due to differences in behaviour between UIA and MSAA text ranges, some UIA text ranges never report "bottom" when moving past the last line of text.

### Description of how this pull request fixes the issue:
In review, normalize text ranges by collapsing to start before expanding by the unit being reviewed (i.e. move an expanded range, not a collapsed one).

### Testing strategy:
Tested Microsoft Word with UIA enabled, an upcoming UIA Windows Console, and Notepad (both MSAA and UIA proxied MSAA) by moving through multiline text. Verified that "bottom" is properly reported when moving by line in all cases.

### Known issues with pull request:
I'm not 100% set on this approach, mostly because I don't fully understand this code. This may introduce additional bugs.

I've opened this PR as a possible fix and to start a discussion on resolving this issue as it will continue affecting word (even after UIA) and will soon affect consoles.
### Change log entries:
== Bug Fixes ==
- When reviewing text in Microsoft Word accessed via UI Automation, "bottom" is now reported when moving beyond the last line of text. (#12808)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [ ] Unit tests.
- [ ] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [ ] User Documentation.
- [x] Change log entry.
- [ ] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
