### PR TITLE
Make OffsetsTedxtInfo behave like UIATextInfo and add additional review bounds checking (alternative solution for #12808)

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1329,7 +1329,7 @@ class GlobalCommands(ScriptableObject):
 		info.expand(textInfos.UNIT_LINE)
 		info.collapse()
 		res=info.move(textInfos.UNIT_LINE,1)
-		if res==0:
+		if res == 0 or info == info.obj.makeTextInfo(textInfos.POSITION_LAST):
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
 			ui.reviewMessage(_("Bottom"))
 		else:
@@ -1400,7 +1400,7 @@ class GlobalCommands(ScriptableObject):
 		info.expand(textInfos.UNIT_WORD)
 		info.collapse()
 		res=info.move(textInfos.UNIT_WORD,1)
-		if res==0:
+		if res == 0 or info == info.obj.makeTextInfo(textInfos.POSITION_LAST):
 			# Translators: a message reported when review cursor is at the bottom line of the current navigator object.
 			ui.reviewMessage(_("Bottom"))
 		else:

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -465,7 +465,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		elif position==textInfos.POSITION_FIRST:
 			self._startOffset=self._endOffset=0
 		elif position==textInfos.POSITION_LAST:
-			self._startOffset=self._endOffset=max(self._getStoryLength()-1,0)
+			self._startOffset = self._endOffset = max(self._getStoryLength(), 0)
 		elif position==textInfos.POSITION_CARET:
 			self._startOffset=self._endOffset=self._getCaretOffset()
 		elif position==textInfos.POSITION_SELECTION:
@@ -637,7 +637,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			self._endOffset=offset
 		else:
 			if (direction>0 and offset<=self._startOffset) or (direction<0 and offset>=self._startOffset) or offset<lowLimit or offset>=highLimit:
-				self._startOffset = self._endOffset = max(self._getStoryLength() - 1, 0)
+				self._startOffset = self._endOffset = max(self._getStoryLength(), 0)
 				return count
 			self._startOffset=self._endOffset=offset
 		if self._startOffset>self._endOffset:

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -601,7 +601,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 
 	def move(self,unit,direction,endPoint=None):
 		if direction==0:
-			return 0;
+			return 0
 		if endPoint=="end":
 			offset=self._endOffset
 		elif endPoint=="start":
@@ -637,7 +637,8 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			self._endOffset=offset
 		else:
 			if (direction>0 and offset<=self._startOffset) or (direction<0 and offset>=self._startOffset) or offset<lowLimit or offset>=highLimit:
-				return 0
+				self._startOffset = self._endOffset = max(self._getStoryLength() - 1, 0)
+				return count
 			self._startOffset=self._endOffset=offset
 		if self._startOffset>self._endOffset:
 			tempOffset=self._startOffset


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #12808.
Alternative solution to #12898.

### Summary of the issue:
`UIATextInfo` and `OffsetsTextInfo` behave differently when moving past the end of the text range, leading to different behaviour when moving the review cursor.

### Description of how this pull request fixes the issue:
This PR:

* Makes `OffsetsTextInfo` act more like modern UIA providers: when attempting to move past the end offset, return that the move was successful and make the range collapsed at `POSITION_LAST`.
* Modifies the review cursor scripts to check for this case.

### Testing strategy:
Tested notepad, `FORMATTED` UIA console, and Word.

### Known issues with pull request:
* I'd appreciate a review of my changes to `OffsetsTextInfo` in particular.
* When moving to the last character of an IA2 web document, subsequent invocations of "review next character" do not report "right" but rather behave like #12808.

### Change log entries:
== Bug Fixes ==
- When moving the review cursor past the end of text controls, "bottom" is reported in more situations. (#12808)

== Changes for Developers ==
- Movement of `OffsetsTextInfo` instances is more similar to that of UIA text ranges: when moving a collapsed range past the end of the document, the move is reported as successful and the `textInfo` is collapsed at `POSITION_LAST`.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
