### PR TITLE
Remove unnecessaryNOQA for speakObjectProperties

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -388,7 +388,7 @@ def getCharDescListFromText(text,locale):
 	return charDescList
 
 
-def speakObjectProperties(  # noqa: C901
+def speakObjectProperties(
 		obj,
 		reason: OutputReason = OutputReason.QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,


### PR DESCRIPTION
### Link to issue number:
None noticed when looking at a `speech` code for #12710 
### Summary of the issue:
Definition of `speakObjectProperties` had unnecessary NOQA comment. 
### Description of how this pull request fixes the issue:
The redundant comment was removed.
### Testing strategy:
Made sure that lint for this branch still passes.
### Known issues with pull request:
None known
### Change log entries:
None needed - comment only change.
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
