### PR TITLE
Move CallCancelled from core and all RPC constants into an enum

### DIFF
--- a/source/RPCConstants.py
+++ b/source/RPCConstants.py
@@ -1,0 +1,14 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2009-2021 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import enum
+
+
+class RPC(enum.IntEnum):
+	E_CALL_CANCELED = -2147418110
+	S_SERVER_UNAVAILABLE = 1722
+	S_CALL_FAILED_DNE = 1727
+	E_CALL_REJECTED = -2147418111
+	E_DISCONNECTED = -2147417848

--- a/source/api.py
+++ b/source/api.py
@@ -20,6 +20,7 @@ import eventHandler
 import braille
 import vision
 import watchdog
+import exceptions
 import appModuleHandler
 import cursorManager
 from typing import Any, Optional
@@ -129,7 +130,7 @@ Before overriding the last object, this function calls event_loseFocus on the ob
 		newAppModules.append(obj.appModule)
 	try:
 		treeInterceptorHandler.cleanup()
-	except watchdog.CallCancelled:
+	except exceptions.CallCancelled:
 		pass
 	treeInterceptorObject=None
 	o=None

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -31,7 +31,7 @@ import config
 import NVDAObjects #Catches errors before loading default appModule
 import api
 import appModules
-import watchdog
+import exceptions
 import extensionPoints
 from fileUtils import getFileVersionInfo
 
@@ -264,7 +264,7 @@ def handleAppSwitch(oldMods, newMods):
 		if not mod.sleepMode and hasattr(mod,'event_appModule_loseFocus'):
 			try:
 				mod.event_appModule_loseFocus()
-			except watchdog.CallCancelled:
+			except exceptions.CallCancelled:
 				pass
 
 	nvdaGuiLostFocus = nextStage and nextStage[-1].appName == "nvda"

--- a/source/core.py
+++ b/source/core.py
@@ -10,9 +10,6 @@ from typing import Optional
 
 RPC_E_CALL_CANCELED = -2147418110
 
-class CallCancelled(Exception):
-	"""Raised when a call is cancelled.
-	"""
 
 import comtypes
 import sys

--- a/source/core.py
+++ b/source/core.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 """NVDA core"""
 
-RPC_E_CALL_CANCELED = -2147418110
 
 
 import comtypes

--- a/source/core.py
+++ b/source/core.py
@@ -3,13 +3,12 @@
 # Derek Riemer, Babbage B.V., Zahari Yurukov, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-from dataclasses import dataclass
-from typing import Optional
 
 """NVDA core"""
 
 
-
+from dataclasses import dataclass
+from typing import Optional
 import comtypes
 import sys
 import winVersion
@@ -23,7 +22,7 @@ import globalVars
 from logHandler import log
 import addonHandler
 import extensionPoints
-import garbageHandler  # noqa: E402
+import garbageHandler
 
 
 # inform those who want to know that NVDA has finished starting up.

--- a/source/exceptions.py
+++ b/source/exceptions.py
@@ -1,0 +1,11 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2011-2021 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+"""General exceptions for NVDA"""
+
+
+class CallCancelled(Exception):
+	"""Raised when a call is cancelled.
+	"""

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -20,17 +20,14 @@ import winKernel
 import buildVersion
 from typing import Optional
 import exceptions
+import RPCConstants
 
 ERROR_INVALID_WINDOW_HANDLE = 1400
 ERROR_TIMEOUT = 1460
-RPC_S_SERVER_UNAVAILABLE = 1722
-RPC_S_CALL_FAILED_DNE = 1727
 EPT_S_NOT_REGISTERED = 1753
 E_ACCESSDENIED = -2147024891
 CO_E_OBJNOTCONNECTED = -2147220995
 EVENT_E_ALL_SUBSCRIBERS_FAILED = -2147220991
-RPC_E_CALL_REJECTED = -2147418111
-RPC_E_DISCONNECTED = -2147417848
 LOAD_WITH_ALTERED_SEARCH_PATH=0x8
 
 def isPathExternalToNVDA(path):
