### PR TITLE
Start dev cycle for 2022.2

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -66,7 +66,7 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2022
-version_major = 1
+version_major = 2
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,20 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.2 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+
+
 = 2022.1 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for the 2022.2 release.
This won't be a compatibly breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] ~Updating espeak (separate PR):~
  - This will be deferred, due to complications with update: https://github.com/nvaccess/nvda/issues/13295 

On merge:
- [x] update auto milestone ID