### PR TITLE
Fix  unbound local variable

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1847,7 +1847,8 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 				log.debug(f"No saved caret position for {docID}")
 				return None
 			log.debug(f"Found saved caret pos {caretPos} for document {docID}")
-		return caretPos
+			return caretPos
+		return None
 
 	def getEnclosingContainerRange(self, textRange):
 		textRange = textRange.copy()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13600 

### Summary of the issue:
PR #13589 introduced an unbound local variable error:
```
ERROR - queueHandler.flushQueue (19:43:42.878) - MainThread (8840):
Error in func VirtualBuffer._loadBufferDone
Traceback (most recent call last):
  File "queueHandler.pyc", line 55, in flushQueue
  File "virtualBuffers\__init__.pyc", line 492, in _loadBufferDone
  File "browseMode.pyc", line 1306, in event_treeInterceptor_gainFocus
  File "virtualBuffers\gecko_ia2.pyc", line 532, in _getInitialCaretPos
  File "browseMode.pyc", line 1850, in _getInitialCaretPos
UnboundLocalError: local variable 'caretPos' referenced before assignment`
```

caretPos will not be set if `self.shouldRememberCaretPositionAcrossLoads` is False.
 
### Description of how this pull request fixes the issue:
Return caretPos within the above if condition and return None by default.

### Testing strategy:
Performed tests in pr #13589 

### Known issues with pull request:
None known.

### Change log entries:
None needed.
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
