### PR TITLE
Windows 11: suppress UIA focus event on InputSite pane window when switching tasks

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -341,7 +341,13 @@ class AppModule(appModuleHandler.AppModule):
 				clsList.insert(0, ImmersiveLauncher)
 			elif uiaClassName == "ListViewItem" and obj.UIAElement.cachedAutomationId.startswith('Suggestion_'):
 				clsList.insert(0, SuggestionListItem)
-			elif uiaClassName == "MultitaskingViewFrame" and role == controlTypes.Role.WINDOW:
+			# Multitasking view frame window
+			elif (
+				# Windows 10 and earlier
+				(uiaClassName == "MultitaskingViewFrame" and role == controlTypes.Role.WINDOW)
+				# Windows 11 where a pane window receives focus when switching tasks
+				or (uiaClassName == "Windows.UI.Input.InputSite.WindowClass" and role == controlTypes.Role.PANE)
+			):
 				clsList.insert(0, MultitaskingViewFrameWindow)
 			# Windows 10 task switch list
 			elif role == controlTypes.Role.LISTITEM and (

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
+# Copyright (C) 2006-2021 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,10 +56,11 @@ If you need this functionality please assign a gesture to the appropriate script
 - When navigating the Windows system tray calendar, NVDA now reports the day of the week in full. (#12757)
 - When using a Chinese input method such as Taiwan - Microsoft Quick in Microsoft Word, scrolling the braille display forward and backward no longer incorrectly keeps jumping back to the original caret position. (#12855)
 - When accessing Microsoft Word documents via UIA, navigating by sentence (alt+downArrow / alt+upArrow) is again possible. (#9254)
-- When accessing MS Word with UIA, paragraph indenting is now reported. (#12899(
+- When accessing MS Word with UIA, paragraph indenting is now reported. (#12899)
 - When accessing MS Word with UIA, change tracking command and some other localized commands are now reported in Word . (#12904)
 - Fixed duplicate braille and speech when 'description' matches 'content' or 'name'. (#12888)
-- In MS Word with UIA enabled, More accurate playing of spelling error sound as you type. (#12161)
+- In MS Word with UIA enabled, more accurate playing of spelling error sounds as you type. (#12161)
+- In Windows 11, NVDA will no longer announce "pane" when pressing Alt+Tab to switch between programs. (#12648)
 -
 
 


### PR DESCRIPTION
Hi,

Would it be possible to put this into 2021.3 unless it should be delayed to 2022.1?

### Link to issue number:
Closes #12648

### Summary of the issue:
When switching tasks in Windows 11, a "pane" window gets focused instead of the app being switched to in some cases.

### Description of how this pull request fixes the issue:
Treat InputSite window class window as a Windows 10 MultitaskingViewFrameWindow object which suppresses UIA focus event.

### Testing strategy:
Manual testing on Windows 11 (prerequisite: Windows App Essentials add-on must be disabled):

1. Without the patch applied, try switching between tasks.
2. With the patch applied, try switching between tasks.

Expected: NVDA will say "pane" in scenario 1, whereas NVDA will not say "pane" in scenario 2 when switching tasks.

### Known issues with pull request:
None yet

### Change log entries:
Bug fixes:

In Windows 11, NVDA will no longer announce "pane" when pressing Alt+Tab to switch between programs. (#12648)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  -xchange log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English

### Additional context:
This problem was reported on Feedback Hub several months ago. This PR was originally part of Wnidows App Essentials add-on but was delayed to see if newer Windows 11 builds resolves it (not resolved so far).

Thanks.