### PR TITLE
add tests for symbol levels

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -31,6 +31,13 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [speech]
 	# The synthesizer to use
 	synth = string(default=auto)
+	# symbolLevel values:
+	#  NONE = 0
+	#  SOME = 100
+	#  MOST = 200
+	#  ALL = 300
+	#  CHAR = 1000
+	#  UNCHANGED = -1
 	symbolLevel = integer(default=100)
 	trustVoiceLanguage = boolean(default=true)
 	includeCLDR = boolean(default=True)

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -12,6 +12,9 @@ import builtins
 import os
 import sys
 import ctypes
+
+import weakref
+
 import locale
 import gettext
 import enum
@@ -41,6 +44,9 @@ CP_ACP = "0"
 LCID_NONE = 0 # 0 used instead of None for backwards compatibility.
 
 LANGS_WITHOUT_TRANSLATIONS: FrozenSet[str] = frozenset(("en",))
+installedTranslation: Optional[weakref.ReferenceType] = None
+"""Saved copy of the installed translation for ease of wrapping.
+"""
 
 
 class LOCALE(enum.IntEnum):
@@ -371,6 +377,9 @@ def setLanguage(lang: str) -> None:
 	setLocale(getLanguage())
 	# Install our pgettext function.
 	builtins.pgettext = makePgettext(trans)
+
+	global installedTranslation
+	installedTranslation = weakref.ref(trans)
 
 
 def localeStringFromLocaleCode(localeCode: str) -> str:

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -28,6 +28,7 @@ from typing import (
 )
 from urllib.parse import quote as _quoteStr
 
