### PR TITLE
HID Braille driver: allow performing chorded gestures (space+dots)

### DIFF
--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -292,10 +292,10 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 				self.routingIndex = buttonCapsInfo.relativeIndexInCollection
 				# Prefix the gesture name with the specific routing collection name (E.g. routerSet1)
 				namePrefix = self._usageIDToGestureName(linkUsagePage, linkUsageID)
-		name = self._usageIDToGestureName(usagePage, usageID)
-		if namePrefix:
-			name = "_".join([namePrefix, name])
-		names.append(name)
+			name = self._usageIDToGestureName(usagePage, usageID)
+			if namePrefix:
+				name = "_".join([namePrefix, name])
+			names.append(name)
 		self.id = "+".join(names)
 
 	def _usageIDToGestureName(self, usagePage: int, usageID: int):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -52,6 +52,7 @@ What's New in NVDA
 - In Windows 10 Calculator, NVDA will announce labels for history and memory list items. (#11858)
 - Gestures such as scrolling and routing again work with HID Braille devices. (#13228)
 - Windows 11 Mail: After switching focus between apps, while reading a long email, NVDA would get stuck on a line of the email. (#13050)
+- HID braille: chorded gestures (E.g. space+dot4) can be successfully performed from the Braille display. (#13326)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None.

### Summary of the issue:
When using a Braille display in NVDA via HID braille, it was impossible to perform chorded gestures, that is space with other dots. E.g. space+dot4 to move down by line.

### Description of how this pull request fixes the issue:
Fix an indenting error which caused only the last key in a chorded gesture to be listed in the BrailleGesture's id.

### Testing strategy:
* Connected to an Orbit Reader 40 in HID Braille mode.
* Opened a web page in browse mode.
* Pressed space+dot4 to move down by line.
* Confirmed the braille display showed the new line.

Also:
* With log level set to input/output,
* Performed multiple chorded gestures, confirming that the logged gesture identifiers contain both space and dots (E.g. br(StandardHid):space+dot4. Previously it whould only say br(StandardHid):space.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
* HID braille: chorded gestures (E.g. space+dot4) can be successfully performed from the Braille display.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
