### PR TITLE
Fix table navigation in browse mode in MS Word for PR #13345

### DIFF
--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -271,3 +271,11 @@ class RootProxyTextInfo(textInfos.TextInfo):
 
 	def _get_pointAtStart(self):
 		return self.innerTextInfo.pointAtStart
+
+	def __eq__(self, other):
+		if isinstance(other, RootProxyTextInfo):
+			other = other.innerTextInfo
+		return self.innerTextInfo.__eq__(other)
+
+	def __hash__(self):
+		return super().__hash__()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Issue with navigating over merged cells in MS Word while in browse mode discussed in PR #13345.
### Summary of the issue:
PR #13345 fixes navigating over merged cells in tables by caching the last column/row. Testing showed that it doesn't work in MS Word  while in browse mode (focus mode works fine). This was tracked down to class UIABrowseModeDocumentTextInfo not implementing __eq__ method. 

### Description of how this pull request fixes the issue:
Fixing that by implementing __eq__ and __hash__ functions in parent class RootProxyTextInfo.

### Testing strategy:
Tested in MS Word. Tried with both checked and unchecked value of "Always use UI Automation to access Microsoft Word document controls when available".
### Known issues with pull request:
N/A
### Change log entries:
Doesn't deserve a separate entry, should be merged with #13345.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
