### PR TITLE
What's new: remove mention of UIA by default in MS Word

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,7 +39,6 @@ Affected users will need to download this update manually.
 - When reading status bar with ``NVDA+end``, the review cursor is no longer moved to its location.
 If you need this functionality please assign a gesture to the appropriate script in the Object Navigation category in the Input Gestures dialog. (#8600)
 - When opening a settings dialog which is already open, NVDA sets focus on the existing dialog rather than raise an error. (#5383)
-- For builds of Microsoft Office 2016/365 greater than 13900, NVDA will now always use UI Automation to access Microsoft Word document controls, no matter whether the user has toggled the Use UI Automation to access Microsoft word document controls advanced setting on or off. (#12770)
 - Updated liblouis braille translator to [3.19.0 https://github.com/liblouis/liblouis/releases/tag/v3.19.0]. (#12810)
   - New braille tables: Russian grade 1, Tshivenda grade 1, Tshivenda grade 2
   -


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

In pr #12989 NVDA no longer defaults to using UIA in MS Word build 13901 or higher. 
This pr removes the relevant line from changes.t2t.

Note that the release blurb for 2021.3 did not explicitly mention this feature thus did not need to be updated.