### PR TITLE
Empty checkable list: trial not to report checkbox.

### DIFF
--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -89,12 +89,14 @@ class ListCtrlAccessible(wx.Accessible):
 	"""WX Accessible implementation for checkable lists which aren't fully accessible."""
 
 	def GetRole(self, childId):
-		if childId == winUser.CHILDID_SELF:
+		(status, role) = super().GetRole(childId)
+		if childId == winUser.CHILDID_SELF or status != wx.ACC_OK:
 			return super().GetRole(childId)
 		return (wx.ACC_OK, wx.ROLE_SYSTEM_CHECKBUTTON)
 
 	def GetState(self, childId):
-		if childId == winUser.CHILDID_SELF:
+		(status, state) = super().GetState(childId)
+		if childId == winUser.CHILDID_SELF or status != wx.ACC_OK:
 			return super().GetState(childId)
 		states = wx.ACC_STATE_SYSTEM_SELECTABLE | wx.ACC_STATE_SYSTEM_FOCUSABLE
 		if self.Window.IsChecked(childId - 1):
@@ -103,7 +105,7 @@ class ListCtrlAccessible(wx.Accessible):
 			# wx doesn't seem to  have a method to check whether a list item is focused.
 			# Therefore, assume that a selected item is focused,which is the case in single select list boxes.
 			states |= wx.ACC_STATE_SYSTEM_SELECTED | wx.ACC_STATE_SYSTEM_FOCUSED
-		return (wx.ACC_OK, states)
+			return (wx.ACC_OK, states)
 
 
 class CustomCheckListBox(wx.CheckListBox):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

In an an empty gui.nvdaControls.CustomCheckListBox, the focus is reported as checkbox even if there is none.
Also, when reporting the focus after having removed all the items of the checkable list, the following error occurs:
```
IO - inputCore.executeGesture (21:33:29.011) - winInputHook (20908):
Input: kb(desktop):NVDA+tab
ERROR - unhandled exception (21:33:29.033) - MainThread (27252):
Traceback (most recent call last):
  File "gui\nvdaControls.pyc", line 100, in GetState
wx._core.wxAssertionError: C++ assertion ""IsValid(uiIndex)"" failed at ..\..\src\msw\checklst.cpp(275) in wxCheckListBox::IsChecked(): bad wxCheckListBox index
```

To reproduce the issue, use the following global plugin in the scratchpad.
[CustomCheckListBox.py.txt](https://github.com/nvaccess/nvda/files/7239483/CustomCheckListBox.py.txt)

To reproduce the error:
* press NVDA+A
* Tab to the "Supprimer jour" button
* Press 7 times to remove all the items in the first list.
* Press NVDA+Tab to have the current focus reported.

### Description of how this pull request fixes the issue:

For now, this PR is an unsuccessful attempt to fix the issue.
I would have expected that `super().GetRole(childId)` and `super().GetState(childId)` would have been successful in the case where the list contains an item with this index. But this does not seem to be the case and in any case, `wx.ACC_OK` is not returned even when the list contains items. I would be curious to know why.
In any case, I would need to find another way to filter the case where GetRole/GetState is called with a childId > 0 whereas the list is empty.

@leonardder would you accept to review the few lines of this PR since you have worked on this topic? Surely, you could have done the PR yourself. But I thought that trying to fix it myself with your help would allow me to understand how this part of code works. Thanks.

### Testing strategy:

### Known issues with pull request:

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
