### PR TITLE
Close WelcomeDialog instances before triggering NVDA Exit

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -685,7 +685,7 @@ class ExitDialog(wx.Dialog):
 		if action >= 2 and config.isAppX:
 			action += 1
 		if action == 0:
-			WelcomeDialog.saveAndCloseInstances()
+			WelcomeDialog.closeInstances()
 			if not core.triggerNVDAExit():
 				log.error("NVDA already in process of exiting, this indicates a logic error.")
 			return  # there's no need to destroy ExitDialog in this instance as triggerNVDAExit will do this

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -26,6 +26,7 @@ import core
 from . import guiHelper
 from .settingsDialogs import SettingsDialog
 from .settingsDialogs import *
+from .startupDialogs import WelcomeDialog
 from .inputGestures import InputGesturesDialog
 import speechDictHandler
 from . import logViewer
@@ -684,6 +685,7 @@ class ExitDialog(wx.Dialog):
 		if action >= 2 and config.isAppX:
 			action += 1
 		if action == 0:
+			WelcomeDialog.saveAndCloseInstances()
 			if not core.triggerNVDAExit():
 				log.error("NVDA already in process of exiting, this indicates a logic error.")
 			return  # there's no need to destroy ExitDialog in this instance as triggerNVDAExit will do this

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -368,7 +368,7 @@ class MainFrame(wx.Frame):
 
 class SysTrayIcon(wx.adv.TaskBarIcon):
 
-	def __init__(self, frame):
+	def __init__(self, frame: MainFrame):
 		super(SysTrayIcon, self).__init__()
 		icon=wx.Icon(ICON_PATH,wx.BITMAP_TYPE_ICO)
 		self.SetIcon(icon, versionInfo.name)

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -4,6 +4,8 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
+from typing import Set
+import weakref
 import wx
 
 import config
@@ -36,10 +38,12 @@ class WelcomeDialog(
 		"Press NVDA+n at any time to activate the NVDA menu.\n"
 		"From this menu, you can configure NVDA, get help and access other NVDA functions."
 	)
+	_instances: Set["WelcomeDialog"] = weakref.WeakSet()
 
 	def __init__(self, parent):
 		# Translators: The title of the Welcome dialog when user starts NVDA for the first time.
 		super().__init__(parent, wx.ID_ANY, _("Welcome to NVDA"))
