### PR TITLE
Remove duplicate changelog entry for "always use UIA in Word"

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,7 +19,6 @@ What's New in NVDA
 - Espeak-ng has been updated to 1.51-dev commit ``74068b91bcd578bd7030a7a6cde2085114b79b44``. (#12665)
 - NVDA will default to eSpeak if no installed OneCore voices support the NVDA preferred language. (#10451)
 - If OneCore voices consistently fail to speak, revert to eSpeak as a synthesizer. (#11544)
-- For builds of Microsoft Office 2016/365 greater than 13900, NVDA will now always use UI Automation to access Microsoft Word document controls, no matter whether the user has toggled the `Use UI Automation to access Microsoft word document controls` advanced setting on or off. 
 - When reading status bar with ``NVDA+end``, the review cursor is no longer moved to its location.
 If you need this functionality please assign a gesture to the appropriate script in the Object Navigation category in the Input Gestures dialog. (#8600)
 - When opening a settings dialog which is already open, NVDA sets focus on the existing dialog rather than raise an error. (#5383)


### PR DESCRIPTION
In changes.t2t are two entries about "always use UIA in Word". I want to remove the first one at line 22 without issue number.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None.

### Summary of the issue:

In changes log there are two entries about information, that NVDA will always use UIA.
I removed the first one.

### Description of how this pull request fixes the issue:

Deleted the first line, which talks about always use UIA in Word.

### Testing strategy:

n/a

Deleted via github web interface

### Known issues with pull request:

None, as I know.

### Change log entries:
New features
Changes
Bug fixes
For Developers

Not needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
