### PR TITLE
Introduce security patch 2021.3.5 to 2022.1beta3

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -265,6 +265,8 @@ class MainFrame(wx.Frame):
 		self._popupSettingsDialog(NVDASettingsDialog, UwpOcrPanel)
 
 	def onSpeechSymbolsCommand(self, evt):
+		if globalVars.appArgs.secure:
+			return
 		self._popupSettingsDialog(SpeechSymbolsDialog)
 
 	def onInputGesturesCommand(self, evt):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -177,6 +177,17 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
 -
 
 
+= 2021.3.5 =
+This is a minor release to fix a security issue.
+Please responsibly disclose security issues to info@nvaccess.org.
+
+== Security Fixes ==
+- Addressed security advisory ``GHSA-xc5m-v23f-pgr7``.
+  - The symbol pronunciation dialog is now disabled in secure mode.
+  -
+-
+
+
 = 2021.3.4 =
 This is a minor release to fix several security issues raised.
 Please responsibly disclose security issues to info@nvaccess.org.


### PR DESCRIPTION
Introduce security fix from the 2021.3.5 patch release.
This can be a squash commit as rc and beta have diverged, and the security patch couldn't share a merge-base with beta.