### PR TITLE
Fixed some escape sequence in strings.

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -716,16 +716,16 @@ class ExcelWorksheet(ExcelBase):
 		# Sheet1!
 		# ''Sheet2 (4)'!
 		# 'profit and loss'!
-		u'^((?P<sheet>(\'[^\']+\'|[^!]+))!)?'
+		r"^((?P<sheet>('[^']+'|[^!]+))!)?"
 		# followed by a unique name (not containing spaces). Example:
 		# rowtitle_ab12-cd34-de45
-		u'(?P<name>\w+)'
+		r'(?P<name>\w+)'
 		# Optionally followed by minimum and maximum addresses, starting with a period (.). Example:
 		# .a1.c3
 		# .ab34
-		u'(\.(?P<minAddress>[a-zA-Z]+[0-9]+)?(\.(?P<maxAddress>[a-zA-Z]+[0-9]+)?'
+		r'(\.(?P<minAddress>[a-zA-Z]+[0-9]+)?(\.(?P<maxAddress>[a-zA-Z]+[0-9]+)?'
 		# Optionally followed by a period (.) and extra random data (sometimes produced by other screen readers)
-		u'(\..*)*)?)?$'
+		r'(\..*)*)?)?$'
 	)
 
 	def populateHeaderCellTrackerFromNames(self,headerCellTracker):

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -175,7 +175,7 @@ def terminate():
 	pass
 
 def _getDefaultAddonPaths():
-	""" Returns paths where addons can be found.
+	r""" Returns paths where addons can be found.
 	For now, only <userConfig>\addons is supported.
 	@rtype: list(string)
 	"""
@@ -517,7 +517,7 @@ class Addon(AddonBase):
 				func(*args,**kwargs)
 
 	def getDocFilePath(self, fileName=None):
-		"""Get the path to a documentation file for this add-on.
+		r"""Get the path to a documentation file for this add-on.
 		The file should be located in C{doc\lang\file} inside the add-on,
 		where C{lang} is the language code and C{file} is the requested file name.
 		Failing that, the language without country is tried.

--- a/source/api.py
+++ b/source/api.py
@@ -457,7 +457,7 @@ def filterFileName(name):
 	@returns: The filtered file name.
 	@rtype: str
 	"""
-	invalidChars=':?*\|<>/"'
+	invalidChars = r':?*\|<>/"'
 	for c in invalidChars:
 		name=name.replace(c,'_')
 	return name

--- a/source/installer.py
+++ b/source/installer.py
@@ -31,7 +31,7 @@ def _getWSH():
 	return _wsh
 
 defaultStartMenuFolder=versionInfo.name
-with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\Microsoft\Windows\CurrentVersion") as k: 
+with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion") as k:
 	programFilesPath=winreg.QueryValueEx(k, "ProgramFilesDir")[0] 
 defaultInstallPath=os.path.join(programFilesPath, versionInfo.name)
 


### PR DESCRIPTION
  ### Link to issue number:
  
  None
  
  ### Summary of the issue:
  
  NVDA code base has some erroneous strings containing backslash:
  * Running NVDA from source, you can get the following warning:
  ```
  DEBUGWARNING - Python warning (23:25:35.885) - MainThread (9764):
  C:\Users\CB232690\Documents\DevP\GIT\nvda\source\api.py:460: DeprecationWarning: invalid escape sequence \|
  ```
  * some functions have docstring containing a backslash where it should be two of them (or a raw string)
  
  ### Description of how this pull request fixes the issue:
  
  * Run fllake8 on the whole codebase and fixed the following 9 errors:
  `9     W605 invalid escape sequence '\w'`
  * Run the following command in command shell:
  `myPrompt> git grep -e "\\[abfntv]" | find ".py">h:\report.txt`
  And inspected the report file.
  Found two docstrings to modify to have backslash appearing correctly in the docstring.
  I did not include escape sequences \u, \x and \U since Python issues an error in case of bad sequence.
  
  ### Testing strategy:
  * For W605 error: copy / paste the modified string before and after in the console and checked their equality, e.g.:
  ```
  >>> a = u'^((?P<sheet>(\'[^\']+\'|[^!]+))!)?'
  >>> b = r"^((?P<sheet>('[^']+'|[^!]+))!)?"
  >>> a == b
  ```
  * Checked manually the modified docstrings in the console:
  ```
  >>> import addonHandler
  >>> help(addonHandler.Addon.getDocFilePath)
  >>> help(addonHandler._getDefaultAddonPaths)
  ```
  
  
  
  ### Known issues with pull request:
  None
  
  ### Change log entries:
  Not needed
  ### Code Review Checklist:
  
  
  - [x] Pull Request description:
  - description is up to date
  - change log entries
  - [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
  - [x] API is compatible with existing add-ons.
  - [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
  - [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
