### PR TITLE
Utilise readonly state when determining browse mode for mail in Windows 11

### DIFF
--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -24,7 +24,7 @@ class MailWordDocument(WordDocument):
 		if controlTypes.State.READONLY in self.states:
 			return True
 
-		# For older versions of Mail (before Windows 11), determine the readonly state
+		# For older versions of Mail (Windows 10), determine the readonly state
 		# based on being in an email with set headers, rather than draft headers.
 
 		# Locate the Reading pane in the ancestors

--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -1,10 +1,11 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016-2019 NV Access Limited, Joseph Lee
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2016-2022 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
-"""An appModule for the Windows 10 Mail app"""
+"""An appModule for the Windows Mail app, for Windows 10 and 11."""
 
+import controlTypes
 import appModuleHandler
 from comtypes import COMError
 import UIAHandler
@@ -19,6 +20,13 @@ class MailWordDocument(WordDocument):
 
 	treeInterceptorClass=MailWordDocumentTreeInterceptor
 	def _get_shouldCreateTreeInterceptor(self):
+		# Newer versions of Mail (Windows 11+) correctly set the readonly state for emails
+		if controlTypes.State.READONLY in self.states:
+			return True
+
+		# For older versions of Mail (before Windows 11), determine the readonly state
+		# based on being in an email with set headers, rather than draft headers.
+
 		# Locate the Reading pane in the ancestors
 		condition=UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_ClassNamePropertyId,"ReadingPaneModern")
 		walker=UIAHandler.handler.clientObject.createTreeWalker(condition)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,11 +45,12 @@ What's New in NVDA
   - Note that in some situations, when inserting or deleting characters in the middle of a line, the characters after the caret may again be read out.
   -
 - MS word with UIA: heading quick nav in browse mode no longer gets stuck on the final heading of a document, nor is this heading shown twice in the NVDA elements list. (#9540)
-- In Windows 8 and later , the File Explorer status bar can now be retrieved using the standard gesture NVDA+end (desktop) / NVDA+shift+end (laptop). (#12845)
+- In Windows 8 and later, the File Explorer status bar can now be retrieved using the standard gesture NVDA+end (desktop) / NVDA+shift+end (laptop). (#12845)
 - Incoming messages in the chat of Skype for Business are reported again. (#9295)
 - NVDA can again duck audio when using the SAPI5 synthesizer on Windows 11. (#12913)
 - In Windows 10 Calculator, NVDA will announce labels for history and memory list items. (#11858)
 - Gestures such as scrolling and routing again work with HID Braille devices. (#13228)
+- Windows 11 Mail: After switching focus between apps, while reading a long email, NVDA would get stuck on a line of the email. (#13050)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes #13050

### Summary of the issue:

To determine if we should use browse mode or focus mode for Windows 10 mail, NVDA
would check if the email headers are set, and not draft headers.
In Windows 11 mail, email headers can be scrolled out of focus.
When returning focus to an email, after headers have been scrolled out of focus, NVDA incorrectly assumes we are in a draft email.

### Description of how this pull request fixes the issue:

Windows 11 correctly sets the readonly state for emails.
This PR uses the readonly state to enable browse mode for mail in Windows 11

### Testing strategy:

Steps to reproduce:

1. Find a long email using Windows Mail, on Windows 11
2. Go down many lines (if sighted, until headers are scrolled out of view)
3. Press a command to open a dialog in NVDA, EG (`NVDA+Ctrl+S`) for the synthesizer dialog,
4. Press escape to close the synthesizer dialog
5. Try arrowing around the email.
    - Before this PR, this would cause the same line  in the email to be repeatedly spoken
    - After this PR, navigation around the email works as expected

### Known issues with pull request:

None

### Change log entries:
Bug fixes

```
- Fixes issue with Windows 11 Mail. After switching focus between apps, while reading a long email, NVDA would get stuck on a line of the email. (#13050)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
