### PR TITLE
Add links for event IDs

### DIFF
--- a/devDocs/technicalDesignOverview.md
+++ b/devDocs/technicalDesignOverview.md
@@ -39,7 +39,7 @@ Several accessibility APIs are used, including Microsoft Active Accessibility (M
 See also:
 - [Stack Overflow: "What is the difference between IAccessible, IAccessible2, UIAutomation and MSAA?"](https://stackoverflow.com/a/55130227)
 - [The Linux Foundation IA2 reference](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/)
-- [IA2 event constants](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_event_i_d_8idl.html#ae26846b6d521727ab696d20c3f43c0b5)
+- [IA2 event constants](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_event_i_d_8idl.html)
   - From the perspective of Windows, the IA2 event constants are considered custom "application specific" event IDs.
 - [Windows event constanstant](https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants)
 

--- a/devDocs/technicalDesignOverview.md
+++ b/devDocs/technicalDesignOverview.md
@@ -34,9 +34,15 @@ Rich accessibility APIs provide additional information, including the ability to
 NVDA relies heavily on accessibility APIs to gather information.
 Several accessibility APIs are used, including Microsoft Active Accessibility (MSAA) (also known as IAccessible), [IAccessible2](http://www.linuxfoundation.org/en/Accessibility/IAccessible2), Java Access Bridge and UI Automation.
 
+**Note:** IAccessible2 was not created by Microsoft, see [Wikipedia for more background](https://en.wikipedia.org/wiki/IAccessible2).
+
 See also:
 - [Stack Overflow: "What is the difference between IAccessible, IAccessible2, UIAutomation and MSAA?"](https://stackoverflow.com/a/55130227)
 - [The Linux Foundation IA2 reference](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/)
+- [IA2 event constants](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_event_i_d_8idl.html#ae26846b6d521727ab696d20c3f43c0b5)
+  - From the perspective of Windows, the IA2 event constants are considered custom "application specific" event IDs.
+- [Windows event constanstant](https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants)
+
 
 #### Tools for investigating Accessibility APIs
 

--- a/devDocs/technicalDesignOverview.md
+++ b/devDocs/technicalDesignOverview.md
@@ -41,7 +41,7 @@ See also:
 - [The Linux Foundation IA2 reference](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/)
 - [IA2 event constants](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_event_i_d_8idl.html)
   - From the perspective of Windows, the IA2 event constants are considered custom "application specific" event IDs.
-- [Windows event constanstant](https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants)
+- [Windows event constants](https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants)
 
 
 #### Tools for investigating Accessibility APIs


### PR DESCRIPTION
Event ID listings for Windows events.
Note about IA2 not developed by MS, hence missing events in Windows event listings.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Listing of windows event constants was missing.

### Description of how this pull request fixes the issue:
Added links to IA2 event constants and Windows event constants. Highlight the background of IA2.

### Testing strategy:
None

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x ] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
