### PR TITLE
create Enums for audioDucking and minor lint

### DIFF
--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -3,16 +3,20 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from enum import IntEnum
+from utils.displayString import DisplayStringIntEnum
 import threading
-from ctypes import *
-from ctypes import oledll
+from typing import Dict
+from ctypes import oledll, wintypes, windll
 import time
 import config
 from logHandler import log
 import systemUtils
 
+
 def _isDebug():
 	return config.conf["debugLog"]["audioDucking"]
+
 
 class AutoEvent(wintypes.HANDLE):
 
@@ -25,24 +29,33 @@ class AutoEvent(wintypes.HANDLE):
 			windll.kernel32.CloseHandle(self)
 
 WAIT_TIMEOUT=0x102
-AUDIODUCKINGMODE_NONE=0
-AUDIODUCKINGMODE_OUTPUTTING=1
-AUDIODUCKINGMODE_ALWAYS=2
 
-audioDuckingModes=[
-	# Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
-	# See the Audio Ducking Mode section of the User Guide for details.
-	_("No ducking"),
-	# Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
-	# See the Audio Ducking Mode section of the User Guide for details.
-	_("Duck when outputting speech and sounds"),
-	# Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
-	# See the Audio Ducking Mode section of the User Guide for details.
-	_("Always duck"),
-]
 
-ANRUS_ducking_AUDIO_ACTIVE=4
-ANRUS_ducking_AUDIO_ACTIVE_NODUCK=8
+class AudioDuckingMode(DisplayStringIntEnum):
+	NONE = 0
+	OUTPUTTING = 1
+	ALWAYS = 2
+
+	@property
+	def _displayStringLabels(self) -> Dict[IntEnum, str]:
+		return {
+			# Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
+			# See the Audio Ducking Mode section of the User Guide for details.
+			AudioDuckingMode.NONE: _("No ducking"),
+			# Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
+			# See the Audio Ducking Mode section of the User Guide for details.
+			AudioDuckingMode.OUTPUTTING: _("Duck when outputting speech and sounds"),
+			# Translators: An audio ducking mode which specifies how NVDA affects the volume of other applications.
+			# See the Audio Ducking Mode section of the User Guide for details.
+			AudioDuckingMode.ALWAYS: _("Always duck"),
+		}
+
+
+class ANRUSDucking(IntEnum):
+	# https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-accsetrunningutilitystate#anrus_priority_audio_active_noduck
+	AUDIO_ACTIVE = 4
+	AUDIO_ACTIVE_NODUCK = 8
+
 
 INITIAL_DUCKING_DELAY=0.15
 
@@ -52,6 +65,7 @@ _duckingRefCountLock = threading.RLock()
 _modeChangeEvent=None
 _lastDuckedTime=0
 
+
 def _setDuckingState(switch):
 	global _lastDuckedTime
 	with _duckingRefCountLock:
@@ -59,10 +73,18 @@ def _setDuckingState(switch):
 			import gui
 			ATWindow=gui.mainFrame.GetHandle()
 			if switch:
-				oledll.oleacc.AccSetRunningUtilityState(ATWindow,ANRUS_ducking_AUDIO_ACTIVE|ANRUS_ducking_AUDIO_ACTIVE_NODUCK,ANRUS_ducking_AUDIO_ACTIVE|ANRUS_ducking_AUDIO_ACTIVE_NODUCK)
+				oledll.oleacc.AccSetRunningUtilityState(
+					ATWindow,
+					ANRUSDucking.AUDIO_ACTIVE | ANRUSDucking.AUDIO_ACTIVE_NODUCK,
+					ANRUSDucking.AUDIO_ACTIVE | ANRUSDucking.AUDIO_ACTIVE_NODUCK
+				)
 				_lastDuckedTime=time.time()
 			else:
-				oledll.oleacc.AccSetRunningUtilityState(ATWindow,ANRUS_ducking_AUDIO_ACTIVE|ANRUS_ducking_AUDIO_ACTIVE_NODUCK,ANRUS_ducking_AUDIO_ACTIVE_NODUCK)
+				oledll.oleacc.AccSetRunningUtilityState(
+					ATWindow,
+					ANRUSDucking.AUDIO_ACTIVE | ANRUSDucking.AUDIO_ACTIVE_NODUCK,
+					ANRUSDucking.AUDIO_ACTIVE_NODUCK
+				)
 		except WindowsError as e:
 			# When the NVDA build is not signed, audio ducking fails with access denied.
 			# A developer built launcher is unlikely to be signed. Catching this error stops developers from looking into
