### PR TITLE
Support math content in MS Word build 14326+ via UIA

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -454,6 +454,7 @@ class WordDocumentNode(UIA):
 			return self._getUIACacheablePropertyValue(self._UIACustomProps.word_mathml.id)
 		except COMError:
 			pass
+		return None
 
 	def _get_role(self):
 		if self.mathMl:

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -321,7 +321,7 @@ class WordDocumentTextInfo(UIATextInfo):
 							mathEndIndex = index
 						curLevel -= 1
 				if mathEndIndex is not None:
-					del fields[mathStartIndex+1:mathEndIndex]
+					del fields[mathStartIndex + 1:mathEndIndex]
 
 		# Sometimes embedded objects and graphics In MS Word can cause a controlStart then a controlEnd with no actual formatChange / text in the middle.
 		# SpeakTextInfo always expects that the first lot of controlStarts will always contain some text.

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -5,6 +5,7 @@
 
 from comtypes import COMError
 from collections import defaultdict
+import buildVersion
 import mathPres
 from scriptHandler import isScriptWaiting
 import textInfos
@@ -411,7 +412,10 @@ class WordBrowseModeDocument(UIABrowseModeDocument):
 		elif obj.role == controlTypes.Role.MATH:
 			# Don't set focus to math equations otherwise they cannot be interacted  with mathPlayer.
 			return False
-		return super(WordBrowseModeDocument,self).shouldSetFocusToObj(obj)
+		return super()._shouldSetFocusToObj(obj)
+
+	if buildVersion.version_year < 2022:
+		shouldSetFocusToObj = _shouldSetFocusToObj  # deprecated to be removed in 2022.1
 
 	def shouldPassThrough(self,obj,reason=None):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -5,7 +5,6 @@
 
 from comtypes import COMError
 from collections import defaultdict
-import buildVersion
 import mathPres
 from scriptHandler import isScriptWaiting
 import textInfos
@@ -413,9 +412,6 @@ class WordBrowseModeDocument(UIABrowseModeDocument):
 			# Don't set focus to math equations otherwise they cannot be interacted  with mathPlayer.
 			return False
 		return super()._shouldSetFocusToObj(obj)
-
-	if buildVersion.version_year < 2022:
-		shouldSetFocusToObj = _shouldSetFocusToObj  # deprecated to be removed in 2022.1
 
 	def shouldPassThrough(self,obj,reason=None):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -5,6 +5,7 @@
 
 from comtypes import COMError
 from collections import defaultdict
+import mathPres
 from scriptHandler import isScriptWaiting
 import textInfos
 import eventHandler
@@ -24,6 +25,7 @@ from NVDAObjects.window.winword import (
 	WordDocument as WordDocumentBase,
 	WordDocumentTextInfo as LegacyWordDocumentTextInfo
 )
+from NVDAObjects import NVDAObject
 from scriptHandler import script
 
 
@@ -130,6 +132,12 @@ class CommentUIATextInfoQuickNavItem(TextAttribUIATextInfoQuickNavItem):
 
 class WordDocumentTextInfo(UIATextInfo):
 
+	def getMathMl(self, field):
+		mathml = field.get('mathml')
+		if not mathml:
+			raise LookupError("No MathML")
+		return mathml
+
 	def _ensureRangeVisibility(self):
 		try:
 			inView = self.pointAtStart in self.obj.location
@@ -192,6 +200,8 @@ class WordDocumentTextInfo(UIATextInfo):
 		elif obj.UIAElement.cachedControlType==UIAHandler.UIA_GroupControlTypeId and obj.name:
 			field['role']=controlTypes.Role.EMBEDDEDOBJECT
 			field['alwaysReportName']=True
+		elif obj.role == controlTypes.Role.MATH:
+			field['mathml'] = obj.mathMl
 		elif obj.UIAElement.cachedControlType==UIAHandler.UIA_CustomControlTypeId and obj.name:
 			# Include foot note and endnote identifiers
 			field['content']=obj.name
@@ -287,6 +297,32 @@ class WordDocumentTextInfo(UIATextInfo):
 		if len(fields)==0: 
 			# Nothing to do... was probably a collapsed range.
 			return fields
