### PR TITLE
Use blockAction.when decorator to have a message reported in secure mode when trying to open the symbol dialog

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -272,9 +272,8 @@ class MainFrame(wx.Frame):
 	def onUwpOcrCommand(self, evt):
 		self._popupSettingsDialog(NVDASettingsDialog, UwpOcrPanel)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onSpeechSymbolsCommand(self, evt):
-		if globalVars.appArgs.secure:
-			return
 		self._popupSettingsDialog(SpeechSymbolsDialog)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)


### PR DESCRIPTION
### Link to issue number:
Fix-up of #13535
Follow-up of #13500

### Summary of the issue:

In #13500 a decorator has been introduced to speak a message when an action is unavailable in secure mode.
In parallel an NVDA 2021.3.5 patch release has been produced; this release contains a fix preventing to open the symbol dialog in secure mode. The 2021.3.5 (rc) branch has then been merged into master to get this fix in master.
This led to the fact that no message was reported when trying to use a script to open the symbol dialog in secure mode.

### Description of how this pull request fixes the issue:

Added the `blockAction.when` decorator where it was missing.
### Testing strategy:
* In input gesture dialog configure a gesture to open the symbol dialog and press OK.
* Restart NVDA with the -s parameter and execute the newly configured gesture.
  Check that the dialog does not open and that a message reports that the action is unavailable in secure screen.
* * Restart NVDA without the -s parameter and execute the newly configured gesture.
  Check that the symbol dialog opens.

### Known issues with pull request:
None

### Change log entries:
Not needed: fixing an issue not yet released.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
