### PR TITLE
For completeness update __int64 to std::uint64_t

### DIFF
--- a/nvdaHelper/remote/excel.cpp
+++ b/nvdaHelper/remote/excel.cpp
@@ -109,8 +109,8 @@ long getCellTextWidth(HWND hwnd, IDispatch* pDispatchRange) {
 	return sizl.cx;
 }
 
-__int64 getCellStates(HWND hwnd, IDispatch* pDispatchRange) {
-	std::int64_t nvCellStates = 0;
+std::uint64_t getCellStates(HWND hwnd, IDispatch* pDispatchRange) {
+	std::uint64_t nvCellStates = 0;
 	// If the current row is a summary row, expose the collapsed or expanded states depending on wither the inner rows are showing or not.
 	CComPtr<IDispatch> pDispatchRow=nullptr;
 	HRESULT res=_com_dispatch_raw_propget(pDispatchRange,XLDISPID_RANGE_ENTIREROW,VT_DISPATCH,&pDispatchRow);


### PR DESCRIPTION
- fix missed std::uint64_t types

### Link to issue number:
Following PR: #13465

### Summary of the issue:
Two locations were not correctly updated to type `std::uint64_t`

### Description of how this pull request fixes the issue:
Update to `std::uint64_t`

### Testing strategy:
Builds

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
