### PR TITLE
Fixup #12984 for isInMessageBox backwards compatibility

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -59,6 +59,9 @@ DONATE_URL = "http://www.nvaccess.org/donate/"
 mainFrame = None
 
 if version_year < 2022:
+	# Like other module level constants, this must be used as follows (#13011):
+	# import gui; doSomething(gui.isInMessageBox)
+	# from gui import isInMessageBox; doSomething(isInMessageBox)
 	isInMessageBox = False
 
 class MainFrame(wx.Frame):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -59,15 +59,7 @@ DONATE_URL = "http://www.nvaccess.org/donate/"
 mainFrame = None
 
 if version_year < 2022:
-	def __getattr__(name):
-		if name == "isInMessageBox":
-			log.warning(
-				"gui.isInMessageBox is deprecated and will be removed in 2022.1."
-				"Consult the changes for developers in 2022.1 for advice on alternatives."
-			)
-			return _isInMessageBox()
-		raise AttributeError(f"module {__name__} has no attribute {name}")
-
+	isInMessageBox = False
 
 class MainFrame(wx.Frame):
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -59,7 +59,7 @@ DONATE_URL = "http://www.nvaccess.org/donate/"
 mainFrame = None
 
 if version_year < 2022:
-	# Like other module level constants, this must be used as follows (#13011):
+	# Like other top level variables, this must be used as follows (#13011):
 	# import gui; doSomething(gui.isInMessageBox)
 	# NOT the following: from gui import isInMessageBox; doSomething(isInMessageBox)
 	isInMessageBox = False

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -61,7 +61,7 @@ mainFrame = None
 if version_year < 2022:
 	# Like other module level constants, this must be used as follows (#13011):
 	# import gui; doSomething(gui.isInMessageBox)
-	# from gui import isInMessageBox; doSomething(isInMessageBox)
+	# NOT the following: from gui import isInMessageBox; doSomething(isInMessageBox)
 	isInMessageBox = False
 
 class MainFrame(wx.Frame):

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -5,6 +5,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from buildVersion import version_year
 import threading
 from typing import Optional
 import wx
@@ -33,9 +34,12 @@ def messageBox(
 	@return: Same as for wx.MessageBox.
 	"""
 	from gui import mainFrame
+	import gui
 	global _messageBoxCounter
 	with _messageBoxCounterLock:
 		_messageBoxCounter += 1
+	if version_year < 2022:
+		gui.isInMessageBox = True
 	try:
 		if not parent:
 			mainFrame.prePopup()
@@ -45,4 +49,6 @@ def messageBox(
 	finally:
 		with _messageBoxCounterLock:
 			_messageBoxCounter -= 1
+		if version_year < 2022:
+			gui.isInMessageBox = isInMessageBox()
 	return res


### PR DESCRIPTION
### Link to issue number:

Fix up of #12984

### Summary of the issue:

Backwards compatibility for the following code was broken in 2021.3 beta.
```py
from gui import isInMessageBox
```

Note: this code creates a copy of the value of `isInMessageBox`, and as such, was only accurate if it was being imported when it was being checked. Importing like this also prevents `gui.isInMessageBox` from being updated:

```py
from gui import isInMessageBox
isInMessageBox = False  # this doesn't update gui.isInMessageBox
```

### Description of how this pull request fixes the issue:

Creates a `isInMessageBox` that is updated by `isInMessageBox`.
Note that while `from gui import isInMessageBox` can run without error now, using or updating the variable will not work as expected, nor has it ever worked properly.

### Testing strategy:

Manual testing with 2021.2 and this PR

1. Open the NVDA python console
1. With no other NVDA dialogs open, run this code snippet, confirm the result is False, False
    ```py
    from gui import isInMessageBox
    print(isInMessageBox)
    
    import gui
    print(gui.isInMessageBox)
    ```
1. Open the About dialog, run the code snippet, confirm the result is False, True, True
    ```py
    print(isInMessageBox)
    
    from gui import isInMessageBox
    print(isInMessageBox)
    
    import gui
    print(gui.isInMessageBox)
    ```
1. With no other NVDA dialogs open, run this code snippet, confirm the result is False, True
    ```py
    from gui import isInMessageBox
    isInMessageBox = True
    
    import gui
    print(gui.isInMessageBox)
    
    gui.isInMessageBox = True
    print(gui.isInMessageBox)
    ```

### Known issues with pull request:

None

### Change log entries:

None needed, fixes regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
