### PR TITLE
Add a helper to getAccessibleChildren

### DIFF
--- a/nvdaHelper/common/ia2utils.cpp
+++ b/nvdaHelper/common/ia2utils.cpp
@@ -97,7 +97,7 @@ getAccessibleChildren(IAccessible* pacc, long indexOfFirstChild, long maxChildCo
 		// no need to shrink to fit, make_pair will copy the vector, using only the first varChildren.size() elements.
 		return std::make_pair(varChildren, S_OK);
 	}
-	catch (std::bad_array_new_length& e) {
+	catch (std::bad_array_new_length&) {
 		return std::make_pair(
 			std::vector<CComVariant>(0),
 			S_FALSE

--- a/nvdaHelper/common/ia2utils.cpp
+++ b/nvdaHelper/common/ia2utils.cpp
@@ -76,24 +76,33 @@ void IA2AttribsToMap(const wstring &attribsString, map<wstring, wstring> &attrib
 
 std::pair<std::vector<CComVariant>, HRESULT>
 getAccessibleChildren(IAccessible* pacc, long indexOfFirstChild, long maxChildCount) {
-	std::vector<CComVariant> varChildren(maxChildCount);
-	const auto res = AccessibleChildren(
-		pacc,
-		indexOfFirstChild,
-		maxChildCount,
-		varChildren.data(),
-		&maxChildCount
-	);
-	if (res != S_OK) {
+	try {
+		std::vector<CComVariant> varChildren(maxChildCount);
+		const auto res = AccessibleChildren(
+			pacc,
+			indexOfFirstChild,
+			maxChildCount,
+			varChildren.data(),
+			&maxChildCount
+		);
+		if (res != S_OK) {
+			return std::make_pair(
+				std::vector<CComVariant>(0),
+				res
+			);
+		}
+		// shrink the vector in case less children were returned.
+		// so that varChildren.size() will equal actual filled size
+		varChildren.resize(maxChildCount);
+		// no need to shrink to fit, make_pair will copy the vector, using only the first varChildren.size() elements.
+		return std::make_pair(varChildren, S_OK);
+	}
+	catch (std::bad_array_new_length& e) {
 		return std::make_pair(
 			std::vector<CComVariant>(0),
-			res
+			S_FALSE
 		);
 	}
-	// shrink the vector in case less children were returned.
-	varChildren.resize(maxChildCount); // so that varChildren.size() will equal actual filled size
-	varChildren.shrink_to_fit(); // so that excess capacity isn't kept
-	return std::make_pair(varChildren, S_OK);
 }
 
 CComPtr<IAccessibleHyperlink> HyperlinkGetter::next() {

--- a/nvdaHelper/common/ia2utils.cpp
+++ b/nvdaHelper/common/ia2utils.cpp
@@ -74,6 +74,28 @@ void IA2AttribsToMap(const wstring &attribsString, map<wstring, wstring> &attrib
 	}
 }
 
+std::pair<std::vector<CComVariant>, HRESULT>
+getAccessibleChildren(IAccessible* pacc, long indexOfFirstChild, long maxChildCount) {
+	std::vector<CComVariant> varChildren(maxChildCount);
+	const auto res = AccessibleChildren(
+		pacc,
+		indexOfFirstChild,
+		maxChildCount,
+		varChildren.data(),
+		&maxChildCount
+	);
+	if (res != S_OK) {
+		return std::make_pair(
+			std::vector<CComVariant>(0),
+			res
+		);
+	}
+	// shrink the vector in case less children were returned.
+	varChildren.resize(maxChildCount); // so that varChildren.size() will equal actual filled size
+	varChildren.shrink_to_fit(); // so that excess capacity isn't kept
+	return std::make_pair(varChildren, S_OK);
+}
+
 CComPtr<IAccessibleHyperlink> HyperlinkGetter::next() {
 	return this->get(this->index++);
 }

--- a/nvdaHelper/common/ia2utils.h
+++ b/nvdaHelper/common/ia2utils.h
@@ -18,6 +18,8 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <atlcomcli.h>
 #include <string>
 #include <map>
+#include <vector>
+#include <utility>
 #include <memory>
 #include <ia2.h>
 
@@ -33,6 +35,12 @@ bool fetchIA2Attributes(IAccessible2* pacc2, std::map<std::wstring, std::wstring
  * @param attribsMap: The map into which the attributes should be placed, with keys and values as strings.
  */
 void IA2AttribsToMap(const std::wstring &attribsString, std::map<std::wstring, std::wstring> &attribsMap);
+
+/**
+* Helper to collect the children for an IAccessible, uses memory managed types that will clear / delete automatically.
+*/
+std::pair<std::vector<CComVariant>, HRESULT>
+getAccessibleChildren(IAccessible* pacc, long indexOfFirstChild, long maxChildCount);
 
 /**
  * Base class to support retrieving hyperlinks (embedded objects) from

--- a/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
+++ b/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
@@ -623,7 +623,7 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 		LOG_DEBUG(L"Fetch children with AccessibleChildren");
 		auto[varChildren, accChildRes] = getAccessibleChildren(pacc, 0, childCount);
 		if(S_OK != accChildRes || varChildren.size() == 0) {
-			LOG_DEBUG(L"Failed to get AccessibleChildren, res: " << accChildRes);
+			LOG_DEBUG(L"Failed to get AccessibleChildren (count: " << childCount << L"), res: " << accChildRes);
 			childCount=0;
 		}
 		LOG_DEBUG(L"got "<< varChildren.size() << L" children");

--- a/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
+++ b/nvdaHelper/vbufBackends/adobeAcrobat/adobeAcrobat.cpp
@@ -17,6 +17,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <iomanip>
 #include <windows.h>
 #include <oleacc.h>
+#include <common/ia2utils.h>
 #include <remote/nvdaHelperRemote.h>
 #include <vbufBase/backend.h>
 #include <common/log.h>
@@ -619,30 +620,22 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 
 	} else if (childCount > 0) {
 		// Iterate through the children.
-		LOG_DEBUG(L"Allocate memory to hold children");
-		VARIANT* varChildren;
-		if((varChildren=(VARIANT*)malloc(sizeof(VARIANT)*childCount))==NULL) {
-			LOG_DEBUG(L"Error allocating varChildren memory");
-			if (stdName)
-				SysFreeString(stdName);
-			return NULL;
-		}
 		LOG_DEBUG(L"Fetch children with AccessibleChildren");
-		if((res=AccessibleChildren(pacc,0,childCount,varChildren,(long*)(&childCount)))!=S_OK) {
-			LOG_DEBUG(L"AccessibleChildren returned "<<res);
+		auto[varChildren, accChildRes] = getAccessibleChildren(pacc, 0, childCount);
+		if(S_OK != accChildRes || varChildren.size() == 0) {
+			LOG_DEBUG(L"Failed to get AccessibleChildren, res: " << accChildRes);
 			childCount=0;
 		}
-		LOG_DEBUG(L"got "<<childCount<<L" children");
-		for(int i=0;i<childCount;++i) {
-			LOG_DEBUG(L"child "<<i);
-			if(varChildren[i].vt==VT_DISPATCH) {
+		LOG_DEBUG(L"got "<< varChildren.size() << L" children");
+		for(auto i = 0u; i < varChildren.size(); ++i) {
+			LOG_DEBUG(L"child " << i);
+			if(VT_DISPATCH == varChildren[i].vt) {
 				LOG_DEBUG(L"QueryInterface dispatch child to IID_IAccesible");
-				IAccessible* childPacc=NULL;
-				if((res=varChildren[i].pdispVal->QueryInterface(IID_IAccessible,(void**)(&childPacc)))!=S_OK) {
-					LOG_DEBUG(L"varChildren["<<i<<L"].pdispVal->QueryInterface to IID_iAccessible returned "<<res);
-					childPacc=NULL;
+				CComQIPtr<IAccessible, &IID_IAccessible> childPacc(varChildren[i].pdispVal);
+				if(!childPacc) {
+					LOG_DEBUG(L"varChildren[" << i << L"]: QueryInterface to IID_iAccessible failed.");
 				}
-				if(childPacc) {
+				else {
 					if (this->isXFA) {
 						// HACK: If this is an XFA document, we must call WindowFromAccessibleObject() so that AccessibleObjectFromEvent() will work for this node.
 						HWND tempHwnd;
@@ -654,15 +647,9 @@ AdobeAcrobatVBufStorage_controlFieldNode_t* AdobeAcrobatVBufBackend_t::fillVBuf(
 					} else {
 						LOG_DEBUG(L"Error in calling fillVBuf");
 					}
-					LOG_DEBUG(L"releasing child IAccessible object");
-					childPacc->Release();
 				}
 			}
-			VariantClear(&(varChildren[i]));
 		}
-		LOG_DEBUG(L"Freeing memory holding children");
-		free(varChildren);
-
 	} else {
 		// No children, so this is a leaf node.
 		if (!this->isXFA && !stdName) {

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -952,7 +952,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 			// The object has no text, but we do want to render its children.
 			auto [varChildren, accChildRes] = getAccessibleChildren(pacc, 0, childCount);
 			if (S_OK != accChildRes || varChildren.size() == 0) {
-				LOG_DEBUG(L"AccessibleChildren failed, res: " << accChildRes);
+				LOG_ERROR(L"AccessibleChildren failed (count: " << childCount << L"), res: " << accChildRes);
 			}
 			LOG_DEBUG(L"got " << varChildren.size() << L" children");
 

--- a/nvdaHelper/vbufBackends/lotusNotesRichText/lotusNotesRichText.cpp
+++ b/nvdaHelper/vbufBackends/lotusNotesRichText/lotusNotesRichText.cpp
@@ -17,6 +17,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <windows.h>
 #include <oleacc.h>
 #include <common/log.h>
+#include <common/ia2utils.h>
 #include <remote/nvdaHelperRemote.h>
 #include <vbufBase/backend.h>
 #include "lotusNotesRichText.h"
@@ -170,12 +171,18 @@ void lotusNotesRichTextVBufBackend_t::render(VBufStorage_buffer_t* buffer, int d
 		VBufStorage_fieldNode_t* previousNode=NULL;
 		long childCount=0;
 		pacc->get_accChildCount(&childCount);
-		VARIANT* varChildren=(VARIANT*)malloc(sizeof(VARIANT)*childCount);
-		HRESULT hRes;
-		hRes=AccessibleChildren(pacc,0,childCount,varChildren,&childCount);
-		for(int i=0;i<childCount;++i) {
-			if(varChildren[i].vt==VT_I4) {
-				previousNode=this->renderControlContent(buffer,parentNode,previousNode,docHandle,pacc,varChildren[i].lVal);
+
+		auto [varChildren, hres] = getAccessibleChildren(pacc, 0, childCount);
+		for(CComVariant& child : varChildren) {
+			if(VT_I4 == child.vt) {
+				previousNode = this->renderControlContent(
+					buffer,
+					parentNode,
+					previousNode,
+					docHandle,
+					pacc,
+					child.lVal
+				);
 			}
 		}
 	} else {


### PR DESCRIPTION
### Link to issue number:
None
Related to #13106

### Summary of the issue:
While working on #13106 I noticed several different approaches to get accessible children.

### Description of how this pull request fixes the issue:
Make all usages of AccessibleChildren conform to a consitant approach (with the exception of getIAccessibleText, which will be addressed separately, via #13127)
Resources are now managed with smart pointers.

### Testing strategy:
- Builds and runs locally.
- Testing from alpha users in the specific applications (webkit, lotus notes, firefox)

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
