### PR TITLE
Update liblouis to 3.20.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 7e5457f91e10
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
-* [liblouis](http://www.liblouis.org/), version 3.19.0
+* [liblouis](http://www.liblouis.org/), version 3.20.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 40.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -362,7 +362,7 @@ addTable("my-g1.utb", _("Burmese grade 1"))
 addTable("my-g2.ctb", _("Burmese grade 2"), contracted=True, input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("nl-NL-g0.utb", _("Dutch (Netherlands) 6 dot"))
+addTable("nl-NL-g0.utb", _("Dutch 6 dot"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("nl-comp8.utb", _("Dutch 8 dot"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -77,7 +77,7 @@ RENAMED_TABLES = {
 	"he.ctb": "he-IL-comp8.utb",
 	"hr.ctb":"hr-comp8.utb",
 	"mn-MN.utb":"mn-MN-g1.utb",
-	"nl-BE-g1.ctb":"nl-BE-g0.utb",
+	"nl-BE-g0.utb": "nl-NL-g0.utb",
 	"nl-NL-g1.ctb":"nl-NL-g0.utb",
 	"no-no.ctb":"no-no-8dot.utb",
 	"no-no-comp8.ctb":"no-no-8dot.utb",
@@ -299,6 +299,9 @@ addTable("it-it-comp6.utb", _("Italian 6 dot computer braille"))
 addTable("it-it-comp8.utb", _("Italian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("ja-kantenji.utb", _("Japanese (Kantenji) literary braille"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("ka-in-g1.utb", _("Kannada grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -359,9 +362,6 @@ addTable("my-g1.utb", _("Burmese grade 1"))
 addTable("my-g2.ctb", _("Burmese grade 2"), contracted=True, input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("nl-BE-g0.utb", _("Dutch (Belgium) 6 dot"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable("nl-NL-g0.utb", _("Dutch (Netherlands) 6 dot"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -398,7 +398,7 @@ addTable("or-in-g1.utb", _("Oriya grade 1"))
 addTable("pl-pl-comp8.ctb", _("Polish 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("Pl-Pl-g1.utb", _("Polish grade 1"))
+addTable("Pl-Pl-g1.utb", _("Polish literary braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("pt-pt-comp8.ctb", _("Portuguese 8 dot computer braille"))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,13 +11,16 @@ What's New in NVDA
 - The new --lang command line parameter allows overriding the configured NVDA language. (#10044)
 - NVDA now warns about command line parameters which are unknown and not used by any add-ons. (#12795)
 - In Microsoft Word accessed via UI Automation, NVDA will now make use of mathPlayer to read and navigate Office math equations. (#12946)
-    - For this to work, you must be running Microsoft Word 365/2016 build 14326 or later. 
-    - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
-    -
+  - For this to work, you must be running Microsoft Word 365/2016 build 14326 or later. 
+  - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
+  -
 -
 
 == Changes ==
 - Espeak-ng has been updated to 1.51-dev commit ``7e5457f91e10``. (#12950)
+- Updated liblouis braille translator to [3.20.0 https://github.com/liblouis/liblouis/releases/tag/v3.20.0]. (#13141)
+  - New braille table: Japanese (Kantenji) literary braille
+  -
 - NVDA will report selection and merged cells in LibreOffice Calc 7.3 and above. (#9310, #6897)
 - Updated Unicode Common Locale Data Repository (CLDR) to 40.0. (#12999)
 - ``NVDA+Numpad Delete`` reports the location of the caret or focused object by default. (#13060)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #2736

### Summary of the issue:
Liblouis 3.20.0 has been released.

### Description of how this pull request fixes the issue:
Updates liblouis to 3.20.0 which offers among other things new table for braille kanji and major updates to the Polish, Chinese, Russian literary and the UEB tables. [Changelog](https://github.com/liblouis/liblouis/releases/tag/v3.20.0).

### Testing strategy:
Ran from sources and try build then loaded the new Japanese braille table. LGTM.

### Known issues with pull request:
- 'nl-BE-g0.utb' was removed. Should we redirect to 'nl-NL-g0.utb'? See https://github.com/liblouis/liblouis/pull/1137

### Change log entries:
Section: Changes

```
- Updated liblouis braille translator to [3.20.0 https://github.com/liblouis/liblouis/releases/tag/v3.20.0]. (#13141)
  - New braille table: Japanese (Kantenji) literary braille
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
