### PR TITLE
MS Word with UIA: ensure document is appropriately scrolled when programmatically setting the caret

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -118,6 +118,28 @@ class CommentUIATextInfoQuickNavItem(TextAttribUIATextInfoQuickNavItem):
 
 class WordDocumentTextInfo(UIATextInfo):
 
+	def _ensureRangeVisibility(self):
+		try:
+			inView = self.pointAtStart in self.obj.location
+		except LookupError:
+			inView = False
+		if not inView:
+			self._rangeObj.ScrollIntoView(True)
+
+	def updateSelection(self):
+		# #9611: The document must be scrolled so that the range is visible on screen
+		# Otherwise trying to set the selection to the range
+		# may cause the selection to remain on the wrong page.
+		self._ensureRangeVisibility()
+		super().updateSelection()
+
+	def updateCaret(self):
+		# #9611: The document must be scrolled so that the range is visible on screen
+		# Otherwise trying to set the caret to the range
+		# may cause the caret to remain on the wrong page.
+		self._ensureRangeVisibility()
+		super().updateCaret()
+
 	def _get_locationText(self):
 		point = self.pointAtStart
 		# UIA has no good way yet to convert coordinates into user-configured distances such as inches or centimetres.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,8 +42,8 @@ If you need this functionality please assign a gesture to the appropriate script
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA no longer redundantly announces when a single cell is selected. (#12530)
 - More dialog text is automatically read in LibreOffice Writer, such as in confirmation dialogs. (#11687)
-- Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)
-- when performing Say all in Microsoft Word via UI automation, the document is now automatically scrolled, and the caret position is correctly updated. (#9611)
+- Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that the current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)
+- When performing Say all in Microsoft Word via UI automation, the document is now automatically scrolled, and the caret position is correctly updated. (#9611)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,6 +42,8 @@ If you need this functionality please assign a gesture to the appropriate script
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA no longer redundantly announces when a single cell is selected. (#12530)
 - More dialog text is automatically read in LibreOffice Writer, such as in confirmation dialogs. (#11687)
+- Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. (#9611)
+- when performing Say all in Microsoft Word via UI automation, the document is now automatically scrolled, and the caret position is correctly updated. (#9611)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #9611
Replaces #12829 

### Summary of the issue:
In Microsoft Word with UIA enabled, the caret may fail to move to the right position when updated programmatically, if the new position is currently off-screen.
Specifically:
* When performing say all and reading past the current page, the document does not scroll and the caret ends up at a random position on the current page.
* In Browse mode, performing a say all, navigating with quick nav, or just moving the arrow keys such that the browse mode cursor moves off the current page, the real (focus mode) caret ends up at a random position on the current page.

### Description of how this pull request fixes the issue:
WordDocumentTextInfo's `updateCaret` and `updateSelection` methods now ensure that the document is currently scrolled such that the text range is visible on screen.

### Testing strategy:
@Qchristensen  has confirmed that issue #9611 has been fixed by testing say all in focus mode, and say all, quick nav and arrow keys in browse mode.

### Known issues with pull request:
This specifically addresses browse mode scrolling issues in MS Word with UIA enabled as these scrolling issues were also affecting syncing of the focus mode caret with the browse mode caret. But there remains scrolling issues in other apps, which have always existed. Pr #9919 goes much further in addressing all of these, but is rather complex and requires a lot more review and testing. This particular pr is much smaller and stays specific to what we need to unblock enabling UIA by default in MS Word.

### Change log entries:
Bug fixes:
* Reading / navigating with browse mode in Microsoft Word via UI automation now ensures the document is always scrolled so that current browse mode position is visible, and that the caret position in focus mode correctly reflects the browse mode position. 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [x] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
