### PR TITLE
Improve reliability of opening user configuration  directory from the start menu

### DIFF
--- a/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.acf
+++ b/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.acf
@@ -25,4 +25,5 @@ interface NvdaControllerInternal {
 	[fault_status,comm_status] installAddonPackageFromPath();
 	[fault_status,comm_status] drawFocusRectNotify();
 	[fault_status,comm_status] reportLiveRegion();
+	[fault_status,comm_status] openConfigDirectory();
 }

--- a/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
+++ b/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
@@ -97,4 +97,9 @@ interface NvdaControllerInternal {
  * @param level The level of live region, I.E. "polite"
  */
 	error_status_t __stdcall reportLiveRegion([in,string] const wchar_t* text, [in,string] const wchar_t* level);
+
+/**
+ * Asks NVDA to open currently used configuration directory.
+ */
+	error_status_t __stdcall openConfigDirectory();
 };

--- a/nvdaHelper/local/nvdaControllerInternal.c
+++ b/nvdaHelper/local/nvdaControllerInternal.c
@@ -79,3 +79,8 @@ error_status_t(__stdcall *_nvdaControllerInternal_reportLiveRegion)(const wchar_
 error_status_t __stdcall nvdaControllerInternal_reportLiveRegion(const wchar_t* text, const wchar_t* politeness) {
 	return _nvdaControllerInternal_reportLiveRegion(text, politeness);
 }
+
+error_status_t(__stdcall *_nvdaControllerInternal_openConfigDirectory)();
+error_status_t __stdcall nvdaControllerInternal_openConfigDirectory() {
+	return _nvdaControllerInternal_openConfigDirectory();
+}

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -62,3 +62,4 @@ EXPORTS
 	logMessage
 	getOleClipboardText
 	_nvdaControllerInternal_reportLiveRegion
+	_nvdaControllerInternal_openConfigDirectory

--- a/nvdaHelper/remote/nvdaHelperRemote.def
+++ b/nvdaHelper/remote/nvdaHelperRemote.def
@@ -20,3 +20,4 @@ EXPORTS
 	nvdaController_cancelSpeech
 	nvdaController_brailleMessage
 	nvdaControllerInternal_reportLiveRegion
+	nvdaControllerInternal_openConfigDirectory

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -28,8 +28,6 @@ import queueHandler
 import api
 import globalVars
 from logHandler import log
-import time
-import globalVars
 
 versionedLibPath = os.path.join(globalVars.appDir, 'lib')
 if os.environ.get('PROCESSOR_ARCHITEW6432') == 'ARM64':
@@ -459,6 +457,14 @@ def nvdaControllerInternal_installAddonPackageFromPath(addonPath):
 	wx.CallAfter(addonGui.handleRemoteAddonInstall, addonPath)
 	return 0
 
+
+@WINFUNCTYPE(c_long)
+def nvdaControllerInternal_openConfigDirectory():
+	import systemUtils
+	systemUtils.openUserConfigurationDirectory()
+	return 0
+
+
 class RemoteLoader64(object):
 
 	def __init__(self):
@@ -528,6 +534,7 @@ def initialize():
 		("nvdaControllerInternal_vbufChangeNotify",nvdaControllerInternal_vbufChangeNotify),
 		("nvdaControllerInternal_installAddonPackageFromPath",nvdaControllerInternal_installAddonPackageFromPath),
 		("nvdaControllerInternal_drawFocusRectNotify",nvdaControllerInternal_drawFocusRectNotify),
+		("nvdaControllerInternal_openConfigDirectory", nvdaControllerInternal_openConfigDirectory),
 	]:
 		try:
 			_setDllFuncPointer(localLib,"_%s"%name,func)

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -11,7 +11,6 @@ Performs miscellaneous tasks which need to be performed in a separate process.
 import sys
 import os
 import globalVars
-import winKernel
 import monkeyPatches.comtypesMonkeyPatches
 
 # Ensure that slave uses generated comInterfaces by adding our comInterfaces to `comtypes.gen` search path.
@@ -42,8 +41,24 @@ except:
 	gettext.install('nvda')
 
 
-import versionInfo
 import logHandler
+
+
+def getNvdaHelperRemote():
+	import buildVersion
+	import ctypes
+	import winKernel
+	# Load nvdaHelperRemote.dll but with an altered search path so it can pick up other dlls in lib
+	h = winKernel.kernel32.LoadLibraryExW(
+		os.path.join(globalVars.appDir, "lib", buildVersion.version, "nvdaHelperRemote.dll"),
+		0,
+		# Using an altered search path is necessary here
+		# As NVDAHelperRemote needs to locate dependent dlls in the same directory
+		# such as minhook.dll.
+		winKernel.LOAD_WITH_ALTERED_SEARCH_PATH
+	)
+	remoteLib = ctypes.WinDLL("nvdaHelperRemote", handle=h)
+	return remoteLib
 
 
 def main():
@@ -79,25 +94,16 @@ def main():
 			import config
 			config._setStartOnLogonScreen(enable)
 		elif action == "explore_userConfigPath":
-			import systemUtils
-			systemUtils.openUserConfigurationDirectory()
+			ret = getNvdaHelperRemote().nvdaControllerInternal_openConfigDirectory()
+			if ret != 0:  # NVDA is not running
+				import systemUtils
+				systemUtils.openDefaultConfigurationDirectory()
 		elif action == "addons_installAddonPackage":
 			try:
 				addonPath=args[0]
 			except IndexError:
 				raise ValueError("Addon path was not provided.")
