### PR TITLE
Fixup FolderId usage and change log

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -103,7 +103,7 @@ def getInstalledUserConfigPath():
 	except WindowsError:
 		configInLocalAppData=False
 	configParent = shlobj.SHGetKnownFolderPath(
-		shlobj.FolderId.LocalAppData if configInLocalAppData else shlobj.FolderId.RoamingAppData
+		shlobj.FolderId.LOCAL_APP_DATA if configInLocalAppData else shlobj.FolderId.ROAMING_APP_DATA
 	)
 	try:
 		return os.path.join(configParent, "nvda")

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -103,7 +103,7 @@ def getInstalledUserConfigPath():
 	except WindowsError:
 		configInLocalAppData=False
 	configParent = shlobj.SHGetKnownFolderPath(
-		shlobj.FOLDERID.LocalAppData.value if configInLocalAppData else shlobj.FOLDERID.RoamingAppData.value
+		shlobj.FolderId.LocalAppData if configInLocalAppData else shlobj.FolderId.RoamingAppData
 	)
 	try:
 		return os.path.join(configParent, "nvda")
@@ -1151,4 +1151,3 @@ class ProfileTrigger(object):
 
 	def __exit__(self, excType, excVal, traceback):
 		self.exit()
-

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -55,7 +55,7 @@ def _suspendWow64RedirectionForFileInfoRetrieval(func):
 	"""
 	@wraps(func)
 	def funcWrapper(filePath, *attributes):
-		nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FOLDERID.System.value)
+		nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.System)
 		if (
 			systemUtils.hasSyswow64Dir()
 			# `os.path.commonpath` is necessary to perform case-insensitive comparisons

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -55,7 +55,7 @@ def _suspendWow64RedirectionForFileInfoRetrieval(func):
 	"""
 	@wraps(func)
 	def funcWrapper(filePath, *attributes):
