### PR TITLE
Ensure the Windows 11 system tray calendar reports the day of the week in full

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1652,7 +1652,8 @@ class UIA(Window):
 			windowHandle=self.windowHandle,
 			UIAElement=element.buildUpdatedCache(UIAHandler.handler.baseCacheRequest)
 		)
-		if not obj: return None
+		if not obj:
+			return None
 		return obj.makeTextInfo(textInfos.POSITION_ALL).text
 
 	def _get_rowHeaderText(self):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1270,6 +1270,14 @@ class UIA(Window):
 		)
 		return self.UIATextPattern
 
+	def _get_UIATableItemPattern(self):
+		self.UIATableItemPattern = self._getUIAPattern(
+			UIAHandler.UIA_TableItemPatternId,
+			UIAHandler.IUIAutomationTableItemPattern,
+			cache=False
+		)
+		return self.UIATableItemPattern
+
 	def _get_UIATextEditPattern(self):
 		if not isinstance(UIAHandler.handler.clientObject,UIAHandler.IUIAutomation3):
 			return None
@@ -1639,6 +1647,14 @@ class UIA(Window):
 			return val
 		return 1
 
+	def _getTextFromHeaderElement(self, element: UIAHandler.IUIAutomationElement) -> typing.Optional[str]:
+		obj = UIA(
+			windowHandle=self.windowHandle,
+			UIAElement=element.buildUpdatedCache(UIAHandler.handler.baseCacheRequest)
+		)
+		if not obj: return None
+		return obj.makeTextInfo(textInfos.POSITION_ALL).text
+
 	def _get_rowHeaderText(self):
 		val=self._getUIACacheablePropertyValue(UIAHandler.UIA_TableItemRowHeaderItemsPropertyId ,True)
 		if val==UIAHandler.handler.reservedNotSupportedValue:
@@ -1649,9 +1665,9 @@ class UIA(Window):
 			e=val.getElement(i)
 			if UIAHandler.handler.clientObject.compareElements(e,self.UIAElement):
 				continue
-			obj=UIA(windowHandle=self.windowHandle,UIAElement=e.buildUpdatedCache(UIAHandler.handler.baseCacheRequest))
-			if not obj: continue
-			text=obj.makeTextInfo(textInfos.POSITION_ALL).text
+			text = self._getTextFromHeaderElement(e)
+			if not text:
+				continue
 			textList.append(text)
 		return " ".join(textList)
 
@@ -1677,9 +1693,9 @@ class UIA(Window):
 			e=val.getElement(i)
 			if UIAHandler.handler.clientObject.compareElements(e,self.UIAElement):
 				continue
-			obj=UIA(windowHandle=self.windowHandle,UIAElement=e.buildUpdatedCache(UIAHandler.handler.baseCacheRequest))
-			if not obj: continue
-			text=obj.makeTextInfo(textInfos.POSITION_ALL).text
+			text = self._getTextFromHeaderElement(e)
+			if not text:
+				continue
 			textList.append(text)
 		return " ".join(textList)
 

--- a/source/appModules/shellexperiencehost.py
+++ b/source/appModules/shellexperiencehost.py
@@ -7,14 +7,22 @@
 Shell Experience Host is home to a number of things, including Action Center and other shell features.
 """
 
+from typing import Optional
+
 import appModuleHandler
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
 from NVDAObjects.UIA import UIA
+from UIAHandler import IUIAutomationElement, UIA_NamePropertyId
 import controlTypes
 import ui
 
-class ActionCenterToggleButton(UIA):
 
+class CalendarViewDayItem(UIA):
+	def _getTextFromHeaderElement(self, element: IUIAutomationElement) -> Optional[str]:
+		return element.GetCurrentPropertyValue(UIA_NamePropertyId)
+
+
+class ActionCenterToggleButton(UIA):
 	# Somehow, item status property repeats when Action Center is opened more than once.
 	_itemStatusMessageCache = None
 
@@ -52,3 +60,9 @@ class AppModule(appModuleHandler.AppModule):
 				pass
 		elif isinstance(obj, UIA) and obj.role == controlTypes.Role.TOGGLEBUTTON and obj.UIAElement.cachedClassName == "ToggleButton":
 			clsList.insert(0, ActionCenterToggleButton)
+		elif (
+			isinstance(obj, UIA)
+			and obj.role == controlTypes.Role.DATAITEM
+			and obj.UIAElement.cachedClassName == "CalendarViewDayItem"
+		):
+			clsList.insert(0, CalendarViewDayItem)

--- a/source/appModules/shellexperiencehost.py
+++ b/source/appModules/shellexperiencehost.py
@@ -19,6 +19,11 @@ import ui
 
 class CalendarViewDayItem(UIA):
 	def _getTextFromHeaderElement(self, element: IUIAutomationElement) -> Optional[str]:
+		# Generally we prefer text content as the header text.
+		# But although this element does expose a UIA text pattern,
+		# The text content is only the 2 character week day abbreviation.
+		# The UIA name property contains the full week day name,
+		# So use that instead.
 		return element.GetCurrentPropertyValue(UIA_NamePropertyId)
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -49,6 +49,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - When reading emails in Outlook and NVDA is accessing the message with UI Automation, certain tables are now marked as layout tables, which means they will no longer be reported by default. (#11430)
 - A rare error when changing audio devices has been fixed. (#12620)
 - Routing keys on Braille displays supported by the HID Braille driver are no longer reversed. (#12860)
+- Ensure the Windows 11 system tray calendar reports the day of the week in full. (#12757)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12757

### Summary of the issue:

While navigating the calendar, NVDA reads days as follows:
`26 data item ‎August‎ ‎2021 row 4 Th column 5` as opposed to `26 data item ‎August‎ ‎2021 row 4 Thursday column 5`.

The abbreviated days of the week, which make up the column headers of the table and aren't focusable, are read.
Instead, the UIA name of the column header should be read.

### Description of how this pull request fixes the issue:

Adds: `UIATableItemPattern`, a small independent change that helped with investigating
Abstracts shared code from `_get_rowHeaderText` and `_get_columnHeaderText` into `_getTextFromHeaderElement`.
Overload `_getTextFromHeaderElement` in `CalendarViewDayItem` to read the correct label.

### Testing strategy:

Manually tested with Win11 using reproduction steps from #12757

### Known issues with pull request:

Further work could be done to parse the date information and localize it, instead of reporting it as a table cell.

### Change log entries:

Bug fixes
```
- Ensure the Windows 11 system tray calendar reports the day of the week in full. (#12757)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
