### PR TITLE
MS Word with UIA: Ensure braille is updated when typing text 

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -412,6 +412,11 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	# Microsoft Word duplicates the full title of the document on this control, which is redundant as it appears in the title of the app itself.
 	name=u""
 
+	def event_textChange(self):
+		# Ensure Braille is updated when text changes,
+		# As Microsoft Word does not fire caret events when typing text, even though the caret does move.
+		braille.handler.handleCaretMove(self)
+
 	def event_UIA_notification(self, activityId=None, **kwargs):
 		# #10851: in recent Word 365 releases, UIA notification will cause NVDA to announce edit functions
 		# such as "delete back word" when Control+Backspace is pressed.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12970
Fixes #13004 
Regression caused by pr #12868 

### Summary of the issue:
When accessing an MS Word document via UIA, the braille display is not updated when typing characters into the document, although it does correctly update if the caret is moved with the arrow keys and such.
Generally, NVDA tells braille to update for each caret event. However, In Microsoft Word, although the caret does technically move when typing characters, Microsoft Word only fires a UIA textchange event (NVDA textChange event), and not a caret event (UIA textSelectionChanged event). 

Before pr #12868 , Braille did seem to update correctly, but that was because NvDA was incorrectly passing an MSAA caret event into the UIA NVDAObject with focus.

### Description of how this pull request fixes the issue:
On the MS Word document NVDAObject, implement an event_textChange method which just instructs Braille to update.

### Testing strategy:
* with Use UIA in MS Word document controls when available turned on
* With a braille display
* Open a blank document in MS Word
* Type some text
* Ensure that as each character is typed, the braille display is updated to reflect the typed text.
* Also performed tests in pr #12868 to ensure that braille still correctly scrolls when using a Chinese input method.

### Known issues with pull request:
None known.

### Change log entries:
None needed - regression was in 2021.3 dev cycle.

New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
