### PR TITLE
UIA text formatting: support paragraph indenting attributes

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -43,6 +43,12 @@ import ui
 import winVersion
 
 
+paragraphIndentIDs = {
+	UIAHandler.UIA_IndentationFirstLineAttributeId: "first-line-indent",
+	UIAHandler.UIA_IndentationLeadingAttributeId: "left-indent",
+	UIAHandler.UIA_IndentationTrailingAttributeId: "right-indent",
+}
+
 class UIATextInfo(textInfos.TextInfo):
 
 	_cache_controlFieldNVDAObjectClass=True
@@ -168,6 +174,8 @@ class UIATextInfo(textInfos.TextInfo):
 					UIAHandler.UIA_IsSuperscriptAttributeId,
 					UIAHandler.UIA_IsSubscriptAttributeId
 				})
+			if formatConfig["reportParagraphIndentation"]:
+				IDs.update(set(paragraphIndentIDs))
 			if formatConfig["reportAlignment"]:
 				IDs.add(UIAHandler.UIA_HorizontalTextAlignmentAttributeId)
 			if formatConfig["reportColor"]:
@@ -223,6 +231,21 @@ class UIATextInfo(textInfos.TextInfo):
 			val=fetcher.getValue(UIAHandler.UIA_StyleNameAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if val!=UIAHandler.handler.reservedNotSupportedValue:
 				formatField["style"]=val
+		if formatConfig["reportParagraphIndentation"]:
+			for ID, fieldAttr in paragraphIndentIDs.items():
+				val = fetcher.getValue(ID, ignoreMixedValues=ignoreMixedValues)
+				if isinstance(val, float):
+					# val is in points (1/72 of an inch)
+					val /= 72.0
+					if languageHandler.useImperialMeasurements():
+						# Translators: a measurement in inches
+						valText = _("{val:.2f} in").format(val=val)
+					else:
+						# Convert from inches to centermetres
+						val *= 2.54
+						# Translators: a measurement in centermetres
+						valText = _("{val:.2f} cm").format(val=val)
+					formatField[fieldAttr] = valText
 		if formatConfig["reportAlignment"]:
 			val=fetcher.getValue(UIAHandler.UIA_HorizontalTextAlignmentAttributeId,ignoreMixedValues=ignoreMixedValues)
 			if val==UIAHandler.HorizontalTextAlignment_Left:

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -43,6 +43,7 @@ class LOCALE(enum.IntEnum):
 	# https://docs.microsoft.com/en-us/windows/win32/intl/locale-information-constants
 	SLANGUAGE = 0x2
 	SLIST = 0xC
+	IMEASURE = 0xD
 	SLANGDISPLAYNAME = 0x6f
 	SENGLISHLANGUAGENAME = 0x00001001
 	SENGLISHCOUNTRYNAME = 0x00001002
@@ -436,6 +437,21 @@ def normalizeLanguage(lang) -> Optional[str]:
 	if len(ld)>=2:
 		ld[1]=ld[1].upper()
 	return "_".join(ld)
+
+
+def useImperialMeasurements(localeName: Optional[str] = None) -> bool:
+	"""
+	Whether or not measurements should be reported as imperial, rather than metric.
+	"""
+	if not localeName:
+		localeName = getLanguage()
+	localeName = normalizeLocaleForWin32(localeName)
+	bufLength = 2
+	buf = ctypes.create_unicode_buffer(bufLength)
+	if not winKernel.kernel32.GetLocaleInfoEx(localeName, LOCALE.IMEASURE, buf, bufLength):
+		raise RuntimeError("LOCALE.IMEASURE not supported")
+	return buf.value == '1'
+
 
 # Map Windows primary locale identifiers to locale names
 # Note these are only primary language codes (I.e. no country information)

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -439,16 +439,13 @@ def normalizeLanguage(lang) -> Optional[str]:
 	return "_".join(ld)
 
 
-def useImperialMeasurements(localeName: Optional[str] = None) -> bool:
+def useImperialMeasurements() -> bool:
 	"""
 	Whether or not measurements should be reported as imperial, rather than metric.
 	"""
-	if not localeName:
-		localeName = getLanguage()
-	localeName = normalizeLocaleForWin32(localeName)
 	bufLength = 2
 	buf = ctypes.create_unicode_buffer(bufLength)
-	if not winKernel.kernel32.GetLocaleInfoEx(localeName, LOCALE.IMEASURE, buf, bufLength):
+	if not winKernel.kernel32.GetLocaleInfoEx(None, LOCALE.IMEASURE, buf, bufLength):
 		raise RuntimeError("LOCALE.IMEASURE not supported")
 	return buf.value == '1'
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,6 +53,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - When navigating the Windows system tray calendar, NVDA now reports the day of the week in full. (#12757)
 - When using a Chinese input method such as Taiwan - Microsoft Quick in Microsoft Word, scrolling the braille display forward and backward no longer incorrectly keeps jumping back to the original caret position. (#12855)
 - When accessing Microsoft Word documents via UIA, navigating by sentence (alt+downArrow / alt+upArrow) is again possible. (#9254)
+- When accessing MS Word with UIA, paragraph indenting is now reported. (#12899(
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12899

### Summary of the issue:
When NVDA accessed Microsoft Word documents with the Word object model, it was able to report paragraph indenting.
If the user configures NvDA to access MS Word via UIA, ro it is used by default in MS Word build 13901 or higher, paragraph indenting is no longer reported.

### Description of how this pull request fixes the issue:
Report paragraph indenting in UIA text controls (including MS Word documents) by fetching and processing the appropriate UIA text attribute values.
These include:
indentationFirstLine, indentationLeading and indentationTrailing.
These values are all given by the UIA provider in points (1/72 of an inch) thus NvDA converts these to either inches or centermetres first.
this pr also adds a new useImperialMeasurements function to languageHandler which returns true if imperial measuremts (inches) should be used according to the user's current Regional preferences, otherwise metric (centermetres).


### Testing strategy:
Ensured NVDA was using UIA to access MS Word. 
Created a new Word document. Typed a line of text. Opened Paragraph properties from the context menu and set values for left indent, right indent and first line indent. Back in the Word document, pressed NVDA+f to report the formatting including paragraph indentation.
Ensured that the values were in inches if The measurement soption in Regional settings was set to U.S. or Centermetres if the setting was Metric.

### Known issues with pull request:
None known.
 
### Change log entries:
Bug fixes
* When accessing MS Word with UIA, paragraph indenting is now reported.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
