### PR TITLE
If AppVeyor install of NVDA fails, ensure installer log can be uploaded successfully

### DIFF
--- a/appveyor/scripts/installNVDA.ps1
+++ b/appveyor/scripts/installNVDA.ps1
@@ -10,14 +10,21 @@ $outputDir=$(resolve-path .\testOutput)
 $installerLogFilePath="$outputDir\nvda_install.log"
 $installerProcess=start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
 try {
-	$installerProcess | wait-process -Timeout 180
+	$installerProcess | wait-process -Timeout 180 -ErrorAction Stop
 	$errorCode=$installerProcess.ExitCode
+	$installlerLogFilePathToUpload = $installerLogFilePath
 } catch {
 	echo "NVDA installer process timed out"
 	$errorCode=1
 	Add-AppveyorMessage "Unable to install NVDA prior to tests."
+	# Since installer failed to exit in the specified timeout the log file is still in use.
+	# Unforturnately `Push-AppveyorArtifact` is unable to upload a file which is  locked
+	# as a work around create a copy of the log and upload that instead.
+	$installerLogFileCopiedPath = "nvda_install_copy.log"
+	Copy-Item $installerLogFilePath $installerLogFileCopiedPath
+	$installlerLogFilePathToUpload = $installerLogFileCopiedPath
 }
-Push-AppveyorArtifact $installerLogFilePath
+Push-AppveyorArtifact $installlerLogFilePathToUpload -FileName "nvda_install.log"
 $crashDump = "$outputDir\nvda_crash.dmp"
 if (Test-Path -Path $crashDump){
 	Push-AppveyorArtifact $crashDump -FileName "nvda_install_crash.dmp"


### PR DESCRIPTION
### Link to issue number:
Fixes #13083
### Summary of the issue:
When NVDA's installer fails to install NVDA and the process is still running the log from the failed installation cannot be uploaded and all tests fail since they're executed against broken installation of NVDA.
### Description of how this pull request fixes the issue:
1. Exceptions raised by `wait-process` are properly caught which in practice means that the block of code responsible for interrupting the build if installer fails to exit in the specified timeout is executed - previously it didn't.
2. Since AppVeyor function used to upload build artifacts is unable to upload files which are in use if the installer process is still running we copy the log and upload it instead of the, currently locked, original file.
### Testing strategy:
With a commit in which I've simulated a crash of nvda_slave inspected [this build log](https://ci.appveyor.com/project/NVAccess/nvda/builds/42096427) and made sure that:
- The message that install process timed out is shown
- the build is interrupted when NVDA fails to install
- The installer log can be downloaded from the artifacts.
### Known issues with pull request:
None known
### Change log entries:
None needed - only affects CI
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
