### PR TITLE
Fix `buildSymbolStore.ps1`

### DIFF
--- a/appveyor/scripts/buildSymbolStore.ps1
+++ b/appveyor/scripts/buildSymbolStore.ps1
@@ -7,5 +7,5 @@ foreach ($syms in
 	"source\lib64\*.dll", "source\lib64\*.exe", "source\lib64\*.pdb",
 	"source\synthDrivers\*.dll", "source\synthDrivers\*.pdb"
 ) {
-	& $env:symstore add /s symbols /compress -:NOREFS /t NVDA /f $syms
+	& $env:symstore add -:NOREFS /s symbols /compress /t NVDA /f $syms
 }


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

Alpha/PR builds are suddenly failing due to the symbol store failing to build.
Example: https://ci.appveyor.com/project/NVAccess/nvda/builds/40999821

The error thrown:
```ps1
The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: 
SYMSTORE ERROR: Class: Syntax. Desc: Invalid compression type '-:NOREFS'.
```

I am unsure what has changed in the past few days. 

The command usage seems inline with the docs https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/symstore-command-line-options - other than the order of arguments.
The example usage implies `-:NOREFS` requires the `/p` switch, but the documentation doesn't specifically note this, as opposed to other commands which require `/p`.

I've raised this issue to find out more from MS: https://github.com/MicrosoftDocs/windows-driver-docs/issues/2931

### Description of how this pull request fixes the issue:

Try re-arranging arguments.

### Testing strategy:
Build PR

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
