### PR TITLE
Add missing import to the MSN messenger appModule

### DIFF
--- a/source/appModules/msnmsgr.py
+++ b/source/appModules/msnmsgr.py
@@ -1,9 +1,8 @@
-#coding=UTF-8
-#appModules/_default.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# -*- coding: UTF-8 -*-
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2007-2021 NV Access Limited, Mesar Hameed, Peter Vágner
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import config
 import winUser
@@ -14,6 +13,8 @@ import textInfos
 import appModuleHandler
 import speech
 import cursorManager
+from comtypes import COMError
+
 
 lastMSNHistoryValue=None
 possibleHistoryWindowNames=frozenset([


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
App module for MSN Messenger references `COMError` but it was not imported.
### Description of how this pull request fixes the issue:
Adds missing import.
### Testing strategy:
Not applicable - just fixes a coding mistake.
### Known issues with pull request:
When I saw the problem my first impulse was to remove MSN Messenger module all together as it is a pretty old software. After further research it turns out that while Microsoft indeed shutdown their MSN servers there are various unofficial hosts to which you can connect with MSN Messenger. I have no evidence that any NVDA user uses them, but I don't have any evidence to the contrary either.
### Change log entries:
None needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
