### PR TITLE
Restart nvda_dmp on exceptions

### DIFF
--- a/source/diffHandler.py
+++ b/source/diffHandler.py
@@ -98,6 +98,7 @@ class DiffMatchPatch(DiffAlgo):
 				]
 		except Exception:
 			log.exception("Exception in DMP, falling back to difflib")
+			self._terminate()
 			return Difflib().diff(newText, oldText)
 
 	def _terminate(self):
@@ -105,8 +106,12 @@ class DiffMatchPatch(DiffAlgo):
 			if DiffMatchPatch._proc:
 				log.debug("Terminating diff-match-patch proxy")
 				# nvda_dmp exits when it receives two zero-length texts.
-				DiffMatchPatch._proc.stdin.write(struct.pack("=II", 0, 0))
-				DiffMatchPatch._proc.wait(timeout=5)
+				try:
+					DiffMatchPatch._proc.stdin.write(struct.pack("=II", 0, 0))
+					DiffMatchPatch._proc.wait(timeout=5)
+				except Exception:
+					log.exception("Exception during DMP termination")
+				DiffMatchPatch._proc = None
 
 
 class Difflib(DiffAlgo):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
In some situations, nvda_dmp stops functioning. NVDA falls back to Difflib in these cases, so the console continues to function, but frequent error sounds are played and Difflib is forceably used until NVDA is restarted.

### Description of how this pull request fixes the issue:
When nvda_dmp fails to diff, restart it.

### Testing strategy:
Added code to randomly cause exceptions to the nvda_dmp flow and observed that diffing remained reliable.

### Known issues with pull request:
None.

### Change log entries:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
