### PR TITLE
Force DictionaryDialog to be subclassed to use it

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3190,13 +3190,21 @@ class DictionaryEntryDialog(
 		self.typeRadioBox.SetSelection(DictionaryEntryDialog.TYPE_LABELS_ORDERING.index(type))
 
 
-class DictionaryDialog(SettingsDialog):
+class DictionaryDialog(
+	SettingsDialog,
+	metaclass=guiHelper.SIPABCMeta,
+):
+	"""A dictionary dialog.
+	A dictionary dialog is a setting dialog containing a list of dictionary entries and buttons to manage them.
+	
+	To use this dialog, override L{__init__} calling super().__init__.
+	"""
+	
 	TYPE_LABELS = {t: l.replace("&", "") for t, l in DictionaryEntryDialog.TYPE_LABELS.items()}
 	helpId = "SpeechDictionaries"
 
+	@abstractmethod
 	def __init__(self,parent,title,speechDict):
-		if type(self) == DictionaryDialog:
-			raise Exception("DictionaryDialog must be subclassed.")
 		self.title = title
 		self.speechDict = speechDict
 		self.tempSpeechDict=speechDictHandler.SpeechDict()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3191,8 +3191,8 @@ class DictionaryEntryDialog(
 
 
 class DictionaryDialog(
-	SettingsDialog,
-	metaclass=guiHelper.SIPABCMeta,
+		SettingsDialog,
+		metaclass=guiHelper.SIPABCMeta,
 ):
 	"""A dictionary dialog.
 	A dictionary dialog is a setting dialog containing a list of dictionary entries and buttons to manage them.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3195,6 +3195,8 @@ class DictionaryDialog(SettingsDialog):
 	helpId = "SpeechDictionaries"
 
 	def __init__(self,parent,title,speechDict):
+		if type(self) == DictionaryDialog:
+			raise Exception("DictionaryDialog must be subclassed.")
 		self.title = title
 		self.speechDict = speechDict
 		self.tempSpeechDict=speechDictHandler.SpeechDict()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -103,6 +103,7 @@ This can dramatically decrease build times on multi core systems. (#13226)
 - ``characterProcessing.SYMLVL_*`` constants are removed - please use ``characterProcessing.SymbolLevel.*`` instead. (#13248)
 - Functions ``loadState`` and ``saveState`` are removed from addonHandler - please use ``addonHandler.state.load`` and ``addonHandler.state.save`` instead. (#13245)
 - Moved the UWP/OneCore interaction layer of NVDAHelper [from C++/CX to C++/Winrt https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/move-to-winrt-from-cx]. (#10662)
+- It is now mandatory to subclass ``DictionaryDialog`` to use it. (#13268)
 -
 
 


### PR DESCRIPTION
### Link to issue number:

Follow-up of #12967

### Summary of the issue:

Since the merge of #12800, trying to re-open an already opened dialog allows to focus it rather than issuing an error message box. The dialog is refocused according to its class, i.e. trying to open a dialog of the same class rather refocus the first already opened dialog of the same class.

But with #12800, it was not possible to open 2 dictionaries of different type (e.g. speech and default). This was fixed with #12967 by subclassing DictionaryDialog.
In #12967, however, the following known issue was mentionned:
> Maybe it would be interesting to forbid to instance an object of class DictionaryDialog directly, i.e. force subclassing.

Indeed, if DictionaryDialog's have been subclassed in NVDA's core, add-on may still instance directly a DictionaryDialog. That should be forbidden as explained in #12967.

However, it could not be done before 2022.1 due to add-ons that may break if they instance directly DictionaryDialog. That's the case of applicationDictionary.

Note: emoticons and EnhancedDictionaries add-ons use DictionaryDialog's but they already subclass it.

### Description of how this pull request fixes the issue:

Option 1 (withdrawn after review):
Raise an error in the `__init__` method of DictionaryDialog if it is instancied from the same class (not a subclass).

Option 2 (implemented after review):
I have abstracted DictionaryDialog as advised in https://github.com/nvaccess/nvda/pull/12967#issuecomment-948089531 and thanks to @lukaszgo1's review.

### Testing strategy:
Manual testing:
1. Created aglobal plugin ([dictTest.py.txt](https://github.com/nvaccess/nvda/files/7919429/dictTest.py.txt)) allowing to open two dictionaries:
   * One directly created from DictionaryDialog
   * One created from a subclass of DictionaryDialog
   And tested that:
   * both dictionaries open with NVDA 2021.3.1
   * Only the subclassed dictionary opens with this PR's code (from source)

2. Tested that NVDA's default, voice and temp dictionaries dialogs still open (from menu).

### Known issues with pull request:
Should be merged in 2022.1 or any API-breaking release.

### Change log entries:
For Developers

`It is now mandatory to subclass DictionaryDialog to use it. (#13268)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
