### PR TITLE
No longer try to detect spelling errors outside of editable content.

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -8,12 +8,9 @@
 """Module that contains the base NVDA object type with dynamic class creation support,
 as well as the associated TextInfo class."""
 
-import os
 import time
-import re
 import typing
 import weakref
-import core
 import textUtils
 from logHandler import log
 import review
@@ -35,7 +32,6 @@ import globalPluginHandler
 import brailleInput
 import locationHelper
 import aria
-import globalVars
 
 
 class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
@@ -1059,45 +1055,6 @@ Tries to force this object to take the focus.
 		"""
 		return None
 
-	def _reportErrorInPreviousWord(self):
-		try:
-			# self might be a descendant of the text control; e.g. Symphony.
-			# We want to deal with the entire text, so use the caret object.
-			info = api.getCaretObject().makeTextInfo(textInfos.POSITION_CARET)
-			# This gets called for characters which might end a word; e.g. space.
-			# The character before the caret is the word end.
-			# The one before that is the last of the word, which is what we want.
-			info.move(textInfos.UNIT_CHARACTER, -2)
-			info.expand(textInfos.UNIT_CHARACTER)
-		except Exception:
-			# Focus probably moved.
-			log.debugWarning("Error fetching last character of previous word", exc_info=True)
-			return
-
-		# Fetch the formatting for the last word to see if it is marked as a spelling error,
-		# However perform the fetch and check in a future core cycle
-		# To give the content control more time to detect and mark the error itself.
-		# #12161: MS Word's UIA implementation certainly requires this delay.
-		def _delayedDetection():
-			try:
-				fields = info.getTextWithFields()
-			except Exception:
-				log.debugWarning("Error fetching formatting for last character of previous word", exc_info=True)
-				return
-			for command in fields:
-				if (
-					isinstance(command, textInfos.FieldCommand)
-					and command.command == "formatChange"
-					and command.field.get("invalid-spelling")
-				):
-					break
-			else:
-				# No error.
-				return
-			import nvwave
-			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "textError.wav"))
-		core.callLater(50, _delayedDetection)
-
 	def _get_liveRegionPoliteness(self) -> aria.AriaLivePoliteness:
 		""" Retrieves the priority with which  updates to live regions should be treated.
 		The base implementation returns C{aria.AriaLivePoliteness.OFF},
@@ -1125,12 +1082,6 @@ Tries to force this object to take the focus.
 			)
 
 	def event_typedCharacter(self,ch):
-		if config.conf["documentFormatting"]["reportSpellingErrors"] and config.conf["keyboard"]["alertForSpellingErrors"] and (
-			# Not alpha, apostrophe or control.
-			ch.isspace() or (ch >= u" " and ch not in u"'\x7f" and not ch.isalpha())
-		):
-			# Reporting of spelling errors is enabled and this character ends a word.
-			self._reportErrorInPreviousWord()
 		speech.speakTypedCharacters(ch)
 		import winUser
 		if config.conf["keyboard"]["beepForLowercaseWithCapslock"] and ch.islower() and winUser.getKeyState(winUser.VK_CAPITAL)&1:

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -26,6 +26,7 @@ from scriptHandler import script
 import api
 import ui
 import braille
+import core
 import nvwave
 import globalVars
 from typing import List, Union
@@ -176,6 +177,58 @@ class EditableText(editableText.EditableText, NVDAObject):
 		if eventHandler.isPendingEvents("gainFocus"):
 			return
 		super()._caretScriptPostMovedHelper(speakUnit, gesture, info)
+
+	def _reportErrorInPreviousWord(self):
+		try:
+			# self might be a descendant of the text control; e.g. Symphony.
+			# We want to deal with the entire text, so use the caret object.
+			info = api.getCaretObject().makeTextInfo(textInfos.POSITION_CARET)
+			# This gets called for characters which might end a word; e.g. space.
+			# The character before the caret is the word end.
+			# The one before that is the last of the word, which is what we want.
+			info.move(textInfos.UNIT_CHARACTER, -2)
+			info.expand(textInfos.UNIT_CHARACTER)
+		except Exception:
+			# Focus probably moved.
+			log.debugWarning("Error fetching last character of previous word", exc_info=True)
+			return
+
+		# Fetch the formatting for the last word to see if it is marked as a spelling error,
+		# However perform the fetch and check in a future core cycle
+		# To give the content control more time to detect and mark the error itself.
+		# #12161: MS Word's UIA implementation certainly requires this delay.
+		def _delayedDetection():
+			try:
+				fields = info.getTextWithFields()
+			except Exception:
+				log.debugWarning("Error fetching formatting for last character of previous word", exc_info=True)
+				return
+			for command in fields:
+				if (
+					isinstance(command, textInfos.FieldCommand)
+					and command.command == "formatChange"
+					and command.field.get("invalid-spelling")
+				):
+					break
+			else:
+				# No error.
+				return
+			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "textError.wav"))
+		core.callLater(50, _delayedDetection)
+
+	def event_typedCharacter(self, ch: str):
+		if(
+			config.conf["documentFormatting"]["reportSpellingErrors"]
+			and config.conf["keyboard"]["alertForSpellingErrors"]
+			and (
+				# Not alpha, apostrophe or control.
+				ch.isspace() or (ch >= " " and ch not in "'\x7f" and not ch.isalpha())
+			)
+		):
+			# Reporting of spelling errors is enabled and this character ends a word.
+			self._reportErrorInPreviousWord()
+		super().event_typedCharacter(ch)
+
 
 class EditableTextWithAutoSelectDetection(EditableText):
 	"""In addition to L{EditableText}, handles reporting of selection changes for objects which notify of them.


### PR DESCRIPTION
### Link to issue number:
Fixes #13051

### Summary of the issue:
During NVDA 2021.3 development cycle we started logging exceptions which occur when we cannot detect if the previous word contains spelling errors. The detection code was placed in the base `NVDAObject` and therefore was triggered when it should not i.e. when checking checkboxes in NVDA's preferences. This causes a unnecessary noise in the log.
### Description of how this pull request fixes the issue:
The detection of spelling errors has been moved from the base `NVDAObjects` to the `NVDAObjects.behaviors.EditableText` and therefore is never triggered outside of the editable text.
### Testing strategy:
Ensured that spelling errors and typed characters are properly reported in MS Word with the object model, Libre Office Writer and in Firefox (both in the standard edit fields and in the compound documents e.g. Etherpad).

### Known issues with pull request:
None known
### Change log entries:
None needed - only affects logging.

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
