### PR TITLE
Fixup of PR 13082: fix a misspell in DefaultAppArgs and no longer use globalVars.appArgs in a boolean context (#13386)

### DIFF
--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -46,16 +46,6 @@ class DefaultAppArgs(argparse.Namespace):
 	copyPortableConfig: bool = False
 	easeOfAccess: bool = False
 
-	def __bool__(self) -> bool:
-		"""Before PR #13082 `appArgs` was set to `None` until it was replaced with the real command line
-		parser. Various parts of NVDA (notably logHandler)
-		expect `appArgs` to be falsy in a logical context
-		until command line arguments are parsed.
-		To preserve the old behavior make the class falsy
-		unless `configPath` is set to something other than the default `None`.
-		"""
-		return self.configPath is not None
-
 
 startTime=0
 desktopObject: typing.Optional['NVDAObjects.NVDAObject'] = None

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -1,7 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NVDA Contributors <http://www.nvda-project.org/>
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2006-2022 NV Access Limited, Łukasz Golonka, Leonard de Ruijter, Babbage B.V.,
+# Aleksey Sadovoy, Peter Vágner
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """global variables module
 @var foregroundObject: holds the current foreground object. The object for the last foreground event received.
@@ -22,7 +23,7 @@ if typing.TYPE_CHECKING:
 	import NVDAObjects  # noqa: F401 used for type checking only
 
 
-class DefautAppArgs(argparse.Namespace):
+class DefaultAppArgs(argparse.Namespace):
 	quit: bool = False
 	check_running: bool = False
 	logFileName: typing.Optional[os.PathLike] = ""
@@ -45,6 +46,16 @@ class DefautAppArgs(argparse.Namespace):
 	copyPortableConfig: bool = False
 	easeOfAccess: bool = False
 
+	def __bool__(self) -> bool:
+		"""Before PR #13082 `appArgs` was set to `None` until it was replaced with the real command line
+		parser. Various parts of NVDA (notably logHandler)
+		expect `appArgs` to be falsy in a logical context
+		until command line arguments are parsed.
+		To preserve the old behavior make the class falsy
+		unless `configPath` is set to something other than the default `None`.
+		"""
+		return self.configPath is not None
+
 
 startTime=0
 desktopObject: typing.Optional['NVDAObjects.NVDAObject'] = None
@@ -59,7 +70,7 @@ navigatorObject: typing.Optional['NVDAObjects.NVDAObject'] = None
 reviewPosition=None
 reviewPositionObj=None
 lastProgressValue=0
-appArgs = DefautAppArgs()
+appArgs = DefaultAppArgs()
 unknownAppArgs: typing.List[str] = []
 settingsRing = None
 speechDictionaryProcessing=True

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -155,7 +155,7 @@ class Logger(logging.Logger):
 			codepath=getCodePath(f)
 		extra["codepath"] = codepath
 
-		if not globalVars.appArgs or globalVars.appArgs.secure:
+		if globalVars.appArgs.secure:
 			# The log might expose sensitive information and the Save As dialog in the Log Viewer is a security risk.
 			activateLogViewer = False
 
@@ -246,8 +246,7 @@ class Logger(logging.Logger):
 		@rtype: bool
 		"""
 		if (
-			not globalVars.appArgs
-			or globalVars.appArgs.secure
+			globalVars.appArgs.secure
 			or not globalVars.appArgs.logFileName
 			or not isinstance(logHandler, FileHandler)
 		):
@@ -268,7 +267,6 @@ class Logger(logging.Logger):
 		"""
 		if (
 			self.fragmentStart is None
-			or not globalVars.appArgs
 			or globalVars.appArgs.secure
 			or not globalVars.appArgs.logFileName
 			or not isinstance(logHandler, FileHandler)


### PR DESCRIPTION
### Link to issue number:
Fix-up of PR #13082
### Summary of the issue:
PR #13082 added fake implementation of `globalVars.appArgs` which is used in cases where command line arguments are not parsed. It introduced two mistakes however:
1. The fake class was named `DefautAppArgs` (note the missing "l")
2. NVDA's logHandler uses `appArgs` in a boolean context to check if log viewer should be opened, determine if log fragment can be marked for copy etc. The new class was always `True` in a boolean context.
### Description of how this pull request fixes the issue:
1. The class is renamed to `DefaultAppArgs`.
2. `logHandler` no longer checks boolean value of `appArgs`. This is safe since:
    - Both `logHandler.Logger.markFragmentStart` and `logHandler.Logger.getFragment` are used only in NVDA and they are invoked by the user action (even before #13082 `appArgs` was always truthy in that context).
    -  The check for `appArgs` being falthy in `logHandler.Logger._log` introduced in 2827a34219e6e9684657039b852c3e0bd63cb3da can also be safely removed since even for NVDA_slave `activateLogViewer` is set to `False` (only two cases where it is set to `True` occur when user invokes log viewer via keyboard command). Also while this is not clarified in this commit at a guess I'd say this check has been added not for any additional security but just to avoid `AttributeError` being raised when trying to access `globalVars.appArgs.secure` when logging from slave.
### Testing strategy:
None needed.
### Known issues with pull request:
None known
### Change log entries:
None needed - at a point where add-ons are loaded `appArgs` was always truthy.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
