### PR TITLE
Remove deprecated SYMLVL constants from characterProcessing

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -4,7 +4,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from versionInfo import version_year
 from enum import IntEnum
 import os
 import codecs
@@ -135,15 +134,6 @@ class SymbolLevel(IntEnum):
 	CHAR = 1000
 	UNCHANGED = -1
 
-
-# The following SYMLVL_ constants are deprecated in #11856 but remain to maintain backwards compatibility.
-# Remove these in 2022.1 and replace instances using them with the SymbolLevel IntEnum.
-if version_year < 2022:
-	SYMLVL_NONE = SymbolLevel.NONE
-	SYMLVL_SOME = SymbolLevel.SOME
-	SYMLVL_MOST = SymbolLevel.MOST
-	SYMLVL_ALL = SymbolLevel.ALL
-	SYMLVL_CHAR = SymbolLevel.CHAR
 
 SPEECH_SYMBOL_LEVEL_LABELS = {
 	# Translators: The level at which the given symbol will be spoken.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -95,6 +95,7 @@ This ensures code will honor the Windows user setting for swapping the primary m
 - ``winVersion.WIN10_RELEASE_NAME_TO_BUILDS`` is removed. (#13211)
 - SCons now builds with multiple concurrent jobs, equal to the number of logical processors in the system.
 This can dramatically decrease build times on multi core systems. (#13226)
+- ``characterProcessing.SYMLVL_*`` constants are removed - please use ``characterProcessing.SymbolLevel.*`` instead. (#13248)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Removes code deprecated as part of PR #11856
### Summary of the issue:
PR #11856 converted module level constants for symbol levels in `characterProcessing` into an enum. The constants were marked for removal in 2022.1.
### Description of how this pull request fixes the issue:
These constants are removed.
### Testing strategy:
With git grep made sure that the removed symbol levels are not used in the source code.
### Known issues with pull request:
None known
### Change log entries:
For Developers
- `characterProcessing.SYMLVL_*` constants are removed - please use `characterProcessing.SymbolLevel.*` instead.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
