### PR TITLE
Fix change log entries added at the start of dev

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,6 +16,7 @@ What's New in NVDA
 
 == Bug Fixes ==
 - The NVDA installer can now run from directories with special characters. (#31270)
+- In Firefox, NVDA no longer fails to report items in web pages when aria-rowindex, aria-colindex, aria-rowcount or aria-colcount attributes are invalid. (#13405)
 -
 
 
@@ -92,7 +93,6 @@ What's New in NVDA
 - NVDA no longer causes 64-bit versions of Notepad++ 8.3 and above to crash. (#13311)
 - Adobe Reader no longer crashes on startup if Adobe Reader's protected mode is enabled. (#11568)
 - Fixed a bug where selecting the Papenmeier Braille Display Driver caused NVDA to crash. (#13348)
-- In Firefox, NVDA no longer fails to report items in web pages when aria-rowindex, aria-colindex, aria-rowcount or aria-colcount attributes are invalid. (#13405)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,8 @@ What's New in NVDA
 
 
 == Changes for Developers ==
+- When retrieving the count of selected children via accSelection, the case where a negative child ID or an IDispatch is returned by IAccessible::get_accSelection is now handled properly. (#13276)
+-
 
 
 = 2022.1 =
@@ -176,7 +178,6 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
     - ``UIAHandler.UIAControlTypesToNVDARoles``
     -
   -
-- When retrieving the count of selected children via accSelection, the case where a negative child ID or an IDispatch is returned by IAccessible::get_accSelection is now handled properly. (#13276)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,7 +15,7 @@ What's New in NVDA
 
 
 == Bug Fixes ==
-- The NVDA installer can now run from directories with special characters. (#31270)
+- The NVDA installer can now run from directories with special characters. (#13270)
 - In Firefox, NVDA no longer fails to report items in web pages when aria-rowindex, aria-colindex, aria-rowcount or aria-colcount attributes are invalid. (#13405)
 -
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When starting the new dev cycle (for 2022.2) there was a period of time where PR's could be merged and their change log entries added to the wrong release. The wrong milestone was also applied.

The PRs affected:
- #13405
- #13367
- #13277

Based on commits on master:
- 1dca11000
- 6e39f7f7b
- 12319e7bc

### Description of how this pull request fixes the issue:
- Fix change log section for commit 1dca11000 from PR #13405
- Fix change log section for commit 6e39f7f7b from PR #13277
- PR #13367 has no change log entry.

The milestones on the issues/PRs will be manually adjusted:
- #13405
  - #13404
- #13367
  -  #13290
- #13277
  - #13276

### Testing strategy:
None

### Known issues with pull request:
If any of these PRs are reverted, commits from this PR will also need to be reverted.
To make this easier, this PR can be merged rather than squash merged.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
