### PR TITLE
Add UI messages when an action cannot be performed

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2250,9 +2250,8 @@ class GlobalCommands(ScriptableObject):
 		),
 		category=SCRCAT_TOOLS
 	)
+	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_startWxInspectionTool(self, gesture):
-		if globalVars.appArgs.secure:
-			return
 		import wx.lib.inspection
 		wx.lib.inspection.InspectionTool().Show()
 
@@ -2284,9 +2283,8 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TOOLS,
 		gesture="kb:NVDA+control+shift+f1"
 	)
+	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_log_markStartThenCopy(self, gesture):
-		if globalVars.appArgs.secure:
-			return
 		if log.fragmentStart is None:
 			if log.markFragmentStart():
 				# Translators: Message when marking the start of a fragment of the log file for later copy
@@ -2315,9 +2313,8 @@ class GlobalCommands(ScriptableObject):
 		description=_("Opens NVDA configuration directory for the current user."),
 		category=SCRCAT_TOOLS
 	)
+	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_openUserConfigurationDirectory(self, gesture):
-		if globalVars.appArgs.secure:
-			return
 		import systemUtils
 		systemUtils.openUserConfigurationDirectory()
 
@@ -2681,9 +2678,11 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TOOLS,
 		gesture="kb:NVDA+control+z"
 	)
+	@gui.blockAction.when(
+		gui.blockAction.Context.WINDOWS_STORE_VERSION,
+		gui.blockAction.Context.SECURE_MODE
+	)
 	def script_activatePythonConsole(self,gesture):
-		if globalVars.appArgs.secure or config.isAppX:
-			return
 		import pythonConsole
 		if not pythonConsole.consoleUI:
 			pythonConsole.initialize()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -309,8 +309,8 @@ class MainFrame(wx.Frame):
 		pythonConsole.activate()
 
 	@blockAction.when(
+		blockAction.Context.SECURE_MODE,
 		blockAction.Context.MODAL_DIALOG_OPEN,
-		blockAction.Context.SECURE_MODE
 	)
 	def onAddonsManagerCommand(self,evt):
 		self.prePopup()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -25,11 +25,11 @@ import queueHandler
 import core
 from . import guiHelper
 from .message import (
-	isModalMessageBoxActive,
 	# messageBox is accessed through `gui.messageBox` as opposed to `gui.message.messageBox` throughout NVDA,
 	# be cautious when removing
 	messageBox,
 )
