### PR TITLE
Fix-up of PR 12801 - use enums in controlTypes replacing old constants 

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -89,7 +89,7 @@ class Dialog(NVDAObject):
 				continue
 			#For particular objects, we want to descend in to them and get their children's message text
 			if childRole in (
-				controlTypes.ROLE_OPTIONPANE,
+				controlTypes.Role.OPTIONPANE,
 				controlTypes.Role.PROPERTYPAGE,
 				controlTypes.Role.PANE,
 				controlTypes.Role.PANEL,


### PR DESCRIPTION
### Link to issue number:
Fix-up of #12801

### Summary of the issue:
PR #12801  introduced usage of a deprecated constant from `controlTypes`.
### Description of how this pull request fixes the issue:
Replaced constant usage with an enum member.
### Testing strategy:
None as such.
### Known issues with pull request:
None known
### Change log entries:
None needed
### Code Review Checklist:

- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] API is compatible with existing addons.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
