### PR TITLE
Add a shortcut key to toggle braille viewer.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2715,6 +2715,28 @@ class GlobalCommands(ScriptableObject):
 		ui.message(state)
 
 	@script(
+		description=_(
+			# Translators: Input help mode message for toggle Braille viewer command.
+			"Toggles the NVDA Braille viewer, a floating window that allows you to view braille output, "
+			"and the text equivalent for each braille character"
+		),
+		category=SCRCAT_TOOLS
+	)
+	def script_toggleBrailleViewer(self, gesture):
+		import brailleViewer
+		if brailleViewer.isBrailleViewerActive():
+			# Translators: The message announced when disabling braille viewer.
+			state = _("Braille viewer disabled")
+			brailleViewer.destroyBrailleViewer()
+			gui.mainFrame.sysTrayIcon.menu_tools_toggleBrailleViewer.Check(False)
+		else:
+			# Translators: The message announced when enabling Braille viewer.
+			state = _("Braille viewer enabled")
+			brailleViewer.createBrailleViewerTool()
+			gui.mainFrame.sysTrayIcon.menu_tools_toggleBrailleViewer.Check(True)
+		ui.message(state)
+
+	@script(
 		# Translators: Input help mode message for toggle braille tether to command
 		# (tethered means connected to or follows).
 		description=_("Toggle tethering of braille between the focus and the review position"),

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
   - This affects the following devices: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
   - Manually selecting the bluetooth COM port is also now supported.
   -
+- Added a command to toggle the braille viewer; there is no default associated gesture. (#13258)
 -
 
 
@@ -73,14 +74,14 @@ What's New in NVDA
 - ``core.CallCancelled`` is now ``exceptions.CallCancelled``. (#12940)
 - All constants starting with RPC from ``core`` and ``logHandler`` are moved into ``RPCConstants.RPC`` enum. (#12940)
 - It is recommended that ``mouseHandler.doPrimaryClick`` and ``mouseHandler.doSecondaryClick`` functions should be used to click the mouse to perform a logical action such as activating (primary) or secondary (show context menu),
-rather than using executeMouseEvent and specifying the left or right mouse button specifically.
+rather than using ``executeMouseEvent`` and specifying the left or right mouse button specifically.
 This ensures code will honor the Windows user setting for swapping the primary mouse button. (#12642)
 - ``config.getSystemConfigPath`` has been removed - there is no replacement. (#12943)
 - ``shlobj.SHGetFolderPath`` has been removed - please use ``shlobj.SHGetKnownFolderPath`` instead. (#12943)
 - ``shlobj`` constants have been removed. A new enum has been created, ``shlobj.FolderId`` for usage with ``SHGetKnownFolderPath``. (#12943)
 - ``diffHandler.get_dmp_algo`` and ``diffHandler.get_difflib_algo`` have been replaced with ``diffHandler.prefer_dmp`` and ``diffHandler.prefer_difflib`` respectively. (#12974)
 - ``languageHandler.curLang`` has been removed - to get the current NVDA language use ``languageHandler.getLanguage()``. (#13082)
-- A `getStatusBarText` method can be implemented on an appModule to customize the way NVDA fetches the text from the status bar. (#12845)
+- A ``getStatusBarText`` method can be implemented on an appModule to customize the way NVDA fetches the text from the status bar. (#12845)
 - ``globalVars.appArgsExtra`` has been removed. (#13087)
   - If your add-on need to process additional command line arguments see the documentation of ``addonHandler.isCLIParamKnown`` and the developer guide for details.
   -

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2200,6 +2200,8 @@ To prevent unintentionally routing to cells, the command is delayed.
 The mouse must hover until the cell turns green.
 The cell will start as a light yellow colour, transition to orange, then suddenly become green.
 
+To toggle the braille viewer from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
 ++ Python Console ++[PythonConsole]
 The NVDA Python console, found under Tools in the NVDA menu, is a development tool which is useful for debugging, general inspection of NVDA internals or inspection of the accessibility hierarchy of an application.
 For more information, please see the [NVDA Developer Guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html].


### PR DESCRIPTION
### Link to issue number:

Fixes #13258

### Summary of the issue:

In #13258, it was asked to have a gesture to toggle braille viewer activation/deactivation as it already exists for speech viewer. It is not very clear why there was a gesture to toggle speech viewer and not for braille viewer.

### Description of how this pull request fixes the issue:

* Created a script with unassigned gesture in the global commands to toggle the braille viewer.
* Updated the user doc

### Testing strategy:
Manual testing:
* Associated a gesture to the new script in the input gesture window
* Checked that this gesture allows to enable/disable the braille viewer
* Checked that the "Braille viewer" item in NVDA -> Tools menu is checked / not checked accordingly
* Tried to open braille viewer with the gesture and close it via the menu and vice versa.

Note: System test is failing on Chrome test, but I think it is unrelated and other PRs also fail the Chrome test.

### Known issues with pull request:

None

### Change log entries:
New features
`Added a command to toggle the braille viewer; there is no default associated gesture. (#13258)`

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
