### PR TITLE
Ensure that NVDA no longer checks validity of input for non contracted braille tables when in text controls

### DIFF
--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -1,9 +1,7 @@
-# -*- coding: UTF-8 -*-
-# brailleInput.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2019 NV Access Limited, Rui Batista, Babbage B.V.
+# Copyright (C) 2012-2021 NV Access Limited, Rui Batista, Babbage B.V.
 
 import os.path
 import time
@@ -253,7 +251,7 @@ class BrailleInputHandler(AutoPropertyObject):
 			if self._translate(endWord):
 				if not endWord:
 					self.cellsWithText.add(pos)
-			elif self.bufferText and not self.useContractedForCurrentFocus:
+			elif self.bufferText and not self.useContractedForCurrentFocus and self._table.contracted:
 				# Translators: Reported when translation didn't succeed due to unsupported input.
 				speech.speakMessage(_("Unsupported input"))
 				self.flushBuffer()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - A rare error when changing audio devices has been fixed. (#12620)
 - Routing keys on Braille displays supported by the HID Braille driver are no longer reversed. (#12860)
 - Ensure the Windows 11 system tray calendar reports the day of the week in full. (#12757)
+- Input with literary braille tables should behave more reliably when in edit fields. (#12667)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #12667

### Summary of the issue:
When entering text from a braille display NVDA reports that it is unsupported even though entered combination is valid. This check has been introduced in #7843 to prevent a situation in which someone uses contracted table outside text content and enters a combination which cannot be converted to a  single character (a good example is entering dots 356 using English UK Grade 2 which is a contraction for "was"). The check however was too broad and didn't take into account that for literary / computer braille tables single  combination of dots can either always be converted to a single character, or if not it does not result in multiple characters i.e.  number sign.
### Description of how this pull request fixes the issue:
Now the check applies only when the table in use is contracted.
### Testing strategy:
- With English UK Grade 2 entered dots 356 in the text editor - ensured that after pressing space dots are translated to was.
- Repeated this test in the web browser - made sure that NVDA reports unsupported input.
- With the same table as above entered dots 125 - ensured that in the text editor the combination was back-translated to 'have' whereas in the web browser NVDA navigated to the next heading.
- Repeated tests from #12667 - made sure that no 'unsupported input' was reported
- With Polish Grade 1 table entered dots 3456-12-46-1 - ensured that this  combination was properly back-translated to 2A
- Got confirmation on #12667 from @Futyn-Maker that the issue is fixed for them.

### Known issues with pull request:
- `brailleInput` is in dire need of unit tests so that future work in this area is safer - I've created #12869 to track this
- According to @aaclause  there are some problems with input for literary tables - they haven't provided more details as of yet other than the fact that problem has not been introduced by this pr.

### Change log entries:
Bug fixes
- Input with literary braille tables should behave more reliably when in edit fields.

### Code Review Checklist:


- [X] Pull Request description is up to date.
- [X] Unit tests.
- [X] System (end to end) tests.
- [X] Manual testing.
- [X] API is compatible with existing addons.
- [X] User Documentation.
- [X] Change log entry.
- [X] Context sensitive help for GUI changes.
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
