### PR TITLE
Store current NVDA's language in globalVars regardless if it has been provided from the command line or not.

### DIFF
--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -20,16 +20,12 @@ languageHandler.setLanguage("en")
 import globalVars  # noqa: E402
 
 
-class AppArgs:
-	# Set an empty comnfig path
-	# This is never used as we don't initialize config, but some modules expect this to be set.
-	configPath = ""
-	secure = False
-	disableAddons = True
-	launcher = False
+# Set an empty config path
+# This is never used as we don't initialize config, but some modules expect this to be set.
+globalVars.appArgs.configPath = ""
+globalVars.appArgs.disableAddons = True
 
 
-globalVars.appArgs = AppArgs()
 # #11971: NVDA is not running, therefore app dir is undefined.
 # Therefore tell NVDA that apt source directory is app dir.
 appDir = os.path.join("..", "source")

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -16,10 +16,37 @@
 @type oldMouseY: int
   @var navigatorObject: holds the current navigator object
 @type navigatorObject: L{NVDAObjects.NVDAObject}
-@var navigatorTracksFocus: if true, the navigator object will follow the focus as it changes
-@type navigatorTracksFocus: boolean
 """
- 
+
+import argparse
+import os
+import typing
+
+
+class DefautAppArgs(argparse.Namespace):
+	quit: bool = False
+	check_running: bool = False
+	logFileName: typing.Optional[os.PathLike] = ""
+	logLevel: int = 0
+	configPath: typing.Optional[os.PathLike] = None
+	language: str = "en"
+	minimal: bool = False
+	secure: bool = False
+	disableAddons: bool = False
+	debugLogging: bool = False
+	noLogging: bool = False
+	changeScreenReaderFlag: bool = True
+	install: bool = False
+	installSilent: bool = False
+	createPortable: bool = False
+	createPortableSilent: bool = False
+	portablePath: typing.Optional[os.PathLike] = None
+	launcher: bool = False
+	enableStartOnLogon: typing.Optional[bool] = None
+	copyPortableConfig: bool = False
+	easeOfAccess: bool = False
+
+
 startTime=0
 desktopObject=None
 foregroundObject=None
@@ -33,7 +60,7 @@ navigatorObject=None
 reviewPosition=None
 reviewPositionObj=None
 lastProgressValue=0
-appArgs=None
+appArgs = DefautAppArgs()
 appArgsExtra=None
 settingsRing = None
 speechDictionaryProcessing=True

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -34,8 +34,6 @@ CP_ACP = "0"
 #: or because it is not a legal locale name (e.g. "zzzz").
 LCID_NONE = 0 # 0 used instead of None for backwards compatibility.
 
-curLang="en"
-
 
 class LOCALE(enum.IntEnum):
 	# Represents NLS constants which can be used with `GetLocaleInfoEx` or `GetLocaleInfoW`
@@ -336,10 +334,9 @@ def setLanguage(lang: str) -> None:
 	Sets the following using `lang` such as "en", "ru_RU", or "es-ES". Use "Windows" to use the system locale
 	 - the windows locale for the thread (fallback to system locale)
 	 - the translation service (fallback to English)
-	 - languageHandler.curLang (match the translation service)
+	 - Current NVDA language (match the translation service)
 	 - the python locale for the thread (match the translation service, fallback to system default)
 	'''
-	global curLang
 	if lang == "Windows":
 		localeName = getWindowsLanguage()
 	else:
@@ -353,17 +350,17 @@ def setLanguage(lang: str) -> None:
 
 	try:
 		trans = gettext.translation("nvda", localedir="locale", languages=[localeName])
-		curLang = localeName
+		globalVars.appArgs.language = localeName
 	except IOError:
 		try:
 			log.debugWarning(f"couldn't set the translation service locale to {localeName}")
 			localeName = localeName.split("_")[0]
 			trans = gettext.translation("nvda", localedir="locale", languages=[localeName])
-			curLang = localeName
+			globalVars.appArgs.language = localeName
 		except IOError:
 			log.debugWarning(f"couldn't set the translation service locale to {localeName}")
 			trans = gettext.translation("nvda", fallback=True)
-			curLang = "en"
+			globalVars.appArgs.language = "en"
 
 	trans.install()
 	setLocale(getLanguage())
@@ -407,7 +404,7 @@ def _setPythonLocale(localeString: str) -> bool:
 def setLocale(localeName: str) -> None:
 	'''
 	Set python's locale using a `localeName` such as "en", "ru_RU", or "es-ES".
-	Will fallback on `curLang` if it cannot be set and finally fallback to the system locale.
+	Will fallback on current NVDA language if it cannot be set and finally fallback to the system locale.
 	Passing NVDA locales straight to python `locale.setlocale` does now work since it tries to normalize the
 	parameter using `locale.normalize` which results in locales unknown to Windows (Python issue 37945).
 	For example executing: `locale.setlocale(locale.LC_ALL, "pl")`
@@ -452,7 +449,7 @@ def setLocale(localeName: str) -> None:
 
 
 def getLanguage() -> str:
-	return curLang
+	return globalVars.appArgs.language
 
 
 def normalizeLanguage(lang: str) -> Optional[str]:

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -366,7 +366,7 @@ def setLanguage(lang: str) -> None:
 			curLang = "en"
 
 	trans.install()
-	setLocale(curLang)
+	setLocale(getLanguage())
 	# Install our pgettext function.
 	builtins.pgettext = makePgettext(trans)
 
@@ -441,14 +441,14 @@ def setLocale(localeName: str) -> None:
 		return
 	# Either Windows does not know the locale, or Python is unable to handle it.
 	# reset to default locale
-	if originalLocaleName == curLang:
+	if originalLocaleName == getLanguage():
 		# reset to system locale default if we can't set the current lang's locale
 		locale.setlocale(locale.LC_ALL, "")
 		log.debugWarning(f"set python locale to system default")
 	else:
-		log.debugWarning(f"setting python locale to the current language {curLang}")
+		log.debugWarning(f"setting python locale to the current language {getLanguage()}")
 		# fallback and try to reset the locale to the current lang
-		setLocale(curLang)
+		setLocale(getLanguage())
 
 
 def getLanguage() -> str:

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -149,7 +149,7 @@ parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str
 parser.add_argument(
 	'--lang',
 	dest='language',
-	default=None,
+	default="en",
 	type=stringToLang,
 	help=(
 		"Override the configured NVDA language."

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -50,16 +50,13 @@ import globalVars
 globalVars.appDir = SOURCE_DIR
 
 # Set options normally taken from the command line.
-class AppArgs:
-	# The path from which to load a configuration file.
-	# Ideally, this would be an in-memory, default configuration.
-	# However, config currently requires a path.
-	# We use the unit test directory, since we want a clean config.
-	configPath = UNIT_DIR
-	secure = False
-	disableAddons = True
-	launcher = False
-globalVars.appArgs = AppArgs()
+# The path from which to load a configuration file.
+# Ideally, this would be an in-memory, default configuration.
+# However, config currently requires a path.
+# We use the unit test directory, since we want a clean config.
+globalVars.appArgs.configPath = UNIT_DIR
+globalVars.appArgs.disableAddons = True
+
 
 # We depend on the current directory to load some files;
 # e.g. braille imports louis which loads liblouis.dll using a relative path.

--- a/tests/unit/test_languageHandler.py
+++ b/tests/unit/test_languageHandler.py
@@ -159,7 +159,7 @@ class Test_languageHandler_setLocale(unittest.TestCase):
 
 	def setUp(self):
 		"""
