### PR TITLE
No longer try to access non-existing registry key in getStartOnLogonScreen

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -387,14 +387,16 @@ def getStartOnLogonScreen() -> bool:
 		log.debugWarning(f"Could not find NVDA reg key {RegistryKey.NVDA}", exc_info=True)
 	except WindowsError:
 		log.error(f"Failed to open NVDA reg key {RegistryKey.NVDA}", exc_info=True)
-	try:
-		return bool(winreg.QueryValueEx(k, "startOnLogonScreen")[0])
-	except FileNotFoundError:
-		log.debug(f"Could not find startOnLogonScreen value for {RegistryKey.NVDA} - likely unset.")
-		return False
-	except WindowsError:
-		log.error(f"Failed to query startOnLogonScreen value for {RegistryKey.NVDA}", exc_info=True)
-		return False
+	else:
+		try:
+			return bool(winreg.QueryValueEx(k, "startOnLogonScreen")[0])
+		except FileNotFoundError:
+			log.debug(f"Could not find startOnLogonScreen value for {RegistryKey.NVDA} - likely unset.")
+			return False
+		except WindowsError:
+			log.error(f"Failed to query startOnLogonScreen value for {RegistryKey.NVDA}", exc_info=True)
+			return False
+	return False
 
 
 def _setStartOnLogonScreen(enable: bool) -> None:


### PR DESCRIPTION
### Link to issue number:
Fix-up of PR #13242
Originally reported by @Stefan-Kliesch-FHP in #13348

### Summary of the issue:
`getStartOnLogonScreen` can fail with `UnboundLocalError` when the autostart key does not exist.
### Description of how this pull request fixes the issue:
If we failed to open autostart key we no longer try to access it.
### Testing strategy:
This is pretty hard to test, but based on the exception from [this comment](https://github.com/nvaccess/nvda/pull/13348#issuecomment-1048691907) I'm pretty confident about this fix.
### Known issues with pull request:
None known
### Change log entries:
None needed - unreleased regression.
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
