### PR TITLE
Cherry pick from RC

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -18,6 +18,7 @@ from collections import namedtuple, defaultdict, OrderedDict
 import threading
 from typing import Iterable
 
+import typing
 import wx
 import hwPortUtils
 import braille
@@ -164,13 +165,22 @@ class _DeviceInfoFetcher(AutoPropertyObject):
 	"""Utility class that caches fetched info for available devices for the duration of one core pump cycle."""
 	cachePropertiesByDefault = True
 
-	def _get_comPorts(self):
+	#: Type info for auto property: _get_comPorts
+	comPorts: typing.List[typing.Dict]
+
+	def _get_comPorts(self) -> typing.List[typing.Dict]:
 		return list(hwPortUtils.listComPorts(onlyAvailable=True))
 
-	def _get_usbDevices(self):
+	#: Type info for auto property: _get_usbDevices
+	usbDevices: typing.List[typing.Dict]
+
+	def _get_usbDevices(self) -> typing.List[typing.Dict]:
 		return list(hwPortUtils.listUsbDevices(onlyAvailable=True))
 
-	def _get_hidDevices(self):
+	#: Type info for auto property: _get_hidDevices
+	hidDevices: typing.List[typing.Dict]
+
+	def _get_hidDevices(self) -> typing.List[typing.Dict]:
 		return list(hwPortUtils.listHidDevices(onlyAvailable=True))
 
 #: The single instance of the device info fetcher.
@@ -333,7 +343,8 @@ class Detector(object):
 		core.post_windowMessageReceipt.unregister(self.handleWindowMessage)
 		self._stopBgScan()
 
-def getConnectedUsbDevicesForDriver(driver) -> Iterable[DeviceMatch]:
+
+def getConnectedUsbDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]:
 	"""Get any connected USB devices associated with a particular driver.
 	@param driver: The name of the driver.
 	@type driver: str
@@ -358,7 +369,8 @@ def getConnectedUsbDevicesForDriver(driver) -> Iterable[DeviceMatch]:
 				if match.type == type and match.id in ids:
 					yield match
 
-def getPossibleBluetoothDevicesForDriver(driver) -> Iterable[DeviceMatch]:
+
+def getPossibleBluetoothDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]:
 	"""Get any possible Bluetooth devices associated with a particular driver.
 	@param driver: The name of the driver.
 	@type driver: str
@@ -631,5 +643,10 @@ addUsbDevices("nattiqbraille", KEY_SERIAL, {
 
 # superBrl
 addUsbDevices("superBrl", KEY_SERIAL, {
-	"VID_10C4&PID_EA60", # SuperBraille 3.2
+	"VID_10C4&PID_EA60",  # SuperBraille 3.2
+})
+
+# seika
+addUsbDevices("seikantk", KEY_HID, {
+	"VID_10C4&PID_EA80",  # Seika Notetaker
 })

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -148,7 +148,17 @@ def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, Devi
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
 		if _isHIDBrailleMatch(match):
-			yield ("hid", match)
+			yield (
+				_getStandardHidDriverName(),
+				match
+			)
+
+
+def _getStandardHidDriverName() -> str:
+	"""Return the name of the standard HID Braille device driver
+	"""
+	import brailleDisplayDrivers.hid
+	return brailleDisplayDrivers.hid.BrailleDisplayDriver.name
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:
@@ -189,7 +199,10 @@ def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str,
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
 		if _isHIDBrailleMatch(match):
-			yield ("hid", match)
+			yield (
+				_getStandardHidDriverName(),
+				match
+			)
 
 
 class _DeviceInfoFetcher(AutoPropertyObject):
@@ -391,7 +404,7 @@ def getConnectedUsbDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]:
 			for port in deviceInfoFetcher.comPorts if "usbID" in port)
 	)
 	for match in usbDevs:
-		if driver == "hid":
+		if driver == _getStandardHidDriverName():
 			if _isHIDBrailleMatch(match):
 				yield match
 		else:
