### PR TITLE
Disable context help in secure screen to avoid a security exploit.

### DIFF
--- a/source/gui/contextHelp.py
+++ b/source/gui/contextHelp.py
@@ -10,6 +10,7 @@ import typing
 import wx
 from logHandler import log
 import documentationUtils
+import globalVars
 
 
 def writeRedirect(helpId: str, helpFilePath: str, contextHelpPath: str):
@@ -73,6 +74,9 @@ def bindHelpEvent(helpId: str, window: wx.Window):
 
 
 def _onEvtHelp(helpId: str, evt: wx.HelpEvent):
+	if globalVars.appArgs.secure:
+		# Disable context help in secure screens to avoid opening a browser with system-wide privileges.
+		return	
 	# Don't call evt.skip. Events bubble upwards through parent controls.
 	# Context help for more specific controls should override the less specific parent controls.
 	showHelp(helpId)

--- a/source/gui/contextHelp.py
+++ b/source/gui/contextHelp.py
@@ -76,7 +76,7 @@ def bindHelpEvent(helpId: str, window: wx.Window):
 def _onEvtHelp(helpId: str, evt: wx.HelpEvent):
 	if globalVars.appArgs.secure:
 		# Disable context help in secure screens to avoid opening a browser with system-wide privileges.
-		return	
+		return
 	# Don't call evt.skip. Events bubble upwards through parent controls.
 	# Context help for more specific controls should override the less specific parent controls.
 	showHelp(helpId)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,7 +27,6 @@ What's New in NVDA
 
 
 == Changes ==
-- Security fix: The addons manager dialog is now disabled on secure screens. (#13059)
 - Espeak-ng has been updated to 1.51-dev commit ``7e5457f91e10``. (#12950)
 - Updated liblouis braille translator to [3.20.0 https://github.com/liblouis/liblouis/releases/tag/v3.20.0]. (#13141)
   - New braille table: Japanese (Kantenji) literary braille
@@ -42,6 +41,8 @@ What's New in NVDA
 
 == Bug Fixes ==
 - Security fix: Prevent object navigation outside of the lockscreen on Windows 10 and Windows 11. (#13328)
+- Security fix: The addons manager dialog is now disabled on secure screens. (#13059)
+- Security fix: NVDA Context help is no longer available on secure screens. (#13353) 
 - Clipboard manager pane should no longer incorrectly steal focus when opening some Office programs. (#12736)
 - On a system where the user has chosen to swap the primary mouse button from the left to the right, NVDA will no longer accidentally bring up a context menu instead of activating an item, in applications such as web browsers. (#12642)
 - When moving the review cursor past the end of text controls, such as in Microsoft Word with UI Automation, "bottom" is correctly reported in more situations. (#12808)


### PR DESCRIPTION
### Link to issue number:
None
Can be considered a follow-up of #13059.

### Summary of the issue:
If you open NVDA parameter from secure screen and press F1, context help opens in Internet explorer.
I am not an expert in security but I think that it's not secure to have access to the browser from secure screen.
More specifically, via the browser open dialog, I am able to open any file in notepad and modify it, e.g. allowing me to activate NVDA console.

### Description of how this pull request fixes the issue:
Since context help is displayed in a browser, disable it on secure screen.

### Testing strategy:
Manual testing
#### Test 1
Simulate secure screen and checked that context help is not available anymore (nothing happens):
* Launch NVDA
* Open NVDA Python console
* Enter the following command:
  `import globalVars;globalVars.appArgs.secure = True`
* Press NVDA+control+G to open NVDA settings window
* Press F1 and checked that nothing ahppens
#### Test 2
Checked that context help is still working in normal mode:
* Launch NVDA
* Press NVDA+control+G to open NVDA settings window
* Press F1 and checked that nothing ahppens

### Known issues with pull request:

Context help is not available anymore on secure screen.
If this is a need, we may open an issue for it and try to address it later.
But I think that the security concern should be addressed first and should not wait for a solution to have context help on secure screen.

### Change log entries:

Changes
In the existing change log, replace:
`- Security fix: The addons manager dialog is now disabled on secure screens. (#13059)`
by:
`- Security fixes: The addons manager dialog and context help are now disabled on secure screens. (#13059, #13353)`

### Additional note

I think `ui.browseableMessage` is also based on a browser. Is there any security concern allowing it on secure screen?
I have not been able to do anything from it since there is no menu or shortcut to do anything it this windows.
Just mentionning it in case someone knows more than I on this topic.


### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