@@ -205,14 +202,33 @@ class Logger(logging.Logger):
 		However, certain exceptions which aren't considered errors (or aren't errors that we can fix) are expected and will therefore be logged at a lower level.
 		"""
 		import comtypes
-		from core import RPC_E_CALL_CANCELED
 		if exc_info is True:
 			exc_info = sys.exc_info()
 
 		exc = exc_info[1]
 		if (
-			(isinstance(exc, WindowsError) and exc.winerror in (ERROR_INVALID_WINDOW_HANDLE, ERROR_TIMEOUT, RPC_S_SERVER_UNAVAILABLE, RPC_S_CALL_FAILED_DNE, EPT_S_NOT_REGISTERED, RPC_E_CALL_CANCELED))
-			or (isinstance(exc, comtypes.COMError) and (exc.hresult in (E_ACCESSDENIED, CO_E_OBJNOTCONNECTED, EVENT_E_ALL_SUBSCRIBERS_FAILED, RPC_E_CALL_REJECTED, RPC_E_CALL_CANCELED, RPC_E_DISCONNECTED) or exc.hresult & 0xFFFF == RPC_S_SERVER_UNAVAILABLE))
+			(
+				isinstance(exc, WindowsError)
+				and exc.winerror in (
+					ERROR_INVALID_WINDOW_HANDLE,
+					ERROR_TIMEOUT,
+					RPCConstants.RPC.S_SERVER_UNAVAILABLE,
+					RPCConstants.RPC.S_CALL_FAILED_DNE,
+					EPT_S_NOT_REGISTERED,
+					RPCConstants.RPC.E_CALL_CANCELED
+				)
+			)
+			or (
+				isinstance(exc, comtypes.COMError)
+				and (
+					exc.hresult in (
+						E_ACCESSDENIED,
+						CO_E_OBJNOTCONNECTED,
+						EVENT_E_ALL_SUBSCRIBERS_FAILED,
+						RPCConstants.RPC.E_CALL_REJECTED,
+						RPCConstants.RPC.E_CALL_CANCELED,
+						RPCConstants.RPC.E_DISCONNECTED
+					) or exc.hresult & 0xFFFF == RPCConstants.RPC.S_SERVER_UNAVAILABLE))
 			or isinstance(exc, exceptions.CallCancelled)
 		):
 			level = self.DEBUGWARNING

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -19,6 +19,7 @@ import globalVars
 import winKernel
 import buildVersion
 from typing import Optional
+import exceptions
 
 ERROR_INVALID_WINDOW_HANDLE = 1400
 ERROR_TIMEOUT = 1460
@@ -204,7 +205,7 @@ class Logger(logging.Logger):
 		However, certain exceptions which aren't considered errors (or aren't errors that we can fix) are expected and will therefore be logged at a lower level.
 		"""
 		import comtypes
-		from core import CallCancelled, RPC_E_CALL_CANCELED
+		from core import RPC_E_CALL_CANCELED
 		if exc_info is True:
 			exc_info = sys.exc_info()
 
@@ -212,7 +213,7 @@ class Logger(logging.Logger):
 		if (
 			(isinstance(exc, WindowsError) and exc.winerror in (ERROR_INVALID_WINDOW_HANDLE, ERROR_TIMEOUT, RPC_S_SERVER_UNAVAILABLE, RPC_S_CALL_FAILED_DNE, EPT_S_NOT_REGISTERED, RPC_E_CALL_CANCELED))
 			or (isinstance(exc, comtypes.COMError) and (exc.hresult in (E_ACCESSDENIED, CO_E_OBJNOTCONNECTED, EVENT_E_ALL_SUBSCRIBERS_FAILED, RPC_E_CALL_REJECTED, RPC_E_CALL_CANCELED, RPC_E_DISCONNECTED) or exc.hresult & 0xFFFF == RPC_S_SERVER_UNAVAILABLE))
-			or isinstance(exc, CallCancelled)
+			or isinstance(exc, exceptions.CallCancelled)
 		):
 			level = self.DEBUGWARNING
 		else:

--- a/source/monkeyPatches/comtypesMonkeyPatches.py
+++ b/source/monkeyPatches/comtypesMonkeyPatches.py
@@ -12,6 +12,7 @@ from ctypes import cast, c_void_p
 from _ctypes import _Pointer
 import importlib
 import sys
+import exceptions
 
 
 def new_WINFUNCTYPE(restype,*argtypes,**kwargs):
@@ -29,13 +30,13 @@ def new_WINFUNCTYPE(restype,*argtypes,**kwargs):
 			try:
 				return super().__call__(*args,**kwargs)
 			except _ctypes.COMError as e:
-				from core import CallCancelled, RPC_E_CALL_CANCELED
+				from core import RPC_E_CALL_CANCELED
 				if e.args[0]==RPC_E_CALL_CANCELED:
 					# As this is a cancelled COM call,
 					# raise CallCancelled instead of the original COMError.
 					# Also raising from None gives a cleaner traceback,
 					# Hiding the fact we were already in an except block.
