### PR TITLE
Fix revert in 5b821c60a

### DIFF
--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -136,7 +136,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 			and controlTypes.State.LINKED not in obj.states
 		)
 
-	def _getControlFieldForObject(self, obj, ignoreEditableText=True):
+	def _getControlFieldForObject(self, obj: NVDAObject, ignoreEditableText=True):
 		if ignoreEditableText and self._isObjectEditableText(obj):
 			# This is basically just a text node.
 			return None
@@ -290,16 +290,18 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 						embedIndex = self._getFirstEmbedIndex(ti)
 					else:
 						embedIndex += 1
-					field = ti.obj.getChild(embedIndex)
-					controlField = self._getControlFieldForObject(field, ignoreEditableText=False)
-					controlField["content"] = field.name
+					childObject: NVDAObject = ti.obj.getChild(embedIndex)
+					controlField = self._getControlFieldForObject(childObject, ignoreEditableText=False)
+					controlField["content"] = childObject.name
 					fields.extend((
 						textInfos.FieldCommand("controlStart", controlField),
 						textUtils.OBJ_REPLACEMENT_CHAR,
 						textInfos.FieldCommand("controlEnd", None)
 					))
-				else:
-					fields.append(field)
+				else:  # str or fieldCommand
+					if not isinstance(textWithEmbeddedObjectsItem, (str, textInfos.FieldCommand)):
+						log.error(f"Unexpected type: {textWithEmbeddedObjectsItem!r}")
+					fields.append(textWithEmbeddedObjectsItem)
 		return fields
 
 	def _findNextContent(self, origin, moveBack=False):


### PR DESCRIPTION


<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12919

### Summary of the issue:
When using NVDA with Libre / Open office Writer, text from the document can not be read.

In #12500 the variable used to iterate over `_iterTextWithEmbeddedObjects` was changed from `field` to `textWithEmbeddedObjectsItem`, additionally `childObject` was used instead of field for `ti.obj.getChild(embedIndex)`

In #12766 some of these changes were reverted, however `textWithEmbeddedObjectsItem` was no longer appended to `fields` instead `field` was.

### Description of how this pull request fixes the issue:
Re-introduce renames.

### Testing strategy:
Manually tested with OpenOffice:
- Create a new document with Writer
- Add text "This is a test"
- Start NVDA, navigate with arrow keys

The content should be read, no error sound should be heard.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