-		`setLocale` doesn't change `languageHandler.curLang`, so reset the locale using `setLanguage` to
+		`setLocale` doesn't change current NVDA language, so reset the locale using `setLanguage` to
 		the current language for each test.
 		"""
 		languageHandler.setLanguage(languageHandler.getLanguage())
@@ -167,7 +167,7 @@ class Test_languageHandler_setLocale(unittest.TestCase):
 	@classmethod
 	def tearDownClass(cls):
 		"""
-		`setLocale` doesn't change `languageHandler.curLang`, so reset the locale using `setLanguage` to
+		`setLocale` doesn't change current NVDA language, so reset the locale using `setLanguage` to
 		the current language so the tests can continue normally.
 		"""
 		languageHandler.setLanguage(languageHandler.getLanguage())
@@ -262,7 +262,7 @@ class Test_LanguageHandler_SetLanguage(unittest.TestCase):
 	def test_NVDASupportedLanguages_LanguageIsSetCorrectly(self):
 		"""
 		Tests languageHandler.setLanguage, using all NVDA supported languages, which should do the following:
-		- set the translation service and languageHandler.curLang
+		- set the translation service and current NVDA language
 		- set the windows locale for the thread (fallback to system default)
 		- set the python locale for the thread (match the translation service, fallback to system default)
 		"""
@@ -270,7 +270,7 @@ class Test_LanguageHandler_SetLanguage(unittest.TestCase):
 			with self.subTest(localeName=localeName):
 				langOnly = localeName.split("_")[0]
 				languageHandler.setLanguage(localeName)
-				# check curLang/translation service is set
+				# check current NVDA language/translation service is set
 				self.assertEqual(languageHandler.getLanguage(), localeName)
 
 				# check Windows thread is set

--- a/tests/unit/test_languageHandler.py
+++ b/tests/unit/test_languageHandler.py
@@ -162,7 +162,7 @@ class Test_languageHandler_setLocale(unittest.TestCase):
 		`setLocale` doesn't change `languageHandler.curLang`, so reset the locale using `setLanguage` to
 		the current language for each test.
 		"""
