### PR TITLE
Ensure office app check is bound to window class

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -746,53 +746,51 @@ class UIAHandler(COMObject):
 		# Ask the window if it supports UIA natively
 		res=windll.UIAutomationCore.UiaHasServerSideProvider(hwnd)
 		if res:
-			# The window does support UIA natively, but MS Word documents now
-			# have a fairly usable UI Automation implementation.
-			# However, builds of MS Office 2016 before build 13901 or so had bugs which
-			# we cannot work around.
-			# Therefore for less recent versions of Office,
-			# if we can inject in-process, refuse to use UIA and instead
-			# fall back to the MS Word object model.
-			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
-			isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
-			if (
-				# An MS Word document window
-				windowClass == "_WwG"
-				and (
-					winVersion.getWinVer() < winVersion.WIN10
-					or (
-						# An MS Office app before build 13901
-						isOfficeApp
-						and (
-							tuple(int(x) for x in appModule.productVersion.split('.')[:3])
-							< (16, 0, 13901)
+			# The window does support UIA natively.
+			if windowClass == "_WwG":
+				# MS Word documents now have a fairly usable UI Automation implementation.
+				# However, builds of MS Office 2016 before build 13901 or so had bugs which
+				# we cannot work around.
+				# Therefore for less recent versions of Office,
+				# if we can inject in-process, refuse to use UIA and instead
+				# fall back to the MS Word object model.
+				canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
+				isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
+				if (
+					(
+						winVersion.getWinVer() < winVersion.WIN10
+						or (
+							# An MS Office app before build 13901
+							isOfficeApp
+							and (
+								tuple(int(x) for x in appModule.productVersion.split('.')[:3])
+								< (16, 0, 13901)
+							)
 						)
 					)
-				)
-				# Disabling is only useful if we can inject in-process (and use our older code)
-				and canUseOlderInProcessApproach
-				# Allow the user to still explicitly force UIA support
-				# no matter the Office version
-				and not config.conf['UIA']['useInMSWordWhenAvailable']
-			):
-				return False
-			# MS Excel spreadsheets now have a fairly usable UI Automation implementation.
-			# However, builds of MS Office 2016 before build 9000 or so had bugs which we
-			# cannot work around.
-			# And even current builds of Office 2016 are still missing enough info from UIA
-			# that it is still impossible to switch to UIA completely.
-			# Therefore, if we can inject in-process, refuse to use UIA and instead fall
-			# back to the MS Excel object model.
-			elif (
-				# An MS Excel spreadsheet window
-				windowClass == "EXCEL7"
-				# Disabling is only useful if we can inject in-process (and use our older code)
-				and appModule.helperLocalBindingHandle
-				# Allow the user to explicitly force UIA support for MS Excel spreadsheets
-				# no matter the Office version
-				and not config.conf['UIA']['useInMSExcelWhenAvailable']
-			):
-				return False
+					# Disabling is only useful if we can inject in-process (and use our older code)
+					and canUseOlderInProcessApproach
+					# Allow the user to still explicitly force UIA support
+					# no matter the Office version
+					and not config.conf['UIA']['useInMSWordWhenAvailable']
+				):
+					return False
+			elif windowClass == "EXCEL7":
+				# MS Excel spreadsheets now have a fairly usable UI Automation implementation.
+				# However, builds of MS Office 2016 before build 9000 or so had bugs which we
+				# cannot work around.
+				# And even current builds of Office 2016 are still missing enough info from UIA
+				# that it is still impossible to switch to UIA completely.
+				# Therefore, if we can inject in-process, refuse to use UIA and instead fall
+				# back to the MS Excel object model.
+				if (				
+					# Disabling is only useful if we can inject in-process (and use our older code)
+					appModule.helperLocalBindingHandle
+					# Allow the user to explicitly force UIA support for MS Excel spreadsheets
+					# no matter the Office version
+					and not config.conf['UIA']['useInMSExcelWhenAvailable']
+				):
+					return False
 			# Unless explicitly allowed, all Chromium implementations (including Edge) should not be UIA,
 			# As their IA2 implementation is still better at the moment.
 			elif (
@@ -807,7 +805,7 @@ class UIAHandler(COMObject):
 				)
 			):
 				return False
-			if windowClass == "ConsoleWindowClass":
+			elif windowClass == "ConsoleWindowClass":
 				return UIAUtils._shouldUseUIAConsole(hwnd)
 		return bool(res)
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -747,13 +747,14 @@ class UIAHandler(COMObject):
 		res=windll.UIAutomationCore.UiaHasServerSideProvider(hwnd)
 		if res:
 			# The window does support UIA natively.
+
+			# MS Word documents now have a fairly usable UI Automation implementation.
+			# However, builds of MS Office 2016 before build 13901 or so had bugs which
+			# we cannot work around.
+			# Therefore for less recent versions of Office,
+			# if we can inject in-process, refuse to use UIA and instead
+			# fall back to the MS Word object model.
 			if windowClass == "_WwG":
-				# MS Word documents now have a fairly usable UI Automation implementation.
-				# However, builds of MS Office 2016 before build 13901 or so had bugs which
-				# we cannot work around.
-				# Therefore for less recent versions of Office,
-				# if we can inject in-process, refuse to use UIA and instead
-				# fall back to the MS Word object model.
 				canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 				isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
 				if (
@@ -775,22 +776,23 @@ class UIAHandler(COMObject):
 					and not config.conf['UIA']['useInMSWordWhenAvailable']
 				):
 					return False
-			elif windowClass == "EXCEL7":
-				# MS Excel spreadsheets now have a fairly usable UI Automation implementation.
-				# However, builds of MS Office 2016 before build 9000 or so had bugs which we
-				# cannot work around.
-				# And even current builds of Office 2016 are still missing enough info from UIA
-				# that it is still impossible to switch to UIA completely.
-				# Therefore, if we can inject in-process, refuse to use UIA and instead fall
-				# back to the MS Excel object model.
-				if (				
-					# Disabling is only useful if we can inject in-process (and use our older code)
-					appModule.helperLocalBindingHandle
-					# Allow the user to explicitly force UIA support for MS Excel spreadsheets
-					# no matter the Office version
-					and not config.conf['UIA']['useInMSExcelWhenAvailable']
-				):
-					return False
+			# MS Excel spreadsheets now have a fairly usable UI Automation implementation.
+			# However, builds of MS Office 2016 before build 9000 or so had bugs which we
+			# cannot work around.
+			# And even current builds of Office 2016 are still missing enough info from UIA
+			# that it is still impossible to switch to UIA completely.
+			# Therefore, if we can inject in-process, refuse to use UIA and instead fall
+			# back to the MS Excel object model.
+			elif (
+				# An MS Excel spreadsheet window
+				windowClass == "EXCEL7"
+				# Disabling is only useful if we can inject in-process (and use our older code)
+				and appModule.helperLocalBindingHandle
+				# Allow the user to explicitly force UIA support for MS Excel spreadsheets
+				# no matter the Office version
+				and not config.conf['UIA']['useInMSExcelWhenAvailable']
+			):
+				return False
 			# Unless explicitly allowed, all Chromium implementations (including Edge) should not be UIA,
 			# As their IA2 implementation is still better at the moment.
 			elif (

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -756,7 +756,9 @@ class UIAHandler(COMObject):
 			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 			isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
 			if (
-				(
+				# An MS Word document window
+				windowClass == "_WwG"
+				and (
 					winVersion.getWinVer() < winVersion.WIN10
 					or (
 						# An MS Office app before build 13901
@@ -767,8 +769,6 @@ class UIAHandler(COMObject):
 						)
 					)
 				)
-				# An MS Word document window
-				and windowClass == "_WwG"
 				# Disabling is only useful if we can inject in-process (and use our older code)
 				and canUseOlderInProcessApproach
 				# Allow the user to still explicitly force UIA support


### PR DESCRIPTION
### Link to issue number:
Fixes #12852

### Summary of the issue:
Secure desktops were severly broken in Alpha.

### Description of how this pull request fixes the issue:
First check for the proper window class before applying logic to detect office apps and versions.

### Testing strategy:
T.B.D. I think we need a signed build for this.

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description is up to date.
- [x] Unit tests.
- [x] System (end to end) tests.
- [ ] Manual testing.
- [x] API is compatible with existing addons.
- [x] User Documentation.
- [x] Change log entry.
- [x] Context sensitive help for GUI changes.
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
