### PR TITLE
Revert "Update to py2exe 0.11.0.1 (#13066)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
 diff_match_patch_python==1.0.2
 
 # Packaging NVDA
-py2exe==0.11.0.1
+py2exe==0.10.1.0
 
 # For building developer documentation
 sphinx==3.4.1

--- a/source/setup.py
+++ b/source/setup.py
@@ -234,12 +234,6 @@ setup(
 		],
 		"packages": [
 			"NVDAObjects",
-			# As of py2exe 0.11.0.0 if the forcibly included package contains subpackages
-			# they need to be listed explicitly (py2exe issue 113).
-			"NVDAObjects.IAccessible",
-			"NVDAObjects.JAB",
-			"NVDAObjects.UIA",
-			"NVDAObjects.window",
 			"virtualBuffers",
 			"appModules",
 			"comInterfaces",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -94,7 +94,6 @@ Note:
 - Note: this is a Add-on API compatibility breaking release. Add-ons will need to be re-tested and have their manifest updated.
 - Although NVDA still requires Visual Studio 2019, Builds should no longer fail if a newer version of Visual Studio (E.g. 2022) is installed along side 2019. (#13033, #13387)
 - Updated SCons to version 4.3.0. (#13033)
-- Updated py2exe to version 0.11.0.1. (#12357, #13066)
 - ``NVDAObjects.UIA.winConsoleUIA.WinConsoleUIA.isImprovedTextRangeAvailable`` has been removed. Use ``apiLevel`` instead. (#12955, #12660)
 - ``TVItemStruct`` has been removed from ``sysTreeView32``. (#12935)
 - ``MessageItem`` has been removed from the Outlook appModule. (#12935)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Reverts pr #13066 

### Summary of the issue:
Some time after we branched for the 2021.3 beta, pr #13066  was merged to master, which upgraded Py2exe to 0.11.1. However, this version of Py2exe fails to build the NVDA distribution when using optimized Python (E.g. when building a release).

```
Traceback (most recent call last):
  File "setup.py", line 290, in <module>
    + getRecursiveDataFiles('documentation', '../user_docs', excludes=('*.t2t', '*.t2tconf', '*/developerGuide.*'))
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\setuptools\__init__.py", line 144, in setup
    return distutils.core.setup(**attrs)
  File "C:\Program Files (x86)\Python37-32\lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:\Program Files (x86)\Python37-32\lib\distutils\dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "C:\Program Files (x86)\Python37-32\lib\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "setup.py", line 114, in run
    super(py2exe, self).run()
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\distutils_buildexe.py", line 192, in run
    self._run()
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\distutils_buildexe.py", line 272, in _run
    builder.analyze()
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\runtime.py", line 172, in analyze
    mf.import_package(modname)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\mf310.py", line 144, in import_package
    self.import_hook(name,  None, ["*"])
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 211, in import_hook
    q, tail = self.find_head_package(parent, name)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 267, in find_head_package
    q = self.import_module(head, qname, parent)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 361, in import_module
    m = self.load_module(fqname, fp, pathname, stuff)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 374, in load_module
    m = self.load_package(fqname, pathname)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 526, in load_package
    self.load_module(fqname, fp, buf, stuff)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 402, in load_module
    self.scan_code(co, m)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 475, in scan_code
    self._safe_import_hook(name, m, fromlist, level=0)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 420, in _safe_import_hook
    self.import_hook(name, caller, level=level)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 211, in import_hook
    q, tail = self.find_head_package(parent, name)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 267, in find_head_package
    q = self.import_module(head, qname, parent)
...
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 361, in import_module
    m = self.load_module(fqname, fp, pathname, stuff)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 402, in load_module
    self.scan_code(co, m)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 508, in scan_code
    self.scan_code(c, m)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 508, in scan_code
    self.scan_code(c, m)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 475, in scan_code
    self._safe_import_hook(name, m, fromlist, level=0)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 435, in _safe_import_hook
    self.import_hook(name, caller, [sub], level=level)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 216, in import_hook
    self.ensure_fromlist(m, fromlist)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 306, in ensure_fromlist
    submod = self.import_module(sub, subname, m)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 355, in import_module
    parent and parent.__path__, parent)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 555, in find_module
    return _find_module(name, path)
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\py2exe\vendor\modulefinder.py", line 89, in _find_module
    spec = importlib.machinery.PathFinder.find_spec(name, path)
  File "<frozen importlib._bootstrap_external>", line 1280, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1246, in _get_spec
TypeError: 'int' object is not iterable
```

This was not noticed until trying to build the NVDA 2022.1beta1 tag.

Example builds:
* [Standard beta try build succeeds](https://ci.appveyor.com/project/NVAccess/nvda/builds/42948127)
* [Release beta try build fails](https://ci.appveyor.com/project/NVAccess/nvda/builds/42948136)

### Description of how this pull request fixes the issue:
This pr reverts pr #13066, restoring Py2exe back to 0.10.1.
 

### Testing strategy:
* Locally verified that NVDA can be built as a release. I.e. `scons dist release=1`.
* [Standard try build of this pr succeeded](https://ci.appveyor.com/project/NVAccess/nvda/builds/42948139)
* [Release try build of this pr succeeded](https://ci.appveyor.com/project/NVAccess/nvda/builds/42949856)

### Known issues with pull request:
None known.

### Change log entries:
None needed.

New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
