### PR TITLE
Revert "Suppress reporting of tables when reading emails in Outlook using UIA"

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -199,14 +199,6 @@ class WordDocumentTextInfo(UIATextInfo):
 				or field.pop('name', None)
 				or obj.name
 			)
-		# #11430: Read-only tables, such as in the Outlook message viewer
-		# should be treated as layout tables.
-		if (
-			obj.appModule.appName == 'outlook'
-			and obj.role == controlTypes.Role.TABLE
-			and controlTypes.State.READONLY in obj.states
-		):
-			field['table-layout'] = True
 		return field
 
 	def _getTextFromUIARange(self, textRange):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -37,9 +37,6 @@ If you need this functionality please assign a gesture to the appropriate script
 - NVDA no longer treats the value of UIA sliders as always percentage based.
 - Reporting the location of a cell in Microsoft Excel when accessed via UI Automation again works correctly on Windows 11. (#12782)
 - NVDA no longer sets invalid Python locales. (#12753)
-- When reading emails in Outlook  via UI Automation, reporting of tables is now suppressed by default. (#11430)
- - If the user needs to temporarily have tables reported when reading an email, the Include Layout Tables option in Browse Mode settings can be turned on.
- -
 - If a disabled addon is uninstalled and then re-installed it is re-enabled. (#12792)
 - Fixed bugs around updating and removing addons where the addon folder has been renamed or has files opened. (#12792, #12629)
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA no longer redundantly announces when a single cell is selected. (#12530)


### PR DESCRIPTION
Reverts nvaccess/nvda#12820
In issue #12853 people seem to prefer the 1 row or 1 column approach.

