### PR TITLE
Scrolling braille in MS Word with a Chinese input method enabled no longer incorrectly jumps back

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -569,7 +569,8 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 	):
 		if isMSAADebugLoggingEnabled():
 			log.debug(
-				f"Directing winEvent to existing focus object {focus}. WinEvent {getWinEventLogInfo(window, objectID, childID)}"
+				f"Directing winEvent to existing focus object {focus}. "
+				f"WinEvent {getWinEventLogInfo(window, objectID, childID)}"
 			)
 		NVDAEvent = (NVDAEvent[0], focus)
 	eventHandler.queueEvent(*NVDAEvent)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -562,7 +562,7 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 		return
 	# if the winEvent is for the object with focus,
 	# Ensure that that the event is send to the existing focus instance,
-	# rather than  a new instance of the object with focus.
+	# rather than a new instance of the object with focus.
 	if (
 		NVDAEvent[1] is not focus
 		and NVDAEvent[1] == focus

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -49,6 +49,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - A rare error when changing audio devices has been fixed. (#12620)
 - Routing keys on Braille displays supported by the HID Braille driver are no longer reversed. (#12860)
 - When navigating the Windows system tray calendar, NVDA now reports the day of the week in full. (#12757)
+- When using a Chinese input method such as Taiwan - Microsoft Quick in Microsoft Word, scrolling the braille display forward and backward no longer incorrectly keeps jumping back to the original caret position. (#12855)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12855

### Summary of the issue:
When in Microsoft Word, and using a Chinese input method such as Taiwan - Microsoft Quick, and NVDA is accessing Microsoft Word via UI Automation, trying to scroll forward through the document with a braille display causes the braille display to keep jumping back to the original caret position.
This is due to the fact that while the Chinese input method is enabled, legacy MSAA caret events are fired on the Word document window. NVDA is not ignoring these, even though NVDA is configured to access Microsoft word with UIA.
 
### Description of how this pull request fixes the issue:
In IAccessibleHandler.processGenericWinEvent: if an MSAA caret event is identified, before we route this onto the focused object, we first check if the focused object is in deed IAccessible (MSAA), and if it is not (E.g. it is UIA) then we drop the event completely.
This pr also improves MSAA debug logging a little by including the winEvent info in the message about the caret being routed to the focus, and also routes generic events for the focus to the existing focus if their event object is not already the existing focus. This really only stops some extra redundant logging.

### Testing strategy:
Opened the test document from #12855 in Microsoft word. Ensured that NVDA was accessing Microsoft Word with UIA (check defInfo in the log viewer). 
Installed the Taiwan - Microsoft Quick input method in Windows language settings.
Switched to the Taiwan - Microsoft quick input method when focused in the word document, by pressing alt+shift 1 or more times until Taiwan - Microsoft Quick is selected.
Press scroll forward on the braille display multiple times, ensuring that the display is showing the correct line and is not jumping back to where the caret was originally positioned.
Also tested that MSAA caret events were still being routed to the focus in an MSAA-based window, such as the Scintilla control in Notepad++. Checked the log viewer with MsAA debug logging enabed to see that the caret events were being routed.
Ensured that generic MSAA events such as stateChange for the focused object are still being routed to the existing focus: Open the NvDA general settings, and tab to one of the checkboxes and press space, ensuring that NVDA reports "checked" if the checkbox was previously unchecked.

### Known issues with pull request:
None known.

### Change log entries:
Bug fixes
* When using a Chinese input method such as Taiwan - Microsoft Quick in Microsoft Word, scrolling the braille display forward and backward no longer incorrectly keeps jumping back to the original caret position. (#12855)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
