### PR TITLE
Scons: provide the number of logical processors as the number of maximum concurrent jobs to speed up builds

### DIFF
--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -15,6 +15,8 @@ if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
 	$sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
 }
 $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
+# Use only 1 concurrent job when building
+$sconsArgs += "-j1"
 # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
 # It's possible to work around this, but the workarounds have annoying side effects.
 Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets

--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -16,7 +16,7 @@ if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
 }
 $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
 # Use only 1 concurrent job when building
-$sconsArgs += "-j1"
+$sconsArgs += " -j1"
 # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
 # It's possible to work around this, but the workarounds have annoying side effects.
 Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets

--- a/sconstruct
+++ b/sconstruct
@@ -7,6 +7,7 @@
 import sys
 import os
 import platform
+import multiprocessing
 
 # Ensure we are inside the Python virtual environment.
 nvdaVenv = os.getenv("NVDA_VENV")
@@ -121,8 +122,12 @@ env = Environment(variables=vars,HOST_ARCH='x86',tools=[
 	"recursiveInstall"
 ])
 
-# speed up subsiquent runs by checking timestamps of targets and dependencies, and only using md5 if timestamps differ.
+# speed up subsequent runs by checking timestamps of targets and dependencies, and only using md5 if timestamps differ.
 env.Decider('MD5-timestamp')
+
+# Make sure to run the build on multiple threads so it runs faster
+env.SetOption('num_jobs', multiprocessing.cpu_count())
+print(f"Building using {env.GetOption('num_jobs')} jobs")
 
 #Make our recursiveCopy function available to any script using this environment
 env.AddMethod(recursiveCopy)

--- a/sconstruct
+++ b/sconstruct
@@ -127,7 +127,8 @@ env.Decider('MD5-timestamp')
 
 # Make sure to run the build on multiple threads so it runs faster
 env.SetOption('num_jobs', multiprocessing.cpu_count())
-print(f"Building using {env.GetOption('num_jobs')} jobs")
+realNumJobs = env.GetOption('num_jobs')
+print(f"Building using {realNumJobs} job{'s' if realNumJobs != 1 else ''}")
 
 #Make our recursiveCopy function available to any script using this environment
 env.AddMethod(recursiveCopy)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -92,6 +92,8 @@ This ensures code will honor the Windows user setting for swapping the primary m
 - ``LOCALE_SLANGUAGE``, ``LOCALE_SLIST`` and ``LOCALE_SLANGDISPLAYNAME`` are removed from ``languageHandler`` - use members of ``languageHandler.LOCALE`` instead. (#12753)
 - Switched from Minhook to Microsoft Detours as a hooking library for NVDA. Hooking with this library is mainly used to aid the display model. (#12964)
 - ``winVersion.WIN10_RELEASE_NAME_TO_BUILDS`` is removed. (#13211)
+- SCons now builds with multiple concurrent jobs, equal to the number of logical processors in the system.
+This can dramatically decrease build times on multi core systems. (#13226)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Building NVDA can take some time. SCons has the ability to provide the number of concurrent jobs during build.

### Description of how this pull request fixes the issue:
Specify the maximum number of concurrent jobs when building NVDA.

### Testing strategy:
Tested locally on an Intel Core i7-9850H using PowerShell's `measure-command { .\scons.bat source }`, ensuring the venv was created prerun.

* Without the change, 170 seconds
* With the change, 59 seconds

### Known issues with pull request:
Output sometimes get a bit scrambled, i.e. the output of the cl command comes before SCons output the name of the file being build.

### Change log entries:
For Developers
- Set up SCons to build with multiple concurrent jobs, equal to the number of logical processors in the system (i.e. 8 on a quat core Intel CPU with hyper threading). This can dramatically decrease build times on multi core systems.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
