### PR TITLE
Added NVDA+8 in Commands Quick Reference.

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1752,6 +1752,7 @@ Enabled by default, this option allows you to choose if gestures (such as key pr
 As an example, if enabled and the letter j was pressed, it would be trapped from reaching the document, even though it is not a quick navigation command nor is it likely to be a command in the application itself.
 In this case NVDA will tell Windows to play a default sound whenever a key which gets trapped is pressed.
 
+%kc:setting
 ==== Automatically set system focus to focusable elements ====[BrowseModeSettingsAutoFocusFocusableElements]
 Key: NVDA+8
 


### PR DESCRIPTION
Asked by @tiago-casal



### Link to issue number:

Fixes #13324.

### Summary of the issue:

NVDA+8 was missing in "Commands Quick Reference" documentation #13324.

### Description of how this pull request fixes the issue:

As per @tiago-casal's instructions in #13324.
Added the missing macro line to have it listed in the command quick ref doc.

### Testing strategy:

Generated locally the documentation and checked that NVDA+8 has appeared in the command quick ref doc.

### Known issues with pull request:
None.

### Change log entries:
Not needed.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
