### PR TITLE
Release lock on mouse keys when exiting.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -216,14 +216,10 @@ class GlobalCommands(ScriptableObject):
 		gestures=("kb:shift+numpadDivide", "kb(laptop):NVDA+control+[")
 	)
 	def script_toggleLeftMouseButton(self,gesture):
-		if winUser.getKeyState(winUser.VK_LBUTTON)&32768:
-			# Translators: This is presented when the left mouse button lock is released (used for drag and drop).
-			ui.message(_("Left mouse button unlock"))
-			mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP,0,0)
+		if mouseHandler.isLeftMouseButtonLocked():
+			mouseHandler.unlockLeftMouseButton()
 		else:
-			# Translators: This is presented when the left mouse button is locked down (used for drag and drop).
-			ui.message(_("Left mouse button lock"))
-			mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_LEFTDOWN,0,0)
+			mouseHandler.lockLeftMouseButton()
 
 	@script(
 		# Translators: Input help mode message for right mouse lock/unlock command.
@@ -232,14 +228,10 @@ class GlobalCommands(ScriptableObject):
 		gestures=("kb:shift+numpadMultiply", "kb(laptop):NVDA+control+]")
 	)
 	def script_toggleRightMouseButton(self,gesture):
-		if winUser.getKeyState(winUser.VK_RBUTTON)&32768:
-			# Translators: This is presented when the right mouse button lock is released (used for drag and drop).
-			ui.message(_("Right mouse button unlock"))
-			mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_RIGHTUP,0,0)
+		if mouseHandler.isRightMouseButtonLocked():
+			mouseHandler.unlockRightMouseButton()
 		else:
-			# Translators: This is presented when the right mouse button is locked down (used for drag and drop).
-			ui.message(_("Right mouse button lock"))
-			mouseHandler.executeMouseEvent(winUser.MOUSEEVENTF_RIGHTDOWN,0,0)
+			mouseHandler.lockRightMouseButton()
 
 	@script(
 		description=_(

--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -260,6 +260,10 @@ def pumpAll():
 
 def terminate():
 	global scrBmpObj, _shapeTimer
+	if isLeftMouseButtonLocked():
+		unlockLeftMouseButton()
+	if isRightMouseButtonLocked():
+		unlockRightMouseButton()
 	scrBmpObj=None
 	winInputHook.terminate()
 	_shapeTimer.Stop()
@@ -336,3 +340,41 @@ def doSecondaryClick(releaseDelay: Optional[float] = None):
 	"""
 	buttonFlags = getLogicalButtonFlags()
 	_doClick(buttonFlags.secondaryDown, buttonFlags.secondaryUp, releaseDelay)
+
+
+def isLeftMouseButtonLocked():
+	""" Tests if the left mouse button is locked """
+	return winUser.getKeyState(winUser.VK_LBUTTON) & 1 << 15
+
+
+def lockLeftMouseButton():
+	""" Locks the left mouse button """
+	# Translators: This is presented when the left mouse button is locked down (used for drag and drop).
+	ui.message(_("Left mouse button lock"))
+	executeMouseEvent(winUser.MOUSEEVENTF_LEFTDOWN, 0, 0)
+
+
+def unlockLeftMouseButton():
+	""" Unlocks the left mouse button """
+	# Translators: This is presented when the left mouse button lock is released (used for drag and drop).
+	ui.message(_("Left mouse button unlock"))
+	executeMouseEvent(winUser.MOUSEEVENTF_LEFTUP, 0, 0)
+
+
+def isRightMouseButtonLocked():
+	""" Tests if the right mouse button is locked """
+	return winUser.getKeyState(winUser.VK_RBUTTON) & 1 << 15
+
+
+def lockRightMouseButton():
+	""" Locks the right mouse button """
+	# Translators: This is presented when the right mouse button is locked down (used for drag and drop).
+	ui.message(_("Right mouse button lock"))
+	executeMouseEvent(winUser.MOUSEEVENTF_RIGHTDOWN, 0, 0)
+
+
+def unlockRightMouseButton():
+	""" Unlocks the right mouse button """
+	# Translators: This is presented when the right mouse button lock is released (used for drag and drop).
+	ui.message(_("Right mouse button unlock"))
+	executeMouseEvent(winUser.MOUSEEVENTF_RIGHTUP, 0, 0)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -28,6 +28,7 @@ What's New in NVDA
 -  NVDA will no longer incorrectly remove text from Java widgets when presenting to the user. (#13102)
 - When reading non-interactive PDFs in Adobe Reader, the type and state of form fields (such as checkboxes and radio buttons) are now reported. (#13285)
 - "Reset configuration to factory defaults" is now accessible in the NVDA menu during secure mode. (#13547)
+- Any locked mouse keys will be unlocked when NVDA exits, previously the mouse button would remain locked. (#13410)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#13410 
### Summary of the issue:
If the user locks a mouse button and then exits NVDA, the mouse button remains locked.
### Description of how this pull request fixes the issue:
The mouse button states are checked in terminate() of the mouseHandler and unlocks the mouse buttons as required.
### Testing strategy:
Manually tested by locking the mouse button and then restarting NVDA.
### Known issues with pull request:
None known.
### Change log entries:
New features
Changes
Any locked mouse keys will be unlocked when NVDA exits, previously the mouse button would remain locked.
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date Done
  - change log entries Done
- [x] Testing:
  - Unit tests Not sure how to create unit tests to test mouse button states.
  - System (end to end) tests Same as unit tests, need help knowing how to test mouse buttons.
  - Manual testing Done
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation Not requested in issue.
  - Developer / Technical Documentation N/A
  - Context sensitive help for GUI changes N/A
- [x] UX of all users considered:
  - Speech  N/A
  - Braille N/A
  - Low Vision N/A
  - Different web browsers N/A
  - Localization in other languages / culture than English N/A