+from . import blockAction
 from .speechDict import (
 	DefaultDictionaryDialog,
 	VoiceDictionaryDialog,
@@ -143,8 +143,8 @@ class MainFrame(wx.Frame):
 
 	def onSaveConfigurationCommand(self,evt):
 		if globalVars.appArgs.secure:
-			# Translators: Reported when current configuration cannot be saved while NVDA is running in secure mode such as in Windows login screen.
-			queueHandler.queueFunction(queueHandler.eventQueue,ui.message,_("Cannot save configuration - NVDA in secure mode"))
+			# Translators: Reported when an action cannot be performed because NVDA is in a secure screen
+			queueHandler.queueFunction(queueHandler.eventQueue, ui.message, _("Not available in secure context"))
 			return
 		try:
 			config.conf.save()
@@ -154,9 +154,8 @@ class MainFrame(wx.Frame):
 			# Translators: Message shown when current configuration cannot be saved such as when running NVDA from a CD.
 			messageBox(_("Could not save configuration - probably read only file system"),_("Error"),wx.OK | wx.ICON_ERROR)
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def _popupSettingsDialog(self, dialog, *args, **kwargs):
-		if isModalMessageBoxActive():
-			return
 		self.prePopup()
 		try:
 			dialog(self, *args, **kwargs).Show()
@@ -169,17 +168,17 @@ class MainFrame(wx.Frame):
 
 		self.postPopup()
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onDefaultDictionaryCommand(self, evt):
-		if not globalVars.appArgs.secure:
-			self._popupSettingsDialog(DefaultDictionaryDialog)
+		self._popupSettingsDialog(DefaultDictionaryDialog)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onVoiceDictionaryCommand(self, evt):
-		if not globalVars.appArgs.secure:
-			self._popupSettingsDialog(VoiceDictionaryDialog)
+		self._popupSettingsDialog(VoiceDictionaryDialog)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onTemporaryDictionaryCommand(self, evt):
-		if not globalVars.appArgs.secure:
-			self._popupSettingsDialog(TemporaryDictionaryDialog)
+		self._popupSettingsDialog(TemporaryDictionaryDialog)
 
 	def onExecuteUpdateCommand(self, evt):
 		if updateCheck and updateCheck.isPendingUpdate():
@@ -206,9 +205,8 @@ class MainFrame(wx.Frame):
 		if not globalVars.appArgs.secure and updateCheck and updateCheck.isPendingUpdate():
 			self.sysTrayIcon.menu.Insert(self.sysTrayIcon.installPendingUpdateMenuItemPos,self.sysTrayIcon.installPendingUpdateMenuItem)
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onExitCommand(self, evt):
-		if isModalMessageBoxActive():
-			return
 		if config.conf["general"]["askToExit"]:
 			self.prePopup()
 			d = ExitDialog(self)
@@ -267,9 +265,9 @@ class MainFrame(wx.Frame):
 	def onSpeechSymbolsCommand(self, evt):
 		self._popupSettingsDialog(SpeechSymbolsDialog)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onInputGesturesCommand(self, evt):
-		if not globalVars.appArgs.secure:
-			self._popupSettingsDialog(InputGesturesDialog)
+		self._popupSettingsDialog(InputGesturesDialog)
 
 	def onAboutCommand(self,evt):
 		# Translators: The title of the dialog to show about info for NVDA.
@@ -310,9 +308,11 @@ class MainFrame(wx.Frame):
 			pythonConsole.initialize()
 		pythonConsole.activate()
 
+	@blockAction.when(
+		blockAction.Context.MODAL_DIALOG_OPEN,
+		blockAction.Context.SECURE_MODE
+	)
 	def onAddonsManagerCommand(self,evt):
-		if isModalMessageBoxActive() or globalVars.appArgs.secure:
-			return
 		self.prePopup()
 		from .addonGui import AddonsDialog
 		d=AddonsDialog(gui.mainFrame)
@@ -326,24 +326,21 @@ class MainFrame(wx.Frame):
 		globalPluginHandler.reloadGlobalPlugins()
 		NVDAObject.clearDynamicClassCache()
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onCreatePortableCopyCommand(self,evt):
-		if isModalMessageBoxActive():
-			return
 		self.prePopup()
 		import gui.installerGui
 		d=gui.installerGui.PortableCreaterDialog(gui.mainFrame)
 		d.Show()
 		self.postPopup()
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onInstallCommand(self, evt):
-		if isModalMessageBoxActive():
-			return
 		from gui import installerGui
 		installerGui.showInstallGui()
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onRunCOMRegistrationFixesCommand(self, evt):
-		if isModalMessageBoxActive():
-			return
 		if messageBox(
 			# Translators: A message to warn the user when starting the COM Registration Fixing tool 
 			_("You are about to run the COM Registration Fixing tool. This tool will try to fix common system problems that stop NVDA from being able to access content in many programs including Firefox and Internet Explorer. This tool must make changes to the System registry and therefore requires administrative access. Are you sure you wish to proceed?"),
@@ -375,13 +372,13 @@ class MainFrame(wx.Frame):
 			wx.OK
 		)
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onConfigProfilesCommand(self, evt):
-		if isModalMessageBoxActive():
-			return
 		self.prePopup()
 		from .configProfiles import ProfilesDialog
 		ProfilesDialog(gui.mainFrame).Show()
 		self.postPopup()
+
 
 class SysTrayIcon(wx.adv.TaskBarIcon):
 
@@ -399,38 +396,8 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			_("NVDA settings"))
 		self.Bind(wx.EVT_MENU, frame.onNVDASettingsCommand, item)
 		if not globalVars.appArgs.secure:
-			# TODO: This code should be moved out into a createSpeechDictsSubMenu function
-			subMenu_speechDicts = wx.Menu()
-			item = subMenu_speechDicts.Append(
-				wx.ID_ANY,
-				# Translators: The label for the menu item to open Default speech dictionary dialog.
-				_("&Default dictionary..."),
-				# Translators: The help text for the menu item to open Default speech dictionary dialog.
-				_("A dialog where you can set default dictionary by adding dictionary entries to the list")
-			)
-			self.Bind(wx.EVT_MENU, frame.onDefaultDictionaryCommand, item)
-			item = subMenu_speechDicts.Append(
-				wx.ID_ANY,
-				# Translators: The label for the menu item to open Voice specific speech dictionary dialog.
-				_("&Voice dictionary..."),
-				_(
-					# Translators: The help text for the menu item
-					# to open Voice specific speech dictionary dialog.
-					"A dialog where you can set voice-specific dictionary by adding"
-					" dictionary entries to the list"
-				)
-			)
-			self.Bind(wx.EVT_MENU, frame.onVoiceDictionaryCommand, item)
-			item = subMenu_speechDicts.Append(
-				wx.ID_ANY,
-				# Translators: The label for the menu item to open Temporary speech dictionary dialog.
-				_("&Temporary dictionary..."),
-				# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
-				_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
-			)
-			self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
 			# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
