### PR TITLE
Add check for open messageBoxes to prevent exit

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -294,11 +294,11 @@ def triggerNVDAExit(newNVDA: Optional[NewNVDAInstance] = None) -> bool:
 	instance information with `newNVDA`.
 	@return: True if this is the first call to trigger the exit, and the shutdown event was queued.
 	"""
-	import gui
+	from gui.message import isInMessageBox
 	import queueHandler
 	global _hasShutdownBeenTriggered
 	with _shuttingDownFlagLock:
-		safeToExit = not gui.isInMessageBox
+		safeToExit = not isInMessageBox()
 		if not safeToExit:
 			log.error("NVDA cannot exit safely, ensure open dialogs are closed")
 			return False

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -24,7 +24,13 @@ import speech
 import queueHandler
 import core
 from . import guiHelper
-from .message import isInMessageBox, messageBox
+from buildVersion import version_year
+from .message import (
+	isInMessageBox as _isInMessageBox,
+	# messageBox is accessed through `gui.messageBox` as opposed to `gui.message.messageBox` throughout NVDA,
+	# be cautious when removing
+	messageBox,
+)
 from .settingsDialogs import (
 	SettingsDialog,
 	DefaultDictionaryDialog,
@@ -38,6 +44,9 @@ from . import logViewer
 import speechViewer
 import winUser
 import api
+
+if version_year < 2022:
+	from .message import _isInMessageBox as isInMessageBox  # noqa F401
 
 try:
 	import updateCheck
@@ -145,7 +154,7 @@ class MainFrame(wx.Frame):
 			messageBox(_("Could not save configuration - probably read only file system"),_("Error"),wx.OK | wx.ICON_ERROR)
 
 	def _popupSettingsDialog(self, dialog, *args, **kwargs):
-		if isInMessageBox():
+		if _isInMessageBox():
 			return
 		self.prePopup()
 		try:
@@ -194,6 +203,8 @@ class MainFrame(wx.Frame):
 			self.sysTrayIcon.menu.Insert(self.sysTrayIcon.installPendingUpdateMenuItemPos,self.sysTrayIcon.installPendingUpdateMenuItem)
 
 	def onExitCommand(self, evt):
+		if _isInMessageBox():
+			return
 		if config.conf["general"]["askToExit"]:
 			self.prePopup()
 			d = ExitDialog(self)
@@ -295,7 +306,7 @@ class MainFrame(wx.Frame):
 		pythonConsole.activate()
 
 	def onAddonsManagerCommand(self,evt):
-		if isInMessageBox():
+		if _isInMessageBox():
 			return
 		self.prePopup()
 		from .addonGui import AddonsDialog
@@ -311,7 +322,7 @@ class MainFrame(wx.Frame):
 		NVDAObject.clearDynamicClassCache()
 
 	def onCreatePortableCopyCommand(self,evt):
-		if isInMessageBox():
+		if _isInMessageBox():
 			return
 		self.prePopup()
 		import gui.installerGui
@@ -320,13 +331,13 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onInstallCommand(self, evt):
-		if isInMessageBox():
+		if _isInMessageBox():
 			return
 		from gui import installerGui
 		installerGui.showInstallGui()
 
 	def onRunCOMRegistrationFixesCommand(self, evt):
-		if isInMessageBox():
+		if _isInMessageBox():
 			return
 		if messageBox(
 			# Translators: A message to warn the user when starting the COM Registration Fixing tool 
@@ -360,7 +371,7 @@ class MainFrame(wx.Frame):
 		)
 
 	def onConfigProfilesCommand(self, evt):
-		if isInMessageBox():
+		if _isInMessageBox():
 			return
 		self.prePopup()
 		from .configProfiles import ProfilesDialog

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -61,7 +61,10 @@ mainFrame = None
 if version_year < 2022:
 	def __getattr__(name):
 		if name == "isInMessageBox":
-			log.warning("gui.isInMessageBox is deprecated and will be removed in 2022.1. Consult the changes for developers in 2022.1 for advice on alternatives.")
+			log.warning(
+				"gui.isInMessageBox is deprecated and will be removed in 2022.1."
+				"Consult the changes for developers in 2022.1 for advice on alternatives."
+			)
 			return _isInMessageBox()
 		raise AttributeError(f"module {__name__} has no attribute {name}")
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -45,9 +45,6 @@ import speechViewer
 import winUser
 import api
 
-if version_year < 2022:
-	from .message import _isInMessageBox as isInMessageBox  # noqa F401
-
 try:
 	import updateCheck
 except RuntimeError:
@@ -60,6 +57,13 @@ DONATE_URL = "http://www.nvaccess.org/donate/"
 
 ### Globals
 mainFrame = None
+
+if version_year < 2022:
+	def __getattr__(name):
+		if name == "isInMessageBox":
+			log.warning("gui.isInMessageBox is deprecated, instead use gui.message.isInMessageBox()")
+			return _isInMessageBox()
+		raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 class MainFrame(wx.Frame):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -5,7 +5,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from typing import Optional
 import time
 import os
 import sys
@@ -25,6 +24,7 @@ import speech
 import queueHandler
 import core
 from . import guiHelper
+from .message import isInMessageBox, messageBox
 from .settingsDialogs import (
 	SettingsDialog,
 	DefaultDictionaryDialog,
@@ -51,7 +51,6 @@ DONATE_URL = "http://www.nvaccess.org/donate/"
 
 ### Globals
 mainFrame = None
-isInMessageBox = False
 
 
 class MainFrame(wx.Frame):
@@ -146,7 +145,7 @@ class MainFrame(wx.Frame):
 			messageBox(_("Could not save configuration - probably read only file system"),_("Error"),wx.OK | wx.ICON_ERROR)
 
 	def _popupSettingsDialog(self, dialog, *args, **kwargs):
-		if isInMessageBox:
+		if isInMessageBox():
 			return
 		self.prePopup()
 		try:
@@ -296,7 +295,7 @@ class MainFrame(wx.Frame):
 		pythonConsole.activate()
 
 	def onAddonsManagerCommand(self,evt):
-		if isInMessageBox:
+		if isInMessageBox():
 			return
 		self.prePopup()
 		from .addonGui import AddonsDialog
@@ -312,7 +311,7 @@ class MainFrame(wx.Frame):
 		NVDAObject.clearDynamicClassCache()
 
 	def onCreatePortableCopyCommand(self,evt):
-		if isInMessageBox:
+		if isInMessageBox():
 			return
 		self.prePopup()
 		import gui.installerGui
@@ -321,15 +320,15 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onInstallCommand(self, evt):
-		if isInMessageBox:
+		if isInMessageBox():
 			return
 		from gui import installerGui
 		installerGui.showInstallGui()
 
 	def onRunCOMRegistrationFixesCommand(self, evt):
-		if isInMessageBox:
+		if isInMessageBox():
 			return
-		if gui.messageBox(
+		if messageBox(
 			# Translators: A message to warn the user when starting the COM Registration Fixing tool 
 			_("You are about to run the COM Registration Fixing tool. This tool will try to fix common system problems that stop NVDA from being able to access content in many programs including Firefox and Internet Explorer. This tool must make changes to the System registry and therefore requires administrative access. Are you sure you wish to proceed?"),
 			# Translators: The title of the warning dialog displayed when launching the COM Registration Fixing tool 
@@ -361,7 +360,7 @@ class MainFrame(wx.Frame):
 		)
 
 	def onConfigProfilesCommand(self, evt):
-		if isInMessageBox:
+		if isInMessageBox():
 			return
 		self.prePopup()
 		from .configProfiles import ProfilesDialog
@@ -575,33 +574,6 @@ def showGui():
 def quit():
 	wx.CallAfter(mainFrame.onExitCommand, None)
 
-
-def messageBox(
-		message: str,
-		caption: str = wx.MessageBoxCaptionStr,
-		style: int = wx.OK | wx.CENTER,
-		parent: Optional[wx.Window] = None
-) -> int:
-	"""Display a message dialog.
-	This should be used for all message dialogs
-	rather than using C{wx.MessageDialog} and C{wx.MessageBox} directly.
-	@param message: The message text.
-	@param caption: The caption (title) of the dialog.
-	@param style: Same as for wx.MessageBox.
-	@param parent: The parent window.
-	@return: Same as for wx.MessageBox.
-	"""
-	global isInMessageBox
-	wasAlready = isInMessageBox
-	isInMessageBox = True
-	if not parent:
-		mainFrame.prePopup()
-	res = wx.MessageBox(message, caption, style, parent or mainFrame)
-	if not parent:
-		mainFrame.postPopup()
-	if not wasAlready:
-		isInMessageBox = False
-	return res
 
 def runScriptModalDialog(dialog, callback=None):
 	"""Run a modal dialog from a script.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -61,7 +61,7 @@ mainFrame = None
 if version_year < 2022:
 	def __getattr__(name):
 		if name == "isInMessageBox":
