### PR TITLE
add bluetooth support for seika notetaker

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -474,8 +474,8 @@ def driverSupportsAutoDetection(driver):
 	return driver in _driverDevices
 
 
-def initialiseDetectionData():
-	""" Initialise detection data.
+def initializeDetectionData():
+	""" Initialize detection data.
 	Calls to addUsbDevices, and addBluetoothDevices.
 	Specify the requirements for a detected device to be considered a
 	match for a specific driver.

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -473,241 +473,258 @@ def driverSupportsAutoDetection(driver):
 	"""
 	return driver in _driverDevices
 
-### Detection data
-# alva
-addUsbDevices("alva", KEY_HID, {
-	"VID_0798&PID_0640", # BC640
-	"VID_0798&PID_0680", # BC680
-	"VID_0798&PID_0699", # USB protocol converter
-})
 
-addBluetoothDevices("alva", lambda m: m.id.startswith("ALVA "))
+def initialiseDetectionData():
+	""" Initialise detection data.
+	Calls to addUsbDevices, and addBluetoothDevices.
+	Specify the requirements for a detected device to be considered a
+	match for a specific driver.
+	"""
+	# alva
+	addUsbDevices("alva", KEY_HID, {
+		"VID_0798&PID_0640",  # BC640
+		"VID_0798&PID_0680",  # BC680
+		"VID_0798&PID_0699",  # USB protocol converter
+	})
 
-# baum
-addUsbDevices("baum", KEY_HID, {
-	"VID_0904&PID_3001", # RefreshaBraille 18
-	"VID_0904&PID_6101", # VarioUltra 20
-	"VID_0904&PID_6103", # VarioUltra 32
-	"VID_0904&PID_6102", # VarioUltra 40
-	"VID_0904&PID_4004", # Pronto! 18 V3
-	"VID_0904&PID_4005", # Pronto! 40 V3
-	"VID_0904&PID_4007", # Pronto! 18 V4
-	"VID_0904&PID_4008", # Pronto! 40 V4
-	"VID_0904&PID_6001", # SuperVario2 40
-	"VID_0904&PID_6002", # SuperVario2 24
-	"VID_0904&PID_6003", # SuperVario2 32
-	"VID_0904&PID_6004", # SuperVario2 64
-	"VID_0904&PID_6005", # SuperVario2 80
-	"VID_0904&PID_6006", # Brailliant2 40
-	"VID_0904&PID_6007", # Brailliant2 24
-	"VID_0904&PID_6008", # Brailliant2 32
-	"VID_0904&PID_6009", # Brailliant2 64
-	"VID_0904&PID_600A", # Brailliant2 80
-	"VID_0904&PID_6201", # Vario 340
-	"VID_0483&PID_A1D3", # Orbit Reader 20
-	"VID_0904&PID_6301",  # Vario 4
-})
+	addBluetoothDevices("alva", lambda m: m.id.startswith("ALVA "))
 
-addUsbDevices("baum", KEY_SERIAL, {
-	"VID_0403&PID_FE70", # Vario 40
-	"VID_0403&PID_FE71", # PocketVario
-	"VID_0403&PID_FE72", # SuperVario/Brailliant 40
-	"VID_0403&PID_FE73", # SuperVario/Brailliant 32
-	"VID_0403&PID_FE74", # SuperVario/Brailliant 64
-	"VID_0403&PID_FE75", # SuperVario/Brailliant 80
-	"VID_0904&PID_2001", # EcoVario 24
-	"VID_0904&PID_2002", # EcoVario 40
-	"VID_0904&PID_2007", # VarioConnect/BrailleConnect 40
-	"VID_0904&PID_2008", # VarioConnect/BrailleConnect 32
-	"VID_0904&PID_2009", # VarioConnect/BrailleConnect 24
-	"VID_0904&PID_2010", # VarioConnect/BrailleConnect 64
-	"VID_0904&PID_2011", # VarioConnect/BrailleConnect 80
-	"VID_0904&PID_2014", # EcoVario 32
-	"VID_0904&PID_2015", # EcoVario 64
-	"VID_0904&PID_2016", # EcoVario 80
-	"VID_0904&PID_3000", # RefreshaBraille 18
-})
+	# baum
+	addUsbDevices("baum", KEY_HID, {
+		"VID_0904&PID_3001",  # RefreshaBraille 18
+		"VID_0904&PID_6101",  # VarioUltra 20
+		"VID_0904&PID_6103",  # VarioUltra 32
+		"VID_0904&PID_6102",  # VarioUltra 40
+		"VID_0904&PID_4004",  # Pronto! 18 V3
+		"VID_0904&PID_4005",  # Pronto! 40 V3
+		"VID_0904&PID_4007",  # Pronto! 18 V4
+		"VID_0904&PID_4008",  # Pronto! 40 V4
+		"VID_0904&PID_6001",  # SuperVario2 40
+		"VID_0904&PID_6002",  # SuperVario2 24
+		"VID_0904&PID_6003",  # SuperVario2 32
+		"VID_0904&PID_6004",  # SuperVario2 64
+		"VID_0904&PID_6005",  # SuperVario2 80
+		"VID_0904&PID_6006",  # Brailliant2 40
+		"VID_0904&PID_6007",  # Brailliant2 24
+		"VID_0904&PID_6008",  # Brailliant2 32
+		"VID_0904&PID_6009",  # Brailliant2 64
+		"VID_0904&PID_600A",  # Brailliant2 80
+		"VID_0904&PID_6201",  # Vario 340
+		"VID_0483&PID_A1D3",  # Orbit Reader 20
+		"VID_0904&PID_6301",  # Vario 4
+	})
 
-addBluetoothDevices("baum", lambda m: any(m.id.startswith(prefix) for prefix in (
-	"Baum SuperVario",
-	"Baum PocketVario",
-	"Baum SVario",
-	"HWG Brailliant",
-	"Refreshabraille",
-	"VarioConnect",
-	"BrailleConnect",
-	"Pronto!",
-	"VarioUltra",
-	"Orbit Reader 20",
-	"Vario 4",
-)))
+	addUsbDevices("baum", KEY_SERIAL, {
+		"VID_0403&PID_FE70",  # Vario 40
+		"VID_0403&PID_FE71",  # PocketVario
+		"VID_0403&PID_FE72",  # SuperVario/Brailliant 40
+		"VID_0403&PID_FE73",  # SuperVario/Brailliant 32
+		"VID_0403&PID_FE74",  # SuperVario/Brailliant 64
+		"VID_0403&PID_FE75",  # SuperVario/Brailliant 80
+		"VID_0904&PID_2001",  # EcoVario 24
+		"VID_0904&PID_2002",  # EcoVario 40
+		"VID_0904&PID_2007",  # VarioConnect/BrailleConnect 40
+		"VID_0904&PID_2008",  # VarioConnect/BrailleConnect 32
+		"VID_0904&PID_2009",  # VarioConnect/BrailleConnect 24
+		"VID_0904&PID_2010",  # VarioConnect/BrailleConnect 64
+		"VID_0904&PID_2011",  # VarioConnect/BrailleConnect 80
+		"VID_0904&PID_2014",  # EcoVario 32
+		"VID_0904&PID_2015",  # EcoVario 64
+		"VID_0904&PID_2016",  # EcoVario 80
+		"VID_0904&PID_3000",  # RefreshaBraille 18
+	})
 
-# brailleNote
-addUsbDevices("brailleNote", KEY_SERIAL, {
-	"VID_1C71&PID_C004", # Apex
-})
-addBluetoothDevices("brailleNote", lambda m:
-	any(first <= m.deviceInfo.get("bluetoothAddress",0) <= last for first, last in (
-		(0x0025EC000000, 0x0025EC01869F), # Apex
-	)) or m.id.startswith("Braillenote"))
+	addBluetoothDevices("baum", lambda m: any(m.id.startswith(prefix) for prefix in (
+		"Baum SuperVario",
+		"Baum PocketVario",
+		"Baum SVario",
+		"HWG Brailliant",
+		"Refreshabraille",
+		"VarioConnect",
+		"BrailleConnect",
+		"Pronto!",
+		"VarioUltra",
+		"Orbit Reader 20",
+		"Vario 4",
+	)))
 
-# brailliantB
-addUsbDevices("brailliantB", KEY_HID, {
-	"VID_1C71&PID_C111",  # Mantis Q 40
-	"VID_1C71&PID_C101",  # Chameleon 20
-	"VID_1C71&PID_C121",  # Humanware BrailleOne 20 HID
-	"VID_1C71&PID_CE01",  # NLS eReader 20 HID
-	"VID_1C71&PID_C006", # Brailliant BI 32, 40 and 80
-	"VID_1C71&PID_C022", # Brailliant BI 14
-	"VID_1C71&PID_C131",  # Brailliant BI 40X
-	"VID_1C71&PID_C141",  # Brailliant BI 20X
-	"VID_1C71&PID_C00A", # BrailleNote Touch
-	"VID_1C71&PID_C00E",  # BrailleNote Touch v2
-})
-addUsbDevices("brailliantB", KEY_SERIAL, {
-	"VID_1C71&PID_C005", # Brailliant BI 32, 40 and 80
-	"VID_1C71&PID_C021", # Brailliant BI 14
-})
-addBluetoothDevices(
-	"brailliantB", lambda m: (
-		m.type == KEY_SERIAL
-		and (
-			m.id.startswith("Brailliant B")
-			or m.id == "Brailliant 80"
-			or "BrailleNote Touch" in m.id
+	# brailleNote
+	addUsbDevices("brailleNote", KEY_SERIAL, {
+		"VID_1C71&PID_C004",  # Apex
+	})
+	addBluetoothDevices("brailleNote", lambda m: (
+		any(
+			first <= m.deviceInfo.get("bluetoothAddress", 0) <= last
+			for first, last in (
+				(0x0025EC000000, 0x0025EC01869F),  # Apex
+			)
+		)
+		or m.id.startswith("Braillenote")
+	))
+
+	# brailliantB
+	addUsbDevices("brailliantB", KEY_HID, {
+		"VID_1C71&PID_C111",  # Mantis Q 40
+		"VID_1C71&PID_C101",  # Chameleon 20
+		"VID_1C71&PID_C121",  # Humanware BrailleOne 20 HID
+		"VID_1C71&PID_CE01",  # NLS eReader 20 HID
+		"VID_1C71&PID_C006",  # Brailliant BI 32, 40 and 80
+		"VID_1C71&PID_C022",  # Brailliant BI 14
+		"VID_1C71&PID_C131",  # Brailliant BI 40X
+		"VID_1C71&PID_C141",  # Brailliant BI 20X
+		"VID_1C71&PID_C00A",  # BrailleNote Touch
+		"VID_1C71&PID_C00E",  # BrailleNote Touch v2
+	})
+	addUsbDevices("brailliantB", KEY_SERIAL, {
+		"VID_1C71&PID_C005",  # Brailliant BI 32, 40 and 80
+		"VID_1C71&PID_C021",  # Brailliant BI 14
+	})
+	addBluetoothDevices(
+		"brailliantB", lambda m: (
+			m.type == KEY_SERIAL
+			and (
+				m.id.startswith("Brailliant B")
+				or m.id == "Brailliant 80"
+				or "BrailleNote Touch" in m.id
+			)
+		)
+		or (
+			m.type == KEY_HID
+			and m.deviceInfo.get("manufacturer") == "Humanware"
+			and m.deviceInfo.get("product") in (
+				"Brailliant HID",
+				"APH Chameleon 20",
+				"APH Mantis Q40",
+				"Humanware BrailleOne",
+				"NLS eReader",
+				"NLS eReader Humanware",
+				"Brailliant BI 40X",
+				"Brailliant BI 20X",
+			)
 		)
 	)
-	or (
-		m.type == KEY_HID
-		and m.deviceInfo.get("manufacturer") == "Humanware"
-		and m.deviceInfo.get("product") in (
-			"Brailliant HID",
-			"APH Chameleon 20",
-			"APH Mantis Q40",
-			"Humanware BrailleOne",
-			"NLS eReader",
-			"NLS eReader Humanware",
-			"Brailliant BI 40X",
-			"Brailliant BI 20X",
+
+	# eurobraille
+	addUsbDevices("eurobraille", KEY_HID, {
+		"VID_C251&PID_1122",  # Esys (version < 3.0, no SD card
+		"VID_C251&PID_1123",  # Esys (version >= 3.0, with HID keyboard, no SD card
+		"VID_C251&PID_1124",  # Esys (version < 3.0, with SD card
+		"VID_C251&PID_1125",  # Esys (version >= 3.0, with HID keyboard, with SD card
+		"VID_C251&PID_1126",  # Esys (version >= 3.0, no SD card
+		"VID_C251&PID_1127",  # Reserved
+		"VID_C251&PID_1128",  # Esys (version >= 3.0, with SD card
+		"VID_C251&PID_1129",  # Reserved
+		"VID_C251&PID_112A",  # Reserved
+		"VID_C251&PID_112B",  # Reserved
+		"VID_C251&PID_112C",  # Reserved
+		"VID_C251&PID_112D",  # Reserved
+		"VID_C251&PID_112E",  # Reserved
+		"VID_C251&PID_112F",  # Reserved
+		"VID_C251&PID_1130",  # Esytime
+		"VID_C251&PID_1131",  # Reserved
+		"VID_C251&PID_1132",  # Reserved
+	})
+
+	addBluetoothDevices("eurobraille", lambda m: m.id.startswith("Esys"))
+
+	# freedomScientific
+	addUsbDevices("freedomScientific", KEY_CUSTOM, {
+		"VID_0F4E&PID_0100",  # Focus 1
+		"VID_0F4E&PID_0111",  # PAC Mate
+		"VID_0F4E&PID_0112",  # Focus 2
+		"VID_0F4E&PID_0114",  # Focus Blue
+	})
+
+	addBluetoothDevices("freedomScientific", lambda m: (
+		any(
+			m.id.startswith(prefix)
+			for prefix in (
+				"F14", "Focus 14 BT",
+				"Focus 40 BT",
+				"Focus 80 BT",
+			)
 		)
+	))
+
+	# handyTech
+	addUsbDevices("handyTech", KEY_SERIAL, {
+		"VID_0403&PID_6001",  # FTDI chip
+		"VID_0921&PID_1200",  # GoHubs chip
+	})
+
+	# Newer Handy Tech displays have a native HID processor
+	addUsbDevices("handyTech", KEY_HID, {
+		"VID_1FE4&PID_0054",  # Active Braille
+		"VID_1FE4&PID_0055",  # Connect Braille
+		"VID_1FE4&PID_0061",  # Actilino
+		"VID_1FE4&PID_0064",  # Active Star 40
+		"VID_1FE4&PID_0081",  # Basic Braille 16
+		"VID_1FE4&PID_0082",  # Basic Braille 20
+		"VID_1FE4&PID_0083",  # Basic Braille 32
+		"VID_1FE4&PID_0084",  # Basic Braille 40
+		"VID_1FE4&PID_008A",  # Basic Braille 48
+		"VID_1FE4&PID_0086",  # Basic Braille 64
+		"VID_1FE4&PID_0087",  # Basic Braille 80
+		"VID_1FE4&PID_008B",  # Basic Braille 160
+		"VID_1FE4&PID_008C",  # Basic Braille 84
+		"VID_1FE4&PID_0093",  # Basic Braille Plus 32
+		"VID_1FE4&PID_0094",  # Basic Braille Plus 40
+	})
+
+	# Some older HT displays use a HID converter and an internal serial interface
+	addUsbDevices("handyTech", KEY_HID, {
+		"VID_1FE4&PID_0003",  # USB-HID adapter
+		"VID_1FE4&PID_0074",  # Braille Star 40
+		"VID_1FE4&PID_0044",  # Easy Braille
+	})
+
+	addBluetoothDevices("handyTech", lambda m: any(m.id.startswith(prefix) for prefix in (
+		"Actilino AL",
+		"Active Braille AB",
+		"Active Star AS",
+		"Basic Braille BB",
+		"Basic Braille Plus BP",
+		"Braille Star 40 BS",
+		"Braillino BL",
+		"Braille Wave BW",
+		"Easy Braille EBR",
+	)))
+
+	# hims
+	# Bulk devices
+	addUsbDevices("hims", KEY_CUSTOM, {
+		"VID_045E&PID_930A",  # Braille Sense & Smart Beetle
+		"VID_045E&PID_930B",  # Braille EDGE 40
+	})
+
+	# Sync Braille, serial device
+	addUsbDevices("hims", KEY_SERIAL, {
+		"VID_0403&PID_6001",
+	})
+
+	addBluetoothDevices("hims", lambda m: any(m.id.startswith(prefix) for prefix in (
+		"BrailleSense",
+		"BrailleEDGE",
+		"SmartBeetle",
+	)))
+
+	# NattiqBraille
+	addUsbDevices("nattiqbraille", KEY_SERIAL, {
+		"VID_2341&PID_8036",  # Atmel-based USB Serial for Nattiq nBraille
+	})
+
+	# superBrl
+	addUsbDevices("superBrl", KEY_SERIAL, {
+		"VID_10C4&PID_EA60",  # SuperBraille 3.2
+	})
+
+	# seika
+	addUsbDevices("seikantk", KEY_HID, {
+		"VID_10C4&PID_EA80",  # Seika Notetaker
+	})
+
+	from brailleDisplayDrivers.seikantk import isSeikaBluetoothDeviceMatch
+	addBluetoothDevices(
+		"seikantk",
+		isSeikaBluetoothDeviceMatch
 	)
-)
-
-# eurobraille
-addUsbDevices("eurobraille", KEY_HID, {
-	"VID_C251&PID_1122", # Esys (version < 3.0, no SD card
-	"VID_C251&PID_1123", # Esys (version >= 3.0, with HID keyboard, no SD card
-	"VID_C251&PID_1124", # Esys (version < 3.0, with SD card
-	"VID_C251&PID_1125", # Esys (version >= 3.0, with HID keyboard, with SD card
-	"VID_C251&PID_1126", # Esys (version >= 3.0, no SD card
-	"VID_C251&PID_1127", # Reserved
-	"VID_C251&PID_1128", # Esys (version >= 3.0, with SD card
-	"VID_C251&PID_1129", # Reserved
-	"VID_C251&PID_112A", # Reserved
-	"VID_C251&PID_112B", # Reserved
-	"VID_C251&PID_112C", # Reserved
-	"VID_C251&PID_112D", # Reserved
-	"VID_C251&PID_112E", # Reserved
-	"VID_C251&PID_112F", # Reserved
-	"VID_C251&PID_1130", # Esytime
-	"VID_C251&PID_1131", # Reserved
-	"VID_C251&PID_1132", # Reserved
-})
-
-addBluetoothDevices("eurobraille", lambda m: m.id.startswith("Esys"))
-
-# freedomScientific
-addUsbDevices("freedomScientific", KEY_CUSTOM, {
-	"VID_0F4E&PID_0100", # Focus 1
-	"VID_0F4E&PID_0111", # PAC Mate
-	"VID_0F4E&PID_0112", # Focus 2
-	"VID_0F4E&PID_0114", # Focus Blue
-})
-
-addBluetoothDevices("freedomScientific", lambda m: any(m.id.startswith(prefix) for prefix in (
-	"F14", "Focus 14 BT",
-	"Focus 40 BT",
-	"Focus 80 BT",
-)))
-
-# handyTech
-addUsbDevices("handyTech", KEY_SERIAL, {
-	"VID_0403&PID_6001", # FTDI chip
-	"VID_0921&PID_1200", # GoHubs chip
-})
-
-# Newer Handy Tech displays have a native HID processor
-addUsbDevices("handyTech", KEY_HID, {
-	"VID_1FE4&PID_0054", # Active Braille
-	"VID_1FE4&PID_0055", # Connect Braille
-	"VID_1FE4&PID_0061",  # Actilino
-	"VID_1FE4&PID_0064",  # Active Star 40
-	"VID_1FE4&PID_0081", # Basic Braille 16
-	"VID_1FE4&PID_0082", # Basic Braille 20
-	"VID_1FE4&PID_0083", # Basic Braille 32
-	"VID_1FE4&PID_0084", # Basic Braille 40
-	"VID_1FE4&PID_008A", # Basic Braille 48
-	"VID_1FE4&PID_0086", # Basic Braille 64
-	"VID_1FE4&PID_0087", # Basic Braille 80
-	"VID_1FE4&PID_008B", # Basic Braille 160
-	"VID_1FE4&PID_008C", # Basic Braille 84
-	"VID_1FE4&PID_0093", # Basic Braille Plus 32
-	"VID_1FE4&PID_0094", # Basic Braille Plus 40
-})
-
-# Some older HT displays use a HID converter and an internal serial interface
-addUsbDevices("handyTech", KEY_HID, {
-	"VID_1FE4&PID_0003", # USB-HID adapter
-	"VID_1FE4&PID_0074", # Braille Star 40
-	"VID_1FE4&PID_0044", # Easy Braille
-})
-
-addBluetoothDevices("handyTech", lambda m: any(m.id.startswith(prefix) for prefix in (
-	"Actilino AL",
-	"Active Braille AB",
-	"Active Star AS",
-	"Basic Braille BB",
-	"Basic Braille Plus BP",
-	"Braille Star 40 BS",
-	"Braillino BL",
-	"Braille Wave BW",
-	"Easy Braille EBR",
-)))
-
-# hims
-# Bulk devices
-addUsbDevices("hims", KEY_CUSTOM, {
-	"VID_045E&PID_930A", # Braille Sense & Smart Beetle
-	"VID_045E&PID_930B", # Braille EDGE 40
-})
-
-# Sync Braille, serial device
-addUsbDevices("hims", KEY_SERIAL, {
-	"VID_0403&PID_6001",
-})
-
-addBluetoothDevices("hims", lambda m: any(m.id.startswith(prefix) for prefix in (
-	"BrailleSense",
-	"BrailleEDGE",
-	"SmartBeetle",
-)))
-
-# NattiqBraille
-addUsbDevices("nattiqbraille", KEY_SERIAL, {
-	"VID_2341&PID_8036",  # Atmel-based USB Serial for Nattiq nBraille
-})
-
-# superBrl
-addUsbDevices("superBrl", KEY_SERIAL, {
-	"VID_10C4&PID_EA60",  # SuperBraille 3.2
-})
-
-# seika
-addUsbDevices("seikantk", KEY_HID, {
-	"VID_10C4&PID_EA80",  # Seika Notetaker
-})
-
-# Bluetooth name of the Seika devices is "TSM abcd", where the "abcd" is a four-digit
-# number, e.g. "TSM 3366", "TSM 0001", etc. There is a space between "TSM" and "abcd".
-seikaBluetoothNameRegex = re.compile(r"TSM \d\d\d\d")
-addBluetoothDevices("seikantk", lambda m: bool(seikaBluetoothNameRegex.match(m.deviceInfo["bluetoothName"])))

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -706,3 +706,8 @@ addUsbDevices("superBrl", KEY_SERIAL, {
 addUsbDevices("seikantk", KEY_HID, {
 	"VID_10C4&PID_EA80",  # Seika Notetaker
 })
+
+# Bluetooth name of the Seika devices is "TSM abcd", where the "abcd" is a four-digit
+# number, e.g. "TSM 3366", "TSM 0001", etc. There is a space between "TSM" and "abcd".
+seikaBluetoothNameRegex = re.compile(r"TSM \d\d\d\d")
+addBluetoothDevices("seikantk", lambda m: bool(seikaBluetoothNameRegex.match(m.deviceInfo["bluetoothName"])))

--- a/source/braille.py
+++ b/source/braille.py
@@ -2497,7 +2497,7 @@ class BrailleDisplayDriver(driverHandler.Driver):
 	@classmethod
 	def _getTryPorts(
 			cls, port: Union[str, bdDetect.DeviceMatch]
-	) -> Iterable[bdDetect.DeviceMatch]:
+	) -> typing.Iterator[bdDetect.DeviceMatch]:
 		"""Returns the ports for this driver to which a connection attempt should be made.
 		This generator function is usually used in L{__init__} to connect to the desired display.
 		@param port: the port to connect to.

