### PR TITLE
Revert "Update py2exe to version  0.11.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
 diff_match_patch_python==1.0.2
 
 # Packaging NVDA
-py2exe==0.11.0.0
+py2exe==0.10.1.0
 
 # For building developer documentation
 sphinx==3.4.1

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,7 +29,6 @@ What's New in NVDA
 
 == Changes for Developers ==
 - Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
-- Updated py2exe to version 0.11.0.0. (#13057)
 - ``NVDAObjects.UIA.winConsoleUIA.WinConsoleUIA.isImprovedTextRangeAvailable`` has been removed. Use ``apiLevel`` instead. (#12955, #12660)
 - ``TVItemStruct`` has been removed from ``sysTreeView32``. (#12935)
 - ``MessageItem`` has been removed from the Outlook appModule. (#12935)


### PR DESCRIPTION
Reverts nvaccess/nvda#13057

Due to https://github.com/nvaccess/nvda/pull/13057#issuecomment-969510836