-					raise CallCancelled("COM call cancelled") from None
+					raise exceptions.CallCancelled("COM call cancelled") from None
 				# Otherwise, just continue the original COMError exception up the stack.
 				raise
 	return WinFunctionType

--- a/source/monkeyPatches/comtypesMonkeyPatches.py
+++ b/source/monkeyPatches/comtypesMonkeyPatches.py
@@ -13,6 +13,7 @@ from _ctypes import _Pointer
 import importlib
 import sys
 import exceptions
+import RPCConstants
 
 
 def new_WINFUNCTYPE(restype,*argtypes,**kwargs):
@@ -30,8 +31,7 @@ def new_WINFUNCTYPE(restype,*argtypes,**kwargs):
 			try:
 				return super().__call__(*args,**kwargs)
 			except _ctypes.COMError as e:
-				from core import RPC_E_CALL_CANCELED
-				if e.args[0]==RPC_E_CALL_CANCELED:
+				if e.args[0] == RPCConstants.RPC.E_CALL_CANCELED:
 					# As this is a cancelled COM call,
 					# raise CallCancelled instead of the original COMError.
 					# Also raising from None gives a cleaner traceback,

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -20,7 +20,7 @@ import textInfos
 import api
 import aria
 import config
-import watchdog
+import exceptions
 
 FORMATSTATE_INSERTED=1
 FORMATSTATE_DELETED=2
@@ -229,7 +229,7 @@ class MSHTML(VirtualBuffer):
 			if not root.IAccessibleRole:
 				# The root object is dead.
 				return False
-		except watchdog.CallCancelled:
+		except exceptions.CallCancelled:
 			# #1831: If the root object isn't responding, treat the buffer as dead.
 			# Otherwise, we'll keep querying it on every focus change and freezing.
 			return False

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -18,7 +18,7 @@ import winKernel
 from logHandler import log
 import globalVars
 import core
-from core import CallCancelled
+import exceptions
 import NVDAHelper
 
 #settings
@@ -226,7 +226,7 @@ def _notifySendMessageCancelled():
 	def sendMessageCallCanceller(frame, event, arg):
 		if frame == caller:
 			# Raising an exception will also cause the profile function to be deactivated.
-			raise CallCancelled
+			raise exceptions.CallCancelled
 	sys.setprofile(sendMessageCallCanceller)
 
 def initialize():
@@ -296,7 +296,7 @@ class CancellableCallThread(threading.Thread):
 		self.name = f"{self.__class__.__module__}.{self.execute.__qualname__}({fname})"
 		# Don't even bother making the call if the core is already dead.
 		if isAttemptingRecovery:
-			raise CallCancelled
+			raise exceptions.CallCancelled
 
 		self._func = func
 		self._args = args
@@ -315,7 +315,7 @@ class CancellableCallThread(threading.Thread):
 		if waitIndex.value == 1:
 			# Cancelled.
 			self.isUsable = False
-			raise CallCancelled
+			raise exceptions.CallCancelled
 
 		exc = self._exc_info
 		if exc:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,6 +23,8 @@ What's New in NVDA
 - ``TVItemStruct`` has been from ``sysTreeView32``. (#12935)
 - ``MessageItem`` has been removed from the Outlook appModule. (#12935)
 - The ``soffice`` appModule has the following classes and functions removed ``JAB_OOTableCell``, ``JAB_OOTable``, ``gridCoordStringToNumbers``. (#12849)
+- core.CallCancelled becomes exceptions.CallCancelled. 
+- All constants starting with RPC from core and logHandler are moved into RPCConstants.RPC enum
 -
 
 


### PR DESCRIPTION
Keeping as a draft until development cycle for 2022.1 starts.
### Link to issue number:
None
### Summary of the issue:
Currently various RPC constants we use are scattered through out the code base. Also some stuff is defined in core but is not related to core in any way.
 
### Description of how this pull request fixes the issue:
- `CallCancelled` is moved to the new `exceptions` module
- All RPC constants both from `core` and from `logHandler` are moved into an enum .
### Testing strategy:
Made sure that logging still works and that `CallCancelled` is raised when appropriate.
### Known issues with pull request:
This breaks backwards compatibility - while these moves are nice from the code layout perspective I don't think they are important enough to justify providing backwards compat.
### Change log entries:
For Developers
- `core.CallCancelled` becomes `exceptions.CallCancelled`
- All constants starting with `RPC` from `core` and `logHandler` are moved into `RPCConstants.RPC` enum.
### Code Review Checklist:



- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
