### PR TITLE
Correct typos in developer documentation

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -387,7 +387,7 @@ Plugins make use of NVDA Objects in three particular ways:
 - Most events that plugins receive take an argument which is the NVDA Object on which the event occurred.
 For example, event_gainFocus takes the NVDA Object that represents the control gaining focus.
 - Scripts, events or other code may fetch objects of interest such as the NVDA Object with focus, NVDA's current navigator object, or perhaps the Desktop NVDA Object.
-The code may then retreave information from that object or perhaps even retreave another object related to it (e.g. its parent, first child, etc.).
+The code may then retrieve information from that object or perhaps even retrieve another object related to it (e.g. its parent, first child, etc.).
 - the Plugin may define its own custom NVDA Object classes which will be used to wrap a specific control to give it extra functionality, mutate its properties, etc.
 -
 
@@ -424,7 +424,7 @@ Currently, the input sources in NVDA are:
 -
 
 When NVDA receives input, it looks for a matching gesture binding in a particular order.
-Once a gesture binding is found, the script is executed and no further bindings are used, nore is that particular gesture passed on automatically to the Operating System.
+Once a gesture binding is found, the script is executed and no further bindings are used, nor is that particular gesture passed on automatically to the Operating System.
 
 The order for gesture binding lookup is:
 - The user specific gesture map
@@ -626,7 +626,7 @@ Similarly, if you match on MSAA's accRole property, you would probably need to i
 You should also consider what properties you are going to override on the custom NVDA Object.
 For instance, if you are going to override an IAccessible specific property, such as shouldAllowIAccessibleFocusEvent, then you need to inherit from NVDAObjects.IAccessible.IAccessible.
 
-the chooseNVDAObjectOverlayClasses method can be implemented on app modules or global plugin classes.
+The chooseNVDAObjectOverlayClasses method can be implemented on app modules or global plugin classes.
 It takes 3 arguments:
 + self: the app module or global plugin instance.
 + obj: the NVDAObject for which classes are being chosen.
@@ -815,7 +815,7 @@ All other fields will be ignored.
 +++ Locale-specific Messages +++
 Each language directory can also contain gettext information, which is the system used to translate the rest of NVDA's user interface and reported messages.
 As with the rest of NVDA, an nvda.mo compiled gettext database file should be placed in the LC_MESSAGES directory within this directory.
-to allow plugins in your add-on to access gettext message information via calls to _(), you must initialize translations at the top of each Python module by calling addonHandler.initTranslation().
+To allow plugins in your add-on to access gettext message information via calls to _(), you must initialize translations at the top of each Python module by calling addonHandler.initTranslation().
 For more information about gettext and NVDA translation in general, please read
 https://github.com/nvaccess/nvda/wiki/Translating
 

--- a/user_docs/pt_BR/developerGuide.t2t
+++ b/user_docs/pt_BR/developerGuide.t2t
@@ -325,7 +325,7 @@ Plugins make use of NVDA Objects in three particular ways:
 - Most events that plugins receive take an argument which is the NVDA Object on which the event occurred.
 For example, event_gainFocus takes the NVDA Object that represents the control gaining focus.
 - Scripts, events or other code may fetch objects of interest such as the NVDA Object with focus, NVDA's current navigator object, or perhaps the Desktop NVDA Object.
-The code may then retrieve information from that object or perhaps even retrieve another object related to it (e.g. its parent, first child, etc.).
+The code may then retreave information from that object or perhaps even retreave another object related to it (e.g. its parent, first child, etc.).
 - the Plugin may define its own custom NVDA Object classes which will be used to wrap a specific control to give it extra functionality, mutate its properties, etc.
 -
 
@@ -364,7 +364,7 @@ Atualmente, os únicos códigos de entrada no NVDA são:
 -
 
 When NVDA receives input, it looks for a matching gesture binding in a particular order.
-Once a gesture binding is found, the script is executed and no further bindings are used, nor is that particular gesture passed on automatically to the Operating System.
+Once a gesture binding is found, the script is executed and no further bindings are used, nore is that particular gesture passed on automatically to the Operating System.
 
 The order for gesture binding lookup is:
 - Loaded Global Plugins
@@ -496,7 +496,7 @@ Similarly, if you match on MSAA's accRole property, you would probably need to i
 You should also consider what properties you are going to override on the custom NVDA Object.
 For instance, if you are going to override an IAccessible specific property, such as shouldAllowIAccessibleFocusEvent, then you need to inherit from NVDAObjects.IAccessible.IAccessible.
 
-The chooseNVDAObjectOverlayClasses method can be implemented on app modules or global plugin classes.
+the chooseNVDAObjectOverlayClasses method can be implemented on app modules or global plugin classes.
 It takes 3 arguments:
 + self: the app module or global plugin instance.
 + obj: the NVDAObject for which classes are being chosen.

--- a/user_docs/pt_BR/developerGuide.t2t
+++ b/user_docs/pt_BR/developerGuide.t2t
@@ -325,7 +325,7 @@ Plugins make use of NVDA Objects in three particular ways:
 - Most events that plugins receive take an argument which is the NVDA Object on which the event occurred.
 For example, event_gainFocus takes the NVDA Object that represents the control gaining focus.
 - Scripts, events or other code may fetch objects of interest such as the NVDA Object with focus, NVDA's current navigator object, or perhaps the Desktop NVDA Object.
-The code may then retreave information from that object or perhaps even retreave another object related to it (e.g. its parent, first child, etc.).
+The code may then retrieve information from that object or perhaps even retrieve another object related to it (e.g. its parent, first child, etc.).
 - the Plugin may define its own custom NVDA Object classes which will be used to wrap a specific control to give it extra functionality, mutate its properties, etc.
 -
 
@@ -364,7 +364,7 @@ Atualmente, os únicos códigos de entrada no NVDA são:
 -
 
 When NVDA receives input, it looks for a matching gesture binding in a particular order.
-Once a gesture binding is found, the script is executed and no further bindings are used, nore is that particular gesture passed on automatically to the Operating System.
+Once a gesture binding is found, the script is executed and no further bindings are used, nor is that particular gesture passed on automatically to the Operating System.
 
 The order for gesture binding lookup is:
 - Loaded Global Plugins
@@ -496,7 +496,7 @@ Similarly, if you match on MSAA's accRole property, you would probably need to i
 You should also consider what properties you are going to override on the custom NVDA Object.
 For instance, if you are going to override an IAccessible specific property, such as shouldAllowIAccessibleFocusEvent, then you need to inherit from NVDAObjects.IAccessible.IAccessible.
 
-the chooseNVDAObjectOverlayClasses method can be implemented on app modules or global plugin classes.
+The chooseNVDAObjectOverlayClasses method can be implemented on app modules or global plugin classes.
 It takes 3 arguments:
 + self: the app module or global plugin instance.
 + obj: the NVDAObject for which classes are being chosen.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
n/a
### Summary of the issue:
The developer documentation has a few spelling errors
### Description of how this pull request fixes the issue:
This patch corrects the spelling errors
### Testing strategy:
n/a
### Known issues with pull request:
none
### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
