### PR TITLE
Initialize MathPlayer when NVDA starts

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -10,12 +10,10 @@ from typing import (
 
 import enum
 from comtypes import COMError
-from collections import defaultdict
 import winVersion
 import mathPres
 from scriptHandler import isScriptWaiting
 import textInfos
-import eventHandler
 import UIAHandler
 import UIAHandler.remote as UIARemote
 from logHandler import log
@@ -24,7 +22,6 @@ import ui
 import speech
 import review
 import braille
-import api
 import browseMode
 from UIAHandler.browseMode import (
 	UIABrowseModeDocument,

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -325,7 +325,6 @@ class WordDocumentTextInfo(UIATextInfo):
 		# But, we therefore need to remove the inner math content if reading by line
 		if not formatConfig or not formatConfig.get('extraDetail'):
 			# We really only want to remove content if we can guarantee that mathPlayer is available.
-			mathPres.ensureInit()
 			if mathPres.speechProvider or mathPres.brailleProvider:
 				curLevel = 0
 				mathLevel = None

--- a/source/braille.py
+++ b/source/braille.py
@@ -654,7 +654,6 @@ class NVDAObjectRegion(Region):
 		)
 		if role == controlTypes.Role.MATH:
 			import mathPres
-			mathPres.ensureInit()
 			if mathPres.brailleProvider:
 				try:
 					text += TEXT_SEPARATOR + mathPres.brailleProvider.getBrailleForMathMl(
@@ -786,7 +785,6 @@ def getControlFieldBraille(  # noqa: C901
 			text += content
 		elif role == controlTypes.Role.MATH:
 			import mathPres
-			mathPres.ensureInit()
 			if mathPres.brailleProvider:
 				try:
 					if text:

--- a/source/core.py
+++ b/source/core.py
@@ -476,6 +476,9 @@ def main():
 	import speech
 	log.debug("Initializing speech")
 	speech.initialize()
+	import mathPres
+	log.debug("Initializing MathPlayer")
+	mathPres.initialize()
 	if not globalVars.appArgs.minimal and (time.time()-globalVars.startTime)>5:
 		log.debugWarning("Slow starting core (%.2f sec)" % (time.time()-globalVars.startTime))
 		# Translators: This is spoken when NVDA is starting.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -624,7 +624,6 @@ def getObjectSpeech(  # noqa: C901
 			sequence.extend(_flattenNestedSequences(speechGen))
 	elif role == controlTypes.Role.MATH:
 		import mathPres
-		mathPres.ensureInit()
 		if mathPres.speechProvider:
 			try:
 				sequence.extend(
@@ -1115,7 +1114,6 @@ def _extendSpeechSequence_addMathForTextInfo(
 		speechSequence: SpeechSequence, info: textInfos.TextInfo, field: textInfos.Field
 ) -> None:
 	import mathPres
-	mathPres.ensureInit()
 	if not mathPres.speechProvider:
 		return
 	try:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ What's New in NVDA
 - 'Baseline' is no longer reported via the report text formatting command (NVDA+F). (#11815)
 - Activate long description no longer has a default gesture assigned. (#13380)
 - Report details summary now has a default gesture, ``NVDA+d``. (#13380)
+- NVDA needs to be restarted after installing MathPlayer. (#TODO)
 -
 
 == Bug Fixes ==
@@ -158,6 +159,7 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
   -
 - Excel cell state constants (``NVSTATE_*``) are now values in the ``NvCellState`` enum, mirrored in the ``NvCellState`` enum in ``NVDAObjects/window/excel.py`` and mapped to ``controlTypes.State`` via _nvCellStatesToStates. (#13465)
 - ``EXCEL_CELLINFO`` struct member ``state`` is now ``nvCellStates``.
+- ``mathPres.ensureInit`` has been removed, MathPlayer is now initialized when NVDA starts. (#TODO)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,7 +45,7 @@ What's New in NVDA
 - 'Baseline' is no longer reported via the report text formatting command (NVDA+F). (#11815)
 - Activate long description no longer has a default gesture assigned. (#13380)
 - Report details summary now has a default gesture, ``NVDA+d``. (#13380)
-- NVDA needs to be restarted after installing MathPlayer. (#TODO)
+- NVDA needs to be restarted after installing MathPlayer. (#13486)
 -
 
 == Bug Fixes ==
@@ -159,7 +159,7 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
   -
 - Excel cell state constants (``NVSTATE_*``) are now values in the ``NvCellState`` enum, mirrored in the ``NvCellState`` enum in ``NVDAObjects/window/excel.py`` and mapped to ``controlTypes.State`` via _nvCellStatesToStates. (#13465)
 - ``EXCEL_CELLINFO`` struct member ``state`` is now ``nvCellStates``.
-- ``mathPres.ensureInit`` has been removed, MathPlayer is now initialized when NVDA starts. (#TODO)
+- ``mathPres.ensureInit`` has been removed, MathPlayer is now initialized when NVDA starts. (#13486)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -610,7 +610,8 @@ A key command is provided to return to the original page containing the embedded
 + Reading Mathematical Content +[ReadingMath]
 Using MathPlayer 4 from Design Science, NVDA can read and interactively navigate supported mathematical content.
 This requires that MathPlayer 4 is installed on the computer.
-MathPlayer is available as a free download from: https://www.dessci.com/en/products/mathplayer/
+MathPlayer is available as a free download from: https://www.dessci.com/en/products/mathplayer/.
+After installing MathPlayer, restart NVDA.
 
 NVDA supports the following types of mathematical content:
 - MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #13463

### Summary of the issue:

``mathPres.ensureInit`` is called whenever math content is expected to be read, including from getTextWithFields.
This is called with every read when using UIA with Word.
If mathPlayer is not installed, this pollutes the log.
Ideally, math should be initialized at NVDA startup time.

### Description of how this pull request fixes the issue:

Makes mathPlayer initialize on start up.
Removes ``mathPlayer.ensureInit`` usages from within NVDA.
External documentation referencing mathPlayer may need to be updated to reflect the need to restart NVDA after installing mathPlayer.

### Testing strategy:

- [x] Test using mathPlayer in MS Word, confirm math is read
- [x] Test that if mathPlayer is not installed, a warning is logged at startup but at no other time.

### Known issues with pull request:

None

### Change log entries:

Changes
```t2t
- NVDA needs to be restarted after installing MathPlayer. (#TODO)
```

For Developers
```t2t
- ``mathPres.ensureInit`` has been removed, MathPlayer is now initialized when NVDA starts.
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
