### PR TITLE
brailleHID driver: Also allow panning with rocker up and rocker down

### DIFF
--- a/source/brailleDisplayDrivers/hid.py
+++ b/source/brailleDisplayDrivers/hid.py
@@ -197,8 +197,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	gestureMap = inputCore.GlobalGestureMap({
 		"globalCommands.GlobalCommands": {
-			"braille_scrollBack": ("br(HID):panLeft",),
-			"braille_scrollForward": ("br(HID):panRight",),
+			"braille_scrollBack": (
+				"br(HID):panLeft",
+				"br(HID):rockerUp",
+			),
+			"braille_scrollForward": (
+				"br(HID):panRight",
+				"br(HID):rockerDown",
+			),
 			"braille_previousLine": ("br(HID):space+dot1",),
 			"braille_nextLine": ("br(HID):space+dot4",),
 			"braille_routeTo": ("br(HID):routerSet1_routerKey",),

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3189,8 +3189,8 @@ NVDA's automatic braille display detection will also recognize any display that 
 Following are the current key assignments for these displays.
 %kc:beginInclude
 || Name | Key |
-| Scroll braille display back | pan left |
-| Scroll braille display forward | pan right |
+| Scroll braille display back | pan left or rocker up |
+| Scroll braille display forward | pan right or rocker down |
 | Move braille display to previous line | space + dot1 |
 | Move braille display to next line | space + dot4 |
 | Route to braille cell | routing set 1|


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None.

### Summary of the issue:
NVDA 2021.3 introduces support for the Braille HID standard.  However this is very new and not many displays support this yet. The displays that do support this vary in the buttons they provide.
It is important that we map panning gestures to enough buttons to ensure that  any display that supports braille HID should be able to be panned.
For instance, one display exposes pan left and pan right buttons from the braille HID specification -- we already map these to NVDA's braille scroll back and forward respectively.
However, the Orbit Reader 20 and 40 do not expose pan left and right keys, but they do have rocker up and rocker down keys.

### Description of how this pull request fixes the issue:
Also map NVDA's braille scroll forward and scroll back to braille HID's rocker down and rocker up keys respectively.

### Testing strategy:
With an Orbit Reader 40 in HID Braille mode: ensured that the display could be scrolled forward and back  by pressing rocker down and rocker up respectively.

### Known issues with pull request:
As this standard becomes more popular and more displays start supporting it, it may become necessary to come up with a way to provide device-specific mappings. But for now, mapping more than less for panning seems smart.
Additionally, users can override the commands for these inputs via the input gestures dialog.

### Change log entries:
None, braileHID introduced in 2021.3.

New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
