### PR TITLE
UI Automation in Windows Console and Windows Terminal: block SV2M2 notification events for now and preserve accessibility after UIA class name change

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1156,7 +1156,12 @@ class UIA(Window):
 		if self.windowClassName == "ConsoleWindowClass":
 			from . import winConsoleUIA
 			winConsoleUIA.findExtraOverlayClasses(self, clsList)
-		elif UIAClassName == "TermControl":
+		elif UIAClassName in ("TermControl", "TermControl2"):
+			# microsoft/terminal#12358: Eventually, TermControl2 should have
+			# a separate overlay class that is not a descendant of LiveText.
+			# TermControl2 sends inserted text using UIA notification events,
+			# so it is no longer necessary to diff the object as with all
+			# previous terminal implementations.
 			from . import winConsoleUIA
 			clsList.append(winConsoleUIA.WinTerminalUIA)
 

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -400,6 +400,17 @@ class WinConsoleUIA(KeyboardHandlerBasedTypedCharSupport):
 				"probably due to a switch to/from the alt buffer."
 			), exc_info=True)
 
+	def event_UIA_notification(self, **kwargs):
+		"""
+		In Windows Sun Valley 2 (SV2 M2), UIA notification events will be sent
+		to announce new text. Block these for now to avoid double-reporting of
+		text changes.
+		@note: In the longer term, NVDA should leverage these events in place
+		of the current LiveText strategy, as performance will likely be
+		significantly improved and #11002 can be completely mitigated.
+		"""
+		log.debugWarning(f"Notification event blocked to avoid double-report: {kwargs}")
+
 
 def findExtraOverlayClasses(obj, clsList):
 	if obj.UIAElement.cachedAutomationId == "Text Area":
@@ -409,4 +420,13 @@ def findExtraOverlayClasses(obj, clsList):
 
 
 class WinTerminalUIA(EnhancedTermTypedCharSupport):
-	pass
+	def event_UIA_notification(self, **kwargs):
+		"""
+		In an upcoming terminal release, UIA notification events will be sent
+		to announce new text. Block these for now to avoid double-reporting of
+		text changes.
+		@note: In the longer term, NVDA should leverage these events in place
+		of the current LiveText strategy, as performance will likely be
+		significantly improved and #11002 can be completely mitigated.
+		"""
+		log.debugWarning(f"Notification event blocked to avoid double-report: {kwargs}")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -59,6 +59,7 @@ What's New in NVDA
 - Fixed a problem where some Focus Blue Braille displays would stop working after waking the computer from sleep. (#9830)
 - 'Baseline' is no longer spuriously reported when the 'report superscript and subscript' option is active. (#11078)
 - In Windows 11, NVDA will no longer prevent navigation in emoji panel when selecting emojis. (#13104)
+- Prevents a bug causing double-reporting when using Windows Console and Terminal. (#13261)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Related to microsoft/terminal#12358 among others (to be released).

### Summary of the issue:
In upcoming Windows Terminal and Windows Console, UIA notification events will be sent when new text is inserted (i.e. for text output) to improve Narrator support. This will result in double-reporting of all terminal output: once from `LiveText` and once from UIA notifications (but without appropriate filtering for typed characters/passwords etc).

As part of the implementation of notifications, I asked Microsoft to change the UIA class name to allow new terminal support (including notifications) in a follow-up NVDA PR, since notifications will require a departure from the terminal strategy used by NVDA in the past. Changing the class name will break NVDA's current ability to identify the terminal and implement accessibility.

### Description of how this pull request fixes the issue:
* Suppress any received UIA notification events in UIA console and terminal for now, but log them for development.
* Support the new UIA class name used by terminals that send notifications.

Ideally, NVDA would use these events in place of `LiveText`. If we could get away without registering for `TextChange` at all, this could be an extreme stability improvement in the terminal as #11002 would be completely circumvented. Also, having new text pushed to us (instead of having to diff) should improve performance considerably in high-volume scenarios.

### Testing strategy:
Tested that support works as expected with the new terminal.

### Known issues with pull request:
It is imperative that this PR be included in 2022.1, as upcoming builds of Windows Terminal will have severely degraded accessibility without it.

### Change log entries:
None (workaround for bug in unreleased code)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
