### PR TITLE
Remove usages of deprecated characterProcessing.SYMLVL_ constants and controlTypes helper functions

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -218,7 +218,7 @@ def handleInputCompositionEnd(result):
 	if curInputComposition and not result:
 		result=curInputComposition.compositionString.lstrip(u'\u3000 ')
 	if result:
-		speech.speakText(result,symbolLevel=characterProcessing.SYMLVL_ALL)
+		speech.speakText(result, symbolLevel=characterProcessing.SymbolLevel.ALL)
 
 def handleInputCompositionStart(compositionString,selectionStart,selectionEnd,isReading):
 	import speech

--- a/source/NVDAObjects/inputComposition.py
+++ b/source/NVDAObjects/inputComposition.py
@@ -72,7 +72,12 @@ class InputComposition(EditableTextWithAutoSelectDetection,Window):
 		if (config.conf["keyboard"]["speakTypedCharacters"] or config.conf["keyboard"]["speakTypedWords"]):
 			newText=calculateInsertedChars(oldString.strip(u'\u3000'),newString.strip(u'\u3000'))
 			if newText:
-				queueHandler.queueFunction(queueHandler.eventQueue,speech.speakText,newText,symbolLevel=characterProcessing.SYMLVL_ALL)
+				queueHandler.queueFunction(
+					queueHandler.eventQueue,
+					speech.speakText,
+					newText,
+					symbolLevel=characterProcessing.SymbolLevel.ALL
+				)
 
 	def compositionUpdate(self,compositionString,selectionStart,selectionEnd,isReading,announce=True):
 		if isReading and not config.conf["inputComposition"]["reportReadingStringChanges"]: return

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -913,7 +913,7 @@ class GlobalCommands(ScriptableObject):
 			if level > curLevel:
 				break
 		else:
-			level = characterProcessing.SYMLVL_NONE
+			level = characterProcessing.SymbolLevel.NONE
 		name = characterProcessing.SPEECH_SYMBOL_LEVEL_LABELS[level]
 		config.conf["speech"]["symbolLevel"] = level.value
 		# Translators: Reported when the user cycles through speech symbol levels

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4394,7 +4394,7 @@ class SpeechSymbolsDialog(SettingsDialog):
 			pass
 		addedSymbol.displayName = identifier
 		addedSymbol.replacement = ""
-		addedSymbol.level = characterProcessing.SYMLVL_ALL
+		addedSymbol.level = characterProcessing.SymbolLevel.ALL
 		addedSymbol.preserve = characterProcessing.SYMPRES_NEVER
 		self.symbols.append(addedSymbol)
 		self.symbolsList.ItemCount = len(self.symbols)

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -553,7 +553,7 @@ class InputManager(baseObject.AutoPropertyObject):
 		speech.speakText(
 			textList[0],
 			reason=controlTypes.OutputReason.MESSAGE,
-			symbolLevel=characterProcessing.SYMLVL_ALL
+			symbolLevel=characterProcessing.SymbolLevel.ALL
 		)
 		for text in textList[1:]:
 			speech.speakMessage(text)

--- a/tests/unit/test_characterProcessing.py
+++ b/tests/unit/test_characterProcessing.py
@@ -9,7 +9,7 @@
 import unittest
 import re
 from characterProcessing import SpeechSymbolProcessor
-from characterProcessing import SYMLVL_ALL
+from characterProcessing import SymbolLevel
 from characterProcessing import processSpeechSymbols as process
 
 
@@ -124,7 +124,7 @@ class TestComplex(unittest.TestCase):
 	def test_engine(self):
 		"""Test inclusion of group replacement in engine
 		"""
-		replaced = process("fr_FR", "Le 03.04.05.", SYMLVL_ALL)
+		replaced = process("fr_FR", "Le 03.04.05.", SymbolLevel.ALL)
 		self.assertEqual(replaced, "Le  03 point 04 point 05  point.")
-		replaced = process("fr_FR", "Le 03/04/05.", SYMLVL_ALL)
+		replaced = process("fr_FR", "Le 03/04/05.", SymbolLevel.ALL)
 		self.assertEqual(replaced, "Le  03 barre oblique 04 barre oblique 05  point.")

--- a/tests/unit/test_controlTypes.py
+++ b/tests/unit/test_controlTypes.py
@@ -10,6 +10,7 @@ import unittest
 import controlTypes
 import versionInfo
 from . import PlaceholderNVDAObject
+from controlTypes.processAndLabelStates import _processNegativeStates, _processPositiveStates
 
 
 class TestLabels(unittest.TestCase):
@@ -53,7 +54,7 @@ class TestProcessStates(unittest.TestCase):
 
 	def test_positiveStates(self):
 		self.assertSetEqual(
-			controlTypes.processPositiveStates(
+			_processPositiveStates(
 				self.obj.role,
 				self.obj.states,
 				controlTypes.OutputReason.FOCUS,
@@ -64,7 +65,7 @@ class TestProcessStates(unittest.TestCase):
 
 	def test_negativeStates(self):
 		self.assertSetEqual(
-			controlTypes.processNegativeStates(
+			_processNegativeStates(
 				self.obj.role,
 				self.obj.states,
 				controlTypes.OutputReason.FOCUS,


### PR DESCRIPTION
### Link to issue number:

Closes #12549 

### Summary of the issue:

characterProcessing.SYMLVL_* constants should be replaced using their equivalent SymbolLevel.* before 2022.1.
Unit testing for controlTypes helper functions needed updating for soon to be removed `processNegativeStates` and  `processPositiveStates` .

### Description of how this pull request fixes the issue:
Update the usages of these constants and helper functions

### Testing strategy:

Search the repo for `2022`  usages and noted deprecations in changes for developers.
Ensure all code deprecated for removal in 2022.1 is not used in the codebase.

It seems like all deprecated code is removed from NVDA after this PR.
When we implement the removals we will still need to check that new usages haven't been introduced.

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
