### PR TITLE
Add Typing to getTextWithFields

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -7,6 +7,10 @@
 This is now used by other applications as well.
 """
 import typing
+from typing import (
+	Optional,
+	Dict,
+)
 
 from comtypes import COMError
 import winUser
@@ -395,7 +399,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 	def _get_text(self):
 		return "".join(self._getText(False))
 
-	def getTextWithFields(self, formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		return self._getText(True, formatConfig)
 
 	def _findUnitEndpoints(self, baseTi, unit, findStart=True, findEnd=True):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -6,6 +6,10 @@
 
 """Support for UI Automation (UIA) controls."""
 import typing
+from typing import (
+	Optional,
+	Dict,
+)
 from ctypes import byref
 from ctypes.wintypes import POINT, RECT
 from comtypes import COMError
@@ -835,7 +839,7 @@ class UIATextInfo(textInfos.TextInfo):
 		if debug:
 			log.debug("_getTextWithFieldsForUIARange end")
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig=config.conf["documentFormatting"]
 		fields=list(self._getTextWithFieldsForUIARange(self.obj.UIAElement,self._rangeObj,formatConfig))

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -2,6 +2,10 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2015-2021 NV Access Limited, Babbage B.V., Leonard de Ruijter
+from typing import (
+	Optional,
+	Dict,
+)
 
 from comtypes import COMError
 from comtypes.automation import VARIANT
@@ -263,7 +267,10 @@ class UIAWebTextInfo(UIATextInfo):
 	# C901 'getTextWithFields' is too complex
 	# Note: when working on getTextWithFields, look for opportunities to simplify
 	# and move logic out into smaller helper functions.
-	def getTextWithFields(self, formatConfig=None):  # noqa: C901
+	def getTextWithFields(  # noqa: C901
+		self,
+		formatConfig: Optional[Dict] = None
+	) -> textInfos.TextInfo.TextWithFieldsT:
 		# We don't want fields for collapsed ranges.
 		# This would normally be a general rule, but MS Word currently needs fields for collapsed ranges,
 		# thus this code is not in the base.

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -3,6 +3,11 @@
 # See the file COPYING for more details.
 # Copyright (C) 2016-2021 NV Access Limited, Joseph Lee, Jakub Lukowicz
 
+from typing import (
+	Optional,
+	Dict,
+)
+
 from comtypes import COMError
 from collections import defaultdict
 from scriptHandler import isScriptWaiting
@@ -264,7 +269,13 @@ class WordDocumentTextInfo(UIATextInfo):
 				docInfo=self.obj.makeTextInfo(textInfos.POSITION_ALL)
 				self.setEndPoint(docInfo,"endToEnd")
 
-	def getTextWithFields(self,formatConfig=None):
+	# C901 'getTextWithFields' is too complex
+	# Note: when working on getTextWithFields, look for opportunities to simplify
+	# and move logic out into smaller helper functions.
+	def getTextWithFields(  # noqa: C901
+		self,
+		formatConfig: Optional[Dict] = None
+	) -> textInfos.TextInfo.TextWithFieldsT:
 		fields = None
 		# #11043: when a non-collapsed text range is positioned within a blank table cell
 		# MS Word does not return the table  cell as an enclosing element,

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -4,6 +4,11 @@
 # See the file COPYING for more details.
 
 import locale
+from typing import (
+	Dict,
+	Optional,
+)
+
 import comtypes.client
 import struct
 import ctypes
@@ -669,7 +674,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError("position: %s"%position)
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig=config.conf["documentFormatting"]
 		textRange=self._rangeObj.duplicate

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -6,6 +6,11 @@
 
 import ctypes
 import time
+from typing import (
+	Optional,
+	Dict,
+)
+
 from comtypes import COMError, GUID, BSTR
 import comtypes.client
 import comtypes.automation
@@ -721,7 +726,13 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError("position: %s"%position)
 
-	def getTextWithFields(self,formatConfig=None):
+	# C901 'getTextWithFields' is too complex
+	# Note: when working on getTextWithFields, look for opportunities to simplify
+	# and move logic out into smaller helper functions.
+	def getTextWithFields(  # noqa: C901
+		self,
+		formatConfig: Optional[Dict] = None
+	) -> textInfos.TextInfo.TextWithFieldsT:
 		if self.isCollapsed: return []
 		if self.obj.ignoreFormatting:
 			return [self.text]

--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -10,7 +10,9 @@ import textUtils
 from logHandler import log
 from textUtils import WCHAR_ENCODING, isLowSurrogate
 
-CommandListT = typing.List[typing.Union[textInfos.FieldCommand, typing.Optional[str]]]
+CommandsT = typing.Union[textInfos.FieldCommand, typing.Optional[str]]
+CommandListT = typing.List[CommandsT]
+
 
 class XMLTextParser(object): 
 

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -2,7 +2,10 @@
 # Copyright (C) 2016-2021 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-from typing import Optional, Dict
+from typing import (
+	Optional,
+	Dict,
+)
 
 from comtypes import COMError
 from comtypes.hresult import S_OK
@@ -260,7 +263,7 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 			text+=", "+_("Page {pageNumber}").format(pageNumber=pageNumber)
 		return text
 
-	def getTextWithFields(self, formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig = config.conf["documentFormatting"]
 		items = super(BookPageViewTextInfo, self).getTextWithFields(formatConfig=formatConfig)

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -3,6 +3,10 @@
 #Copyright (C) 2012-2018 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
+from typing import (
+	Optional,
+	Dict,
+)
 
 import comtypes
 from comtypes.automation import IDispatch
@@ -1024,7 +1028,7 @@ class SlideShowTreeInterceptorTextInfo(NVDAObjectTextInfo):
 			return (0,self._getStoryLength())
 		raise LookupError
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		fields = self.obj.rootNVDAObject.basicTextFields
 		text = self.obj.rootNVDAObject.basicText
 		out = []

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -2,6 +2,11 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2010-2021 NV Access Limited, Bram Duvigneau
+from typing import (
+	Optional,
+	Dict,
+)
+
 import textUtils
 import winUser
 import textInfos
@@ -271,7 +276,7 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 		text = info._getTextRange(0, info._startOffset)
 		return text.count(textUtils.OBJ_REPLACEMENT_CHAR)
 
-	def getTextWithFields(self, formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		# Get the initial control fields.
 		fields = []
 		rootObj = self.obj.rootNVDAObject

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -22,7 +22,13 @@ from logHandler import log
 import windowUtils
 from locationHelper import RectLTRB, RectLTWH
 import textUtils
-from typing import Union, List, Tuple
+from typing import (
+	Union,
+	List,
+	Tuple,
+	Optional,
+	Dict
+)
 
 #: A text info unit constant for a single chunk in a display model
 UNIT_DISPLAYCHUNK = "displayChunk"
@@ -420,7 +426,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 	def _getTextRange(self, start, end):
 		return u"".join(x for x in self._getFieldsInRange(start,end) if isinstance(x,str))
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		start=self._startOffset
 		end=self._endOffset
 		if start==end:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -366,7 +366,6 @@ class TextInfo(baseObject.AutoPropertyObject):
 		Subclasses may override this. The base implementation just returns the text.
 		@param formatConfig: Document formatting configuration, useful if you wish to force a particular
 			configuration for a particular task.
-		@type formatConfig: dict
 		@return: A sequence of text strings interspersed with associated field commands.
 		""" 
 		return [self.text]

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -359,7 +359,9 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> List[Union[str, FieldCommand]]:
+	TextWithFieldsT = List[Union[str, FieldCommand]]
+
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> "TextInfo.TextWithFieldsT":
 		"""Retrieves the text in this range, as well as any control/format fields associated therewith.
 		Subclasses may override this. The base implementation just returns the text.
 		@param formatConfig: Document formatting configuration, useful if you wish to force a particular

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -16,7 +16,11 @@ from treeInterceptorHandler import TreeInterceptor
 import api
 import textUtils
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import (
+	Optional,
+	Tuple,
+	Dict,
+)
 from logHandler import log
 
 @dataclass
@@ -560,7 +564,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			else:
 				self._startOffset=self._endOffset
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig=config.conf["documentFormatting"]
 		if self.detectFormattingAfterCursorMaybeSlow and not formatConfig['detectFormatAfterCursor']:

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -232,7 +232,7 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def _get_boundingRects(self):
 		return self.innerTextInfo.boundingRects
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		return self.innerTextInfo.getTextWithFields(formatConfig=formatConfig)
 
 	def expand(self,unit):

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -278,12 +278,12 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		if not text:
 			return [""]
 		commandList = XMLFormatting.XMLTextParser().parse(text)
-		commandList = list([
+		commandList = [
 			self._normalizeCommand(command)
 			for command in commandList
 			# drop None to convert from XMLFormatting.CommandListT to textInfos.TextInfo.TextWithFieldsT
 			if command is not None
-		])
+		]
 		return commandList
 
 	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -281,6 +281,8 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 		commandList = list([
 			self._normalizeCommand(command)
 			for command in commandList
+			# drop None to convert from XMLFormatting.CommandListT to textInfos.TextInfo.TextWithFieldsT
+			if command is not None
 		])
 		return commandList
 

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -263,10 +263,10 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 					return placeholder
 		return None
 
-	def _getFieldsInRange(self,start,end):
+	def _getFieldsInRange(self, start: int, end: int) -> textInfos.TextInfo.TextWithFieldsT:
 		text=NVDAHelper.VBuf_getTextInRange(self.obj.VBufHandle,start,end,True)
 		if not text:
-			return ""
+			return [""]
 		commandList: typing.List[textInfos.FieldCommand] = XMLFormatting.XMLTextParser().parse(text)
 		for command in commandList:
 			if not isinstance(command, textInfos.FieldCommand):

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -10,7 +10,10 @@ import threading
 import ctypes
 import collections
 import itertools
-import typing
+from typing import (
+	Optional,
+	Dict,
+)
 import weakref
 import wx
 import review
@@ -276,7 +279,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo,textInfos.offs
 				command.field = self._normalizeFormatField(field)
 		return commandList
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		start=self._startOffset
 		end=self._endOffset
 		if start==end:

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -16,6 +16,10 @@ import textInfos
 import api
 import config
 import locationHelper
+from typing import (
+	Optional,
+	Dict,
+)
 
 """
 Handler for NVDA's legacy Windows Console support,
