### PR TITLE
Fix reading order / description spoken during quick nav

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1784,6 +1784,20 @@ def getControlFieldSpeech(  # noqa: C901
 	description: Optional[str] = None
 	_descriptionFrom = attrs.get('_description-from', controlTypes.DescriptionFrom.UNKNOWN)
 	_descriptionIsContent: bool = attrs.get("descriptionIsContent", False)
+	_reportDescriptionAsAnnotation: bool = (
+		# Don't report other sources of description like "title" all the time
+		# The usages of these is not consistent and often does not seem to have
+		# Screen Reader users in mind
+		config.conf["annotations"]["reportAriaDescription"]
+		and not _descriptionIsContent
+		and controlTypes.DescriptionFrom.ARIA_DESCRIPTION == _descriptionFrom
+		and reason in (
+			OutputReason.FOCUS,
+			OutputReason.QUICKNAV,
+			OutputReason.CARET,
+			OutputReason.SAYALL,
+		)
+	)
 	if (
 		(
 			config.conf["presentation"]["reportObjectDescriptions"]
@@ -1795,19 +1809,7 @@ def getControlFieldSpeech(  # noqa: C901
 			# Not used internally, but may be used by addons.
 			attrs.get('alwaysReportDescription', False)
 		)
-		or (
-			# Don't report other sources of description like "title" all the time
-			# The usages of these is not consistent and often does not seem to have
-			# Screen Reader users in mind
-			config.conf["annotations"]["reportAriaDescription"]
-			and not _descriptionIsContent
-			and controlTypes.DescriptionFrom.ARIA_DESCRIPTION == _descriptionFrom
-			and reason in (
-				OutputReason.FOCUS,
-				OutputReason.CARET,
-				OutputReason.SAYALL,
-			)
-		)
+		or _reportDescriptionAsAnnotation
 	):
 		description = attrs.get('description')
 
@@ -2024,7 +2026,7 @@ def getControlFieldSpeech(  # noqa: C901
 		out = []
 		if isCurrent != controlTypes.IsCurrent.NO:
 			out.extend(isCurrentSequence)
-		if descriptionSequence:
+		if descriptionSequence and _reportDescriptionAsAnnotation:
 			out.extend(descriptionSequence)
 		# Speak expanded / collapsed / level for treeview items (in ARIA treegrids)
 		if role == controlTypes.Role.TREEVIEWITEM:

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1166,7 +1166,6 @@ def test_quickNavTargetReporting():
 	_asserts.strings_match(
 		actualSpeech,
 		SPEECH_SEP.join([
-			"A bunch of text.",  # article (ancestor) description
 			"Quick Nav Target",  # Heading content (quick nav target), should read first
 			"heading",  # Heading role
 			"level 1",  # Heading level
@@ -1238,7 +1237,6 @@ def test_focusTargetReporting():
 	_asserts.strings_match(
 		actualSpeech,
 		SPEECH_SEP.join([
-			"A bunch of text.",  # description for article
 			"Focus Target",  # link content (focus target), should read first
 			"link",  # link role
 		]),

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1194,3 +1194,140 @@ def test_quickNavTargetReporting():
 			"A bunch of text.",  # article (ancestor) description
 		])
 	)
+
+
+def test_focusTargetReporting():
+	"""
+	When moving focus the target object should be spoken first, inner context should be given before outer
+	context.
+	"""
+	spy = _NvdaLib.getSpyLib()
+	REPORT_ARTICLES = ["documentFormatting", "reportArticles"]
+	spy.set_configValue(REPORT_ARTICLES, False)
+
+	_chrome.prepareChrome(
+		"""
+		<a href="#">before Target</a>
+		<div
+			aria-describedby="descId"
+			aria-labelledby="labelId"
+			role="article"
+		>
+			<a href="#">Focus Target</a>
+			<div id="labelId">
+					<div>Some name.</div>
+			</div>
+			<div id="descId">
+					<span>A bunch of text.</span>
+			</div>
+		</div>
+		"""
+	)
+	# Set focus
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"before Target",
+			"link",
+		])
+	)
+
+	# Focus the link
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"A bunch of text.",  # description for article
+			"Focus Target",  # link content (focus target), should read first
+			"link",  # link role
+		]),
+		message="browse mode - focus with Report Articles disabled"
+	)
+	# Reset to allow trying again with report articles enabled
+	actualSpeech = _chrome.getSpeechAfterKey("shift+tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"before Target",
+			"link",
+		])
+	)
+
+	# Focus the link with report articles enabled
+	spy.set_configValue(REPORT_ARTICLES, True)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"Focus Target",  # link content (focus target), should read first
+			"link",  # link role
+			"article",  # article role, enabled via report article
+			"A bunch of text.",  # article (ancestor) description
+		]),
+		message="browse mode - focus with Report Articles enabled"
+	)
+
+	# Reset to allow trying again in focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("shift+tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"before Target",
+			"link",
+		])
+	)
+
+	# Force focus mode
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+space")
+	_asserts.strings_match(
+		actualSpeech,
+		"Focus mode"
+	)
+
+	spy.set_configValue(REPORT_ARTICLES, False)
+	# Focus the link
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_CALL_SEP.join([
+			SPEECH_SEP.join([
+				"Some name.",  # name for article
+				"article",  # article role, enabled via report article
+				"A bunch of text.",  # description for article
+			]),
+			SPEECH_SEP.join([
+				"Focus Target",  # link content (focus target), should read first
+				"link",  # link role
+			]),
+		]),
+		message="focus mode - focus with Report Articles disabled"
+	)
+	# Reset to allow trying again with report articles enabled
+	actualSpeech = _chrome.getSpeechAfterKey("shift+tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"before Target",
+			"link",
+		])
+	)
+
+	# Focus the link with report articles enabled
+	spy.set_configValue(REPORT_ARTICLES, True)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_CALL_SEP.join([
+			SPEECH_SEP.join([
+				"Some name.",  # name for article
+				"article",  # article role, enabled via report article
+				"A bunch of text.",  # description for article
+			]),
+			SPEECH_SEP.join([
+				"Focus Target",  # link content (focus target), should read first
+				"link",  # link role
+			]),
+		]),
+		message="focus mode - focus with Report Articles enabled"
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -101,4 +101,6 @@ Prevent Duplicate Speech From Description while in Browse mode with tab nav
 Only report description in focus mode due to reportObjectDescriptions
 	[Documentation]	The term object in reportObjectDescriptions (essentially) means focus mode.
 	test_ensureNoBrowseModeDescription
