### PR TITLE
Create 2021.3.3 on rc

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -67,7 +67,7 @@ def formatVersionForGUI(year, major, minor):
 name = "NVDA"
 version_year = 2021
 version_major = 3
-version_minor = 1
+version_minor = 3
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()
 publisher="unknown"

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,11 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2021.3.3 =
+This release is identical to 2021.3.2.
+A bug existed in NVDA 2021.3.2 where it incorrectly identified itself 2021.3.1.
+This release correctly identifies itself as 2021.3.3.
+
 
 = 2021.3.2 =
 This is a minor release to fix several security issues raised.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,7 +5,7 @@ What's New in NVDA
 
 = 2021.3.3 =
 This release is identical to 2021.3.2.
-A bug existed in NVDA 2021.3.2 where it incorrectly identified itself 2021.3.1.
+A bug existed in NVDA 2021.3.2 where it incorrectly identified itself as 2021.3.1.
 This release correctly identifies itself as 2021.3.3.
 
 


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:

Due to `version_minor` not being updated, a bug existed in NVDA 2021.3.2 where it incorrectly identified itself 2021.3.1.

### Description of how this pull request fixes the issue:

Increases version number, update changelog

### Testing strategy:

N/A

### Known issues with pull request:

None 

### Change log entries:

See PR

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
