### PR TITLE
Improve variable naming and remove exception handling when setting language in core.main

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -245,16 +245,16 @@ def getWxLangOrNone() -> Optional['wx.LanguageInfo']:
 	import languageHandler
 	import wx
 	lang = languageHandler.getLanguage()
-	locale = wx.Locale()
-	wxLang = locale.FindLanguageInfo(lang)
+	wxLocaleObj = wx.Locale()
+	wxLang = wxLocaleObj.FindLanguageInfo(lang)
 	if not wxLang and '_' in lang:
-		wxLang = locale.FindLanguageInfo(lang.split('_')[0])
+		wxLang = wxLocaleObj.FindLanguageInfo(lang.split('_')[0])
 	# #8064: Wx might know the language, but may not actually contain a translation database for that language.
 	# If we try to initialize this language, wx will show a warning dialog.
 	# #9089: some languages (such as Aragonese) do not have language info, causing language getter to fail.
 	# In this case, wxLang is already set to None.
 	# Therefore treat these situations like wx not knowing the language at all.
-	if wxLang and not locale.IsAvailable(wxLang.Language):
+	if wxLang and not wxLocaleObj.IsAvailable(wxLang.Language):
 		wxLang = None
 	if not wxLang:
 		log.debugWarning("wx does not support language %s" % lang)
@@ -413,13 +413,10 @@ def main():
 		except:
 			pass
 	logHandler.setLogLevelFromConfig()
-	try:
-		lang = config.conf["general"]["language"]
-		import languageHandler
-		log.debug("setting language to %s"%lang)
-		languageHandler.setLanguage(lang)
-	except:
-		log.warning("Could not set language to %s"%lang)
+	lang = config.conf["general"]["language"]
+	import languageHandler
+	log.debug(f"setting language to {lang}")
+	languageHandler.setLanguage(lang)
 	log.info(f"Windows version: {winVersion.getWinVer()}")
 	log.info("Using Python version %s"%sys.version)
 	log.info("Using comtypes version %s"%comtypes.__version__)
@@ -594,13 +591,13 @@ def main():
 	messageWindow = MessageWindow(versionInfo.name)
 
 	# initialize wxpython localization support
-	locale = wx.Locale()
+	wxLocaleObj = wx.Locale()
 	wxLang = getWxLangOrNone()
 	if hasattr(sys,'frozen'):
-		locale.AddCatalogLookupPathPrefix(os.path.join(globalVars.appDir, "locale"))
+		wxLocaleObj.AddCatalogLookupPathPrefix(os.path.join(globalVars.appDir, "locale"))
 	if wxLang:
 		try:
-			locale.Init(wxLang.Language)
+			wxLocaleObj.Init(wxLang.Language)
 		except:
 			log.error("Failed to initialize wx locale",exc_info=True)
 		finally:


### PR DESCRIPTION
### Link to issue number:
Follow up from #12753

### Summary of the issue:
During debugging for PR #12753 some issues in code around setting language in `core.main` become  evident. In particular:
- `wx.Locale` object was called `locale` effectively  shadowing built-in Python module. While normally there is no reason to have `locale` imported in that scope if it is necessary for debugging the name is rather unfortunate.
- `except` around importing `languageHandler` and setting language was too broad hiding eventual issues.
### Description of how this pull request fixes the issue:
- `locale` was renamed to `wxLocaleObj`.
- We're no longer catching any exceptions when importing `languageHandler`  and setting language - if any of these fails  NVDA is non functional and the exception should propagate.
### Testing strategy:
Ensured that NVDA still starts. Existing unit tests making sure that `languageHandler` is importable and that the process of setting language does not raise any exceptions.
### Known issues with pull request:
None known
### Change log entries:
None needed.
### Code Review Checklist:
- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] API is compatible with existing addons.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