-			menu_preferences.AppendSubMenu(subMenu_speechDicts, _("Speech &dictionaries"))
+			menu_preferences.AppendSubMenu(self._createSpeechDictsSubMenu(frame), _("Speech &dictionaries"))
 		if not globalVars.appArgs.secure:
 			# Translators: The label for the menu item to open Punctuation/symbol pronunciation dialog.
 			item = menu_preferences.Append(wx.ID_ANY, _("&Punctuation/symbol pronunciation..."))
@@ -565,6 +532,38 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			# The NVDA menu didn't actually appear for some reason.
 			appModules.nvda.nvdaMenuIaIdentity = None
 		mainFrame.postPopup()
+
+	def _createSpeechDictsSubMenu(self, frame: wx.Frame) -> wx.Menu:
+		subMenu_speechDicts = wx.Menu()
+		item = subMenu_speechDicts.Append(
+			wx.ID_ANY,
+			# Translators: The label for the menu item to open Default speech dictionary dialog.
+			_("&Default dictionary..."),
+			# Translators: The help text for the menu item to open Default speech dictionary dialog.
+			_("A dialog where you can set default dictionary by adding dictionary entries to the list")
+		)
+		self.Bind(wx.EVT_MENU, frame.onDefaultDictionaryCommand, item)
+		item = subMenu_speechDicts.Append(
+			wx.ID_ANY,
+			# Translators: The label for the menu item to open Voice specific speech dictionary dialog.
+			_("&Voice dictionary..."),
+			_(
+				# Translators: The help text for the menu item
+				# to open Voice specific speech dictionary dialog.
+				"A dialog where you can set voice-specific dictionary by adding"
+				" dictionary entries to the list"
+			)
+		)
+		self.Bind(wx.EVT_MENU, frame.onVoiceDictionaryCommand, item)
+		item = subMenu_speechDicts.Append(
+			wx.ID_ANY,
+			# Translators: The label for the menu item to open Temporary speech dictionary dialog.
+			_("&Temporary dictionary..."),
+			# Translators: The help text for the menu item to open Temporary speech dictionary dialog.
+			_("A dialog where you can set temporary dictionary by adding dictionary entries to the edit box")
+		)
+		self.Bind(wx.EVT_MENU, frame.onTemporaryDictionaryCommand, item)
+		return subMenu_speechDicts
 
 
 def initialize():

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -42,7 +42,7 @@ class Context(_Context, Enum):
 def when(*contexts: Context):
 	"""Returns a function wrapper.
 	A function decorated with `when` will exit early if any supplied context in `contexts` is active.
-	The first suppplied context to block will be reported as a message.
+	The first supplied context to block will be reported as a message.
 	Consider supplying permanent conditions first.
 
 	For example, to block a function when a modal dialog is open (a temporary condition)

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -36,7 +36,6 @@ class Context(_Context, Enum):
 		# Translators: Reported when an action cannot be performed because NVDA is waiting
 		# for a response from a modal dialog
 		_("Action unavailable while a dialog requires a response"),
-
 	)
 
 

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -1,0 +1,58 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+import config
+from dataclasses import dataclass
+from enum import Enum
+from functools import wraps
+import globalVars
+from typing import Callable
+import ui
+from gui.message import isModalMessageBoxActive
+
+
+@dataclass
+class _Context:
+	blockActionIf: Callable[[], bool]
+	translatedMessage: str
+
+
+class Context(_Context, Enum):
+	SECURE_MODE = (
+		lambda: globalVars.appArgs.secure,
+		# Translators: Reported when an action cannot be performed because NVDA is in a secure screen
+		_("Action unavailable in secure context"),
+	)
+	WINDOWS_STORE_VERSION = (
+		lambda: config.isAppX,
+		# Translators: Reported when an action cannot be performed because NVDA has been installed
+		# from the Windows Store.
+		_("Action unavailable in NVDA Windows Store version"),
+	)
+	MODAL_DIALOG_OPEN = (
+		isModalMessageBoxActive,
+		# Translators: Reported when an action cannot be performed because NVDA is waiting
+		# for a response from a modal dialog
+		_("Action unavailable as an open dialog requires a response"),
+	)
+
+
+def when(*contexts: Context):
+	"""Returns a function wrapper.
+	A function decorated with `when` will exit early if any supplied context in `contexts` is active.
+
+	For example, a function decorated with `@blockAction.when(blockAction.Context.SECURE_MODE)`
+	will return without running if secure mode is active.
+	"""
+	def _wrap(func):
+		@wraps(func)
+		def funcWrapper(*args, **kwargs):
+			for context in contexts:
+				if context.blockActionIf():
+					ui.message(context.translatedMessage)
+					return
+			return func(*args, **kwargs)
+		return funcWrapper
+	return _wrap

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -11,6 +11,7 @@ import globalVars
 from typing import Callable
 import ui
 from gui.message import isModalMessageBoxActive
+import queueHandler
 
 
 @dataclass
@@ -54,7 +55,7 @@ def when(*contexts: Context):
 		def funcWrapper(*args, **kwargs):
 			for context in contexts:
 				if context.blockActionIf():
-					ui.message(context.translatedMessage)
+					queueHandler.queueFunction(queueHandler.eventQueue, ui.message, context.translatedMessage)
 					return
 			return func(*args, **kwargs)
 		return funcWrapper

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -42,9 +42,12 @@ class Context(_Context, Enum):
 def when(*contexts: Context):
 	"""Returns a function wrapper.
 	A function decorated with `when` will exit early if any supplied context in `contexts` is active.
