### PR TITLE
Fix crashes in 64-bit builds of Notepad++ 8.3 and later

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -1,19 +1,16 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2009-2019 NV Access Limited, Arnold Loubriat, Babbage B.V., Łukasz Golonka
+# Copyright (C) 2007-2022 NV Access Limited, Arnold Loubriat, Babbage B.V., Łukasz Golonka, Joseph Lee,
+# Peter Vágner
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 import ctypes
-import speech
 import textInfos.offsets
 import winKernel
 import winUser
-import globalVars
 import controlTypes
-import config
 from . import Window
-from .. import NVDAObjectTextInfo
 from ..behaviors import EditableTextWithAutoSelectDetection
 import watchdog
 import eventHandler
@@ -67,13 +64,14 @@ class CharacterRangeStruct(ctypes.Structure):
 		('cpMax',ctypes.c_long),
 	]
 
-class TextRangeStruct(ctypes.Structure):
-	_fields_=[
-		('chrg',CharacterRangeStruct),
-		('lpstrText',ctypes.c_char_p),
-	]
 
 class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
+
+	class TextRangeStruct(ctypes.Structure):
+		_fields_ = [
+			('chrg', CharacterRangeStruct),
+			('lpstrText', ctypes.c_char_p),
+		]
 
 	def _get_encoding(self):
 		cp=watchdog.cancellableSendMessage(self.obj.windowHandle,SCI_GETCODEPAGE,0,0)
@@ -171,7 +169,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getTextRange(self,start,end):
 		bufLen = (end - start) + 1
-		textRange = TextRangeStruct()
+		textRange = self.TextRangeStruct()
 		textRange.chrg.cpMin = start
 		textRange.chrg.cpMax = end
 		processHandle = self.obj.processHandle

--- a/source/appModules/notepad++.py
+++ b/source/appModules/notepad++.py
@@ -3,49 +3,14 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-import ctypes
+"""This is just an alias which maps the appModule for Notepad++ to the right binary file
+by exposing everything from the real module in its namespace.
+"""
 
-import appModuleHandler
-import NVDAObjects.window.scintilla as ScintillaBase
-
-
-class CharacterRangeStructLongLong(ctypes.Structure):
-	"""By default character ranges in Scintilla are represented by longs.
-	However long is not big enough for files over 2 GB,
-	therefore in 64-bit builds of Notepad++ 8.3 and later
-	these ranges are represented by longlong.
-	"""
-	_fields_ = [
-		('cpMin', ctypes.c_longlong),
-		('cpMax', ctypes.c_longlong),
-	]
+import nvdaBuiltin.appModules.notepadPlusPlus as baseAppMod
 
 
-class ScintillaTextInfoNpp83(ScintillaBase.ScintillaTextInfo):
-	"""Text info for 64-bit builds of Notepad++ 8.3 and later.
-	"""
-
-	class TextRangeStruct(ctypes.Structure):
-		_fields_ = [
-			('chrg', CharacterRangeStructLongLong),
-			('lpstrText', ctypes.c_char_p),
-		]
-
-
-class NppEdit(ScintillaBase.Scintilla):
-
-	name = None  # The name of the editor is not useful.
-
-	def _get_TextInfo(self):
-		if self.appModule.is64BitProcess:
-			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
-			if int(appVerMajor) >= 8 and int(appVerMinor) >= 3:
-				return ScintillaTextInfoNpp83
-		return super().TextInfo
-
-
-class AppModule(appModuleHandler.AppModule):
-
-	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if obj.windowClassName == "Scintilla" and obj.windowControlID == 0:
-			clsList.insert(0, NppEdit)
+for name, value in baseAppMod.__dict__.items():
+	if name.startswith("_"):
+		continue
+	globals()[name] = value