-		languageHandler.setLanguage(languageHandler.curLang)
+		languageHandler.setLanguage(languageHandler.getLanguage())
 
 	@classmethod
 	def tearDownClass(cls):
@@ -170,7 +170,7 @@ class Test_languageHandler_setLocale(unittest.TestCase):
 		`setLocale` doesn't change `languageHandler.curLang`, so reset the locale using `setLanguage` to
 		the current language so the tests can continue normally.
 		"""
-		languageHandler.setLanguage(languageHandler.curLang)
+		languageHandler.setLanguage(languageHandler.getLanguage())
 
 	def test_SupportedLocale_LocaleIsSet(self):
 		"""
@@ -271,7 +271,7 @@ class Test_LanguageHandler_SetLanguage(unittest.TestCase):
 				langOnly = localeName.split("_")[0]
 				languageHandler.setLanguage(localeName)
 				# check curLang/translation service is set
-				self.assertEqual(languageHandler.curLang, localeName)
+				self.assertEqual(languageHandler.getLanguage(), localeName)
 
 				# check Windows thread is set
 				threadLocale = ctypes.windll.kernel32.GetThreadLocale()

--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -38,7 +38,7 @@ class MockSynth:
 class test_synthDriverHandler(unittest.TestCase):
 
 	def setUp(self) -> None:
-		self._oldLang = languageHandler.curLang
+		self._oldLang = languageHandler.getLanguage()
 		self._oldSynthConfig = config.conf["speech"]["synth"]
 		self._originalSynth = synthDriverHandler._curSynth
 		self._originalGetSynthDriver = synthDriverHandler._getSynthDriver

--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -6,6 +6,7 @@
 """Unit tests for the synthDriverHandler
 """
 import config
+import globalVars
 import languageHandler
 import synthDriverHandler
 from synthDrivers.oneCore import SynthDriver as OneCoreSynthDriver
