### PR TITLE
Dont report description in browse mode with reportObjectDescriptions

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -702,8 +702,10 @@ def getControlFieldBraille(  # noqa: C901
 	_descriptionIsContent: bool = field.get("descriptionIsContent", False)
 	if (
 		not _descriptionIsContent
-		and config.conf["presentation"]["reportObjectDescriptions"]
-		or (
+		# Note "reportObjectDescriptions" is not a reason to include description,
+		# "Object" implies focus/object nav, getControlFieldBraille calculates text for Browse mode.
+		# There is no way to identify getControlFieldBraille being called for reason focus, as is done in speech.
+		and (
 			config.conf["annotations"]["reportAriaDescription"]
 			and _descriptionFrom == controlTypes.DescriptionFrom.ARIA_DESCRIPTION
 		)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1914,8 +1914,8 @@ class InputCompositionPanel(SettingsPanel):
 
 class ObjectPresentationPanel(SettingsPanel):
 
-	# Translators: This is a label appearing on the document formatting settings panel.
 	panelDescription = _(
+		# Translators: This is a label appearing on the Object Presentation settings panel.
 		"Configure how much information NVDA will present about controls."
 		" These options don't apply to browse mode."
 	)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -47,10 +47,6 @@ import keyboardHandler
 import characterProcessing
 from . import guiHelper
 
-#: The size that settings panel text descriptions should be wrapped at.
-# Ensure self.scaleSize is used to adjust for OS scaling adjustments.
-PANEL_DESCRIPTION_WIDTH = 544
-
 try:
 	import updateCheck
 except RuntimeError:
@@ -65,6 +61,10 @@ import weakref
 import time
 import keyLabels
 from .dpiScalingHelper import DpiScalingHelperMixinWithoutInit
+
+#: The size that settings panel text descriptions should be wrapped at.
+# Ensure self.scaleSize is used to adjust for OS scaling adjustments.
+PANEL_DESCRIPTION_WIDTH = 544
 
 class SettingsDialog(
 		DpiScalingHelperMixinWithoutInit,
@@ -1917,7 +1917,8 @@ class ObjectPresentationPanel(SettingsPanel):
 	panelDescription = _(
 		# Translators: This is a label appearing on the Object Presentation settings panel.
 		"Configure how much information NVDA will present about controls."
-		" These options don't apply to browse mode."
+		" These options apply to focus reporting and NVDA object navigation,"
+		" but not when reading text content e.g. web content with browse mode."
 	)
 
 	# Translators: This is the label for the object presentation panel.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -46,6 +46,11 @@ import core
 import keyboardHandler
 import characterProcessing
 from . import guiHelper
+
+#: The size that settings panel text descriptions should be wrapped at.
+# Ensure self.scaleSize is used to adjust for OS scaling adjustments.
+PANEL_DESCRIPTION_WIDTH = 544
+
 try:
 	import updateCheck
 except RuntimeError:
@@ -1908,6 +1913,13 @@ class InputCompositionPanel(SettingsPanel):
 
 
 class ObjectPresentationPanel(SettingsPanel):
+
+	# Translators: This is a label appearing on the document formatting settings panel.
+	panelDescription = _(
+		"Configure how much information NVDA will present about controls."
+		" These options don't apply to browse mode."
+	)
+
 	# Translators: This is the label for the object presentation panel.
 	title = _("Object Presentation")
 	helpId = "ObjectPresentationSettings"
@@ -1932,6 +1944,12 @@ class ObjectPresentationPanel(SettingsPanel):
 
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+
+		self.windowText = sHelper.addItem(
+			wx.StaticText(self, label=self.panelDescription)
+		)
+		self.windowText.Wrap(self.scaleSize(PANEL_DESCRIPTION_WIDTH))
+
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings panel.
 		reportToolTipsText = _("Report &tooltips")
@@ -2975,7 +2993,7 @@ class AdvancedPanel(SettingsPanel):
 		warningGroup.addItem(warningText)
 
 		self.windowText = warningGroup.addItem(wx.StaticText(warningBox, label=self.warningExplanation))
-		self.windowText.Wrap(self.scaleSize(544))
+		self.windowText.Wrap(self.scaleSize(PANEL_DESCRIPTION_WIDTH))
 
 		enableAdvancedControlslabel = _(
 			# Translators: This is the label for a checkbox in the Advanced settings panel.

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -115,6 +115,10 @@ class TreeInterceptor(baseObject.ScriptableObject):
 		"""
 		raise NotImplementedError
 
+	#: Typing for autoproperty _get_passThrough
+	# Whether most scripts should temporarily pass through this interceptor without being intercepted.
+	passThrough: bool
+
 	def _get_passThrough(self):
 		"""Whether most scripts should temporarily pass through this interceptor without being intercepted.
 		"""

--- a/tests/system/libraries/AssertsLib.py
+++ b/tests/system/libraries/AssertsLib.py
@@ -12,24 +12,26 @@ builtIn: BuiltIn = BuiltIn()
 # In Robot libraries, class name must match the name of the module. Use caps for both.
 class AssertsLib:
 	@staticmethod
-	def strings_match(actual, expected, ignore_case=False):
+	def strings_match(actual, expected, ignore_case=False, comparison="speech", message=""):
+		message += '\n' if message else ''
 		# Include expected text in robot test report so that the actual behavior
 		# can be determined entirely from the report, even when the test passes.
 		builtIn.log(
-			f"assert string matches (ignore case: {ignore_case}):  '{expected}'",
+			f"{message}assert {comparison} string matches (ignore case: {ignore_case}):  '{expected}'",
 			level="INFO"
 		)
 		try:
 			builtIn.should_be_equal_as_strings(
 				actual,
 				expected,
-				msg="Actual speech != Expected speech",
+				msg=f"{message}{comparison} Actual != Expected",
 				ignore_case=ignore_case
 			)
 		except AssertionError:
 			# Occasionally on assert failure the repr of the string makes it easier to determine the differences.
 			builtIn.log(
-				"repr of actual vs expected (ignore_case={}):\n{}\nvs\n{}".format(
+				"repr of ({}) actual vs expected (ignore_case={}):\n{}\nvs\n{}".format(
+					comparison,
 					ignore_case,
 					repr(actual),
 					repr(expected)
@@ -37,3 +39,11 @@ class AssertsLib:
 				level="DEBUG"
 			)
 			raise
+
+	@staticmethod
+	def speech_matches(actual, expected, ignore_case=False, message=""):
+		AssertsLib.strings_match(actual, expected, ignore_case, comparison="speech", message=message)
+
+	@staticmethod
+	def braille_matches(actual, expected, ignore_case=False, message=""):
+		AssertsLib.strings_match(actual, expected, ignore_case, comparison="braille", message=message)

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -22,7 +22,10 @@ from os.path import (
 	splitext as _splitext,
 )
 import tempfile as _tempFile
-from typing import Optional as _Optional
+from typing import (
+	Optional as _Optional,
+	Tuple as _Tuple,
+)
 from urllib.parse import quote as _quoteStr
 
 from robotremoteserver import (
@@ -405,3 +408,25 @@ def getSpeechAfterKey(key) -> str:
 	spy.wait_for_speech_to_finish(speechStartedIndex=nextSpeechIndex)
 	speech = spy.get_speech_at_index_until_now(nextSpeechIndex)
 	return speech
+
+
+def getSpeechAndBrailleAfterKey(key) -> _Tuple[str, str]:
+	"""Ensure speech has stopped, press key, and get speech until it stops, report the status of the
+	braille display.
+	@return: Tuple of Speech then Braille.
+	"""
+	spy = getSpyLib()
+	spy.wait_for_speech_to_finish()
+
+	nextSpeechIndex = spy.get_next_speech_index()
+	nextBrailleIndex = spy.get_next_braille_index()
+
+	spy.emulateKeyPress(key)
+
+	spy.wait_for_speech_to_finish(speechStartedIndex=nextSpeechIndex)
+	speech = spy.get_speech_at_index_until_now(nextSpeechIndex)
+
+	spy.wait_for_braille_update(nextBrailleIndex)
+	braille = spy.get_last_braille()
+
+	return speech, braille

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -26,6 +26,7 @@ Optional[Any]  # None or the value when the evaluator was met
 	"""Repeatedly tries to get a value up until a time limit expires. Tries are separated by
 	a time interval. The call will block until shouldStopEvaluator returns True when given the value,
 	the default evaluator just returns the value converted to a boolean.
+	@param errorMessage Use 'None' to suppress the exception.
 	@return A tuple, (True, value) if evaluator condition is met, otherwise (False, None)
 	@raises RuntimeError if the time limit expires and an errorMessage is given.
 	"""

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -11,6 +11,7 @@ of a package.
 import typing
 from typing import Optional
 
+import extensionPoints
 import globalPluginHandler
 import threading
 from .blockUntilConditionMet import _blockUntilConditionMet
@@ -37,6 +38,32 @@ def _importRobotRemoteServer() -> typing.Type:
 	return RobotRemoteServer
 
 
+class BrailleViewerSpy:
+	postBrailleUpdate = extensionPoints.Action()
+
+	def __init__(self):
+		self._last = ""
+
+	def updateBrailleDisplayed(
+			self,
+			cells,  # ignored
+			rawText,
+			currentCellCount,  # ignored
+	):
+		rawText = rawText.strip()
+		if rawText and rawText != self._last:
+			self._last = rawText
+			self.postBrailleUpdate.notify(rawText=rawText)
+
+	isDestroyed: bool = False
+
+	def saveInfoAndDestroy(self):
+		if not self.isDestroyed:
+			self.isDestroyed = True
+			import brailleViewer
+			brailleViewer._onGuiDestroyed()
+
+
 class NVDASpyLib:
 	""" Robot Framework Library to spy on NVDA during system tests.
 	Used to determine if NVDA has finished starting, and various ways of getting speech output.
@@ -50,10 +77,20 @@ class NVDASpyLib:
 			[""],  # initialise with an empty string, this allows for access via [-1]. This is equiv to no speech.
 		]
 		self._lastSpeechTime_requiresLock = _timer()
-		#: Lock to protect members written in _onNvdaSpeech.
+		#: Lock to protect members that are written to in _onNvdaSpeech.
 		self._speechLock = threading.RLock()
+
+		# braille raw text (not dots) cache is ordered temporally,
+		# oldest at low indexes, most recent at highest index.
+		self._nvdaBraille_requiresLock = [  # requires thread locking before read/write
+			"",  # initialise with an empty string, this allows for access via [-1]. This is equiv to no braille.
+		]
+		#: Lock to protect members that are written to in _onNvdaBraille.
+		self._brailleLock = threading.RLock()
+
 		self._isNvdaStartupComplete = False
 		self._allSpeechStartIndex = self.get_last_speech_index()
+		self._allBrailleStartIndex = self.get_last_braille_index()
 		self._maxKeywordDuration = 30
 		self._registerWithExtensionPoints()
 
@@ -66,6 +103,9 @@ class NVDASpyLib:
 		# Import path must be valid after `speechSpySynthDriver.py` is moved to "scratchpad/synthDrivers/"
 		from synthDrivers.speechSpySynthDriver import post_speech
 		post_speech.register(self._onNvdaSpeech)
+
+		self._brailleSpy = BrailleViewerSpy()
+		self._brailleSpy.postBrailleUpdate.register(self._onNvdaBraille)
 
 	def set_configValue(self, keyPath: typing.List[str], val: typing.Union[str, bool, int]):
 		import config
@@ -92,6 +132,16 @@ class NVDASpyLib:
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
 		self._isNvdaStartupComplete = True
+		import brailleViewer
+		brailleViewer._brailleGui = self._brailleSpy
+		self.setBrailleCellCount(120)
+		brailleViewer.postBrailleViewerToolToggledAction.notify(created=True)
+
+	def _onNvdaBraille(self, rawText: str):
+		if not rawText:
+			return
+		with self._brailleLock:
+			self._nvdaBraille_requiresLock.append(rawText)
 
 	def _onNvdaSpeech(self, speechSequence=None):
 		if not speechSequence:
@@ -143,6 +193,27 @@ class NVDASpyLib:
 			finished = self.SPEECH_HAS_FINISHED_SECONDS < _timer() - self._lastSpeechTime_requiresLock
 			return started and finished
 
+	def setBrailleCellCount(self, brailleCellCount: int):
+		import brailleViewer
+		brailleViewer.DEFAULT_NUM_CELLS = brailleCellCount
+
+	def _getBrailleAtIndex(self, brailleIndex: int) -> str:
+		with self._brailleLock:
+			return self._nvdaBraille_requiresLock[brailleIndex]
+
+	def get_braille_at_index_until_now(self, brailleIndex: int) -> str:
+		""" All raw braille text from (and including) the index until now.
+		@param brailleIndex:
+		@return: The raw text, each update on a new line
+		"""
+		with self._brailleLock:
+			rangeOfInterest = self._nvdaBraille_requiresLock[brailleIndex:]
+			return "\n".join(rangeOfInterest)
+
+	def get_last_braille_index(self) -> int:
+		with self._brailleLock:
+			return len(self._nvdaBraille_requiresLock) - 1
+
 	def _devInfoToLog(self):
 		import api
 		obj = api.getNavigatorObject()
@@ -162,6 +233,14 @@ class NVDASpyLib:
 				log.debug(f"All speech:\n{repr(self._nvdaSpeech_requiresLock)}")
 			except Exception:
 				log.error("Unable to log speech")
+
+	def dump_braille_to_log(self):
+		log.debug("dump_braille_to_log.")
+		with self._brailleLock:
+			try:
+				log.debug(f"All braille:\n{repr(self._nvdaBraille_requiresLock)}")
+			except Exception:
+				log.error("Unable to log braille")
 
 	def _minTimeout(self, timeout: float) -> float:
 		"""Helper to get the minimum value, the timeout passed in, or self._maxKeywordDuration"""
@@ -236,6 +315,28 @@ class NVDASpyLib:
 			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),
 			errorMessage="Speech did not finish before timeout"
 		)
+
+	def wait_for_braille_update(
+			self,
+			nextBrailleIndex: int,
+			maxWaitSeconds=5.0,
+	):
+		"""Wait until there is at least a single update.
+		@note there may be subsequent braille updates. This method does not confirm updates are finished.
+		"""
+		_blockUntilConditionMet(
+			getValue=lambda: self.get_last_braille_index() == nextBrailleIndex,
+			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),
+			errorMessage=None
+		)
+
+	def get_last_braille(self) -> str:
+		return self._getBrailleAtIndex(-1)
+
+	def get_next_braille_index(self) -> int:
+		""" @return: the next index that will be used.
+		"""
+		return self.get_last_braille_index() + 1
 
 	def emulateKeyPress(self, kbIdentifier: str, blockUntilProcessed=True):
 		"""

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1043,6 +1043,7 @@ def test_ensureNoBrowseModeDescription():
 		actualSpeech,
 		SPEECH_SEP.join([
 			"link",  # role description
+			# No link description (from title)
 			"Apple",  # link name / contents
 		]),
 		message="Test browse mode with reportObjectDescriptions=True"
@@ -1051,7 +1052,7 @@ def test_ensureNoBrowseModeDescription():
 		actualBraille,
 		BRAILLE_SEP.join([
 			"lnk",  # role description
-			"Cat",  # link description (from title)
+			# No link description (from title)
 			"Apple",  # link name / contents
 		]),
 		message="Test browse mode with reportObjectDescriptions=True"
@@ -1067,6 +1068,7 @@ def test_ensureNoBrowseModeDescription():
 		actualSpeech,
 		SPEECH_SEP.join([
 			"link",  # role description
+			# No link description (from title)
 			"Apple",  # link name / contents
 		]),
 		message="Test browse mode with reportObjectDescriptions=False"
@@ -1075,6 +1077,7 @@ def test_ensureNoBrowseModeDescription():
 		actualBraille,
 		BRAILLE_SEP.join([
 			"lnk",  # role description
+			# No link description (from title)
 			"Apple",  # link name / contents
 		]),
 		message="Test browse mode with reportObjectDescriptions=False"
@@ -1117,6 +1120,7 @@ def test_ensureNoBrowseModeDescription():
 		SPEECH_SEP.join([
 			"Banana",  # link name / contents
 			"link",  # role description
+			# No link description (from title)
 		]),
 		message="Test focus mode with reportObjectDescriptions=False"
 	)
@@ -1125,6 +1129,7 @@ def test_ensureNoBrowseModeDescription():
 		BRAILLE_SEP.join([
 			"Banana",  # link name / contents
 			"lnk",  # role description
+			# No link description (from title)
 		]),
 		message="Test focus mode with reportObjectDescriptions=False"
 	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -19,6 +19,8 @@ Test Teardown	default teardown
 default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
+	dump_speech_to_log
+	dump_braille_to_log
 	exit chrome
 	quit NVDA
 
@@ -96,3 +98,6 @@ Prevent Duplicate Speech From Description while in Focus mode
 	preventDuplicateSpeechFromDescription_focus
 Prevent Duplicate Speech From Description while in Browse mode with tab nav
 	test_preventDuplicateSpeechFromDescription_browse_tab
+Only report description in focus mode due to reportObjectDescriptions
+	[Documentation]	The term object in reportObjectDescriptions (essentially) means focus mode.
+	test_ensureNoBrowseModeDescription

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -101,3 +101,4 @@ Prevent Duplicate Speech From Description while in Browse mode with tab nav
 Only report description in focus mode due to reportObjectDescriptions
 	[Documentation]	The term object in reportObjectDescriptions (essentially) means focus mode.
 	test_ensureNoBrowseModeDescription
+

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -70,6 +70,7 @@ To match the production build environment, update Visual Studio to keep in sync 
 - ``LOCALE_SLANGUAGE``, ``LOCALE_SLIST`` and ``LOCALE_SLANGDISPLAYNAME`` are moved to the ``LOCALE`` enum in languageHandler.
 They are still available at the module level but are deprecated and to be removed in NVDA 2022.1. (#12753)
 - The usage of functions ``addonHandler.loadState`` and ``addonHandler.saveState`` should be replaced with their equivalents ``addonHandler.state.save`` and ``addonHandler.state.load`` before 2022.1. (#12792)
+- Braille output can now be checked in system tests. (#12917)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1580,6 +1580,7 @@ To toggle simple review mode from anywhere, please assign a custom gesture using
 
 +++ Object Presentation (NVDA+control+o) +++[ObjectPresentationSettings]
 The Object Presentation category in the NVDA Settings dialog is used to set how much information NVDA will present about controls such as description, position information and so on.
+These options don't typically apply to browse mode.
 This category contains the following options:
 
 ==== Report tooltips ====[ObjectPresentationReportToolTips]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1581,7 +1581,7 @@ To toggle simple review mode from anywhere, please assign a custom gesture using
 +++ Object Presentation (NVDA+control+o) +++[ObjectPresentationSettings]
 The Object Presentation category in the NVDA Settings dialog is used to set how much information NVDA will present about controls such as description, position information and so on.
 These options don't typically apply to browse mode.
-This category contains the following options:
+These options typically apply to focus reporting and NVDA object navigation, but not reading text content e.g. browse mode.
 
 ==== Report tooltips ====[ObjectPresentationReportToolTips]
 A checkbox that when checked tells NVDA to report tooltips as they appear.


### PR DESCRIPTION
### Link to issue number:
Fixes: #12750

### Summary of the issue:
Historically the option "Object presentation: Report Object Descriptions" (default: true) has been limited to focus mode and object navigation.
In Report aria-description always #12500 this was changed to report descriptions always.
Historically, the word "object" in the settings category, and the name of this option was supposed to imply "focus mode / object nav specific behavior".

### Description of how this pull request fixes the issue:
- Introduces a way to test braille (not dots, raw text) output.
- Reverts changes from #12500 that aimed to make the reportObjectDescriptions behavior consistent between browse and focus modes.
- Updates the user docs to specify that options in the Object Presentation category don't apply to browse mode.

### Testing strategy:
System tests with examples inspired by #12750.
- Browse mode (nav by down arrow) with reportObjectDescriptions True and False
- Focus mode (nav by tab) with reportObjectDescriptions True and False

### Known issues with pull request:
None

### Change log entries:

For Developers:
```
- Braille output can now be checked in system tests.
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
