### PR TITLE
Prevent Object Navigation Outside of the Lock Screen

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
+# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
 # Davy Kager
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -10,7 +10,6 @@ as well as the associated TextInfo class."""
 
 import os
 import time
-import re
 import typing
 import weakref
 import core
@@ -1296,11 +1295,16 @@ This code is executed if a gain focus event is received by this object.
 			return "%r (truncated)" % string[:truncateLen]
 		return repr(string)
 
-	def _get_devInfo(self):
+	devInfo: typing.List[str]
+	"""Information about this object useful to developers."""
+
+	# C901 '_get_devInfo' is too complex
+	# Note: when working on _get_devInfo, look for opportunities to simplify
+	# and move logic out into smaller helper functions.
+	def _get_devInfo(self) -> typing.List[str]:  # noqa: C901
 		"""Information about this object useful to developers.
 		Subclasses may extend this, calling the superclass property first.
 		@return: A list of text strings providing information about this object useful to developers.
-		@rtype: list of str
 		"""
 		info = []
 		try:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -564,6 +564,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 
 	#: Typing information for auto-property: _get_parent
 	parent: typing.Optional['NVDAObject']
+	"This object's parent (the object that contains this object)."
 
 	def _get_parent(self) -> typing.Optional['NVDAObject']:
 		"""Retrieves this object's parent (the object that contains this object).
@@ -580,17 +581,23 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		self.parent = parent
 		return parent
 
-	def _get_next(self):
+	#: Typing information for auto-property: _get_next
+	next: typing.Optional['NVDAObject']
+	"The object directly after this object with the same parent."
+
+	def _get_next(self) -> typing.Optional['NVDAObject']:
 		"""Retrieves the object directly after this object with the same parent.
 		@return: the next object if it exists else None.
-		@rtype: L{NVDAObject} or None
 		"""
 		return None
 
-	def _get_previous(self):
+	#: Typing information for auto-property: _get_previous
+	previous: typing.Optional['NVDAObject']
+	"The object directly before this object with the same parent."
+
+	def _get_previous(self) -> typing.Optional['NVDAObject']:
 		"""Retrieves the object directly before this object with the same parent.
 		@return: the previous object if it exists else None.
-		@rtype: L{NVDAObject} or None
 		"""
 		return None
 

--- a/source/api.py
+++ b/source/api.py
@@ -49,6 +49,8 @@ def _isSecureObjectWhileLockScreenActivated(obj: NVDAObjects.NVDAObject) -> bool
 	if lockAppModule is None:
 		return False
 
+	# The LockApp process might be kept alive
+	# So determine if it is active, check the foreground window
 	foregroundHWND = winUser.getForegroundWindow()
 	foregroundProcessId, _threadId = winUser.getWindowThreadProcessID(foregroundHWND)
 

--- a/source/api.py
+++ b/source/api.py
@@ -228,8 +228,6 @@ def setMouseObject(obj: NVDAObjects.NVDAObject) -> None:
 
 def getDesktopObject() -> NVDAObjects.NVDAObject:
 	"""Get the desktop object"""
-	if _isSecureObjectWhileLockScreenActivated(globalVars.desktopObject):
-		None
 	return globalVars.desktopObject
 
 

--- a/source/api.py
+++ b/source/api.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, James Teh, Michael Curran, Peter Vagner, Derek Riemer,
+# Copyright (C) 2006-2022 NV Access Limited, James Teh, Michael Curran, Peter Vagner, Derek Riemer,
 # Davy Kager, Babbage B.V., Leonard de Ruijter, Joseph Lee, Accessolutions, Julien Cochuyt
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
@@ -32,6 +32,36 @@ if typing.TYPE_CHECKING:
 	import documentBase
 
 
