### PR TITLE
Fixed typo in autoSettings.py

### DIFF
--- a/source/autoSettingsUtils/autoSettings.py
+++ b/source/autoSettingsUtils/autoSettings.py
@@ -154,8 +154,8 @@ class AutoSettings(AutoPropertyObject):
 		@param settings: The settings to load.
 		"""
 		section = cls._getConfigSection()
-		setingsId = cls.getId()
-		conf = config.conf[section][setingsId]
+		settingsId = cls.getId()
+		conf = config.conf[section][settingsId]
 		for setting in settings:
 			if not setting.useConfig:
 				continue


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Mistyped settingsID as setingsID on lines 157 and 158 in nvda\source\autoSettingsUtils\autoSettings.py
### Description of how this pull request fixes the issue:
I corrected it, just added a letter 't'.
### Testing strategy:
manual testing
### Known issues with pull request:
None
### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
