### PR TITLE
Correctly reconnect to Focus Blue displays on resume

### DIFF
--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -278,7 +278,8 @@ class Bulk(IoBase):
 				log.debug("Open write handle failed: %s" % ctypes.WinError())
 			raise ctypes.WinError()
 		super(Bulk, self).__init__(readHandle, onReceive,
-			writeFileHandle=writeHandle, onReceiveSize=onReceiveSize, ignoreError=ignoreError)
+		                           writeFileHandle=writeHandle, onReceiveSize=onReceiveSize,
+		                           ignoreError=ignoreError)
 
 	def close(self):
 		super(Bulk, self).close()

--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -39,7 +39,8 @@ class IoBase(object):
 			fileHandle: Union[ctypes.wintypes.HANDLE],
 			onReceive: Callable[[bytes], None],
 			writeFileHandle: Optional[ctypes.wintypes.HANDLE] = None,
-			onReceiveSize: int = 1
+			onReceiveSize: int = 1,
+			ignoreError: Optional[Callable[[int], bool]] = None
 	):
 		"""Constructor.
 		@param fileHandle: A handle to an open I/O device opened for overlapped I/O.
@@ -48,11 +49,14 @@ class IoBase(object):
 		@param onReceive: A callable taking the received data as its only argument.
 		@param writeFileHandle: A handle to an open output device opened for overlapped I/O.
 		@param onReceiveSize: The size (in bytes) of the data with which to call C{onReceive}.
+		@param ignoreError: If provided, a callback that takes the error code for failed I/O and
+		  returns true if the erro should be ignored
 		"""
 		self._file = fileHandle
 		self._onReceive = onReceive
 		self._writeFile = writeFileHandle if writeFileHandle is not None else fileHandle
 		self._readSize = onReceiveSize
+		self._ignoreError = ignoreError
 		self._readBuf = ctypes.create_string_buffer(onReceiveSize)
 		self._readOl = OVERLAPPED()
 		self._recvEvt = winKernel.createEvent()
@@ -141,8 +145,10 @@ class IoBase(object):
 			self._ioDone = None
 			return
 		elif error != 0:
-			raise ctypes.WinError(error)
-		self._notifyReceive(self._readBuf[:numberOfBytes])
+			if not self._ignoreError or not self._ignoreError(error):
+				raise ctypes.WinError(error)
+		if error == 0:
+			self._notifyReceive(self._readBuf[:numberOfBytes])
 		winKernel.kernel32.SetEvent(self._recvEvt)
 		self._asyncRead()
 
@@ -244,13 +250,16 @@ class Bulk(IoBase):
 	def __init__(
 			self, path: str, epIn: int, epOut: int,
 			onReceive: Callable[[bytes], None],
-			onReceiveSize: int = 1
+			onReceiveSize: int = 1,
+			ignoreError: Optional[Callable[[int], bool]] = None
 	):
 		"""Constructor.
 		@param path: The device path.
 		@param epIn: The endpoint to read data from.
 		@param epOut: The endpoint to write data to.
 		@param onReceive: A callable taking a received input report as its only argument.
+		@param ignoreError: An optional callable that takes an I/O error code and
+		  indicates if it should be ignored, potentially after handling it
 		"""
 		if _isDebug():
 			log.debug("Opening device %s" % path)
@@ -269,7 +278,7 @@ class Bulk(IoBase):
 				log.debug("Open write handle failed: %s" % ctypes.WinError())
 			raise ctypes.WinError()
 		super(Bulk, self).__init__(readHandle, onReceive,
-			writeFileHandle=writeHandle, onReceiveSize=onReceiveSize)
+			writeFileHandle=writeHandle, onReceiveSize=onReceiveSize, ignoreError=ignoreError)
 
 	def close(self):
 		super(Bulk, self).close()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -55,6 +55,7 @@ What's New in NVDA
 - Windows 11 Mail: After switching focus between apps, while reading a long email, NVDA would get stuck on a line of the email. (#13050)
 - HID braille: chorded gestures (E.g. space+dot4) can be successfully performed from the Braille display. (#13326)
 - Fixed an issue where multiple settings dialogs could be opened at the same time. (#12818)
+- Fixed a problem where some Focus Blue Braille displays would stop working after waking the computer from sleep. (#9830)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes https://github.com/nvaccess/nvda/issues/9830

### Summary of the issue: 
NVDA doesn't correctly regain control of some Focus Blue displays after the user has left the post-resume secure desktop. When in this state, Braille is only sent to the display when on a secure desktop. To regain normal functionality, the user must restart NVDA, possibly after unplugging the display and plugging it back in again.

From a technical perspective, the failure mode shows up as an error 995 (referring to cancelled I/O operations) in the background reader thread, which then leads to all the ack packets timing out.

### Description of how this pull request fixes the issue:

This PR adds an `onReadError` callback to `hwIo`, which allows `hwIo` users to handle I/O errors that can't be caught with a try/catch (since the exception happens on a different thread).

It then uses this callback to detect the interrupted I/O characteristic of the post-resume failure state. When the issue occurs, the driver is terminated and reinitialized.

### Testing strategy:

I suspended and resumed my computer while running a development build that included this fix and observed that, unlike with the latest release, the Braille display reflected changes to what I'd typed in a terminal after resume, instead of consistently showing "Secure Desktop".

I also checked the logs to ensure that the driver was only initialized once and that there weren't other exceptions being thrown as a result of this change.

### Known issues with pull request:

None

### Change log entries:
New features
Changes
Bug fixes
- Fixed a problem where some Focus Blue Braille displays would stop working after waking the computer from sleep
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered: (N/A)
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
