### PR TITLE
Fix error fetching details

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -240,7 +240,10 @@ IAccessible2StatesToNVDAStates = {
 }
 
 
-def normalizeIAccessible(pacc, childID=0):
+def normalizeIAccessible(
+		pacc: Union[IUnknown, IA.IAccessible, IA2.IAccessible2],
+		childID=0
+) -> Union[IA.IAccessible, IA2.IAccessible2]:
 	if not isinstance(pacc, IA.IAccessible):
 		try:
 			pacc = pacc.QueryInterface(IA.IAccessible)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -242,7 +242,7 @@ IAccessible2StatesToNVDAStates = {
 
 def normalizeIAccessible(
 		pacc: Union[IUnknown, IA.IAccessible, IA2.IAccessible2],
-		childID=0
+		childID: int = 0
 ) -> Union[IA.IAccessible, IA2.IAccessible2]:
 	if not isinstance(pacc, IA.IAccessible):
 		try:

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1561,7 +1561,7 @@ the NVDAObject for IAccessible
 						IAccessibleChildID=0
 					)
 		except (NotImplementedError, COMError):
-			log.debug("Unable to fetch _IA2Relations")
+			log.debug("Unable to fetch _IA2Relations", exc_info=True)
 			pass
 		return None
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1485,7 +1485,11 @@ the NVDAObject for IAccessible
 			maxRelations: int = 1,
 	) -> typing.List[ctypes.POINTER(IUnknown)]:
 		"""Gets the target IAccessible (actually IUnknown; use QueryInterface or
-		normalizeIAccessible to resolve) for the relations with given type."""
+		normalizeIAccessible to resolve) for the relations with given type.
+		Allows escape of exception: COMError(-2147417836, 'Requested object does not exist.'),
+		callers should handle this, for this reason consider using _getIA2RelationFirstTarget
+		if only the first target is required, and you wish the target to be converted to an IAccessible
+		"""
 		acc = self.IAccessibleObject
 		if not isinstance(acc, IA2.IAccessible2):
 			raise NotImplementedError
@@ -1549,16 +1553,9 @@ the NVDAObject for IAccessible
 	detailsRelations: typing.Iterable["IAccessible"]
 
 	def _get_detailsRelations(self) -> typing.Iterable["IAccessible"]:
-		relations = self._getIA2TargetsForRelationsOfType(
-			IAccessibleHandler.RelationType.DETAILS,
-			maxRelations=1
-		)
-		if not relations:
+		relationTarget = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.DETAILS)
+		if not relationTarget:
 			return ()
-		relationTarget = IAccessible(
-			IAccessibleObject=IAccessibleHandler.normalizeIAccessible(relations[0]),
-			IAccessibleChildID=0
-		)
 		return (relationTarget, )
 
 	#: Type definition for auto prop '_get_flowsTo'

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -68,7 +68,6 @@ class Mozilla(ia2Web.Ia2Web):
 		# Although slower, we have to fetch the details relations instead.
 		detailsRelations = self.detailsRelations
 		if not detailsRelations:
-			log.error("should be able to fetch detailsRelations")
 			return None
 		for target in detailsRelations:
 			# just take the first for now.


### PR DESCRIPTION
### Link to issue number:
Fixes #13433
Fixes #13430

### Summary of the issue:
Gecko applications (Firefox / thunderbird / instantbird) occasionally are raising a COM error "No such interface supported"
when aria-details relation is fetched.
This exception should be handled as per `getIA2RelationFirstTarget`.
Additionally:
- `getIA2RelationFirstTarget` failed to convert IUnknown to NVDAObject.IAccessible. This was missed due to failure with typing system, `ctypes.POINTER(IUnknown)` is not recognised and becomes `Any`.
- Unecessary firefox error loging on a missing detailsSummary.


### Description of how this pull request fixes the issue:
- Prevent ComError escaping when checking for aria-details by using `getIA2RelationFirstTarget` directly.
- Ensure that IUnkown is converted to an IAccessible in `getIA2RelationFirstTarget`
- Remove unecessary firefox error log on missing detailsSummary.

### Testing strategy:
Using https://codepen.io/reefturner/pen/RwjBXPv
Test reporting details in firefox and in Edge.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