-		nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.System)
+		nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.SYSTEM)
 		if (
 			systemUtils.hasSyswow64Dir()
 			# `os.path.commonpath` is necessary to perform case-insensitive comparisons

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -13,12 +13,12 @@ and "C:\Winnt" on another.
 
 import comtypes
 import ctypes
-import enum
+from enum import Enum
 import functools
-import typing
+from typing import Optional, Union
 
 
-class FolderId(str, enum.Enum):
+class FolderId(str, Enum):
 	"""Contains guids of known folders from Knownfolders.h. Full list is availabe at:
 	https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid"""
 	#: The file system directory that serves as a common repository for application-specific data.
@@ -38,10 +38,17 @@ class FolderId(str, enum.Enum):
 
 
 @functools.lru_cache(maxsize=128)
-def SHGetKnownFolderPath(folderGuid: FolderId, dwFlags: int = 0, hToken: typing.Optional[int] = None) -> str:
+def SHGetKnownFolderPath(
+		folderGuid: Union[FolderId, str],
+		dwFlags: int = 0,
+		hToken: Optional[int] = None
+) -> str:
 	"""Wrapper for `SHGetKnownFolderPath` which caches the results
 	to avoid calling the win32 function unnecessarily."""
-	guid = comtypes.GUID(folderGuid.value)
+	if isinstance(folderGuid, FolderId):
+		folderGuid = folderGuid.value
+	guid = comtypes.GUID(folderGuid)
+
 	pathPointer = ctypes.c_wchar_p()
 	res = ctypes.windll.shell32.SHGetKnownFolderPath(
 		comtypes.byref(guid),

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -18,7 +18,7 @@ import functools
 import typing
 
 
-class FOLDERID(str, enum.Enum):
+class FolderId(str, enum.Enum):
 	"""Contains guids of known folders from Knownfolders.h. Full list is availabe at:
 	https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid"""
 	#: The file system directory that serves as a common repository for application-specific data.
@@ -38,10 +38,10 @@ class FOLDERID(str, enum.Enum):
 
 
 @functools.lru_cache(maxsize=128)
-def SHGetKnownFolderPath(folderGuid: str, dwFlags: int = 0, hToken: typing.Optional[int] = None) -> str:
+def SHGetKnownFolderPath(folderGuid: FolderId, dwFlags: int = 0, hToken: typing.Optional[int] = None) -> str:
 	"""Wrapper for `SHGetKnownFolderPath` which caches the results
 	to avoid calling the win32 function unnecessarily."""
-	guid = comtypes.GUID(folderGuid)
+	guid = comtypes.GUID(folderGuid.value)
 	pathPointer = ctypes.c_wchar_p()
 	res = ctypes.windll.shell32.SHGetKnownFolderPath(
 		comtypes.byref(guid),
@@ -50,7 +50,7 @@ def SHGetKnownFolderPath(folderGuid: str, dwFlags: int = 0, hToken: typing.Optio
 		ctypes.byref(pathPointer)
 	)
 	if res != 0:
-		raise RuntimeError(f"SHGetKnownFolderPath failed with erro code {res}")
+		raise RuntimeError(f"SHGetKnownFolderPath failed with error code {res}")
 	path = pathPointer.value
 	ctypes.windll.ole32.CoTaskMemFree(pathPointer)
 	return path

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -23,18 +23,18 @@ class FolderId(str, Enum):
 	https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid"""
 	#: The file system directory that serves as a common repository for application-specific data.
 	#: A typical path is C:\Documents and Settings\username\Application Data.
-	RoamingAppData = "{3EB685DB-65F9-4CF6-A03A-E3EF65729F3D}"
+	ROAMING_APP_DATA = "{3EB685DB-65F9-4CF6-A03A-E3EF65729F3D}"
 	#: The file system directory that serves as a data repository for local (nonroaming) applications.
 	#: A typical path is C:\Documents and Settings\username\Local Settings\Application Data.
-	LocalAppData = "{F1B32785-6FBA-4FCF-9D55-7B8E7F157091}"
+	LOCAL_APP_DATA = "{F1B32785-6FBA-4FCF-9D55-7B8E7F157091}"
 	#: The file system directory that contains application data for all users.
 	#: A typical path is C:\Documents and Settings\All Users\Application Data.
 	#: This folder is used for application data that is not user specific.
-	ProgramData = "{62AB5D82-FDC1-4DC3-A9DD-070D1D495D97}"
+	PROGRAM_DATA = "{62AB5D82-FDC1-4DC3-A9DD-070D1D495D97}"
 	#  The Windows System folder.
 	# A typical path is C:\Windows\System32.
-	System = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}"
-	SystemX86 = "{D65231B0-B2F1-4857-A4CE-A8E7C6EA7D27}"
+	SYSTEM = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}"
+	SYSTEM_X86 = "{D65231B0-B2F1-4857-A4CE-A8E7C6EA7D27}"
 
 
 @functools.lru_cache(maxsize=128)

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -9,7 +9,6 @@ import ctypes
 import winKernel
 import shellapi
 import winUser
-import os
 import functools
 import shlobj
 
@@ -17,8 +16,8 @@ import shlobj
 @functools.lru_cache(maxsize=1)
 def hasSyswow64Dir() -> bool:
 	"""Returns `True` if the current system has separate system32 directories for 32-bit processes."""
-	nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.System)
-	Syswow64Sys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.SystemX86)
+	nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.SYSTEM)
+	Syswow64Sys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.SYSTEM_X86)
 	return nativeSys32 != Syswow64Sys32
 
 

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -17,8 +17,8 @@ import shlobj
 @functools.lru_cache(maxsize=1)
 def hasSyswow64Dir() -> bool:
 	"""Returns `True` if the current system has separate system32 directories for 32-bit processes."""
-	nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FOLDERID.System.value)
-	Syswow64Sys32 = shlobj.SHGetKnownFolderPath(shlobj.FOLDERID.SystemX86.value)
+	nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.System)
+	Syswow64Sys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.SystemX86)
 	return nativeSys32 != Syswow64Sys32
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,9 +40,14 @@ What's New in NVDA
   - ``constants.SVE*`` usages should be replaced with ``SpeechVoiceEvents.*``
   -
 - The ``soffice`` appModule has the following classes and functions removed ``JAB_OOTableCell``, ``JAB_OOTable``, ``gridCoordStringToNumbers``. (#12849)
-- core.CallCancelled becomes exceptions.CallCancelled. 
-- All constants starting with RPC from core and logHandler are moved into RPCConstants.RPC enum
-- It is recommended that mouseHandler.doPrimaryClick and mouseHandler.doSecondaryClick functions should be used to click the mouse to perform a logical action such as activating (primary) or secondary (show context menu), rather than using executeMouseEvent and specifying the left or right mouse button specifically. This ensures code will honor the Windows user setting for swapping the primary mouse button. (#12642)
+- ``core.CallCancelled`` is now ``exceptions.CallCancelled``. (#12940)
+- All constants starting with RPC from ``core`` and ``logHandler`` are moved into ``RPCConstants.RPC`` enum. (#12940)
+- It is recommended that ``mouseHandler.doPrimaryClick`` and ``mouseHandler.doSecondaryClick`` functions should be used to click the mouse to perform a logical action such as activating (primary) or secondary (show context menu),
+rather than using executeMouseEvent and specifying the left or right mouse button specifically.
+This ensures code will honor the Windows user setting for swapping the primary mouse button. (#12642)
+- ``config.getSystemConfigPath`` has been removed - there is no replacement. (#12943)
+- ``shlobj.SHGetFolderPath`` has been removed - please use ``shlobj.SHGetKnownFolderPath`` instead. (#12943)
+- ``shlobj`` constants have been removed. A new enum has been created, ``shlobj.FolderId`` for usage with ``SHGetKnownFolderPath``. (#12943)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixup of #12943

### Summary of the issue:

Changelog entries were missing for #12943

[UpperCamelCase is the standard](https://github.com/nvaccess/nvda/blob/master/devDocs/codingStandards.md) for class names, including enums, however `FOLDERID` was used as the casing for the enum, which mirrors the windows constants. 
There is a similar issue for the enum members (which used UpperCamelCase instead of CAP_SNAKE_CASE).

If we want to change our practice to be consistent with what an Enum represents, we should update `codingStandards.md`

Also the enum type was not being fully leveraged by `SHGetKnownFolderPath`, requiring `.value` to be used unnecessarily when calling the function.

### Description of how this pull request fixes the issue:

Updates the casing of the enum and it's members. Updates the change log, and fixes up some earlier entries.

### Testing strategy:

None

### Known issues with pull request:

None

### Change log entries:
See diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
