### PR TITLE
Fix-up of 12814: Ensure that role label for landmark is once again abbreviated in braille

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -719,7 +719,7 @@ def getControlFieldBraille(  # noqa: C901
 	roleText = field.get('roleTextBraille', field.get('roleText'))
 	landmark = field.get("landmark")
 	if not roleText and role == controlTypes.Role.LANDMARK and landmark:
-		roleText = f"{controlTypes.Role.LANDMARK.displayString} {landmarkLabels[landmark]}"
+		roleText = f"{roleLabels[controlTypes.Role.LANDMARK]} {landmarkLabels[landmark]}"
 
 	content = field.get("content")
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,8 @@ What's New in NVDA
 
 
 == Bug Fixes ==
+- Landmark is once again abbreviated in braille. #13158
+-
 
 
 = 2021.3 =


### PR DESCRIPTION
Opened against beta since this PR fixes regression introduced in 2021.3 development cycle and   including in a point release seems very low risk.

### Link to issue number:
Fixes #13158
### Summary of the issue:
PR #12814 replaced usages of deprecated `controlTypes.roleLabels` with `role.displayString`. However braille has its own mapping of roles to labels which should be used for abbreviations of roles for braille. The role label used for speech has been mistakenly used for a role of landmark.
### Description of how this pull request fixes the issue:
Once again uses braille abbreviation of landmark for landmarks.
### Testing strategy:
Performed STR from #13158 - made sure that 'lmk' is shown on a braille display for landmarks.
### Known issues with pull request:
None known
### Change log entries:
Bug fixes
`- Landmark is once again abbreviated in braille (#13158)`

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
