### PR TITLE
Fix regression causing older versions of NotePad++ to crash

### DIFF
--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -48,7 +48,7 @@ class NppEdit(ScintillaBase.Scintilla):
 			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
 			# appVerMinor could be either one digit (e.g. in 8.3), two digits (e.g. in 8.21), or even three (8.1.9.2)
 			appVerMinor = appVerMinor.ljust(3, '0')
-			if int(appVerMajor) >= 8 and int(appVerMinor) >= 300:
+			if int(appVerMajor) >= 8 and int(appVerMinor[0]) >= 3:
 				return ScintillaTextInfoNpp83
 		return super().TextInfo
 

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -46,8 +46,10 @@ class NppEdit(ScintillaBase.Scintilla):
 	def _get_TextInfo(self):
 		if self.appModule.is64BitProcess:
 			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
-			# The minor version of Notepad++ can consist of one or more digits,
-			# e.g. '3' in '8.3', '21' in '8.2.1' or '192' in '8.1.9.2'.
+			# When retrieving the version, Notepad++ concatenates
+			# minor, patch, build in major.minor.patch.build to the form of major.minor
+			# https://github.com/notepad-plus-plus/npp-usermanual/blob/master/content/docs/plugin-communication.md#nppm_getnppversion
+			# e.g. '8.3' for '8.3', '8.21' for '8.2.1' and '8.192' for '8.1.9.2'.
 			# Therefore, only use the first digit of the minor version to match against version 8.3 or later.
 			if int(appVerMajor) >= 8 and int(appVerMinor[0]) >= 3:
 				return ScintillaTextInfoNpp83

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -46,7 +46,9 @@ class NppEdit(ScintillaBase.Scintilla):
 	def _get_TextInfo(self):
 		if self.appModule.is64BitProcess:
 			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
-			if int(appVerMajor) >= 8 and int(appVerMinor) >= 3:
+			# appVerMinor could be either one digit (e.g. in 8.3), two digits (e.g. in 8.21), or even three (8.1.9.2)
+			appVerMinor = appVerMinor.ljust(3, '0')
+			if int(appVerMajor) >= 8 and int(appVerMinor) >= 300:
 				return ScintillaTextInfoNpp83
 		return super().TextInfo
 

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -46,6 +46,9 @@ class NppEdit(ScintillaBase.Scintilla):
 	def _get_TextInfo(self):
 		if self.appModule.is64BitProcess:
 			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
+			# The minor version of Notepad++ can consist of one or more digits,
+			# e.g. '3' in '8.3', '21' in '8.2.1' or '192' in '8.1.9.2'.
+			# Therefore, only use the first digit of the minor version to match against version 8.3 or later.
 			if int(appVerMajor) >= 8 and int(appVerMinor[0]) >= 3:
 				return ScintillaTextInfoNpp83
 		return super().TextInfo

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -46,8 +46,6 @@ class NppEdit(ScintillaBase.Scintilla):
 	def _get_TextInfo(self):
 		if self.appModule.is64BitProcess:
 			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
-			# appVerMinor could be either one digit (e.g. in 8.3), two digits (e.g. in 8.21), or even three (8.1.9.2)
-			appVerMinor = appVerMinor.ljust(3, '0')
 			if int(appVerMajor) >= 8 and int(appVerMinor[0]) >= 3:
 				return ScintillaTextInfoNpp83
 		return super().TextInfo


### PR DESCRIPTION
### Link to issue number:
Fixes regression caused by #13364
Closes #13397

### Summary of the issue:
The version matching to apply the new NP++ 8.3+ behavior was incorrect, as it doesn't work for versions like 8.2.1 and 8.1.9.2.

### Description of how this pull request fixes the issue:
Only match against the first character of the minor version.

### Testing strategy:
Tested on version 8.1.9.2, 8.2.1, 8.3 and 8.3.1 of NP++ 

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