@@ -81,18 +103,20 @@ def _setDuckingState(switch):
 				)
 				raise e
 
+
 def _ensureDucked():
 	global _duckingRefCount
 	with _duckingRefCountLock:
 		_duckingRefCount+=1
 		if _isDebug():
 			log.debug("Increased ref count, _duckingRefCount=%d"%_duckingRefCount)
-		if _duckingRefCount==1  and _audioDuckingMode!=AUDIODUCKINGMODE_NONE:
+		if _duckingRefCount == 1 and _audioDuckingMode != AudioDuckingMode.NONE:
 			_setDuckingState(True)
 			delta=0
 		else:
 			delta=time.time()-_lastDuckedTime
 		return delta,_modeChangeEvent
+
 
 def _unensureDucked(delay=True):
 	global _duckingRefCount
@@ -106,14 +130,15 @@ def _unensureDucked(delay=True):
 		_duckingRefCount-=1
 		if _isDebug():
 			log.debug("Decreased  ref count, _duckingRefCount=%d"%_duckingRefCount)
-		if _duckingRefCount==0 and _audioDuckingMode!=AUDIODUCKINGMODE_NONE:
+		if _duckingRefCount == 0 and _audioDuckingMode != AudioDuckingMode.NONE:
 			_setDuckingState(False)
+
 
 def setAudioDuckingMode(mode):
 	global _audioDuckingMode, _modeChangeEvent
 	if not isAudioDuckingSupported():
 		raise RuntimeError("audio ducking not supported")
-	if mode<0 or mode>=len(audioDuckingModes):
+	if mode < 0 or mode >= len(AudioDuckingMode):
 		raise ValueError("%s is not an audio ducking mode")
 	with _duckingRefCountLock:
 		oldMode=_audioDuckingMode
@@ -122,14 +147,15 @@ def setAudioDuckingMode(mode):
 		_modeChangeEvent=AutoEvent()
 		if _isDebug():
 			log.debug("Switched modes from %s, to %s"%(oldMode,mode))
-		if oldMode==AUDIODUCKINGMODE_NONE and mode!=AUDIODUCKINGMODE_NONE and _duckingRefCount>0:
+		if oldMode == AudioDuckingMode.NONE and mode != AudioDuckingMode.NONE and _duckingRefCount > 0:
 			_setDuckingState(True)
-		elif oldMode!=AUDIODUCKINGMODE_NONE and mode==AUDIODUCKINGMODE_NONE and _duckingRefCount>0:
+		elif oldMode != AudioDuckingMode.NONE and mode == AudioDuckingMode.NONE and _duckingRefCount > 0:
 			_setDuckingState(False)
-		if oldMode!=AUDIODUCKINGMODE_ALWAYS and mode==AUDIODUCKINGMODE_ALWAYS:
+		if oldMode != AudioDuckingMode.ALWAYS and mode == AudioDuckingMode.ALWAYS:
 			_ensureDucked()
-		elif oldMode==AUDIODUCKINGMODE_ALWAYS and mode!=AUDIODUCKINGMODE_ALWAYS:
+		elif oldMode == AudioDuckingMode.ALWAYS and mode != AudioDuckingMode.ALWAYS:
 			_unensureDucked(delay=False)
+
 
 def initialize():
 	if not isAudioDuckingSupported():
@@ -138,7 +164,10 @@ def initialize():
 	setAudioDuckingMode(config.conf['audio']['audioDuckingMode'])
 	config.post_configProfileSwitch.register(handlePostConfigProfileSwitch)
 
+
 _isAudioDuckingSupported=None
+
+
 def isAudioDuckingSupported():
 	global _isAudioDuckingSupported
 	if _isAudioDuckingSupported is None:
@@ -149,8 +178,10 @@ def isAudioDuckingSupported():
 		_isAudioDuckingSupported &= systemUtils.hasUiAccess()
 	return _isAudioDuckingSupported
 
+
 def handlePostConfigProfileSwitch():
 	setAudioDuckingMode(config.conf['audio']['audioDuckingMode'])