@@ -45,7 +46,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		config.conf["speech"]["synth"] = FAKE_DEFAULT_LANG
 		synthDriverHandler._curSynth = MockSynth(FAKE_DEFAULT_SYNTH_NAME)
 		synthDriverHandler._getSynthDriver = self._mock_getSynthDriver
-		languageHandler.curLang = FAKE_DEFAULT_LANG
+		globalVars.appArgs.language = FAKE_DEFAULT_LANG
 
 	@staticmethod
 	def _mock_getSynthDriver(synthName: str) -> Callable[[], MockSynth]:
@@ -55,7 +56,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		config.conf["speech"]["synth"] = self._oldSynthConfig
 		synthDriverHandler._curSynth = self._originalSynth
 		synthDriverHandler._getSynthDriver = self._originalGetSynthDriver
-		languageHandler.curLang = self._oldLang
+		globalVars.appArgs.language = self._oldLang
 
 	def test_setSynth_auto(self):
 		"""
@@ -99,7 +100,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		"""
 		Ensures that if oneCore supports the current language, setSynth("auto") uses "oneCore".
 		"""
-		# test setup ensures curLang is supported for oneCore
+		# test setup ensures current NVDA language is supported for oneCore
 		synthDriverHandler.setSynth(None)  # reset the synth so there is no fallback
 		synthDriverHandler.setSynth("auto")
 		self.assertEqual(synthDriverHandler.getSynth().name, "oneCore")
@@ -110,7 +111,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		Ensures that if oneCore doesn't support the current language, setSynth("auto") falls back to the
 		current synth, or espeak if there is no current synth.
 		"""
-		languageHandler.curLang = "bar"  # set the lang so it is not supported
+		globalVars.appArgs.language = "bar"  # set the lang so it is not supported
 		synthDriverHandler.setSynth("auto")
 		self.assertEqual(synthDriverHandler.getSynth().name, FAKE_DEFAULT_SYNTH_NAME)
 		synthDriverHandler.setSynth(None)  # reset the synth so there is no fallback

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -58,6 +58,7 @@ This ensures code will honor the Windows user setting for swapping the primary m
 - ``shlobj.SHGetFolderPath`` has been removed - please use ``shlobj.SHGetKnownFolderPath`` instead. (#12943)
 - ``shlobj`` constants have been removed. A new enum has been created, ``shlobj.FolderId`` for usage with ``SHGetKnownFolderPath``. (#12943)
 - ``diffHandler.get_dmp_algo`` and ``diffHandler.get_difflib_algo`` have been replaced with ``diffHandler.prefer_dmp`` and ``diffHandler.prefer_difflib`` respectively. (#12974)
+- ``languageHandler.curLang`` has been removed - to get the current NVDA language use ``languageHandler.getLanguage()``. (#13082)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Follow up of #10089 and #12958

### Summary of the issue:
PR #12958 introduced additional command line parameter which allows to set NVDA's language. The currently set language is stored in `globalVars.appArgs.language` however when it is not overridden from the CLI this variable is set to `None`.  TO improve consistency with `globalVars.appArgs.configPath` it makes sense to store current NVDA's language in globalVars regardless of where it comes from.
### Description of how this pull request fixes the issue:
Current NVDA language is now stored in `globalVars.appArgs.language` - it still can be accessed via `languageHandler.getLanguage` which is a recommended way to get its value for add-ons developers. To make this work for nvda_slave it has been necessary to provide a 'fake' implementation of `globalVars.appArgs` which is  used in cases where command line arguments are not available or not yet parsed. This also provides type hints for values of `appArgs` so I'd say it is beneficial regardless.
### Testing strategy:
- Unit test for `languageHandler`
- Tested that `globalVars.appArgs.language` contains the language currently set in the preferences.
### Known issues with pull request:
None known
### Change log entries:
For Developers
- `languageHandler.curLang` has been removed - to access current NVDA language use `languageHandler.getLanguage()`

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