+def _isLockAppAndAlive(appModule: "appModuleHandler.AppModule"):
+	return appModule.appName == "lockapp" and appModule.isAlive
+
+
+def _isSecureObjectWhileLockScreenActivated(obj: NVDAObjects.NVDAObject) -> bool:
+	"""
+	While Windows is locked, Windows 10 and 11 allow for object navigation outside of the lockscreen.
+	@return: C{True} if the Windows 10/11 lockscreen is active and C{obj} is outside of the lockscreen.
+
+	According to MS docs, "There is no function you can call to determine whether the workstation is locked."
+	https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-lockworkstation
+	"""
+	runningAppModules = appModuleHandler.runningTable.values()
+	lockAppModule = next(filter(_isLockAppAndAlive, runningAppModules), None)
+	if lockAppModule is None:
+		return False
+
+	foregroundHWND = winUser.getForegroundWindow()
+	foregroundProcessId, _threadId = winUser.getWindowThreadProcessID(foregroundHWND)
+
+	isLockAppForeground = foregroundProcessId == lockAppModule.processID
+	isObjectOutsideLockApp = obj.appModule.processID != foregroundProcessId
+
+	if isLockAppForeground and isObjectOutsideLockApp:
+		if log.isEnabledFor(log.DEBUG):
+			devInfo = '\n'.join(obj.devInfo)
+			log.debug(f"Attempt at navigating to a secure object: {devInfo}")
+		return True
+	return False
+
 #User functions
 
 def getFocusObject() -> NVDAObjects.NVDAObject:
@@ -41,40 +71,50 @@ def getFocusObject() -> NVDAObjects.NVDAObject:
 	"""
 	return globalVars.focusObject
 
-def getForegroundObject():
+
+def getForegroundObject() -> NVDAObjects.NVDAObject:
 	"""Gets the current foreground object.
 	This (cached) object is the (effective) top-level "window" (hwnd).
 	EG a Dialog rather than the focused control within the dialog.
 	The cache is updated as queued events are processed, as such there will be a delay between the winEvent
 	and this function matching. However, within NVDA this should be used in order to be in sync with other
 	functions such as "getFocusAncestors".
-@returns: the current foreground object
-@rtype: L{NVDAObjects.NVDAObject}
-"""
+	@returns: the current foreground object
+	"""
 	return globalVars.foregroundObject
 
