### PR TITLE
clean up getTextFromIAccessible

### DIFF
--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -32,11 +32,11 @@ bool getTextFromIAccessible(
 ) {
 	if (!pacc2) {
 		return false;
-	bool gotText = false;
-	IAccessibleText* paccText = NULL;
-	if (pacc2->QueryInterface(IID_IAccessibleText, (void**)&paccText) != S_OK) {
-		paccText = NULL;
 	}
+
+	bool gotText = false;
+	CComQIPtr<IAccessibleText, &IID_IAccessibleText> paccText(pacc2);
+
 	if (!paccText && recurse && !useNewText) {
 		//no IAccessibleText interface, so try children instead
 		long childCount = 0;
@@ -120,7 +120,6 @@ bool getTextFromIAccessible(
 			SysFreeString(bstrText);
 			textBuf.append(1, L' ');
 		}
-		paccText->Release();
 	}
 	if (!gotText && !useNewText) {
 		//We got no text from IAccessibleText interface or children, so try name and/or description

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -70,8 +70,8 @@ bool getTextFromIAccessible(
 		long startOffset = 0;
 		//If requested, get the text from IAccessibleText::newText rather than just IAccessibleText::text.
 		if (useNewText) {
-			IA2TextSegment newSeg = { 0 };
-			if (paccText->get_newText(&newSeg) == S_OK && newSeg.text) {
+			IA2TextSegment newSeg {};
+			if (S_OK == paccText->get_newText(&newSeg) && newSeg.text) {
 				bstrText = newSeg.text;
 				startOffset = newSeg.start;
 			}
@@ -90,8 +90,9 @@ bool getTextFromIAccessible(
 				wchar_t realChar = bstrText[index];
 				bool charAdded = false;
 				if (realChar == OBJ_REPLACEMENT_CHAR) {
-					long hyperlinkIndex;
-					if (paccHypertext && paccHypertext->get_hyperlinkIndex(startOffset + index, &hyperlinkIndex) == S_OK) {
+					const long charIndex = startOffset + index;
+					long hyperlinkIndex = 0;
+					if (paccHypertext && paccHypertext->get_hyperlinkIndex(charIndex, &hyperlinkIndex) == S_OK) {
 						IAccessibleHyperlink* paccHyperlink = NULL;
 						if (paccHypertext->get_hyperlink(hyperlinkIndex, &paccHyperlink) == S_OK) {
 							IAccessible2* pacc2Child = NULL;

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -44,9 +44,9 @@ bool getTextFromIAccessible(
 			VARIANT* varChildren = new VARIANT[childCount];
 			AccessibleChildren(pacc2, 0, childCount, varChildren, &childCount);
 			for (int i = 0; i < childCount; ++i) {
-				if (varChildren[i].vt == VT_DISPATCH) {
-					IAccessible2* pacc2Child = NULL;
-					if (varChildren[i].pdispVal && varChildren[i].pdispVal->QueryInterface(IID_IAccessible2, (void**)&pacc2Child) == S_OK) {
+				if (varChildren[i].vt == VT_DISPATCH && varChildren[i].pdispVal) {
+					CComQIPtr<IAccessible2, &IID_IAccessible2> pacc2Child(varChildren[i].pdispVal);
+					if (pacc2Child) {
 						map<wstring, wstring> childAttribsMap;
 						fetchIA2Attributes(pacc2Child, childAttribsMap);
 						auto liveItr = childAttribsMap.find(L"live");
@@ -59,7 +59,6 @@ bool getTextFromIAccessible(
 								true // includeTopLevelText
 							);
 						}
-						pacc2Child->Release();
 					}
 				}
 				VariantClear(varChildren + i);

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -100,7 +100,7 @@ bool getTextFromIAccessible(
 								map<wstring, wstring> childAttribsMap;
 								fetchIA2Attributes(pacc2Child, childAttribsMap);
 								auto liveItr = childAttribsMap.find(L"live");
-								if (liveItr == childAttribsMap.end() || liveItr->second.compare(L"off") != 0) {
+								if (liveItr == childAttribsMap.end() || liveItr->second != L"off") {
 									if (getTextFromIAccessible(textBuf, pacc2Child)) {
 										gotText = true;
 									}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -74,7 +74,7 @@ bool getTextFromIAccessible(
 	}
 
 	bool gotText = false;
-	CComQIPtr<IAccessibleText, &IID_IAccessibleText> paccText(pacc2);
+	CComQIPtr<IAccessibleText> paccText(pacc2);
 
 	if (!paccText && recurse && !useNewText) {
 		//no IAccessibleText interface, so try children instead
@@ -83,7 +83,7 @@ bool getTextFromIAccessible(
 			auto[varChildren, accChildRes] = getAccessibleChildren(pacc2, 0, childCount);
 			for(auto& child : varChildren){
 				if (child.vt == VT_DISPATCH && child.pdispVal) {
-					CComQIPtr<IAccessible2, &IID_IAccessible2> pacc2Child(child.pdispVal);
+					CComQIPtr<IAccessible2> pacc2Child(child.pdispVal);
 					if (pacc2Child) {
 						map<wstring, wstring> childAttribsMap;
 						fetchIA2Attributes(pacc2Child, childAttribsMap);
@@ -120,7 +120,7 @@ bool getTextFromIAccessible(
 		//If we got text, add it to  the string provided, however if there are embedded objects in the text, recurse in to these
 		if (bstrText) {
 			long textLength = SysStringLen(bstrText);
-			CComQIPtr<IAccessibleHypertext, &IID_IAccessibleHypertext> paccHypertext;
+			CComQIPtr<IAccessibleHypertext> paccHypertext;
 			if (recurse) {
 				paccHypertext = pacc2;
 			}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -93,10 +93,10 @@ bool getTextFromIAccessible(
 					const long charIndex = startOffset + index;
 					long hyperlinkIndex = 0;
 					if (paccHypertext && paccHypertext->get_hyperlinkIndex(charIndex, &hyperlinkIndex) == S_OK) {
-						IAccessibleHyperlink* paccHyperlink = NULL;
-						if (paccHypertext->get_hyperlink(hyperlinkIndex, &paccHyperlink) == S_OK) {
-							IAccessible2* pacc2Child = NULL;
-							if (paccHyperlink->QueryInterface(IID_IAccessible2, (void**)&pacc2Child) == S_OK) {
+						CComPtr<IAccessibleHyperlink> paccHyperlink;
+						if (S_OK == paccHypertext->get_hyperlink(hyperlinkIndex, &paccHyperlink)) {
+							CComQIPtr <IAccessible2> pacc2Child(paccHyperlink);
+							if (pacc2Child) {
 								map<wstring, wstring> childAttribsMap;
 								fetchIA2Attributes(pacc2Child, childAttribsMap);
 								auto liveItr = childAttribsMap.find(L"live");
@@ -106,9 +106,7 @@ bool getTextFromIAccessible(
 									}
 								}
 								charAdded = true;
-								pacc2Child->Release();
 							}
-							paccHyperlink->Release();
 						}
 					}
 				}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -51,9 +51,13 @@ bool getTextFromIAccessible(
 						fetchIA2Attributes(pacc2Child, childAttribsMap);
 						auto liveItr = childAttribsMap.find(L"live");
 						if (liveItr == childAttribsMap.end() || liveItr->second.compare(L"off") != 0) {
-							if (getTextFromIAccessible(textBuf, pacc2Child)) {
-								gotText = true;
-							}
+							gotText |= getTextFromIAccessible(
+								textBuf,
+								pacc2Child,
+								false, // useNewText
+								true, // recurse
+								true // includeTopLevelText
+							);
 						}
 						pacc2Child->Release();
 					}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -20,6 +20,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <common/ia2utils.h>
 
 using namespace std;
+auto constexpr OBJ_REPLACEMENT_CHAR = L'\xfffc';
 
 
 bool getTextFromIAccessible(
@@ -83,7 +84,7 @@ bool getTextFromIAccessible(
 			for (long index = 0; index < textLength; ++index) {
 				wchar_t realChar = bstrText[index];
 				bool charAdded = false;
-				if (realChar == L'\xfffc') {
+				if (realChar == OBJ_REPLACEMENT_CHAR) {
 					long hyperlinkIndex;
 					if (paccHypertext && paccHypertext->get_hyperlinkIndex(startOffset + index, &hyperlinkIndex) == S_OK) {
 						IAccessibleHyperlink* paccHyperlink = NULL;
@@ -108,7 +109,7 @@ bool getTextFromIAccessible(
 				if (!charAdded && includeTopLevelText) {
 					textBuf.append(1, realChar);
 					charAdded = true;
-					if (realChar != L'\xfffc' && !iswspace(realChar)) {
+					if (realChar != OBJ_REPLACEMENT_CHAR && !iswspace(realChar)) {
 						gotText = true;
 					}
 				}
@@ -129,7 +130,7 @@ bool getTextFromIAccessible(
 		pacc2->get_accName(varChild, &val);
 		if (val) {
 			for (int i = 0; val[i] != L'\0'; ++i) {
-				if (val[i] != L'\xfffc' && !iswspace(val[i])) {
+				if (val[i] != OBJ_REPLACEMENT_CHAR && !iswspace(val[i])) {
 					valEmpty = false;
 					break;
 				}
@@ -146,7 +147,7 @@ bool getTextFromIAccessible(
 		pacc2->get_accDescription(varChild, &val);
 		if (val) {
 			for (int i = 0; val[i] != L'\0'; ++i) {
-				if (val[i] != L'\xfffc' && !iswspace(val[i])) {
+				if (val[i] != OBJ_REPLACEMENT_CHAR && !iswspace(val[i])) {
 					valEmpty = false;
 					break;
 				}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -66,7 +66,7 @@ bool getTextFromIAccessible(
 	}
 	else if (paccText) {
 		//We can use IAccessibleText because it exists
-		BSTR bstrText = NULL;
+		CComBSTR bstrText;
 		long startOffset = 0;
 		//If requested, get the text from IAccessibleText::newText rather than just IAccessibleText::text.
 		if (useNewText) {
@@ -118,7 +118,6 @@ bool getTextFromIAccessible(
 				}
 			}
 			if (paccHypertext) paccHypertext->Release();
-			SysFreeString(bstrText);
 			textBuf.append(1, L' ');
 		}
 	}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -82,8 +82,10 @@ bool getTextFromIAccessible(
 		//If we got text, add it to  the string provided, however if there are embedded objects in the text, recurse in to these
 		if (bstrText) {
 			long textLength = SysStringLen(bstrText);
-			IAccessibleHypertext* paccHypertext = NULL;
-			if (!recurse || pacc2->QueryInterface(IID_IAccessibleHypertext, (void**)&paccHypertext) != S_OK) paccHypertext = NULL;
+			CComQIPtr<IAccessibleHypertext, &IID_IAccessibleHypertext> paccHypertext;
+			if (recurse) {
+				paccHypertext = pacc2;
+			}
 			for (long index = 0; index < textLength; ++index) {
 				wchar_t realChar = bstrText[index];
 				bool charAdded = false;
@@ -117,7 +119,6 @@ bool getTextFromIAccessible(
 					}
 				}
 			}
-			if (paccHypertext) paccHypertext->Release();
 			textBuf.append(1, L' ');
 		}
 	}

--- a/nvdaHelper/remote/textFromIAccessible.cpp
+++ b/nvdaHelper/remote/textFromIAccessible.cpp
@@ -30,6 +30,8 @@ bool getTextFromIAccessible(
 	bool recurse,
 	bool includeTopLevelText
 ) {
+	if (!pacc2) {
+		return false;
 	bool gotText = false;
 	IAccessibleText* paccText = NULL;
 	if (pacc2->QueryInterface(IID_IAccessibleText, (void**)&paccText) != S_OK) {


### PR DESCRIPTION
### Link to issue number:
Depends on:
- https://github.com/nvaccess/nvda/pull/13126
- #13106

### Summary of the issue:
The moved function `getTextFromIAccessible` doesn't use smart pointers, was missing some explicit initialization, and logic could be simplified.

### Description of how this pull request fixes the issue:
- Introduce (CCom) smart pointers.
- Initialize all variables.
- Simplify logic where obvious.
- ~[ ] Also split based on "useNewText" https://github.com/nvaccess/nvda/pull/13106#discussion_r765567962~ This has been dropped. It will be kept in mind for future work in the area.

### Testing strategy:
- Builds runs locally
- Testing with annotations changes.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
