### PR TITLE
Remove deprecated constants from languageHandler

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -4,7 +4,8 @@
 # See the file COPYING for more details.
 
 """Language and localization support.
-This module assists in NVDA going global through language services such as converting Windows locale ID's to friendly names and presenting available languages.
+This module assists in NVDA going global through language services
+such as converting Windows locale ID's to friendly names and presenting available languages.
 """
 
 import builtins
@@ -14,7 +15,6 @@ import ctypes
 import locale
 import gettext
 import enum
-import buildVersion
 import globalVars
 from logHandler import log
 import winKernel
@@ -46,14 +46,6 @@ class LOCALE(enum.IntEnum):
 	SENGLISHLANGUAGENAME = 0x00001001
 	SENGLISHCOUNTRYNAME = 0x00001002
 	IDEFAULTANSICODEPAGE = 0x00001004
-
-
-# These constants are deprecated and  members of LOCALE enum should be used instead
-# They would be removed in NVDA 2022.1
-if buildVersion.version_year < 2022:
-	LOCALE_SLANGUAGE = LOCALE.SLANGUAGE
-	LOCALE_SLIST = LOCALE.SLIST
-	LOCALE_SLANGDISPLAYNAME = LOCALE.SLANGDISPLAYNAME
 
 
 def isNormalizedWin32Locale(localeName: str) -> bool:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -83,6 +83,7 @@ This ensures code will honor the Windows user setting for swapping the primary m
   - Removed ``IA2_RELATION_FLOWS_TO``
   - Removed ``IA2_RELATION_CONTAINING_DOCUMENT``
   -
+- ``LOCALE_SLANGUAGE``, ``LOCALE_SLIST`` and ``LOCALE_SLANGDISPLAYNAME`` are removed from ``languageHandler`` - use members of ``languageHandler.LOCALE`` instead. (#12753)
 -
 
 


### PR DESCRIPTION

### Link to issue number:
None. Removes code marked as deprecated in #12753 
### Summary of the issue:
As part of #12753 various constants in `languageHandler` were moved into an enum but kept at the module level for backwards compatibility. Since NVDA 2022.1 is a backwards compatibility breaking release it makes sense to remove them.
### Description of how this pull request fixes the issue:
Deprecated constants are removed.
### Testing strategy:
Made sure that removed constants are not used directly in the code.
### Known issues with pull request:
None known
### Change log entries:
For Developers
- `LOCALE_SLANGUAGE`, `LOCALE_SLIST` and `LOCALE_SLANGDISPLAYNAME` are removed from `languageHandler` - use members of ` `languageHandler.LOCALE` instead (#12753 )
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