-			log.warning("gui.isInMessageBox is deprecated, instead use gui.message.isInMessageBox()")
+			log.warning("gui.isInMessageBox is deprecated and will be removed in 2022.1. Consult the changes for developers in 2022.1 for advice on alternatives.")
 			return _isInMessageBox()
 		raise AttributeError(f"module {__name__} has no attribute {name}")
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -5,6 +5,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from typing import Optional
 import time
 import os
 import sys
@@ -574,20 +575,21 @@ def showGui():
 def quit():
 	wx.CallAfter(mainFrame.onExitCommand, None)
 
-def messageBox(message, caption=wx.MessageBoxCaptionStr, style=wx.OK | wx.CENTER, parent=None):
+
+def messageBox(
+		message: str,
+		caption: str = wx.MessageBoxCaptionStr,
+		style: int = wx.OK | wx.CENTER,
+		parent: Optional[wx.Window] = None
+) -> int:
 	"""Display a message dialog.
 	This should be used for all message dialogs
 	rather than using C{wx.MessageDialog} and C{wx.MessageBox} directly.
 	@param message: The message text.
-	@type message: str
 	@param caption: The caption (title) of the dialog.
-	@type caption: str
 	@param style: Same as for wx.MessageBox.
-	@type style: int
-	@param parent: The parent window (optional).
-	@type parent: C{wx.Window}
+	@param parent: The parent window.
 	@return: Same as for wx.MessageBox.
-	@rtype: int
 	"""
 	global isInMessageBox
 	wasAlready = isInMessageBox
