### PR TITLE
Work around start-up crash in Adobe Reader protected mode 

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -97,7 +97,12 @@ env.Append(CCFLAGS=[
 
 env.Append(CXXFLAGS=['/EHsc'])
 
-env.Append(CPPPATH=['#/include','#/miscDeps/include',Dir('.').abspath])
+env.Append(CPPPATH=[
+	'#/include',
+	'#/include/wil/include',
+	'#/miscDeps/include',
+	Dir('.').abspath
+])
 if TARGET_ARCH == "arm64":
 	subsystem = "/subsystem:windows,6.02"
 else:

--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -134,13 +134,15 @@ bool isAppContainerProcess() {
 		LOG_DEBUGWARNING(L"Could not open process token");
 		return false;
 	}
+	// TokenIsAppContainer only requires a return buffer the size of a DWORD
+	// See https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_information_class
 	DWORD isAppContainer=0;
 	DWORD return_length = 0;
 	if(!GetTokenInformation(tokenHandle.get(), TokenIsAppContainer, &isAppContainer, sizeof(isAppContainer), &return_length)) {
 		LOG_DEBUGWARNING(L"GetTokenInformation for Token_isAppContainer failed");
 		return false;
 	}
-	return isAppContainer;
+	return isAppContainer != 0;
 }
 
 void IA2Support_inProcess_initialize() {

--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -34,7 +34,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 using namespace std;
 
 #define APPLICATION_USER_MODEL_ID_MAX_LENGTH 131
-// Forward declaire GetCurrentApplicationUserModelId for later lookup in kernel32.dll
+// Forward declare GetCurrentApplicationUserModelId for later lookup in kernel32.dll
 // Used in isSuspendableProcess.
 LONG WINAPI GetCurrentApplicationUserModelId(UINT32* pBufSize,PWSTR buf);
 

--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -120,7 +120,7 @@ bool isSuspendableProcess() {
 		return false;
 	}
 	UINT32 bufSize=APPLICATION_USER_MODEL_ID_MAX_LENGTH+1;
-	std::vector<wchar_t> buf(bufSize, L'\0');
+	std::wstring buf(bufSize, L'\0');
 	LONG res=GetCurrentApplicationUserModelId_fp(&bufSize,buf.data());
 	if(res != ERROR_SUCCESS) {
 		return false;

--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -17,6 +17,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #define WIN32_LEAN_AND_MEAN 
 #include <windows.h>
 #include <objbase.h>
+#include <wil/resource.h>
 #include <ia2.h>
 #include <remote/nvdaControllerInternal.h>
 #include <common/log.h>
@@ -104,30 +105,57 @@ LRESULT CALLBACK IA2Support_uninstallerHook(int code, WPARAM wParam, LPARAM lPar
 	return 0;
 }
 
+bool isSuspendableProcess() {
+	wil::unique_hmodule kernel32Handle {LoadLibrary(L"kernel32.dll")};
+	if(!kernel32Handle) {
+		LOG_ERROR(L"Can't load kernel32.dll");
+		return false; 
+	}
+	GetCurrentApplicationUserModelId_funcType GetCurrentApplicationUserModelId_fp=(GetCurrentApplicationUserModelId_funcType)GetProcAddress(kernel32Handle.get(),"GetCurrentApplicationUserModelId");
+	if(!GetCurrentApplicationUserModelId_fp) {
+		LOG_DEBUGWARNING(L"getCurrentApplicationUserModelID function not available");
+		return false;
+	}
+	UINT32 bufSize=APPLICATION_USER_MODEL_ID_MAX_LENGTH+1;
+	std::vector<wchar_t> buf(bufSize, L'\0');
+	LONG res=GetCurrentApplicationUserModelId_fp(&bufSize,buf.data());
+	if(res != ERROR_SUCCESS) {
+		return false;
+	} 
+	return true;
+}
+
+bool isAppContainerProcess() {
+	wil::unique_handle tokenHandle{nullptr};
+	if(!OpenProcessToken(GetCurrentProcess(), TOKEN_READ, &tokenHandle) || !tokenHandle) {
+		LOG_DEBUGWARNING(L"Could not open process token");
+		return false;
+	}
+	DWORD isAppContainer=0;
+	DWORD return_length = 0;
+	if(!GetTokenInformation(tokenHandle.get(), TokenIsAppContainer, &isAppContainer, sizeof(isAppContainer), &return_length)) {
+		LOG_DEBUGWARNING(L"GetTokenInformation for Token_isAppContainer failed");
+		return false;
+	}
+	return isAppContainer;
+}
+
 void IA2Support_inProcess_initialize() {
 	if (isIA2Installed||isIA2SupportDisabled)
 		return;
 	// #5417: disable IAccessible2 support for suspendable processes to work around a deadlock in NVDAHelperRemote (specifically seen in Win10 searchUI)
-	HMODULE kernel32Handle=LoadLibrary(L"kernel32.dll");
-	if(!kernel32Handle) {
-		LOG_ERROR(L"Can't load kernel32.dll");
-		return; 
+	isIA2SupportDisabled = isSuspendableProcess();
+	if(isIA2SupportDisabled) {
+		LOG_DEBUGWARNING(L"Not installing IA2 support as  process is suspendable");
+		return;
 	}
-	GetCurrentApplicationUserModelId_funcType GetCurrentApplicationUserModelId_fp=(GetCurrentApplicationUserModelId_funcType)GetProcAddress(kernel32Handle,"GetCurrentApplicationUserModelId");
-	if(GetCurrentApplicationUserModelId_fp) {
-		UINT32 bufSize=APPLICATION_USER_MODEL_ID_MAX_LENGTH+1;
-		wchar_t* buf=(wchar_t*)malloc(bufSize*sizeof(wchar_t));
-		LONG res=GetCurrentApplicationUserModelId_fp(&bufSize,buf);
-		if(res==ERROR_SUCCESS) {
-			isIA2SupportDisabled=true;
-			LOG_DEBUGWARNING(L"disabling IA2 support");
-		} else if(res==ERROR_INSUFFICIENT_BUFFER) {
-			LOG_ERROR(L"string not long enough");
-		}
-		free(buf);
+	// #12920: Registering COM interfaces in an appContainer can cause memory corruption,
+	// such as in Adobe Reader.
+	isIA2SupportDisabled = isAppContainerProcess();
+	if(isIA2SupportDisabled) {
+		LOG_DEBUGWARNING(L"Not installing IA2 support as process is an app container");
+		return;
 	}
-	FreeLibrary(kernel32Handle);
-	if(isIA2SupportDisabled) return;
 	// Try to install IA2 support on focus/foreground changes.
 	// This hook will be unregistered by the callback once IA2 support is successfully installed.
 	registerWinEventHook(IA2Support_winEventProcHook);

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -66,6 +66,7 @@ What's New in NVDA
 - Fixed several cases where list items could not be reported in 64 bit applications, such as REAPER. (#8175)
 - In the Microsoft Edge downloads manager, NVDA will now automatically switch to focus mode once the list item with the most recent download gains focus. (#13221)
 - NVDA no longer causes 64-bit versions of Notepad++ 8.3 and above to crash. (#13311)
+- Adobe Reader no longer crashes on startup if Adobe Reader's protected mode is enabled. (#11568)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #11568 
Partial fix for #12920 

### Summary of the issue:
Recent versions of Adobe Reader introduced a Protected Mode, where by the Adobe Acrobat process has less privileges and is sandboxed. This ensures that insecure PDFs do not have a chance to affect the rest of the Operating System.
By default Adobe Reader is configured to enter its Protected mode on start-up, and to set the 'isAppContainer' attribute on its process token.
There seems to be a bug however, either in Adobe Reader, the Windows OS, or NVDA (NV access and Adobe cannot be sure) that causes the Adobe Reader process to become unstable when NVDA tires to register IAccessible2. Specifically, the call to CoGetPSClsid seems to start making things unstable. The further call to CoRegisterPSClsid fails, and then eventually the process completely crashes randomly in places such as TSF initialization.
The upshot is that If Adobe Reader is started when NVDA is running, many errors are written to NVDA's log, and Adobe Reader closes straight away.
 
### Description of how this pull request fixes the issue:
NVDAHelper's IAccessible2 registration code now checks if the process token has the 'IsAppContainer' attribute, and of so refuses to install IAccessible2 support.
Note that Adobe Reader itself does not require IAccessible2 to function.
Also, the 'IsAppContainer' is only set on very heavily sandboxed sitations, and is not the same as the app container that is used for Windows Desktop Bridge apps. Thus, refusing to install IAccessible2 into processes with the 'IsAppContainer' attribute has no other known side affects.
 
### Testing strategy:
* Installed Adobe Reader 32 bit.
* With NVDA running, launched Adobe Reader 32 bit. Ensured that it did not close / crash.
* Ensured that errors were not written to the NVDA log.
* Repeated all the previous steps but this time with Adobe Reader 64 bit.
* Ensured that IAccessible2 support was still being registered in other processes E.g. Firefox, by compiling NvDAHelper with nvdaHelperLogLevel set to debug and looking at the log for the appropriate registration messages.

### Known issues with pull request:
Note that this pr does not address the crashes in Adobe Reader 64 bit when trying to read a PDF. This is a very separate issue.

### Change log entries:
New features
Changes
Bug fixes
* Adobe Reader no longer closes due to a crash on launch. (#11568)

For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
