### PR TITLE
Again allow closing audio device on idle, opt in

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -48,6 +48,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 # Audio settings
 [audio]
 	audioDuckingMode = integer(default=0)
+	# 0:default, 1:yes, 2:no
+	leaveDeviceOpenOnIdle = integer(0, 2, default=0)
 
 # Braille settings
 [braille]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2796,6 +2796,39 @@ class AdvancedPanelControls(
 		self.cancelExpiredFocusSpeechCombo.defaultValue = self._getDefaultValue(
 			["featureFlag", "cancelExpiredFocusSpeech"]
 		)
+		# Translators: This is the label for a group of advanced options in the
+		#  Advanced settings panel
+		label = _("Audio")
+		audioSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		audioGroup = guiHelper.BoxSizerHelper(audioSizer, sizer=audioSizer)
+		sHelper.addItem(audioGroup)
+
+		leaveDeviceOpenOnIdleChoices = [
+			# Translators: Label for the 'Leave audio device open when no sound is playing' combobox
+			# in the Advanced settings panel.
+			_("Default (Yes)"),
+			# Translators: Label for the 'Leave audio device open when no sound is playing' combobox
+			# in the Advanced settings panel.
+			_("Yes"),
+			# Translators: Label for the 'Leave audio device open when no sound is playing' combobox
+			# in the Advanced settings panel.
+			_("No"),
+		]
+
+		# Translators: This is the label for combobox in the Advanced settings panel.
+		leaveDeviceOpenOnIdleText = _("Leave audio device &open when no sound is playing:")
+		self.leaveDeviceOpenOnIdleCombo: wx.Choice = audioGroup.addLabeledControl(
+			leaveDeviceOpenOnIdleText,
+			wx.Choice,
+			choices=leaveDeviceOpenOnIdleChoices
+		)
+		self.bindHelpEvent("leaveDeviceOpenOnIdle", self.leaveDeviceOpenOnIdleCombo)
+		self.leaveDeviceOpenOnIdleCombo.SetSelection(
+			config.conf["audio"]["leaveDeviceOpenOnIdle"]
+		)
+		self.leaveDeviceOpenOnIdleCombo.defaultValue = self._getDefaultValue(
+			["audio", "leaveDeviceOpenOnIdle"]
+		)
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
@@ -2913,6 +2946,7 @@ class AdvancedPanelControls(
 			and self.ConsoleUIACheckBox.IsChecked() == (self.ConsoleUIACheckBox.defaultValue == 'UIA')
 			and self.winConsoleSpeakPasswordsCheckBox.IsChecked() == self.winConsoleSpeakPasswordsCheckBox.defaultValue
 			and self.cancelExpiredFocusSpeechCombo.GetSelection() == self.cancelExpiredFocusSpeechCombo.defaultValue
+			and self.leaveDeviceOpenOnIdleCombo.GetSelection() == self.leaveDeviceOpenOnIdleCombo.defaultValue
 			and self.UIAInChromiumCombo.GetSelection() == self.UIAInChromiumCombo.defaultValue
 			and self.keyboardSupportInLegacyCheckBox.IsChecked() == self.keyboardSupportInLegacyCheckBox.defaultValue
 			and self.diffAlgoCombo.GetSelection() == self.diffAlgoCombo.defaultValue
@@ -2933,6 +2967,7 @@ class AdvancedPanelControls(
 		self.UIAInChromiumCombo.SetSelection(self.UIAInChromiumCombo.defaultValue)
 		self.winConsoleSpeakPasswordsCheckBox.SetValue(self.winConsoleSpeakPasswordsCheckBox.defaultValue)
 		self.cancelExpiredFocusSpeechCombo.SetSelection(self.cancelExpiredFocusSpeechCombo.defaultValue)
+		self.leaveDeviceOpenOnIdleCombo.SetSelection(self.leaveDeviceOpenOnIdleCombo.defaultValue)
 		self.keyboardSupportInLegacyCheckBox.SetValue(self.keyboardSupportInLegacyCheckBox.defaultValue)
 		self.diffAlgoCombo.SetSelection(self.diffAlgoCombo.defaultValue == 'auto')
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
@@ -2954,6 +2989,7 @@ class AdvancedPanelControls(
 			config.conf['UIA']['winConsoleImplementation'] = "auto"
 		config.conf["terminals"]["speakPasswords"] = self.winConsoleSpeakPasswordsCheckBox.IsChecked()
 		config.conf["featureFlag"]["cancelExpiredFocusSpeech"] = self.cancelExpiredFocusSpeechCombo.GetSelection()
+		config.conf["audio"]["leaveDeviceOpenOnIdle"] = self.leaveDeviceOpenOnIdleCombo.GetSelection()
 		config.conf["UIA"]["allowInChromium"] = self.UIAInChromiumCombo.GetSelection()
 		config.conf["terminals"]["keyboardSupportInLegacy"]=self.keyboardSupportInLegacyCheckBox.IsChecked()
 		diffAlgoChoice = self.diffAlgoCombo.GetSelection()

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -168,7 +168,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 			samplesPerSec: int,
 			bitsPerSample: int,
 			outputDevice: typing.Union[str, int] = WAVE_MAPPER,
-			closeWhenIdle: bool = False,
+			closeWhenIdle: Optional[bool] = None,
 			wantDucking: bool = True,
 			buffered: bool = False
 		):
@@ -196,7 +196,11 @@ class WavePlayer(garbageHandler.TrackedObject):
 				self._audioDucker=audioDucking.AudioDucker()
 		#: If C{True}, close the output device when no audio is being played.
 		#: @type: bool
-		self.closeWhenIdle = closeWhenIdle
+		if closeWhenIdle is not None:
+			self.closeWhenIdle = closeWhenIdle
+		else:
+			leaveOpen = config.conf["audio"]["leaveDeviceOpenOnIdle"]
+			self.closeWhenIdle = leaveOpen == 2
 		if buffered:
 			#: Minimum size of the buffer before audio is played.
 			#: However, this is ignored if an C{onDone} callback is provided to L{feed}.


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/issues/11615#issuecomment-764619365

### Summary of the issue:
On some Dell laptops, e.g. one owned by @jcsteh and my corporate laptop, NVDA tends to trigger an issue in the Waves Audio component installed on these laptops that causes a severe memory leak. This effectively means that you have to reboot your system at least an hour. There is a workaround to disable the waves audio suite on these machines, but that has several drawbacks.

### Description of how this pull request fixes the issue:
As an attempt to fix this, I added a flag to advanced settings to restore the old audio behavior (i.e. directly close on idle by default).

### Testing strategy:
t.b.d.

### Known issues with pull request:
None known

### Change log entries:
New features

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
