### PR TITLE
Add setting to disable standard hid braille

### DIFF
--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -18,6 +18,14 @@ from hwIo import intToByte
 from bdDetect import HID_USAGE_PAGE_BRAILLE
 
 
+def isSupportEnabled() -> bool:
+	import config
+	return config.conf["braille"]["enableHidBrailleSupport"] in [
+		1,  # yes
+		0,  # Use default/recommended value, currently "yes"
+	]
+
+
 class BraillePageUsageID(enum.IntEnum):
 	UNDEFINED = 0
 	BRAILLE_DISPLAY = 0x1
@@ -77,6 +85,13 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 	# Translators: The name of a series of braille displays.
 	description = _("Standard HID Braille Display")
 	isThreadSafe = True
+
+	@classmethod
+	def check(cls):
+		return (
+			isSupportEnabled()
+			and super().check()
+		)
 
 	def __init__(self, port="auto"):
 		super().__init__()

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -69,6 +69,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	readByParagraph = boolean(default=false)
 	wordWrap = boolean(default=true)
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
+	enableHidBrailleSupport = integer(0, 2, default=0)  # 0:Use default/recommended value (yes), 1:yes, 2:no
 
 	# Braille display driver settings
 	[[__many__]]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2702,6 +2702,42 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
+		label = _("HID Braille Standard")
+		hidBrailleSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		hidBrailleBox = hidBrailleSizer.GetStaticBox()
+		hidBrailleGroup = guiHelper.BoxSizerHelper(self, sizer=hidBrailleSizer)
+		self.bindHelpEvent("HIDBraille", hidBrailleBox)
+		sHelper.addItem(hidBrailleGroup)
+
+		supportHidBrailleChoices = [
+			# Translators: Label for option in the 'Enable support for HID braille' combobox
+			# in the Advanced settings panel.
+			_("Default (Yes)"),
+			# Translators: Label for option in the 'Enable support for HID braille' combobox
+			# in the Advanced settings panel.
+			_("Yes"),
+			# Translators: Label for option in the 'Enable support for HID braille' combobox
+			# in the Advanced settings panel.
+			_("No"),
+		]
+
+		# Translators: This is the label for a checkbox in the
+		#  Advanced settings panel.
+		label = _("Enable support for HID braille")
+		self.supportHidBrailleCheckbox: wx.Choice = hidBrailleGroup.addLabeledControl(
+			labelText=label,
+			wxCtrlClass=wx.Choice,
+			choices=supportHidBrailleChoices,
+		)
+		self.supportHidBrailleCheckbox.SetSelection(
+			config.conf["braille"]["enableHidBrailleSupport"]
+		)
+		self.supportHidBrailleCheckbox.defaultValue = self._getDefaultValue(
+			["braille", "enableHidBrailleSupport"]
+		)
+
+		# Translators: This is the label for a group of advanced options in the
+		#  Advanced settings panel
 		label = _("Terminal programs")
 		terminalsSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
 		terminalsBox = terminalsSizer.GetStaticBox()
@@ -2910,6 +2946,7 @@ class AdvancedPanelControls(
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.annotationsDetailsCheckBox.IsChecked() == self.annotationsDetailsCheckBox.defaultValue
 			and self.ariaDescCheckBox.IsChecked() == self.ariaDescCheckBox.defaultValue
+			and self.supportHidBrailleCheckbox.GetSelection() == self.supportHidBrailleCheckbox.defaultValue
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -2927,6 +2964,7 @@ class AdvancedPanelControls(
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.annotationsDetailsCheckBox.SetValue(self.annotationsDetailsCheckBox.defaultValue)
 		self.ariaDescCheckBox.SetValue(self.ariaDescCheckBox.defaultValue)
+		self.supportHidBrailleCheckbox.SetSelection(self.supportHidBrailleCheckbox.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self._defaultsRestored = True
@@ -2955,6 +2993,8 @@ class AdvancedPanelControls(
 		)
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
+		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCheckbox.GetSelection()
+
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2724,15 +2724,15 @@ class AdvancedPanelControls(
 		# Translators: This is the label for a checkbox in the
 		#  Advanced settings panel.
 		label = _("Enable support for HID braille")
-		self.supportHidBrailleCheckbox: wx.Choice = hidBrailleGroup.addLabeledControl(
+		self.supportHidBrailleCombo: wx.Choice = hidBrailleGroup.addLabeledControl(
 			labelText=label,
 			wxCtrlClass=wx.Choice,
 			choices=supportHidBrailleChoices,
 		)
-		self.supportHidBrailleCheckbox.SetSelection(
+		self.supportHidBrailleCombo.SetSelection(
 			config.conf["braille"]["enableHidBrailleSupport"]
 		)
-		self.supportHidBrailleCheckbox.defaultValue = self._getDefaultValue(
+		self.supportHidBrailleCombo.defaultValue = self._getDefaultValue(
 			["braille", "enableHidBrailleSupport"]
 		)
 
@@ -2946,7 +2946,7 @@ class AdvancedPanelControls(
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.annotationsDetailsCheckBox.IsChecked() == self.annotationsDetailsCheckBox.defaultValue
 			and self.ariaDescCheckBox.IsChecked() == self.ariaDescCheckBox.defaultValue
-			and self.supportHidBrailleCheckbox.GetSelection() == self.supportHidBrailleCheckbox.defaultValue
+			and self.supportHidBrailleCombo.GetSelection() == self.supportHidBrailleCombo.defaultValue
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -2964,7 +2964,7 @@ class AdvancedPanelControls(
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.annotationsDetailsCheckBox.SetValue(self.annotationsDetailsCheckBox.defaultValue)
 		self.ariaDescCheckBox.SetValue(self.ariaDescCheckBox.defaultValue)
-		self.supportHidBrailleCheckbox.SetSelection(self.supportHidBrailleCheckbox.defaultValue)
+		self.supportHidBrailleCombo.SetSelection(self.supportHidBrailleCombo.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self._defaultsRestored = True
@@ -2993,7 +2993,7 @@ class AdvancedPanelControls(
 		)
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
-		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCheckbox.GetSelection()
+		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCombo.GetSelection()
 
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,7 @@ This is a minor release to fix several issues in 2021.3.
 
 == Changes ==
 - The new HID Braille protocol is no longer preferred when another braille display driver can be used. (#13153)
+- The new HID Braille protocol can be disabled via a setting in the advanced settings panel. (#13180)
 -
 
 


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:
Due to the late nature of changes to HID braille support, as a precaution add a work around in case users encounter issues.

### Description of how this pull request fixes the issue:
Allow users to prevent HID braille from being used.

### Testing strategy:
- Locally modified the config via the settings panel.
- Testing via RC

### Known issues with pull request:
None

### Change log entries:
```
Changes
- The new HID Braille protocol can be disabled via a setting in the advanced settings panel.
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
