### PR TITLE
Report details summary with Firefox

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -45,6 +45,8 @@ class Ia2Web(IAccessible):
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
 		if not self.hasDetails:
+			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
+			log.debug("no details-roles")
 			return None
 		detailsRelations = self.detailsRelations
 		if not detailsRelations:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -20,6 +20,7 @@ from .ia2TextMozilla import MozillaCompoundTextInfo
 import aria
 import api
 import speech
+import config
 
 class Ia2Web(IAccessible):
 	IAccessibleTableUsesTableCellIndexAttrib=True
@@ -46,7 +47,8 @@ class Ia2Web(IAccessible):
 	def _get_detailsSummary(self) -> typing.Optional[str]:
 		if not self.hasDetails:
 			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
-			log.debug("no details-roles")
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("no details-roles")
 			return None
 		detailsRelations = self.detailsRelations
 		if not detailsRelations:

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -13,6 +13,10 @@ from . import IAccessible, WindowRoot
 from logHandler import log
 from NVDAObjects.behaviors import RowWithFakeNavigation
 from . import ia2Web
+from typing import (
+	Optional,
+)
+
 
 class Mozilla(ia2Web.Ia2Web):
 
@@ -57,6 +61,26 @@ class Mozilla(ia2Web.Ia2Web):
 			elif self.table and self.table.presentationType==self.presType_layout:
 				presType=self.presType_layout
 		return presType
+
+	def _get_detailsSummary(self) -> Optional[str]:
+		# Unlike base Ia2Web implementation, the details-roles
+		# IA2 attribute is not exposed in FireFox.
+		# Although slower, we have to fetch the details relations instead.
+		detailsRelations = self.detailsRelations
+		if not detailsRelations:
+			log.error("should be able to fetch detailsRelations")
+			return None
+		for target in detailsRelations:
+			# just take the first for now.
+			return target.summarizeInProcess()
+
+	@property
+	def hasDetails(self) -> bool:
+		# Unlike base Ia2Web implementation, the details-roles
+		# IA2 attribute is not exposed in FireFox.
+		# Although slower, we have to fetch the details relations instead.
+		return bool(self.detailsRelations)
+
 
 class Document(ia2Web.Document):
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -482,10 +482,14 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	detailsSummary: typing.Optional[str]
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
+		log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
 		return None
 
 	@property
 	def hasDetails(self) -> bool:
+		"""Default implementation is based on the result of _get_detailsSummary
+		In most instances this should be optimised.
+		"""
 		return bool(self.detailsSummary)
 
 	def _get_controllerFor(self):

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -482,7 +482,8 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	detailsSummary: typing.Optional[str]
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
+		if config.conf["debugLog"]["annotations"]:
+			log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
 		return None
 
 	@property

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -271,6 +271,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	speechManager = boolean(default=false)
 	synthDriver = boolean(default=false)
 	nvwave = boolean(default=false)
+	annotations = boolean(default=false)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1988,7 +1988,8 @@ class GlobalCommands(ScriptableObject):
 			return
 		caret.expand(textInfos.UNIT_CHARACTER)
 		nvdaObject: NVDAObject = caret.NVDAObjectAtStart
-		log.debug(f"Trying with nvdaObject : {nvdaObject}")
+		if config.conf["debugLog"]["annotations"]:
+			log.debug(f"Trying with nvdaObject : {nvdaObject}")
 
 		annotation: Optional[str] = nvdaObject.detailsSummary
 		if annotation:
@@ -2000,13 +2001,16 @@ class GlobalCommands(ScriptableObject):
 			# There may still be an object with focus that has details.
 			# There isn't a known test case for this, however there isn't a known downside to attempt this.
 			focus = api.getFocusObject()
-			log.debug(f"Trying focus object: {focus}")
+			if config.conf["debugLog"]["annotations"]:
+				log.debug(f"Trying focus object: {focus}")
 			annotation = focus.detailsSummary
 			if annotation:
-				log.debug("focus object has details, able to proceed")
+				if config.conf["debugLog"]["annotations"]:
+					log.debug("focus object has details, able to proceed")
 
 		if not annotation:
-			log.debug("no details annotation found")
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("no details annotation found")
 			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
 			ui.message(_("No additional details"))
 			return

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2914,6 +2914,7 @@ class AdvancedPanelControls(
 			"speechManager",
 			"synthDriver",
 			"nvwave",
+			"annotations",
 		]
 		# Translators: This is the label for a list in the
 		#  Advanced settings panel


### PR DESCRIPTION
### Link to issue number:
#13391
#13106

### Summary of the issue:
Details summary can not be reported in firefox browse mode.

### Description of how this pull request fixes the issue:
Firefox does not yet expose the IA2 attribute "details-roles", used a proxy / optimization for fetching details relations.
The absence of this prevented the details summary being fetched.
Instead, use the existence of details relations to confirm.

### Testing strategy:
Using [code pen - editor](https://codepen.io/reefturner/pen/RwjBXPv) or [code pen - fullpage](https://codepen.io/reefturner/full/RwjBXPv)
Manual testing in Firefox

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
