### PR TITLE
Change log: move the change log item for issue #12946 from 2021.3 to 2022.1 section

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,10 @@ What's New in NVDA
 - In recent builds of Microsoft Word via UI Automation on Windows 11, the existence of bookmarks, draft comments and resolved comments are now reported in both speech and braille. (#12861)
 - The new --lang command line parameter allows overriding the configured NVDA language. (#10044)
 - NVDA now warns about command line parameters which are unknown and not used by any add-ons. (#12795)
+- In Microsoft Word accessed via UI Automation, NVDA will now make use of mathPlayer to read and navigate Office math equations. (#12946)
+    - For this to work, you must be running Microsoft Word 365/2016 build 14326 or later. 
+    - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
+    -
 -
 
 == Changes ==
@@ -96,10 +100,6 @@ Affected users will need to download this update manually.
 - Error notifications can be enabled (advanced settings) when using any version of NVDA. (#12672)
 - In Windows 10 and later, NVDA will announce the suggestion count when entering search terms in apps such as Settings and Microsoft Store. (#7330, #12758, #12790)
 - Table navigation is now supported in grid controls created using the Out-GridView cmdlet in PowerShell. (#12928)
-- In Microsoft Word accessed via UI Automation, NVDA will now make use of mathPlayer to read and navigate Office math equations. (#12946)
-    - For this to work, you must be running Microsoft Word 365/2016 build 14326 or later. 
-    - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
-    -
 -
 
 


### PR DESCRIPTION

### Link to issue number:

Cf. https://github.com/nvaccess/nvda/pull/12977#issuecomment-978816237

### Summary of the issue:

The PR #12977 has been retargetted from beta to master. But at that time, the change log was already updated in the PR's branch and it has not been modified when master branch was retargetted.

### Description of how this pull request fixes the issue:

* I have moved the corresponding change log item from 2021.3 section to 2022.1 section.
* I have checked that no other item has been forgotten with the following diff:
  `git diff beta master -- user_docs\en\changes.t2t`
  The unique diff item not in the 2022.1 section is the one moved in the current PR.

### Testing strategy:

Check the generated html change log in the appVeyor artifacts.

### Known issues with pull request:
None.
### Change log entries:
None
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
