### PR TITLE
Show IAccessible2 relations in developer info

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1712,6 +1712,11 @@ the NVDAObject for IAccessible
 			except Exception as e:
 				ret = "exception: %s" % e
 			info.append("IAccessible2 attributes: %s" % ret)
+			try:
+				ret = ", ".join(r.RelationType for r in self._IA2Relations)
+			except Exception as e:
+				ret = "exception: %s" % e
+			info.append(f"IAccessible2 relations: {ret}")
 		return info
 
 	def _get_language(self):

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1715,7 +1715,7 @@ the NVDAObject for IAccessible
 			try:
 				ret = ", ".join(r.RelationType for r in self._IA2Relations)
 			except Exception as e:
-				ret = "exception: %s" % e
+				ret = f"exception: {e}"
 			info.append(f"IAccessible2 relations: {ret}")
 		return info
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -113,6 +113,7 @@ This can dramatically decrease build times on multi core systems. (#13226)
 - ``easeOfAccess.ROOT_KEY``, ``easeOfAccess.APP_KEY_PATH`` are deprecated, please use``easeOfAccess.RegistryKey.ROOT``, ``easeOfAccess.RegistryKey.APP`` instead. These will be removed in 2023. (#13242)
 - ``easeOfAccess.APP_KEY_NAME`` has been deprecated, to be removed in 2023. (#13242)
 - ``DictionaryDialog`` and ``DictionaryEntryDialog`` are moved from ``gui.settingsDialogs`` to ``gui.speechDict``. (#13294)
+- IAccessible2 relations are now shown in developer info for IAccessible2 objects. (#13315)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
IAccessible2 has a concept of relations between objects. Among other things, this is used for aria-details, aria-controls, etc.

### Description of how this pull request fixes the issue:
Show the relations for an object in the developer info for ease of debugging. Note that this only shows the relations, not the objects itself.

### Testing strategy:
Used the example from https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls to prove that the relations shown in code are also visible in the developer info with this patch applied.

### Known issues with pull request:
None known

### Change log entries:
For Developers
- IAccessible2 relations are now shown in developer info for IAccessible2 objects.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
