### PR TITLE
Browse mode in MS Word with UIA: ensure scrolling and carret position are always synched

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -329,6 +329,9 @@ class WordDocumentTextInfo(UIATextInfo):
 
 class WordBrowseModeDocument(UIABrowseModeDocument):
 
+	def scrollToPosition(self, info: UIATextInfo):
+		info._rangeObj.scrollIntoView(True)
+
 	def shouldSetFocusToObj(self,obj):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		if obj.role==controlTypes.Role.EDITABLETEXT and obj.UIAElement.cachedAutomationID.startswith('UIA_AutomationId_Word_Content'):

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1336,6 +1336,20 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 				return
 		super(BrowseModeDocumentTreeInterceptor,self)._activatePosition(obj=obj)
 
+	def scrollToPosition(self, info: textInfos.TextInfo):
+		"""
+		Ensures the document is scrolled such that the given textInfo is visible on screen.
+		"""
+		obj=info.NVDAObjectAtStart
+		if not obj:
+			log.debugWarning("Invalid NVDAObjectAtStart")
+			return
+		if obj==self.rootNVDAObject:
+			return
+		obj.scrollIntoView()
+		if self.programmaticScrollMayFireEvent:
+			self._lastProgrammaticScrollTime = time.time()
+
 	def _set_selection(self, info, reason=OutputReason.CARET):
 		super(BrowseModeDocumentTreeInterceptor, self)._set_selection(info)
 		if isScriptWaiting() or not info.isCollapsed:
@@ -1355,15 +1369,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		else:
 			self._lastCaretMoveWasFocus = False
 			focusObj=info.focusableNVDAObjectAtStart
-			obj=info.NVDAObjectAtStart
-			if not obj:
-				log.debugWarning("Invalid NVDAObjectAtStart")
-				return
-			if obj==self.rootNVDAObject:
-				return
-			obj.scrollIntoView()
-			if self.programmaticScrollMayFireEvent:
-				self._lastProgrammaticScrollTime = time.time()
+			self.scrollToPosition(info)
 		if focusObj:
 			self.passThrough = self.shouldPassThrough(focusObj, reason=reason)
 			if (

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1340,11 +1340,11 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		"""
 		Ensures the document is scrolled such that the given textInfo is visible on screen.
 		"""
-		obj=info.NVDAObjectAtStart
+		obj = info.NVDAObjectAtStart
 		if not obj:
 			log.debugWarning("Invalid NVDAObjectAtStart")
 			return
-		if obj==self.rootNVDAObject:
+		if obj == self.rootNVDAObject:
 			return
 		obj.scrollIntoView()
 		if self.programmaticScrollMayFireEvent:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,6 +40,7 @@ If you need this functionality please assign a gesture to the appropriate script
  -
 - If a disabled addon is uninstalled and then re-installed it is re-enabled. (#12792)
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
+- Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #9611
Replaces pr #12803 

### Summary of the issue:
When reading / navigating with browse mode in Microsoft Word via UI Automation, the document does not always scroll so that the current browse mode position is visible on screen, nor does the focus mode caret position stay in sync with the browse mode caret, especially when moving across pages in browse mode.
Browse mode currently only knows how to scroll to objects in the document, not specific text range positions. Thus, it is only able to scroll to lists, tables and graphics, and not any arbitrary text.
Also, setting the caret in Microsoft Word to a range that is on a page that is currently off screen seems to fail and or set the caret to a random point on the current page.

### Description of how this pull request fixes the issue:
* `browseMode.BrowseModeDocument`: abstract the scrolling code out of `_set_selection` into its own `scrollToPosition` method on `BrowseModeDocument`.
* BrowseModeDocument for MS Word with UIA: override scrollToPosition to just call IUIAutomationTextRange::ScrollIntoView. This ensures that the specific text range for the given TextInfo is visible on screen, rather than scrolling to the deepest object (which is only tables and lists in MS Word, so was not always accurate).

### Testing strategy:
* Requires testing by a sighted person with steps from #9611 

### Known issues with pull request:
This specifically addresses browse mode scrolling issues in MS Word with UIA enabled as these scrolling issues were also affecting syncing of the focus mode caret with the browse mode caret. But there remains scrolling issues in other apps, which have always existed. Pr #9919  goes much further in addressing all of these, but is rather complex and requires a lot more review and testing. This particular pr is much smaller and stays specific to what we need to unblock enabling UIA by default in MS Word.
 

### Change log entries:
Bug fixes:
* Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
