### PR TITLE
Fixup of #12861: custom annotations in Word break annotations in elem…

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -102,7 +102,7 @@ def getCommentInfoFromPosition(position):
 			comment = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_NamePropertyId)
 			author = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAuthorPropertyId)
 			date = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationDateTimePropertyId)
-			return dict(comment=f"kaas {comment}", author=author, date=date)
+			return dict(comment=comment, author=author, date=date)
 		elif (
 			not obj.parent
 			# Because the name of this object is language sensetive check if it has UIA Annotation Pattern

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -92,7 +92,8 @@ def getCommentInfoFromPosition(position):
 		UIAElement=UIAElement.buildUpdatedCache(UIAHandler.handler.baseCacheRequest)
 		typeID = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAnnotationTypeIdPropertyId)
 		# Use Annotation Type Comment if available
-		cats = position.obj._UIACustomAnnotationTypes
+		obj = UIA(UIAElement=UIAElement)
+		cats = obj._UIACustomAnnotationTypes
 		if (
 			typeID == UIAHandler.AnnotationType_Comment
 			or (typeID and typeID == cats.microsoftWord_draftComment)
@@ -101,26 +102,24 @@ def getCommentInfoFromPosition(position):
 			comment = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_NamePropertyId)
 			author = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAuthorPropertyId)
 			date = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationDateTimePropertyId)
-			return dict(comment=comment, author=author, date=date)
-		else:
-			obj = UIA(UIAElement=UIAElement)
-			if (
-				not obj.parent
-				# Because the name of this object is language sensetive check if it has UIA Annotation Pattern
-				or not obj.parent.UIAElement.getCurrentPropertyValue(
-					UIAHandler.UIA_IsAnnotationPatternAvailablePropertyId
-				)
-			):
-				continue
-			comment = obj.makeTextInfo(textInfos.POSITION_ALL).text
-			tempObj = obj.previous.previous
-			authorObj = tempObj or obj.previous
-			author = authorObj.name
-			if not tempObj:
-				return dict(comment=comment, author=author)
-			dateObj = obj.previous
-			date = dateObj.name
-			return dict(comment=comment, author=author, date=date)
+			return dict(comment=f"kaas {comment}", author=author, date=date)
+		elif (
+			not obj.parent
+			# Because the name of this object is language sensetive check if it has UIA Annotation Pattern
+			or not obj.parent.UIAElement.getCurrentPropertyValue(
+				UIAHandler.UIA_IsAnnotationPatternAvailablePropertyId
+			)
+		):
+			continue
+		comment = obj.makeTextInfo(textInfos.POSITION_ALL).text
+		tempObj = obj.previous.previous
+		authorObj = tempObj or obj.previous
+		author = authorObj.name
+		if not tempObj:
+			return dict(comment=comment, author=author)
+		dateObj = obj.previous
+		date = dateObj.name
+		return dict(comment=comment, author=author, date=date)
 
 
 def getPresentableCommentInfoFromPosition(commentInfo):


### PR DESCRIPTION
### Link to issue number:
Fixup for #12861

### Summary of the issue:
The following error is in the log when vieiwing annotations in the elements list:

```
ERROR - queueHandler.flushQueue (19:47:20.811) - MainThread (9476):
Error in func ElementsListDialog.initElementType
Traceback (most recent call last):
  File "queueHandler.pyc", line 55, in flushQueue
  File "browseMode.pyc", line 1054, in initElementType
  File "browseMode.pyc", line 1074, in filter
  File "NVDAObjects\UIA\wordDocument.pyc", line 139, in label
  File "NVDAObjects\UIA\wordDocument.pyc", line 95, in getCommentInfoFromPosition
AttributeError: 'WordBrowseModeDocument' object has no attribute '_UIACustomAnnotationTypes'
```

### Description of how this pull request fixes the issue:
Hopefully fix this, though I don't have a way to reproduce how the custom annotations work. @michaelDCurran  could you please take a look?

### Testing strategy:
To be tested with a real test case, to be provided.

### Known issues with pull request:
None known

### Change log entries:
None needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