@@ -226,7 +230,7 @@ class WinConsoleTextInfo(textInfos.offsets.OffsetsTextInfo):
 			start=end=self._getCaretOffset()
 		return start,end
 
-	def getTextWithFields(self,formatConfig=None):
+	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		commands=[]
 		if self.isCollapsed:
 			return commands


### PR DESCRIPTION
### Link to issue number:
Noticed during investigation of #12919

### Summary of the issue:
`getTextWithFields` is expected to return `TextWithFieldsT` which is a  `List[Union[str, FieldCommand]]`
Many of the overrides of `getTextWithFields` didn't specify the type, thus did not benefit from type hinting, some of them 
return incorrect types.

### Description of how this pull request fixes the issue:
- add type info to all definitions of `getTextWithFields`
- Ensure that where the helper function `_getFieldsInRange` is used, it must return `TextWithFieldsT`
- Make `_getFieldsInRange` easier to read, break out the normalization of commands.
- Handle any None values to return TextInfo.TextWithFieldsT

Note `_getFieldsInRange` was in one case returning an empty string, not a list with an empty string, this has been resolved.

### Testing strategy:
Test early on alpha.

### Known issues with pull request:
The `_getFieldsInRange` empty string may have been treated as an empty iterable, in which case the more correct modification would be to return an empty list.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
