### PR TITLE
Fix UnboundLocalError in _isUIAWindowHelper

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -747,6 +747,8 @@ class UIAHandler(COMObject):
 		res=windll.UIAutomationCore.UiaHasServerSideProvider(hwnd)
 		if res:
 			# The window does support UIA natively.
+			# Detect if we can also inject in-process
+			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 
 			# MS Word documents now have a fairly usable UI Automation implementation.
 			# However, builds of MS Office 2016 before build 13901 or so had bugs which
@@ -755,7 +757,6 @@ class UIAHandler(COMObject):
 			# if we can inject in-process, refuse to use UIA and instead
 			# fall back to the MS Word object model.
 			if windowClass == "_WwG":
-				canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 				isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
 				if (
 					(


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fix-up of #12854.

### Summary of the issue:
In #12854 the `CanUseOlderInProcessApproach` check was moved to run only when checking Office windows. However, it is also used to check whether to use UIA in Chromium.

### Description of how this pull request fixes the issue:
Move this check before all usages, restoring the ability to use UIA in Chromium.

### Testing strategy:
Verified the functionality of UIA Word and Edgium.

### Known issues with pull request:
None.

### Change log entries:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