+		WelcomeDialog._instances.add(self)
 
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: The header for the Welcome dialog when user starts NVDA for the first time.
@@ -108,6 +112,7 @@ class WelcomeDialog(
 		except Exception:
 			log.debugWarning("Could not save", exc_info=True)
 		self.EndModal(wx.ID_OK)
+		self.Close()
 
 	@classmethod
 	def run(cls):
@@ -117,8 +122,16 @@ class WelcomeDialog(
 		gui.mainFrame.prePopup()
 		d = cls(gui.mainFrame)
 		d.ShowModal()
-		wx.CallAfter(d.Destroy)
 		gui.mainFrame.postPopup()
+
+	@classmethod
+	def saveAndCloseInstances(cls):
+		instances = list(cls._instances)
+		for instance in instances:
+			if instance and not instance.IsBeingDeleted() and instance.IsModal():
+				instance.onOk(None)  # Save and close
+			else:
+				cls._instances.remove(instance)
 
 
 class LauncherDialog(

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -125,11 +125,11 @@ class WelcomeDialog(
 		gui.mainFrame.postPopup()
 
 	@classmethod
-	def saveAndCloseInstances(cls):
+	def closeInstances(cls):
 		instances = list(cls._instances)
 		for instance in instances:
 			if instance and not instance.IsBeingDeleted() and instance.IsModal():
-				instance.onOk(None)  # Save and close
+				instance.EndModal(wx.ID_CLOSE_ALL)
 			else:
 				cls._instances.remove(instance)
 

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -39,6 +39,22 @@ def NVDA_Starts():
 	_process.process_should_be_running(_nvdaProcessAlias)
 
 
+def open_welcome_dialog_from_menu():
+	spy = _nvdaLib.getSpyLib()
+	spy.emulateKeyPress("NVDA+n")
+	spy.emulateKeyPress("h")
+	spy.emulateKeyPress("l")
+	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present.
+
+
+def open_about_dialog_from_menu():
+	spy = _nvdaLib.getSpyLib()
+	spy.emulateKeyPress("NVDA+n")
+	spy.emulateKeyPress("h")
+	spy.emulateKeyPress("a")
+	spy.wait_for_specific_speech("About NVDA")  # ensure the dialog is present.
+
+
 def quits_from_menu(showExitDialog=True):
 	"""Ensure NVDA can be quit from menu."""
 	spy = _nvdaLib.getSpyLib()

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -77,17 +77,14 @@ def quits_from_menu(showExitDialog=True):
 		_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little for it
 		spy.emulateKeyPress("enter", blockUntilProcessed=False)  # don't block so NVDA can exit
 
-	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
+	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
 	_process.process_should_be_stopped(_nvdaProcessAlias)
 
 
 def quits_from_keyboard():
 	"""Ensure NVDA can be quit from keyboard."""
 	spy = _nvdaLib.getSpyLib()
-	spy.wait_for_specific_speech("Welcome to NVDA")  # ensure the dialog is present.
-	spy.wait_for_speech_to_finish()
-	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
-	spy.emulateKeyPress("enter")
+	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little for it
 
 	spy.emulateKeyPress("NVDA+q")
 	exitTitleIndex = spy.wait_for_specific_speech("Exit NVDA")
@@ -103,8 +100,9 @@ def quits_from_keyboard():
 		])
 	)
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
+	_process.process_should_be_running(_nvdaProcessAlias)
 	spy.emulateKeyPress("enter", blockUntilProcessed=False)  # don't block so NVDA can exit
-	_process.wait_for_process(_nvdaProcessAlias, timeout="10 sec")
+	_process.wait_for_process(_nvdaProcessAlias, timeout="3 sec")
 	_process.process_should_be_stopped(_nvdaProcessAlias)
 
 

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -36,6 +36,18 @@ Quits from keyboard
 	[Documentation]	Starts NVDA and ensures that it can be quit using the keyboard
 	quits_from_keyboard	# run test
 
+Quits from keyboard with welcome dialog open
+	[Documentation]	Starts NVDA and ensures that it can be quit with the welcome dialog open
+	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
+	open about dialog from menu
+	quits from keyboard	# run test
+
+Quits from keyboard with about dialog open
+	[Documentation]	Starts NVDA and ensures that it can be quit with the about dialog open
+	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
+	open welcome dialog from menu
+	quits from keyboard	# run test
+
 Quits from menu
 	[Documentation]	Starts NVDA and ensures that it can be quit using the keyboard
 	[Setup]	start NVDA	standard-dontShowExitDialog.ini

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -45,6 +45,8 @@ Quits from keyboard with welcome dialog open
 Quits from keyboard with about dialog open
 	[Documentation]	Starts NVDA and ensures that it can be quit with the about dialog open
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
+	# Excluded to be fixed still (#12907, #12957)
+	[Tags]	excluded_from_build
 	open about dialog from menu
 	quits from keyboard	# run test
 

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -39,13 +39,13 @@ Quits from keyboard
 Quits from keyboard with welcome dialog open
 	[Documentation]	Starts NVDA and ensures that it can be quit with the welcome dialog open
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
-	open about dialog from menu
+	open welcome dialog from menu
 	quits from keyboard	# run test
 
 Quits from keyboard with about dialog open
 	[Documentation]	Starts NVDA and ensures that it can be quit with the about dialog open
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
-	open welcome dialog from menu
+	open about dialog from menu
 	quits from keyboard	# run test
 
 Quits from menu


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #12907 

### Summary of the issue:

NVDA crashes if the welcome dialog is open, and was opened via the NVDA menu.

### Description of how this pull request fixes the issue:

Track instances of the welcome dialog as they are created, close them all before the exit dialog is triggers an exit.
As the cause of this problem is complicated, and a proper fix is risky, this small patch avoids touching the core module.

### Testing strategy:

Manual testing:

1. Start NVDA, close any open dialogs
1. Open the Welcome Dialog via `NVDA menu > Help`
1. Exit NVDA ([exiting NVDA methods](https://github.com/nvaccess/nvda/blob/master/devDocs/startupShutdown.md#nvda-can-be-shutdown-by))

Confirm the other way to start a Welcome Dialog exits correctly.

1. Start NVDA with the Welcome Dialog set to open on startup
1. Exit NVDA ([exiting NVDA methods](https://github.com/nvaccess/nvda/blob/master/devDocs/startupShutdown.md#nvda-can-be-shutdown-by)) with the Welcome Dialog still open

System tests have been added which test the issue for quitting from keyboard via the Exit Dialog

### Known issues with pull request:

The About Dialog still shares this problem, however it is harder to track instances of `wx.MessageBox`, it will need to be subclassed. Note the failure from the about dialog test in https://github.com/nvaccess/nvda/pull/12957#issuecomment-946324067
This will be attempted in a separate PR.

### Change log entries:

I think none needed - this is a rare bug fix that is a recent regression.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