--- a/source/braille.py
+++ b/source/braille.py
@@ -2309,6 +2309,7 @@ def initialize():
 	newTableName = brailleTables.RENAMED_TABLES.get(oldTableName)
 	if newTableName:
 		config.conf["braille"]["translationTable"] = newTableName
+	bdDetect.initialiseDetectionData()
 	handler = BrailleHandler()
 	# #7459: the syncBraille has been dropped in favor of the native hims driver.
 	# Migrate to renamed drivers as smoothly as possible.

--- a/source/braille.py
+++ b/source/braille.py
@@ -2321,7 +2321,7 @@ def initialize():
 	newTableName = brailleTables.RENAMED_TABLES.get(oldTableName)
 	if newTableName:
 		config.conf["braille"]["translationTable"] = newTableName
-	bdDetect.initialiseDetectionData()
+	bdDetect.initializeDetectionData()
 	handler = BrailleHandler()
 	# #7459: the syncBraille has been dropped in favor of the native hims driver.
 	# Migrate to renamed drivers as smoothly as possible.

--- a/source/brailleDisplayDrivers/seika.py
+++ b/source/brailleDisplayDrivers/seika.py
@@ -92,7 +92,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			# Read out the input buffer
 			versionS = self._ser.read(12)
 			log.debug(f"receive {versionS}")
