### PR TITLE
MS Word with UIA: do not fetch text-column-number as this causes MS Word to crash

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -438,11 +438,15 @@ class WordDocumentTextInfo(UIATextInfo):
 				)
 				if isinstance(sectionNumber, int):
 					formatField.field['section-number'] = sectionNumber
-				textColumnNumber = UIARemote.msWord_getCustomAttributeValue(
-					docElement, textRange, UIACustomAttributeID.COLUMN_NUMBER
-				)
-				if isinstance(textColumnNumber, int):
-					formatField.field['text-column-number'] = textColumnNumber
+				if False:
+					# #13511: Fetching of text-column-number is disabled
+					# as it causes Microsoft Word 16.0.1493 and newer to crash!!
+					# This should only be reenabled for versions identified not to crash.
+					textColumnNumber = UIARemote.msWord_getCustomAttributeValue(
+						docElement, textRange, UIACustomAttributeID.COLUMN_NUMBER
+					)
+					if isinstance(textColumnNumber, int):
+						formatField.field['text-column-number'] = textColumnNumber
 		return formatField
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13511
Fixes #13503 

### Summary of the issue:
Fetching text-column-number using UIA custom patterns in MS Word, causes MS Word to crash.
this can happen when opening a blank document on MS Word start-up.
This has been reported to Microsoft.

### Description of how this pull request fixes the issue:
No longer fetch text-column-number in MS Word with UIA. This should only be reenabled in future for newer versions of MS Word identified not to crash.

### Testing strategy:
Opened a blank document in MS Word. MS Word no longer crashes on start-up. Confirmed that other custom attributes such as section number and bookmark still get reported.

### Known issues with pull request:
None known.

### Change log entries:
None needed.

New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