-def setForegroundObject(obj):
+
+def setForegroundObject(obj: NVDAObjects.NVDAObject) -> bool:
 	"""Stores the given object as the current foreground object.
 	Note: does not cause the operating system to change the foreground window,
 		but simply allows NVDA to keep track of what the foreground window is.
 		Alternative names for this function may have been:
 		- setLastForegroundWindow
 		- setLastForegroundEventObject
-@param obj: the object that will be stored as the current foreground object
-@type obj: NVDAObjects.NVDAObject
-"""
+	@param obj: the object that will be stored as the current foreground object
+	"""
 	if not isinstance(obj,NVDAObjects.NVDAObject):
+		return False
+	if _isSecureObjectWhileLockScreenActivated(obj):
 		return False
 	globalVars.foregroundObject=obj
 	return True
 
-def setFocusObject(obj):
-	"""Stores an object as the current focus object. (Note: this does not physically change the window with focus in the operating system, but allows NVDA to keep track of the correct object).
-Before overriding the last object, this function calls event_loseFocus on the object to notify it that it is loosing focus. 
-@param obj: the object that will be stored as the focus object
-@type obj: NVDAObjects.NVDAObject
-"""
+
+# C901 'setFocusObject' is too complex
+# Note: when working on setFocusObject, look for opportunities to simplify
+# and move logic out into smaller helper functions.
+def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
+	"""Stores an object as the current focus object.
+	Note: this does not physically change the window with focus in the operating system,
+	but allows NVDA to keep track of the correct object.
+	Before overriding the last object,
+	this function calls event_loseFocus on the object to notify it that it is losing focus.
+	@param obj: the object that will be stored as the focus object
+	"""
 	if not isinstance(obj,NVDAObjects.NVDAObject):
+		return False
+	if _isSecureObjectWhileLockScreenActivated(obj):
 		return False
 	if globalVars.focusObject:
 		eventHandler.executeEvent("loseFocus",globalVars.focusObject)
@@ -176,16 +216,26 @@ def getMouseObject():
 	"""Returns the object that is directly under the mouse"""
 	return globalVars.mouseObject
 
-def setMouseObject(obj):
+
+def setMouseObject(obj: NVDAObjects.NVDAObject) -> None:
 	"""Tells NVDA to remember the given object as the object that is directly under the mouse"""
+	if _isSecureObjectWhileLockScreenActivated(obj):
+		return
 	globalVars.mouseObject=obj
 
-def getDesktopObject():
+
+def getDesktopObject() -> NVDAObjects.NVDAObject:
 	"""Get the desktop object"""
+	if _isSecureObjectWhileLockScreenActivated(globalVars.desktopObject):
+		None
 	return globalVars.desktopObject
 
-def setDesktopObject(obj):
-	"""Tells NVDA to remember the given object as the desktop object"""
+
+def setDesktopObject(obj: NVDAObjects.NVDAObject) -> None:
+	"""Tells NVDA to remember the given object as the desktop object.
+	We cannot prevent setting this when _isSecureObjectWhileLockScreenActivated is True,
+	as NVDA needs to set the desktopObject on start, and NVDA may start from the lockscreen.
+	"""
 	globalVars.desktopObject=obj
 
 
@@ -231,36 +281,45 @@ def setReviewPosition(
 		visionContext = vision.constants.Context.REVIEW
 	vision.handler.handleReviewMove(context=visionContext)
 
-def getNavigatorObject():
-	"""Gets the current navigator object. Navigator objects can be used to navigate around the operating system (with the number pad) with out moving the focus. If the navigator object is not set, it fetches it from the review position. 
-@returns: the current navigator object
-@rtype: L{NVDAObjects.NVDAObject}
-"""
+
+def getNavigatorObject() -> NVDAObjects.NVDAObject:
+	"""Gets the current navigator object.
+	Navigator objects can be used to navigate around the operating system (with the numpad),
+	without moving the focus.
+	If the navigator object is not set, it fetches and sets it from the review position.
+	@returns: the current navigator object
+	"""
 	if globalVars.navigatorObject:
 		return globalVars.navigatorObject
+	elif review.getCurrentMode() == 'object':
+		obj = globalVars.reviewPosition.obj
 	else:
-		if review.getCurrentMode()=='object':
-			obj=globalVars.reviewPosition.obj
-		else:
-			try:
-				obj=globalVars.reviewPosition.NVDAObjectAtStart
-			except (NotImplementedError,LookupError):
-				obj=globalVars.reviewPosition.obj
-		globalVars.navigatorObject=getattr(obj,'rootNVDAObject',None) or obj
+		try:
+			obj = globalVars.reviewPosition.NVDAObjectAtStart
+		except (NotImplementedError, LookupError):
+			obj = globalVars.reviewPosition.obj
+	nextObj = getattr(obj, 'rootNVDAObject', None) or obj
+	if _isSecureObjectWhileLockScreenActivated(nextObj):
 		return globalVars.navigatorObject
+	globalVars.navigatorObject = nextObj
+	return globalVars.navigatorObject
 
-def setNavigatorObject(obj,isFocus=False):
-	"""Sets an object to be the current navigator object. Navigator objects can be used to navigate around the operating system (with the number pad) with out moving the focus. It also sets the current review position to None so that next time the review position is asked for, it is created from the navigator object.  
-@param obj: the object that will be set as the current navigator object
-@type obj: NVDAObjects.NVDAObject  
-@param isFocus: true if the navigator object was set due to a focus change.
-@type isFocus: bool
-"""
-	if not isinstance(obj,NVDAObjects.NVDAObject):
+
+def setNavigatorObject(obj: NVDAObjects.NVDAObject, isFocus: bool = False) -> Optional[bool]:
+	"""Sets an object to be the current navigator object.
+	Navigator objects can be used to navigate around the operating system (with the numpad),
+	without moving the focus.
+	It also sets the current review position to None so that next time the review position is asked for,
+	it is created from the navigator object.
+	@param obj: the object that will be set as the current navigator object
+	@param isFocus: true if the navigator object was set due to a focus change.
+	"""
+
+	if not isinstance(obj, NVDAObjects.NVDAObject):
+		return False
+	if _isSecureObjectWhileLockScreenActivated(obj):
 		return False
 	globalVars.navigatorObject=obj
-	oldPos=globalVars.reviewPosition
-	oldPosObj=globalVars.reviewPositionObj
 	globalVars.reviewPosition=None
 	globalVars.reviewPositionObj=None
 	reviewMode=review.getCurrentMode()

--- a/source/appModules/lockapp.py
+++ b/source/appModules/lockapp.py
@@ -3,6 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from typing import Callable, TYPE_CHECKING
 import appModuleHandler
 import controlTypes
 import inputCore
@@ -11,6 +12,9 @@ import eventHandler
 import config
 from NVDAObjects.UIA import UIA
 from globalCommands import GlobalCommands
+
+if TYPE_CHECKING:
+	import NVDAObjects
 
 """App module for the Windows 10 and 11 lock screen.
 The lock screen runs as the logged in user on the default desktop,
