### PR TITLE
Add a script to report locationText for the position of the system caret

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -7,7 +7,7 @@
 # Julien Cochuyt, Jakub Lukowicz
 
 import itertools
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import audioDucking
 import touchHandler
@@ -1067,7 +1067,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakObject(curObject, reason=controlTypes.OutputReason.QUERY)
 
 	@staticmethod
-	def _reportLocationText(objs) -> None:
+	def _reportLocationText(objs: Tuple[Union[None, NVDAObject, textInfos.TextInfo], ...]) -> None:
 		for obj in objs:
 			if obj is not None and obj.locationText:
 				ui.message(obj.locationText)
@@ -1078,9 +1078,9 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Description for a keyboard command which reports location of the
-			# review cursor falling back to the location of navigator object if needed.
+			# review cursor, falling back to the location of navigator object if needed.
 			"Reports information about the location of the text at the review cursor "
-			"or  location of the  navigator object if there is no text under review cursor."
+			"or location of the navigator object if there is no text under review cursor."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
 	)
@@ -1102,7 +1102,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Description for a keyboard command which reports location of the
 			# current caret position falling back to the location of focused object if needed.
 			"Reports information about the location of the text at the caret, "
-			"or  location of the  currently focused object if there is no caret."
+			"or location of the currently focused object if there is no caret."
 		),
 		category=SCRCAT_SYSTEMCARET,
 	)
@@ -1142,7 +1142,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Description for a keyboard command
 			# which reports location of the text at the caret position
 			# or object with focus if there is no caret.
-			"Reports information about the location of the text or object at the positionn of system caret "
+			"Reports information about the location of the text or object at the position of system caret "
 			"Pressing twice may provide further detail."
 		),
 		category=SCRCAT_SYSTEMCARET,
@@ -1868,9 +1868,12 @@ class GlobalCommands(ScriptableObject):
 			)
 
 	@staticmethod
-	def _getTIAtCaret(fallbackToPOSITION_FIRST=False, reportFailure=True):
+	def _getTIAtCaret(
+			fallbackToPOSITION_FIRST: bool = False,
+			reportFailure: bool = True
+	) -> Optional[textInfos.TextInfo]:
 		# Returns text info at the caret position if there is a caret in the current control, None otherwise.
-		# Note that if there is  no caret this fact is announced  in speech and braille
+		# Note that if there is no caret this fact is announced in speech and braille
 		# unless reportFailure is set to C{False}
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1066,6 +1066,62 @@ class GlobalCommands(ScriptableObject):
 		else:
 			speech.speakObject(curObject, reason=controlTypes.OutputReason.QUERY)
 
