### PR TITLE
Don't braille or speak duplicate name / content / description

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -541,7 +541,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 	if(pacc->get_accName(varChild,&name)!=S_OK)
 		name=NULL;
 
-	std::optional<wstring> description{ getAccDescription(pacc, varChild) }; // todo: fix usages to use optional
+	std::optional<wstring> description{ getAccDescription(pacc, varChild) };
 	if (description.has_value()) {
 		parentNode->addAttribute(L"description", description.value());
 	}

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -273,6 +273,15 @@ bool hasAriaHiddenAttribute(const map<wstring,wstring>& IA2AttribsMap){
 	return (IA2AttribsMapIt != IA2AttribsMap.end() && IA2AttribsMapIt->second == L"true");
 }
 
+std::optional<wstring> getAccDescription(IAccessible2* pacc, VARIANT childID) {
+	std::optional<wstring> desc;
+	CComBSTR rawDesc;
+	if (S_OK == pacc->get_accDescription(childID, &rawDesc)) {
+		desc = rawDesc;
+	}
+	return desc;
+}
+
 /**
  * Get the selected item or the first item if no item is selected.
  */
@@ -532,12 +541,9 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 	if(pacc->get_accName(varChild,&name)!=S_OK)
 		name=NULL;
 
-	wstring description;
-	BSTR rawDesc=NULL;
-	if(pacc->get_accDescription(varChild,&rawDesc)==S_OK) {
-		description=rawDesc;
-		parentNode->addAttribute(L"description",description);
-		SysFreeString(rawDesc);
+	std::optional<wstring> description{ getAccDescription(pacc, varChild) }; // todo: fix usages to use optional
+	if (description.has_value()) {
+		parentNode->addAttribute(L"description", description.value());
 	}
 
 	wstring locale;
@@ -793,15 +799,26 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 				// Maintain curNodePaccTable2 for child rendering until any table cells are found.
 				paccTable2 = curNodePaccTable2;
 			}
-			// Add the table summary if one is present and the table is visible.
-			if (isVisible &&
-				(!description.empty() && (tempNode = buffer->addTextFieldNode(parentNode, previousNode, description))) ||
-				// If there is no caption, the summary (if any) is the name.
-				// There is no caption if the label isn't visible.
-				(name && !labelVisible && (tempNode = buffer->addTextFieldNode(parentNode, previousNode, name)))
-			) {
-				if(!locale.empty()) tempNode->addAttribute(L"language",locale);
-				previousNode = tempNode;
+
+			
+			{ // Add the table summary if one is present and the table is visible.
+				VBufStorage_fieldNode_t* summaryTempNode = nullptr;
+				if (isVisible && description.has_value()) {
+					tempNode = summaryTempNode = buffer->addTextFieldNode(parentNode, previousNode, description.value());
+				}
+				else if (
+						// If there is no caption, the summary (if any) is the name.
+						// There is no caption if the label isn't visible.
+						name && !labelVisible
+					) {
+					tempNode = summaryTempNode = buffer->addTextFieldNode(parentNode, previousNode, name);
+				}
+				if (summaryTempNode != nullptr) {
+					if (!locale.empty()) {
+						summaryTempNode->addAttribute(L"language", locale);
+					}
+					previousNode = summaryTempNode;
+				}
 			}
 		}
 	}
@@ -1097,6 +1114,15 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 				}
 			}
 		}
+	}
+
+	//If the description matches the content, notify NVDA to prevent duplicate reporting
+	const bool descriptionIsContent = (
+		description.has_value()
+		&& nodeContentMatchesString(parentNode, description.value())
+	);
+	if (descriptionIsContent){
+		parentNode->addAttribute(L"descriptionIsContent", L"true");
 	}
 
 

--- a/nvdaHelper/vbufBase/utils.cpp
+++ b/nvdaHelper/vbufBase/utils.cpp
@@ -160,3 +160,16 @@ bool nodeHasUsefulContent(VBufStorage_fieldNode_t* node) {
 	}
 	return false;
 }
+
+/*
+Used to prevent duplicate content.
+*/
+bool nodeContentMatchesString(VBufStorage_fieldNode_t* node, const wstring& testStr) {
+	const int length = node->getLength();
+	if (length != testStr.length()) {
+		return false;
+	}
+	wstring content;
+	node->getTextInRange(0, length, content, false);
+	return content == testStr;
+}

