### PR TITLE
Excel with UIA: Silence redundant selected announcement for focused cells

### DIFF
--- a/source/NVDAObjects/UIA/excel.py
+++ b/source/NVDAObjects/UIA/excel.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2021 NV Access Limited
+# Copyright (C) 2018-2021 NV Access Limited, Leonard de Ruijter
 
 from typing import Optional, Tuple
 import UIAHandler
@@ -350,6 +350,14 @@ class ExcelCell(ExcelObject):
 
 	def _get_states(self):
 		states = super().states
+		if controlTypes.State.FOCUSED in states and self.selectionContainer.getSelectedItemsCount() == 0:
+			# #12530: In some versions of Excel, the selection pattern reports 0 selected items,
+			# even though the focused UIA element reports as selected.
+			# NVDA only silences the positive SELECTED state when one item is selected.
+			# Therefore, by discarding both the SELECTED and SELECTABLE states,
+			# we eliminate the redundant selection announcement.
+			states.discard(controlTypes.State.SELECTED)
+			states.discard(controlTypes.State.SELECTABLE)
 		if self._isContentTooLargeForCell:
 			if not self._nextCellHasContent:
 				states.add(controlTypes.State.OVERFLOWING)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,6 +40,7 @@ If you need this functionality please assign a gesture to the appropriate script
  -
 - If a disabled addon is uninstalled and then re-installed it is re-enabled. (#12792)
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
+- When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA no longer redundantly announces when a single cell is selected. (#12530)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #12530

### Summary of the issue:
With UIA enabled for MS Excel, NVDA redundantly announces selected for every selected cell in Excel when it receives focus

### Description of how this pull request fixes the issue:
In at least some versions of Excel, the selection pattern reports 0 selected items, even though the focused UIA element reports as selected. NVDA only silences the positive SELECTED state when one item is selected. Therefore, by discarding both the SELECTED and SELECTABLE states, we eliminate the redundant selection announcement.

### Testing strategy:
Tested str from #12530 

### Known issues with pull request:
None known

### Change log entries:
Bug fixes
- When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA no longer redundantly announces when a single cell is selected. (#12259 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [ ] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