+	The first suppplied context to block will be reported as a message.
+	Consider supplying permanent conditions first.
 
-	For example, a function decorated with `@blockAction.when(blockAction.Context.SECURE_MODE)`
-	will return without running if secure mode is active.
+	For example, to block a function when a modal dialog is open (a temporary condition)
+	and in secure mode (permanent during run time), decorate it with
+	`@blockAction.when(blockAction.Context.SECURE_MODE, blockAction.Context.MODAL_DIALOG_OPEN)`.
 	"""
 	def _wrap(func):
 		@wraps(func)

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -35,7 +35,8 @@ class Context(_Context, Enum):
 		isModalMessageBoxActive,
 		# Translators: Reported when an action cannot be performed because NVDA is waiting
 		# for a response from a modal dialog
-		_("Action unavailable as an open dialog requires a response"),
+		_("Action unavailable while a dialog requires a response"),
+
 	)
 
 
@@ -46,8 +47,8 @@ def when(*contexts: Context):
 	Consider supplying permanent conditions first.
 
 	For example, to block a function when a modal dialog is open (a temporary condition)
-	and in secure mode (permanent during run time), decorate it with
-	`@blockAction.when(blockAction.Context.SECURE_MODE, blockAction.Context.MODAL_DIALOG_OPEN)`.
+	and in the Windows Store version (per installation), decorate it with
+	`@blockAction.when(blockAction.Context.WINDOWS_STORE_VERSION, blockAction.Context.MODAL_DIALOG_OPEN)`.
 	"""
 	def _wrap(func):
 		@wraps(func)

--- a/source/gui/contextHelp.py
+++ b/source/gui/contextHelp.py
@@ -7,8 +7,9 @@ import os
 import tempfile
 import typing
 
-from gui import blockAction
 import wx
+
+from gui import blockAction
 from logHandler import log
 import documentationUtils
 

--- a/source/gui/contextHelp.py
+++ b/source/gui/contextHelp.py
@@ -1,16 +1,16 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2020 NV Access Limited, Thomas Stivers
+# Copyright (C) 2017-2022 NV Access Limited, Thomas Stivers
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import os
 import tempfile
 import typing
 
+from gui import blockAction
 import wx
 from logHandler import log
 import documentationUtils
-import globalVars
 
 
 def writeRedirect(helpId: str, helpFilePath: str, contextHelpPath: str):
@@ -73,10 +73,8 @@ def bindHelpEvent(helpId: str, window: wx.Window):
 	log.debug(f"Did context help binding for {window.__class__.__qualname__}")
 
 
+@blockAction.when(blockAction.Context.SECURE_MODE)
 def _onEvtHelp(helpId: str, evt: wx.HelpEvent):
-	if globalVars.appArgs.secure:
-		# Disable context help in secure screens to avoid opening a browser with system-wide privileges.
-		return
 	# Don't call evt.skip. Events bubble upwards through parent controls.
 	# Context help for more specific controls should override the less specific parent controls.
 	showHelp(helpId)

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -1,8 +1,7 @@
-#gui/logViewer.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-# Copyright (C) 2008-2020 NV Access Limited
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2008-2022 NV Access Limited
 
 """Provides functionality to view the NVDA log.
 """
