### PR TITLE
Secure mode decorator usage: Follow-up of #13500 and #13548

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -151,11 +151,8 @@ class MainFrame(wx.Frame):
 		# Translators: Reported when configuration has been restored to defaults by using restore configuration to factory defaults item in NVDA menu.
 		queueHandler.queueFunction(queueHandler.eventQueue,ui.message,_("Configuration restored to factory defaults"))
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onSaveConfigurationCommand(self,evt):
-		if globalVars.appArgs.secure:
-			# Translators: Reported when an action cannot be performed because NVDA is in a secure screen
-			queueHandler.queueFunction(queueHandler.eventQueue, ui.message, _("Not available in secure context"))
-			return
 		try:
 			config.conf.save()
 			# Translators: Reported when current configuration has been saved.
@@ -285,6 +282,7 @@ class MainFrame(wx.Frame):
 		# Translators: The title of the dialog to show about info for NVDA.
 		messageBox(versionInfo.aboutMessage, _("About NVDA"), wx.OK)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onCheckForUpdateCommand(self, evt):
 		updateCheck.UpdateChecker().check()
 
@@ -340,8 +338,8 @@ class MainFrame(wx.Frame):
 		NVDAObject.clearDynamicClassCache()
 
 	@blockAction.when(
-		blockAction.Context.MODAL_DIALOG_OPEN,
 		blockAction.Context.SECURE_MODE,
+		blockAction.Context.MODAL_DIALOG_OPEN,
 	)
 	def onCreatePortableCopyCommand(self,evt):
 		self.prePopup()
@@ -351,16 +349,16 @@ class MainFrame(wx.Frame):
 		self.postPopup()
 
 	@blockAction.when(
+		blockAction.Context.SECURE_MODE,
 		blockAction.Context.MODAL_DIALOG_OPEN,
-		blockAction.Context.SECURE_MODE
 	)
 	def onInstallCommand(self, evt):
 		from gui import installerGui
 		installerGui.showInstallGui()
 
 	@blockAction.when(
+		blockAction.Context.SECURE_MODE,
 		blockAction.Context.MODAL_DIALOG_OPEN,
-		blockAction.Context.SECURE_MODE
 	)
 	def onRunCOMRegistrationFixesCommand(self, evt):
 		if messageBox(


### PR DESCRIPTION
### Link to issue number:
Follow-up of #13500 and #13548

### Summary of the issue:
Some inconsistencies and issues were seen in secure mode usage:
1. As explained in its documentation `@blockAction.when` decorator should first check more permanent conditions. Thus, the order should be: windows store (per installation), then secure mode (per NVDA session) and then modal dialog opene (can occur during a session).
   In some cases `@blockAction.when` previously checked and reportsed first modal dialog, and then secure mode if no dialog open. This was the case for the following commands decorated in #13548:
   * `onCreatePortableCopyCommand`
   * `onInstallCommand`
   * `onRunCOMRegistrationFixesCommand`
   On the contrary, it was not the case for `onAddonsManagerCommand.

2. #13548 decorated some commands to future-proof them. However, it was not the case for `onCheckForUpdateCommand`.

3. In #13500, secure mode decorator was not used for `onSaveConfigurationCommand`.

### Description of how this pull request fixes the issue:

1. `@blockAction.when` now checks and reports first secure mode, then modal for all commands where these two checks are made.

2. Add secure mode decorators to future-proof `onCheckForUpdateCommand`.

3. Use secure mode decorator for `onSaveConfigurationCommand`. The reported message is now "Action unavailable in secure context" instead of "Cannot save configuration - NVDA in secure mode".

### Testing strategy:

Manual test:
For 1. and 2., I have created [this global plugin](https://github.com/nvaccess/nvda/files/8366549/test.py.txt) copied in an add-on (since the scratchpad cannot be used in secure mode). Thanks to it, I can execute a command of `gui.mainFrame` by just selecting the name of this command and pressing NVDA+F6.

I have checked for points 1, 2 and 3 the behavior of impacted commands in secure mode and in normal mode. Secure mode was tested by using the flag `-s`.

For 1. I have tested with and without the About dialog opened.

### Known issues with pull request:
None

### Change log entries:
Not needed, follow-up of PRs not yet released.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
