### PR TITLE
Adding commands to jump to first/last row/column in tables

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,6 +7,10 @@ What's New in NVDA
 
 == New Features ==
 - Support for interacting with Microsoft Loop Components in Microsoft Office products. (#13617)
+- New table navigation commands have been added. (#957)
+ - ``control+alt+home/end`` to jump to first/last column.
+ - ``control+alt+pageUp/pageDown`` to jump to first/last row.
+ -
 -
 
 == Changes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -342,6 +342,10 @@ When within a table, the following key commands are also available:
 | Move to next column | control+alt+rightArrow | Moves the system caret to the next column (staying in the same row) |
 | Move to previous row | control+alt+upArrow | Moves the system caret to the previous row (staying in the same column) |
 | Move to next row | control+alt+downArrow | Moves the system caret to the next row (staying in the same column) |
+| Move to first column | control+alt+home | Moves the system caret to the first column (staying in the same row) |
+| Move to last column | control+alt+end | Moves the system caret to the last column (staying in the same row) |
+| Move to first row | control+alt+pageUp | Moves the system caret to the first row (staying in the same column) |
+| Move to last row | control+alt+pageDown | Moves the system caret to the last row (staying in the same column) |
 %kc:endInclude
 
 ++ Object Navigation ++[ObjectNavigation]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
fixes #957

### Summary of the issue:
Introduce commands to jump to first/last row/column in current table.
### Description of how this pull request fixes the issue:
Implements new commands in class DocumentWithTableNavigation.
### Testing strategy:
* Tested in Chrome, Firefox, Edge.
* Tested in HTML tables with merged cells provided in https://github.com/nvaccess/nvda/pull/13345#issuecomment-1046376381
* Also tested on MSWord table from previous comment in both browse and focus mode.
* Tested in HTML table with missing cells.
### Known issues with pull request:
Will cause merge conflicts with #13345 - will be happy to resolve them once it lands.
### Change log entries:
New features
* New table navigation commands: Control+Alt+Home/End to jump to first/last column; Control+Alt+PageUp/PageDown to jump to first/last row.
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English