### PR TITLE
Revert UI a in ms word by default

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -747,36 +747,36 @@ class UIAHandler(COMObject):
 		# Ask the window if it supports UIA natively
 		res=windll.UIAutomationCore.UiaHasServerSideProvider(hwnd)
 		if res:
-			# The window does support UIA natively.
-
-			# MS Word documents now have a fairly usable UI Automation implementation.
+			# The window does support UIA natively, but MS Word documents now
+			# have a fairly usable UI Automation implementation.
 			# However, builds of MS Office 2016 before build 13901 or so had bugs which
 			# we cannot work around.
 			# Therefore for less recent versions of Office,
 			# if we can inject in-process, refuse to use UIA and instead
 			# fall back to the MS Word object model.
-			if windowClass == "_WwG":
-				canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
-				isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
-				if (
-					(
-						winVersion.getWinVer() < winVersion.WIN10
-						or (
-							# An MS Office app before build 13901
-							isOfficeApp
-							and (
-								tuple(int(x) for x in appModule.productVersion.split('.')[:3])
-								< (16, 0, 13901)
-							)
+			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
+			isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
+			if (
+				(
+					winVersion.getWinVer() < winVersion.WIN10
+					or (
+						# An MS Office app before build 13901
+						isOfficeApp
+						and (
+							tuple(int(x) for x in appModule.productVersion.split('.')[:3])
+							< (16, 0, 13901)
 						)
 					)
-					# Disabling is only useful if we can inject in-process (and use our older code)
-					and canUseOlderInProcessApproach
-					# Allow the user to still explicitly force UIA support
-					# no matter the Office version
-					and not config.conf['UIA']['useInMSWordWhenAvailable']
-				):
-					return False
+				)
+				# An MS Word document window
+				and windowClass == "_WwG"
+				# Disabling is only useful if we can inject in-process (and use our older code)
+				and canUseOlderInProcessApproach
+				# Allow the user to still explicitly force UIA support
+				# no matter the Office version
+				and not config.conf['UIA']['useInMSWordWhenAvailable']
+			):
+				return False
 			# MS Excel spreadsheets now have a fairly usable UI Automation implementation.
 			# However, builds of MS Office 2016 before build 9000 or so had bugs which we
 			# cannot work around.
@@ -808,7 +808,7 @@ class UIAHandler(COMObject):
 				)
 			):
 				return False
-			elif windowClass == "ConsoleWindowClass":
+			if windowClass == "ConsoleWindowClass":
 				return UIAUtils._shouldUseUIAConsole(hwnd)
 		return bool(res)
 

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -748,8 +748,6 @@ class UIAHandler(COMObject):
 		res=windll.UIAutomationCore.UiaHasServerSideProvider(hwnd)
 		if res:
 			# The window does support UIA natively.
-			# Detect if we can also inject in-process
-			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 
 			# MS Word documents now have a fairly usable UI Automation implementation.
 			# However, builds of MS Office 2016 before build 13901 or so had bugs which
@@ -758,6 +756,7 @@ class UIAHandler(COMObject):
 			# if we can inject in-process, refuse to use UIA and instead
 			# fall back to the MS Word object model.
 			if windowClass == "_WwG":