-
+Quick Nav reports target first
+	[Documentation]	Quick Nav target should always be reported before ancestors. Ancestors should be reported from inner to outer.
+	test_quickNavTargetReporting

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -104,3 +104,6 @@ Only report description in focus mode due to reportObjectDescriptions
 Quick Nav reports target first
 	[Documentation]	Quick Nav target should always be reported before ancestors. Ancestors should be reported from inner to outer.
 	test_quickNavTargetReporting
+Focus reports target first
+	[Documentation]	Focus target should always be reported before ancestors. Ancestors should be reported from inner to outer.
+	test_focusTargetReporting


### PR DESCRIPTION

### Link to issue number:
fixes #12751

### Summary of the issue:
When using quick nav (`"h"` in browse mode) to navigate to a heading nested in an article with a description, the description is announced before the heading. For quicknav and for focus changes, the most inner element should always be announced first, working outwards to provide additional context.

Using the following example:

`data:text/html,<p>Start</p><article aria-describedby="desc"><h4>Test Title</h4><p id="desc">Test description</p>`

With "report articles" unchecked, speech should be:
`Test title heading level 4`

Instead it was:
`Test description Test title heading level 4`

With "report articles" checked, speech was:
`Test title heading level 4 article test description`

### Description of how this pull request fixes the issue:
- Adds a test for quick nav reporting and focus changed reporting. The target element is a child node of a container that is usually spoken.
- Don't speak description for the container unless it is an aria-description.


### Testing strategy:
System tests

### Known issues with pull request:
Is aria-description doing the right thing in this case?

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
