### PR TITLE
Log `FileNotFoundError` at debug level when querying log-in registry keys

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -240,7 +240,7 @@ def getStartOnLogonScreen() -> bool:
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
 		return bool(winreg.QueryValueEx(k, "startOnLogonScreen")[0])
-	except WindowsError as winError:
+	except WindowsError:
 		log.error("Unable to query registry value for startOnLogonScreen.", exc_info=True)
 		return False
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -200,6 +200,7 @@ def getStartAfterLogon():
 		val = winreg.QueryValueEx(k, u"nvda")[0]
 		return os.stat(val) == os.stat(sys.argv[0])
 	except (WindowsError, OSError):
+		log.error("Unable to query registry value for getStartAfterLogon", exc_info=True)
 		return False
 
 def setStartAfterLogon(enable):
@@ -221,6 +222,7 @@ def setStartAfterLogon(enable):
 		try:
 			winreg.DeleteValue(k, u"nvda")
 		except WindowsError:
+			log.error("Unable to query registry value for setStartAfterLogon", exc_info=True)
 			pass
 
 
@@ -239,7 +241,7 @@ def getStartOnLogonScreen() -> bool:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
 		return bool(winreg.QueryValueEx(k, "startOnLogonScreen")[0])
 	except WindowsError as winError:
-		log.exception(f"Unable to query registry value for startOnLogonScreen. Error: {winError}")
+		log.error("Unable to query registry value for startOnLogonScreen.", exc_info=True)
 		return False
 
 def _setStartOnLogonScreen(enable):

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -231,13 +231,15 @@ SLAVE_FILENAME = os.path.join(globalVars.appDir, "nvda_slave.exe")
 #: Note that NVDA is a 32-bit application, so on X64 systems, this will evaluate to "SOFTWARE\WOW6432Node\nvda"
 NVDA_REGKEY = r"SOFTWARE\NVDA"
 
-def getStartOnLogonScreen():
+
+def getStartOnLogonScreen() -> bool:
 	if easeOfAccess.willAutoStart(winreg.HKEY_LOCAL_MACHINE):
 		return True
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, NVDA_REGKEY)
-		return bool(winreg.QueryValueEx(k, u"startOnLogonScreen")[0])
-	except WindowsError:
+		return bool(winreg.QueryValueEx(k, "startOnLogonScreen")[0])
+	except WindowsError as winError:
+		log.exception(f"Unable to query registry value for startOnLogonScreen. Error: {winError}")
 		return False
 
 def _setStartOnLogonScreen(enable):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixup of #13173 

### Summary of the issue:

The logging of these exceptions was overzealous. If the registry keys have not yet been set, then there is no need for an ERROR level log.

### Description of how this pull request fixes the issue:

Changes the log level for `FileNotFoundError`

### Testing strategy:

Test with PR build and try build

### Known issues with pull request:

None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
