### PR TITLE
Update py2exe to version  0.11.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
 diff_match_patch_python==1.0.2
 
 # Packaging NVDA
-py2exe==0.10.1.0
+py2exe==0.11.0.0
 
 # For building developer documentation
 sphinx==3.4.1

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,6 +29,7 @@ What's New in NVDA
 
 == Changes for Developers ==
 - Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
+- Updated py2exe to version 0.11.0.0. (#13057)
 - ``NVDAObjects.UIA.winConsoleUIA.WinConsoleUIA.isImprovedTextRangeAvailable`` has been removed. Use ``apiLevel`` instead. (#12955, #12660)
 - ``TVItemStruct`` has been removed from ``sysTreeView32``. (#12935)
 - ``MessageItem`` has been removed from the Outlook appModule. (#12935)


### PR DESCRIPTION
### Link to issue number:
Closes #12357

### Summary of the issue:
NVDA currently uses py2exe version 0.10.1.0 to create a binary version since never versions of py2exe causes errors during build (https://github.com/py2exe/py2exe/issues/112). These errors has been fixed by @albertosottile in version 0.11.0.0. While never version of py2exe does not provide us with any advantages for now not upgrading regularly might make it difficult to do so when we would need to move to Python 3.10  or later (currently used version of py2exe supports only up to 3.9).

### Description of how this pull request fixes the issue:
Updates version of py2exe we're using to 0.11.0.0
### Testing strategy:
- Created a self signed launcher - made sure that NVDA functions well in general
- Tested that NVDA_eoaproxy works
- Smoke tested NVDA-dmp and NVDA_slave
### Known issues with pull request:
A try branch should be created from this one before it is merged so that we can ensure that .appx package can be created.
### Change log entries:
For Developers
- Updated py2exe to version 0.11.0.0

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