+
+		# MS Word tries to produce speakable math content within equations.
+		# However, using mathPlayer with the exposed mathml property on the equation is much nicer.
+		# But, we therefore need to remove the inner math content if reading by line
+		if not formatConfig or not formatConfig.get('extraDetail'):
+			# We really only want to remove content if we can guarantee that mathPlayer is available.
+			mathPres.ensureInit()
+			if mathPres.speechProvider or mathPres.brailleProvider:
+				curLevel = 0
+				mathLevel = None
+				mathStartIndex = None
+				mathEndIndex = None
+				for index in range(len(fields)):
+					field = fields[index]
+					if isinstance(field, textInfos.FieldCommand) and field.command == "controlStart":
+						curLevel += 1
+						if mathLevel is None and field.field.get('mathml'):
+							mathLevel = curLevel
+							mathStartIndex = index
+					elif isinstance(field, textInfos.FieldCommand) and field.command == "controlEnd":
+						if curLevel == mathLevel:
+							mathEndIndex = index
+						curLevel -= 1
+				if mathEndIndex is not None:
+					del fields[mathStartIndex+1:mathEndIndex]
+
 		# Sometimes embedded objects and graphics In MS Word can cause a controlStart then a controlEnd with no actual formatChange / text in the middle.
 		# SpeakTextInfo always expects that the first lot of controlStarts will always contain some text.
 		# Therefore ensure that the first lot of controlStarts does contain some text by inserting a blank formatChange and empty string in this case.
@@ -368,15 +404,21 @@ class WordDocumentTextInfo(UIATextInfo):
 
 class WordBrowseModeDocument(UIABrowseModeDocument):
 
-	def shouldSetFocusToObj(self,obj):
+	def _shouldSetFocusToObj(self, obj: NVDAObject) -> bool:
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		if obj.role==controlTypes.Role.EDITABLETEXT and obj.UIAElement.cachedAutomationID.startswith('UIA_AutomationId_Word_Content'):
+			return False
+		elif obj.role == controlTypes.Role.MATH:
+			# Don't set focus to math equations otherwise they cannot be interacted  with mathPlayer.
 			return False
 		return super(WordBrowseModeDocument,self).shouldSetFocusToObj(obj)
 
 	def shouldPassThrough(self,obj,reason=None):
 		# Ignore strange editable text fields surrounding most inner fields (links, table cells etc) 
 		if obj.role==controlTypes.Role.EDITABLETEXT and obj.UIAElement.cachedAutomationID.startswith('UIA_AutomationId_Word_Content'):
+			return False
+		elif obj.role == controlTypes.Role.MATH:
+			# Don't  activate focus mode for math equations otherwise they cannot be interacted  with mathPlayer.
 			return False
 		return super(WordBrowseModeDocument,self).shouldPassThrough(obj,reason=reason)
 
@@ -403,7 +445,15 @@ class WordBrowseModeDocument(UIABrowseModeDocument):
 class WordDocumentNode(UIA):
 	TextInfo=WordDocumentTextInfo
 
+	def _get_mathMl(self):
+		try:
+			return self._getUIACacheablePropertyValue(self._UIACustomProps.word_mathml.id)
+		except COMError:
+			pass
+
 	def _get_role(self):
+		if self.mathMl:
+			return controlTypes.Role.MATH
 		role=super(WordDocumentNode,self).role
 		# Footnote / endnote elements currently have a role of unknown. Force them to editableText so that theyr text is presented correctly
 		if role==controlTypes.Role.UNKNOWN:

--- a/source/_UIACustomProps.py
+++ b/source/_UIACustomProps.py
@@ -88,3 +88,11 @@ class CustomPropertiesCommon:
 			programmaticName="ItemCount",
 			uiaType=UIAutomationType.INT,
 		)