-			#Load nvdaHelperRemote.dll but with an altered search path so it can pick up other dlls in lib
-			import ctypes
-			h = ctypes.windll.kernel32.LoadLibraryExW(
-				os.path.join(globalVars.appDir, "lib", versionInfo.version, "nvdaHelperRemote.dll"),
-				0,
-				# Using an altered search path is necessary here
-				# As NVDAHelperRemote needs to locate dependent dlls in the same directory
-				# such as minhook.dll.
-				winKernel.LOAD_WITH_ALTERED_SEARCH_PATH
-			)
-			remoteLib=ctypes.WinDLL("nvdaHelperRemote",handle=h)
-			ret = remoteLib.nvdaControllerInternal_installAddonPackageFromPath(addonPath)
+			ret = getNvdaHelperRemote().nvdaControllerInternal_installAddonPackageFromPath(addonPath)
 			if ret != 0:
 				import winUser
 				winUser.MessageBox(0,

--- a/source/shellapi.py
+++ b/source/shellapi.py
@@ -1,4 +1,3 @@
-#shellapi.py
 #A part of NonVisual Desktop Access (NVDA)
 #Copyright (C) 2006-2009 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.
@@ -6,6 +5,8 @@
 
 from ctypes import *
 from ctypes.wintypes import *
+from typing import Optional
+
 
 shell32 = windll.shell32
 
@@ -33,9 +34,20 @@ SHELLEXECUTEINFO = SHELLEXECUTEINFOW
 
 SEE_MASK_NOCLOSEPROCESS = 0x00000040
 
-def ShellExecute(hwnd, operation, file, parameters, directory, showCmd):
+
+def ShellExecute(
+		hwnd: Optional[int],
+		operation: Optional[str],
+		file: str,
+		parameters: Optional[str],
+		directory: Optional[str],
+		showCmd: int
+) -> None:
+	if not file:
+		raise RuntimeError("file cannot be None")
 	if shell32.ShellExecuteW(hwnd, operation, file, parameters, directory, showCmd) <= 32:
 		raise WinError()
+
 
 def ShellExecuteEx(execInfo):
 	if not shell32.ShellExecuteExW(byref(execInfo)):

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2020-2021 NV Access Limited, Łukasz Golonka
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,15 +24,18 @@ def hasSyswow64Dir() -> bool:
 def openUserConfigurationDirectory():
 	"""Opens directory containing config files for the current user"""
 	import globalVars
-	try:
-		# configPath is guaranteed to be correct for NVDA, however it will not exist for NVDA_slave.
-		path = globalVars.appArgs.configPath
-	except AttributeError:
-		import config
-		path = config.getUserDefaultConfigPath()
-		if not path:
-			raise ValueError("no user default config path")
-		config.initConfigPath(path)
+	shellapi.ShellExecute(0, None, globalVars.appArgs.configPath, None, None, winUser.SW_SHOWNORMAL)
+
+
+def openDefaultConfigurationDirectory():
+	"""Opens the directory which would be used to store configuration by default.
+	Used as a fallback when trying to explore user config from the start menu,
+	and NVDA is not running."""
+	import config
+	path = config.getUserDefaultConfigPath()
+	if not path:
+		raise ValueError("no user default config path")
+	config.initConfigPath(path)
 	shellapi.ShellExecute(0, None, path, None, None, winUser.SW_SHOWNORMAL)
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13094

### Summary of the issue:
When opening user configuration directory from the start menu NVDA first tries to open path from `globalVars.appArgs.configPath` and if this fails falls back to the default path for the configuration. In PR  #13082 a 'fake' implementation of `globalVars.appArgs` has been provided, and therefore `configPath` always exists, but for nvda_slave is set to `None`. This causes a wrong folder to be opened (`ShellExecute` opens a default document folder when given `NULL` as a file to open for whatever reason). Aside from this newly introduced issue if the `configPath` is overridden from the command line for the running instance of NVDA this was not reflected when opening user configuration directory from the start menu since slave has no access to `globalVars`  of the running NVDA.
### Description of how this pull request fixes the issue:
- If NVDA is running slave requests NVDA to open currently used configuration folder via RPC
- When NVDA is not running, or the version in use has older RPC interface which does not support opening of the config directory the behavior has not changed and the default directory is opened.
- Type hints were added to our wrapper around `ShellExecute` and it is no longer possible to pass `None` as a file to be opened.
### Testing strategy:
With the launcher created from the code in this PR:
- Ensured that gesture for opening current user config opens correct folder both when configuration has been overridden from the command line or not
- With the build from this PR installed and NVDA running activated an option to open configuration directory from the start menu both with the default config and the different folder specified from the command line - made sure that correct folder was opened in both cases
- With the build from this PR installed and without running NVDA activated a shortcut to open config folder from the start menu - made sure that the default configuration directory was opened
- With the build from this PR installed and older version of NVDA running made sure that when 'explore user configuration directory' is invoked from the start menu default configuration folder is opened and there is no error.
- With the build from this PR installed and older version of NVDA running made sure #11867 has not been reintroduced by opening an add-on file from the Windows Explorer.
### Known issues with pull request:
None known
### Change log entries:
None needed - unreleased regression.
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
