### PR TITLE
Adobe Acrobat: report type and state of form fields in non-interactive PDFs

### DIFF
--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -36,7 +36,7 @@ stdNamesToRoles = {
 	# H1 to H6 handled separately
 	# Span, Quote, Note, Reference, BibEntry, Code, Figure
 	"Formula": controlTypes.Role.MATH,
-	"Form": controlTypes.Role.FORM,
+	# form: a form field - MSAA roles are already much more specific here.
 }
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ What's New in NVDA
 - In Firefox, NVDA no longer fails to report items in web pages when aria-rowindex, aria-colindex, aria-rowcount or aria-colcount attributes are invalid. (#13405)
 - The cursor does not switch row or column anymore when using table navigation to navigate through merged cells. (#7278)
 -  NVDA will no longer incorrectly remove text from Java widgets when presenting to the user. (#13102)
+- When reading non-interactive PDFs in Adobe Reader, the type and state of form fields (such as checkboxes and radio buttons) are now reported. (#13285)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13285 

### Summary of the issue:
Non-interactive PDFs can contain form fields such as checkboxes and radio buttons. however, NVDA does not report any meaningful type or state for them at all.
This is due to the fact that NVDA specifically maps the PDF stdName (tag) of 'Form' to NVDA's Form role. Thereby completely overriding any more detailed MSAA role Adobe has provided.
This was most likely due to a mis-understanding of the PDF spec. The `<form>` tag means form field, not form.
 
### Description of how this pull request fixes the issue:
Remove the mapping of Form stdName to NVDA's Form role. so that NVDA will fall back to using the MSAA role / states provided by Adobe Acrobat.

### Testing strategy:
Opened the test file provided   in #13285  Adobe Reader, and arrowed down to the checkbox. Ensured that NVDA reported the checkbox was a checkbox and that it was checked.

### Known issues with pull request:
NVDA does however also report unavailable and readonly states on this checkbox. But I think this is because the checkbox is non-interactive, I.e. cannot be actually changed. If this is found to be problematic, it should be addressed in further issues / prs. Right now we are reporting the information that Adobe provides us.

### Change log entries:
New features
Changes
Bug fixes
- When reading non-interactive PDFs in Adobe Reader, the type and state of form fields (such as checkboxes and radio buttons) are now reported. (#13285) 
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
