### PR TITLE
Prepare for selective UIA event registration by default

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -356,7 +356,7 @@ class UIAHandler(COMObject):
 			self.rootElement=self.clientObject.getRootElementBuildCache(self.baseCacheRequest)
 			self.reservedNotSupportedValue=self.clientObject.ReservedNotSupportedValue
 			self.ReservedMixedAttributeValue=self.clientObject.ReservedMixedAttributeValue
-			if config.conf['UIA']['selectiveEventRegistration']:
+			if utils._shouldSelectivelyRegister():
 				self._createLocalEventHandlerGroup()
 			self._registerGlobalEventHandlers()
 			if winVersion.getWinVer() >= winVersion.WIN11:
@@ -388,13 +388,13 @@ class UIAHandler(COMObject):
 			self,
 			*self.clientObject.IntSafeArrayToNativeArray(
 				globalEventHandlerGroupUIAPropertyIds
-				if config.conf['UIA']['selectiveEventRegistration']
+				if utils._shouldSelectivelyRegister()
 				else UIAPropertyIdsToNVDAEventNames
 			)
 		)
 		for eventId in (
 			globalEventHandlerGroupUIAEventIds
-			if config.conf['UIA']['selectiveEventRegistration']
+			if utils._shouldSelectivelyRegister()
 			else UIAEventIdsToNVDAEventNames
 		):
 			self.globalEventHandlerGroup.AddAutomationEventHandler(

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -9,6 +9,7 @@ import config
 import ctypes
 import UIAHandler
 import weakref
+import winVersion
 from functools import lru_cache
 from logHandler import log
 from .constants import WinConsoleAPILevel
@@ -350,3 +351,14 @@ def _getConhostAPILevel(hwnd: int) -> WinConsoleAPILevel:
 	except (COMError, ValueError):
 		log.exception()
 		return WinConsoleAPILevel.END_INCLUSIVE
+
+
+def _shouldSelectivelyRegister() -> bool:
+	"Determinbes whether to register for UIA events selectively or globally."
+	setting = config.conf['UIA']['eventRegistration']
+	if setting == "selective":
+		return True
+	elif setting == "global":
+		return False
+	else:
+		return winVersion.getWinVer() >= winVersion.WIN11_22H2

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -354,7 +354,7 @@ def _getConhostAPILevel(hwnd: int) -> WinConsoleAPILevel:
 
 
 def _shouldSelectivelyRegister() -> bool:
-	"Determinbes whether to register for UIA events selectively or globally."
+	"Determines whether to register for UIA events selectively or globally."
 	setting = config.conf['UIA']['eventRegistration']
 	if setting == "selective":
 		return True

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -9,7 +9,6 @@ import config
 import ctypes
 import UIAHandler
 import weakref
-import winVersion
 from functools import lru_cache
 from logHandler import log
 from .constants import WinConsoleAPILevel
@@ -356,9 +355,4 @@ def _getConhostAPILevel(hwnd: int) -> WinConsoleAPILevel:
 def _shouldSelectivelyRegister() -> bool:
 	"Determines whether to register for UIA events selectively or globally."
 	setting = config.conf['UIA']['eventRegistration']
-	if setting == "selective":
-		return True
-	elif setting == "global":
-		return False
-	else:
-		return winVersion.getWinVer() >= winVersion.WIN11_22H2
+	return setting == "selective"

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -12,7 +12,7 @@ from configobj import ConfigObj
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config 
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 6
+latestSchemaVersion = 7
 
 #: The configuration specification string
 #: @type: String
@@ -234,7 +234,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	enabled = boolean(default=true)
 	useInMSExcelWhenAvailable = boolean(default=false)
 	winConsoleImplementation= option("auto", "legacy", "UIA", default="auto")
-	selectiveEventRegistration = boolean(default=false)
+	eventRegistration = option("auto", "selective", "global", default="auto")
 	# 0:default, 1:Only when necessary, 2:yes, 3:no
 	allowInChromium = integer(0, 3, default=0)
 	# 0:default (where suitable), 1:Only when necessary, 2: where suitable, 3: always

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -1,8 +1,8 @@
 # -*- coding: UTF-8 -*-
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016–2022 NV Access Limited, Bill Dengler
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2016–2022 NV Access Limited, Bill Dengler
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """
 Contains upgrade steps for the NVDA configuration files. These steps are run to ensure that a configuration file

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -15,7 +15,9 @@ that no information is lost, while updating the ConfigObj to meet the requiremen
 """
 
 from logHandler import log
-from typing import Dict
+from typing import (
+	Dict,
+)
 
 
 def upgradeConfigFrom_0_to_1(profile):

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -104,6 +104,8 @@ def upgradeConfigFrom_5_to_6(profile: dict):
 def upgradeConfigFrom_6_to_7(profile: Dict[str, str]) -> None:
 	"""
 	Selective UIA registration check box has been replaced with event registration multi choice.
+	If the user has explicitly enabled selective UIA event registration, set the new eventRegistration preference to selective.
+	Otherwise, the default value, auto, will be used.
 	"""
 	try:
 		selectiveEventRegistration = profile['UIA']['selectiveEventRegistration']

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -15,6 +15,7 @@ that no information is lost, while updating the ConfigObj to meet the requiremen
 """
 
 from logHandler import log
+from typing import Dict
 
 
 def upgradeConfigFrom_0_to_1(profile):

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -107,7 +107,8 @@ def upgradeConfigFrom_5_to_6(profile: dict):
 def upgradeConfigFrom_6_to_7(profile: Dict[str, str]) -> None:
 	"""
 	Selective UIA registration check box has been replaced with event registration multi choice.
-	If the user has explicitly enabled selective UIA event registration, set the new eventRegistration preference to selective.
+	If the user has explicitly enabled selective UIA event registration, set
+	the new eventRegistration preference to selective.
 	Otherwise, the default value, auto, will be used.
 	"""
 	try:

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -99,3 +99,16 @@ def upgradeConfigFrom_5_to_6(profile: dict):
 	if useInMSWord:
 		from . import AllowUiaInMSWord
 		profile['UIA']['allowInMSWord'] = AllowUiaInMSWord.ALWAYS.value
+
+
+def upgradeConfigFrom_6_to_7(profile: dict):
+	"""
+	Selective UIA registration check box has been replaced with event registration multi choice.
+	"""
+	try:
+		selectiveEventRegistration = profile['UIA']['selectiveEventRegistration']
+		del profile['UIA']['selectiveEventRegistration']
+	except KeyError:
+		selectiveEventRegistration = False
+	if selectiveEventRegistration:
+		profile['UIA']['eventRegistration'] = "selective"

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2016 NV Access Limited
+#Copyright (C) 2016–2022 NV Access Limited, Bill Dengler
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -101,7 +101,7 @@ def upgradeConfigFrom_5_to_6(profile: dict):
 		profile['UIA']['allowInMSWord'] = AllowUiaInMSWord.ALWAYS.value
 
 
-def upgradeConfigFrom_6_to_7(profile: dict):
+def upgradeConfigFrom_6_to_7(profile: Dict[str, str]) -> None:
 	"""
 	Selective UIA registration check box has been replaced with event registration multi choice.
 	"""

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2654,17 +2654,46 @@ class AdvancedPanelControls(
 		UIAGroup = guiHelper.BoxSizerHelper(self, sizer=UIASizer)
 		sHelper.addItem(UIAGroup)
 
-		# Translators: This is the label for a checkbox in the
-		#  Advanced settings panel.
-		label = _("Enable &selective registration for UI Automation events and property changes")
-		self.selectiveUIAEventRegistrationCheckBox = UIAGroup.addItem(wx.CheckBox(UIABox, label=label))
+		# Translators: This is the label for a combo box for selecting the
+		# means of registering for UI Automation events in the advanced settings panel.
+		# Choices are automatic, selectively, and globally.
+		selectiveUIAEventRegistrationComboText = _("Regi&stration for UI Automation events and property changes:")
+		selectiveUIAEventRegistrationChoices = [
+			# Translators: A choice in a combo box in the advanced settings
+			# panel to have NVDA decide whether to register
+			# selectively or globally for UI Automation events.
+			_("Automatic (prefer selectively)"),
+			# Translators: A choice in a combo box in the advanced settings
+			# panel to have NVDA register selectively for UI Automation events
+			# (i.e. not to request events for objects outside immediate focus).
+			_("Selectively"),
+			# Translators: A choice in a combo box in the advanced settings
+			# panel to have NVDA register for all UI Automation events
+			# in all cases.
+			_("Globally")
+		]
+		#: The possible event registration config values, in the order they appear
+		#: in the combo box.
+		self.selectiveUIAEventRegistrationVals = (
+			"auto",
+			"selective",
+			"global"
+		)
+		self.selectiveUIAEventRegistrationCombo = UIAGroup.addLabeledControl(
+			selectiveUIAEventRegistrationComboText,
+			wx.Choice,
+			choices=selectiveUIAEventRegistrationChoices
+		)
 		self.bindHelpEvent(
 			"AdvancedSettingsSelectiveUIAEventRegistration",
-			self.selectiveUIAEventRegistrationCheckBox
+			self.selectiveUIAEventRegistrationCombo
 		)
-		self.selectiveUIAEventRegistrationCheckBox.SetValue(config.conf["UIA"]["selectiveEventRegistration"])
-		self.selectiveUIAEventRegistrationCheckBox.defaultValue = (
-			self._getDefaultValue(["UIA", "selectiveEventRegistration"])
+		curChoice = self.selectiveUIAEventRegistrationVals.index(
+			config.conf['UIA']['eventRegistration']
+		)
+		self.selectiveUIAEventRegistrationCombo.SetSelection(curChoice)
+		self.selectiveUIAEventRegistrationCombo.defaultValue = self.selectiveUIAEventRegistrationVals.index(
+			self._getDefaultValue(["UIA", "eventRegistration"])
 		)
 
 		label = pgettext(
@@ -3031,8 +3060,8 @@ class AdvancedPanelControls(
 			self._defaultsRestored
 			and self.scratchpadCheckBox.IsChecked() == self.scratchpadCheckBox.defaultValue
 			and (
-				self.selectiveUIAEventRegistrationCheckBox.IsChecked()
-				== self.selectiveUIAEventRegistrationCheckBox.defaultValue
+				self.selectiveUIAEventRegistrationCombo.GetSelection()
+				== self.selectiveUIAEventRegistrationCombo.defaultValue
 			)
 			and self.UIAInMSWordCombo.GetSelection() == self.UIAInMSWordCombo.defaultValue
 			and self.UIAInMSExcelCheckBox.IsChecked() == self.UIAInMSExcelCheckBox.defaultValue
@@ -3054,7 +3083,9 @@ class AdvancedPanelControls(
 
 	def restoreToDefaults(self):
 		self.scratchpadCheckBox.SetValue(self.scratchpadCheckBox.defaultValue)
-		self.selectiveUIAEventRegistrationCheckBox.SetValue(self.selectiveUIAEventRegistrationCheckBox.defaultValue)
+		self.selectiveUIAEventRegistrationCombo.SetSelection(
+			self.selectiveUIAEventRegistrationCombo.defaultValue == 'auto'
+		)
 		self.UIAInMSWordCombo.SetSelection(self.UIAInMSWordCombo.defaultValue)
 		self.UIAInMSExcelCheckBox.SetValue(self.UIAInMSExcelCheckBox.defaultValue)
 		self.consoleCombo.SetSelection(self.consoleCombo.defaultValue == 'auto')
@@ -3075,7 +3106,10 @@ class AdvancedPanelControls(
 	def onSave(self):
 		log.debug("Saving advanced config")
 		config.conf["development"]["enableScratchpadDir"]=self.scratchpadCheckBox.IsChecked()
-		config.conf["UIA"]["selectiveEventRegistration"] = self.selectiveUIAEventRegistrationCheckBox.IsChecked()
+		selectiveUIAEventRegistrationChoice = self.selectiveUIAEventRegistrationCombo.GetSelection()
+		config.conf['UIA']['eventRegistration'] = (
+			self.selectiveUIAEventRegistrationVals[selectiveUIAEventRegistrationChoice]
+		)
 		config.conf["UIA"]["allowInMSWord"] = self.UIAInMSWordCombo.GetSelection()
 		config.conf["UIA"]["useInMSExcelWhenAvailable"] = self.UIAInMSExcelCheckBox.IsChecked()
 		consoleChoice = self.consoleCombo.GetSelection()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2662,7 +2662,7 @@ class AdvancedPanelControls(
 			# Translators: A choice in a combo box in the advanced settings
 			# panel to have NVDA decide whether to register
 			# selectively or globally for UI Automation events.
-			_("Automatic (prefer selectively)"),
+			_("Automatic (globally)"),
 			# Translators: A choice in a combo box in the advanced settings
 			# panel to have NVDA register selectively for UI Automation events
 			# (i.e. not to request events for objects outside immediate focus).

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2114,6 +2114,11 @@ This button opens the directory where you can place custom code while developing
 This button is only enabled if NVDA is configured to enable loading custom code from the Developer Scratchpad Directory.
 
 ==== Registration for UI Automation events and property changes ====[AdvancedSettingsSelectiveUIAEventRegistration]
+: Default
+  Automatic
+: Options
+  Automatic, Selectively, Globally
+
 This option changes how NVDA registers for events fired by the Microsoft UI Automation accessibility API.
 The registration for UI Automation events and property changes combo box has three options:
 - Automatic: "selectively" on Windows 11 Sun Valley 2 (version 22H2) and later, "globally" otherwise.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2122,7 +2122,7 @@ This button is only enabled if NVDA is configured to enable loading custom code 
 
 This option changes how NVDA registers for events fired by the Microsoft UI Automation accessibility API.
 The registration for UI Automation events and property changes combo box has three options:
-- Automatic: "selectively" on Windows 11 Sun Valley 2 (version 22H2) and later, "globally" otherwise.
+- Automatic: Currently equivalent to "globally".
 - Selectively: NVDA will limit event registration to the system focus for most events.
 If you suffer from performance issues in one or more applications, We recommend you to try this functionality to see whether performance improves.
 However, on older versions of Windows, NVDA may have trouble tracking focus in some controls (such as the task manager and emoji panel).

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2113,12 +2113,16 @@ If you wish to distribute custom code to others, you should package it as an NVD
 This button opens the directory where you can place custom code while developing it.
 This button is only enabled if NVDA is configured to enable loading custom code from the Developer Scratchpad Directory.
 
-==== Enable selective registration for UI Automation events and property changes ====[AdvancedSettingsSelectiveUIAEventRegistration]
+==== Registration for UI Automation events and property changes ====[AdvancedSettingsSelectiveUIAEventRegistration]
 This option changes how NVDA registers for events fired by the Microsoft UI Automation accessibility API.
-When this option is disabled, NVDA registers for many UIA events that are processed and discarded within NVDA itself.
-This has a major negative impact on performance, especially in applications like Microsoft Visual Studio.
-Therefore, when this option is enabled, NVDA will limit event registration to the system focus for most events.
+The registration for UI Automation events and property changes combo box has three options:
+- Automatic: "selectively" on Windows 11 Sun Valley 2 (version 22H2) and later, "globally" otherwise.
+- Selectively: NVDA will limit event registration to the system focus for most events.
 If you suffer from performance issues in one or more applications, We recommend you to try this functionality to see whether performance improves.
+However, on older versions of Windows, NVDA may have trouble tracking focus in some controls (such as the task manager and emoji panel).
+- Globally: NVDA registers for many UIA events that are processed and discarded within NVDA itself.
+While focus tracking is more reliable in more situations, performance is significantly degraded, especially in applications like Microsoft Visual Studio.
+-
 
 ==== Use UI automation to access Microsoft Word document controls ====[MSWordUIA]
 Configures whether or not NVDA should use the UI Automation accessibility API to access Microsoft Word documents, rather than the older Microsoft Word object model.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2118,6 +2118,7 @@ This button is only enabled if NVDA is configured to enable loading custom code 
   Automatic
 : Options
   Automatic, Selectively, Globally
+:
 
 This option changes how NVDA registers for events fired by the Microsoft UI Automation accessibility API.
 The registration for UI Automation events and property changes combo box has three options:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
We would like to switch to selective UIA event registration by default.

### Description of how this pull request fixes the issue:
Convert the selective UIA registration option to a ternary setting and factor out logic to determine whether to register selectively into a new function.

### Testing strategy:
N/A

### Known issues with pull request:
None known

### Change log entries:
Not user-facing

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
