### PR TITLE
MS Word with UIA: correctly fetch formatting in blank table cells and at the end of the document

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -592,7 +592,7 @@ class UIATextInfo(textInfos.TextInfo):
 		rangeIter=iterUIARangeByUnit(textRange,unit) if unit is not None else [textRange]
 		for tempRange in rangeIter:
 			text=self._getTextFromUIARange(tempRange) or ""
-			if text:
+			if text is not None:
 				if debug:
 					log.debug("Chunk has text. Fetching formatting")
 				try:
@@ -607,7 +607,9 @@ class UIATextInfo(textInfos.TextInfo):
 					continue
 				if debug:
 					log.debug("Yielding formatting and text")
-				yield field
+					log.debug(f"field: {field}, text: {text}")
+				if field:
+					yield field
 				yield text
 		if debug:
 			log.debug("Done _getTextWithFields_text")

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -121,7 +121,9 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 	tempRange=rangeObj.clone()
 	tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeStart)
 	endRange=tempRange.Clone()
+	loopCount = 0
 	while relativeGTOperator(endRange.Move(unit,minRelativeDistance),0):
+		loopCount += 1
 		tempRange.MoveEndpointByRange(Endpoint_relativeEnd,endRange,Endpoint_relativeStart)
 		pastEnd=relativeGTOperator(tempRange.CompareEndpoints(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd),0)
 		if pastEnd:
@@ -139,6 +141,11 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 	if relativeLTOperator(tempRange.CompareEndpoints(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd),0):
 		tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd)
 		yield tempRange.clone()
+	elif loopCount == 0:
+		# We Could not walk at all.
+		# So just yield the original range
+		yield rangeObj
+
 
 def getEnclosingElementWithCacheFromUIATextRange(textRange,cacheRequest):
 	"""A thin wrapper around IUIAutomationTextRange3::getEnclosingElementBuildCache if it exists, otherwise IUIAutomationTextRange::getEnclosingElement and then IUIAutomationElement::buildUpdatedCache."""

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,6 +73,7 @@ What's New in NVDA
 - NVDA no longer causes 64-bit versions of Notepad++ 8.3 and above to crash. (#13311)
 - Adobe Reader no longer crashes on startup if Adobe Reader's protected mode is enabled. (#11568)
 - Fixed a bug where selecting the Papenmeier Braille Display Driver caused NVDA to crash. (#13348)
+- In Microsoft word with UIA: page number and other formatting is no longer inappropriately announced when moving from a blank table cell to a cell with content, or from the end of the document into existing content. (#13458, #13459)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13458 
fixes #13459 
Partial fix for #13462 

### Summary of the issue:
In MS word via UIA:
When at the end of a document and arrowing left or up into existing content, or when on a blank table cell and arrowing, tabbing or NVDA table cell navigating back into a cell with content, NVDA reports all formatting set for automatic reporting, even if the formatting between the blank position and the existing content does not differ. 
For example, when on a blank table cell and pressing control+alt+leftArrow and moving to a cell with existing content, NVDA will report "section 1, page 1" before reporting the content of the cell. If the user has enabled automatic reporting of font color, then the font color will also be included.
This is due to the fact that NVDA fails to fetch formatting for blank table cells, and the insertion point at the end of the document. But still clears the formatting cache. Thus when fetching valid formatting after this, all the formatting is treated as changed.
Related somewhat to this, is the fact that new list items are not announced when being inserted at the end of the document.

### Description of how this pull request fixes the issue:
* UIAHandler.utils.iterUIARangeByUnit: when at the end of the document, it is impossible to move by unit at all. Thus if we cannot walk at all, then just yield the original range. This ensures that we do actually fetch text and fields for the insertion point at the end of the document.
* UIATextInfo's _getTextWithFields_text: don't refuse to yield a formatField before an empty text string. This is true on empty table cells and at the end of the document.

### Testing strategy:
In MS Word via UIA:
* Created a 2 by 2 table in a new document.
* Filled in r1c1 with content. 
* Moved to r1c2 with control+alt+rightArrow. NVDA annonced "column 2"
* Moved back to r1c1. NVDA announced "column 1" and did not inappropriately announce "section 1" or any other unchanged formatting.
* Move to the end of the document. 
* Typed "1. Fish" and pressed enter.
* Read the current line with NVDA+upArrow (dekstop) / NVDA+l (laptop). NVDA correctly announced "2.".

### Known issues with pull request:
Automatic announcement of new list items numbers/bullets when pressing enter still does not work, probably due to some strangeness with comparing the start of UIA textRanges. further investigation is required on #13462  however at least reading the line manually does announce the new number / bullet.

### Change log entries:
New features
Changes
Bug fixes
* In Microsoft word with UIA: page number, and other formatting is no longer inappropriately announced when moving from a blank table cell to a cell with content, or from the end of the document into existing content. (#13458, #13459)
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English