### PR TITLE
Fix Excel error due to state enum changes

### DIFF
--- a/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
+++ b/nvdaHelper/interfaces/nvdaInProcUtils/nvdaInProcUtils.idl
@@ -34,7 +34,7 @@ typedef struct {
 	BSTR address;
 	BSTR inputTitle;
 	BSTR inputMessage;
-	hyper states;
+	hyper nvCellStates;  // bitwise OR of the NvCellState enum values that apply to this cell.
 	long rowNumber;
 	long rowSpan;
 	long columnNumber;

--- a/nvdaHelper/remote/excel/Constants.h
+++ b/nvdaHelper/remote/excel/Constants.h
@@ -1,12 +1,12 @@
 /*
 This file is a part of the NVDA project.
-Copyright 2019-2020 NV Access Limited, Accessolutions, Julien Cochuyt
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.0, as published by
-    the Free Software Foundation.
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Copyright 2019-2022 NV Access Limited, Accessolutions, Julien Cochuyt
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2.0, as published by
+the Free Software Foundation.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
@@ -78,17 +78,25 @@ const long NVCELLINFOFLAG_COMMENTS=0x40;
 const long NVCELLINFOFLAG_FORMULA=0x80;
 const long NVCELLINFOFLAG_ALL=0xffff;
 
-// NVDA states
-const __int64 NVSTATE_EXPANDED=0x100;
-const __int64 NVSTATE_COLLAPSED=0x200;
-const __int64 NVSTATE_LINKED=0x1000;
-const __int64 NVSTATE_HASPOPUP=0x2000;
-const __int64 NVSTATE_PROTECTED=0x4000;
-const __int64 NVSTATE_HASFORMULA=0x1000000000;
-const __int64 NVSTATE_HASCOMMENT=0x2000000000;
-const __int64 NVSTATE_CROPPED=0x8000000000;
-const __int64 NVSTATE_OVERFLOWING=0x10000000000;
-const __int64 NVSTATE_UNLOCKED=0x20000000000;
+constexpr std::uint64_t setBit(const unsigned int bitPos) {
+	return std::uint64_t(1) << bitPos;
+}
+
+/*NVDA sell specific states.
+These values must match NvCellState enum in source/nvdaObjects/excel.py
+*/
+enum NvCellState : std::uint64_t {
+	EXPANDED = setBit(1),
+	COLLAPSED = setBit(2),
+	LINKED = setBit(3),
+	HASPOPUP = setBit(4),
+	PROTECTED = setBit(5),
+	HASFORMULA = setBit(6),
+	HASCOMMENT = setBit(7),
+	CROPPED = setBit(8),
+	OVERFLOWING = setBit(9),
+	UNLOCKED = setBit(10)
+};
 
 // an HRESULT error code randomly given by Excel such as for validation.type when there is no validation on the cell
 const HRESULT XLGeneralError=0x800a03ec;

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1066,6 +1066,7 @@ NVCELLINFOFLAG_ALL=0xffff
 
 
 class NvCellState(enum.IntEnum):
+	# These values must match NvCellState in `nvdaHelper/remote/excel/constants.h`
 	EXPANDED = 1 << 1,
 	COLLAPSED = 1 << 2,
 	LINKED = 1 << 3,

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -5,6 +5,11 @@
 
 import abc
 import ctypes
+import enum
+from typing import (
+	Optional, Dict,
+)
+
 from comtypes import COMError, BSTR
 import comtypes.automation
 import wx
@@ -1059,13 +1064,41 @@ NVCELLINFOFLAG_COMMENTS=0x40
 NVCELLINFOFLAG_FORMULA=0x80
 NVCELLINFOFLAG_ALL=0xffff
 
+
+class NvCellState(enum.IntEnum):
+	EXPANDED = 1 << 1,
+	COLLAPSED = 1 << 2,
+	LINKED = 1 << 3,
+	HASPOPUP = 1 << 4,
+	PROTECTED = 1 << 5,
+	HASFORMULA = 1 << 6,
+	HASCOMMENT = 1 << 7,
+	CROPPED = 1 << 8,
+	OVERFLOWING = 1 << 9,
+	UNLOCKED = 1 << 10,
+
+
+nvCellStatesToStates: Dict[NvCellState, controlTypes.State] = {
+	NvCellState.EXPANDED: controlTypes.State.EXPANDED,
+	NvCellState.COLLAPSED: controlTypes.State.COLLAPSED,
+	NvCellState.LINKED: controlTypes.State.LINKED,
+	NvCellState.HASPOPUP: controlTypes.State.HASPOPUP,
+	NvCellState.PROTECTED: controlTypes.State.PROTECTED,
+	NvCellState.HASFORMULA: controlTypes.State.HASFORMULA,
+	NvCellState.HASCOMMENT: controlTypes.State.HASCOMMENT,
+	NvCellState.CROPPED: controlTypes.State.CROPPED,
+	NvCellState.OVERFLOWING: controlTypes.State.OVERFLOWING,
+	NvCellState.UNLOCKED: controlTypes.State.UNLOCKED,
+}
+
+
 class ExcelCellInfo(ctypes.Structure):
 		_fields_=[
 			('text',comtypes.BSTR),
 			('address',comtypes.BSTR),
 			('inputTitle',comtypes.BSTR),
 			('inputMessage',comtypes.BSTR),
-			('states',ctypes.c_longlong),
+			('nvCellStates', ctypes.c_longlong),  # bitwise OR of the NvCellState enum values.
 			('rowNumber',ctypes.c_long),
 			('rowSpan',ctypes.c_long),
 			('columnNumber',ctypes.c_long),
@@ -1074,6 +1107,7 @@ class ExcelCellInfo(ctypes.Structure):
 			('comments',comtypes.BSTR),
 			('formula',comtypes.BSTR),
 		]
+
 
 class ExcelCellInfoQuickNavItem(browseMode.QuickNavItem):
 
@@ -1181,7 +1215,10 @@ class FormulaExcelCellInfoQuicknavIterator(ExcelCellInfoQuicknavIterator):
 
 class ExcelCell(ExcelBase):
 
-	def _get_excelCellInfo(self):
+	excelCellInfo: Optional[ExcelCellInfo]
+	"""Type info for auto property: _get_excelCellInfo"""
+
+	def _get_excelCellInfo(self) -> Optional[ExcelCellInfo]:
 		if not self.appModule.helperLocalBindingHandle:
 			return None
 		ci=ExcelCellInfo()
@@ -1382,10 +1419,14 @@ class ExcelCell(ExcelBase):
 		cellInfo=self.excelCellInfo
 		if not cellInfo:
 			return states
-		stateBits=cellInfo.states
-		for state in controlTypes.State:
-			if stateBits & state.value:
-				states.add(state)
+		nvCellStates = cellInfo.nvCellStates
+
+		for possibleCellState in NvCellState:
+			if nvCellStates & possibleCellState.value:
+				states.add(
+					# intentionally use indexing operator so an error is raised for a missing key
+					nvCellStatesToStates[possibleCellState]
+				)
 		return states
 
 	def event_typedCharacter(self,ch):

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1078,7 +1078,7 @@ class NvCellState(enum.IntEnum):
 	UNLOCKED = 1 << 10,
 
 
-nvCellStatesToStates: Dict[NvCellState, controlTypes.State] = {
+_nvCellStatesToStates: Dict[NvCellState, controlTypes.State] = {
 	NvCellState.EXPANDED: controlTypes.State.EXPANDED,
 	NvCellState.COLLAPSED: controlTypes.State.COLLAPSED,
 	NvCellState.LINKED: controlTypes.State.LINKED,
@@ -1425,7 +1425,7 @@ class ExcelCell(ExcelBase):
 			if nvCellStates & possibleCellState.value:
 				states.add(
 					# intentionally use indexing operator so an error is raised for a missing key
-					nvCellStatesToStates[possibleCellState]
+					_nvCellStatesToStates[possibleCellState]
 				)
 		return states
 

--- a/tests/unit/test_excel.py
+++ b/tests/unit/test_excel.py
@@ -1,0 +1,18 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2022 NV Access Limited
+
+"""Unit tests for the excel module.
+"""
+
+import unittest
+import NVDAObjects.window.excel as excel
+
+
+class TestCellStates(unittest.TestCase):
+	def test_cellStateMapsToState(self):
+		"""All Excel Cell info states should map to a controlTypes.State
+		"""
+		for cellState in excel.NvCellState:
+			excel._nvCellStatesToStates[cellState]  # throws if cellState is missing

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -156,6 +156,8 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
     - ``UIAHandler.UIAControlTypesToNVDARoles``
     -
   -
+- Excel cell state constants (``NVSTATE_*``) are now values in the ``NvCellState`` enum, mirrored in the ``NvCellState`` enum in ``NVDAObjects/window/excel.py`` and mapped to ``controlTypes.State`` via _nvCellStatesToStates. (#13465)
+- ``EXCEL_CELLINFO`` struct member ``state`` is now ``nvCellStates``.
 -
 
 


### PR DESCRIPTION
### Link to issue number:
fixes #13457

### Summary of the issue:
With UIA for Excel disabled, navigating to a cell with a formula and "has formula" is not reported.
This is a regression caused by #13414

In `NVDAHelper/remote/excel.cpp` the properties of a cell are determined and bits are set on the `state` member of a `EXCEL_CELLINFO` struct.
The constatnts used for this are in `NVDAHelper/remote/excel/Constants.h`, see the `NVSTATE_*` constants, previously these matched the `controlTypes.State` constants directly. 

### Description of how this pull request fixes the issue:
Rather than couple the excel implementation to the controlTypes implementation, these constants have been converted to enums (both in C++ and in Python), renumbered, and an explicit mapping to the corresponding `controlTypes.State` enum has been created.

### Testing strategy:
- Added a unit test to ensure all cellState values are mapped.
- Manually tested Excel with formula and comments on cells (both with UIA and without).

### Known issues with pull request:
None

### Change log entries:
For Developers
```
- Excel cell state constants (``NVSTATE_*``) are now values in the ``NvCellState`` enum, mirrored in the ``NvCellState`` enum in ``NVDAObjects/window/excel.py`` and mapped to ``controlTypes.State`` via _nvCellStatesToStates.
- ``EXCEL_CELLINFO`` struct member ``state`` is now ``nvCellStates``.
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