@@ -408,7 +421,7 @@ def getPossibleBluetoothDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]
 	@return: Port information for each port.
 	@raise LookupError: If there is no detection data for this driver.
 	"""
-	if driver == "hid":
+	if driver == _getStandardHidDriverName():
 		matchFunc = _isHIDBrailleMatch
 	else:
 		matchFunc = _driverDevices[driver][KEY_BLUETOOTH]

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -157,8 +157,8 @@ def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, Devi
 def _getStandardHidDriverName() -> str:
 	"""Return the name of the standard HID Braille device driver
 	"""
-	import brailleDisplayDrivers.hid
-	return brailleDisplayDrivers.hid.HidBrailleDriver.name
+	import brailleDisplayDrivers.hidBrailleStandard
+	return brailleDisplayDrivers.hidBrailleStandard.HidBrailleDriver.name
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -14,6 +14,7 @@ For drivers in add-ons, this must be done in a global plugin.
 """
 
 import itertools
+import typing
 from collections import namedtuple, defaultdict, OrderedDict
 import threading
 from typing import Iterable
@@ -110,24 +111,39 @@ def addBluetoothDevices(driver, matchFunc):
 	devs = _getDriver(driver)
 	devs[KEY_BLUETOOTH] = matchFunc
 
-def getDriversForConnectedUsbDevices():
+
+def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, DeviceMatch]]:
 	"""Get any matching drivers for connected USB devices.
-	@return: Pairs of drivers and device information.
-	@rtype: generator of (str, L{DeviceMatch}) tuples
+	Looks for (and yields) custom drivers first, then considers if the device is may be compatible with the
+	Standard HID Braille spec.
+	@return: Generator of pairs of drivers and device information.
 	"""
-	usbDevs = itertools.chain(
-		(DeviceMatch(KEY_CUSTOM, port["usbID"], port["devicePath"], port)
-			for port in deviceInfoFetcher.usbDevices),
-		(DeviceMatch(KEY_HID, port["usbID"], port["devicePath"], port)
-			for port in deviceInfoFetcher.hidDevices if port["provider"]=="usb"),
-		(DeviceMatch(KEY_SERIAL, port["usbID"], port["port"], port)
-			for port in deviceInfoFetcher.comPorts if "usbID" in port)
+	usbCustomDeviceMatches = (
+		DeviceMatch(KEY_CUSTOM, port["usbID"], port["devicePath"], port)
+		for port in deviceInfoFetcher.usbDevices
 	)
-	for match in usbDevs:
+	usbComDeviceMatches = (
+		DeviceMatch(KEY_SERIAL, port["usbID"], port["port"], port)
+		for port in deviceInfoFetcher.comPorts
+		if "usbID" in port
+	)
+	# Tee is used to ensure that the DeviceMatches aren't created multiple times.
+	# The processing of these HID device matches, looking for a custom driver, means that all
+	# HID device matches are created, and by teeing the output the matches don't need to be created again.
+	# The corollary is that clients of this method don't have to process all devices (and create all
+	# device matches), if one is found early the iteration can stop.
+	usbHidDeviceMatches, usbHidDeviceMatchesForCustom = itertools.tee((
+		DeviceMatch(KEY_HID, port["usbID"], port["devicePath"], port)
+		for port in deviceInfoFetcher.hidDevices
+		if port["provider"] == "usb"
+	))
+	for match in itertools.chain(usbCustomDeviceMatches, usbHidDeviceMatchesForCustom, usbComDeviceMatches):
 		for driver, devs in _driverDevices.items():
 			for type, ids in devs.items():
 				if match.type==type and match.id in ids:
 					yield driver, match
+
+	for match in usbHidDeviceMatches:
 		# Check for the Braille HID protocol after any other device matching.
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
@@ -135,25 +151,36 @@ def getDriversForConnectedUsbDevices():
 			yield ("hid", match)
 
 
-def getDriversForPossibleBluetoothDevices():
+def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str, DeviceMatch]]:
 	"""Get any matching drivers for possible Bluetooth devices.
-	@return: Pairs of drivers and port information.
-	@rtype: generator of (str, L{DeviceMatch}) tuples
+	Looks for (and yields) custom drivers first, then considers if the device is may be compatible with the
+	Standard HID Braille spec.
+	@return: Generator of pairs of drivers and port information.
 	"""
