### PR TITLE
Stop using legacy git protocol when downloading configobj from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ SCons==4.1.0.post1
 comtypes==1.1.8
 pyserial==3.5
 wxPython==4.1.1
-git+git://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
+git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
 
 #NVDA_DMP requires diff-match-patch
 diff_match_patch_python==1.0.2


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
As described [here](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git) GitHub is in the process of disabling the old `git://` protocol. Currently url to configObj in our requirements file is using it making it impossible to install the dependency from the repository.
The error when creating fresh virtual Env is as follows:
```
  Cloning git://github.com/DiffSK/configobj (to revision 3e2f4cc) to c:\users\lukasz\appdata\local\temp\pip-install-jkglcb73\configobj_55089512823849d0b8e6188aefdf3cc6
  Running command git clone --filter=blob:none -q git://github.com/DiffSK/configobj 'C:\Users\Lukasz\AppData\Local\Temp\pip-install-jkglcb73\configobj_55089512823849d0b8e6188aefdf3cc6'
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
WARNING: Discarding git+git://github.com/DiffSK/configobj@3e2f4cc#egg=configobj. Command errored out with exit status 128: git clone --filter=blob:none -q git://github.com/DiffSK/configobj 'C:\U
sers\Lukasz\AppData\Local\Temp\pip-install-jkglcb73\configobj_55089512823849d0b8e6188aefdf3cc6' Check the logs for full command output.
Collecting SCons==4.1.0.post1
  Using cached SCons-4.1.0.post1-py3-none-any.whl (4.1 MB)
Collecting comtypes==1.1.8
  Using cached comtypes-1.1.8.zip (181 kB)
  Preparing metadata (setup.py) ... done
Collecting pyserial==3.5
  Using cached pyserial-3.5-py2.py3-none-any.whl (90 kB)
Collecting wxPython==4.1.1
  Using cached wxPython-4.1.1-cp37-cp37m-win32.whl (15.1 MB)
ERROR: Could not find a version that satisfies the requirement configobj (unavailable) (from versions: 4.5.3, 4.6.0, 4.7.0, 4.7.1, 4.7.2, 5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6)
ERROR: No matching distribution found for configobj (unavailable)
Traceback (most recent call last):
  File "D:\my_repos\nvda\venvUtils\\ensureVenv.py", line 148, in <module>
    ensureVenvAndRequirements()
  File "D:\my_repos\nvda\venvUtils\\ensureVenv.py", line 125, in ensureVenvAndRequirements
    return createVenvAndPopulate()
  File "D:\my_repos\nvda\venvUtils\\ensureVenv.py", line 87, in createVenvAndPopulate
    shell=True,
  File "C:\Python37\lib\subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['D:\\my_repos\\nvda\\venvUtils\\..\\.venv\\scripts\\activate.bat', '&&', 'py', '-m', 'pip', 'install', '--upgrade', 'pip', '&&', 'py', '-m', 'pip', 'inst
all', '-r', 'D:\\my_repos\\nvda\\venvUtils\\..\\requirements.txt']' returned non-zero exit status 1.

```
### Description of how this pull request fixes the issue:
Use https for the url to configObj repository.
### Testing strategy:
Ensured that virtual environment can be successfully created and configobj is installed.
### Known issues with pull request:
None known
### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
