### PR TITLE
Fixed a security issue where you could get a browse dialog on a secure screen via addon manager

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2558,6 +2558,8 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TOOLS
 	)
 	def script_activateAddonsManager(self,gesture):
+		if globalVars.appArgs.secure:
+			return
 		wx.CallAfter(gui.mainFrame.onAddonsManagerCommand, None)
 
 	@script(


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
If a user bound a gesture to open the addon manager, and copied it to their config at secure screens, someone could press it, get a browse dialog, and run CMD as systemroot, as well as do all sorts of other things
### Description of how this pull request fixes the issue:
Added a check in globalCommands.py to see if we're on a secure screen before opening the addon manager via a gesture.
### Testing strategy:
1. Ran NVDA from source.
2. Bound a gesture to open the addon manager.
3. Copied my config to secure screens.
4. Pressed windows+l to log out, and attempted to press it
### Known issues with pull request:
None
### Change log entries:
Not really sure if this deserves a CL entry, but if so...

Bug fixes
* It is no longer possible to open the addons manager from a secure screen, in order to avoid a security exploit.
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
