### PR TITLE
Update liblouis to 3.21.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 7e5457f91e10
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
-* [liblouis](http://www.liblouis.org/), version 3.20.0
+* [liblouis](http://www.liblouis.org/), version 3.21.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 40.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2021 NV Access Limited, Joseph Lee, Babbage B.V.
+# Copyright (C) 2008-2022 NV Access Limited, Joseph Lee, Babbage B.V.
 
 """Manages information about available braille translation tables.
 """
@@ -128,6 +128,9 @@ addTable("bg.ctb", _("Bulgarian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("bg.utb", _("Bulgarian grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("ca-g1.ctb", _("Catalan grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ckb-g1.ctb", _("Central Kurdish grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -63,29 +63,31 @@ def listTables():
 
 #: Maps old table names to new table names for tables renamed in newer versions of liblouis.
 RENAMED_TABLES = {
-	"ar-fa.utb" : "fa-ir-g1.utb",
-	"da-dk-g16.utb":"da-dk-g16.ctb",
-	"da-dk-g18.utb":"da-dk-g18.ctb",
-	"de-de-g0.utb":"de-g0.utb",
-	"de-de-g1.ctb":"de-g1.ctb",
-	"de-de-g2.ctb":"de-g2.ctb",
-	"en-us-comp8.ctb" : "en-us-comp8-ext.utb",
-	"fr-ca-g1.utb":"fr-bfu-comp6.utb",
-	"Fr-Ca-g2.ctb":"fr-bfu-g2.ctb",
+	"ar-fa.utb": "fa-ir-g1.utb",
+	"da-dk-g16.utb": "da-dk-g16.ctb",
+	"da-dk-g18.utb": "da-dk-g18.ctb",
+	"de-de-g0.utb": "de-g0.utb",
+	"de-de-g1.ctb": "de-g1.ctb",
+	"de-de-g2.ctb": "de-g2.ctb",
+	"de-g0-bidi.utb": "de-g0-detailed.utb",
+	"de-g1-bidi.ctb": "de-g1-detailed.ctb",
+	"en-us-comp8.ctb": "en-us-comp8-ext.utb",
+	"fr-ca-g1.utb": "fr-bfu-comp6.utb",
+	"Fr-Ca-g2.ctb": "fr-bfu-g2.ctb",
 	"gr-bb.ctb": "grc-international-en.utb",
-	"gr-gr-g1.utb":"el.ctb",
+	"gr-gr-g1.utb": "el.ctb",
 	"he.ctb": "he-IL-comp8.utb",
-	"hr.ctb":"hr-comp8.utb",
-	"mn-MN.utb":"mn-MN-g1.utb",
+	"hr.ctb": "hr-comp8.utb",
+	"mn-MN.utb": "mn-MN-g1.utb",
 	"nl-BE-g0.utb": "nl-NL-g0.utb",
-	"nl-NL-g1.ctb":"nl-NL-g0.utb",
-	"no-no.ctb":"no-no-8dot.utb",
-	"no-no-comp8.ctb":"no-no-8dot.utb",
-	"ru-compbrl.ctb":"ru.ctb",
+	"nl-NL-g1.ctb": "nl-NL-g0.utb",
+	"no-no.ctb": "no-no-8dot.utb",
+	"no-no-comp8.ctb": "no-no-8dot.utb",
+	"ru-compbrl.ctb": "ru.ctb",
 	"ru-ru-g1.utb": "ru-litbrl-detailed.utb",
-	"sk-sk-g1.utb":"sk-g1.ctb",
-	"UEBC-g1.ctb":"en-ueb-g1.ctb",
-	"UEBC-g2.ctb":"en-ueb-g2.ctb",
+	"sk-sk-g1.utb": "sk-g1.ctb",
+	"UEBC-g1.ctb": "en-ueb-g1.ctb",
+	"UEBC-g2.ctb": "en-ueb-g2.ctb",
 	"vi-g1.ctb": "vi-vn-g1.ctb",
 }
 
@@ -161,6 +163,9 @@ addTable("da-dk-g26.ctb", _("Danish 6 dot grade 2"), contracted=True)
 addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("de-comp6.utb", _("German 6 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("de-de-comp8.ctb", _("German 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -168,14 +173,14 @@ addTable("de-g0.utb", _("German grade 0"), input=False)
 
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("de-g0-bidi.utb", _("German grade 0 (detailed)"))
+addTable("de-g0-detailed.utb", _("German grade 0 (detailed)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("de-g1.ctb", _("German grade 1"), input=False)
 
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("de-g1-bidi.ctb", _("German grade 1 (detailed)"))
+addTable("de-g1-detailed.ctb", _("German grade 1 (detailed)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("de-g2.ctb", _("German grade 2"), contracted=True, input=False)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,9 +29,11 @@ What's New in NVDA
 
 == Changes ==
 - Espeak-ng has been updated to 1.51-dev commit ``7e5457f91e10``. (#12950)
-- Updated liblouis braille translator to [3.20.0 https://github.com/liblouis/liblouis/releases/tag/v3.20.0]. (#13141)
-  - New braille table: Japanese (Kantenji) literary braille
-  -
+- Updated liblouis braille translator to [3.21.0 https://github.com/liblouis/liblouis/releases/tag/v3.21.0]. (#13141, #13438)
+  - Added new braille table: Japanese (Kantenji) literary braille.
+  - Added new German 6 dot computer braille table.
+  - Added Catalan grade 1 braille table. (#13408)
+  - 
 - NVDA will report selection and merged cells in LibreOffice Calc 7.3 and above. (#9310, #6897)
 - Updated Unicode Common Locale Data Repository (CLDR) to 40.0. (#12999)
 - ``NVDA+Numpad Delete`` reports the location of the caret or focused object by default. (#13060)


### PR DESCRIPTION
### Link to issue number:
Fixes #13408

### Summary of the issue:
Liblouis 3.21.0 has been released.

### Description of how this pull request fixes the issue:
Updates liblouis to 3.21.0 which mainly brings major updates for Hungarian and German. [Changelog](https://github.com/liblouis/liblouis/releases/tag/v3.21.0).

### Testing strategy:
Ran from sources and loaded the new braille tables. LGTM.

### Known issues with pull request:
None

### Change log entries:
Section: Changes

```
- Updated liblouis braille translator to [3.21.0 https://github.com/liblouis/liblouis/releases/tag/v3.21.0]. (#13438)
  - Added new German 6 dot computer braille table.
- Added Catalan grade 1 braille table. (#13408)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
