### PR TITLE
Don't log error for RPC_E_DISCONNECTED 

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -960,13 +960,17 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 					// This is certainly an error, and indicates a bug in the IA2 provider.
 					LOG_ERROR(msg.str());
 					break;
-				case CO_E_OBJNOTCONNECTED:
-					msg << L" (CO_E_OBJNOTCONNECTED, Object is not connected to server)";
-					// CO_E_OBJNOTCONNECTED indicates that the parent died since the query
+				case RPC_E_DISCONNECTED:
+					msg << L" (RPC_E_DISCONNECTED, object invoked has disconnected from its clients.)";
+					// RPC_E_DISCONNECTED indicates that the parent died since the query
 					// to accChildCount, and returning no children indicates that all children
 					// died since the call to accChildCount.
 					// Even if the children had been rendered, they were removed immediately thereafter.
 					// Therfore log at debug level, this is expected to occur in dynamic content.
+					LOG_DEBUG(msg.str());
+					break;
+				case CO_E_OBJNOTCONNECTED:
+					msg << L" (CO_E_OBJNOTCONNECTED, Object is not connected to server)";
 					LOG_DEBUG(msg.str());
 					break;
 				default:

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -957,38 +957,25 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 				switch (accChildRes) {
 				case E_NOINTERFACE:
 					msg << L" (E_NOINTERFACE, No such interface supported)";
-					// This is certainly an error, and indicates a bug in the IA2 provider.
-					LOG_ERROR(msg.str());
+					LOG_ERROR(msg.str());  // Indicates a bug in the IA2 provider.
 					break;
 				case RPC_E_DISCONNECTED:
 					msg << L" (RPC_E_DISCONNECTED, object invoked has disconnected from its clients.)";
-					// RPC_E_DISCONNECTED indicates that the parent died since the query
-					// to accChildCount, and returning no children indicates that all children
-					// died since the call to accChildCount.
-					// Even if the children had been rendered, they were removed immediately thereafter.
-					// Therefore log at debug level, this is expected to occur in dynamic content.
-					LOG_DEBUG(msg.str());
+					// RPC_E_DISCONNECTED indicates that the parent died since the query to accChildCount.
+					LOG_DEBUG(msg.str());  // This is expected to occur in dynamic content.
 					break;
 				case CO_E_OBJNOTCONNECTED:
 					msg << L" (CO_E_OBJNOTCONNECTED, Object is not connected to server)";
 					LOG_DEBUG(msg.str());
 					break;
-				case S_FALSE:
-					if (varChildren.size() == 0 && childCount > 0) {
-						msg << L" (S_FALSE, expected childcount, got no children, children may have been removed from document.)";
-						// Returning no children indicates that all children
-						// died since the call to accChildCount.
-						// Even if the children had been rendered, they were removed immediately thereafter.
-						// Therefore log at debug level, this is expected to occur in dynamic content.
-						LOG_DEBUG(msg.str());
-						break;
-					}
-					else {
-						// theoretically this cause can not be hit, included only for the benefit of developers
-						msg << L" (S_FALSE, unknown cause)";
-						LOG_ERROR(msg.str());
-						break;
-					}
+				case S_FALSE:  // Success, but unexpeced number of children were returned.
+					msg << L" (S_FALSE, expected childcount, got "
+						<< varChildren.size()
+						<< L". Children may have been removed from document.)";
+					// Returning no children indicates that all children died since the call to accChildCount.
+					// Even if the children had been rendered, they were removed immediately thereafter.
+					LOG_DEBUG(msg.str());  // This is expected to occur in dynamic content.
+					break;
 				default:
 					// Other unknown failures, log at error.
 					LOG_ERROR(msg.str());

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -966,13 +966,29 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 					// to accChildCount, and returning no children indicates that all children
 					// died since the call to accChildCount.
 					// Even if the children had been rendered, they were removed immediately thereafter.
-					// Therfore log at debug level, this is expected to occur in dynamic content.
+					// Therefore log at debug level, this is expected to occur in dynamic content.
 					LOG_DEBUG(msg.str());
 					break;
 				case CO_E_OBJNOTCONNECTED:
 					msg << L" (CO_E_OBJNOTCONNECTED, Object is not connected to server)";
 					LOG_DEBUG(msg.str());
 					break;
+				case S_FALSE:
+					if (varChildren.size() == 0 && childCount > 0) {
+						msg << L" (S_FALSE, expected childcount, got no children, children may have been removed from document.)";
+						// Returning no children indicates that all children
+						// died since the call to accChildCount.
+						// Even if the children had been rendered, they were removed immediately thereafter.
+						// Therefore log at debug level, this is expected to occur in dynamic content.
+						LOG_DEBUG(msg.str());
+						break;
+					}
+					else {
+						// theoretically this cause can not be hit, included only for the benefit of developers
+						msg << L" (S_FALSE, unknown cause)";
+						LOG_ERROR(msg.str());
+						break;
+					}
 				default:
 					// Other unknown failures, log at error.
 					LOG_ERROR(msg.str());


### PR DESCRIPTION
### Link to issue number:
Fixes #13244

### Summary of the issue:
Error sound when navigating headings and log message:
```
ERROR - RPC process 17524 (firefox.exe) (04:50:40.730) - Dummy-446 (12556):
Thread 19316, build\x86_64\vbufBackends\gecko_ia2\gecko_ia2.cpp, GeckoVBufBackend_t::fillVBuf, 955:
AccessibleChildren failed (count: 2), res: -2147417848
```
In another instance:
```
ERROR - RPC process 7696 (firefox.exe) (22:29:53.494) - Dummy-21 (7004):
Thread 6684, build\x86_64\vbufBackends\gecko_ia2\gecko_ia2.cpp, GeckoVBufBackend_t::fillVBuf, 955:
AccessibleChildren failed (count: 1), res: -2147467262
```

- `E_NOINTERFACE` is `DWORD 0x80004002L == -2147467262`
- `RPC_E_DISCONNECTED` is `DWORD 0x80010108L == -2147417848`
- `CO_E_OBJNOTCONNECTED` is `DWORD 0x800401FDL == -2,147,220,995`

Note there are two failures, one requires a fix in Firefox, the other shouldn't be logged at the error level
https://github.com/nvaccess/nvda/issues/13244#issuecomment-1015124347

### Description of how this pull request fixes the issue:
Log failures due to `RPC_E_DISCONNECTED` or `CO_E_OBJNOTCONNECTED` as a debug messages, this indicates that the parent no longer exists (has been removed from the render). This can be common on dynamic pages.

Continue to log an error for failure due to `E_NOINTERFACE` and any other "unknown" failures.

### Testing strategy:
Locally ran with Firefox and Chrome.
Alpha usage.

### Known issues with pull request:
None.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
