### PR TITLE
Use `WordDocument` of `Winword` appModule both with IAccessible and UIA.

### DIFF
--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -11,13 +11,15 @@ Microsoft Word only.
 import appModuleHandler
 from scriptHandler import script
 import ui
-from NVDAObjects.IAccessible.winword import WordDocument
+from NVDAObjects.IAccessible.winword import WordDocument as IAccessibleWordDocument
+from NVDAObjects.UIA.wordDocument import WordDocument as UIAWordDocument
+from NVDAObjects.window.winword import WordDocument
 
 
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if WordDocument in clsList:
+		if UIAWordDocument in clsList or IAccessibleWordDocument in clsList:
 			clsList.insert(0, WinwordWordDocument)
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -54,6 +54,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - When using a Chinese input method such as Taiwan - Microsoft Quick in Microsoft Word, scrolling the braille display forward and backward no longer incorrectly keeps jumping back to the original caret position. (#12855)
 - When accessing Microsoft Word documents via UIA, navigating by sentence (alt+downArrow / alt+upArrow) is again possible. (#9254)
 - When accessing MS Word with UIA, paragraph indenting is now reported. (#12899(
+- When accessing MS Word with UIA, change tracking command and some other localized commands are now reported in Word . (#12904)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None

Fix-up of #11824.

### Summary of the issue:

The class `appModules.winword.WinwordWordDocument` is used only in Word if using IAccessible, whereas it should be used with both IAccessible and UIA. This leads to the following consequences when using UIA for Word:
* Toggle change tracking script (ctrl+shift+E) is not vocalized in Word when NVDA uses UIA to access information; this script works only if NVDA uses IAccessible for Word.
* The class `appModules.winword.WinwordWordDocument` is used in some `gestures.ini` files (fr, it, pt_PT) to localize scripts corresponding to shortcuts that operate only in Word, not in Outlook; e.g. ctrl+R that performs left paragraph indent in French Word instead of left paragraph alignment in French Outlook.

### Description of how this pull request fixes the issue:

Use the class `appModules.winword.WinwordWordDocument` with both IAccessible and UIA.

### Testing strategy:

Perform the following two tests with the following versions of Word 2016:
* newer Word 2016 using UIA: version '16.0.14430.20234'
* older Word 2016 using IAccessible: version '16.0.5188.1000' 

Test 1:
Test that the toggle change tracking is reported when pressing the corresponding shortcut (specifically ctrl+shift+R on my French Office version).
Note: for anyone wanting to test on English Office and NVDA, the shortcut is ctrl+shift+E.

Test 2:
On French Word and French NVDA, test that the script increasing left paragraph indent reports the new indentation when the corresponding shortcut is pressed.
Note: Cannot be tested on English versions of Word and NVDA. Similar tests can be done however for Italian and Portuguese (pt_PT).

### Known issues with pull request:
None

### Change log entries:
Bug fixes

`When accessing MS Word with UIA, , change tracking command and some other localized commands are now reported in Word . (#12904)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
