### PR TITLE
Add secure mode decorators to future-proof code

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2266,6 +2266,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TOOLS,
 		gesture="kb:NVDA+f1"
 	)
+	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_navigatorObject_devInfo(self,gesture):
 		obj=api.getNavigatorObject()
 		if hasattr(obj, "devInfo"):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -190,6 +190,7 @@ class MainFrame(wx.Frame):
 	def onTemporaryDictionaryCommand(self, evt):
 		self._popupSettingsDialog(TemporaryDictionaryDialog)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onExecuteUpdateCommand(self, evt):
 		if updateCheck and updateCheck.isPendingUpdate():
 			destPath, version, apiVersion, backCompatToAPIVersion = updateCheck.getPendingUpdate()
@@ -313,6 +314,7 @@ class MainFrame(wx.Frame):
 		else:
 			brailleViewer.createBrailleViewerTool()
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onPythonConsoleCommand(self, evt):
 		import pythonConsole
 		if not pythonConsole.consoleUI:
@@ -337,7 +339,10 @@ class MainFrame(wx.Frame):
 		globalPluginHandler.reloadGlobalPlugins()
 		NVDAObject.clearDynamicClassCache()
 
-	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
+	@blockAction.when(
+		blockAction.Context.MODAL_DIALOG_OPEN,
+		blockAction.Context.SECURE_MODE,
+	)
 	def onCreatePortableCopyCommand(self,evt):
 		self.prePopup()
 		import gui.installerGui
@@ -345,12 +350,18 @@ class MainFrame(wx.Frame):
 		d.Show()
 		self.postPopup()
 
-	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
+	@blockAction.when(
+		blockAction.Context.MODAL_DIALOG_OPEN,
+		blockAction.Context.SECURE_MODE
+	)
 	def onInstallCommand(self, evt):
 		from gui import installerGui
 		installerGui.showInstallGui()
 
-	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
+	@blockAction.when(
+		blockAction.Context.MODAL_DIALOG_OPEN,
+		blockAction.Context.SECURE_MODE
+	)
 	def onRunCOMRegistrationFixesCommand(self, evt):
 		if messageBox(
 			# Translators: A message to warn the user when starting the COM Registration Fixing tool 
@@ -409,7 +420,6 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		if not globalVars.appArgs.secure:
 			# Translators: The label for a submenu under NvDA Preferences menu to select speech dictionaries.
 			menu_preferences.AppendSubMenu(self._createSpeechDictsSubMenu(frame), _("Speech &dictionaries"))
-		if not globalVars.appArgs.secure:
 			# Translators: The label for the menu item to open Punctuation/symbol pronunciation dialog.
 			item = menu_preferences.Append(wx.ID_ANY, _("&Punctuation/symbol pronunciation..."))
 			self.Bind(wx.EVT_MENU, frame.onSpeechSymbolsCommand, item)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Certain mainFrame commands e.g. `gui.mainFrame.ExampleCommands` are only exposed via the NVDA menu not in secure mode.
In the future, input gestures might be created for these commands, exposing them in secure mode.

Additionally, the log viewer is disable in secure mode, so `script_navigatorObject_devInfo` should be blocked, as it is misleading. The logs should not be accessible when running in secure mode.
Debug logging in secure screens can be configured with the `serviceDebug` parameter.

### Description of how this pull request fixes the issue:
Adds secure mode decorators to commands that are currently inaccessible in secure mode.

### Testing strategy:
The decorator has been tested in #13539 and other PRs.
Other than `script_navigatorObject_devInfo`, these messages should be currently inaccessible to the user.

### Known issues with pull request:
None

### Change log entries:
N/A, no user facing changes

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
