### PR TITLE
Fix-up of PR 13060: Make punctuation in the descriptions of scripts more consistent

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1079,7 +1079,7 @@ class GlobalCommands(ScriptableObject):
 		description=_(
 			# Translators: Description for a keyboard command which reports location of the
 			# review cursor, falling back to the location of navigator object if needed.
-			"Reports information about the location of the text at the review cursor "
+			"Reports information about the location of the text at the review cursor, "
 			"or location of the navigator object if there is no text under review cursor."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
@@ -1115,7 +1115,7 @@ class GlobalCommands(ScriptableObject):
 		description=_(
 			# Translators: Description for a keyboard command which reports location of the
 			# currently focused object.
-			"Reports information about the location of the currently focused object"
+			"Reports information about the location of the currently focused object."
 		),
 		category=SCRCAT_FOCUS,
 	)
@@ -1142,7 +1142,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Description for a keyboard command
 			# which reports location of the text at the caret position
 			# or object with focus if there is no caret.
-			"Reports information about the location of the text or object at the position of system caret "
+			"Reports information about the location of the text or object at the position of system caret. "
 			"Pressing twice may provide further detail."
 		),
 		category=SCRCAT_SYSTEMCARET,


### PR DESCRIPTION
### Link to issue number:
Fix-up of PR #13060

### Summary of the issue:
Punctuation in the descriptions of the new scripts added in PR #13060 was used inconsistently i.e. missing full stops and commas.

### Description of how this pull request fixes the issue:
Fixed these inconsistencies by making sure that all full sentences ends with a full stop and added a missing comma.
### Testing strategy:
Double checked descriptions of these scripts.
### Known issues with pull request:
None known
### Change log entries:
None needed
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