+				canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
 				isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
 				if (
 					(

--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -749,30 +749,19 @@ class UIAHandler(COMObject):
 		if res:
 			# The window does support UIA natively, but MS Word documents now
 			# have a fairly usable UI Automation implementation.
-			# However, builds of MS Office 2016 before build 13901 or so had bugs which
+			# However, builds of MS Office 2016 before build 9000 or so had bugs which
 			# we cannot work around.
-			# Therefore for less recent versions of Office,
-			# if we can inject in-process, refuse to use UIA and instead
+			# And even current builds of Office 2016 are still missing enough info from
+			# UIA that it is still impossible to switch to UIA completely.
+			# Therefore, if we can inject in-process, refuse to use UIA and instead
 			# fall back to the MS Word object model.
 			canUseOlderInProcessApproach = bool(appModule.helperLocalBindingHandle)
-			isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
 			if (
-				(
-					winVersion.getWinVer() < winVersion.WIN10
-					or (
-						# An MS Office app before build 13901
-						isOfficeApp
-						and (
-							tuple(int(x) for x in appModule.productVersion.split('.')[:3])
-							< (16, 0, 13901)
-						)
-					)
-				)
-				# An MS Word document window
-				and windowClass == "_WwG"
+				# An MS Word document window 
+				windowClass=="_WwG" 
 				# Disabling is only useful if we can inject in-process (and use our older code)
 				and canUseOlderInProcessApproach
-				# Allow the user to still explicitly force UIA support
+				# Allow the user to explicitly force UIA support for MS Word documents
 				# no matter the Office version
 				and not config.conf['UIA']['useInMSWordWhenAvailable']
 			):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2622,7 +2622,7 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a checkbox in the
 		#  Advanced settings panel.
-		label = _("Always use UI Automation to access Microsoft &Word document controls when available")
+		label = _("Use UI Automation to access Microsoft &Word document controls when available")
 		self.UIAInMSWordCheckBox = UIAGroup.addItem(wx.CheckBox(UIABox, label=label))
 		self.bindHelpEvent("AdvancedSettingsUseUiaForWord", self.UIAInMSWordCheckBox)
 		self.UIAInMSWordCheckBox.SetValue(config.conf["UIA"]["useInMSWordWhenAvailable"])

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1836,12 +1836,12 @@ This has a major negative impact on performance, especially in applications like
 Therefore, when this option is enabled, NVDA will limit event registration to the system focus for most events.
 If you suffer from performance issues in one or more applications, We recommend you to try this functionality to see whether performance improves.
 
-==== Always use UI automation to access Microsoft Word document controls when available ====[AdvancedSettingsUseUiaForWord]
-When this option is enabled, NVDA will always try to use the Microsoft UI Automation accessibility API in order to fetch information from Microsoft Word document controls, even for less recent builds of Microsoft Office 2016/365.
+==== Use UI automation to access Microsoft Word document controls when available ====[AdvancedSettingsUseUiaForWord]
+When this option is enabled, NVDA will try to use the Microsoft UI Automation accessibility API in order to fetch information from Microsoft Word document controls.
 This includes Microsoft Word itself, and also the Microsoft Outlook message viewer and composer.
- For Microsoft Office with a build version of 16.0.13901 or greater, NVDA will always use UI Automation to access Microsoft Word documents no matter how this setting is configured. 
-For the most recent versions of Microsoft Office 2016/365 running on Windows 10 and later, UI Automation support is complete enough to provide access to Microsoft Word documents almost equal to NVDA's existing Microsoft Word support, with the added advantage that responsiveness is majorly increased.
-However, There may be some information which is either not exposed, or exposed incorrectly in some  older builds of Microsoft Office, which means this UI automation support cannot always be relied upon.
+ For the most recent versions of Microsoft Office 2016/365 running on Windows 10 and later, UI Automation support is complete enough to provide access to Microsoft Word documents almost equal to NVDA's existing Microsoft Word support, with the added advantage that responsiveness is majorly increased.
+However, There may be some information which is either not exposed, or exposed incorrectly in some versions of Microsoft Office, which means this UI automation support cannot always be relied upon.
+We still do not recommend that  the majority of users turn this on by default, though we do welcome users of Office 2016/365 to test this feature and provide feedback.
 
 ==== Use UI Automation to access the Windows Console when available ====[AdvancedSettingsConsoleUIA]
 When this option is enabled, NVDA will use a new, work in progress version of its support for Windows Console which takes advantage of [accessibility improvements made by Microsoft https://devblogs.microsoft.com/commandline/whats-new-in-windows-console-in-windows-10-fall-creators-update/]. This feature is highly experimental and is still incomplete, so its use is not yet recommended. However, once completed, it is anticipated that this new support will become the default, improving NVDA's performance and stability in Windows command consoles.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None.

### Summary of the issue:
We have tried to switch to using UI automation to access MS Word documents by default in NVDA 2021.3. However, there are still several issues remaining with our UIA support. Switching to UIA by default should be held back until these are addressed.
Some of these include:
* Support for math: #12946
 * Reporting of line numbers: Requires UIA custom patterns support\
 
Over the last couple of months our UIA support has had a lot of fixes and improvements, mainly spured on by the apparent need to switch due to NVDA and MS Word not playing well together with the introduction of Modern Comments in MS Word build 13901. However, a work around has been found for #12982 now, making the swich less of a high priority.

### Description of how this pull request fixes the issue:
Reverts #12859 
Reverts #12854 
Reverts #12770 

### Testing strategy:
With a build of MS Word 13901 or highera dn NVDA advanced setting: use UIA to access MS Word documents when available turned off, Open a Word document and ensure that UIA is not being used to access the document.
When the document is focused, the name of the focused object is "Microsoft Word document" and the role is "edit".

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
