### PR TITLE
Advanced settings panel: restore accelerator key

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2655,7 +2655,7 @@ class AdvancedPanelControls(
 		label = pgettext(
 			"advanced.uiaWithMSWord",
 			# Translators: Label for the Use UIA with MS Word combobox, in the Advanced settings panel.
-			"Use UI Automation to access Microsoft Word document controls"
+			"Use UI Automation to access Microsoft &Word document controls"
 		)
 		wordChoices = (
 			# Translators: Label for the default value of the Use UIA with MS Word combobox,


### PR DESCRIPTION
### Link to issue number:
Fix-up of #13437.
### Summary of the issue:
With #13437, the option "Use UI Automation to access Microsoft Word document controls" in Advanced settings panel has become a combo-box; it was a checkbox before.
In the same time, the accelerator key (mapped to W) has been removed for this option: "&" removed from the label.
When testing Word with and without UIA, it was handy to focus the Advanced panel, check the first checkbox and press alt+W to jump directly to this option.
Now tabbing between the options is required.

### Description of how this pull request fixes the issue:
Just add the "&" in the label to restore the accelerator key for this option.

### Testing strategy:
Opened the adv settings panel and checked that alt+W jumps to the target option.

### Known issues with pull request:
* I would have wished to open this PR against beta to fix the issue immediately before the stable release. However, we are already in the translation freeze, thus this is not possible to change a translatable string, unfortunately. If a new translation freeze should occur, please reconsider merging this PR in beta.
* There does not seem to be a rule to define which options has an accelerator key and which has not.
Advanced settings panel have a lot of options missing accelerator key.
If you have a good reason to add them, I will be happy to do it in this PR.

### Change log entries:
Not needed: minor fix.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
