### PR TITLE
Fixing GC unreachable error of table navigation 

### DIFF
--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -212,7 +212,7 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		# For more info see issue #11919 and #7278.
 		if (
 			self._lastTableSelection
-			and origRow== self._lastTableSelection.lastRow
+			and origRow == self._lastTableSelection.lastRow
 			and origCol == self._lastTableSelection.lastCol
 			and self._lastTableSelection.axis == axis
 		):

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -31,11 +31,19 @@ class _Movement(str, Enum):
 
 @dataclass
 class _TableSelection:
-	selection: textInfos.TextInfo
+	"""
+		Caches information about user navigating around the table.
+		This class is used to store true row/column number when navigating through merged cells.
+		lastRow/lastCol store coordinates of the last cell user explicitly navigated to.
+		If they don't match current selection we invalidate this cache.
+		If they match, we use trueRow/trueCol to maintain row/column through merged cells.
+	"""
 	axis: _Axis
-	row: int
+	lastRow: int
+	lastCol: int
+	trueRow: int
 	rowSpan: int
-	col: int
+	trueCol: int
 	colSpan: int
 
 
@@ -204,34 +212,38 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		# For more info see issue #11919 and #7278.
 		if (
 			self._lastTableSelection
-			and self.selection == self._lastTableSelection.selection
+			and origRow== self._lastTableSelection.lastRow
+			and origCol == self._lastTableSelection.lastCol
 			and self._lastTableSelection.axis == axis
 		):
 			if axis == _Axis.ROW:
-				origCol = self._lastTableSelection.col
+				origCol = self._lastTableSelection.trueCol
 				origColSpan = self._lastTableSelection.colSpan
 			else:
-				origRow = self._lastTableSelection.row
+				origRow = self._lastTableSelection.trueRow
 				origRowSpan = self._lastTableSelection.rowSpan
 
 		try:
 			info = self._getNearestTableCell(tableID, self.selection, origRow, origCol, origRowSpan, origColSpan, movement, axis)
+			newTableID, newRow, newCol, newRowSpan, newColSpan = self._getTableCellCoords(info)
 		except LookupError:
 			# Translators: The message reported when a user attempts to use a table movement command
 			# but the cursor can't be moved in that direction because it is at the edge of the table.
 			ui.message(_("Edge of table"))
 			# Retrieve the cell on which we started.
 			info = self._getTableCellAt(tableID, self.selection,origRow, origCol)
+			newTableID, newRow, newCol, newRowSpan, newColSpan = self._getTableCellCoords(info)
 
 		speakTextInfo(info, formatConfig=formatConfig, reason=controlTypes.OutputReason.CARET)
 		info.collapse()
 		self.selection = info
 		self._lastTableSelection = _TableSelection(
-			selection=self.selection,
+			lastRow=newRow,
+			lastCol=newCol,
 			axis=axis,
-			row=origRow,
+			trueRow=origRow,
 			rowSpan=origRow,
-			col=origCol,
+			trueCol=origCol,
 			colSpan=origColSpan,
 		)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#13578
### Summary of the issue:
Intermittent GC error "unreachable objects" caused by PR #13345.
### Description of how this pull request fixes the issue:
The root cause was that we used to store TextInfo object inside Document, thus creating a cyclic reference. Such reference loops cannot be deleted by zeroing reference counter and can only be deleted by full GC sweep. I am not sure why NVDA prints warnings in this case.
This was fixed by not storing TextInfo in the first place. We now store last cell coordinates as lastRow/lastCol. Table cache is going to be valid as long as row/col of current selection are the same as stored lastRow/lastCol - and in this case we will be using trueRow/trueCol to compute next cell to preserve coordinates when navigating through merged cells.
### Testing strategy:
Tested in HTML tables in both Chrome and Firefox.
Tested using explicit test case by @lukaszgo1 in #13578.
### Known issues with pull request:
N/A
### Change log entries:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [x]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
