### PR TITLE
Add system tests for aria-roledescription

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -470,6 +470,197 @@ def test_tableInStyleDisplayTable():
 	)
 
 
+def test_ariaRoleDescription_focus():
+	"""
+	NVDA should report the custom role of an object on focus.
+	"""
+	_chrome.prepareChrome(
+		"""
+		<button aria-roledescription="pizza">Cheese</button><br />
+		<button aria-roledescription="pizza">Meat</button>
+		"""
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"Cheese  pizza"
+	)
+	# Force focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"Meat  pizza"
+	)
+
+
+def test_ariaRoleDescription_inline_browseMode():
+	"""
+	NVDA should report the custom role for inline elements in browse mode.
+	"""
+	_chrome.prepareChrome(
+		"""
+		<p>Start
+		<img aria-roledescription="drawing" alt="Our logo" src="https://www.nvaccess.org/images/logo.png" />
+		End</p>
+		"""
+	)
+	# When reading the entire line,
+	# entering the custom role should be reported,
+	# but not exiting
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"Start  drawing  Our logo  End"
+	)
+	# When reading the line by word,
+	# Both entering and exiting the custom role should be reported.
+	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"drawing  Our"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"logo  out of drawing"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"End"
+	)
+
+
+def test_ariaRoleDescription_block_browseMode():
+	"""
+	NVDA should report the custom role at start and end for block elements in browse mode.
+	"""
+	_chrome.prepareChrome(
+		"""
+		<aside aria-roledescription="warning">
+		<p>Wet paint!</p>
+		<p>Please be careful.</p>
+		</aside>
+		<p>End</p>
+		"""
+	)
+	# when reading the page by line,
+	# both entering and exiting the custom role should be reported.
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"warning  Wet paint!"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"Please be careful."
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"out of warning  End"
+	)
+
+
+def test_ariaRoleDescription_inline_contentEditable():
+	"""
+	NVDA should report the custom role for inline elements in content editables.
+	"""
+	_chrome.prepareChrome(
+		"""
+		<div contenteditable="true">
+		<p>Top line</p>
+		<p>Start
+		<img aria-roledescription="drawing" alt="Our logo" src="https://www.nvaccess.org/images/logo.png" />
+		End</p>
+		</div>
+		"""
+	)
+	# Force focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"section  multi line  editable  Top line"
+	)
+	# When reading the entire line,
+	# entering the custom role should be reported,
+	# but not exiting
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"Start  drawing  Our logo    End"
+	)
+	# When reading the line by word,
+	# Both entering and exiting the custom role should be reported.
+	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"drawing  Our logo    out of drawing"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"End"
+	)
+
+
+def test_ariaRoleDescription_block_contentEditable():
+	"""
+	NVDA should report the custom role at start and end for block elements in content editables.
+	"""
+	_chrome.prepareChrome(
+		"""
+		<div contenteditable="true">
+		<p>Top line</p>
+		<aside aria-roledescription="warning">
+		<p>Wet paint!</p>
+		<p>Please be careful.</p>
+		</aside>
+		<p>End</p>
+		</div>
+		"""
+	)
+	# Force focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		"section  multi line  editable  Top line"
+	)
+	# when reading the page by line,
+	# both entering and exiting the custom role should be reported.
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"warning  Wet paint!"
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"Please be careful."
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"out of warning  End"
+	)
+
+
 annotation = "User nearby, Aaron"
 linkDescription = "opens in a new tab"
 linkTitle = "conduct a search"

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -60,6 +60,21 @@ i12147
 Table in style display: table
 	[Documentation]	Properly announce table row/column count and working table navigation for a HTML table in a div with style display: table
 	test_tableInStyleDisplayTable
+ARIA roleDescription focus
+	[Documentation]	report focusing an element with a custom role	
+	test_ariaRoleDescription_focus
+ARIA roleDescription inline browse mode
+	[Documentation]	Read an inline element with a custom role in browse mode
+	test_ariaRoleDescription_inline_browseMode
+ARIA roleDescription block browse mode
+	[Documentation]	Read an block element with a custom role in browse mode
+	test_ariaRoleDescription_block_browseMode
+ARIA roleDescription inline content editable
+	[Documentation]	Read an inline element with a custom role in content editables 
+	test_ariaRoleDescription_inline_contentEditable
+ARIA roleDescription block content editable
+	[Documentation]	Read an block element with a custom role in content editables 
+	test_ariaRoleDescription_block_contentEditable
 ARIA description Focus Mode
 	[Documentation]	Navigate to a span with aria-description in focus mode
 	test_ariaDescription_focusMode

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -67,7 +67,7 @@ ARIA roleDescription inline browse mode
 	[Documentation]	Read an inline element with a custom role in browse mode
 	test_ariaRoleDescription_inline_browseMode
 ARIA roleDescription block browse mode
-	[Documentation]	Read an block element with a custom role in browse mode
+	[Documentation]	Read a block element with a custom role in browse mode
 	test_ariaRoleDescription_block_browseMode
 ARIA roleDescription inline content editable
 	[Documentation]	Read an inline element with a custom role in content editables 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None.

### Summary of the issue:
NVDA's support for aria-roledescription did not have system tests.

### Description of how this pull request fixes the issue:
Add system tests for aria-roledescription including:
* gain focus (browse and focus modes)
* inline element in browse mode (reading by line and word)
* Block element in browse mode (reading by line)
* inline element in a content editable (reading by line and word)
* Block element in a content editable (reading by line)

### Testing strategy:
System tests pass.

### Known issues with pull request:
None.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
