### PR TITLE
Remove unused and / or broken code

### DIFF
--- a/source/NVDAObjects/IAccessible/sysTreeView32.py
+++ b/source/NVDAObjects/IAccessible/sysTreeView32.py
@@ -3,10 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2007-2020 NV Access Limited
 
-from ctypes import *
-from ctypes.wintypes import *
 import api
-import winKernel
 import controlTypes
 import speech
 import UIAHandler
@@ -36,19 +33,6 @@ TVGN_PREVIOUS=2
 TVGN_PARENT=3
 TVGN_CHILD=4
 
-class TVItemStruct(Structure):
-	_fields_=[
-		('mask',c_uint),
-		('hItem',c_void_p),
-		('state',c_uint),
-		('stateMask',c_uint),
-		('pszText',LPWSTR),
-		('cchTextMax',c_int),
-		('iImage',c_int),
-		('iSelectedImage',c_int),
-		('cChildren',c_int),
-		('lParam',LPARAM),
-	]
 
 class TreeView(IAccessible):
 

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -256,29 +256,6 @@ class SuperGridClient2010(IAccessible):
 		obj.parent=self.parent
 		eventHandler.executeEvent("gainFocus",obj)
 
-class MessageItem(Window):
-
-	def __init__(self,windowHandle=None,parent=None,msg=None):
-		if not parent or not msg:
-			raise ArguementError("__init__ needs windowHandle, parent and msg arguments")
-		if not windowHandle:
-			windowHandle=parent.windowHandle
-		self.msg=msg
-		self.parent=parent
-		Window.__init__(self,windowHandle=windowHandle)
-
-	def _get_name(self):
-		typeID=self.msg.Class
-		if typeID==40:
-			return getContactString(self.msg)
-		elif typeID==43:
-			return getReceivedMessageString(self.msg)
-
-	def _get_role(self):
-		return controlTypes.Role.LISTITEM
-
-	def _get_states(self):
-		return frozenset([controlTypes.State.SELECTED])
 
 class AddressBookEntry(IAccessible):
 

--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -20,30 +20,6 @@ import NVDAObjects.IAccessible
 import winUser
 
 
-def getPath(obj, ancestor):
-	"""Gets the path of the object with respect to its ancestor.
-	the ancestor is typically the forground object.
-
-	@returns: A list of coordinates relative to the ansestor.
-	@rtype: L{list}
-	"""
-	path = []
-	cancel = 0
-	if obj == stopObj: return []
-	p = obj
-	while p != stopObj:
-		counter = 0
-		while p.previous:
-			p = p.previous
-			counter += 1
-			cancel += 1
-			# Looks like we have an infinite ancestry, so get out
-			if cancel == 50: return [-1]
-		path.append(counter)
-		p = p.parent
-	path.reverse()
-	return path
-
 def fetchObject(obj, path):
 	"""Fetch the child object  described by path.
 	@returns: requested object if found, or None

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,8 @@ What's New in NVDA
 == Changes for Developers ==
 - Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
 - ``NVDAObjects.UIA.winConsoleUIA.WinConsoleUIA.isImprovedTextRangeAvailable`` has been removed. Use ``apiLevel`` instead. (#12955, #12660)
+- ``TVItemStruct`` has been from ``sysTreeView32``. (#12935)
+- ``MessageItem`` has been removed from the Outlook appModule. (#12935)
 -
 
 


### PR DESCRIPTION
Keeping as a draft until development cycle for 2022.1 begins, as these changes break backwards compatibility.
### Link to issue number:
None
### Summary of the issue:
NVDA contains some broken and / or unused code. 2022.1 seems a good opportunity to get rid of it.
### Description of how this pull request fixes the issue:
This PR removes the following:
- sysTreeView32 contains unused `TVItemStruct` - no idea what for (this code was there and was unused since 97a2fc65c31cb0718374e6df82b5eb5337b24b2f so for as long as this module).
- `MessageItem` class from the app Module for Outlook (last usages removed in #9603)
- `getPath` from the poedit appModule - this function was not used anywhere and in addition was broken (it references nonexistent variable `stopObj`
### Testing strategy:
With git grep ensured that removed code is not used.
### Known issues with pull request:
There is probably more dead code in NVDA - I've removed only what I've encountered when working on various other fixes in the past.
### Change log entries:
For Developers

- `TVItemStruct` is removed from sysTreeView32
- `MessageItem` has been removed from Outlook appModule.
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
