### PR TITLE
Disable logging in secure mode

### DIFF
--- a/devDocs/technicalDesignOverview.md
+++ b/devDocs/technicalDesignOverview.md
@@ -67,6 +67,14 @@ Aside from accessibility and native APIs, Windows provides many functions which 
 Information that can be obtained includes the class name of a window, the current foreground window and system battery status.
 Tasks that can be performed include moving/clicking the mouse and sending key presses.
 
+### Logging
+
+#### Logging in secure mode
+`logHandler.initialize` prevents logging in secure mode.
+This is because it is a security concern to log during secure mode (e.g. passwords are logged).
+To change this for testing, patch the source build.
+`nvda.log` files are then generated in the System profile's `%TEMP%` directory.
+
 ## NVDA Components
 NVDA is built with an extensible, modular, object oriented, abstract design.
 It is divided into several distinct components.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

Thanks to @CyrilleB79 for reporting

### Link to issue number:

GitHub Advisory GHSA-354r-wr4v-cx28: https://github.com/nvaccess/nvda/security/advisories/GHSA-354r-wr4v-cx28

### Summary of the issue:

With the `--debug-logging` NVDA command line option, it is possible to enable debug logging in secure mode.
From a secure screen, it is possible to activate debug logging by restarting NVDA and selecting "Restart with debug logging" in the Exit Dialog.
This creates an instance of NVDA performing debug logging from the system profile, from a secure context.

### Description of how this pull request fixes the issue:

Prevents debug logging in secure mode.
Removes "Restart with debug logging" from the exit dialog options.
Removes "Install pending update" from the exit dialog options.

### Testing strategy:

Run nvda with `-s` and `--debug-logging`.
- Confirm that no new `nvda.log` is created
   - (eg in `source/nvda.log` when running from source, in `%TEMP%/nvda.log` when running as installed).

Run nvda with `-s`.
- Open the exit dialog with `nvda+q`.
- Check that "Restart with debug logging enabled" is not listed.
- Check that "Install pending update" is not listed.

Start NVDA normally and with the -s option. For each run:
- Test each restart option

### Known issues with pull request:

None

### Change log entries:

Security fixes
```
- Addressed security advisory ``GHSA-354r-wr4v-cx28``. (#13488)
  - Remove the ability to start NVDA with debug logging enabled when NVDA runs in secure mode.
  - Remove the ability to update NVDA when NVDA runs in secure mode.
  -
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
