### PR TITLE
Announce highlight instead of marked

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -184,7 +184,7 @@ roleLabels = {
 	# Translators: Displayed in braille for an object which is a figure.
 	controlTypes.Role.FIGURE: _("fig"),
 	# Translators: Displayed in braille for an object which represents marked (highlighted) content
-	controlTypes.Role.MARKED_CONTENT: _("mrkd"),
+	controlTypes.Role.MARKED_CONTENT: _("hlght"),
 }
 
 positiveStateLabels = {

--- a/source/controlTypes/role.py
+++ b/source/controlTypes/role.py
@@ -482,7 +482,7 @@ _roleLabels: Dict[Role, str] = {
 	# Translators: Identifies a figure (commonly seen on some websites).
 	Role.FIGURE: _("figure"),
 	# Translators: Identifies marked (highlighted) content
-	Role.MARKED_CONTENT: _("marked content"),
+	Role.MARKED_CONTENT: _("highlighted"),
 }
 
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -488,10 +488,10 @@ class GlobalCommands(ScriptableObject):
 		config.conf["documentFormatting"]["reportHighlight"] = shouldReport
 		if shouldReport:
 			# Translators: The message announced when toggling the report marked document formatting setting.
-			state = _("report marked on")
+			state = _("report highlighted on")
 		else:
 			# Translators: The message announced when toggling the report marked document formatting setting.
-			state = _("report marked off")
+			state = _("report highlighted off")
 		ui.message(state)
 
 	@script(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2209,7 +2209,7 @@ class DocumentFormattingPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
-		highlightText = _("Mar&ked (highlighted text)")
+		highlightText = _("Highlighted (mar&ked) text")
 		self.highlightCheckBox = fontGroup.addItem(
 			wx.CheckBox(fontGroupBox, label=highlightText)
 		)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -649,3 +649,52 @@ def test_i10840():
 		nextActualSpeech,
 		"column 2  items"
 	)
+
+
+def test_mark_browse():
+	_chrome.prepareChrome(
+		"""
+		<div>
+			<p>The word <mark>Kangaroo</mark> is important.</p>
+		</div>
+		"""
+	)
+	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
+	_asserts.strings_match(
+		actualSpeech,
+		"The word  highlighted  Kangaroo  out of highlighted  is important."
+	)
+	# Test moving by word
+	actualSpeech = _chrome.getSpeechAfterKey("numpad6")
+	_asserts.strings_match(
+		actualSpeech,
+		"word"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("numpad6")
+	_asserts.strings_match(
+		actualSpeech,
+		"highlighted  Kangaroo  out of highlighted"
+	)
+
+
+def test_mark_focus():
+	_chrome.prepareChrome(
+		"""
+		<div>
+			<p>The word <a href="#"><mark>Kangaroo</mark></a> is important.</p>
+		</div>
+		"""
+	)
+
+	# Force focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+
+	actualSpeech = _chrome.getSpeechAfterKey('tab')
+	_asserts.strings_match(
+		actualSpeech,
+		"link  highlighted  Kangaroo"
+	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -681,7 +681,7 @@ def test_mark_focus():
 	_chrome.prepareChrome(
 		"""
 		<div>
-			<p>The word <a href="#"><mark>Kangaroo</mark></a> is important.</p>
+			<p>The word <mark><a href="#">Kangaroo</a></mark> is important.</p>
 		</div>
 		"""
 	)
@@ -696,5 +696,5 @@ def test_mark_focus():
 	actualSpeech = _chrome.getSpeechAfterKey('tab')
 	_asserts.strings_match(
 		actualSpeech,
-		"link  highlighted  Kangaroo"
+		"highlighted\nKangaroo  link"
 	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -48,7 +48,7 @@ def checkbox_labelled_by_inner_element():
 	)
 
 
-def test_aria_details():
+def test_mark_aria_details():
 	_chrome.prepareChrome(
 		"""
 		<div>
@@ -69,7 +69,7 @@ def test_aria_details():
 	actualSpeech = _chrome.getSpeechAfterKey('downArrow')
 	_asserts.strings_match(
 		actualSpeech,
-		"The word  marked content  has details  cat  out of marked content  has a comment tied to it."
+		"The word  highlighted  has details  cat  out of highlighted  has a comment tied to it."
 	)
 	# this word has no details attached
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
@@ -87,7 +87,7 @@ def test_aria_details():
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"marked content  has details  cat  out of marked content"
+		"highlighted  has details  cat  out of highlighted"
 	)
 	# read the details summary
 	actualSpeech = _chrome.getSpeechAfterKey("NVDA+\\")

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -50,10 +50,10 @@ ARIA checkbox
 	[Documentation]	Navigate to an unchecked checkbox in reading mode.
 	[Tags]	aria-at
 	test_ariaCheckbox_browseMode
-ARIA details
-	[Documentation]	Ensure a summary of aria-details is read on command.
+ARIA marked and aria details
+	[Documentation]	Ensure a summary of aria-details is read on command from a mark element
 	[Tags]	annotations
-	test aria details
+	test_mark_aria_details
 i12147
 	[Documentation]	New focus target should be announced if the triggering element is removed when activated
 	test_i12147

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -41,7 +41,6 @@ pr11606
 	test_pr11606
 ARIA treegrid
 	[Documentation]	Ensure that ARIA treegrids are accessible as a standard table in browse mode.
-	# Excluded due to regular failures.
 	test_ariaTreeGrid_browseMode
 ARIA invalid spelling and grammar
 	[Documentation]	Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
@@ -50,7 +49,13 @@ ARIA checkbox
 	[Documentation]	Navigate to an unchecked checkbox in reading mode.
 	[Tags]	aria-at
 	test_ariaCheckbox_browseMode
-ARIA marked and aria details
+Marked Browse mode
+	[Documentation]	Ensure that Marked content is read in browse mode
+	test_mark_browse
+Marked Focus mode
+	[Documentation]	Ensure that Marked content is read in Focus mode
+	test_mark_focus
+ARIA details
 	[Documentation]	Ensure a summary of aria-details is read on command from a mark element
 	[Tags]	annotations
 	test_mark_aria_details

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - Updated liblouis braille translator to [3.19.0 https://github.com/liblouis/liblouis/releases/tag/v3.19.0]. (#12810)
   - New braille tables: Russian grade 1, Tshivenda grade 1, Tshivenda grade 2
   -
+- Instead of "marked content" or "mrkd", "highlight" or "hlight" will be announced for speech and braille respectively. (#12892)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1745,7 +1745,7 @@ You can configure reporting of:
  - Font attributes
  - Superscripts and subscripts
  - Emphasis
- - Marked (Highlighted text)
+ - Highlighted (Marked) text
  - Style
  - Colours
 - Document information


### PR DESCRIPTION
### Link to issue number:
Perhaps #4247 can be closed?

Prior work: https://github.com/nvaccess/nvda/pull/11436

### Summary of the issue:
'mark' elements were being reported as "marked content".
This is long. Additionally, the standard visual representation of `mark` is a yellow background, as if the text has been highlighted.
Arguably, "highlighted" is a more common phrase in English.
It is also more specific to this visual representation.
The more generaral "marked" content could mean many different kinds of markings with varied semantics.
With the introduction of "role-description", less common usages of `mark` can be achived.

### Description of how this pull request fixes the issue:
Use "highlight" instead of "marked content" for speech.
Use "hlght" instead of "mrkd" for braille

### Testing strategy:
System tests

### Known issues with pull request:
Some users may already be familiar with "marked content".

### Change log entries:
Changes
```
- Instead of "marked content" or "mrkd", "highlight" or "hlight" will be announced for speech and braille respectively.
```
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