+
 
 class AudioDucker(object):
 	""" Create one of these objects to manage ducking of background audio. 
@@ -189,7 +220,7 @@ class AudioDucker(object):
 			disableEvent=self._disabledEvent=AutoEvent()
 			if debug:
 				log.debug("whenWasDucked %s, deltaMS %s"%(whenWasDucked,deltaMS))
-			if deltaMS<=0 or _audioDuckingMode==AUDIODUCKINGMODE_NONE:
+			if deltaMS <= 0 or _audioDuckingMode == AudioDuckingMode.NONE:
 				return True
 		import NVDAHelper
 		if not NVDAHelper.localLib.audioDucking_shouldDelay():

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -108,11 +108,11 @@ class GlobalCommands(ScriptableObject):
 			ui.message(_("Audio ducking not supported"))
 			return
 		curMode=config.conf['audio']['audioDuckingMode']
-		numModes=len(audioDucking.audioDuckingModes)
+		numModes = len(audioDucking.AudioDuckingMode)
 		nextMode=(curMode+1)%numModes
 		audioDucking.setAudioDuckingMode(nextMode)
 		config.conf['audio']['audioDuckingMode']=nextMode
-		nextLabel=audioDucking.audioDuckingModes[nextMode]
+		nextLabel = audioDucking.AudioDuckingMode(nextMode).displayString
 		ui.message(nextLabel)
 
 	@script(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1058,7 +1058,11 @@ class SynthesizerSelectionDialog(SettingsDialog):
 
 		# Translators: This is a label for the audio ducking combo box in the Synthesizer Settings dialog.
 		duckingListLabelText = _("Audio d&ucking mode:")
-		self.duckingList=settingsSizerHelper.addLabeledControl(duckingListLabelText, wx.Choice, choices=audioDucking.audioDuckingModes)
+		self.duckingList = settingsSizerHelper.addLabeledControl(
+			duckingListLabelText,
+			wx.Choice,
+			choices=audioDucking.AudioDuckingMode._displayStringLabels.values()
+		)
 		self.bindHelpEvent("SelectSynthesizerDuckingMode", self.duckingList)
 		index=config.conf['audio']['audioDuckingMode']
 		self.duckingList.SetSelection(index)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1066,7 +1066,7 @@ class SynthesizerSelectionDialog(SettingsDialog):
 		self.duckingList = settingsSizerHelper.addLabeledControl(
 			duckingListLabelText,
 			wx.Choice,
-			choices=audioDucking.AudioDuckingMode._displayStringLabels.values()
+			choices=[mode.displayString for mode in audioDucking.AudioDuckingMode]
 		)
 		self.bindHelpEvent("SelectSynthesizerDuckingMode", self.duckingList)
 		index=config.conf['audio']['audioDuckingMode']

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,14 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+== TBA 2022.1 Changes for Developers ==
+- ``audioDucking.AUDIODUCKINGMODE_*`` constants are now a ``DisplayStringIntEnum``.
+  - usages should be replaced with ``AudioDuckingMode.*``
+  - usages of ``audioDucking.audioDuckingModes`` should be replaced with ``AudioDuckingMode.*.displayString``
+  -
+- ``audioDucking.ANRUS_ducking_*`` constants usages should be replaced with ``ANRUSDucking.*``
+-
+
 = 2021.3 =
 
 == New Features ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,7 +20,7 @@ What's New in NVDA
 == Changes for Developers ==
 - Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
 - ``NVDAObjects.UIA.winConsoleUIA.WinConsoleUIA.isImprovedTextRangeAvailable`` has been removed. Use ``apiLevel`` instead. (#12955, #12660)
-- ``TVItemStruct`` has been from ``sysTreeView32``. (#12935)
+- ``TVItemStruct`` has been removed from ``sysTreeView32``. (#12935)
 - ``MessageItem`` has been removed from the Outlook appModule. (#12935)
 - ``audioDucking.AUDIODUCKINGMODE_*`` constants are now a ``DisplayStringIntEnum``. (#12926)
   - usages should be replaced with ``AudioDuckingMode.*``


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None

### Summary of the issue:

While debugging #12913, I created some Enums to help with logging and understanding the code.
This is not a focused refactor, and as such, more work could be done to improve the audioDucking API.

### Description of how this pull request fixes the issue:

- Implements `IntEnum`s for constants
- Add some comments
- Clean up imports

### Testing strategy:

with a try build of this PR: 
- [x] Test the audio ducking menu 
- [x] Test the input gesture(s) to trigger audioducking
- [x] Test audio ducking as a feature

### Known issues with pull request:

Note, this is an API breaking change and should not be merged until 2022.1.
I have just created this PR as the work should not be lost, but adding backwards compatibility is not worth prioritising.

### Change log entries:

See diff in changes.t2t

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
