### PR TITLE
Merge security fixes from 2021.3.4

### DIFF
--- a/devDocs/technicalDesignOverview.md
+++ b/devDocs/technicalDesignOverview.md
@@ -67,6 +67,14 @@ Aside from accessibility and native APIs, Windows provides many functions which 
 Information that can be obtained includes the class name of a window, the current foreground window and system battery status.
 Tasks that can be performed include moving/clicking the mouse and sending key presses.
 
+### Logging
+
+#### Logging in secure mode
+`logHandler.initialize` prevents logging in secure mode.
+This is because it is a security concern to log during secure mode (e.g. passwords are logged).
+To change this for testing, patch the source build.
+`nvda.log` files are then generated in the System profile's `%TEMP%` directory.
+
 ## NVDA Components
 NVDA is built with an extensible, modular, object oriented, abstract design.
 It is divided into several distinct components.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2105,6 +2105,8 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TOOLS
 	)
 	def script_startWxInspectionTool(self, gesture):
+		if globalVars.appArgs.secure:
+			return
 		import wx.lib.inspection
 		wx.lib.inspection.InspectionTool().Show()
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -171,13 +171,16 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	def onDefaultDictionaryCommand(self,evt):
-		self._popupSettingsDialog(DefaultDictionaryDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(DefaultDictionaryDialog)
 
 	def onVoiceDictionaryCommand(self,evt):
-		self._popupSettingsDialog(VoiceDictionaryDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(VoiceDictionaryDialog)
 
 	def onTemporaryDictionaryCommand(self,evt):
-		self._popupSettingsDialog(TemporaryDictionaryDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(TemporaryDictionaryDialog)
 
 	def onExecuteUpdateCommand(self, evt):
 		if updateCheck and updateCheck.isPendingUpdate():
@@ -266,7 +269,8 @@ class MainFrame(wx.Frame):
 		self._popupSettingsDialog(SpeechSymbolsDialog)
 
 	def onInputGesturesCommand(self, evt):
-		self._popupSettingsDialog(InputGesturesDialog)
+		if not globalVars.appArgs.secure:
+			self._popupSettingsDialog(InputGesturesDialog)
 
 	def onAboutCommand(self,evt):
 		# Translators: The title of the dialog to show about info for NVDA.
@@ -395,8 +399,9 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			# Translators: The description for the menu item to open NVDA Settings dialog.
 			_("NVDA settings"))
 		self.Bind(wx.EVT_MENU, frame.onNVDASettingsCommand, item)
-		subMenu_speechDicts = wx.Menu()
 		if not globalVars.appArgs.secure:
+			# TODO: This code should be moved out into a createSpeechDictsSubMenu function
+			subMenu_speechDicts = wx.Menu()
 			item = subMenu_speechDicts.Append(
 				wx.ID_ANY,
 				# Translators: The label for the menu item to open Default speech dictionary dialog.
@@ -417,16 +422,16 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 				)
 			)
 			self.Bind(wx.EVT_MENU, frame.onVoiceDictionaryCommand, item)
-		item = subMenu_speechDicts.Append(
-			wx.ID_ANY,
-			# Translators: The label for the menu item to open Temporary speech dictionary dialog.
-			_("&Temporary dictionary..."),
-			# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
-			_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
-		)
-		self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
-		# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
-		menu_preferences.AppendSubMenu(subMenu_speechDicts,_("Speech &dictionaries"))
+			item = subMenu_speechDicts.Append(
+				wx.ID_ANY,
+				# Translators: The label for the menu item to open Temporary speech dictionary dialog.
+				_("&Temporary dictionary..."),
+				# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
+				_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
+			)
+			self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
+			# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
+			menu_preferences.AppendSubMenu(subMenu_speechDicts, _("Speech &dictionaries"))
 		if not globalVars.appArgs.secure:
 			# Translators: The label for the menu item to open Punctuation/symbol pronunciation dialog.
 			item = menu_preferences.Append(wx.ID_ANY, _("&Punctuation/symbol pronunciation..."))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -162,6 +162,25 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
 -
 
 
+= 2021.3.4 =
+This is a minor release to fix several security issues raised.
+Please responsibly disclose security issues to info@nvaccess.org.
+
+== Security Fixes ==
+- Addressed security advisory ``GHSA-354r-wr4v-cx28``. (#13488)
+  - Remove the ability to start NVDA with debug logging enabled when NVDA runs in secure mode.
+  - Remove the ability to update NVDA when NVDA runs in secure mode.
+  -
+- Addressed security advisory ``GHSA-wg65-7r23-h6p9``. (#13489)
+  - Remove the ability to open the input gestures dialog in secure mode.
+  - Remove the ability to open the default, temporary and voice dictionary dialogs in secure mode.
+  -
+- Addressed security advisory ``GHSA-mvc8-5rv9-w3hx``. (#13487)
+  - The wx GUI inspection tool is now disabled in secure mode.
+  -
+-
+
+
 = 2021.3.3 =
 This release is identical to 2021.3.2.
 A bug existed in NVDA 2021.3.2 where it incorrectly identified itself as 2021.3.1.


### PR DESCRIPTION
### Link to issue number:
- [GitHub Advisory GHSA-wg65-7r23-h6p9](https://github.com/nvaccess/nvda/security/advisories/GHSA-wg65-7r23-h6p9)
- [GitHub Advisory GHSA-mvc8-5rv9-w3hx](https://github.com/nvaccess/nvda/security/advisories/GHSA-mvc8-5rv9-w3hx)
- [GitHub Advisory GHSA-354r-wr4v-cx28](https://github.com/nvaccess/nvda/security/advisories/GHSA-354r-wr4v-cx28)

### Summary of the issue:
Several security fixes have been introduced to address (soon to published) security advisories.

### Description of how this pull request fixes the issue:
Note about the state of the rc branch:
- Initially changes for 2021.3.1 were delivered to beta, subsequently it was decided to avoid complications with translations, to make changes directly on RC.
- The changes were cherry picked from beta.
- There were then several more changes made squashed / merged to RC
- These changes need to be cherry picked back into the beta branch.
- This was done in https://github.com/nvaccess/nvda/pull/13185

Similarly, the security fixes already merged into the rc branch must be merged separately to beta then to master.
To ensure the same commits are in the history of the 2021.3.4 release, 2022.1 release and master, the changes were merged (not squashed) into rc, and now with this PR also into beta, then beta can be merged back to master.
Merge in:
- https://github.com/nvaccess/nvda/pull/13487
- https://github.com/nvaccess/nvda/pull/13488
- https://github.com/nvaccess/nvda/pull/13489
- https://github.com/nvaccess/nvda/pull/13490

### Testing strategy:
See individual PRs

### Known issues with pull request:
None

### Change log entries:
Included

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
