### PR TITLE
Further debug information for system tests

### DIFF
--- a/tests/system/libraries/SystemTestSpy/speechSpySynthDriver.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpySynthDriver.py
@@ -9,6 +9,7 @@ output during system tests.
 Note: The name of this module must match the name of the synth driver, and the configured synthesizer
 in the `tests/system/nvdaSettingsFiles/*.ini` files.
 """
+from logHandler import log
 
 import synthDriverHandler
 import extensionPoints
@@ -35,11 +36,16 @@ class SpeechSpySynthDriver(synthDriverHandler.SynthDriver):
 	}
 
 	def speak(self, speechSequence):
+		log.debug(f"Start of Speak: {speechSequence}")
 		for item in speechSequence:
 			if isinstance(item, IndexCommand):
+				log.debug(f"index reached: {item.index}")
 				synthDriverHandler.synthIndexReached.notify(synth=self, index=item.index)
+		log.debug("done speaking")
 		synthDriverHandler.synthDoneSpeaking.notify(synth=self)
+		log.debug("post_speech notify start")
 		post_speech.notify(speechSequence=speechSequence)
+		log.debug("post_speech notify complete")
 
 	def cancel(self):
 		pass


### PR DESCRIPTION
### Link to issue number:
Help investigate #13401

### Summary of the issue:
An unknown issue caused a system test failure.
When investigating it wasn't clear whether the second speech sequence made it to the 'spySynthDriver'.

### Description of how this pull request fixes the issue:
Adds further logging to the spy's implementation of `synthDriver.speak`

### Testing strategy:
Build / system tests


### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