--- a/source/appModules/notepad++.py
+++ b/source/appModules/notepad++.py
@@ -7,10 +7,4 @@
 by exposing everything from the real module in its namespace.
 """
 
-import nvdaBuiltin.appModules.notepadPlusPlus as baseAppMod
-
-
-for name, value in baseAppMod.__dict__.items():
-	if name.startswith("_"):
-		continue
-	globals()[name] = value
+from .notepadPlusPlus import *  # noqa: F401, F403

--- a/source/appModules/notepad++.py
+++ b/source/appModules/notepad++.py
@@ -1,0 +1,51 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited, Łukasz Golonka
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import ctypes
+
+import appModuleHandler
+import NVDAObjects.window.scintilla as ScintillaBase
+
+
+class CharacterRangeStructLongLong(ctypes.Structure):
+	"""By default character ranges in Scintilla are represented by longs.
+	However long is not big enough for files over 2 GB,
+	therefore in 64-bit builds of Notepad++ 8.3 and later
+	these ranges are represented by longlong.
+	"""
+	_fields_ = [
+		('cpMin', ctypes.c_longlong),
+		('cpMax', ctypes.c_longlong),
+	]
+
+
+class ScintillaTextInfoNpp83(ScintillaBase.ScintillaTextInfo):
+	"""Text info for 64-bit builds of Notepad++ 8.3 and later.
+	"""
+
+	class TextRangeStruct(ctypes.Structure):
+		_fields_ = [
+			('chrg', CharacterRangeStructLongLong),
+			('lpstrText', ctypes.c_char_p),
+		]
+
+
+class NppEdit(ScintillaBase.Scintilla):
+
+	name = None  # The name of the editor is not useful.
+
+	def _get_TextInfo(self):
+		if self.appModule.is64BitProcess:
+			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
+			if int(appVerMajor) >= 8 and int(appVerMinor) >= 3:
+				return ScintillaTextInfoNpp83
+		return super().TextInfo
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if obj.windowClassName == "Scintilla" and obj.windowControlID == 0:
+			clsList.insert(0, NppEdit)

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -1,0 +1,58 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited, Łukasz Golonka
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+"""AppModule for Notepad++.
+Do not rename! The executable file for Notepad++ is named `notepad++` and `+` is not a valid character
+in Python's import statements.
+This module is mapped to the right binary separately
+and the current name makes it possible to expose it from `nvdaBuiltin` for add-on developers.
+"""
+
+import ctypes
+
+import appModuleHandler
+import NVDAObjects.window.scintilla as ScintillaBase
+
+
+class CharacterRangeStructLongLong(ctypes.Structure):
+	"""By default character ranges in Scintilla are represented by longs.
+	However long is not big enough for files over 2 GB,
+	therefore in 64-bit builds of Notepad++ 8.3 and later
+	these ranges are represented by longlong.
+	"""
+	_fields_ = [
+		('cpMin', ctypes.c_longlong),
+		('cpMax', ctypes.c_longlong),
+	]
+
+
+class ScintillaTextInfoNpp83(ScintillaBase.ScintillaTextInfo):
+	"""Text info for 64-bit builds of Notepad++ 8.3 and later.
+	"""
+
+	class TextRangeStruct(ctypes.Structure):
+		_fields_ = [
+			('chrg', CharacterRangeStructLongLong),
+			('lpstrText', ctypes.c_char_p),
+		]
+
+
+class NppEdit(ScintillaBase.Scintilla):
+
+	name = None  # The name of the editor is not useful.
+
+	def _get_TextInfo(self):
+		if self.appModule.is64BitProcess:
+			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
+			if int(appVerMajor) >= 8 and int(appVerMinor) >= 3:
+				return ScintillaTextInfoNpp83
+		return super().TextInfo
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		if obj.windowClassName == "Scintilla" and obj.windowControlID == 0:
+			clsList.insert(0, NppEdit)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -65,6 +65,7 @@ What's New in NVDA
 - Prevents a bug causing double-reporting when using Windows Console and Terminal. (#13261)
 - Fixed several cases where list items could not be reported in 64 bit applications, such as REAPER. (#8175)
 - In the Microsoft Edge downloads manager, NVDA will now automatically switch to focus mode once the list item with the most recent download gains focus. (#13221)
+- NVDA no longer causes 64-bit versions of Notepad++ 8.3 and above to crash. (#13311)
 -
 
 == Changes for Developers ==
@@ -131,6 +132,7 @@ This can dramatically decrease build times on multi core systems. (#13226)
 - ``UIAAutomationId`` property for UIA objects should be preferred over ``cachedAutomationId``. (#13125, #11447)
   - ``cachedAutomationId`` can be used if obtained directly from the element.
   -
+- ``NVDAObjects.window.scintilla.CharacterRangeStruct`` has moved to ``NVDAObjects.window.scintilla.Scintilla.CharacterRangeStruct``. (#13364)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13311

### Summary of the issue:
NVDA causes a crash when interacting with 64-bit builds of Notepad+++ 8.3. This happens because Notepad++ developers decided to deviate from the official Scintilla interface (they character points are represented by longlong rather than long in 64-bit builds). Since this allowed them to introduce the support for much bigger files this change is going to stay and NVDA has to adapt (see explanations in https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11133).

### Description of how this pull request fixes the issue:
For 64-bit builds of Notepad++ 8.3 and above `longlong` is used for representing characters points.
### Testing strategy:
Tested that:
- Notepad++ 8.3 x64 no longer crashes and text can be read normally.
- 32-bit build of the same version of NPP works as well as it used to before this change.
- Older version of Notepad++ x64 works normally and long is used for characters points there.
- Different editor (teXnicCenter) using Scintilla is not negatively affected.
- The newly introduced appmodule can be imported by using `from nvdaBuiltin.appModules import notepadPlusPlus` in an add-on.
### Known issues with pull request:
To make this work for add-ons wanting to extend the built-in appModule the 'real' module is named notepadPlusPlus and then it is mapped to the notepad++ via an dummy alias appModule. The alias module would be removed as soon as #13366 is merged.
### Change log entries:
Bug fixes
 - NVDA no longer causes 64-bit versions of Notepad++ 8.3 and above to crash.

For Developers
- `NVDAObjects.window.scintilla.CharacterRangeStruct` becomes `NVDAObjects.window.scintilla.Scintilla.CharacterRangeStruct`

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
