### PR TITLE
Revert "Ensure documents always scroll to exact browse mode position"

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -122,12 +122,6 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	detectFormattingAfterCursorMaybeSlow=False
 
-	def scrollIntoView(self):
-		self.obj.IAccessibleTextObject.scrollSubstringTo(
-			self._startOffset, self._endOffset,
-			IA2.IA2_SCROLL_TYPE_TOP_LEFT
-		)
-
 	def _get_encoding(self):
 		return super().encoding
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -45,9 +45,6 @@ import winVersion
 
 class UIATextInfo(textInfos.TextInfo):
 
-	def scrollIntoView(self):
-		self._rangeObj.scrollIntoView(True)
-
 	_cache_controlFieldNVDAObjectClass=True
 	def _get_controlFieldNVDAObjectClass(self):
 		"""

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -888,12 +888,6 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 			field['line-prefix']=mapPUAToUnicode.get(bullet,bullet)
 		return field
 
-	def scrollIntoView(self):
-		try:
-			self.obj.WinwordWindowObject.ScrollIntoView(self._rangeObj, True)
-		except COMError:
-			log.debugWarning("Can't scroll", exc_info=True)
-
 	def expand(self,unit):
 		if unit==textInfos.UNIT_LINE: 
 			try:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1238,7 +1238,6 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 			return self.obj.rootNVDAObject
 		return item.obj
 
-
 class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation,cursorManager.CursorManager,BrowseModeTreeInterceptor,treeInterceptorHandler.DocumentTreeInterceptor):
 
 	programmaticScrollMayFireEvent = False
@@ -1356,7 +1355,13 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		else:
 			self._lastCaretMoveWasFocus = False
 			focusObj=info.focusableNVDAObjectAtStart
-			info.scrollIntoView()
+			obj=info.NVDAObjectAtStart
+			if not obj:
+				log.debugWarning("Invalid NVDAObjectAtStart")
+				return
+			if obj==self.rootNVDAObject:
+				return
+			obj.scrollIntoView()
 			if self.programmaticScrollMayFireEvent:
 				self._lastProgrammaticScrollTime = time.time()
 		if focusObj:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -640,13 +640,6 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
-	def scrollIntoView(self):
-		"""
-		Scrolls the window to ensure that this text range is visible.
-		"""
-		raise NotImplementedError
-
-
 RE_EOL = re.compile("\r\n|[\n\r]")
 def convertToCrlf(text):
 	"""Convert a string so that it contains only CRLF line endings.

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -186,9 +186,6 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def _set__rangeObj(self,r):
 		self.innerTextInfo._rangeObj=r
 
-	def scrollIntoView(self):
-		self.innerTextInfo.scrollIntoView()
-
 	def _get_locationText(self):
 		return self.innerTextInfo.locationText
 

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -394,18 +394,6 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		obj = self.obj.getNVDAObjectFromIdentifier(docHandle, nodeId)
 		return obj.mathMl
 
-	def scrollIntoView(self):
-		# Scroll the deepest object at this point into view.
-		obj = self.NVDAObjectAtStart
-		if not obj:
-			log.debugWarning("Invalid NVDAObjectAtStart")
-			return
-		if obj == self.obj.rootNVDAObject:
-			# However never scroll to the  document itself
-			return
-		obj.scrollIntoView()
-
-
 class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	TextInfo=VirtualBufferTextInfo

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,7 +40,6 @@ If you need this functionality please assign a gesture to the appropriate script
  -
 - If a disabled addon is uninstalled and then re-installed it is re-enabled. (#12792)
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
-- Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)
 -
 
 


### PR DESCRIPTION
Reverts nvaccess/nvda#12803
It is possible that this implementation is not complete enough: IAccessible2 text may not always scroll. MSHTML scrolling is not implemented.
There is a much more thorough implementation in pr #9919 which we should review and consider at a later date.
However for now, a much smaller pr will be created to just specifically address Microsoft Word with UIA as in this app, scrolling affects the syncing of the caret position