-			if versionS.startswith(prefix=(
+			if versionS.startswith((
 				b'\x00\x05(\x08v5.0\x01\x01\x01\x01',
 				b'\x00\x05(\x08seika\x00'
 			)):

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -66,6 +66,8 @@ SEIKA_HID_FEATURES = b"".join([
 	b"\x00\x00\x03\x00",
 ])
 SEIKA_CMD_ON = b"\x41\x01"
+""" Unknown why this is required. Used for HID (via setFeature), but not for serial.
+"""
 
 vidpid = "VID_10C4&PID_EA80"
 hidvidpid = "HID\\VID_10C4&PID_EA80"
@@ -141,7 +143,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 						bytesize=serial.EIGHTBITS,
 						stopbits=serial.STOPBITS_ONE,
 					)
-					# Does the device need to be sent SEIKA_CMD_ON as per USB-HID?
+					# Note: SEIKA_CMD_ON not sent as per USB-HID, testing from users hasn't indicated any problems.
+					# The exact purpose of SEIKA_CMD_ON isn't known/documented here.
 				else:
 					log.debug(f"Port type not handled: {match.type}")
 					continue

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -101,7 +101,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		"""
 		return braille.getSerialPorts(isSeikaBluetoothDeviceInfo)
 
-	def __init__(self, port=bdDetect.KEY_HID):
+	def __init__(self, port: typing.Union[None, str, DeviceMatch]):
 		super().__init__()
 		self.numCells = 0
 		self.numBtns = 0

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -62,7 +62,7 @@ SEIKA_HID_FEATURES = b"".join([
 	b"\x50\x00\x00",
 	int.to_bytes(BAUD, length=2, byteorder="big", signed=False),  # b"\x25\x80"
 	b"\x00\x00\x03\x00",
-	])
+])
 SEIKA_CMD_ON = b"\x41\x01"
 
 vidpid = "VID_10C4&PID_EA80"

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -81,7 +81,13 @@ def isSeikaBluetoothName(bluetoothName: str) -> bool:
 
 
 def isSeikaBluetoothDeviceInfo(deviceInfo: typing.Dict[str, str]) -> bool:
-	return isSeikaBluetoothName(deviceInfo["bluetoothName"])
+	# bluetoothName is listed in information from L{hwPortUtils.listComPorts} when 'hwIo' debug logging
+	# category is enabled.
+	btNameKey = "bluetoothName"
+	return (
+		btNameKey in deviceInfo
+		and isSeikaBluetoothName(deviceInfo["bluetoothName"])
+	)
 
 
 def isSeikaBluetoothDeviceMatch(match: DeviceMatch) -> bool:

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -101,7 +101,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				if self.isHid:
 					log.info(f"Trying Seika notetaker on USB-HID")
 					self._dev = dev = hwIo.Hid(
-						path=match.port, # for a Hid match type 'port' is actually 'path'.
+						path=match.port,  # for a Hid match type 'port' is actually 'path'.
 						onReceive=self._onReceive
 					)
 					dev.setFeature(SEIKA_HID_FEATURES)  # baud rate, stop bit usw

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -159,7 +159,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def display(self, cells: List[int]):
 		# cells will already be padded up to numCells.
-		cellBytes = SEIKA_SEND_TEXT + self.numCells.to_bytes(1, 'little') + bytes(cells)
+		cellBytes = SEIKA_SEND_TEXT + bytes([self.numCells]) + bytes(cells)
 		self._dev.write(cellBytes)
 
 	def _onReceive(self, data: bytes):

--- a/tests/unit/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_brailleDisplayDrivers.py
@@ -12,9 +12,11 @@ import unittest
 import braille
 
 
-class FakeseikantkDriver(seikantk.BrailleDisplayDriver):
-	def __init__(self):
+class FakeSeikantkDriver(seikantk.BrailleDisplayDriver):
+	def __init__(self, isHid: bool):
 		"""Sets the variables necessary to test _onReceive without a braille device connected.
+		@param isHid: True if hid messages should be tested, False if serial (bluetooth) messages should be
+		tested.
 		"""
 		# Variables that need to be set to spoof receiving data
 		self._hidBuffer = b""
@@ -23,6 +25,7 @@ class FakeseikantkDriver(seikantk.BrailleDisplayDriver):
 		# Used to capture information for testing
 		self._pressedKeys = set()
 		self._routingIndexes = set()
+		self.isHid = isHid
 
 	def _handleKeys(self, arg: bytes):
 		"""Overridden method to capture data"""
@@ -36,28 +39,39 @@ class FakeseikantkDriver(seikantk.BrailleDisplayDriver):
 		"""Overridden method to capture data"""
 		self._routingIndexes = seikantk._getRoutingIndexes(arg)
 
-	def simulateMessageReceived(self, sampleMessage: bytes):
+	def simulateMessageReceived(self, sampleMessage: bytes) -> None:
+		if self.isHid:
+			return self.simulateHidMessageReceived(sampleMessage)
+		else:
+			return self.simulateSerialMessageReceived(sampleMessage)
+
+	def simulateHidMessageReceived(self, sampleMessage: bytes):
 		PRE_CANARY = bytes([2])  # start of text character
 		POST_CANARY = bytes([3])  # end of text character
 
 		for byteToSend in sampleMessage:
 			# the middle byte is the only one used, padded by a byte on either side.
-			self._onReceive(PRE_CANARY + bytes([byteToSend]) + POST_CANARY)
+			self._onReceiveHID(PRE_CANARY + bytes([byteToSend]) + POST_CANARY)
+
+	def simulateSerialMessageReceived(self, sampleMessage: bytes):
+		for byteToSend in sampleMessage:
+			# the bytes sent one at a time, with no padding
+			self._onReceiveSerial(bytes([byteToSend]))
 
 
-class TestseikantkDriver(unittest.TestCase):
+class TestSeikantkDriver_HID(unittest.TestCase):
 	def test_handleInfo(self):
 		SBDDesc = b"foobarloremips"  # a dummy description as this isn't specified in the spec
 		example16Cell = bytes([0xff, 0xff, 0xa2, 0x11, 0x16, 0x10, 0x10]) + SBDDesc
 		example40Cell = bytes([0xff, 0xff, 0xa2, 0x11, 0x16, 0x28, 0x28]) + SBDDesc
-		seikaTestDriver = FakeseikantkDriver()
+		seikaTestDriver = FakeSeikantkDriver(isHid=True)
 		seikaTestDriver.simulateMessageReceived(example16Cell)
 		self.assertEqual(22, seikaTestDriver.numBtns)
 		self.assertEqual(16, seikaTestDriver.numCells)
 		self.assertEqual(16, seikaTestDriver.numRoutingKeys)
 		self.assertEqual(SBDDesc.decode("UTF-8"), seikaTestDriver._description)
 
-		seikaTestDriver = FakeseikantkDriver()
+		seikaTestDriver = FakeSeikantkDriver(isHid=True)
 		seikaTestDriver.simulateMessageReceived(example40Cell)
 		self.assertEqual(22, seikaTestDriver.numBtns)
 		self.assertEqual(40, seikaTestDriver.numCells)
@@ -86,7 +100,54 @@ class TestseikantkDriver(unittest.TestCase):
 			expectedKeyNames: Set[str],
 			expectedRoutingIndexes: Set[int]
 	):
-		seikaTestDriver = FakeseikantkDriver()
+		seikaTestDriver = FakeSeikantkDriver(isHid=True)
+		seikaTestDriver.simulateMessageReceived(sampleMessage)
+		self.assertEqual(expectedKeyNames, seikaTestDriver._pressedKeys)
+		self.assertEqual(expectedRoutingIndexes, seikaTestDriver._routingIndexes)
+
+
+class TestSeikantkDriver_Serial(unittest.TestCase):
+	def test_handleInfo(self):
+		SBDDesc = b"foobarloremips"  # a dummy description as this isn't specified in the spec
+		example16Cell = bytes([0xff, 0xff, 0xa2, 0x11, 0x16, 0x10, 0x10]) + SBDDesc
+		example40Cell = bytes([0xff, 0xff, 0xa2, 0x11, 0x16, 0x28, 0x28]) + SBDDesc
+		seikaTestDriver = FakeSeikantkDriver(isHid=False)
+		seikaTestDriver.simulateMessageReceived(example16Cell)
+		self.assertEqual(22, seikaTestDriver.numBtns)
+		self.assertEqual(16, seikaTestDriver.numCells)
+		self.assertEqual(16, seikaTestDriver.numRoutingKeys)
+		self.assertEqual(SBDDesc.decode("UTF-8"), seikaTestDriver._description)
+
+		seikaTestDriver = FakeSeikantkDriver(isHid=False)
+		seikaTestDriver.simulateMessageReceived(example40Cell)
+		self.assertEqual(22, seikaTestDriver.numBtns)
+		self.assertEqual(40, seikaTestDriver.numCells)
+		self.assertEqual(40, seikaTestDriver.numRoutingKeys)
+		self.assertEqual(SBDDesc.decode("UTF-8"), seikaTestDriver._description)
+
+	def test_handleRouting(self):
+		example16Cell = bytes([0xff, 0xff, 0xa4, 0x02, 0b10000001, 0b10000001])
+		example40Cell = bytes([0xff, 0xff, 0xa4, 0x05, 0b10000001, 0b10000001, 0b10000001, 0b10000001, 0b10000001])
+		self._simulateKeyPress(example16Cell, set(), {0, 7, 8, 15})
+		self._simulateKeyPress(example40Cell, set(), {0, 7, 8, 15, 16, 23, 24, 31, 32, 39})
+
+	def test_handleKeys(self):
+		example4 = bytes([0xff, 0xff, 0xa6, 0x03, 0b10000001, 0x00, 0b00100000])
+		self._simulateKeyPress(example4, {"d1", "d8", "RJ_DOWN"}, set())
+
+	def test_handleKeysAndRouting(self):
+		example16Cell = bytes([0xff, 0xff, 0xa8, 0x05, 0x00, 0b10010000, 0x00, 0x00, 0x40])
+		example40Cell = bytes([0xff, 0xff, 0xa8, 0x08, 0x00, 0b00100000, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00])
+		self._simulateKeyPress(example16Cell, {"LJ_CENTER", "LJ_UP"}, {14})
+		self._simulateKeyPress(example40Cell, {"LJ_LEFT", "LJ_DOWN"}, {17})
+
+	def _simulateKeyPress(
+			self,
+			sampleMessage: bytes,
+			expectedKeyNames: Set[str],
+			expectedRoutingIndexes: Set[int]
+	):
+		seikaTestDriver = FakeSeikantkDriver(isHid=False)
 		seikaTestDriver.simulateMessageReceived(sampleMessage)
 		self.assertEqual(expectedKeyNames, seikaTestDriver._pressedKeys)
 		self.assertEqual(expectedRoutingIndexes, seikaTestDriver._routingIndexes)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,6 +15,9 @@ What's New in NVDA
   - MathType equations must also be manually converted to Office Math by selecting each and choosing Equation options -> Convert to Office Math in the context menu.
   -
 - Reporting of "has details" and the associated command to summarize the details relation have been updated to work in focus mode. (#13106)
+- Seika Notetaker can now be auto-detected when connected via USB and Bluetooth. (#13191, #13142)
+  - This affects the following devices: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
+  - Manually selecting the bluetooth COM port is also now supported.
 -
 
 == Changes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -18,7 +18,9 @@ What's New in NVDA
 - Seika Notetaker can now be auto-detected when connected via USB and Bluetooth. (#13191, #13142)
   - This affects the following devices: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
   - Manually selecting the bluetooth COM port is also now supported.
+  -
 -
+
 
 == Changes ==
 - Espeak-ng has been updated to 1.51-dev commit ``7e5457f91e10``. (#12950)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2365,7 +2365,7 @@ The following displays support this automatic detection functionality.
 - HIMS Braille Sense/Braille EDGE/Smart Beetle/Sync Braille Series
 - Eurobraille Esys/Esytime/Iris displays
 - Nattiq nBraille displays
-- Seika Notetaker
+- Seika Notetaker: MiniSeika (16, 24 cells), V6Pro (40 cells)
 - Any Display that supports the Standard HID Braille protocol
 -
 
@@ -2742,14 +2742,21 @@ Please see the display's documentation for descriptions of where these keys can 
 %kc:endInclude
 
 ++ Seika Braille Displays ++[Seika]
-The Seika Version 3, 4 and 5 (40 cells), Seika80 (80 cells), and Notetaker (16 cells) braille displays from [Nippon Telesoft https://www.nippontelesoft.com/] are supported.
-You can find more information about the displays and the required drivers at https://en.seika-braille.com/down/index.html
-You must first install the USB drivers provided by the manufacturer.
+The following Seika Braille displays from Nippon Telesoft are supported in two groups with different functionality:
+- [Seika Version 3, 4, and 5 (40 cells), Seika80 (80 cells) #SeikaBrailleDisplays]
+- [MiniSeika (16, 24 cells), V6Pro (40 cells) #SeikaNotetaker]
+-
+You can find more information about the displays at https://en.seika-braille.com/down/index.html.
 
-The Notetaker does support NVDA's automatic background braille display detection functionality via USB and Bluetooth.
-Other displays do not yet support NVDA's automatic background braille display detection functionality.
 
-Following are the key assignments for this display with NVDA.
++++ Seika Version 3, 4, and 5 (40 cells), Seika80 (80 cells) +++[SeikaBrailleDisplays]
+- These displays do not yet support NVDA's automatic background braille display detection functionality.
+- Select "Seika Braille Displays" to manually configure
+- A device drivers must be installed before using Seika v3/4/5/80.
+The drivers are [provided by the manufacturer https://en.seika-braille.com/down/index.html].
+-
+
+The Seika Braille Display key assignments follow.
 Please see the display's documentation for descriptions of where these keys can be found.
 %kc:beginInclude
 || Name | Key |
@@ -2766,7 +2773,15 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | routing |
 %kc:endInclude
 
-The Seika Braille Notetaker has the following key assignments with NVDA:
+
++++ MiniSeika (16, 24 cells), V6Pro (40 cells) +++[SeikaNotetaker]
+- NVDA's automatic background braille display detection functionality is supported via USB and Bluetooth.
+- Select "Seika Notetaker" or "auto" to configure.
+- No extra drivers are required when using a Seika Notetaker braille display.
+-
+
+The Seika Notetaker key assignments follow.
+Please see the display's documentation for descriptions of where these keys can be found.
 %kc:beginInclude
 || Name | Key |
 | Scroll braille display back | left |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2787,11 +2787,11 @@ The Seika Braille Notetaker has the following key assignments with NVDA:
 | shift+downArrow key | Space+RJ down, Backspace+RJ down |
 | shift+leftArrow key | Space+RJ left, Backspace+RJ left |
 | shift+rightArrow key | Space+RJ right, Backspace+RJ right |
-| enter key | RJ center, d8
+| enter key | RJ center, dot8
 | escape key | Space+RJ center |
 | windows key | Backspace+RJ center |
 | space key | Space, Backspace |
-| backspace key | d7 |
+| backspace key | dot7 |
 | pageup key | space+LJ right |
 | pagedown key | space+LJ left |
 | home key | space+LJ up |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2365,7 +2365,7 @@ The following displays support this automatic detection functionality.
 - HIMS Braille Sense/Braille EDGE/Smart Beetle/Sync Braille Series
 - Eurobraille Esys/Esytime/Iris displays
 - Nattiq nBraille displays
-- Seika Notetaker: MiniSeika (16, 24 cells), V6Pro (40 cells)
+- Seika Notetaker: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
 - Any Display that supports the Standard HID Braille protocol
 -
 
@@ -2744,7 +2744,7 @@ Please see the display's documentation for descriptions of where these keys can 
 ++ Seika Braille Displays ++[Seika]
 The following Seika Braille displays from Nippon Telesoft are supported in two groups with different functionality:
 - [Seika Version 3, 4, and 5 (40 cells), Seika80 (80 cells) #SeikaBrailleDisplays]
-- [MiniSeika (16, 24 cells), V6Pro (40 cells) #SeikaNotetaker]
+- [MiniSeika (16, 24 cells), V6, and V6Pro (40 cells) #SeikaNotetaker]
 -
 You can find more information about the displays at https://en.seika-braille.com/down/index.html.
 
@@ -2774,7 +2774,7 @@ Please see the display's documentation for descriptions of where these keys can 
 %kc:endInclude
 
 
-+++ MiniSeika (16, 24 cells), V6Pro (40 cells) +++[SeikaNotetaker]
++++ MiniSeika (16, 24 cells), V6, and V6Pro (40 cells) +++[SeikaNotetaker]
 - NVDA's automatic background braille display detection functionality is supported via USB and Bluetooth.
 - Select "Seika Notetaker" or "auto" to configure.
 - No extra drivers are required when using a Seika Notetaker braille display.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2365,6 +2365,7 @@ The following displays support this automatic detection functionality.
 - HIMS Braille Sense/Braille EDGE/Smart Beetle/Sync Braille Series
 - Eurobraille Esys/Esytime/Iris displays
 - Nattiq nBraille displays
+- Seika Notetaker
 - Any Display that supports the Standard HID Braille protocol
 -
 
@@ -2741,11 +2742,12 @@ Please see the display's documentation for descriptions of where these keys can 
 %kc:endInclude
 
 ++ Seika Braille Displays ++[Seika]
-The Seika Version 3, 4 and 5 (40 cells) and Seika80 (80 cells) braille displays from [Nippon Telesoft https://www.nippontelesoft.com/] are supported.
+The Seika Version 3, 4 and 5 (40 cells), Seika80 (80 cells), and Notetaker (16 cells) braille displays from [Nippon Telesoft https://www.nippontelesoft.com/] are supported.
 You can find more information about the displays and the required drivers at https://en.seika-braille.com/down/index.html
 You must first install the USB drivers provided by the manufacturer.
 
-These displays do not yet support NVDA's automatic background braille display detection functionality.
+The Notetaker does support NVDA's automatic background braille display detection functionality via USB and Bluetooth.
+Other displays do not yet support NVDA's automatic background braille display detection functionality.
 
 Following are the key assignments for this display with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.
@@ -2763,6 +2765,40 @@ Please see the display's documentation for descriptions of where these keys can 
 | NVDA Menu | left+right |
 | Route to braille cell | routing |
 %kc:endInclude
+
+The Seika Braille Notetaker has the following key assignments with NVDA:
+%kc:beginInclude
+|| Name | Key |
+| Scroll braille display back | left |
+| Scroll braille display forward | right |
+| Say all | space+Backspace |
+| NVDA Menu | Left+Right |
+| Move braille display to previous line | LJ up |
+| Move braille display to next line | LJ down |
+| Toggle braille tethered to | LJ center |
+| tab | LJ right |
+| shift+tab | LJ left |
+| upArrow key | RJ up |
+| downArrow key | RJ down |
+| leftArrow key | RJ left |
+| rightArrow key | RJ right |
+| Route to braille cell | routing |
+| shift+upArrow key | Space+RJ up, Backspace+RJ up |
+| shift+downArrow key | Space+RJ down, Backspace+RJ down |
+| shift+leftArrow key | Space+RJ left, Backspace+RJ left |
+| shift+rightArrow key | Space+RJ right, Backspace+RJ right |
+| enter key | RJ center, d8
+| escape key | Space+RJ center |
+| windows key | Backspace+RJ center |
+| space key | Space, Backspace |
+| backspace key | d7 |
+| pageup key | space+LJ right |
+| pagedown key | space+LJ left |
+| home key | space+LJ up |
+| end key | space+LJ down |
+| control+home key | backspace+LJ up |
+| control+end key | backspace+LJ down |
+
 
 ++ Papenmeier BRAILLEX Newer Models ++[Papenmeier]
 The following Braille displays are supported: 


### PR DESCRIPTION
### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/13142

### Summary of the issue:
Seika Notetaker can not be autodetected via bluetooth

### Description of how this pull request fixes the issue:
Add a way to identify the Seika device when connected by bluetooth

As per https://github.com/nvaccess/nvda/issues/13142#issuecomment-996441860 the bluetooth name for Seika devices should be `TSM`, a space, then 4 digits.

### Testing strategy:
Ask Seika users to test when connected via bluetooth.

### Known issues with pull request:
If ALL Seika devices use this bluetooth name, we may not be able to differentiate which driver to use `seika` vs `seika notetaker`.

### Change log entries:
```
New features
- Seika Notetaker can now be auto-detected when connected via Bluetooth
```

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
