### PR TITLE
Fixup of pr 12925: errors due to delayed spelling detection when pressing tab sometimes

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1065,7 +1065,7 @@ Tries to force this object to take the focus.
 		def _delayedDetection():
 			try:
 				fields = info.getTextWithFields()
-			except RuntimeError:
+			except Exception:
 				log.debugWarning("Error fetching formatting for last character of previous word", exc_info=True)
 				return
 			for command in fields:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12930
Fixup of #12925 

### Summary of the issue:
When fetching the formatting of the last typed word after a delay, in order to detect if there is a spelling error, errors can occur if the underlying object dies or is replaced.
For example:
when first pressing tab in the Firefox profile selection dialog:
```
ERROR - queueHandler.flushQueue (18:07:01.213) - MainThread (3880):
Error in func NVDAObject._reportErrorInPreviousWord.<locals>._delayedDetection
Traceback (most recent call last):
  File "queueHandler.pyc", line 55, in flushQueue
  File "NVDAObjects\__init__.pyc", line 1067, in _delayedDetection
  File "textInfos\offsets.pyc", line 573, in getTextWithFields
  File "NVDAObjects\IAccessible\__init__.pyc", line 241, in _getFormatFieldAndOffsets
AttributeError: 'NoneType' object has no attribute 'IAccessibleTextObject'
```

### Description of how this pull request fixes the issue:
Catch Exception rather than RuntimeError when fetching formatting by calling GetTextWithFields.
Note that this exception will still be logged at debug warning.

### Testing strategy:
* Performed tests in pr #12925 to ensure that issue #12161 is still fixed.
* Opened the Firefox profile selection dialog: `firefox -profilemanager` and pressed tab. Ensured that the NVDA error sound was not played but the error was still logged at debugWarning.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
