### PR TITLE
Disable GUI inspection tool in secure mode

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2105,6 +2105,8 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TOOLS
 	)
 	def script_startWxInspectionTool(self, gesture):
+		if globalVars.appArgs.secure:
+			return
 		import wx.lib.inspection
 		wx.lib.inspection.InspectionTool().Show()
 


### PR DESCRIPTION
Thanks to @CyrilleB79 for reporting.

### Link to issue number:
GitHub Advisory GHSA-mvc8-5rv9-w3hx: https://github.com/nvaccess/nvda/security/advisories/GHSA-mvc8-5rv9-w3hx

### Summary of the issue:

The wx GUI inspection tool includes a python console. 
If the user binds a gesture to the startWxInspectionTool script and their config is copied to be used on logon screen, this tool can be opened from the logon screen.
This allows a user to open the python console from the logon screen with system privileges.

### Description of how this pull request fixes the issue:

Disable the possibility to open wx GUI inspection tool when NVDA is running in secure mode.

### Testing strategy:

Manual test:
* Start NVDA normally
* From input gesture dialog, Bind a gesture to open the wx GUI inspection tool.
* Execute the gesture and check that the tool starts.
* Type Windows+R, type "nvda -s" and Enter to restart NVDA in secure mode.
* Execute the gesture and check that the tool does not start.

### Known issues with pull request:
None

### Change log entries:

Security fixes
`The wx GUI inspection tool is now disabled on secure screens.`

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
