### PR TITLE
Fix port listing for seikantk driver

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -643,5 +643,10 @@ addUsbDevices("nattiqbraille", KEY_SERIAL, {
 
 # superBrl
 addUsbDevices("superBrl", KEY_SERIAL, {
-	"VID_10C4&PID_EA60", # SuperBraille 3.2
+	"VID_10C4&PID_EA60",  # SuperBraille 3.2
+})
+
+# seika
+addUsbDevices("seikantk", KEY_HID, {
+	"VID_10C4&PID_EA80",  # Seika Notetaker
 })

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -18,6 +18,7 @@ from collections import namedtuple, defaultdict, OrderedDict
 import threading
 from typing import Iterable
 
+import typing
 import wx
 import hwPortUtils
 import braille
@@ -164,13 +165,22 @@ class _DeviceInfoFetcher(AutoPropertyObject):
 	"""Utility class that caches fetched info for available devices for the duration of one core pump cycle."""
 	cachePropertiesByDefault = True
 
-	def _get_comPorts(self):
+	#: Type info for auto property: _get_comPorts
+	comPorts: typing.List[typing.Dict]
+
+	def _get_comPorts(self) -> typing.List[typing.Dict]:
 		return list(hwPortUtils.listComPorts(onlyAvailable=True))
 
-	def _get_usbDevices(self):
+	#: Type info for auto property: _get_usbDevices
+	usbDevices: typing.List[typing.Dict]
+
+	def _get_usbDevices(self) -> typing.List[typing.Dict]:
 		return list(hwPortUtils.listUsbDevices(onlyAvailable=True))
 
-	def _get_hidDevices(self):
+	#: Type info for auto property: _get_hidDevices
+	hidDevices: typing.List[typing.Dict]
+
+	def _get_hidDevices(self) -> typing.List[typing.Dict]:
 		return list(hwPortUtils.listHidDevices(onlyAvailable=True))
 
 #: The single instance of the device info fetcher.
@@ -333,7 +343,8 @@ class Detector(object):
 		core.post_windowMessageReceipt.unregister(self.handleWindowMessage)
 		self._stopBgScan()
 
-def getConnectedUsbDevicesForDriver(driver) -> Iterable[DeviceMatch]:
+
+def getConnectedUsbDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]:
 	"""Get any connected USB devices associated with a particular driver.
 	@param driver: The name of the driver.
 	@type driver: str
@@ -358,7 +369,8 @@ def getConnectedUsbDevicesForDriver(driver) -> Iterable[DeviceMatch]:
 				if match.type == type and match.id in ids:
 					yield match
 
-def getPossibleBluetoothDevicesForDriver(driver) -> Iterable[DeviceMatch]:
+
+def getPossibleBluetoothDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]:
 	"""Get any possible Bluetooth devices associated with a particular driver.
 	@param driver: The name of the driver.
 	@type driver: str

--- a/source/braille.py
+++ b/source/braille.py
@@ -2454,11 +2454,11 @@ class BrailleDisplayDriver(driverHandler.Driver):
 			pass
 
 	@classmethod
-	def getManualPorts(cls) -> Iterable[str]:
+	def getManualPorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
 		"""Get possible manual hardware ports for this driver.
 		This is for ports which cannot be detected automatically
 		such as serial ports.
-		@return: The name and description for each port.
+		@return: An iterator containing the name and description for each port.
 		"""
 		raise NotImplementedError
 
@@ -2723,7 +2723,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 inputCore.registerGestureSource("br", BrailleDisplayGesture)
 
 
-def getSerialPorts(filterFunc=None):
+def getSerialPorts(filterFunc=None) -> typing.Iterator[typing.Tuple[str, str]]:
 	"""Get available serial ports in a format suitable for L{BrailleDisplayDriver.getManualPorts}.
 	@param filterFunc: a function executed on every dictionary retrieved using L{hwPortUtils.listComPorts}.
 		For example, this can be used to filter by USB or Bluetooth com ports.

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -83,8 +83,10 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		return True
 
 	@classmethod
-	def getManualPorts(cls):
-		return cls.path
+	def getManualPorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
+		"""@return: An iterator containing the name and description for each port.
+		"""
+		return braille.getSerialPorts()
 
 	def __init__(self, port="hid"):
 		super().__init__()

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -64,8 +64,6 @@ vidpid = "VID_10C4&PID_EA80"
 hidvidpid = "HID\\VID_10C4&PID_EA80"
 SEIKA_NAME = "seikantk"
 
-bdDetect.addUsbDevices(SEIKA_NAME, bdDetect.KEY_HID, {vidpid, })
-
 
 class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.IoBase

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -77,10 +77,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			path = d["devicePath"]
 
 	@classmethod
-	def check(cls):
-		return True
-
-	@classmethod
 	def getManualPorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
 		"""@return: An iterator containing the name and description for each port.
 		"""

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -8,6 +8,7 @@
 
 import itertools
 import ctypes
+import typing
 from ctypes.wintypes import BOOL, WCHAR, HWND, DWORD, ULONG, WORD, USHORT
 import winreg
 import winKernel
@@ -124,12 +125,13 @@ DIREG_DEV = 0x00000001
 def _isDebug():
 	return config.conf["debugLog"]["hwIo"]
 
-def listComPorts(onlyAvailable=True):
+
+# C901 'listComPorts' is too complex. Look for opportunities to break this method down.
+def listComPorts(onlyAvailable=True) -> typing.Iterator[typing.Dict]:  # noqa: C901
 	"""List com ports on the system.
 	@param onlyAvailable: Only return ports that are currently available.
 	@type onlyAvailable: bool
 	@return: Dicts including keys of port, friendlyName and hardwareID.
-	@rtype: generator of dict
 	"""
 	flags = DIGCF_DEVICEINTERFACE
 	if onlyAvailable:
@@ -334,12 +336,12 @@ def getWidcommBluetoothPortInfo(port):
 				return addr, name
 	raise LookupError
 
-def listUsbDevices(onlyAvailable=True):
+
+def listUsbDevices(onlyAvailable=True) -> typing.Iterator[typing.Dict]:
 	"""List USB devices on the system.
 	@param onlyAvailable: Only return devices that are currently available.
 	@type onlyAvailable: bool
 	@return: Generates dicts including keys of usbID (VID and PID), devicePath and hardwareID.
-	@rtype: generator of dict
 	"""
 	flags = DIGCF_DEVICEINTERFACE
 	if onlyAvailable:
@@ -483,14 +485,15 @@ def _getHidInfo(hwId, path):
 	return info
 
 _hidGuid = None
-def listHidDevices(onlyAvailable=True):
+
+
+def listHidDevices(onlyAvailable=True) -> typing.Iterator[typing.Dict]:
 	"""List HID devices on the system.
 	@param onlyAvailable: Only return devices that are currently available.
 	@type onlyAvailable: bool
 	@return: Generates dicts including keys such as hardwareID,
 		usbID (in the form "VID_xxxx&PID_xxxx")
 		and devicePath.
-	@rtype: generator of dict
 	"""
 	global _hidGuid
 	if not _hidGuid:


### PR DESCRIPTION
### Link to issue number:
fixes #13121

### Summary of the issue:
Although the braille display can be used via automatic detection, trying to configure manually results in an error.
Braille expects to be able to call `ports.update(cls.getManualPorts())`, other drivers all return an iterator of tuples, each containing two strings. However the seikantk driver attempts to return the device path, from the log:
```
DEBUG - hwPortUtils.listHidDevices (12:56:39.981) - MainThread (1252):
{'hardwareID': 'HID\\VID_10C4&PID_EA80&REV_0100', 'devicePath': '\\\\?\\hid#vid_10c4&pid_ea80#6&392c7606&5&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}', 'provider': 'usb', 'usbID': 'VID_10C4&PID_EA80', 'vendorID': 4292, 'productID': 60032, 'versionNumber': 256, 'manufacturer': 'Silicon Laboratories', 'product': 'CP2110 HID USB-to-UART Bridge', 'HIDUsagePage': 65280}
```

### Description of how this pull request fixes the issue:
- Use the same approach as other device drivers, relying on `braille.getSerialPorts()`
- Corrects / adds missing type information.

### Testing strategy:
Since I do not have a device, I'll rely on reporters to test this PR.

### Known issues with pull request:
None

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
