### PR TITLE
Allow opt out of venv recreation when requirements have changed

### DIFF
--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -79,9 +79,9 @@ def populate():
 	shutil.copy(requirements_path, venv_orig_requirements_path)
 
 
-def createVenvAndPopulate():
+def createVenv():
 	"""
-	Creates the NVDA build system's Python virtual environment and installs all required packages.
+	Creates the NVDA build system's Python virtual environment.
 	This function will overwrite any existing virtual environment found at c{venv_path}.
 	"""
 	print("Creating virtual environment...", flush=True)
@@ -96,6 +96,7 @@ def createVenvAndPopulate():
 	)
 	with open(venv_python_version_path, "w") as f:
 		f.write(sys.version)
+
 
 def createVenvAndPopulate():
 	createVenv()
@@ -142,7 +143,7 @@ def ensureVenvAndRequirements():
 			"with those used in automated builds. "
 			"Would you like to continue recreating the environment?"
 		):
-			return createVenv()
+			return createVenvAndPopulate()
 		return populate()
 
 

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -96,6 +96,9 @@ def createVenvAndPopulate():
 	)
 	with open(venv_python_version_path, "w") as f:
 		f.write(sys.version)
+
+def createVenvAndPopulate():
+	createVenv()
 	populate()
 
 
@@ -139,9 +142,8 @@ def ensureVenvAndRequirements():
 			"with those used in automated builds. "
 			"Would you like to continue recreating the environment?"
 		):
-			return createVenvAndPopulate()
-		else:
-			return populate()
+			return createVenv()
+		return populate()
 
 
 if __name__ == '__main__':

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -52,23 +52,13 @@ def fetchRequirementsSet(path: str) -> Set[str]:
 	return set(lines)
 
 
-def createVenvAndPopulate():
+def populate():
 	"""
-	Creates the NVDA build system's Python virtual environment and installs all required packages.
-	this function will overwrite any existing virtual environment found at c{venv_path}.
+	Installs all required packages within the virtual environment.
+	When called stand alone, this function only ensures that NVDA's package requirements are met,
+	without recreating the full environment.
+	This means that transitive dependencies can get out of sync with those used in automated builds.
 	"""
-	print("Creating virtual environment...", flush=True)
-	subprocess.run(
-		[
-			sys.executable,
-			"-m", "venv",
-			"--clear",
-			venv_path,
-		],
-		check=True
-	)
-	with open(venv_python_version_path, "w") as f:
-		f.write(sys.version)
 	print("Installing packages in virtual environment...", flush=True)
 	subprocess.run(
 		[
@@ -89,12 +79,32 @@ def createVenvAndPopulate():
 	shutil.copy(requirements_path, venv_orig_requirements_path)
 
 
+def createVenvAndPopulate():
+	"""
+	Creates the NVDA build system's Python virtual environment and installs all required packages.
+	This function will overwrite any existing virtual environment found at c{venv_path}.
+	"""
+	print("Creating virtual environment...", flush=True)
+	subprocess.run(
+		[
+			sys.executable,
+			"-m", "venv",
+			"--clear",
+			venv_path,
+		],
+		check=True
+	)
+	with open(venv_python_version_path, "w") as f:
+		f.write(sys.version)
+	populate()
+
+
 def ensureVenvAndRequirements():
 	"""
 	Ensures that the NVDA build system's Python virtual environment is created and up to date.
 	If a previous virtual environment exists but has a miss-matching Python version
-	or pip package requirements have changed,
-	The virtual environment is recreated with the updated version of Python and packages.
+	the virtual environment is recreated with the updated version of Python.
+	When pip package requirements have changed, this function asks the user to recreate the environment.
 	If a virtual environment is found but does not seem to be ours,
 	This function asks the user if it should be overwritten or not.
 	"""
@@ -121,8 +131,17 @@ def ensureVenvAndRequirements():
 	newRequirements = fetchRequirementsSet(requirements_path)
 	addedRequirements = newRequirements - oldRequirements
 	if addedRequirements:
-		print(f"Added or changed package requirements. {addedRequirements}")
-		return createVenvAndPopulate()
+		if askYesNoQuestion(
+			f"Added or changed package requirements. {addedRequirements}\n"
+			"You are encouraged to recreate the virtual environment. "
+			"If you choose no, the new requirements will be installed without recreating. "
+			"This means that transitive dependencies can get out of sync "
+			"with those used in automated builds. "
+			"Would you like to continue recreating the environment?"
+		):
+			return createVenvAndPopulate()
+		else:
+			return populate()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When the requirements file changes, the ensureVenv script forcefully recreates the environment. In many cases, this behavior is slightly harsh.

### Description of how this pull request fixes the issue:
Instead of always recreating the environment, ask the user what to do. If "No" is chosen, the requirements file is installed without recreating.

### Testing strategy:
Tested both paths by changing a single line in the requirements file.

### Known issues with pull request:
None

### Change log entries:
Probably not relevant.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