@@ -687,9 +689,12 @@ class ExitDialog(wx.Dialog):
 			action += 1
 		if action == 0:
 			WelcomeDialog.closeInstances()
-			if not core.triggerNVDAExit():
+			if core.triggerNVDAExit():
+				# there's no need to destroy ExitDialog in this instance as triggerNVDAExit will do this
+				return
+			else:
 				log.error("NVDA already in process of exiting, this indicates a logic error.")
-			return  # there's no need to destroy ExitDialog in this instance as triggerNVDAExit will do this
+				return
 		elif action == 1:
 			queueHandler.queueFunction(queueHandler.eventQueue,core.restart)
 		elif action == 2:

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -34,11 +34,13 @@ def messageBox(
 	global _isInMessageBox
 	wasAlready = _isInMessageBox
 	_isInMessageBox = True
-	if not parent:
-		mainFrame.prePopup()
-	res = wx.MessageBox(message, caption, style, parent or mainFrame)
-	if not parent:
-		mainFrame.postPopup()
-	if not wasAlready:
-		_isInMessageBox = False
+	try:
+		if not parent:
+			mainFrame.prePopup()
+		res = wx.MessageBox(message, caption, style, parent or mainFrame)
+		if not parent:
+			mainFrame.postPopup()
+	finally:
+		if not wasAlready:
+			_isInMessageBox = False
 	return res

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -5,14 +5,16 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+import threading
 from typing import Optional
 import wx
 
-_isInMessageBox = False
+_messageBoxCounterLock = threading.Lock()
+_messageBoxCounter = 0
 
 
 def isInMessageBox() -> bool:
-	return _isInMessageBox
+	return _messageBoxCounter != 0
 
 
 def messageBox(
@@ -31,9 +33,9 @@ def messageBox(
 	@return: Same as for wx.MessageBox.
 	"""
 	from gui import mainFrame
-	global _isInMessageBox
-	wasAlready = _isInMessageBox
-	_isInMessageBox = True
+	global _messageBoxCounter
+	with _messageBoxCounterLock:
+		_messageBoxCounter += 1
 	try:
 		if not parent:
 			mainFrame.prePopup()
@@ -41,6 +43,6 @@ def messageBox(
 		if not parent:
 			mainFrame.postPopup()
 	finally:
-		if not wasAlready:
-			_isInMessageBox = False
+		with _messageBoxCounterLock:
+			_messageBoxCounter -= 1
 	return res

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -1,0 +1,44 @@
+# -*- coding: UTF-8 -*-
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from typing import Optional
+import wx
+
+_isInMessageBox = False
+
+
+def isInMessageBox() -> bool:
+	return _isInMessageBox
+
+
+def messageBox(
+		message: str,
+		caption: str = wx.MessageBoxCaptionStr,
+		style: int = wx.OK | wx.CENTER,
+		parent: Optional[wx.Window] = None
+) -> int:
+	"""Display a message dialog.
+	This should be used for all message dialogs
+	rather than using C{wx.MessageDialog} and C{wx.MessageBox} directly.
+	@param message: The message text.
+	@param caption: The caption (title) of the dialog.
+	@param style: Same as for wx.MessageBox.
+	@param parent: The parent window.
+	@return: Same as for wx.MessageBox.
+	"""
+	from gui import mainFrame
+	global _isInMessageBox
+	wasAlready = _isInMessageBox
+	_isInMessageBox = True
+	if not parent:
+		mainFrame.prePopup()
+	res = wx.MessageBox(message, caption, style, parent or mainFrame)
+	if not parent:
+		mainFrame.postPopup()
+	if not wasAlready:
+		_isInMessageBox = False
+	return res

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -45,7 +45,7 @@ Quits from keyboard with welcome dialog open
 Quits from keyboard with about dialog open
 	[Documentation]	Starts NVDA and ensures that it can be quit with the about dialog open
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
-	# Excluded to be fixed still (#12907, #12957)
+	# Excluded to be fixed still (#12976)
 	[Tags]	excluded_from_build
 	open about dialog from menu
 	quits from keyboard	# run test

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,6 +43,7 @@ If you need this functionality please assign a gesture to the appropriate script
   - New braille tables: Russian grade 1, Tshivenda grade 1, Tshivenda grade 2
   -
 - Instead of "marked content" or "mrkd", "highlight" or "hlght" will be announced for speech and braille respectively. (#12892)
+- NVDA will no longer attempt to exit when dialogs are awaiting a required action (eg Confirm/Cancel). (#12984)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Relates to #12976 

### Summary of the issue:

NVDA crashes if you attempt to exit NVDA with a messageBox open (eg the About Dialog).
This is due to wx Idle Events firing on the dialogs while they are being forced to close in the exit process.

1. Have NVDA running
2. Press NVDA+n then h to open the help menu, down arrow to "About dialog" and enter to open that.
3. Press NVDA+Q then ENTER to quit NVDA

### Description of how this pull request fixes the issue:

Prevent exit while a MessageBox dialog is open - this is because the state of a MessageBox dialog is important and should be determined before exit.

### Testing strategy:

1. Start NVDA, close any open dialogs
1. Open a message dialog, such as the About Dialog via `NVDA menu > About`
1. Attempt to exit NVDA ([exiting NVDA methods](https://github.com/nvaccess/nvda/blob/master/devDocs/startupShutdown.md#nvda-can-be-shutdown-by))
1. Confirm the exit dialog does not open and the exit does not occur when the ExitDialog is disabled

### Known issues with pull request:

The state of the About Dialog is not important, and a different dialog that can be expected to close on exit should be used instead.

The messageBox module could be redesigned, but this is the safest solution while preserving backwards compatibility.

### Change log entries:
Changes

```t2t
- NVDA will no longer attempt to exit when dialogs are awaiting a required action (eg Confirm/Cancel).
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
