### PR TITLE
Split description and helpText properties

### DIFF
--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -46,6 +46,7 @@ winEventIDsToNVDAEventNames = {
 	winUser.EVENT_OBJECT_HIDE: "hide",
 	winUser.EVENT_OBJECT_DESTROY: "destroy",
 	winUser.EVENT_OBJECT_DESCRIPTIONCHANGE: "descriptionChange",
+	winUser.EVENT_OBJECT_HELPCHANGE: "helpTextChange",
 	winUser.EVENT_OBJECT_LOCATIONCHANGE: "locationChange",
 	winUser.EVENT_OBJECT_NAMECHANGE: "nameChange",
 	winUser.EVENT_OBJECT_SELECTION: "selection",

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -989,34 +989,45 @@ the NVDAObject for IAccessible
 
 	re_positionInfoEncodedAccDescription=re.compile(r"L(?P<level>\d+)(?:, (?P<indexInGroup>\d+) of (?P<similarItemsInGroup>\d+))?")
 
-	def _get_decodedAccDescription(self):
+	decodedAccDescription: Optional[str]
+	"""Typing information for auto property _get_decodedAccDescription"""
+
+	def _get_decodedAccDescription(self) -> Optional[str]:
 		try:
-			description=self.IAccessibleObject.accDescription(self.IAccessibleChildID)
+			description = self.IAccessibleObject.accDescription(self.IAccessibleChildID)
 		except COMError:
 			return None
 		if not description:
 			return None
 		if description.lower().startswith('description:'):
 			return description[12:].strip()
-		m=self.re_positionInfoEncodedAccDescription.match(description)
+		m = self.re_positionInfoEncodedAccDescription.match(description)
 		if m:
 			return m
 		return description
 
-	hasEncodedAccDescription=False #:If true, accDescription contains info such as level, and number of items etc.
+	hasEncodedAccDescription = False
+	"""If true, accDescription contains info such as level, and number of items etc."""
 
-	def _get_description(self):
+	def _get_description(self) -> Optional[str]:
 		if self.hasEncodedAccDescription:
-			d=self.decodedAccDescription
-			if isinstance(d,str):
+			d = self.decodedAccDescription
+			if isinstance(d, str):
 				return d
 			else:
-				return ""
+				return None
 		try:
-			res=self.IAccessibleObject.accDescription(self.IAccessibleChildID)
+			res = self.IAccessibleObject.accDescription(self.IAccessibleChildID)
 		except COMError:
-			res=None
-		return res if isinstance(res,str) and not res.isspace() else None
+			res = None
+		return res if isinstance(res, str) and not res.isspace() else None
+
+	def _get_helpText(self) -> Optional[str]:
+		try:
+			res = self.IAccessibleObject.accHelp(self.IAccessibleChildID)
+		except COMError:
+			res = None
+		return res if isinstance(res, str) and not res.isspace() else None
 
 	def _get_keyboardShortcut(self):
 		try:
@@ -2206,7 +2217,8 @@ class Titlebar(IAccessible):
 	presentationType=IAccessible.presType_layout
 
 	def _get_description(self):
-		return ""
+		return None
+
 
 class ReBarWindow32Client(IAccessible):
 	"""

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1588,20 +1588,29 @@ class UIA(Window):
 				role=superRole
 		return role
 
-	def _get_UIAFullDescription(self):
-		try:
-			return self._getUIACacheablePropertyValue(UIAHandler.UIA_FullDescriptionPropertyId) or ""
-		except COMError:
-			return ""
+	UIAFullDescription: Optional[str]
+	"""Typing information for auto property _get_UIAFullDescription"""
 
-	def _get_UIAHelpText(self):
+	def _get_UIAFullDescription(self) -> Optional[str]:
 		try:
-			return self._getUIACacheablePropertyValue(UIAHandler.UIA_HelpTextPropertyId) or ""
+			return self._getUIACacheablePropertyValue(UIAHandler.UIA_FullDescriptionPropertyId) or None
 		except COMError:
-			return ""
+			return None
 
-	def _get_description(self):
-		return self.UIAFullDescription or self.UIAHelpText
+	UIAHelpText: Optional[str]
+	"""Typing information for auto property _get_UIAHelpText"""
+
+	def _get_UIAHelpText(self) -> Optional[str]:
+		try:
+			return self._getUIACacheablePropertyValue(UIAHandler.UIA_HelpTextPropertyId) or None
+		except COMError:
+			return None
+
+	def _get_description(self) -> Optional[str]:
+		return self.UIAFullDescription
+
+	def _get_helpText(self) -> Optional[str]:
+		return self.UIAHelpText
 
 	def _get_keyboardShortcut(self):
 		# Build the keyboard shortcuts list early for readability.
@@ -2249,17 +2258,17 @@ class SensitiveSlider(UIA):
 		else:
 			super(SensitiveSlider,self).event_valueChange()
 
+
 class ControlPanelLink(UIA):
 
-	def _get_description(self):
-		desc = self.UIAHelpText
-		try:
-			i=desc.find('\n')
-		except:
-			i=None
-		if i:
-			desc=desc[i+1:]
-		return desc
+	def _get_helpText(self) -> Optional[str]:
+		help = super().helpText
+		if help:
+			i = help.find('\n')
+			if i > 0:
+				help = help[i + 1:]
+		return help
+
 
 class ComboBoxWithoutValuePattern(UIA):
 	"""A combo box without the Value pattern.

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -504,19 +504,27 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""
 		return ""
 
-	#: Typing information for auto property _get_description
-	description: str
+	description: typing.Optional[str]
+	"""Typing information for auto property _get_description"""
 
-	def _get_description(self) -> str:
-		"""The description or help text of this object.
+	def _get_description(self) -> typing.Optional[str]:
+		"""The description of this object.
 		"""
-		return ""
+		return None
 
 	#: Typing information for auto property _get_descriptionFrom
 	descriptionFrom: controlTypes.DescriptionFrom
 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
 		return controlTypes.DescriptionFrom.UNKNOWN
+
+	helpText: typing.Optional[str]
+	"""Typing information for auto property _get_helpText"""
+
+	def _get_helpText(self) -> typing.Optional[str]:
+		"""The help text of this object.
+		"""
+		return None
 
 	annotations: AnnotationOrigin
 	"""Typing information for auto property _get_annotations
@@ -1339,6 +1347,12 @@ This code is executed if a gain focus event is received by this object.
 	def event_descriptionChange(self):
 		if self is api.getFocusObject():
 			speech.speakObjectProperties(self, description=True, reason=controlTypes.OutputReason.CHANGE)
+		braille.handler.handleUpdate(self)
+		vision.handler.handleUpdate(self, property="description")
+
+	def event_helpTextChange(self):
+		if self is api.getFocusObject():
+			speech.speakObjectProperties(self, helpText=True, reason=controlTypes.OutputReason.CHANGE)
 		braille.handler.handleUpdate(self)
 		vision.handler.handleUpdate(self, property="description")
 

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -187,7 +187,8 @@ UIALiveSettingtoNVDAAriaLivePoliteness: Dict[str, aria.AriaLivePoliteness] = {
 
 UIAPropertyIdsToNVDAEventNames={
 	UIA.UIA_NamePropertyId: "nameChange",
-	UIA.UIA_HelpTextPropertyId: "descriptionChange",
+	UIA.UIA_FullDescriptionPropertyId: "descriptionChange",
+	UIA.UIA_HelpTextPropertyId: "helpTextChange",
 	UIA.UIA_ExpandCollapseExpandCollapseStatePropertyId: "stateChange",
 	UIA.UIA_ToggleToggleStatePropertyId: "stateChange",
 	UIA.UIA_IsEnabledPropertyId: "stateChange",

--- a/source/braille.py
+++ b/source/braille.py
@@ -627,6 +627,9 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 	description = propertyValues.get("description")
 	if description:
 		textList.append(description)
+	helpText = propertyValues.get("helpText")
+	if helpText:
+		textList.append(helpText)
 	hasDetails = propertyValues.get("hasDetails")
 	if hasDetails:
 		textList.append(_getAnnotationProperty(propertyValues))
@@ -723,6 +726,14 @@ class NVDAObjectRegion(Region):
 			)
 		)
 		description = obj.description if _shouldUseDescription else None
+		# determine if description should be read
+		_shouldUseHelpText = (
+			obj.helpText
+			# the help text must not be a duplicate of name, prevent double braille
+			and presConfig["reportObjectHelpTexts"]
+			and obj.helpText != name
+		)
+		helpText = obj.helpText if _shouldUseHelpText else None
 		detailsRoles = obj.annotations.roles if obj.annotations else None
 		text = getPropertiesBraille(
 			name=name,
@@ -735,6 +746,7 @@ class NVDAObjectRegion(Region):
 			value=obj.value if not NVDAObjectHasUsefulText(obj) else None ,
 			states=obj.states,
 			description=description,
+			helpText=helpText,
 			keyboardShortcut=obj.keyboardShortcut if presConfig["reportKeyboardShortcuts"] else None,
 			positionInfo=obj.positionInfo if presConfig["reportObjectPositionInformation"] else None,
 			cellCoordsText=obj.cellCoordsText if config.conf["documentFormatting"]["reportTableCellCoords"] else None,

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -107,6 +107,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 		reportTooltips = boolean(default=false)
 		reportHelpBalloons = boolean(default=true)
 		reportObjectDescriptions = boolean(default=True)
+		reportObjectHelpTexts = boolean(default=True)
 		reportDynamicContentChanges = boolean(default=True)
 		reportAutoSuggestionsWithSound = boolean(default=True)
 	[[progressBarUpdates]]

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -376,3 +376,14 @@ def upgradeConfigFrom_10_to_11(profile: ConfigObj) -> None:
 			"hidBrailleStandard added to braille display auto detection excluded displays. "
 			f"List is now: {profile['braille']['auto']['excludedDisplays']}"
 		)
+
+
+def upgradeConfigFrom_11_to_12(profile) -> None:
+	"Reporting of object help texts can now be configured separately to descriptions."
+	try:
+		profile['presentation']['reportObjectHelpTexts'] = (
+			profile['presentation']['reportObjectDescriptions']
+		)
+	except KeyError:
+		# Setting does not exist, no need for upgrade of this setting
+		log.debug("reportObjectDescriptions not present, no action taken.")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2074,6 +2074,13 @@ class ObjectPresentationPanel(SettingsPanel):
 		self.bindHelpEvent("ObjectPresentationReportDescriptions", self.descriptionCheckBox)
 		self.descriptionCheckBox.SetValue(config.conf["presentation"]["reportObjectDescriptions"])
 
+		# Translators: This is the label for a checkbox in the
+		# object presentation settings panel.
+		helpTextsLabel = _("Report object &help texts")
+		self.helptextsCheckBox = sHelper.addItem(wx.CheckBox(self, label=helpTextsLabel))
+		self.bindHelpEvent("ObjectPresentationReportHelpTexts", self.helptextsCheckBox)
+		self.helptextsCheckBox.SetValue(config.conf["presentation"]["reportObjectHelpTexts"])
+
 		# Translators: This is the label for a combobox in the
 		# object presentation settings panel.
 		progressLabelText = _("Progress &bar output:")
@@ -2124,10 +2131,12 @@ class ObjectPresentationPanel(SettingsPanel):
 		config.conf["presentation"]["reportObjectPositionInformation"]=self.positionInfoCheckBox.IsChecked()
 		config.conf["presentation"]["guessObjectPositionInformationWhenUnavailable"]=self.guessPositionInfoCheckBox.IsChecked()
 		config.conf["presentation"]["reportObjectDescriptions"]=self.descriptionCheckBox.IsChecked()
+		config.conf["presentation"]["reportObjectHelpTexts"] = self.helptextsCheckBox.IsChecked()
 		config.conf["presentation"]["progressBarUpdates"]["progressBarOutputMode"]=self.progressLabels[self.progressList.GetSelection()][0]
 		config.conf["presentation"]["progressBarUpdates"]["reportBackgroundProgressBars"]=self.reportBackgroundProgressBarsCheckBox.IsChecked()
 		config.conf["presentation"]["reportDynamicContentChanges"]=self.dynamicContentCheckBox.IsChecked()
 		config.conf["presentation"]["reportAutoSuggestionsWithSound"]=self.autoSuggestionSoundsCheckBox.IsChecked()
+
 
 class BrowseModePanel(SettingsPanel):
 	# Translators: This is the label for the browse mode settings panel.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -713,6 +713,7 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		'hasDetails': config.conf["annotations"]["reportDetails"],
 		"detailsRoles": config.conf["annotations"]["reportDetails"],
 		'descriptionFrom': config.conf["annotations"]["reportAriaDescription"],
+		'helpText': True,
 		'keyboardShortcut': True,
 		'positionInfo_level': True,
 		'positionInfo_indexInGroup': True,
@@ -735,6 +736,8 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		allowProperties["positionInfo_level"] = False
 	if not config.conf["presentation"]["reportObjectDescriptions"]:
 		allowProperties["description"] = False
+	if not config.conf["presentation"]["reportObjectHelpTexts"]:
+		allowProperties["helpText"] = False
 	if not config.conf["presentation"]["reportKeyboardShortcuts"]:
 		allowProperties["keyboardShortcut"] = False
 	if not config.conf["presentation"]["reportObjectPositionInformation"]:
@@ -1742,6 +1745,10 @@ def getPropertiesSpeech(  # noqa: C901
 	description: Optional[str] = propertyValues.get('description')
 	if description:
 		textList.append(description)
+	# sometimes helpText key is present but value is None
+	helpText: Optional[str] = propertyValues.get('helpText')
+	if helpText:
+		textList.append(helpText)
 	# sometimes keyboardShortcut key is present but value is None
 	keyboardShortcut: Optional[str] = propertyValues.get('keyboardShortcut')
 	textList.extend(getKeyboardShortcutsSpeech(keyboardShortcut))

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1988,6 +1988,9 @@ When on, NVDA will report position information for more controls such as menus a
 ==== Report Object descriptions ====[ObjectPresentationReportDescriptions]
 Uncheck this checkbox if you don't wish to have the description reported along with objects (i.e. search suggestions, reporting of whole dialog window right after the dialog opens, etc.).
 
+==== Report Object help texts ====[ObjectPresentationReportHelpTexts]
+Uncheck this checkbox if you don't wish to have the help text reported along with objects.
+
 %kc:setting
 ==== Progress bar output ====[ObjectPresentationProgressBarOutput]
 Key: NVDA+u


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/issues/8604#issuecomment-913117417

### Summary of the issue:
In some rare cases with UIA, both the FullDescription property and HelpText property are provided with different information.

### Description of how this pull request fixes the issue:
This pr adss a new helpText property and implements it for UIA and IAccessible. for UIA, description now consistently maps to FullDescription whereas helpText maps to the helpText property.

### Testing strategy:
@chigkim it would be awesome if you could have a test with this.

### Known issues with pull request:
When both description and help text are provided, descriptions comes first and helptext follows, though there's probably no noticeable gap between the announcement of the two

### Change log entries:
Changes:
- The option in NVDA"s object presentation settings to report object descriptions has been split into two options: report object descriptions and report help texts.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [ ] Manual testing.
- [ ] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
