### PR TITLE
Fix HID after Custom driver

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -146,8 +146,12 @@ def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, Devi
 		# Check for the Braille HID protocol after any other device matching.
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
-		if match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE:
+		if _isHIDBrailleMatch(match):
 			yield ("hid", match)
+
+
+def _isHIDBrailleMatch(match: DeviceMatch) -> bool:
+	return match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE
 
 
 def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str, DeviceMatch]]:
@@ -183,7 +187,7 @@ def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str,
 		# Check for the Braille HID protocol after any other device matching.
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
-		if match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE:
+		if _isHIDBrailleMatch(match):
 			yield ("hid", match)
 
 
@@ -377,7 +381,7 @@ def getConnectedUsbDevicesForDriver(driver) -> Iterable[DeviceMatch]:
 	)
 	for match in usbDevs:
 		if driver == "hid":
-			if match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE:
+			if _isHIDBrailleMatch(match):
 				yield match
 		else:
 			devs = _driverDevices[driver]
@@ -393,8 +397,7 @@ def getPossibleBluetoothDevicesForDriver(driver) -> Iterable[DeviceMatch]:
 	@raise LookupError: If there is no detection data for this driver.
 	"""
 	if driver == "hid":
-		def matchFunc(match):
-			return match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE
+		matchFunc = _isHIDBrailleMatch
 	else:
 		matchFunc = _driverDevices[driver][KEY_BLUETOOTH]
 		if not callable(matchFunc):

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -157,7 +157,7 @@ def _getStandardHidDriverName() -> str:
 	"""Return the name of the standard HID Braille device driver
 	"""
 	import brailleDisplayDrivers.hid
-	return brailleDisplayDrivers.hid.BrailleDisplayDriver.name
+	return brailleDisplayDrivers.hid.HidBrailleDriver.name
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -147,7 +147,17 @@ def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, Devi
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
 		if _isHIDBrailleMatch(match):
-			yield ("hid", match)
+			yield (
+				_getStandardHidDriverName(),
+				match
+			)
+
+
+def _getStandardHidDriverName() -> str:
+	"""Return the name of the standard HID Braille device driver
+	"""
+	import brailleDisplayDrivers.hid
+	return brailleDisplayDrivers.hid.BrailleDisplayDriver.name
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:
@@ -188,7 +198,10 @@ def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str,
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
 		if _isHIDBrailleMatch(match):
-			yield ("hid", match)
+			yield (
+				_getStandardHidDriverName(),
+				match
+			)
 
 
 class _DeviceInfoFetcher(AutoPropertyObject):
@@ -380,7 +393,7 @@ def getConnectedUsbDevicesForDriver(driver) -> Iterable[DeviceMatch]:
 			for port in deviceInfoFetcher.comPorts if "usbID" in port)
 	)
 	for match in usbDevs:
-		if driver == "hid":
+		if driver == _getStandardHidDriverName():
 			if _isHIDBrailleMatch(match):
 				yield match
 		else:
@@ -396,7 +409,7 @@ def getPossibleBluetoothDevicesForDriver(driver) -> Iterable[DeviceMatch]:
 	@return: Port information for each port.
 	@raise LookupError: If there is no detection data for this driver.
 	"""
-	if driver == "hid":
+	if driver == _getStandardHidDriverName():
 		matchFunc = _isHIDBrailleMatch
 	else:
 		matchFunc = _driverDevices[driver][KEY_BLUETOOTH]

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -156,8 +156,8 @@ def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, Devi
 def _getStandardHidDriverName() -> str:
 	"""Return the name of the standard HID Braille device driver
 	"""
-	import brailleDisplayDrivers.hid
-	return brailleDisplayDrivers.hid.HidBrailleDriver.name
+	import brailleDisplayDrivers.hidBrailleStandard
+	return brailleDisplayDrivers.hidBrailleStandard.HidBrailleDriver.name
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:

--- a/source/braille.py
+++ b/source/braille.py
@@ -2258,10 +2258,15 @@ class _BgThread:
 			if cls.exit:
 				break
 
-#: Maps old braille display driver names to new drivers that supersede old drivers.
+
+# Maps old braille display driver names to new drivers that supersede old drivers.
+# Ensure that if a user has set a preferred driver which has changed name, the new
+# user preference is retained.
 RENAMED_DRIVERS = {
-	"syncBraille":"hims",
-	"alvaBC6":"alva"
+	# "oldDriverName": "newDriverName"
+	"syncBraille": "hims",
+	"alvaBC6": "alva",
+	"hid": "hidBrailleStandard",
 }
 
 handler: BrailleHandler

--- a/source/brailleDisplayDrivers/hid.py
+++ b/source/brailleDisplayDrivers/hid.py
@@ -71,7 +71,7 @@ class ButtonCapsInfo:
 	relativeIndexInCollection: int = 0
 
 
-class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+class HidBrailleDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.hid.Hid
 	name = "hid"
 	# Translators: The name of a series of braille displays.
@@ -235,7 +235,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
 
-	source = BrailleDisplayDriver.name
+	source = HidBrailleDriver.name
 
 	def __init__(self, driver, dataIndices):
 		super().__init__()
@@ -307,3 +307,6 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 		# Join the words together as  camelcase.
 		name = "".join(wordList)
 		return name
+
+
+BrailleDisplayDriver = HidBrailleDriver

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -73,7 +73,7 @@ class ButtonCapsInfo:
 
 class HidBrailleDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.hid.Hid
-	name = "hid"
+	name = "hidBrailleStandard"
 	# Translators: The name of a series of braille displays.
 	description = _("Standard HID Braille Display")
 	isThreadSafe = True


### PR DESCRIPTION
### Link to issue number:
#13153

### Summary of the issue:
It was still possible for a standard HID braille driver to take preference over a custom braille driver.

### Description of how this pull request fixes the issue:
Ensure all devices are processed looking for a custom braille driver before reprocessing all devices looking for a standard HID braille driver.

While here I have tried to disambiguate the `hid.BrailleDisplayDriver` class.
- Changing the name of the class should make logging clearer, instead of logging from `BrailleDisplayDriver` logging should come from `HidBrailleDriver`. This class is still mapped to the `BrailleDisplayDriver` name in the module.
- Changing the name of the file / name property on the class, makes it harder to confuse with other usages of "hid" constant (now only `KEY_HID`)
- Rather than yielding a string constant that happens to match the name of the driver, lazy import and expose from the class.

### Testing strategy:
Ask RC users to test again.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