+
+		# A property for fetching raw MathML from an equation node in Microsoft Word.
+		# Available in MS Word build 14326 and higher.
+		self.word_mathml = CustomPropertyInfo(
+			guid=GUID("{FA170AB3-3229-4E7C-827F-DD05EE0481D9}"),
+			programmaticName="Word.MathML",
+			uiaType=UIAutomationType.STRING,
+		)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -72,6 +72,10 @@ Affected users will need to download this update manually.
 - Error notifications can be enabled (advanced settings) when using any version of NVDA. (#12672)
 - In Windows 10 and later, NVDA will announce the suggestion count when entering search terms in apps such as Settings and Microsoft Store. (#7330, #12758, #12790)
 - Table navigation is now supported in grid controls created using the Out-GridView cmdlet in PowerShell. (#12928)
+- In Microsoft Word accessed via UI Automation, NVDA will now make use of mathPlayer to read and navigate Office math equations. (#12946)
+    - For this to work, you must be running Microsoft Word 365/2016 build 14326 or later. 
+    - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
+    -
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -620,13 +620,14 @@ Note however that any previously created MathType equations must be  first conve
 Microsoft Word also now provides linea symbol-based navigation through the equations itself, and supports inputting math using several syntaxes, including LateX. For further details, please see [Linear format equations using UnicodeMath and LaTeX in Word https://support.microsoft.com/en-us/office/linear-format-equations-using-unicodemath-and-latex-in-word-2e00618d-b1fd-49d8-8cb4-8d17f25754f8]
 - Microsoft Powerpoint, and older versions of Microsoft Word: 
 NVDA can read and navigate MathType equations in both Microsoft Powerpoint and Microsoft word.
-MathType needs to be installed in order for  this to work.
+MathType needs to be installed in order for this to work.
 The trial version is sufficient.
 It can be downloaded from https://www.dessci.com/en/products/mathtype/
-- Adobe Reader 
+- Adobe Reader:
 Note that this is not an official standard yet, so there is currently no publicly available software that can produce this content.
 - Kindle Reader for PC:
 NVDA can read and navigate Math in Kindle for PC for books with accessible math.
+-
 
 When reading a document, NVDA will speak any supported mathematical content where it occurs.
 If you are using a braille display, it will also be displayed in braille.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -614,14 +614,19 @@ MathPlayer is available as a free download from: https://www.dessci.com/en/produ
 
 NVDA supports the following types of mathematical content:
 - MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.
-- Design Science MathType in Microsoft Word and PowerPoint.
-MathType needs to be installed in order for this to work.
+- Microsoft Word 365 Modern Math Equations via UI automation:
+NVDA is able to read and interact with math equations in Microsoft Word 365/2016 build 14326 and higher.
+Note however that any previously created MathType equations must be  first converted to Office Math by selecting each and choosing Equation Options -> Convert to Office Math in the context menu. Ensure your version of MathType is the latest version before doing this.
+Microsoft Word also now provides linea symbol-based navigation through the equations itself, and supports inputting math using several syntaxes, including LateX. For further details, please see [Linear format equations using UnicodeMath and LaTeX in Word https://support.microsoft.com/en-us/office/linear-format-equations-using-unicodemath-and-latex-in-word-2e00618d-b1fd-49d8-8cb4-8d17f25754f8]
+- Microsoft Powerpoint, and older versions of Microsoft Word: 
+NVDA can read and navigate MathType equations in both Microsoft Powerpoint and Microsoft word.
+MathType needs to be installed in order for  this to work.
 The trial version is sufficient.
 It can be downloaded from https://www.dessci.com/en/products/mathtype/
-- MathML in Adobe Reader.
+- Adobe Reader 
 Note that this is not an official standard yet, so there is currently no publicly available software that can produce this content.
-- Math in Kindle for PC for books with accessible math.
--
+- Kindle Reader for PC:
+NVDA can read and navigate Math in Kindle for PC for books with accessible math.
 
 When reading a document, NVDA will speak any supported mathematical content where it occurs.
 If you are using a braille display, it will also be displayed in braille.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12946
Fixes #12941 

### Summary of the issue:
NVDA was able to provide rich support of mathematical content in Microsoft Word by making use of MathPlayer, MathType and the MS Word object model.
However, when NVDA only relies on UI Automation to access MS Word docuents, it is no longer possible to fetch mathMl from MathType equations via the MS Word object model.
However, Microsoft very recently added a new UI Automation custom property for fetching raw mathMl from an Office Equation node, thus if NVDa were to fetch this mathMl, then it could pass it along to mathPlayer as usual, then providing rich reading / navigation of math content in MS word again.

### Description of how this pull request fixes the issue:
* Register the mathMl UIA custom property.
* Fetch the raw mathMl from an MS Word Office Equation node.
* Expose it for the rest of NVDA to find and use with mathPlayer.

Note that MS Word also provides a basic form of linea symbol navigation in equations, so we make sure that the mathMl is exposed to mathPlayer when moving by line, replacing MS Word's own inner math content. But if moving by word/character, then MS Word's own inner math content is left in tact.

### Testing strategy:
* Opened an MS Word document
* Started typing a math equation by pressing alt+=
* Typed an equation like `x^2+x+1` and pressed enter.
* Pressed up arrow to move back up to the equation, confirming that NVDA read out the equation with mathPlayer, and also brailled the equation in Nemeth code. 
* Used the left and right arrow keys to move through the equation by symbol. Confirming that Microsoft Word's own navigation was used, and each symbol was reported.
* Pressed NvDA+alt+m to interact with the Math using MathPlayer and moved aorund the math tree with the arrows.
* Pressed escape to exit Math interaction mode.
* Switched to Browse mode with NVDA+space.
* Pressed enter to activate the current item in browse mode, ensuring that mat interaction mode was entered.
* Pressed ecape to exit math interaction mode.
* Still in browse mode, pressed NvDA+alt+m to enter math interaction mode.
* Pressed escape to exit math interaction mode.

### Known issues with pull request:
Users / authors will have to convert any old MathType equations to Office Equations by selecting each equation, and then choosing Equation Options -> Convert to Office math in the context menu.
The experience for typing math equations is now slightly different in that the user needs to now use Microsoft Word's own math input feature. I.e. pressing alt+= and typing the equation. However, MS Word does now support several input syntaxes, including LateX similar to MathType.

### Change log entries:
New features
In Microsoft Word accessed via UI Automation, NVDA will now make use of mathPlayer to read and navigate Office math equations. (#12946)
    - For this to work, you must be running Microsoft Word 365/2016 build 14326 or later. 
    - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
