### PR TITLE
App modules/SearchUI: announce search result details with the 2019 UI redesign applied

### DIFF
--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2015-2021 NV Access Limited, Joseph Lee
+# Copyright (C) 2015-2022 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -44,6 +44,12 @@ class AppModule(appModuleHandler.AppModule):
 			if obj.UIAAutomationId == "SearchTextBox":
 				clsList.insert(0, StartMenuSearchField)
 			# #10329: Since 2019, some suggestion items are grouped inside another suggestions list item.
+			# #13544: grandparent must be checked due to redesign in 2019.
 			# Because of this, result details will not be announced like in the past.
-			elif obj.role == controlTypes.Role.LISTITEM and isinstance(obj.parent, SuggestionListItem):
+			elif (
+				obj.role == controlTypes.Role.LISTITEM and (
+					isinstance(obj.parent, SuggestionListItem)
+					or isinstance(obj.parent.parent, SuggestionListItem)
+				)
+			):
 				clsList.insert(0, SuggestionListItem)

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -4,6 +4,8 @@
 # See the file COPYING for more details.
 
 """App module for Start menu/Windows Search/Cortana user interface in Windows 10 Version 1909 and earlier.
+This app module also serves as the basis for Start menu in Windows 10 Version 2004 and later
+as well as Windows 11, represented by alias app modules.
 """
 
 import appModuleHandler

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -14,10 +14,12 @@ import winVersion
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
 from NVDAObjects.UIA import UIA, SearchField, SuggestionListItem
 
+
 class StartMenuSearchField(SearchField):
 
 	# #7370: do not announce text when start menu (searchui) closes.
 	announceNewLineText = False
+
 
 class AppModule(appModuleHandler.AppModule):
 
@@ -34,7 +36,7 @@ class AppModule(appModuleHandler.AppModule):
 			):
 				obj.name = obj.firstChild.name
 
-	def chooseNVDAObjectOverlayClasses(self,obj,clsList):
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if isinstance(obj, IAccessible):
 			try:
 				# #5288: Never use ContentGenericClient, as this uses displayModel

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -36,6 +36,7 @@ What's New in NVDA
   -
 - Visual Studio now correctly reports line indentation. (#13574)
 - NVDA can now beep or speak on Java application progress bars (#13594)
+- NVDA will once again announce Start menu search result details in recent Windows 10 and 11 releases. (#13544)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13544 

### Summary of the issue:
In 2019, Start menu/Windows Search UI has changed, causing NVDA to not announce search result details. This was traced to search result items being grandchildren of the results list.

### Description of how this pull request fixes the issue:
In addition to lint and documentation update, check the instance of the obj.parent.parent (grandparent) to make sure it is results list so NVDA can announce search result details. This is applicable to Windows 10 and 11.

### Testing strategy:
Manual testing:

1. Open Start enu and search for things.
2. Press down arrow to review results.
3. Press Tab to review result groups.

### Known issues with pull request:
None

### Change log entries:
Bug fixes:

NVDA will once again announce Start menu search result details in recent Windows 10 and 11 releases. (#13544)

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