+import typing
 from robotremoteserver import (
 	test_remote_server as _testRemoteServer,
 	stop_remote_server as _stopRemoteServer,
@@ -38,6 +39,9 @@ from SystemTestSpy import (
 	_nvdaSpyAlias,
 	configManager
 )
+
+if typing.TYPE_CHECKING:
+	from SystemTestSpy.speechSpyGlobalPlugin import NVDASpyLib
 
 # Imported for type information
 from robot.libraries.BuiltIn import BuiltIn
@@ -383,11 +387,10 @@ class NvdaLib:
 		return saveToPath
 
 
-def getSpyLib():
+def getSpyLib() -> "NVDASpyLib":
 	""" Gets the spy library instance. This has been augmented with methods for all supported keywords.
 	Requires NvdaLib and nvdaSpy (remote library - see speechSpyGlobalPlugin) to be initialised.
 	On failure check order of keywords in Robot log and NVDA log for failures.
-	@rtype: SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib
 	@return: Remote NVDA spy Robot Framework library.
 	"""
 	nvdaLib = _getLib("NvdaLib")

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -8,6 +8,7 @@ It allows tests to get information out of NVDA.
 It is copied into the (system test specific) NVDA profile directory. It becomes the '__init__.py' file as part
 of a package.
 """
+import gettext
 import typing
 from typing import Optional
 
@@ -116,6 +117,41 @@ class NVDASpyLib:
 			penultimateConf = penultimateConf[key]
 		ultimateKey = keyPath[-1]
 		penultimateConf[ultimateKey] = val
+
+	fakeTranslations: typing.Optional[gettext.NullTranslations] = None
+
+	def override_translationString(self, invariantString: str, replacementString: str):
+		import languageHandler
+		if not self.fakeTranslations:
+			class Translation_Fake(gettext.NullTranslations):
+				originalTranslationFunction: Optional
+				translationResults: typing.Dict[str, str]
+
+				def __init__(
+						self,
+						originalTranslationFunction: Optional
+				):
+					self.originalTranslationFunction = originalTranslationFunction
+					self.translationResults = {}
+					super().__init__()
+					self.install()
+
+				def gettext(self, msg: str) -> str:
+					if msg in self.translationResults:
+						return self.translationResults[msg]
+					if self.originalTranslationFunction:
+						return self.originalTranslationFunction.gettext(msg)
+					return msg
+
+				def restore(self) -> None:
+					self.translationResults.clear()
+					if self.originalTranslationFunction:
+						self.originalTranslationFunction.install()
+
+			self.fakeTranslations = Translation_Fake(
+				languageHandler.installedTranslation() if languageHandler.installedTranslation else None
+			)
+		self.fakeTranslations.translationResults[invariantString] = replacementString
 
 	def queueNVDAMainThreadCrash(self):
 		from queueHandler import queueFunction, eventQueue

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -29,7 +29,7 @@ class Move(_enum.Enum):
 	CHAR = "numpad3"
 	WORD = "numpad6"
 	LINE = "numpad9"
-	HOME = "control+home"
+	HOME = "shift+numpad7"
 
 
 class SymLevel(_enum.Enum):

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -107,27 +107,6 @@ def test_moveByWord():
 	_doTest(
 		navKey=Move.WORD,
 		reportedAfterLast=EndSpeech.BOTTOM,
-		symbolLevel=SymLevel.ALL,
-		expectedSpeech=[
-			'Say',
-			'left paren(quietly right paren)',  # parenthesis are named
-			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
-			'don tick t',  # mid-word symbol
-			'right dash pointing arrow', 't dash shirt',
-			# end of first line
-			'blank',  # single space and newline
-			'tab',  # tab and newline
-			'blank',  # 4 spaces and newline
-			'right dash pointing arrow',  # no space before or after symbol
-			't dash shirt',  # no space before or after symbol
-			't dash shirt',  # no character before or after symbol (no newline)
-			'blank'  # end of doc
-		]
-	)
-	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
-	_doTest(
-		navKey=Move.WORD,
-		reportedAfterLast=EndSpeech.BOTTOM,
 		symbolLevel=SymLevel.NONE,
 		expectedSpeech=[
 			'Say',
@@ -145,28 +124,32 @@ def test_moveByWord():
 		],
 	)
 
+	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
+
+	_doTest(
+		navKey=Move.WORD,
+		reportedAfterLast=EndSpeech.BOTTOM,
+		symbolLevel=SymLevel.ALL,
+		expectedSpeech=[
+			'Say',
+			'left paren(quietly right paren)',  # parenthesis are named
+			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
+			'don tick t',  # mid-word symbol
+			'right dash pointing arrow', 't dash shirt',
+			# end of first line
+			'blank',  # single space and newline
+			'tab',  # tab and newline
+			'blank',  # 4 spaces and newline
+			'right dash pointing arrow',  # no space before or after symbol
+			't dash shirt',  # no space before or after symbol
+			't dash shirt',  # no character before or after symbol (no newline)
+			'blank'  # end of doc
+		]
+	)
+
 
 def test_moveByLine():
 	_notepad.prepareNotepad(_getMoveByLineTestSample())
-	_doTest(
-		navKey=Move.LINE,
-		symbolLevel=SymLevel.ALL,
-		reportedAfterLast=EndSpeech.BOTTOM,
-		expectedSpeech=[
-			'Say',
-			'left paren(quietly right paren)',
-			'quote Hello comma,', 'Jim quote  dot.',
-			'don tick t',
-			'right-pointing arrow', 't-shirt',  # symbols each on a line
-			'right-pointing arrow', 't-shirt',  # symbols and a space each on a line
-			'right-pointing arrow  t-shirt',  # symbols joined no space
-			'blank',  # single space
-			'tab',  # single tab
-			'blank',  # 4 spaces
-			'blank',  # end of doc
-		],
-	)
-	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
 	_doTest(
 		navKey=Move.LINE,
 		reportedAfterLast=EndSpeech.BOTTOM,
@@ -185,37 +168,49 @@ def test_moveByLine():
 		]
 	)
 
+	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position
+
+	_doTest(
+		navKey=Move.LINE,
+		symbolLevel=SymLevel.ALL,
+		reportedAfterLast=EndSpeech.BOTTOM,
+		expectedSpeech=[
+			'Say',
+			'left paren(quietly right paren)',
+			'quote Hello comma,', 'Jim quote  dot.',
+			'don tick t',
+			'right-pointing arrow', 't-shirt',  # symbols each on a line
+			'right-pointing arrow', 't-shirt',  # symbols and a space each on a line
+			'right-pointing arrow  t-shirt',  # symbols joined no space
+			'blank',  # single space
+			'tab',  # single tab
+			'blank',  # 4 spaces
+			'blank',  # end of doc
+		],
+	)
+
 
 def test_moveByChar():
 	_notepad.prepareNotepad(_getMoveByCharTestSample())
 	# Symbol level should not affect move by character
 	# use the same expected speech with symbol level none and all.
-	symLevelNoneExpected = [
-		'S', 'space',
-		'left paren', 'right paren',
-		'quote', 'tick',
-		'e', 'comma',
-		'right pointing arrow', 't shirt',
-		'tab',
-		'carriage return',  # on Windows/notepad newline is \r\n
-		'line feed',  # on Windows/notepad newline is \r\n
-	]
 	# Bug: With symbol level ALL text due to a symbol substitution has further substitutions applied:
 	# IE: "t-shirt" either becomes "t shirt" or "t dash shirt" dependent on symbol level.
-	exceptions = {
-		'right pointing arrow': 'right dash pointing arrow',
-		't shirt': 't dash shirt',
-	}
-	symLevelAllExpected = [
-		e if e not in exceptions.keys() else exceptions[e]
-		for e in symLevelNoneExpected
-	]
 
 	_doTest(
 		navKey=Move.CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
 		symbolLevel=SymLevel.NONE,
-		expectedSpeech=symLevelNoneExpected,
+		expectedSpeech=[
+			'S', 'space',
+			'left paren', 'right paren',
+			'quote', 'tick',
+			'e', 'comma',
+			'right pointing arrow', 't shirt',   # note no dash, sym level All has
+			'tab',
+			'carriage return',  # on Windows/notepad newline is \r\n
+			'line feed',  # on Windows/notepad newline is \r\n
+		],
 	)
 
 	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position.
@@ -224,7 +219,16 @@ def test_moveByChar():
 		navKey=Move.CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
 		symbolLevel=SymLevel.ALL,
-		expectedSpeech=symLevelAllExpected,
+		expectedSpeech=[
+			'S', 'space',
+			'left paren', 'right paren',
+			'quote', 'tick',
+			'e', 'comma',
+			'right dash pointing arrow', 't dash shirt',  # note has dash, sym level None doesn't
+			'tab',
+			'carriage return',  # on Windows/notepad newline is \r\n
+			'line feed',  # on Windows/notepad newline is \r\n
+		],
 	)
 
 

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -104,6 +104,15 @@ def _getMoveByCharTestSample() -> str:
 
 def test_moveByWord():
 	"""Move by word with symbol level 'all' then with symbol level 'none'
+	Symbol expectations:
+	➔ - When replaced by speech "right-pointing arrow", the dash should not be removed.
+	👕 - When replaced by speech "t-shirt", the dash should not be removed, honor the replacement text for
+			symbols/punctuation.
+
+	There should not be any "empty" words. E.G. a word made of two bar chars: ||
+	Something should be reported, even at symbol level None. Possible:
+	- The names of the characters: "bar bar", what if there are many (hundreds) symbols?
+	- A placeholder speech UI E.G "symbols". Will it be obvious this is a placeholder?
 	"""
 	_notepad.prepareNotepad(_getMoveByWordTestSample())
 	_doTest(
@@ -112,17 +121,17 @@ def test_moveByWord():
 		symbolLevel=SymLevel.NONE,
 		expectedSpeech=[
 			'Say',
-			'(quietly)', 'Hello,', 'Jim', '.',  # no symbols named
-			"don't",  # mid-word symbol
-			'right pointing arrow', 't shirt',
+			'(quietly)', 'Hello,', 'Jim', '.',  # Expected: no symbols named
+			"don't",  # Expected: mid-word symbol
+			'right pointing arrow', 't shirt',  # todo: Expect dash
 			'1', 'bar', '2', '', '3', '', '4',  # todo: There should not be any "empty" words.
 			# end of first line
 			'blank',  # single space and newline
-			'',  # tab and newline
+			'',  # tab and newline  todo: There should not be any "empty" words.
 			'blank',  # 4 spaces and newline
 			'right pointing arrow',
-			't shirt',  # no space before or after symbol
-			't shirt',  # no character before or after symbol (no newline)
+			't shirt',  # todo: Expect dash
+			't shirt',  # todo: Expect dash
 			'blank',  # end of doc
 		],
 	)
@@ -135,39 +144,50 @@ def test_moveByWord():
 		symbolLevel=SymLevel.ALL,
 		expectedSpeech=[
 			'Say',
-			'left paren(quietly right paren)',  # parenthesis are named
-			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
-			'don tick t',  # mid-word symbol
-			'right dash pointing arrow', 't dash shirt',
-			'1', 'bar', '2', 'bar  bar', '3', 'bar  bar  bar', '4',
+			'left paren(quietly right paren)',  # Expect: parenthesis are named
+			'quote Hello comma,', 'Jim', 'quote  dot.',  # Expect: quote, comma and dot are named
+			'don tick t',  # Expect: mid-word symbol substituted
+			'right dash pointing arrow', 't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
+			'1', 'bar', '2', 'bar  bar', '3', 'bar  bar  bar', '4',  # Expect no empty words.
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right dash pointing arrow',  # no space before or after symbol
-			't dash shirt',  # no space before or after symbol
-			't dash shirt',  # no character before or after symbol (no newline)
+			'right dash pointing arrow',  # todo: Expect dash symbol not to be replaced with word.
+			't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
+			't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
 			'blank'  # end of doc
 		]
 	)
 
 
 def test_moveByLine():
+	"""
+	Symbol expectations:
+	➔ - When replaced by speech "right-pointing arrow", the dash should not be removed.
+	👕 - When replaced by speech "t-shirt", the dash should not be removed, honor the replacement text for
+			symbols/punctuation.
+
+	There should not be any "empty" lines. E.G. a line with only space / tabs
+	Something should be reported, even at symbol level None. Possible:
+	- The names of the characters: "tab space", what if there are many (hundreds)?
+	- A placeholder speech UI E.G "whitespace". Will it be obvious this is a placeholder?
+	"""
 	_notepad.prepareNotepad(_getMoveByLineTestSample())
 	_doTest(
 		navKey=Move.LINE,
 		reportedAfterLast=EndSpeech.BOTTOM,
 		symbolLevel=SymLevel.NONE,
 		expectedSpeech=[
-			'Say', '(quietly)', 'Hello,', 'Jim .', "don't",
-			'',  # right arrow symbol
+			'Say', '(quietly)', 'Hello,', 'Jim .', "don't",  # Expect:
+			'',  # todo: Expect 'right-pointing arrow'
 			't-shirt',
-			'',  # right arrow symbol
+			'',  # todo: Expect 'right-pointing arrow'
 			't-shirt',
-			't-shirt',  # note missing right arrow symbol
-			'1   2    3     4',
+			't-shirt',  # todo: Expect 'right-pointing arrow t-shirt'
+			'1   2    3     4',  # todo: Should symbols be passed to synth, i.e. "1 | 2 || 3 etc"?
 			'blank',  # single space
-			'',  # tab
+			'',  # tab  # todo: There should not be any "empty" lines.
 			'blank',  # four spaces
 			'blank',  # end of doc
 		]
@@ -181,13 +201,13 @@ def test_moveByLine():
 		reportedAfterLast=EndSpeech.BOTTOM,
 		expectedSpeech=[
 			'Say',
-			'left paren(quietly right paren)',
-			'quote Hello comma,', 'Jim quote  dot.',
-			'don tick t',
-			'right-pointing arrow', 't-shirt',  # symbols each on a line
-			'right-pointing arrow', 't-shirt',  # symbols and a space each on a line
-			'right-pointing arrow  t-shirt',  # symbols joined no space
-			'1  bar  2  bar  bar  3  bar  bar  bar  4',
+			'left paren(quietly right paren)',  # Expect: parenthesis are named
+			'quote Hello comma,', 'Jim quote  dot.',  # Expect: quote, comma and dot are named
+			'don tick t',  # Expect: mid-word symbol substituted
+			'right-pointing arrow', 't-shirt',  # Expect dash
+			'right-pointing arrow', 't-shirt',  # Expect dash
+			'right-pointing arrow  t-shirt',  # Expect dash
+			'1  bar  2  bar  bar  3  bar  bar  bar  4',  # Expect | symbol replaced with bar.
 			'blank',  # single space
 			'tab',  # single tab
 			'blank',  # 4 spaces
@@ -197,41 +217,50 @@ def test_moveByLine():
 
 
 def test_moveByChar():
-	_notepad.prepareNotepad(_getMoveByCharTestSample())
+	"""
 	# Symbol level should not affect move by character
 	# use the same expected speech with symbol level none and all.
-	# Bug: With symbol level ALL text due to a symbol substitution has further substitutions applied:
-	# IE: "t-shirt" either becomes "t shirt" or "t dash shirt" dependent on symbol level.
+	Symbol expectations:
+	➔ - When replaced by speech "right-pointing arrow", the dash should not be removed.
+	👕 - When replaced by speech "t-shirt", the dash should not be removed, honor the replacement text for
+			symbols/punctuation.
+
+	There should not be any "empty" characters.
+	"""
+	_notepad.prepareNotepad(_getMoveByCharTestSample())
 
 	_doTest(
 		navKey=Move.CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
 		symbolLevel=SymLevel.NONE,
 		expectedSpeech=[
-			'S', 'space',
-			'left paren', 'right paren',
-			'quote', 'tick',
-			'e', 'comma',
-			'right pointing arrow', 't shirt',   # note no dash, sym level All has
-			'tab',
-			'carriage return',  # on Windows/notepad newline is \r\n
+			'S', 'space',  # Expect whitespace named.
+			'left paren', 'right paren',  # Expect parens named
+			'quote', 'tick',  # Expect quote and apostrophe named
+			'e', 'comma',  # Expect comma named
+			'right pointing arrow', 't shirt',   # todo: Expect dash i.e. 'right-pointing arrow', 't-shirt'
+			'tab',  # Expect tab named
+			'carriage return',  # Expect Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n
 		],
 	)
 
 	_NvdaLib.getSpeechAfterKey(Move.HOME.value)  # reset to start position.
 
+	# todo: Bug, with symbol level ALL text due to a symbol substitution has further substitutions applied:
+	#       IE: "t-shirt" either becomes "t shirt" or "t dash shirt" dependent on symbol level.
 	_doTest(
 		navKey=Move.CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
 		symbolLevel=SymLevel.ALL,
 		expectedSpeech=[
-			'S', 'space',
-			'left paren', 'right paren',
-			'quote', 'tick',
-			'e', 'comma',
-			'right dash pointing arrow', 't dash shirt',  # note has dash, sym level None doesn't
-			'tab',
+			'S', 'space',  # Expect whitespace named.
+			'left paren', 'right paren',  # Expect parens named
+			'quote', 'tick',  # Expect quote and apostrophe named
+			'e', 'comma',  # Expect comma named
+			# todo: Expect no replacement with word 'dash' i.e. expect 'right-pointing arrow', 't-shirt'
+			'right dash pointing arrow', 't dash shirt',
+			'tab',  # Expect whitespace named.
 			'carriage return',  # on Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n
 		],
@@ -261,7 +290,7 @@ def test_symbolInSpeechUI():
 		# Illustrates a bug in NVDA. The internal speech UI is processed substituting symbols.
 		# This can be a major issue in languages other than English.
 		[
-			# 'tick' is a bug
+			# todo: 'tick' is a bug
 			"shouldn tick t sub tick symbol"  # intentionally concatenate strings
 			"\nblank",
 		],

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -62,6 +62,7 @@ def _getMoveByWordTestSample() -> str:
 		" don't"  # test punctuation inside a word.
 		# symbols have space before and after, so it is considered a word
 		" ➔ 👕 \n"  # test Symbols containing punctuations (right-pointing arrow, t-shirt)
+		"1 | 2 || 3 ||| 4\n"  # test single/multiple symbols within a "word" issue #10855
 		' \n'  # single space
 		'\t\n'  # single tab
 		'    \n'  # 4 spaces
@@ -82,6 +83,7 @@ def _getMoveByLineTestSample() -> str:
 		'➔', '👕',  # test Symbols containing punctuations (right-pointing arrow, t-shirt)
 		'➔ ', '👕 ',  # test Symbols containing punctuations with joined space
 		'➔👕',  # test Symbols containing punctuations without space
+		"1 | 2 || 3 ||| 4",  # test single/multiple symbols within a "word" issue #10855
 		' ',  # single space
 		'\t',  # single tab
 		'    ',  # 4 spaces
@@ -113,6 +115,7 @@ def test_moveByWord():
 			'(quietly)', 'Hello,', 'Jim', '.',  # no symbols named
 			"don't",  # mid-word symbol
 			'right pointing arrow', 't shirt',
+			'1', 'bar', '2', '', '3', '', '4',  # todo: There should not be any "empty" words.
 			# end of first line
 			'blank',  # single space and newline
 			'',  # tab and newline
@@ -136,6 +139,7 @@ def test_moveByWord():
 			'quote Hello comma,', 'Jim', 'quote  dot.',  # quote, comma and dot are named
 			'don tick t',  # mid-word symbol
 			'right dash pointing arrow', 't dash shirt',
+			'1', 'bar', '2', 'bar  bar', '3', 'bar  bar  bar', '4',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
@@ -161,6 +165,7 @@ def test_moveByLine():
 			'',  # right arrow symbol
 			't-shirt',
 			't-shirt',  # note missing right arrow symbol
+			'1   2    3     4',
 			'blank',  # single space
 			'',  # tab
 			'blank',  # four spaces
@@ -182,6 +187,7 @@ def test_moveByLine():
 			'right-pointing arrow', 't-shirt',  # symbols each on a line
 			'right-pointing arrow', 't-shirt',  # symbols and a space each on a line
 			'right-pointing arrow  t-shirt',  # symbols joined no space
+			'1  bar  2  bar  bar  3  bar  bar  bar  4',
 			'blank',  # single space
 			'tab',  # single tab
 			'blank',  # 4 spaces

--- a/tests/system/robot/notepadTests.py
+++ b/tests/system/robot/notepadTests.py
@@ -6,6 +6,8 @@
 """Logic for reading text using NVDA in the notepad text editor.
 """
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
+import typing as _typing
+
 from SystemTestSpy import (
 	_getLib,
 )
@@ -14,49 +16,192 @@ from SystemTestSpy import (
 from NotepadLib import NotepadLib as _NotepadLib
 from AssertsLib import AssertsLib as _AssertsLib
 import NvdaLib as _NvdaLib
+from robot.libraries.BuiltIn import BuiltIn
 
+_builtIn: BuiltIn = BuiltIn()
 _notepad: _NotepadLib = _getLib("NotepadLib")
 _asserts: _AssertsLib = _getLib("AssertsLib")
+
+navToNextCharKey = "numpad3"
+navToNextWordKey = "numpad6"
+navToNextLineKey = "numpad9"
+
+
+def _pressKeyAndCollectSpeech(key: str, numberOfTimes: int) -> _typing.List[str]:
+	actual = []
+	for _ in range(numberOfTimes):
+		spoken = _NvdaLib.getSpeechAfterKey(key)
+		# collect all output before asserting to show full picture of behavior
+		actual.append(spoken)
+	return actual
+
+
+def _doMoveByWordTest(expected: _typing.List[str]):
+	_moveByWordData = (
+		'Say (quietly) "Hello, Jim ". ➔ 👕 \n'
+		' \n'  # single space
+		'\t\n'
+		'    \n'  # 4 spaces
+		'➔\n'
+		'👕\n'  # no space after symbol
+		'👕'  # no character (no newline) after symbol
+	)
+	_notepad.prepareNotepad(f"Test: {_moveByWordData}")
+	actual = _pressKeyAndCollectSpeech(navToNextWordKey, numberOfTimes=len(expected))
+	_builtIn.should_be_equal(actual, expected)
+	# ensure all words tested
+	actual = _pressKeyAndCollectSpeech(navToNextWordKey, 1)
+	_builtIn.should_be_equal(actual, [f"Bottom\n{expected[-1]}", ])
 
 
 def test_moveByWord_symbolLevelWord():
 	"""Disabled due to revert of PR #11856 is: "Speak all symbols when moving by words (#11779)
 	"""
-	# unlike other symbols used, symbols.dic doesn't preserve quote symbols with SYMPRES_ALWAYS
-	_wordsToExpected = {
-		'Say': 'Say',
-		'(quietly)': 'left paren(quietly right paren)',
-		'"Hello,': 'quote Hello comma,',
-		'Jim".': 'Jim quote  dot.',
-		'➔': 'right-pointing arrow',  # Speech for symbols shouldn't change
-		'👕': 't-shirt',  # Speech for symbols shouldn't change
-	}
-
 	spy = _NvdaLib.getSpyLib()
 	spy.set_configValue(["speech", "symbolLevelWordAll"], True)
 
-	textStr = ' '.join(_wordsToExpected.keys())
-	_notepad.prepareNotepad(f"Test: {textStr}")
-	for expectedWord in _wordsToExpected.values():
-		wordSpoken = _NvdaLib.getSpeechAfterKey("numpad6")  # navigate to next word
-		_asserts.strings_match(wordSpoken, expectedWord)
+	# unlike other symbols used, symbols.dic doesn't preserve quote symbols with SYMPRES_ALWAYS
+	_doMoveByWordTest(expected=[
+		'Say',
+		'(quietly)',
+		'Hello,',
+		'Jim',
+		'.',
+		'right pointing arrow',  # has space before and after symbol
+		't shirt',  # has space before and after symbol
+		# end of first line
+		'blank',  # single space and newline
+		'',  # tab and newline
+		'blank',  # 4 spaces and newline
+		'right pointing arrow',  # no space before or after symbol
+		't shirt',  # no space before or after symbol
+		't shirt',  # no character before or after symbol (no newline)
+		'blank',  # end of doc
+	])
 
 
 def test_moveByWord():
-	_wordsToExpected = {
-		'Say': 'Say',
-		'(quietly)': '(quietly)',
-		'"Hello,': 'Hello,',
-		'Jim".': 'Jim .',
-		'➔': 'right pointing arrow',
-		'👕': 't shirt',
-	}
-
 	spy = _NvdaLib.getSpyLib()
 	spy.set_configValue(["speech", "symbolLevelWordAll"], False)
 
-	textStr = ' '.join(_wordsToExpected.keys())
-	_notepad.prepareNotepad(f"Test: {textStr}")
-	for expectedWord in _wordsToExpected.values():
-		wordSpoken = _NvdaLib.getSpeechAfterKey("numpad6")  # navigate to next word
-		_asserts.strings_match(wordSpoken, expectedWord)
+	_doMoveByWordTest(expected=[
+		'Say',
+		'(quietly)',
+		'Hello,',
+		'Jim',
+		'.',
+		'right pointing arrow',  # has space before and after symbol
+		't shirt',  # has space before and after symbol
+		# end of first line
+		'blank',  # single space and newline
+		'',  # tab and newline
+		'blank',  # 4 spaces and newline
+		'right pointing arrow',  # no space before or after symbol
+		't shirt',  # no space before or after symbol
+		't shirt',  # no character before or after symbol (no newline)
+		'blank',  # end of doc
+	])
+
+
+def _doMoveByLineTest():
+	testData = [
+		'Say',
+		'(quietly)',
+		'"Hello,',
+		'Jim".',
+		'➔',
+		'👕',
+		'➔ ',
+		'👕 ',
+		'➔👕',
+		' ',
+		'\t',
+		'    ',
+		'',
+	]
+
+	expected = [
+		'Say',
+		'(quietly)',
+		'Hello,',
+		'Jim .',
+		'right-pointing arrow',
+		't-shirt',
+		'right-pointing arrow',
+		't-shirt',
+		'right-pointing arrow  t-shirt',
+		'blank',  # single space
+		'',  # tab
+		'blank',  # four spaces
+		'blank',  # end of doc
+	]
+
+	textStr = '\n'.join(testData)
+
+	_notepad.prepareNotepad(f"Test:\n{textStr}")  # initial new line which isn't spoken
+	actual = _pressKeyAndCollectSpeech(navToNextLineKey, numberOfTimes=len(expected))
+	_builtIn.should_be_equal(actual, expected)
+	# ensure all lines tested
+	actual = _pressKeyAndCollectSpeech(navToNextLineKey, 1)
+	_builtIn.should_be_equal(actual, [f"Bottom\n{expected[-1]}", ])
+
+
+def test_moveByLine():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], False)
+	_doMoveByLineTest()
+
+
+def test_moveByLine_symbolLevelWord():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], True)
+	_doMoveByLineTest()
+
+
+def _doMoveByCharTest(expected: _typing.List[str]):
+	_text = 'S ()e,➔👕\t\na'  # note, 'a' is on next line and won't be spoken
+
+	_notepad.prepareNotepad(f" {_text}")
+	actual = _pressKeyAndCollectSpeech(navToNextCharKey, numberOfTimes=len(expected))
+	_builtIn.should_be_equal(actual, expected)
+	# ensure all chars tested
+	actual = _pressKeyAndCollectSpeech(navToNextCharKey, 1)
+	_builtIn.should_be_equal(actual, [f"Right\n{expected[-1]}", ])
+
+
+def test_moveByChar():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], False)
+
+	_doMoveByCharTest(expected=[
+		'S',
+		'space',
+		'left paren',
+		'right paren',
+		'e',
+		'comma',
+		'right pointing arrow',
+		't shirt',
+		'tab',
+		'carriage return',  # on Windows/notepad newline is \r\n
+		'line feed',  # on Windows/notepad newline is \r\n
+	])
+
+
+def test_moveByChar_symbolLevelWord():
+	spy = _NvdaLib.getSpyLib()
+	spy.set_configValue(["speech", "symbolLevelWordAll"], True)
+
+	_doMoveByCharTest([
+		'S',
+		'space',
+		'left paren',
+		'right paren',
+		'e',
+		'comma',
+		'right pointing arrow',
+		't shirt',
+		'tab',
+		'carriage return',  # on Windows/notepad newline is \r\n
+		'line feed',  # on Windows/notepad newline is \r\n
+	])

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -27,19 +27,6 @@ default setup
 	start NVDA	standard-dontShowWelcomeDialog.ini
 
 *** Test Cases ***
-moveByWord with symbolLevelWord
-	# Disabled due to revert of PR #11856 is: "Speak all symbols when moving by words (#11779)
-	[Tags]	excluded_from_build
-	[Documentation]	Ensure all symbols are read when navigating by word.
-	test_moveByWord_symbolLevelWord
-moveByLine with symbolLevelWord
-	[Documentation]	Ensure all symbols are read when navigating by line.
-	[Tags]	excluded_from_build
-	test_moveByLine_symbolLevelWord
-moveByCharacter with symbolLevelWord
-	[Documentation]	Ensure all symbols are read when navigating by character.
-	[Tags]	excluded_from_build
-	test_moveByChar_symbolLevelWord
 
 moveByWord
 	[Documentation]	Ensure symbols announced as expected when navigating by word (numpad 6).

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -28,6 +28,10 @@ default setup
 
 *** Test Cases ***
 
+symbolInSpeechUI
+	[Documentation]	Ensure symbols aren't substituted within NVDA speech UI.
+	test_symbolInSpeechUI
+
 moveByWord
 	[Documentation]	Ensure symbols announced as expected when navigating by word (numpad 6).
 	test_moveByWord

--- a/tests/system/robot/notepadTests.robot
+++ b/tests/system/robot/notepadTests.robot
@@ -19,7 +19,7 @@ Test Teardown	default teardown
 default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
-	Run Keyword If Test Failed	dump_speech_to_log
+	dump_speech_to_log
 	exit notepad
 	quit NVDA
 
@@ -32,6 +32,21 @@ moveByWord with symbolLevelWord
 	[Tags]	excluded_from_build
 	[Documentation]	Ensure all symbols are read when navigating by word.
 	test_moveByWord_symbolLevelWord
+moveByLine with symbolLevelWord
+	[Documentation]	Ensure all symbols are read when navigating by line.
+	[Tags]	excluded_from_build
+	test_moveByLine_symbolLevelWord
+moveByCharacter with symbolLevelWord
+	[Documentation]	Ensure all symbols are read when navigating by character.
+	[Tags]	excluded_from_build
+	test_moveByChar_symbolLevelWord
+
 moveByWord
-	[Documentation]	Ensure symbols announced as expected when navigating by word.
+	[Documentation]	Ensure symbols announced as expected when navigating by word (numpad 6).
 	test_moveByWord
+moveByLine
+	[Documentation]	Ensure symbols announced as expected when navigating by line (numpad 9).
+	test_moveByLine
+moveByCharacter
+	[Documentation]	Ensure symbols announced as expected when navigating by character (numpad 3).
+	test_moveByChar

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-"""Logic for reading text using NVDA in the notepad text editor.
+"""Tests for symbol pronunciation within NVDA.
 """
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
 import enum as _enum

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -54,3 +54,8 @@ selectionByCharacter
 	[Documentation]	Ensure symbols announced as expected when selecting by character (shift+right arrow).
 	[Tags]	selection
 	test_selByChar
+
+tableHeaderSymbols
+	[Documentation]	Ensure symbols announced as expected in table headers.
+	[Tags]	table
+	test_tableHeaders

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -3,13 +3,13 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 *** Settings ***
-Documentation	Plaintext test cases in notepad
-Force Tags	NVDA	smoke test	notepad
+Documentation	Symbol pronunciation tests
+Force Tags	NVDA	smoke test	symbols
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py
 # for test cases
-Library	notepadTests.py
+Library	symbolPronunciationTests.py
 Library	ScreenCapLibrary
 
 Test Setup	default setup

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -41,3 +41,16 @@ moveByLine
 moveByCharacter
 	[Documentation]	Ensure symbols announced as expected when navigating by character (numpad 3).
 	test_moveByChar
+
+selectionByWord
+	[Documentation]	Ensure symbols announced as expected when selecting by word (shift+control+right arrow).
+	[Tags]	selection
+	test_selByWord
+selectionByLine
+	[Documentation]	Ensure symbols announced as expected when selecting by line (shift+down arrow).
+	[Tags]	selection
+	test_selByLine
+selectionByCharacter
+	[Documentation]	Ensure symbols announced as expected when selecting by character (shift+right arrow).
+	[Tags]	selection
+	test_selByChar


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Related to issue #11779, #10855, and PR #12710

### Summary of the issue:
PR #12710 has been suffering from scope creep, several of the problems discussed pre-existed in NVDA.

With Symbol level all:
-  '👕' symbol ("t-shirt") spoken as 't dash shirt' when moving by word or character
- Text "don't" spoken as "don tick t" when moving by word
- Symbols in NVDA speech UI (EG "spelling error" in French "Faute d'orthographe") are processed as symbols. The example "Faute d'orthographe" becomes "Faute d apostrophe orthographe", equivalent to "spelling e tick rror" in English, except that "apostrophe" is a longer word than "tick".

### Description of how this pull request fixes the issue:
Note, this PR does not introduce user visible changes. It is intended to help developers reason about the behavior of NVDA.

- Test (to demonstrate) behavior with Symbol level All and None (as the boundary cases for behavior) when moving by word, line, character.
- Test (to demonstrate) behavior with Symbol Level All when speech UI contains a symbol. For this, the System Test Spy global plugin had to be modified to alter translation strings of NVDA at runtime.

### Testing strategy:
System tests.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
