### PR TITLE
Multiple dictionary dialogs can now be opened simultaneously if the dictionaries are of different types

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -24,11 +24,15 @@ import speech
 import queueHandler
 import core
 from . import guiHelper
-from .settingsDialogs import SettingsDialog
+from .settingsDialogs import (
+	SettingsDialog,
+	DefaultDictionaryDialog,
+	VoiceDictionaryDialog,
+	TemporaryDictionaryDialog,
+)
 from .settingsDialogs import *
 from .startupDialogs import WelcomeDialog
 from .inputGestures import InputGesturesDialog
-import speechDictHandler
 from . import logViewer
 import speechViewer
 import winUser
@@ -156,16 +160,13 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onDefaultDictionaryCommand(self,evt):
-		# Translators: Title for default speech dictionary dialog.
-		self._popupSettingsDialog(DictionaryDialog,_("Default dictionary"),speechDictHandler.dictionaries["default"])
+		self._popupSettingsDialog(DefaultDictionaryDialog)
 
 	def onVoiceDictionaryCommand(self,evt):
-		# Translators: Title for voice dictionary for the current voice such as current eSpeak variant.
-		self._popupSettingsDialog(DictionaryDialog,_("Voice dictionary (%s)")%speechDictHandler.dictionaries["voice"].fileName,speechDictHandler.dictionaries["voice"])
+		self._popupSettingsDialog(VoiceDictionaryDialog)
 
 	def onTemporaryDictionaryCommand(self,evt):
-		# Translators: Title for temporary speech dictionary dialog (the voice dictionary that is active as long as NvDA is running).
-		self._popupSettingsDialog(DictionaryDialog,_("Temporary dictionary"),speechDictHandler.dictionaries["temp"])
+		self._popupSettingsDialog(TemporaryDictionaryDialog)
 
 	def onExecuteUpdateCommand(self, evt):
 		if updateCheck and updateCheck.isPendingUpdate():

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3249,6 +3249,37 @@ class DictionaryDialog(SettingsDialog):
 		self.dictList.SetFocus()
 
 
+class DefaultDictionaryDialog(DictionaryDialog):
+	def __init__(self, parent):
+		super().__init__(
+			parent,
+			# Translators: Title for default speech dictionary dialog.
+			title=_("Default dictionary"),
+			speechDict=speechDictHandler.dictionaries["default"],
+		)
+
+
+class VoiceDictionaryDialog(DictionaryDialog):
+	def __init__(self, parent):
+		super().__init__(
+			parent,
+			# Translators: Title for voice dictionary for the current voice such as current eSpeak variant.
+			title=_("Voice dictionary (%s)") % speechDictHandler.dictionaries["voice"].fileName,
+			speechDict=speechDictHandler.dictionaries["voice"],
+		)
+
+
+class TemporaryDictionaryDialog(DictionaryDialog):
+	def __init__(self, parent):
+		super().__init__(
+			parent,
+			# Translators: Title for temporary speech dictionary dialog (the voice dictionary that is active as long
+			# as NvDA is running).
+			title=_("Temporary dictionary"),
+			speechDict=speechDictHandler.dictionaries["temp"],
+		)
+
+
 class BrailleSettingsPanel(SettingsPanel):
 	# Translators: This is the label for the braille panel
 	title = _("Braille")


### PR DESCRIPTION
Opened against beta branch since it is a follow-up of #12800.
Cc @seanbudd 

### Link to issue number:

Fix-up of #12800.
Described in https://github.com/nvaccess/nvda/pull/12800#issuecomment-911676751, paragraph "Test almost successful", "Test 2".

### Summary of the issue:

Since the merge of #12800, trying to re-open an already opened dialog allows to focus it rather than issuing an error as done previously. However, in the case of dictionaries, if you try to open the voice dictionary while the default is already open will lead to focus the default dictionary rather than opening the voice dictionary dialog;

### Description of how this pull request fixes the issue:

Since the check of an existing opened dialog is made on the class of the dialog, I have sub-classed `DictionaryDialog` for the three types of dictionaries to make them distinct one from another.

### Testing strategy:

Test 1:
* Tried to open the 3 dictionary dialogs simultaneously, either with the menu or with keyboard shortcut.

Test 2:
* Open the three dictionaries windows
* Updated them all (at least adding one entry for each)
* Close them all
* Re-open them all one by one to check that the content has been correctly updated.

### Known issues with pull request:

Maybe it would be interesting to forbid to instance an object of class `DictionaryDialog` directly, i.e. force subclassing.
I do not know however how it can be acheived and do not even know if it is pythonic.
Comments are welcome.

### Change log entries:
Not needed if merged along with #12800 in 2021.3.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
