### PR TITLE
Rewrote and expanded the Browse mode: Use Screen Layout section in the user guide to correct missing information

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1709,7 +1709,7 @@ This field sets the amount of lines you will move by when pressing page up or pa
 ==== Use screen layout ====[BrowseModeSettingsScreenLayout]
 Key: NVDA+v
 
-This option allows you to specify whether browse mode should place clickable content (links, buttons and fields) on its own line, or if it should keep it in the flow of text as it is visually shown. Note that this only applies to browse mode as it is used in web browsers. Apps such as Microsoft Word and Outlook are unaffected by this option, and always use screen layout.
+This option allows you to specify whether browse mode should place clickable content (links, buttons and fields) on its own line, or if it should keep it in the flow of text as it is visually shown. Note that this option doesn't apply to Microsoft Office apps such as Outlook and Word, which always use screen layout.
 When screen layout is enabled, page elements will stay as they are visually shown. For example, a visual line of multiple links will be presented in speech and braille as multiple links on the same line. If it is disabled, then page elements will be placed on their own lines, which may be easier to understand during line by line page navigation, and may make items easier to interact with for some users.
 
 ==== Enable browse mode on page load ====[BrowseModeSettingsEnableOnPageLoad]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1709,8 +1709,8 @@ This field sets the amount of lines you will move by when pressing page up or pa
 ==== Use screen layout ====[BrowseModeSettingsScreenLayout]
 Key: NVDA+v
 
-This option allows you to specify whether content in browse mode should place content such as links and other fields on their own line, or if it should keep them in the flow of text as it is visually shown.
-If the option is enabled then things will stay as they are visually shown, but if it is disabled then fields will be placed on their own line.
+This option allows you to specify whether browse mode should place clickable content (links, buttons and fields) on its own line, or if it should keep it in the flow of text as it is visually shown. Note that this only applies to browse mode as it is used in web browsers. Apps such as Microsoft Word and Outlook are unaffected by this option, and always use screen layout.
+When screen layout is enabled, page elements will stay as they are visually shown. For example, a visual line of multiple links will be presented in speech and braille as multiple links on the same line. If it is disabled, then page elements will be placed on their own lines, which may be easier to understand during line by line page navigation, and may make items easier to interact with for some users.
 
 ==== Enable browse mode on page load ====[BrowseModeSettingsEnableOnPageLoad]
 This checkbox toggles whether browse mode should be automatically enabled when loading a page.


### PR DESCRIPTION
### Link to issue number:

Addresses a concern raised in #13354 

### Summary of the issue:

In [this comment](https://github.com/nvaccess/nvda/issues/13354#issuecomment-1043570903), @CyrilleB79 pointed out that the user guide does not indicate that screen layout is always used in Outlook, irrespective of the "Use screen layout" setting.
It seems reasonable for the user to assume, since it isn't otherwise indicated, that turning off screen layout will be effective anywhere browse mode is used, when in fact this is not the case.

### Description of how this pull request fixes the issue:

I added a note to the section in the user guide, explaining that this option is not applicable to Microsoft Office applications.

While looking at the section, I thought that it didn't really explain well the difference between screen layout and not screen layout, and used terms like "fields" in a way that most users might not associate with the elements changed by the option.

### Testing strategy:

N/A

### Known issues with pull request:

I'm not convinced that the result is the best way to present screen layout or the option, but I think it is preferable to what was there, at least until something better comes along.

### Change log entries:

User Guide: Improved the explanation of the browse mode "Use screen layout" option, now including that it doesn't apply to Outlook, Word, etc.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