@@ -11,6 +10,8 @@ import wx
 import globalVars
 import gui
 import gui.contextHelp
+from gui import blockAction
+
 
 #: The singleton instance of the log viewer UI.
 logViewer = None
@@ -102,15 +103,15 @@ class LogViewer(
 			return
 		evt.Skip()
 
+
+# The log might expose sensitive information and the Save As dialog in the Log Viewer is a security risk.
+@blockAction.when(blockAction.Context.SECURE_MODE)
 def activate():
 	"""Activate the log viewer.
 	If the log viewer has not already been created and opened, this will create and open it.
 	Otherwise, it will be brought to the foreground if possible.
 	"""
 	global logViewer
-	if globalVars.appArgs.secure:
-		# The log might expose sensitive information and the Save As dialog in the Log Viewer is a security risk.
-		return
 	if not logViewer:
 		logViewer = LogViewer(gui.mainFrame)
 	# Check if log was properly initialized

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -1,8 +1,7 @@
-#inputCore.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2010-2019 NV Access Limited, Babbage B.V., Mozilla Corporation
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2010-2022 NV Access Limited, Babbage B.V., Mozilla Corporation
 
 """Core framework for handling input from the user.
 Every piece of input from the user (e.g. a key press) is represented by an L{InputGesture}.
@@ -12,11 +11,10 @@ For example, it is used to execute gestures and handle input help.
 
 import sys
 import os
-import itertools
 import weakref
 import time
 from typing import Dict, Any, Tuple, List, Union
-
+from gui import blockAction
 import configobj
 from speech import sayAll
 import baseObject
@@ -32,7 +30,6 @@ from logHandler import log
 import globalVars
 import languageHandler
 import controlTypes
-import keyLabels
 import winKernel
 
 #: Script category for emulated keyboard keys.
@@ -376,12 +373,11 @@ class GlobalGestureMap(object):
 			raise ValueError("Mapping not found")
 		scripts.remove((module, className, script))
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def save(self):
 		"""Save this gesture map to disk.
 		@precondition: L{load} must have been called.
 		"""
-		if globalVars.appArgs.secure:
-			return
 		if not self.fileName:
 			raise ValueError("No file name")
 		out = configobj.ConfigObj(encoding="UTF-8")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,13 @@ What's New in NVDA
 == Changes ==
 - NSIS has been updated to version 3.08. (#9134)
 - Added new role for "busy indicator" controls. (#10644)
+- NVDA now announces when an NVDA action cannot be performed. (#13500)
+  - This includes when:
+    - using the NVDA Windows Store version
+    - in a secure context
+    - waiting for a response to a modal dialog
+    -
+  -
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,9 +13,9 @@ What's New in NVDA
 - Added new role for "busy indicator" controls. (#10644)
 - NVDA now announces when an NVDA action cannot be performed. (#13500)
   - This includes when:
-    - using the NVDA Windows Store version
-    - in a secure context
-    - waiting for a response to a modal dialog
+    - Using the NVDA Windows Store version.
+    - In a secure context.
+    - Waiting for a response to a modal dialog.
     -
   -
 -


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes #6549

### Summary of the issue:

Some UI messages are missing when an action cannot be performed.
If a user should be notified if they cannot perform an action due to being in secure mode, using the windows store version or a modal dialog is blocking.

### Description of how this pull request fixes the issue:

The following ui messages have been added and implemented 

- Not available in Windows Store version
- Not available in secure context
- Not available while dialog response required

These were found by searching for usages of `config.isAppX` `globalVars.appArgs.secure` and `isModalMessageBoxActive`, respectively.


### Testing strategy:

- [x] secure context:
   - Perform an action that is not available in a secure context
       - e.g. opening the GUI inspection tool #13487)
   - confirm ui message is spoken
- [x] Modal message box:
   -  Perform an action that is not available with a modal open 
       - e.g. nvda+q while the about dialog is open
   - confirm message is spoken
- [ ] Using Windows store version:
   -  Perform an action that is not available when using the windows store version:
       - e.g. activating the python console
   - confirm message is spoken

### Known issues with pull request:

Some messages may be confusing or unexpected

### Change log entries:

Changes
```t2t
- NVDA now announces when an action cannot be performed due to not being available:
  - in the Windows Store version
  - in a secure context
  - while waiting for a response to a modal dialog
  -
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