-	btDevs = itertools.chain(
-		(DeviceMatch(KEY_SERIAL, port["bluetoothName"], port["port"], port)
-			for port in deviceInfoFetcher.comPorts
-			if "bluetoothName" in port),
-		(DeviceMatch(KEY_HID, port["hardwareID"], port["devicePath"], port)
-			for port in deviceInfoFetcher.hidDevices if port["provider"]=="bluetooth"),
+	btSerialMatchesForCustom = (
+		DeviceMatch(KEY_SERIAL, port["bluetoothName"], port["port"], port)
+		for port in deviceInfoFetcher.comPorts
+		if "bluetoothName" in port
 	)
-	for match in btDevs:
+	# Tee is used to ensure that the DeviceMatches aren't created multiple times.
+	# The processing of these HID device matches, looking for a custom driver, means that all
+	# HID device matches are created, and by teeing the output the matches don't need to be created again.
+	# The corollary is that clients of this method don't have to process all devices (and create all
+	# device matches), if one is found early the iteration can stop.
+	btHidDevMatchesForHid, btHidDevMatchesForCustom = itertools.tee((
+		DeviceMatch(KEY_HID, port["hardwareID"], port["devicePath"], port)
+		for port in deviceInfoFetcher.hidDevices
+		if port["provider"] == "bluetooth"
+	))
+	for match in itertools.chain(btSerialMatchesForCustom, btHidDevMatchesForCustom):
 		for driver, devs in _driverDevices.items():
 			matchFunc = devs[KEY_BLUETOOTH]
 			if not callable(matchFunc):
 				continue
 			if matchFunc(match):
 				yield driver, match
+
+	for match in btHidDevMatchesForHid:
 		# Check for the Braille HID protocol after any other device matching.
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -158,7 +158,7 @@ def _getStandardHidDriverName() -> str:
 	"""Return the name of the standard HID Braille device driver
 	"""
 	import brailleDisplayDrivers.hid
-	return brailleDisplayDrivers.hid.BrailleDisplayDriver.name
+	return brailleDisplayDrivers.hid.HidBrailleDriver.name
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -147,8 +147,12 @@ def getDriversForConnectedUsbDevices() -> typing.Iterator[typing.Tuple[str, Devi
 		# Check for the Braille HID protocol after any other device matching.
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
-		if match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE:
+		if _isHIDBrailleMatch(match):
 			yield ("hid", match)
+
+
+def _isHIDBrailleMatch(match: DeviceMatch) -> bool:
+	return match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE
 
 
 def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str, DeviceMatch]]:
@@ -184,7 +188,7 @@ def getDriversForPossibleBluetoothDevices() -> typing.Iterator[typing.Tuple[str,
 		# Check for the Braille HID protocol after any other device matching.
 		# This ensures that a vendor specific driver is preferred over the braille HID protocol.
 		# This preference may change in the future.
-		if match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE:
+		if _isHIDBrailleMatch(match):
 			yield ("hid", match)
 
 
@@ -388,7 +392,7 @@ def getConnectedUsbDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]:
 	)
 	for match in usbDevs:
 		if driver == "hid":
-			if match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE:
+			if _isHIDBrailleMatch(match):
 				yield match
 		else:
 			devs = _driverDevices[driver]
@@ -405,8 +409,7 @@ def getPossibleBluetoothDevicesForDriver(driver) -> typing.Iterator[DeviceMatch]
 	@raise LookupError: If there is no detection data for this driver.
 	"""
 	if driver == "hid":
-		def matchFunc(match):
-			return match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE
+		matchFunc = _isHIDBrailleMatch
 	else:
 		matchFunc = _driverDevices[driver][KEY_BLUETOOTH]
 		if not callable(matchFunc):

--- a/source/braille.py
+++ b/source/braille.py
@@ -2258,10 +2258,15 @@ class _BgThread:
 			if cls.exit:
 				break
 
-#: Maps old braille display driver names to new drivers that supersede old drivers.
+
+# Maps old braille display driver names to new drivers that supersede old drivers.
+# Ensure that if a user has set a preferred driver which has changed name, the new
+# user preference is retained.
 RENAMED_DRIVERS = {
-	"syncBraille":"hims",
-	"alvaBC6":"alva"
+	# "oldDriverName": "newDriverName"
+	"syncBraille": "hims",
+	"alvaBC6": "alva",
+	"hid": "hidBrailleStandard",
 }
 
 handler: BrailleHandler

--- a/source/braille.py
+++ b/source/braille.py
@@ -2454,11 +2454,11 @@ class BrailleDisplayDriver(driverHandler.Driver):
 			pass
 
 	@classmethod
-	def getManualPorts(cls) -> Iterable[str]:
+	def getManualPorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
 		"""Get possible manual hardware ports for this driver.
 		This is for ports which cannot be detected automatically
 		such as serial ports.
-		@return: The name and description for each port.
+		@return: An iterator containing the name and description for each port.
 		"""
 		raise NotImplementedError
 
@@ -2723,7 +2723,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 inputCore.registerGestureSource("br", BrailleDisplayGesture)
 
 
-def getSerialPorts(filterFunc=None):
+def getSerialPorts(filterFunc=None) -> typing.Iterator[typing.Tuple[str, str]]:
 	"""Get available serial ports in a format suitable for L{BrailleDisplayDriver.getManualPorts}.
 	@param filterFunc: a function executed on every dictionary retrieved using L{hwPortUtils.listComPorts}.
 		For example, this can be used to filter by USB or Bluetooth com ports.

--- a/source/brailleDisplayDrivers/hid.py
+++ b/source/brailleDisplayDrivers/hid.py
@@ -71,7 +71,7 @@ class ButtonCapsInfo:
 	relativeIndexInCollection: int = 0
 
 
-class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+class HidBrailleDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.hid.Hid
 	name = "hid"
 	# Translators: The name of a series of braille displays.
@@ -235,7 +235,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
 
-	source = BrailleDisplayDriver.name
+	source = HidBrailleDriver.name
 
 	def __init__(self, driver, dataIndices):
 		super().__init__()
@@ -307,3 +307,6 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 		# Join the words together as  camelcase.
 		name = "".join(wordList)
 		return name
+
+
+BrailleDisplayDriver = HidBrailleDriver

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -18,6 +18,14 @@ from hwIo import intToByte
 from bdDetect import HID_USAGE_PAGE_BRAILLE
 
 
+def isSupportEnabled() -> bool:
+	import config
+	return config.conf["braille"]["enableHidBrailleSupport"] in [
+		1,  # yes
+		0,  # Use default/recommended value, currently "yes"
+	]
+
+
 class BraillePageUsageID(enum.IntEnum):
 	UNDEFINED = 0
 	BRAILLE_DISPLAY = 0x1
@@ -77,6 +85,13 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 	# Translators: The name of a series of braille displays.
 	description = _("Standard HID Braille Display")
 	isThreadSafe = True
+
+	@classmethod
+	def check(cls):
+		return (
+			isSupportEnabled()
+			and super().check()
+		)
 
 	def __init__(self, port="auto"):
 		super().__init__()

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -73,7 +73,7 @@ class ButtonCapsInfo:
 
 class HidBrailleDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.hid.Hid
-	name = "hid"
+	name = "hidBrailleStandard"
 	# Translators: The name of a series of braille displays.
 	description = _("Standard HID Braille Display")
 	isThreadSafe = True

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -64,8 +64,6 @@ vidpid = "VID_10C4&PID_EA80"
 hidvidpid = "HID\\VID_10C4&PID_EA80"
 SEIKA_NAME = "seikantk"
 
-bdDetect.addUsbDevices(SEIKA_NAME, bdDetect.KEY_HID, {vidpid, })
-
 
 class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.IoBase
@@ -79,12 +77,10 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			path = d["devicePath"]
 
 	@classmethod
-	def check(cls):
-		return True
-
-	@classmethod
-	def getManualPorts(cls):
-		return cls.path
+	def getManualPorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
+		"""@return: An iterator containing the name and description for each port.
+		"""
+		return braille.getSerialPorts()
 
 	def __init__(self, port="hid"):
 		super().__init__()

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -69,6 +69,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	readByParagraph = boolean(default=false)
 	wordWrap = boolean(default=true)
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
+	enableHidBrailleSupport = integer(0, 2, default=0)  # 0:Use default/recommended value (yes), 1:yes, 2:no
 
 	# Braille display driver settings
 	[[__many__]]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2702,6 +2702,42 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
+		label = _("HID Braille Standard")
+		hidBrailleSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		hidBrailleBox = hidBrailleSizer.GetStaticBox()
+		hidBrailleGroup = guiHelper.BoxSizerHelper(self, sizer=hidBrailleSizer)
+		self.bindHelpEvent("HIDBraille", hidBrailleBox)
+		sHelper.addItem(hidBrailleGroup)
+
+		supportHidBrailleChoices = [
+			# Translators: Label for option in the 'Enable support for HID braille' combobox
+			# in the Advanced settings panel.
+			_("Default (Yes)"),
+			# Translators: Label for option in the 'Enable support for HID braille' combobox
+			# in the Advanced settings panel.
+			_("Yes"),
+			# Translators: Label for option in the 'Enable support for HID braille' combobox
+			# in the Advanced settings panel.
+			_("No"),
+		]
+
+		# Translators: This is the label for a checkbox in the
+		#  Advanced settings panel.
+		label = _("Enable support for HID braille")
+		self.supportHidBrailleCombo: wx.Choice = hidBrailleGroup.addLabeledControl(
+			labelText=label,
+			wxCtrlClass=wx.Choice,
+			choices=supportHidBrailleChoices,
+		)
+		self.supportHidBrailleCombo.SetSelection(
+			config.conf["braille"]["enableHidBrailleSupport"]
+		)
+		self.supportHidBrailleCombo.defaultValue = self._getDefaultValue(
+			["braille", "enableHidBrailleSupport"]
+		)
+
+		# Translators: This is the label for a group of advanced options in the
+		#  Advanced settings panel
 		label = _("Terminal programs")
 		terminalsSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
 		terminalsBox = terminalsSizer.GetStaticBox()
@@ -2910,6 +2946,7 @@ class AdvancedPanelControls(
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.annotationsDetailsCheckBox.IsChecked() == self.annotationsDetailsCheckBox.defaultValue
 			and self.ariaDescCheckBox.IsChecked() == self.ariaDescCheckBox.defaultValue
+			and self.supportHidBrailleCombo.GetSelection() == self.supportHidBrailleCombo.defaultValue
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -2927,6 +2964,7 @@ class AdvancedPanelControls(
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.annotationsDetailsCheckBox.SetValue(self.annotationsDetailsCheckBox.defaultValue)
 		self.ariaDescCheckBox.SetValue(self.ariaDescCheckBox.defaultValue)
+		self.supportHidBrailleCombo.SetSelection(self.supportHidBrailleCombo.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self._defaultsRestored = True
@@ -2955,6 +2993,8 @@ class AdvancedPanelControls(
 		)
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
+		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCombo.GetSelection()
+
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -8,6 +8,7 @@
 
 import itertools
 import ctypes
+import typing
 from ctypes.wintypes import BOOL, WCHAR, HWND, DWORD, ULONG, WORD, USHORT
 import winreg
 import winKernel
@@ -124,12 +125,13 @@ DIREG_DEV = 0x00000001
 def _isDebug():
 	return config.conf["debugLog"]["hwIo"]
 
-def listComPorts(onlyAvailable=True):
+
+# C901 'listComPorts' is too complex. Look for opportunities to break this method down.
+def listComPorts(onlyAvailable=True) -> typing.Iterator[typing.Dict]:  # noqa: C901
 	"""List com ports on the system.
 	@param onlyAvailable: Only return ports that are currently available.
 	@type onlyAvailable: bool
 	@return: Dicts including keys of port, friendlyName and hardwareID.
-	@rtype: generator of dict
 	"""
 	flags = DIGCF_DEVICEINTERFACE
 	if onlyAvailable:
@@ -334,12 +336,12 @@ def getWidcommBluetoothPortInfo(port):
 				return addr, name
 	raise LookupError
 
-def listUsbDevices(onlyAvailable=True):
+
+def listUsbDevices(onlyAvailable=True) -> typing.Iterator[typing.Dict]:
 	"""List USB devices on the system.
 	@param onlyAvailable: Only return devices that are currently available.
 	@type onlyAvailable: bool
 	@return: Generates dicts including keys of usbID (VID and PID), devicePath and hardwareID.
-	@rtype: generator of dict
 	"""
 	flags = DIGCF_DEVICEINTERFACE
 	if onlyAvailable:
@@ -483,14 +485,15 @@ def _getHidInfo(hwId, path):
 	return info
 
 _hidGuid = None
-def listHidDevices(onlyAvailable=True):
+
+
+def listHidDevices(onlyAvailable=True) -> typing.Iterator[typing.Dict]:
 	"""List HID devices on the system.
 	@param onlyAvailable: Only return devices that are currently available.
 	@type onlyAvailable: bool
 	@return: Generates dicts including keys such as hardwareID,
 		usbID (in the form "VID_xxxx&PID_xxxx")
 		and devicePath.
-	@rtype: generator of dict
 	"""
 	global _hidGuid
 	if not _hidGuid:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,7 @@ This is a minor release to fix several issues in 2021.3.
 
 == Changes ==
 - The new HID Braille protocol is no longer preferred when another braille display driver can be used. (#13153)
+- The new HID Braille protocol can be disabled via a setting in the advanced settings panel. (#13180)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,8 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2021.3.1 =
+This is a minor release to fix several issues in 2021.3.
+
 
 == Changes ==
 - The new HID Braille protocol is no longer preferred when another braille display driver can be used. (#13153)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Initially changes for the point release were delivered to beta, subsequently it was decided to avoid complications with translations, to make changes directly on RC.
The changes were cherry picked from beta.
There were then several more changes made squashed / merged to RC
These changes need to be cherry picked back into the beta branch.

### Description of how this pull request fixes the issue:
- Cherry pick (and recreate one merge) changes on RC not on Beta
- Fast forward beta to the head of this branch 

### Testing strategy:
Check that the diff between the release tag an this branch is only the translations (already on beta):
```
git diff release-2021.3.1 --stat
 source/locale/de/LC_MESSAGES/nvda.po |   20 +-
 source/locale/de/symbols.dic         |    6 +-
 source/locale/fr/symbols.dic         |    1 +
 source/locale/ka/symbols.dic         |  156 +-
 source/locale/sl/LC_MESSAGES/nvda.po | 9621 ++++++++++++++++++----------------
 source/locale/sl/symbols.dic         |  602 ++-
 source/locale/tr/LC_MESSAGES/nvda.po |   35 +-
 source/locale/vi/LC_MESSAGES/nvda.po |    8 +-
 source/locale/zh_CN/symbols.dic      |  200 +-
 user_docs/tr/userGuide.t2t           |   12 +-
 user_docs/vi/changes.t2t             |    2 +-
 user_docs/zh_CN/userGuide.t2t        |    2 +-
 user_docs/zh_TW/userGuide.t2t        |    2 +-
 13 files changed, 5745 insertions(+), 4922 deletions(-)
```

### Known issues with pull request:
- RC will need to be reset to beta prior to the next release.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
