### PR TITLE
stop HID Braille routing keys from being back to front

### DIFF
--- a/source/brailleDisplayDrivers/hid.py
+++ b/source/brailleDisplayDrivers/hid.py
@@ -128,7 +128,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		capsByDataIndex = {}
 		relativeIndexInCollection = 0
 		lastLinkCollection = None
-		for buttonCaps in self._dev.inputButtonCaps:
+		# Walk through all the available input buttons
+		# storing them in a dictionary, keyed by their data index.
+		# Also store the index of each button, relative to the collection it is a part of,
+		# As this relative index is used as the routing index for routing keys.
+		# We must however walk through the input buttons in reverse order
+		# as windows loads the input caps arrays in reverse,
+		# See https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/button-capability-arrays
+		for buttonCaps in reversed(self._dev.inputButtonCaps):
 			if buttonCaps.LinkCollection != lastLinkCollection:
 				lastLinkCollection = buttonCaps.LinkCollection
 				relativeIndexInCollection = 0
@@ -261,7 +268,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 				usagePage == HID_USAGE_PAGE_BRAILLE
 				and usageID == BraillePageUsageID.ROUTER_KEY
 			):
-				self.routingIndex = buttonCapsInfo.relativeIndexInCollection + 1
+				self.routingIndex = buttonCapsInfo.relativeIndexInCollection
 				# Prefix the gesture name with the specific routing collection name (E.g. routerSet1)
 				namePrefix = self._usageIDToGestureName(linkUsagePage, linkUsageID)
 		name = self._usageIDToGestureName(usagePage, usageID)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -48,6 +48,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - When performing Say all in Microsoft Word via UI automation, the document is now automatically scrolled, and the caret position is correctly updated. (#9611)
 - When reading emails in Outlook and NVDA is accessing the message with UI Automation, certain tables are now marked as layout tables, which means they will no longer be reported by default. (#11430)
 - A rare error when changing audio devices has been fixed. (#12620)
+- Routing keys on Braille displays supported by the HID Braille driver are no longer reversed. (#12860)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes routing key bug mentioned by @FelixGruetzmacher in pr #12523 
 
### Summary of the issue:
When testing with multiple HID braille displays, it has been found that NVDA's handling of routing keys seems to be reversed, and also offset by 1.
the offset by 1 issue is just an incorrect assumption by me -- NVDA's routing key routing indexes start at 0, not 1.
However, the reverse order of the keys is due to the fact that Windows apparently loads its HID input button caps arrays in reverse order. This fact is mentioned in the Microsoft Docs article at https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/button-capability-arrays

### Description of how this pull request fixes the issue:
In the HID braille driver:
* Stop adding 1 to the routing index
* Walk through the input button caps array in reverse order. This then means that the calculated relative index of a button in its collection will now be relative from the start of the collection, rather than the end which is what we want.

### Testing strategy:
On an Orbit Reader 40 set to HID Braille mode: pressed various routing keys to ensure the cursor moved to the cell directly under that routing key.

### Known issues with pull request:
None known.

### Change log entries:
Bug fixes
* Routing keys on Braille displays using the HID Braille protocol are no longer reversed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
