### PR TITLE
Scons: revert providing the number of logical processors as the number of maximum concurrent jobs to speed up builds by default

### DIFF
--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -15,8 +15,6 @@ if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
 	$sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
 }
 $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"
-# Use only 1 concurrent job when building
-$sconsArgs += " -j1"
 # We use cmd to run scons because PowerShell throws exceptions if warnings get dumped to stderr.
 # It's possible to work around this, but the workarounds have annoying side effects.
 Set-AppveyorBuildVariable "sconsOutTargets" $sconsOutTargets

--- a/sconstruct
+++ b/sconstruct
@@ -125,10 +125,17 @@ env = Environment(variables=vars,HOST_ARCH='x86',tools=[
 # speed up subsequent runs by checking timestamps of targets and dependencies, and only using md5 if timestamps differ.
 env.Decider('MD5-timestamp')
 
-# Make sure to run the build on multiple threads so it runs faster
-env.SetOption('num_jobs', multiprocessing.cpu_count())
-realNumJobs = env.GetOption('num_jobs')
-print(f"Building using {realNumJobs} job{'s' if realNumJobs != 1 else ''}")
+# Warn to run the build on multiple threads so it runs faster
+numJobs = env.GetOption('num_jobs')
+numCores = multiprocessing.cpu_count()
+if numJobs < numCores:
+	print(
+		f"Warning: Building with {numJobs} concurrent job{'s' if numJobs != 1 else ''} "
+		f"while {numCores} CPU threads are available. "
+		f"Running SCONS with the parameter '-j{numCores}' may lead to a faster build."
+	)
+else:
+	print(f"Building with {numJobs} concurrent jobs")
 
 #Make our recursiveCopy function available to any script using this environment
 env.AddMethod(recursiveCopy)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -116,8 +116,8 @@ This ensures code will honor the Windows user setting for swapping the primary m
 - ``LOCALE_SLANGUAGE``, ``LOCALE_SLIST`` and ``LOCALE_SLANGDISPLAYNAME`` are removed from ``languageHandler`` - use members of ``languageHandler.LOCALE`` instead. (#12753)
 - Switched from Minhook to Microsoft Detours as a hooking library for NVDA. Hooking with this library is mainly used to aid the display model. (#12964)
 - ``winVersion.WIN10_RELEASE_NAME_TO_BUILDS`` is removed. (#13211)
-- SCons now builds with multiple concurrent jobs, equal to the number of logical processors in the system.
-This can dramatically decrease build times on multi core systems. (#13226)
+- SCons now warns to build with a number of jobs that is equal to the number of logical processors in the system.
+This can dramatically decrease build times on multi core systems. (#13226, #13371)
 - ``characterProcessing.SYMLVL_*`` constants are removed - please use ``characterProcessing.SymbolLevel.*`` instead. (#13248)
 - Functions ``loadState`` and ``saveState`` are removed from addonHandler - please use ``addonHandler.state.load`` and ``addonHandler.state.save`` instead. (#13245)
 - Moved the UWP/OneCore interaction layer of NVDAHelper [from C++/CX to C++/Winrt https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/move-to-winrt-from-cx]. (#10662)


### PR DESCRIPTION
### Link to issue number:
Reverts #13226

### Summary of the issue:
While building NVDA with multiple jobs leads to faster build times, it also leads to scrambled output which can be quite annoying when debugging.

### Description of how this pull request fixes the issue:
Disable multiple jobs by default but warn users to run with -jX to get a faster build if applicable.

### Testing strategy:
Tested specifying several numbers of build jobs on the command line

### Known issues with pull request:
None known

### Change log entries:
included in pr

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
