### PR TITLE
Disable error sounds even for testing builds

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -280,8 +280,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [featureFlag]
 	# 0:default, 1:yes, 2:no
 	cancelExpiredFocusSpeech = integer(0, 2, default=0)
-	# 0:Only in test versions, 1:yes
-	playErrorSound = integer(0, 1, default=0)
+	# 0:Only in test versions, 1:yes, 2: no
+	playErrorSound = integer(0, 2, default=0)
 """
 
 #: The configuration specification

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2934,6 +2934,8 @@ class AdvancedPanelControls(
 			pgettext("advanced.playErrorSound", "Only in NVDA test versions"),
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
 			pgettext("advanced.playErrorSound", "Yes"),
+			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
+			pgettext("advanced.playErrorSound", "No"),
 		)
 		self.playErrorSoundCombo = debugLogGroup.addLabeledControl(label, wx.Choice, choices=playErrorSoundChoices)
 		self.bindHelpEvent("PlayErrorSound", self.playErrorSoundCombo)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -111,6 +111,9 @@ def shouldPlayErrorSound() -> bool:
 		return False
 
 	import config
+	# Don't play the error sound if this is disabled in config.
+	if (config.conf is not None and config.conf["featureFlag"]["playErrorSound"] == 2):
+		return False
 	# Only play the error sound if this is a test version or if the config states it explicitly.
 	return (
 		buildVersion.isTestVersion

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1938,6 +1938,7 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
 Choosing Yes allows to enable error sounds whatever your current NVDA version is.
+Choosing No allows to disable error sounds whatever your current NVDA version is.
 
 ++ miscellaneous Settings ++[MiscSettings]
 Besides the [NVDA Settings #NVDASettings] dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number: None

### Summary of the issue:
It is not possible for now to disable error sounds for testing builds of NVDA, however special setting was added some time ago and disabling error sounds completely could also be included.

### Description of how this pull request fixes the issue:
Added one more config value for disabling sound;
Added corresponding item in GUI combobox;
In logHandler added a check for corresponding "No" option of playing error sounds

### Testing strategy:
Manually tested and confirmed that setting "No" in play error sounds option disables it completely.

### Known issues with pull request:

### Change log entries:
New features
Changes
It is no possible to disable logging error sounds also for testing copies of NVDA.
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
