### PR TITLE
Start dev cycle 2022.1

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited
+# Copyright (C) 2006-2022 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -65,8 +65,8 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2021
-version_major = 3
+version_year = 2022
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,22 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.1 =
+
+== New Features ==
+-
+
+== Changes ==
+-
+
+== Bug Fixes ==
+-
+
+== Changes for Developers ==
+- Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
+-
+
+
 = 2021.3 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for the 2022.1 release

Following [wiki to start a new dev cycle](https://github.com/nvaccess/nvda/wiki/MakingAnOfficialRelease#starting-a-new-dev-cycle):

- Adds space in the change log
- Updates the build version.


Since this will be a compatibility breaking release, there is a note in the change log.
There will also be a PR created to update the Addon API compatibility, however this PR won't be merged until the first beta.