### PR TITLE
WordDocument with UIA:  don't support resolved or draft comments in NVDA Elements List

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -92,12 +92,7 @@ def getCommentInfoFromPosition(position):
 		UIAElement=UIAElement.buildUpdatedCache(UIAHandler.handler.baseCacheRequest)
 		typeID = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAnnotationTypeIdPropertyId)
 		# Use Annotation Type Comment if available
-		cats = position.obj._UIACustomAnnotationTypes
-		if (
-			typeID == UIAHandler.AnnotationType_Comment
-			or (typeID and typeID == cats.microsoftWord_draftComment)
-			or (typeID and typeID == cats.microsoftWord_resolvedComment)
-		):
+		if typeID == UIAHandler.AnnotationType_Comment:
 			comment = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_NamePropertyId)
 			author = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAuthorPropertyId)
 			date = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationDateTimePropertyId)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Supersedes pr #13149 
 
### Summary of the issue:
The following error is in the log when viewing annotations in the NVDA elements list:
```
ERROR - queueHandler.flushQueue (19:47:20.811) - MainThread (9476):
Error in func ElementsListDialog.initElementType
Traceback (most recent call last):
  File "queueHandler.pyc", line 55, in flushQueue
  File "browseMode.pyc", line 1054, in initElementType
  File "browseMode.pyc", line 1074, in filter
  File "NVDAObjects\UIA\wordDocument.pyc", line 139, in label
  File "NVDAObjects\UIA\wordDocument.pyc", line 95, in getCommentInfoFromPosition
AttributeError: 'WordBrowseModeDocument' object has no attribute '_UIACustomAnnotationTypes'
```

This is because getCommentInfoFromPosition tries to fetch custom annotation types off its obj property, which it incorrectly expects to be a UIA NVDAObject. But in this case it is a TreeInterceptor.

PR #13149  was opened to address this by specifically creating a UIA NVDAObject rather than getting it from the position TextInfo. However, Further investigation has found that it is actually not necessary to even support custom annotation types (draft comment, resolved comment) in getCommentInfoFromPosition as:
1. Quicknav / Elements List iteration was never updated to specifically jump to / list those custom comment types. See `CommentUIATextInfoQuickNavItem.wantedAttribValues`
2. Although the IUIAutomationTextRange implementation in MS Word does return these custom comment types in GetAttributeValue when given UIA_AnnotationTypesAttributeId, the elements returned with UIA_AnnotationObjectsAttributeId only ever return the standard Comment annotation type via their UIA_AnnotationAnnotationTypeId property. In fact for draft comments, no annotation objects are returned at all.
In short, supporting custom comment annotation types in getCommentInfoFromPosition was not necessary in the first place.

### Description of how this pull request fixes the issue:
Remove support for custom comment annotation types from getCommentInfoFromPosition. It again only supports the standard comment annotation type.

### Testing strategy:
With a very recent build of Microsoft Word supporting custom annotations:
* Create a document in Microsoft word.
* Type the line: "Hello, this is a test."
* Highlight the word "this" and insert a new comment.
* Highlight the word "is" and insert a new comment. But also then resolve that comment from the context menu.
* Highlight the word "test" and insert a new comment, but don't actually press post, just move back to the document, leaving it as a draft.
* Read the current line in the document. You should here "Hello, has comment this has resolved comment is a has draft comment test".
* Switch on NVDA browse mode with NVDA+space.
* Try to quicknav to the comments with the letter 'a'. You should only get to the standard comment "this" and none of the other two.
* Open the NVDA elements list and choose 'Annotations'. The list should display only the standard comment "this" and none of the other two. There should be no error in the  log.

### Known issues with pull request:
This fixes the reported error, but does not make it possible to jump to / list draft or resolved comments. this could be considered at a later stage if Microsoft was ever to expose the more specific custom comment type in the comment object's annotationTypeId.
 
### Change log entries:
None needed.
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English