### PR TITLE
Better detection of spelling errors when typing in MS Word with UIA

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -13,7 +13,7 @@ import time
 import re
 import typing
 import weakref
-
+import core
 import textUtils
 from logHandler import log
 import review
@@ -1053,21 +1053,34 @@ Tries to force this object to take the focus.
 			# The one before that is the last of the word, which is what we want.
 			info.move(textInfos.UNIT_CHARACTER, -2)
 			info.expand(textInfos.UNIT_CHARACTER)
-			fields = info.getTextWithFields()
-		except RuntimeError:
-			return
-		except:
+		except Exception:
 			# Focus probably moved.
 			log.debugWarning("Error fetching last character of previous word", exc_info=True)
 			return
-		for command in fields:
-			if isinstance(command, textInfos.FieldCommand) and command.command == "formatChange" and command.field.get("invalid-spelling"):
-				break
-		else:
-			# No error.
-			return
-		import nvwave
-		nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "textError.wav"))
+
+		# Fetch the formatting for the last word to see if it is marked as a spelling error,
+		# However perform the fetch and check in a future core cycle
+		# To give the content control more time to detect and mark the error itself.
+		# #12161: MS Word's UIA implementation certainly requires this delay.
+		def _delayedDetection():
+			try:
+				fields = info.getTextWithFields()
+			except RuntimeError:
+				log.debugWarning("Error fetching formatting for last character of previous word", exc_info=True)
+				return
+			for command in fields:
+				if (
+					isinstance(command, textInfos.FieldCommand)
+					and command.command == "formatChange"
+					and command.field.get("invalid-spelling")
+				):
+					break
+			else:
+				# No error.
+				return
+			import nvwave
+			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "textError.wav"))
+		core.callLater(50, _delayedDetection)
 
 	def _get_liveRegionPoliteness(self) -> aria.AriaLivePoliteness:
 		""" Retrieves the priority with which  updates to live regions should be treated.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,6 +57,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - When accessing MS Word with UIA, paragraph indenting is now reported. (#12899(
 - When accessing MS Word with UIA, change tracking command and some other localized commands are now reported in Word . (#12904)
 - Fixed duplicate braille and speech when 'description' matches 'content' or 'name'. (#12888)
+- In MS Word with UIA enabled, More accurate playing of spelling error sound as you type. (#12161)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12161 

### Summary of the issue:
When in any editable text control (E.g. a Word document), each time the user completes a word by typing space or another punctuation character, NVDA checks the formatting of the completed word to see if it is marked as a spelling error, and if so plays a special text error buzz sound.
However, in at least MS Word with UIA, this check for spelling errors never really finds an error as MS Word has not yet actually detected the error itself.
We need to slow down NVDA's detection to give the app more time.
 
### Description of how this pull request fixes the issue:
Delay the fetch and check of the completed word's formatting into a future core cycle (specifically a 50 ms delay) to give the app more time to detect the error itself.

### Testing strategy:
In MS Word with UIA enabled/disabled, and Mozilla Thunderbird:
Created a new document or message, and started typing text with errors. Ensured that NVDA played the spelling error sound when the completed word had an error.
This test was performed both on a plugged in machine on a high-performance power profile, and a machine on battery, on a power saver profile.
 All scenarios played the spelling error sound at the appropriate time.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
NVDA more accurately detects spelling errors as you type in MS Word with UIA enabled. (#12161)
 For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
