### PR TITLE
No longer use fileinput when generating COMInterfaces as it breaks parallel builds

### DIFF
--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -12,7 +12,6 @@
 #http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 ###
 from typing import List
-import fileinput
 import re
 from SCons.Node.FS import File
 
@@ -45,15 +44,18 @@ except ModuleNotFoundError:
 """)
 
 	importPattern = re.compile(r"from comtypes\.gen import ([\w]+)\n")
-	for line in fileinput.input(path, inplace=True):
-		# Note: The fileinput module temporarily redirects stdout to the file.
-		# So print is used to write the file.
-		match = importPattern.match(line)
-		if match:
-			libId = match.group(1)
-			print(importTemplate.format(libIdentifier=libId), end='')
-		else:
-			print(line, end='')
+	IDEFriendlyContent = list()
+	with open(path, "r") as interfaceFile:
+		for line in interfaceFile:
+			match = importPattern.match(line)
+			if match:
+				libId = match.group(1)
+				IDEFriendlyContent.append(importTemplate.format(libIdentifier=libId))
+			else:
+				IDEFriendlyContent.append(line)
+	with open(path, "w") as interfaceFile:
+		interfaceFile.write("".join(IDEFriendlyContent))
+
 
 def interfaceAction(target:List[File], source, env):
 	clsid = env.get('clsid')

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -54,7 +54,7 @@ except ModuleNotFoundError:
 			else:
 				IDEFriendlyContent.append(line)
 	with open(path, "w") as interfaceFile:
-		interfaceFile.write("".join(IDEFriendlyContent))
+		interfaceFile.writelines(IDEFriendlyContent)
 
 
 def interfaceAction(target:List[File], source, env):


### PR DESCRIPTION
### Link to issue number:
Fixes #13290
Related to [this thread on nvda-devel](https://groups.io/g/nvda-devel/topic/89208225#46086) by @MarcoZehe 
### Summary of the issue:
PR #13226 started building nVDA in parallel. While this offers significant speed improvements the way in which we were generating COMInterfaces was not thread safe. The issue was caused by the `fileinput` module which redirects stdout to a given file and this cannot be done in multiple threads at the same time. Also, as discovered by @MarcoZehe in the thread linked above when stdout is redirected to a file some other build step which is executing in a separate thread can write to it and the text which should be shown on screen ends up in the COMInterface file.
### Description of how this pull request fixes the issue:
Were not using `fileinput` anymore - the IDE friendly content is generated in memory and then written to the file afterwards.
### Testing strategy:
Made sure that COMInterfaces can be generated from a clean checkout.
### Known issues with pull request:
None known
### Change log entries:
None needed.
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
