### PR TITLE
Adding jump to first/last row/column commands in list views and Tree Views.

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -658,6 +658,59 @@ class RowWithFakeNavigation(NVDAObject):
 	# Translators: The description of an NVDA command.
 	script_moveToPreviousRow.__doc__ = _("Moves the navigator object and focus to the previous row")
 
+	@script(
+		description=_(
+			# Translators: The description of an NVDA command.
+			"Moves the navigator object to the first column"
+		),
+		gesture="kb:Control+Alt+Home",
+		canPropagate=True,
+	)
+	def script_moveToFirstColumn(self, gesture):
+		new = self.firstChild
+		while new and new.location and new.location.width == 0:
+			new = new.next
+		self._moveToColumn(new)
+
+	@script(
+		description=_(
+			# Translators: The description of an NVDA command.
+			"Moves the navigator object to the last column"
+		),
+		gesture="kb:Control+Alt+End",
+		canPropagate=True,
+	)
+	def script_moveToLastColumn(self, gesture):
+		new = self.lastChild
+		# In some cases, e.g. in NVDA symbol pronounciation llist view lastChild returns none.
+		if not new and len(self.children) > 0:
+			new = self.children[-1]
+		while new and new.location and new.location.width == 0:
+			new = new.previous
+		self._moveToColumn(new)
+
+	@script(
+		description=_(
+			# Translators: The description of an NVDA command.
+			"Moves the navigator object to the first row"
+		),
+		gesture="kb:Control+Alt+PageUp",
+		canPropagate=True,
+	)
+	def script_moveToFirstRow(self, gesture):
+		self._moveToRow(self.parent.firstChild)
+
+	@script(
+		description=_(
+			# Translators: The description of an NVDA command.
+			"Moves the navigator object to the last row"
+		),
+		gesture="kb:Control+Alt+PageDown",
+		canPropagate=True,
+	)
+	def script_moveToLastRow(self, gesture):
+		self._moveToRow(self.parent.lastChild)
+
 	__gestures = {
 		"kb:control+alt+rightArrow": "moveToNextColumn",
 		"kb:control+alt+leftArrow": "moveToPreviousColumn",


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#957
### Summary of the issue:
Introduce commands to jump to first/last row/column in current table.
### Description of how this pull request fixes the issue:
This PR introduces Control+Alt+Home/End/PageUp/PageDown commands in ListViews and TreeViews - implemented in `class RowWithFakeNavigation`.
### Testing strategy:
* Tested in NVDA Punctuation/Symbol pronounciation list view.
* Tested in Thunderbird messages ListView and TreeView.

### Known issues with pull request:
In Thunderbird Control+Alt+PageUp command doesn't work - this is due to the fact that `focus.parent.firstChild` is an object with different role. This appears to be a problem on Thunderbird side. It also affects other table navigation commands, e.g. Control+Alt+UpArrow.

### Change log entries:
Please use changelog entry from #13435.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English