### PR TITLE
Fix-up of PR 12943 - Avoid os.path.commonPath` when comparing paths of the binaries as it does not work for files on different drives

### DIFF
--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -58,8 +58,8 @@ def _suspendWow64RedirectionForFileInfoRetrieval(func):
 		nativeSys32 = shlobj.SHGetKnownFolderPath(shlobj.FolderId.SYSTEM)
 		if (
 			systemUtils.hasSyswow64Dir()
-			# `os.path.commonpath` is necessary to perform case-insensitive comparisons
-			and os.path.commonpath([nativeSys32]) == os.path.commonpath([nativeSys32, filePath])
+			# Path's returned from `appModule.appPath` and `shlobj.SHGetKnownFolderPath` often differ in case
+			and filePath.casefold().startswith(nativeSys32.casefold())
 		):
 			with winKernel.suspendWow64Redirection():
 				return func(filePath, *attributes)


### PR DESCRIPTION
### Link to issue number:
Fixes #13008

### Summary of the issue:
PR #12943 improved code which retrieves version information for a given executable files placed in system32 under 64-bit versions of Windows. To do so it is necessary to check if path of the given binary starts with path of system32 directory for the current system. The recommended way to compare path's in a case insensitive way was `os.path`commonPath`, however it turns out it does not work when path's are from different drives.
In case of reporter of #13008 they had Office installed in a custom location probably on non system disk.
### Description of how this pull request fixes the issue:
This PR simplifies the code to use standard `str.casefold` for comparisons.
### Testing strategy:
- Made sure that product name and product version can be retrieved for a binary  placed on non system disk - previously it resulted in an exception.
- Got confirmation from reporter of #13008 that they problem is no longer reproducible.
### Known issues with pull request:
None known
### Change log entries:
None needed - regression not in a release.
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