+	@staticmethod
+	def _reportLocationText(objs) -> None:
+		for obj in objs:
+			if obj is not None and obj.locationText:
+				ui.message(obj.locationText)
+				return
+		# Translators: message when there is no location information
+		ui.message(_("No location information"))
+
+	@script(
+		description=_(
+			# Translators: Description for a keyboard command which reports location of the
+			# review cursor falling back to the location of navigator object if needed.
+			"Reports information about the location of the text at the review cursor "
+			"or  location of the  navigator object if there is no text under review cursor."
+		),
+		category=SCRCAT_OBJECTNAVIGATION,
+	)
+	def script_reportReviewCursorLocation(self, gesture):
+		self._reportLocationText((api.getReviewPosition(), api.getNavigatorObject()))
+
+	@script(
+		description=_(
+			# Translators: Description for a keyboard command which reports location of the navigator object.
+			"Reports information about the location of the current navigator object."
+		),
+		category=SCRCAT_OBJECTNAVIGATION,
+	)
+	def script_reportCurrentNavigatorObjectLocation(self, gesture):
+		self._reportLocationText((api.getNavigatorObject(),))
+
+	@script(
+		description=_(
+			# Translators: Description for a keyboard command which reports location of the
+			# current caret position falling back to the location of focused object if needed.
+			"Reports information about the location of the text at the caret, "
+			"or  location of the  currently focused object if there is no caret."
+		),
+		category=SCRCAT_SYSTEMCARET,
+	)
+	def script_reportCaretLocation(self, gesture):
+		self._reportLocationText(
+			(self._getTIAtCaret(fallbackToPOSITION_FIRST=True, reportFailure=False), api.getFocusObject())
+		)
+
+	@script(
+		description=_(
+			# Translators: Description for a keyboard command which reports location of the
+			# currently focused object.
+			"Reports information about the location of the currently focused object"
+		),
+		category=SCRCAT_FOCUS,
+	)
+	def script_reportFocusObjectLocation(self, gesture):
+		self._reportLocationText((api.getFocusObject(),))
+
 	@script(
 		description=_(
 			# Translators: Description for report review cursor location command.
@@ -1073,18 +1129,30 @@ class GlobalCommands(ScriptableObject):
 			"Pressing twice may provide further detail."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
+		gestures=("kb:NVDA+shift+numpadDelete", "kb(laptop):NVDA+shift+delete")
+	)
+	def script_navigatorObject_currentDimensions(self, gesture):
+		if scriptHandler.getLastScriptRepeatCount() == 0:
+			self.script_reportReviewCursorLocation(gesture)
+		else:
+			self.script_reportCurrentNavigatorObjectLocation(gesture)
+
+	@script(
+		description=_(
+			# Translators: Description for a keyboard command
+			# which reports location of the text at the caret position
+			# or object with focus if there is no caret.
+			"Reports information about the location of the text or object at the positionn of system caret "
+			"Pressing twice may provide further detail."
+		),
+		category=SCRCAT_SYSTEMCARET,
 		gestures=("kb:NVDA+numpadDelete", "kb(laptop):NVDA+delete")
 	)
-	def script_navigatorObject_currentDimensions(self,gesture):
-		count=scriptHandler.getLastScriptRepeatCount()
-		locationText=api.getReviewPosition().locationText if count==0 else None
-		if not locationText:
-			locationText=api.getNavigatorObject().locationText
-		if not locationText:
-			# Translators: message when there is no location information for the review cursor
-			ui.message(_("No location information"))
-			return
-		ui.message(locationText)
+	def script_caretPos_currentDimensions(self, gesture):
+		if scriptHandler.getLastScriptRepeatCount() == 0:
+			self.script_reportCaretLocation(gesture)
+		else:
+			self.script_reportFocusObjectLocation(gesture)
 
 	@script(
 		description=_(
@@ -1800,9 +1868,10 @@ class GlobalCommands(ScriptableObject):
 			)
 
 	@staticmethod
-	def _getTIAtCaret(fallbackToPOSITION_FIRST=False):
+	def _getTIAtCaret(fallbackToPOSITION_FIRST=False, reportFailure=True):
 		# Returns text info at the caret position if there is a caret in the current control, None otherwise.
-		# Note that if there is  no caret this fact is announced  in speech and braille.
+		# Note that if there is  no caret this fact is announced  in speech and braille
+		# unless reportFailure is set to C{False}
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor
 		if(
@@ -1816,8 +1885,9 @@ class GlobalCommands(ScriptableObject):
 			if fallbackToPOSITION_FIRST:
 				return obj.makeTextInfo(textInfos.POSITION_FIRST)
 			else:
-				# Translators: Reported when there is no caret.
-				ui.message(_("No caret"))
+				if reportFailure:
+					# Translators: Reported when there is no caret.
+					ui.message(_("No caret"))
 
 	@script(
 		# Translators: Input help mode message for report formatting command.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,6 +14,8 @@ What's New in NVDA
 - Espeak-ng has been updated to 1.51-dev commit ``7e5457f91e10``. (#12950)
 - NVDA will report selection and merged cells in LibreOffice Calc 7.3 and above. (#9310, #6897)
 - Updated Unicode Common Locale Data Repository (CLDR) to 40.0. (#12999)
+- ``NVDA+Numpad Delete`` reports the location of the caret or focused object by default. (#13060)
+- ``NVDA+Shift+Numpad Delete`` reports the location of the review cursor. (#13060)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -332,6 +332,7 @@ NVDA provides the following key commands in relation to the system caret:
 | Read current line | NVDA+upArrow | NVDA+l | Reads the line where the system caret is currently situated. Pressing twice spells the line. Pressing three times spells the line using character descriptions. |
 | Read current text selection | NVDA+Shift+upArrow | NVDA+shift+s | Reads any currently selected text |
 | Report text formatting | NVDA+f | NVDA+f | Reports the formatting of the text where the caret is currently situated. Pressing twice shows the information in browse mode |
+| Report caret location | NVDA+numpadDelete | NVDA+delete | none | Reports information about the location of the text or object at the position of system caret. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail. |
 | Next sentence | alt+downArrow | alt+downArrow | Moves the caret to the next sentence and announces it. (only supported in Microsoft Word and Outlook) |
 | Previous sentence | alt+upArrow | alt+upArrow | Moves the caret to the previous sentence and announces it. (only supported in Microsoft Word and Outlook) |
 
@@ -380,7 +381,7 @@ To navigate by object, use the following commands:
 | Move to focus object | NVDA+numpadMinus | NVDA+backspace | none | Moves to the object that currently has the system focus, and also places the review cursor at the position of the System caret, if it is showing |
 | Activate current navigator object | NVDA+numpadEnter | NVDA+enter | double-tap | Activates the current navigator object (similar to clicking with the mouse or pressing space when it has the system focus) |
 | Move System focus or caret to current review position | NVDA+shift+numpadMinus | NVDA+shift+backspace | none | pressed once Moves the System focus to the current navigator object, pressed twice moves the system caret to the position of the review cursor |
-| Report review cursor location | NVDA+numpadDelete | NVDA+delete | none | Reports information about the location of the text or object at the review cursor. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail. |
+| Report review cursor location | NVDA+shift+numpadDelete | NVDA+shift+delete | none | Reports information about the location of the text or object at the review cursor. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail. |
 | Move review cursor to status bar | none | none | none | Reports the Status Bar if NVDA finds one. It also moves the navigator object to this location. |
 %kc:endInclude
 


### PR DESCRIPTION

### Link to issue number:
Closes #9147
Related to #7314

### Summary of the issue:
Currently it is impossible to report locationText for the current caret position only for the position of the review cursor. This is problematic in several cases:
- As described in #9147 there are cases in which it is useful to query  the name of the current sheet in MS Excel
- In edit controls and / or web browsers sighted people can simply glance at the scroll bar to determine their position in the text

While for people working with review cursor following system caret current NVDA+Numpad delete is sufficient for these use cases when review cursor does not follow caret you need  to move it to focus every time when you need to check your current position which wastes time, and more importantly makes your review position lost.

### Description of how this pull request fixes the issue:
- NVDA+numpad delete reports location of the caret or focused  object if there is no caret by default.
- Script for reporting review cursor position has been reassigned to NVDA+shift+Numpad delete - for most users there is no change as navigator follows focus and review follows caret by default.
- The modified scripts are splitted into separate ones for querying location of the text / object as discussed in #7314.
### Testing strategy:
Ensured that modified scripts works.
### Known issues with pull request:
None known
### Change log entries:
Changes
- NVDA+Numpad delete reports location of the caret / focused object by default - add shift to report location of the review cursor.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
