### PR TITLE
Support the Modern Comments side track pane in MS Word when not accessing MS Word documents via UIA 

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -537,7 +537,7 @@ class UIAHandler(COMObject):
 			# #12982: This element may be the root of an MS Word document
 			# for which we may be refusing to use UIA as its implementation may be incomplete.
 			# However, there are some controls embedded in the MS Word document window
-			# such as the Modern comments side track pain
+			# such as the Modern comments side track pane
 			# for which we do have to use UIA.
 			# But, if focus jumps from one of these controls back to the document (E.g. the user presses escape),
 			# we receive no MSAA focus event, only a UIA focus event.
@@ -864,7 +864,7 @@ class UIAHandler(COMObject):
 		"""
 		Detects if the given UIA element represents a control in a NetUI container
 		embedded within a MS Word document window.
-		E.g. the Modern Comments side track pain.
+		E.g. the Modern Comments side track pane.
 		This method also caches the answer on the element itself
 		to both speed up checking later and to allow checking on an already dead element
 		E.g. a previous focus.
@@ -926,7 +926,7 @@ class UIAHandler(COMObject):
 			# #12982: although NVDA by default may not treat this element's window as native UIA,
 			# E.g. it is proxied from MSAA, or NVDA has specifically black listed it,
 			# It may be an element from a NetUIcontainer embedded in a Word document,
-			# such as the MS Word Modern Comments side track pain.
+			# such as the MS Word Modern Comments side track pane.
 			# These elements are only exposed via UIA, and not MSAA,
 			# thus we must treat these elements as native UIA.
 			if self._isNetUIEmbeddedInWordDoc(UIAElement):

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -45,6 +45,10 @@ from queue import Queue
 import aria
 
 
+#: The window class name for Microsoft Word documents.
+# Microsoft Word's UI Automation implementation
+# also exposes this value as the document UIA element's classname property.
+MS_WORD_DOCUMENT_WINDOW_CLASS = "_WwG"
 
 HorizontalTextAlignment_Left=0
 HorizontalTextAlignment_Centered=1
@@ -768,7 +772,7 @@ class UIAHandler(COMObject):
 			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 			if (
 				# An MS Word document window 
-				windowClass=="_WwG" 
+				windowClass == MS_WORD_DOCUMENT_WINDOW_CLASS
 				# Disabling is only useful if we can inject in-process (and use our older code)
 				and canUseOlderInProcessApproach
 				# Allow the user to explicitly force UIA support for MS Word documents
@@ -860,7 +864,7 @@ class UIAHandler(COMObject):
 		if getattr(element, '_isNetUIEmbeddedInWordDoc', False):
 			return True
 		windowHandle = self.getNearestWindowHandle(element)
-		if winUser.getClassName(windowHandle) != '_WwG':
+		if winUser.getClassName(windowHandle) != MS_WORD_DOCUMENT_WINDOW_CLASS:
 			return False
 		condition = UIAUtils.createUIAMultiPropertyCondition(
 			{UIA.UIA_ClassNamePropertyId: 'NetUIHWNDElement'},
@@ -869,7 +873,7 @@ class UIAHandler(COMObject):
 		walker = self.clientObject.createTreeWalker(condition)
 		cacheRequest = self.clientObject.createCacheRequest()
 		cacheRequest.AddProperty(UIA.UIA_ClassNamePropertyId)
-		cacheRequest.addProperty(UIA.UIA_NativeWindowHandlePropertyId)
+		cacheRequest.AddProperty(UIA.UIA_NativeWindowHandlePropertyId)
 		ancestor = walker.NormalizeElementBuildCache(element, cacheRequest)
 		# ancestor will either be the embedded NetUIElement, or just hit the root of the MS Word document window
 		if ancestor.CachedClassName != 'NetUIHWNDElement':
@@ -888,7 +892,7 @@ class UIAHandler(COMObject):
 		if (
 			isinstance(oldFocus, NVDAObjects.UIA.UIA)
 			and getattr(oldFocus.UIAElement, '_isNetUIEmbeddedInWordDoc', False)
-			and element.CachedClassName == '_WwG'
+			and element.CachedClassName == MS_WORD_DOCUMENT_WINDOW_CLASS
 			and element.CachedControlType == UIA.UIA_DocumentControlTypeId
 			and self.getNearestWindowHandle(element) == oldFocus.windowHandle
 			and not self.isUIAWindow(oldFocus.windowHandle)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,6 +73,7 @@ If you need this functionality please assign a gesture to the appropriate script
 - Fixed duplicate braille and speech when 'description' matches 'content' or 'name'. (#12888)
 - In MS Word with UIA enabled, more accurate playing of spelling error sounds as you type. (#12161)
 - In Windows 11, NVDA will no longer announce "pane" when pressing Alt+Tab to switch between programs. (#12648)
+- The new Modern Comments side track pane is now supported in MS Word when not accessing the document via UIA. Press alt+f12 to move between the side track pane and the document. (#12982)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12982 

### Summary of the issue:
In build 13901, MS Word introduced "Modern comments" which allows comment threads (I.e. an initial comment plus replies) and the ability to resolve or reopen threads. The new UI to do this is exposed as a new comments side pane which shows the comments and replies in a treeview. This UI is only exposed via UI Automation.
This UI is supposed to completely replace the older Comments story in a document.
As this new UI is imbedded within the document, it shares the same window handle. If NvDA is using the object model to access the document (I.e. the UIA provider of the document's window is ignored) then NVDA never sees the modern comments UI at all. It seems that MS Word does not ever proxy this to MSAA either.
Also, if MS Word detects that something is trying to access the comments via the object model in the old way (E.g. calls comment.range) then the Modern comments UI is disabled (hidden) and MS Word ends up in a state where querying the range at the selection of the object model is no longer in the comments story, yet the UI is not shown either. This MS Word bug is known to Microsoft however they have no plans or willingness to fix it. Their only recommended solution is to stop using the object model and just use UIA.

### Description of how this pull request fixes the issue:
in `UIAHandler.handler.isUIAElement`: return true if the element's windowHandle is _WwG but an ancestor of the element has a UIA className of NetUIHWNDElement.
I.e. this UIA element is a control of a NetUI container embedded in an MS Word document. E.g. a control in the Modern Comments side track pane.
Also, if there is a UIA focus event for the Word document root, even though we are not classing that window as native UIA, if the previously focused object was a control in a NetUI container embedded in the same Word document, then generate an MSAA focus event for the document, as MS Word will not do this itself.

Note that allowing NVDA to track the focus with UIA for these embedded controls is enough to work around the issue, as this then means that focus never hits the Word document while the Comments side track pane should be focused, thus avoids making object model calls MS Word does not like or expect.

### Testing strategy:
This can only be tested in conjunction with PR #12989  as UIA in MS word should not be used by default.
1. Ensure that the NVDA advanced setting: Use UIA in MS Word document controls when available is turned off.
2. Open a new MS Word document.
3. Ensure the build of MS Word is 13901 or later.
4. Type some text. E.g. "this is a test".
5. Select a word, E.g. "This".
6.  In the context menu, choose "New Comment".
7. Ensure that focus lands in the Modern Comments side track pane ready for you to type the comment.
8. Type a comment, and tab to the Post comment button and press enter.
8. press alt+f12 to move back to the document and ensure that the arrow keys cause the caret to move and NVDA speaks the characters.
9. Again, select the same word you created the comment for.
10. Press alt+f12 to move to the Modern comment side track pane for this comment.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
* The new Modern Comments side track pane is now supported in MS Word when not accessing the document via UIA. Press alt+f12 to move between the side track pane and the document.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
