### PR TITLE
Correcting typos in appveyor/scripts/installNVDA.ps1

### DIFF
--- a/appveyor/scripts/installNVDA.ps1
+++ b/appveyor/scripts/installNVDA.ps1
@@ -12,7 +12,7 @@ $installerProcess=start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--i
 try {
 	$installerProcess | wait-process -Timeout 180 -ErrorAction Stop
 	$errorCode=$installerProcess.ExitCode
-	$installlerLogFilePathToUpload = $installerLogFilePath
+	$installerLogFilePathToUpload = $installerLogFilePath
 } catch {
 	echo "NVDA installer process timed out"
 	$errorCode=1
@@ -22,9 +22,9 @@ try {
 	# as a work around create a copy of the log and upload that instead.
 	$installerLogFileCopiedPath = "nvda_install_copy.log"
 	Copy-Item $installerLogFilePath $installerLogFileCopiedPath
-	$installlerLogFilePathToUpload = $installerLogFileCopiedPath
+	$installerLogFilePathToUpload = $installerLogFileCopiedPath
 }
-Push-AppveyorArtifact $installlerLogFilePathToUpload -FileName "nvda_install.log"
+Push-AppveyorArtifact $installerLogFilePathToUpload -FileName "nvda_install.log"
 $crashDump = "$outputDir\nvda_crash.dmp"
 if (Test-Path -Path $crashDump){
 	Push-AppveyorArtifact $crashDump -FileName "nvda_install_crash.dmp"

--- a/appveyor/scripts/installNVDA.ps1
+++ b/appveyor/scripts/installNVDA.ps1
@@ -18,7 +18,7 @@ try {
 	$errorCode=1
 	Add-AppveyorMessage "Unable to install NVDA prior to tests."
 	# Since installer failed to exit in the specified timeout the log file is still in use.
-	# Unforturnately `Push-AppveyorArtifact` is unable to upload a file which is  locked
+	# Unfortunately `Push-AppveyorArtifact` is unable to upload a file which is  locked
 	# as a work around create a copy of the log and upload that instead.
 	$installerLogFileCopiedPath = "nvda_install_copy.log"
 	Copy-Item $installerLogFilePath $installerLogFileCopiedPath


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

While working with installNVDA.ps1, I noticed that the variable:

```
$installerLogFilePathToUpload
```
was being spelled:
```
$installlerLogFilePathToUpload
```

Since I was fixing that, I also corrected a typo in a comment.

### Description of how this pull request fixes the issue:

Corrected the spelling of the variable name in all three uses, by removing the first "l".

### Testing strategy:

None - my build environment is broken currently, but this should have no effect on anything.
The try build should confirm that it works.

### Known issues with pull request:

### Change log entries:

None needed.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
