### PR TITLE
Disable dictionary dialogs and input gesture dialog in secure mode

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -171,13 +171,16 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onDefaultDictionaryCommand(self,evt):
-		self._popupSettingsDialog(DefaultDictionaryDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(DefaultDictionaryDialog)
 
 	def onVoiceDictionaryCommand(self,evt):
-		self._popupSettingsDialog(VoiceDictionaryDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(VoiceDictionaryDialog)
 
 	def onTemporaryDictionaryCommand(self,evt):
-		self._popupSettingsDialog(TemporaryDictionaryDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(TemporaryDictionaryDialog)
 
 	def onExecuteUpdateCommand(self, evt):
 		if updateCheck and updateCheck.isPendingUpdate():
@@ -266,7 +269,8 @@ class MainFrame(wx.Frame):
 		self._popupSettingsDialog(SpeechSymbolsDialog)
 
 	def onInputGesturesCommand(self, evt):
-		self._popupSettingsDialog(InputGesturesDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(InputGesturesDialog)
 
 	def onAboutCommand(self,evt):
 		# Translators: The title of the dialog to show about info for NVDA.
@@ -395,8 +399,9 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			# Translators: The description for the menu item to open NVDA Settings dialog.
 			_("NVDA settings"))
 		self.Bind(wx.EVT_MENU, frame.onNVDASettingsCommand, item)
-		subMenu_speechDicts = wx.Menu()
 		if not globalVars.appArgs.secure:
+			# TODO: This code should be moved out into a createSpeechDictsSubMenu function
+			subMenu_speechDicts = wx.Menu()
 			item = subMenu_speechDicts.Append(
 				wx.ID_ANY,
 				# Translators: The label for the menu item to open Default speech dictionary dialog.
@@ -417,16 +422,16 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 				)
 			)
 			self.Bind(wx.EVT_MENU, frame.onVoiceDictionaryCommand, item)
-		item = subMenu_speechDicts.Append(
-			wx.ID_ANY,
-			# Translators: The label for the menu item to open Temporary speech dictionary dialog.
-			_("&Temporary dictionary..."),
-			# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
-			_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
-		)
-		self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
-		# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
-		menu_preferences.AppendSubMenu(subMenu_speechDicts,_("Speech &dictionaries"))
+			item = subMenu_speechDicts.Append(
+				wx.ID_ANY,
+				# Translators: The label for the menu item to open Temporary speech dictionary dialog.
+				_("&Temporary dictionary..."),
+				# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
+				_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
+			)
+			self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
+			# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
+			menu_preferences.AppendSubMenu(subMenu_speechDicts, _("Speech &dictionaries"))
 		if not globalVars.appArgs.secure:
 			# Translators: The label for the menu item to open Punctuation/symbol pronunciation dialog.
 			item = menu_preferences.Append(wx.ID_ANY, _("&Punctuation/symbol pronunciation..."))


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

Thank you @CyrilleB79 and @paulber19 for reporting

### Link to issue number:
GitHub Advisory GHSA-wg65-7r23-h6p9: https://github.com/nvaccess/nvda/security/advisories/GHSA-wg65-7r23-h6p9

### Summary of the issue:

The following menu items are hidden from the menu in secure mode:
- Input gesture
- Default dictionary
- Voice dictionary

However it is still possible to assign gestures to the scripts allowing to open these dialogs.

Gestures being set on the system profile may "pollute" public configuration.
If unexpected gestures or speech is being replaced, a user may be unable to sign-in to Windows.

### Description of how this pull request fixes the issue:

For these commands, return early without opening the dialog if NVDA runs in secure mode.

### Testing strategy:

Manual test:
* Assign 3 gestures to the scripts allowing to open the Input gesture dialog, the Default dictionary dialog and the Voice dictionary dialog.
* Copy your config to secure screens
* Run NVDA in secure mode and checked that these scripts do nothing.
* Run NVDA in normal mode and checked that each of these scripts opens the expected dialog.

### Known issues with pull request:

None

### Change log entries:
Security fixes
```
- Addressed security advisory ``GHSA-wg65-7r23-h6p9``. (#13489)
  - Remove the ability to open the input gestures dialog in secure mode.
  - Remove the ability to open the default, temporary and voice dictionary dialogs in secure mode.
  -
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
