### PR TITLE
Solve the problem of character sensitivity in the terminal with nvda/…

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -19,6 +19,9 @@ import ctypes
 from ctypes import wintypes
 import monkeyPatches
 
+for i in range(len(sys.argv)):
+	sys.argv[i] = sys.argv[i].lower()
+
 monkeyPatches.applyMonkeyPatches()
 
 #: logger to use before the true NVDA log is initialised.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#12434
### Summary of the issue:
Hello, I worked on this issue, I located the entry point of nvda software which is nvda.pyw in the source folder.

### Description of how this pull request fixes the issue:
For the solution I used 'sys' library, I edit all the arguments and lower them using 'lower()' function before any process from the parser. As this parser uses also 'sys.argv', I put the changes in the begining of the file.
see line 22 + 23

here is the code:

for i in range(len(sys.argv)):
	sys.argv[i]=sys.argv[i].lower()

### Testing strategy:
Later I wrote a small program to test this changes using sys and parser and it worked pretty fine, which made me test it on nvda and it ignores the case sensitivity of the commands while using CMD.

### Known issues with pull request:
https://github.com/nvaccess/nvda/issues/12434

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  -  Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