--- a/nvdaHelper/vbufBase/utils.h
+++ b/nvdaHelper/vbufBase/utils.h
@@ -60,6 +60,12 @@ void multiValueAttribsStringToMap(const std::wstring &attribsString, multiValueA
  */
 bool nodeHasUsefulContent(VBufStorage_fieldNode_t* node);
 
+/**
+ * Determine whether a buffer node's description is the same as it's content.
+ * This can happen with links that have a title attribute matching the content.
+ */
+bool nodeContentMatchesString(VBufStorage_fieldNode_t* node, const std::wstring& testStr);
+
 inline bool isPrivateCharacter(wchar_t ch) {
 	return (ch>=L'\xe000'&&ch<=L'\xf8ff')||(ch==L'\x200b');
 }

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -696,12 +696,12 @@ def test_preventDuplicateSpeechFromDescription_browse_tab():
 	actualSpeech = _chrome.getSpeechAfterKey('tab')
 	_asserts.strings_match(
 		actualSpeech,
-		"apple  link  apple"
+		"apple  link"
 	)
 	actualSpeech = _chrome.getSpeechAfterKey('tab')
 	_asserts.strings_match(
 		actualSpeech,
-		"banana  link  banana"
+		"banana  link"
 	)
 
 
@@ -728,10 +728,10 @@ def preventDuplicateSpeechFromDescription_focus():
 	actualSpeech = _chrome.getSpeechAfterKey('tab')
 	_asserts.strings_match(
 		actualSpeech,
-		"apple  link  apple"
+		"apple  link"
 	)
 	actualSpeech = _chrome.getSpeechAfterKey('tab')
 	_asserts.strings_match(
 		actualSpeech,
-		"banana  link  banana"
+		"banana  link"
 	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -23,6 +23,12 @@ _chrome: _ChromeLib = _getLib("ChromeLib")
 _asserts: _AssertsLib = _getLib("AssertsLib")
 
 
+#: Double space is used to separate semantics in speech output this typically
+# adds a slight pause to the synthesizer.
+SPEECH_SEP = "  "
+SPEECH_CALL_SEP = '\n'
+
+
 ARIAExamplesDir = os.path.join(
 	_NvdaLib._locations.repoRoot, "include", "w3c-aria-practices", "examples"
 )
@@ -152,7 +158,7 @@ def announce_list_item_when_moving_by_word_or_character():
 	actualSpeech = _chrome.getSpeechAfterKey("rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"\n".join([
+		SPEECH_CALL_SEP.join([
 			"list item  level 1",
 			"b"
 		])
@@ -259,7 +265,7 @@ def test_pr11606():
 	actualSpeech = _chrome.getSpeechAfterKey("rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"\n".join([
+		SPEECH_CALL_SEP.join([
 			"out of link",
 			"space"
 		])
@@ -328,7 +334,7 @@ def test_ariaTreeGrid_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("enter")
 	_asserts.strings_match(
 		actualSpeech,
-		"\n".join([
+		SPEECH_CALL_SEP.join([
 			# focus mode turns on
 			"Focus mode",
 			# Focus enters the ARIA treegrid (table)
@@ -522,7 +528,7 @@ def test_ariaDescription_focusMode():
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
 	_asserts.strings_match(
 		actualSpeech,
-		"  ".join([
+		SPEECH_SEP.join([
 			"User nearby, Aaron",  # annotation
 			"Here is a sentence that is being edited by someone else.",  # span text
 			"Multiple can edit this.",  # bold paragraph text
@@ -534,7 +540,7 @@ def test_ariaDescription_focusMode():
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
 	_asserts.strings_match(
 		actualSpeech,
-		"  ".join([  # two space separator
+		SPEECH_SEP.join([  # two space separator
 			"An element with a role, follow",  # paragraph text
 			"link",  # link role
 			"opens in a new tab",  # link description
@@ -548,7 +554,7 @@ def test_ariaDescription_focusMode():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	_asserts.strings_match(
 		actualSpeech,
-		"  ".join([
+		SPEECH_SEP.join([
 			"Testing the title attribute,",  # paragraph text
 			"link",  # link role
 			"to google's",  # link contents (name)
@@ -575,7 +581,7 @@ def test_ariaDescription_browseMode():
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
 	_asserts.strings_match(
 		actualSpeech,
-		"  ".join([
+		SPEECH_SEP.join([
 			"User nearby, Aaron",  # annotation
 			"Here is a sentence that is being edited by someone else.",  # span text
 			"Multiple can edit this.",  # bold paragraph text
@@ -587,7 +593,7 @@ def test_ariaDescription_browseMode():
 	# reporting aria-description only supported in Chrome canary 92.0.4479.0+
 	_asserts.strings_match(
 		actualSpeech,
-		"  ".join([  # two space separator
+		SPEECH_SEP.join([  # two space separator
 			"An element with a role, follow",  # paragraph text
 			"link",  # link role
 			"opens in a new tab",  # link description
@@ -601,7 +607,7 @@ def test_ariaDescription_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	_asserts.strings_match(
 		actualSpeech,
-		"  ".join([
+		SPEECH_SEP.join([
 			"Testing the title attribute,",  # paragraph text
 			"link",  # link role
 			"to google's",  # link contents (name)
@@ -626,15 +632,15 @@ def test_ariaDescription_sayAll():
 	# - Chrome 92.0.4479.0+
 	_asserts.strings_match(
 		actualSpeech,
-		"\n".join([
+		SPEECH_CALL_SEP.join([
 			"Test page load complete",
 			"edit  multi line  This is a line with no annotation",
-			"  ".join([
+			SPEECH_SEP.join([
 				"User nearby, Aaron",  # annotation
 				"Here is a sentence that is being edited by someone else.",  # span text
 				"Multiple can edit this.",  # bold paragraph text
 			]),
-			"  ".join([  # two space separator
+			SPEECH_SEP.join([  # two space separator
 				"An element with a role, follow",  # paragraph text
 				"link",  # link role
 				"opens in a new tab",  # link description
@@ -643,7 +649,7 @@ def test_ariaDescription_sayAll():
 			]),
 			# 'title' attribute for link ("conduct a search") should not be announced.
 			# too often title is used without screen reader users in mind, and is overly verbose.
-			"  ".join([
+			SPEECH_SEP.join([
 				"Testing the title attribute,",  # paragraph text
 				"link",  # link role
 				# note description missing when sourced from title attribute
@@ -710,10 +716,11 @@ def test_preventDuplicateSpeechFromDescription_browse_tab():
 	- speech.reportObjectDescriptions default:True
 	"""
 	spy = _NvdaLib.getSpyLib()
-	spy.set_configValue(["speech", "reportObjectDescriptions"], True)
+	REPORT_OBJ_DESC_KEY = ["presentation", "reportObjectDescriptions"]
+	spy.set_configValue(REPORT_OBJ_DESC_KEY, True)
 
 	_chrome.prepareChrome(
-		f"""
+		"""
 		<a href="#" title="apple" style="display:block">apple</a>
 		<a href="#" title="banana" aria-label="banana" style="display:block">contents</a>
 		"""
@@ -739,10 +746,11 @@ def preventDuplicateSpeechFromDescription_focus():
 	- speech.reportObjectDescriptions default:True
 	"""
 	spy = _NvdaLib.getSpyLib()
-	spy.set_configValue(["speech", "reportObjectDescriptions"], True)
+	REPORT_OBJ_DESC_KEY = ["presentation", "reportObjectDescriptions"]
+	spy.set_configValue(REPORT_OBJ_DESC_KEY, True)
 
 	_chrome.prepareChrome(
-		f"""
+		"""
 		<a href="#" title="apple" style="display:block">apple</a>
 		<a href="#" title="banana" aria-label="banana" style="display:block">contents</a>
 		"""

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -649,3 +649,89 @@ def test_i10840():
 		nextActualSpeech,
 		"column 2  items"
 	)
+
+
+def test_preventDuplicateSpeechFromDescription_browse_downArrow():
+	"""
+	When description matches name/content, it should not be spoken.
+	This prevents duplicate speech.
+	"""
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "reportObjectDescriptions"], True)
+
+	_chrome.prepareChrome(
+		f"""
+		<a href="#" title="apple" style="display:block">apple</a>
+		<a href="#" title="banana" aria-label="banana" style="display:block">contents</a>
+		"""
+	)
+	# Read in browse
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		"link  apple"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		"link  banana"
+	)
+
+
+def test_preventDuplicateSpeechFromDescription_browse_tab():
+	"""
+	When description matches name/content, it should not be spoken.
+	This prevents duplicate speech.
+	"""
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "reportObjectDescriptions"], True)
+
+	_chrome.prepareChrome(
+		f"""
+		<a href="#" title="apple" style="display:block">apple</a>
+		<a href="#" title="banana" aria-label="banana" style="display:block">contents</a>
+		"""
+	)
+	# Read in browse
+	actualSpeech = _chrome.getSpeechAfterKey('tab')
+	_asserts.strings_match(
+		actualSpeech,
+		"apple  link  apple"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey('tab')
+	_asserts.strings_match(
+		actualSpeech,
+		"banana  link  banana"
+	)
+
+
+def preventDuplicateSpeechFromDescription_focus():
+	"""
+	When description matches name/content, it should not be spoken.
+	This prevents duplicate speech.
+	"""
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "reportObjectDescriptions"], True)
+
+	_chrome.prepareChrome(
+		f"""
+		<a href="#" title="apple" style="display:block">apple</a>
+		<a href="#" title="banana" aria-label="banana" style="display:block">contents</a>
+		"""
+	)
+	# Force focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey('tab')
+	_asserts.strings_match(
+		actualSpeech,
+		"apple  link  apple"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey('tab')
+	_asserts.strings_match(
+		actualSpeech,
+		"banana  link  banana"
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -72,3 +72,9 @@ ARIA description Say All
 i10840
 	[Documentation]	The name of table header cells should only be conveyed once when navigating directly to them in browse mode (chrome self-references a header cell as its own header, which used to cause the name to be announced twice)
 	test_i10840
+Prevent Duplicate Speech From Description while in Focus mode
+	preventDuplicateSpeechFromDescription_focus
+Prevent Duplicate Speech From Description while in Browse mode with tab nav
+	test_preventDuplicateSpeechFromDescription_browse_tab
+Prevent Duplicate Speech From Description while in Browse mode with down arrow nav
+	test_preventDuplicateSpeechFromDescription_browse_downArrow

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -64,7 +64,7 @@ ARIA description Focus Mode
 	[Documentation]	Navigate to a span with aria-description in focus mode
 	test_ariaDescription_focusMode
 ARIA description Browse Mode
-	[Documentation]	Navigate to a span with aria-description in browse mode
+	[Documentation]	Navigate (down arrow, in browse mode) aria-description is read, other sources of description are not.
 	test_ariaDescription_browseMode
 ARIA description Say All
 	[Documentation]	Say all, contents includes aria-description
@@ -76,5 +76,3 @@ Prevent Duplicate Speech From Description while in Focus mode
 	preventDuplicateSpeechFromDescription_focus
 Prevent Duplicate Speech From Description while in Browse mode with tab nav
 	test_preventDuplicateSpeechFromDescription_browse_tab
-Prevent Duplicate Speech From Description while in Browse mode with down arrow nav
-	test_preventDuplicateSpeechFromDescription_browse_downArrow

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - When accessing Microsoft Word documents via UIA, navigating by sentence (alt+downArrow / alt+upArrow) is again possible. (#9254)
 - When accessing MS Word with UIA, paragraph indenting is now reported. (#12899(
 - When accessing MS Word with UIA, change tracking command and some other localized commands are now reported in Word . (#12904)
+- Fixed duplicate braille and speech when 'description' matches 'content' or 'name'. (#12888)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Related to #12750


### Summary of the issue:
When a link has a `title` attribute that matches the content, braille (and speech) is duplicated.

An example:
```html
<a href="#" title="apple" style="display:block">apple</a>
```
Two links URL encoded:
```
data:text/html,%3Ca href%3D"%23" title%3D"apple" style%3D"display%3Ablock"%3Eapple%3C%2Fa%3E%3Ca href%3D"%23" title%3D"banana" aria-label%3D"banana" style%3D"display%3Ablock"%3Econtents%3C%2Fa%3E
```

### Description of how this pull request fixes the issue:
Tests have been added for speech, to show current behavior (duplicated name/content/description)
The duplicate speech/braille is fixed:
- In focus mode, ensuring that description is not reported if it matches name
- In browse mode, when filling the virtual buffer identifying when description matches the node contents and adding an attribute.

### Testing strategy:
- System tests added for speech:
  - browse mode navigation with tab
  - browse mode navigation with down arrow
  - focus mode navigation with tab

Manual testing using the braille viewer with the same sample.
- Further manual testing from more experienced braille users would be appreciated.

### Known issues with pull request:
None

### Change log entries:

Bug fixes
``` 
- Fixed duplicate braille and speech when 'description' matches 'content' or 'name'. #12888
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
