### PR TITLE
Fix backspace in Visual Studio editor

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -544,7 +544,7 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 			# #13098: However, limit this specifically to UIA Word documents,
 			# As other UIA documents (E.g. Visual Studio)
 			# Seem to rely on MSAA caret events,
-			# as they do not fire their own UIA caret events. 
+			# as they do not fire their own UIA caret events.
 			from NVDAObjects.UIA.wordDocument import WordDocument
 			if isinstance(focus, WordDocument):
 				if isMSAADebugLoggingEnabled():

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -539,12 +539,20 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 		winUser.EVENT_OBJECT_SHOW
 	):
 		if not isinstance(focus, NVDAObjects.IAccessible.IAccessible):
-			if isMSAADebugLoggingEnabled():
-				log.debug(
-					f"Ignoring MSAA caret event on non-MSAA focus {focus}, "
-					f"winEvent {getWinEventLogInfo(window, objectID, childID)}"
-				)
-			return False
+			# #12855: Ignore MSAA caret event on non-MSAA focus.
+			# as Chinese input method fires MSAA caret events over and over on UIA Word documents.
+			# #13098: However, limit this specifically to UIA Word documents,
+			# As other UIA documents (E.g. Visual Studio)
+			# Seem to rely on MSAA caret events,
+			# as they do not fire their own UIA caret events. 
+			from NVDAObjects.UIA.wordDocument import WordDocument
+			if isinstance(focus, WordDocument):
+				if isMSAADebugLoggingEnabled():
+					log.debug(
+						f"Ignoring MSAA caret event on focused UIA Word document"
+						f"winEvent {getWinEventLogInfo(window, objectID, childID)}"
+					)
+				return False
 		if isMSAADebugLoggingEnabled():
 			log.debug(
 				"handling winEvent as caret event on focus. "


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13098

### Summary of the issue:
Pr #12868 fixes issue #12855 by disallowing MSAA caret events on any non-MSAA focus object, in order to stop repeating caret events on UIA Word documents when using a Chinese input method and therefore caused Braille to keep jumping back when scrolling.
However, it seems that some UIA implementations such as Visual Studio do not fire their own UIA caret events, and therefore actually depend on these MSAA caret events.

### Description of how this pull request fixes the issue:
Only ignore MSAA caret events on UIA Word documents, rather than all non-MSAA focus objects.

### Testing strategy:
* [x] Performed tests in #12855 
* [ ] Ensured backspace speaks again in Visual Studio

### Known issues with pull request:
None known.

### Change log entries:
None needed.

New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
