### PR TITLE
Remove deprecated loadState and saveState from addonHandler

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2012-2021 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
+# Copyright (C) 2012-2022 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
 # Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -30,7 +30,6 @@ import addonAPIVersion
 from . import addonVersionCheck
 from .addonVersionCheck import isAddonCompatible
 import extensionPoints
-import buildVersion
 
 
 MANIFEST_FILENAME = "manifest.ini"
@@ -119,15 +118,6 @@ class AddonsState(collections.UserDict):
 
 
 state = AddonsState()
-
-
-# Deprecated - use `state.save` and `state.load` instead.
-if buildVersion.version_year < 2022:
-	def saveState():
-		state.save()
-
-	def loadState():
-		state.load()
 
 
 def getRunningAddons():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -96,6 +96,7 @@ This ensures code will honor the Windows user setting for swapping the primary m
 - SCons now builds with multiple concurrent jobs, equal to the number of logical processors in the system.
 This can dramatically decrease build times on multi core systems. (#13226)
 - ``characterProcessing.SYMLVL_*`` constants are removed - please use ``characterProcessing.SymbolLevel.*`` instead. (#13248)
+- Functions ``loadState`` and ``saveState`` are removed from addonHandler - please use ``addonHandler.state.load`` and ``addonHandler.state.save`` instead. (#13245)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Removes code deprecated as part of PR #12792
### Summary of the issue:
PR #12792 converted state in `addonHandler` to a class deprecating some module level functions in the process.
### Description of how this pull request fixes the issue:
Deprecated `loadState` and `saveState` are removed from `addonHandler`.
### Testing strategy:
With git grep made sure that these functions are not used anywhere in the source code.
### Known issues with pull request:
None known
### Change log entries:
For Developers
- Functions `loadState` and `saveState` are removed from `addonHandler` - please use `addonHandler.state.load` and `addonHandler.state.save` instead.

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