@@ -28,6 +32,13 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
 		if isinstance(obj,UIA) and obj.role==controlTypes.Role.PANE and obj.UIAElement.cachedClassName=="LockAppContainer":
 			clsList.insert(0,LockAppContainer)
+
+	def event_foreground(self, obj: NVDAObjects.NVDAObject, nextHandler: Callable[[], None]):
+		"""Set mouse object explicitly before continuing to the next handler.
+		This is to prevent the mouse focus remaining on the desktop when locking the screen.
+		"""
+		api.setMouseObject(obj)
+		nextHandler()
 
 	SAFE_SCRIPTS = {
 		GlobalCommands.script_reportCurrentFocus,

--- a/source/appModules/lockapp.py
+++ b/source/appModules/lockapp.py
@@ -33,12 +33,25 @@ class AppModule(appModuleHandler.AppModule):
 		if isinstance(obj,UIA) and obj.role==controlTypes.Role.PANE and obj.UIAElement.cachedClassName=="LockAppContainer":
 			clsList.insert(0,LockAppContainer)
 
-	def event_foreground(self, obj: NVDAObjects.NVDAObject, nextHandler: Callable[[], None]):
+	def event_foreground(self, obj: "NVDAObjects.NVDAObject", nextHandler: Callable[[], None]):
 		"""Set mouse object explicitly before continuing to the next handler.
 		This is to prevent the mouse focus remaining on the desktop when locking the screen.
 		"""
 		api.setMouseObject(obj)
 		nextHandler()
+
+	def event_NVDAObject_init(self, obj: "NVDAObjects.NVDAObject") -> None:
+		"""
+		Prevent users from object navigating outside of the lock screen.
+		While usages of `api._isSecureObjectWhileLockScreenActivated` in the api module prevent
+		the user from moving to the object, this event handling prevents reading the objects.
+		"""
+		if obj.parent and obj.parent.appModule.appName != "lockapp":
+			obj.parent = None
+		if obj.next and obj.next.appModule.appName != "lockapp":
+			obj.next = None
+		if obj.previous and obj.previous.appModule.appName != "lockapp":
+			obj.previous = None
 
 	SAFE_SCRIPTS = {
 		GlobalCommands.script_reportCurrentFocus,

--- a/source/appModules/lockapp.py
+++ b/source/appModules/lockapp.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2015 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2015-2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import appModuleHandler
 import controlTypes
@@ -12,12 +12,13 @@ import config
 from NVDAObjects.UIA import UIA
 from globalCommands import GlobalCommands
 
-"""App module for the Windows 10 lock screen.
+"""App module for the Windows 10 and 11 lock screen.
 The lock screen runs as the logged in user on the default desktop,
 so we need to explicitly stop people from accessing/changing things outside of the lock screen.
+This is done in the api module by utilizing _isSecureObjectWhileLockScreenActivated.
 """
 
-# Windows 10 lock screen container
+# Windows 10 and 11 lock screen container
 class LockAppContainer(UIA):
 	# Make sure the user can get to this so they can dismiss the lock screen from a touch screen.
 	presentationType=UIA.presType_content
@@ -27,11 +28,6 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
 		if isinstance(obj,UIA) and obj.role==controlTypes.Role.PANE and obj.UIAElement.cachedClassName=="LockAppContainer":
 			clsList.insert(0,LockAppContainer)
-
-	def event_NVDAObject_init(self, obj):
-		if obj.role == controlTypes.Role.WINDOW:
-			# Stop users from being able to object navigate out of the lock screen.
-			obj.parent = None
 
 	SAFE_SCRIPTS = {
 		GlobalCommands.script_reportCurrentFocus,
@@ -46,6 +42,7 @@ class AppModule(appModuleHandler.AppModule):
 		GlobalCommands.script_navigatorObject_next,
 		GlobalCommands.script_navigatorObject_previous,
 		GlobalCommands.script_navigatorObject_firstChild,
+		GlobalCommands.script_navigatorObject_devInfo,
 		GlobalCommands.script_review_activate,
 		GlobalCommands.script_review_top,
 		GlobalCommands.script_review_previousLine,

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -1,26 +1,25 @@
-#globalVars.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2007 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2022 NVDA Contributors <http://www.nvda-project.org/>
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
 """global variables module
 @var foregroundObject: holds the current foreground object. The object for the last foreground event received.
-@type foregroundObject: L{NVDAObjects.NVDAObject}
-  @var focusObject: holds the current focus object
-@type focusObject: L{NVDAObjects.NVDAObject}
+@var focusObject: holds the current focus object
 @var mouseObject: holds the object that is at the position of the mouse pointer
-@type mouseObject: L{NVDAObjects.NVDAObject}
 @var mouseOldX: the last x coordinate of the mouse pointer before its current position
 @type oldMouseX: int
 @var mouseOldY: the last y coordinate of the mouse pointer before its current position
 @type oldMouseY: int
-  @var navigatorObject: holds the current navigator object
-@type navigatorObject: L{NVDAObjects.NVDAObject}
+@var navigatorObject: holds the current navigator object
 """
 
 import argparse
 import os
 import typing
+
+if typing.TYPE_CHECKING:
+	import NVDAObjects  # noqa: F401 used for type checking only
 
 
 class DefautAppArgs(argparse.Namespace):
@@ -48,15 +47,15 @@ class DefautAppArgs(argparse.Namespace):
 
 
 startTime=0
-desktopObject=None
-foregroundObject=None
-focusObject=None
-focusAncestors=[]
+desktopObject: typing.Optional['NVDAObjects.NVDAObject'] = None
+foregroundObject: typing.Optional['NVDAObjects.NVDAObject'] = None
+focusObject: typing.Optional['NVDAObjects.NVDAObject'] = None
+focusAncestors: typing.List['NVDAObjects.NVDAObject'] = []
 focusDifferenceLevel=None
-mouseObject=None
+mouseObject: typing.Optional['NVDAObjects.NVDAObject'] = None
 mouseOldX=None
 mouseOldY=None
-navigatorObject=None
+navigatorObject: typing.Optional['NVDAObjects.NVDAObject'] = None
 reviewPosition=None
 reviewPositionObj=None
 lastProgressValue=0

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -1,8 +1,7 @@
-#winUser.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited, Babbage B.V.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2022 NV Access Limited, Babbage B.V.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """Functions that wrap Windows API functions from user32.dll"""
 
@@ -11,6 +10,7 @@ from ctypes import *
 from ctypes import byref, WinError, Structure, c_int, c_char
 from ctypes.wintypes import *
 from ctypes.wintypes import HWND, RECT, DWORD
+from typing import Tuple
 import winKernel
 from textUtils import WCHAR_ENCODING
 import enum
@@ -457,7 +457,8 @@ def isDescendantWindow(parentHwnd,childHwnd):
 	else:
 		return False
 
-def getForegroundWindow():
+
+def getForegroundWindow() -> HWND:
 	return user32.GetForegroundWindow()
 
 def setForegroundWindow(hwnd):
@@ -492,10 +493,12 @@ def unhookWinEvent(*args):
 def sendMessage(hwnd,msg,param1,param2):
 	return user32.SendMessageW(hwnd,msg,param1,param2)
 
-def getWindowThreadProcessID(hwnd):
+
+def getWindowThreadProcessID(hwnd: HWND) -> Tuple[int, int]:
+	"""Returns a tuple of (processID, threadID)"""
 	processID=c_int()
 	threadID=user32.GetWindowThreadProcessId(hwnd,byref(processID))
-	return (processID.value,threadID)
+	return (processID.value, threadID)
 
 def getClassName(window):
 	buf=create_unicode_buffer(256)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -38,6 +38,7 @@ What's New in NVDA
 -
 
 == Bug Fixes ==
+- Security fix: Prevent object navigation outside of the lockscreen on Windows 10 and Windows 11. (#13328)
 - Clipboard manager pane should no longer incorrectly steal focus when opening some Office programs. (#12736)
 - On a system where the user has chosen to swap the primary mouse button from the left to the right, NVDA will no longer accidentally bring up a context menu instead of activating an item, in applications such as web browsers. (#12642)
 - When moving the review cursor past the end of text controls, such as in Microsoft Word with UI Automation, "bottom" is correctly reported in more situations. (#12808)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

None, follow up on #5269

### Summary of the issue:

On earlier Windows 10 builds, the top-level Window (`Role.WINDOW`) of the lock screen cannot directly navigate to the system with object navigation, but its parent can. This was fixed in a commit addressing #5269.

On Windows 11 and newer Windows 10 builds, the top-level Window can directly navigate to the system with object navigation.

STR:
1. Press Windows+L
2. press containing object (NVDA+numpad8/NVDA+shift+upArrow),
3. then you can use next object (NVDA+numpad6/NVDA+shift+rightArrow) to navigate the system.

On Windows 10 and 11, using "Navigate to the object under the mouse" (`NVDA+numpadMultiply/NVDA+shift+n`), you can navigate outside to the system from the lock screen.

Microsoft is aware of this issue.

### Description of how this pull request fixes the issue:

This PR adds a function which checks if the lockapp is the foreground window, and if so, if a given object is outside of the lockapp.
To prevent focus objects being set or used for navigation, this function is utilised in various `api` methods.

An overlay class is also added which prevents navigation and announcement of content outside of the lockapp.

This PR also adds `GlobalCommands.script_navigatorObject_devInfo` to the allowed commands on the lockscreen to aid with debugging.
This command should be safe as:
1. The command only logs objects it can navigate to
1. The log viewer cannot be accessed from the lockscreen

### Testing strategy:

Manual testing on Windows 11, Windows 10 21H2, Windows 10 1809
- [x] Attempt to navigate outside the top level window of the lock screen using object navigation using STR
- [x] Ensure the lock screen can still be navigated with object navigation

### Known issues with pull request:

Performing 2 windows windll at every attempt to object navigate might add latency to object navigation.
This is mitigated by checking first if the lockapp appModule is running, however the lockapp process stays alive for sometime and cannot be used by itself.

>There is no function you can call to determine whether the workstation is locked.
https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-lockworkstation
https://stackoverflow.com/questions/34514644/in-python-3-how-can-i-tell-if-windows-is-locked

An advisory is required to be sent out for earlier NVDA versions.

### Change log entries:
Bug fixes

```
- Security fix: Prevent object navigation outside of the lockscreen on Windows 10 and Windows 11.
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
