### PR TITLE
Fix ARIA treegrid test to expect group position on row in focus mode

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -664,7 +664,7 @@ def test_ariaTreeGrid_browseMode():
 			# Focus enters the ARIA treegrid (table)
 			"Inbox  table",
 			# Focus lands on row 2
-			"level 1  Treegrids are awesome Want to learn how to use them? aaron at thegoogle dot rocks  expanded",
+			"level 1  Treegrids are awesome Want to learn how to use them? aaron at thegoogle dot rocks  expanded  1 of 1",
 		])
 	)
 

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -664,7 +664,12 @@ def test_ariaTreeGrid_browseMode():
 			# Focus enters the ARIA treegrid (table)
 			"Inbox  table",
 			# Focus lands on row 2
-			"level 1  Treegrids are awesome Want to learn how to use them? aaron at thegoogle dot rocks  expanded  1 of 1",
+			SPEECH_SEP.join([
+				"level 1",
+				"Treegrids are awesome Want to learn how to use them? aaron at thegoogle dot rocks",
+				"expanded",
+				"1 of 1"
+			]),
 		])
 	)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #13586 

### Summary of the issue:
Our system test for ARIA treegrid fails as it does not expect group position (E.g. 1. of 1) to be announced when focusing a row in focus mode. 
It seems that although the test always exposed aria-posinset and aria-setsize, Chrome was not exposing this via accessibility until now (Likely Chromium 100).

### Description of how this pull request fixes the issue:
Update the test to expect "1 of 1" at the end of speech.

### Testing strategy:
* [ ] System test runs again

### Known issues with pull request:
None known.

### Change log entries:
None needed.
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
