### PR TITLE
No longer fail to read list of tweets in Tween

### DIFF
--- a/source/appModules/tween.py
+++ b/source/appModules/tween.py
@@ -1,12 +1,12 @@
-#appModules/tween.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2012-2013 James Teh
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2012-2022 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """App module for Tween
 """
 
+from typing import Optional
 import appModuleHandler
 import controlTypes
 from NVDAObjects.window import Window
@@ -14,6 +14,7 @@ import winUser
 from NVDAObjects.IAccessible.sysListView32 import ListItem
 import displayModel
 import locationHelper
+
 
 class TweetListItem(ListItem):
 
@@ -27,24 +28,30 @@ class TweetListItem(ListItem):
 		finally:
 			self._isGettingName = False
 
-	def _getColumnHeaderRaw(self, index):
+	def _getColumnHeaderRaw(self, index: int) -> Optional[str]:
 		if self._isGettingName and index in (1, 2):
 			# If this is for use in the name property,
 			# don't include the headers for the Name and Post columns.
 			return None
-		return super(TweetListItem, self)._getColumnHeaderRaw(index)
+		res = super()._getColumnHeaderRaw(index)
+		if res:
+			res = res.replace("▾", "")
+		return res
 
-	def _getColumnContentRaw(self, index):
+	def _getColumnContentRaw(self, index: int) -> Optional[str]:
 		if controlTypes.State.INVISIBLE not in self.states and index == 3:
 			# This is the date column.
 			# Its content is overridden on screen,
 			# so use display model.
 			left, top, width, height = self._getColumnLocationRaw(index)
-			content = displayModel.DisplayModelTextInfo(self,
-				locationHelper.RectLTRB(left, top, left + width, top + height)).text
+			content = displayModel.DisplayModelTextInfo(
+				self,
+				locationHelper.RectLTRB(left, top, left + width, top + height)
+			).text
 			if content:
 				return content
-		return super(TweetListItem, self)._getColumnContentRaw(index)
+		return super()._getColumnContentRaw(index)
+
 
 class AppModule(appModuleHandler.AppModule):
 


### PR DESCRIPTION
Opened against beta since this PR fixes regression introduced during 2022.1 development cycle.
### Link to issue number:
Fix-up of PR #13271
### Summary of the issue:
PR #13271 moved most of the logic for retrieving content in syslistview32 controls in process. As part of this work `_getColumnLocationRaw` was changed to return an instance of `ctypes.wintypes.RECT` rather than one of `locationHelper` classes,  additionally the returned coordinates were no longer normalized. Some places in NVDA expects `_getColumnLocationRaw` to return normalized coordinates - in particular this affects the list control in Tween and my add-on for Becky! Internet Mail. The error when trying to navigate the list was as follows:
```
ERROR - scriptHandler.executeScript (21:29:59.073) - MainThread (1152):
error executing script: <bound method GlobalCommands.script_reportCurrentFocus of <globalCommands.GlobalCommands object at 0x064ECAD0>> with gesture 'NVDA+tab'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 212, in executeScript
  File "globalCommands.pyc", line 2032, in script_reportCurrentFocus
  File "speech\speech.pyc", line 561, in speakObject
  File "speech\speech.pyc", line 604, in getObjectSpeech
  File "speech\speech.pyc", line 453, in getObjectPropertiesSpeech
  File "baseObject.pyc", line 42, in __get__
  File "baseObject.pyc", line 146, in _getPropertyViaCache
  File "appModules\tween.pyc", line 26, in _get_name
  File "baseObject.pyc", line 42, in __get__
  File "baseObject.pyc", line 146, in _getPropertyViaCache
  File "NVDAObjects\IAccessible\sysListView32.pyc", line 531, in _get_name
  File "NVDAObjects\IAccessible\sysListView32.pyc", line 459, in _getColumnContent
  File "appModules\tween.pyc", line 42, in _getColumnContentRaw
TypeError: cannot unpack non-iterable RECT object

```
Note that for these controls we cannot just use location returned from `_getColumnLocation` since indexes provided to it are not constant for a given column - they can change for example when user reorders columns.
### Description of how this pull request fixes the issue:
1. Renames raw getters to rawInProc to clarify that these methods are used in-process
2. Add docstrings to clarify when and why these methods are used
3. The location normalization is once again performed by `_getColumnLocationRaw`
4. In the Tween app Module annoying decorational Unicode symbol is removed from the columns header - this is not strictly related to the main issue.
### Testing strategy:
1. Made sure that lists in Tween are once again readable and that for the date column the displayed content is used.
2. Repeated these tests with reordered columns - made sure there is no change.
3. Smoke tested various other list controls.
4. Inspected usages of other methods modified in PR #13271 no more issues were noticed.
### Known issues with pull request:
None known
### Change log entries:
None needed if this is included in 2022.1

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
