### PR TITLE
In the console, when pressing up/down arrow and history start or end is reached, do not move the caret anymore

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -409,8 +409,8 @@ class ConsoleUI(
 			self.execute()
 			return
 		elif key in (wx.WXK_UP, wx.WXK_DOWN):
-			if self.historyMove(-1 if key == wx.WXK_UP else 1):
-				return
+			self.historyMove(-1 if key == wx.WXK_UP else 1)
+			return
 		elif key == wx.WXK_F6:
 			self.outputCtrl.SetFocus()
 			return


### PR DESCRIPTION
### Link to issue number:

Fixes #12632

### Summary of the issue:

In Python console, up/down arrow behaves as follow:
1. If command history start or end is not reached, move to previous or next item in the command history.
2. If command history start or end is reached, move the caret one character left or right; this is the default behaviour of some single line edit fields (cf. #12780)
The point 2. is an unintuitive corner case. Indeed, up/down arrow cannot be used generally in this field to navigate character by character, this is only partially possible in some rare cases, i.e. at the edge of command history buffer.

### Description of how this pull request fixes the issue:

Navigation character by character with up/down arrows should be totally disabled in the console input field.
The caret should not move at all if the line has not been updated.

### Testing strategy:

* Checked that up/down arrows still work in the console to re-read the command history
* When reaching the first command in history, pressed up arrow again and checked that the caret does not move left anymore (STR of #12632).
* STR 3:
  * Type various commands in the console
  * Type a last command without pressing Enter
  * Turn back some characters left with left arrow
  * Press down arrow once and checked that the caret has not moved.

### Known issues with pull request:

In the case the Narrator is used along with NVDA (which is a very unlikely use case):
When pressing up arrow, the last character of the first command in history will be read instead of the whole line.

An alternative solution that would be compatible with Narrator could be to use a multi-line edit field even if it is only filled with one line of thext. But the implementation would be more complex; I do not think it is worth implementing it to support this very unlikely use case.

### Change log entries:

This tiny fix does not deserve an entry in the change log.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
