### PR TITLE
Fix Enum str mixup

### DIFF
--- a/source/IAccessibleHandler/types.py
+++ b/source/IAccessibleHandler/types.py
@@ -19,7 +19,7 @@ IAccessibleObjectIdentifierType = Tuple[
 
 # IAccessible2 relations (not included in the typelib)
 @enum.unique
-class RelationType(enum.Enum):
+class RelationType(str, enum.Enum):
 	FLOWS_FROM = "flowsFrom"
 	FLOWS_TO = "flowsTo"
 	CONTAINING_DOCUMENT = "containingDocument"

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1469,17 +1469,27 @@ the NVDAObject for IAccessible
 
 	def _getIA2RelationFirstTarget(
 			self,
-			relationType: str
+			relationType: typing.Union[str, "IAccessibleHandler.RelationType"]
 	) -> typing.Optional["IAccessible"]:
 		""" Get the first target for the relation of type.
-		@param relationType: A IAccessibleHandler.IA2_RELATION_* constant.
+		@param relationType: The type of relation to fetch.
 		"""
+		if not isinstance(relationType, IAccessibleHandler.RelationType):
+			if isinstance(relationType, str):
+				relationType = IAccessibleHandler.RelationType(relationType)
+			else:
+				raise TypeError(f"Bad type for 'relationType' arg, got: {type(relationType)}")
+
+		relationType = typing.cast(IAccessibleHandler.RelationType, relationType)
 
 		for relation in self._IA2Relations:
 			try:
 				if relation.relationType == relationType:
+					# Take the first of 'relation.nTargets' see IAccessibleRelation._methods_
+					target = relation.target(0)
+					ia2Object = IAccessibleHandler.normalizeIAccessible(target)
 					return IAccessible(
-						IAccessibleObject=IAccessibleHandler.normalizeIAccessible(relation.target(0)),
+						IAccessibleObject=ia2Object,
 						IAccessibleChildID=0
 					)
 			except COMError:


### PR DESCRIPTION
### Link to issue number:
fixes #13109

### Summary of the issue:
Thunderbird and Firefox were broken with PR #13096. 

### Description of how this pull request fixes the issue:
- The `RelationType` enum now also inherits from `str`, its values can now be used as a string value.
- Fixed conversion of plain `str` types to `RelationType`
- Introduced a faster approach to get relation targets of the relation type.

### Testing strategy:
- Tested locally with Firefox.
- Ask reporters to verify fix.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
