### PR TITLE
[Cherry-pick to beta] Advanced settings panel: restore accelerator key

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2655,7 +2655,7 @@ class AdvancedPanelControls(
 		label = pgettext(
 			"advanced.uiaWithMSWord",
 			# Translators: Label for the Use UIA with MS Word combobox, in the Advanced settings panel.
-			"Use UI Automation to access Microsoft Word document controls"
+			"Use UI Automation to access Microsoft &Word document controls"
 		)
 		wordChoices = (
 			# Translators: Label for the default value of the Use UIA with MS Word combobox,


### PR DESCRIPTION
Important: PR targetting beta before translation freeze extension. Please consider it before the new translation freeze / the beta4. Thanks.
Cc @seanbudd, @feerrenrut, @michaelDCurran 

### Link to issue number:

PR #13563.

### Summary of the issue:

PR #13563 restores an accelerator key that has been removed by #13437 during NVDA 2022.1 release cycle.
Unfortunately, PR #13563 has been opened after translation freeze and thus could not integrate 2022.1.

However in #13563, I have written:
> I would have wished to open this PR against beta to fix the issue immediately before the stable release. However, we are already in the translation freeze, thus this is not possible to change a translatable string, unfortunately. If a new translation freeze should occur, please reconsider merging this PR in beta.

According to [this thread](https://groups.io/g/nvda-translations/topic/translatable_string_freeze/90098170?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,90098170,previd%3D1649308490212410677,nextid%3D1623982324898190313&previd=1649308490212410677&nextid=1623982324898190313), an extension translation freeze is in preparation with new translatable strings.
Thus this allow to integrate this fix for 2022.1 considering that the accelerator key was removed during 2022.1 dev cycle.

### Description of how this pull request fixes the issue:

Cherry-pick the commit corresponding to #13563, i.e. c4466885d884ec3deaf1525633f9c2bd2f9af0dc.

### Testing strategy:
Manual check of the access key in the advanced settings panel.

### Known issues with pull request:
I have no experience of cherry picking. Could it have a bad side effect when merging back beta to master?

### Change log entries:
New featuresNone
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
