### PR TITLE
Prevent crash from terminated ocSpeech

### DIFF
--- a/nvdaHelper/localWin10/oneCoreSpeech.cpp
+++ b/nvdaHelper/localWin10/oneCoreSpeech.cpp
@@ -295,7 +295,7 @@ bool __stdcall ocSpeech_supportsProsodyOptions() {
 }
 
 std::wstring createMarkersString_(IVectorView<IMediaMarker> markers) {
-	std::wstring markersStr;  // for large strings, reserving would speed this up.
+	std::wstring markersStr;  // for large strings, preallocating / reserving may speed this up.
 	bool firstComplete = false;
 	for (auto const& marker : markers) {
 		if (firstComplete) {
@@ -433,8 +433,9 @@ bool isUniversalApiContractVersion_(const int major, const int minor) {
 }
 
 
+
 void preventEndUtteranceSilence_(std::shared_ptr<winrtSynth> synth) {
-	// By default, OneCore speech appends a  large annoying chunk of silence at the end of every utterance.
+	// By default, OneCore speech appends a large annoying chunk of silence at the end of every utterance.
 	// Newer versions of OneCore speech allow disabling this feature, so turn it off where possible.
 	const bool isAppendSilenceAvailable = isUniversalApiContractVersion_(6, 0);
 	if (isAppendSilenceAvailable) {

--- a/nvdaHelper/localWin10/oneCoreSpeech.cpp
+++ b/nvdaHelper/localWin10/oneCoreSpeech.cpp
@@ -1,19 +1,18 @@
 /*
-Code for C dll bridge to Windows OneCore voices.
-This file is a part of the NVDA project.
-URL: http://www.nvaccess.org/
-Copyright 2016-2020 Tyler Spivey, NV Access Limited, Leonard de Ruijter.
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.0, as published by
-    the Free Software Foundation.
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-This license can be found at:
-http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+Copyright (C) 2016-2022 NV Access Limited, Tyler Spivey, Leonard de Ruijter
+This file may be used under the terms of the GNU General Public License, version 2 or later.
+For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 */
 
 #include <string>
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <functional>
+#include <shared_mutex>
+#include <condition_variable>
 #include <winrt/Windows.Media.SpeechSynthesis.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Foundation.h>
@@ -22,99 +21,393 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <common/log.h>
 #include "oneCoreSpeech.h"
 
-using namespace std;
-using namespace winrt;
 using namespace winrt::Windows::Media::SpeechSynthesis;
 using namespace winrt::Windows::Storage::Streams;
 using namespace winrt::Windows::Media;
 using namespace winrt::Windows::Foundation::Collections;
 using winrt::Windows::Foundation::Metadata::ApiInformation;
+using winrtSynth = winrt::Windows::Media::SpeechSynthesis::SpeechSynthesizer;
+using SharedLock = std::shared_lock<std::shared_timed_mutex>;
+using UniqueLock = std::unique_lock<std::shared_timed_mutex>;
+
+/*
+* See design notes in oneCoreSpeech.h
+*/
+
+using ocSpeech_CallbackT = void(BYTE* data, int length, const wchar_t* markers);
+
+class OcSpeechState {
+public:
+	std::shared_ptr<winrtSynth> getSynth(void* token) {
+		if (isTokenValid(token)) {
+			return m_synth;
+		}
+		return std::shared_ptr<winrtSynth>();
+	}
+
+	std::function<ocSpeech_CallbackT> getCB() {
+		return m_callback;
+	}
+
+	bool isTokenValid(void* token) {
+		if (
+			!isActive()  // token can't be valid if one core is not active
+			|| token == nullptr  // indicates this was never a valid token
+			|| token != m_synth.get()  // only a token matching the synth pointer are active
+			|| isTokenTerminated_(token)
+		) {
+			LOG_DEBUG(
+				L"Token not active: " << token
+				<< L" Terminated tokens: " << getTerminatedTokensString()
+			);
+			return false;
+		}
+		return true;
+	}
+
+	bool isTokenTerminated_(void* token) {
+		if (token == nullptr) {
+			LOG_ERROR(L"token is nullptr, it was never valid.");
+		}
+		for (const auto& t : m_terminatedTokens) {
+			if (t.first == token) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	std::wstring getTerminatedTokensString() {
+		std::wstringstream ss;
+		for (const auto t : m_terminatedTokens) {
+			ss << t.first << L"(use: " << t.second.use_count() << L"), ";
+		}
+		return ss.str();
+	}
+
+	void* activate(std::function<ocSpeech_CallbackT> cb) {
+		LOG_INFO(L"Activating");
+		if(!isTerminated()){
+			LOG_ERROR(L"Unable to activate if not terminated.");
+			return nullptr;
+		}
+		auto synth = std::make_shared<winrtSynth>();
+		LOG_DEBUG(L"new token val: " << synth.get());
+		removeTokenFromTerminated(synth.get());
+		m_callback = cb;
+		m_synth = synth;
+		if (!isActive()){
+			LOG_ERROR(L"Activating failed");
+		}
+		return m_synth.get();
+	}
+
+	void terminate() {
+		LOG_INFO(L"Terminating");
+		if (!isActive()) {
+			LOG_ERROR(L"Unable to terminate if not active");
+			return;
+		}
+		m_terminatedTokens.push_back({ m_synth.get(), m_synth });  // record weak_ptr for debugging.
+		LOG_DEBUG(L" Terminated tokens: " << getTerminatedTokensString());
+
+		m_synth.reset();
+		m_callback = std::function<ocSpeech_CallbackT>();
+
+		if (!isTerminated()) {
+			LOG_ERROR(L"Terminating failed");
+		}
+	}
+
+	/* Get the usage count of the last synth to be terminated.
+	* Useful for debugging.
+	*/
+	int getLastSynthUsageCount() {
+		if (m_terminatedTokens.size() > 0) {
+			return m_terminatedTokens.rbegin()->second.use_count();
+		}
+		return 0;
+	}
+
+private:
+	bool isActive() {
+		const bool isSynthActive = bool(m_synth);
+		const bool isCallbackActive = bool(m_callback);
+		if (isSynthActive && isCallbackActive) {  // don't care about last synth. Status only useful for debugging.
+			return true;
+		}
+		LOG_DEBUG(
+			"oneCoreSpeech not Active. "
+			<< createStateString(isSynthActive, isCallbackActive)
+		);
+		return false;
+	}
+
+	bool isTerminated() {
+		const bool isSynthActive = bool(m_synth);
+		const bool isCallbackActive = bool(m_callback);
+		if (!isSynthActive && !isCallbackActive) {  // don't care about last synth. Status only useful for debugging.
+			return true;
+		}
+		LOG_DEBUG(
+			L"oneCoreSpeech not Terminated. "
+			<< createStateString(isSynthActive, isCallbackActive)
+		);
+		return false;
+	}
+
+	void removeTokenFromTerminated(void* token) {
+		auto numErased = std::erase_if(m_terminatedTokens, [token](auto& tokenPair) {
+			return tokenPair.first == token;
+		});
+		if (numErased != 0) {
+			LOG_DEBUG("Remove from terminated erased count: " << numErased << " while removing: " << token);
+		}
+	}
+
+	std::wstring createStateString(const bool isSynthActive, const bool isCallbackActive) {
+		std::wstringstream ss;
+		ss << std::boolalpha
+			<< L"m_synth: " << isSynthActive
+			<< L" m_callback: " << isCallbackActive
+			<< L" terminated tokens: " << getTerminatedTokensString();
+		return ss.str();
+	}
+
+	std::shared_ptr<winrtSynth> m_synth;  // Held until terminate is called
+
+	// Async code holds a shared_ptr keeping m_lastSynth active, this weak_ptr lets us check
+	// when / if it expires and confirm the usage count.
+	std::function < ocSpeech_CallbackT > m_callback;
+
+	// m_terminatedTokens allows explicitly confirming that a token has been terminated.
+	// order of termination is maintained.
+	std::vector<std::pair<void*, std::weak_ptr<winrtSynth>>> m_terminatedTokens; // Only for debugging.
+};
+
+
+OcSpeechState g_state;
+
+// Mutex to protect against state changes (of g_state).
+// Allows shared read access (protectedCallback_)
+// and exclusive write access (ocSpeech_initialize, ocSpeech_terminate)
+std::shared_timed_mutex g_OcSpeechStateMutex{};
+
+// The max wait time for to acquire a lock. Exceeding this likely indicates a deadlock.
+std::chrono::duration g_maxWaitForLock(std::chrono::seconds(3));
+
+UniqueLock getUniqueLock_(std::wstring forPurpose) {
+	UniqueLock lock(g_OcSpeechStateMutex, std::defer_lock);
+	bool owned = lock.try_lock();
+	if (!owned) {
+		LOG_DEBUG(L"Locking will block, try for timeout: " << forPurpose);
+		owned = lock.try_lock_for(g_maxWaitForLock);
+	}
+	if (!owned) {
+		LOG_ERROR(L"Unable to lock after timeout: " << forPurpose);
+	}
+	return lock;
+}
+
+void preventEndUtteranceSilence_(std::shared_ptr<winrtSynth> synth);
+
+void* __stdcall ocSpeech_initialize(ocSpeech_Callback fn) {
+	LOG_INFO(L"ocSpeech_initialize");
+	// Ensure there are no pending shared locks, all async speak calls must be finished
+	auto lock = getUniqueLock_(L"ocSpeech_initialize");
+	if (!lock) {
+		return nullptr;
+	}
+	LOG_DEBUG(L"ocSpeech_initialize lock acquired");
+
+	auto token = g_state.activate(fn);
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"Unable to initialize.");
+		return nullptr;
+	}
+	preventEndUtteranceSilence_(synth);
+	return token;
+}
+
+void __stdcall ocSpeech_terminate(void* token) {
+	std::wstringstream ss;
+	ss << L"ocSpeech_terminate, token: " << token;
+	LOG_INFO(ss.str());
+	// Acquire a unique lock to ensure that no callbacks can happen while changing state.
+	// Changing state must be atomic.
+	auto lock = getUniqueLock_(ss.str());
+	if (!lock) {
+		return;
+	}
+	if (!g_state.isTokenValid(token)) {
+		LOG_ERROR(L"ocSpeech_terminate error");
+		return;
+	}
+	g_state.terminate();
+}
+
+
+/* Internal convenience pairing for a winRT synth result.
+*/
+struct SpeakResult {
+	Buffer buffer;
+	std::wstring markersStr;
+};
+
+/*Call the external callback.
+* This requires a shared lock on the callback / g_OcSpeechStateMutex.
+* This shared ownership prevents (blocks) unique locks from being acquired, thus blocking
+* ocSpeech_initialize and ocSpeech_terminate.
+* If the given token is no longer valid, the callback will not be called.
+*/
+void protectedCallback_(
+	void* token,
+	std::optional<SpeakResult> result,
+	std::function<ocSpeech_CallbackT> cb
+) {
+	// Prevent any unique locks being acquired.
+	SharedLock lock(g_OcSpeechStateMutex, std::defer_lock);
+	const bool owned = lock.try_lock();
+	if (!owned) {
+		LOG_DEBUG(L"protectedCallback_ - Unable to lock. Token: " << token);
+		return;
+	}
+	LOG_DEBUG(L"protectedCallback, token: " << token);
+	if (!g_state.isTokenValid(token)) {
+		LOG_INFO(L"not calling CB, token: " << token);
+		return;
+	}
+	LOG_DEBUG(L"calling CB, token: " << token);
+	if (result.has_value()) {
+		cb(result->buffer.data(), result->buffer.Length(), result->markersStr.c_str());
+	}
+	else {
+		cb(nullptr, 0, nullptr);
+	}
+	LOG_DEBUG(L"Finished CB, token: " << token);
+}
+
+bool isUniversalApiContractVersion_(const int major, const int minor);
 
 bool __stdcall ocSpeech_supportsProsodyOptions() {
-	return ApiInformation::IsApiContractPresent(hstring{L"Windows.Foundation.UniversalApiContract"}, 5, 0);
+	return isUniversalApiContractVersion_(5, 0);
 }
 
-OcSpeech::OcSpeech() : synth(SpeechSynthesizer{}) {
-	// By default, OneCore speech appends a  large annoying chunk of silence at the end of every utterance.
-	// Newer versions of OneCore speech allow disabling this feature, so turn it off where possible.
-	if (ApiInformation::IsApiContractPresent(hstring{L"Windows.Foundation.UniversalApiContract"}, 6, 0)) {
-		synth.Options().AppendedSilence(SpeechAppendedSilence::Min);
-	} else {
-		LOG_DEBUGWARNING(L"AppendedSilence not supported");
+std::wstring createMarkersString_(IVectorView<IMediaMarker> markers) {
+	std::wstring markersStr;  // for large strings, reserving would speed this up.
+	bool firstComplete = false;
+	for (auto const& marker : markers) {
+		if (firstComplete) {
+			markersStr += L"|";
+		}
+		else {
+			firstComplete = false;
+		}
+		markersStr += marker.Text();
+		markersStr += L":";
+		markersStr += std::to_wstring(marker.Time().count());
 	}
+	return markersStr;
 }
 
-OcSpeech* __stdcall ocSpeech_initialize() {
-	auto instance = new OcSpeech;
-	return instance;
-}
-
-void __stdcall ocSpeech_terminate(OcSpeech* instance) {
-	delete instance;
-}
-
-void __stdcall ocSpeech_setCallback(OcSpeech* instance, ocSpeech_Callback fn) {
-	instance->setCallback(fn);
-}
-
-void OcSpeech::setCallback(ocSpeech_Callback fn) {
-	callback = fn;
-}
-
-fire_and_forget OcSpeech::speak(hstring text) {
+/*
+Send speech text to OneCore, call back to NVDA with synthesized speech.
+This is an async function, it runs in the background via the Windows thread pool.
+@param originToken Used to track the origin init of this call. Allows detection of synchronization errors.
+@param text The text to synthesize.
+@param synth A copy of the shared pointer to the winRT Synth.
+This is safe to use from another thread (a reference to the same shared pointer is not).
+@param cb The function associated with originToken. To be called when a result is available.
+*/
+winrt::fire_and_forget
+speak(
+	void* originToken,
+	winrt::hstring text,
+	std::shared_ptr<winrtSynth> synth,
+	std::function<ocSpeech_CallbackT> cb
+) {
 	// Ensure we catch all exceptions in this method,
-
 	// as an unhandled exception causes std::terminate to get called, resulting in a crash.
 	// See https://devblogs.microsoft.com/oldnewthing/20190320-00/?p=102345
 	try {
 		// Ensure that work is performed on a background thread.
-		co_await resume_background();
+		// Note only use local var, not vars by ref.
+		// See Microsoft docs:
+		// https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/concurrency#parameter-passing
+		co_await winrt::resume_background();
 
-		wstring markersStr;
 		SpeechSynthesisStream speechStream{ nullptr };
 		try {
-			speechStream = co_await synth.SynthesizeSsmlToStreamAsync(text);
-		} catch (hresult_error const& e) {
+			speechStream = co_await synth->SynthesizeSsmlToStreamAsync(text);
+		}
+		catch (winrt::hresult_error const& e) {
 			LOG_ERROR(L"Error " << e.code() << L": " << e.message().c_str());
-			callback(nullptr, 0, nullptr);
+			protectedCallback_(originToken, std::optional<SpeakResult>(), cb);
 			co_return;
 		}
 		// speechStream.Size() is 64 bit, but Buffer can only take 32 bit.
 		// We shouldn't get values above 32 bit in reality.
-		const unsigned int size = static_cast<unsigned int>(speechStream.Size());
-		Buffer buffer { size };
-
-		IVectorView<IMediaMarker> markers = speechStream.Markers();
-		for (auto const& marker : markers) {
-			if (markersStr.length() > 0) {
-				markersStr += L"|";
+		const std::uint32_t size = static_cast<std::uint32_t>(speechStream.Size());
+		std::optional<SpeakResult> result(SpeakResult{
+			Buffer(size),
+			createMarkersString_(speechStream.Markers())
 			}
-			markersStr += marker.Text();
-			markersStr += L":";
-			markersStr += to_wstring(marker.Time().count());
-		}
+		);
 		try {
-			co_await speechStream.ReadAsync(buffer, size, InputStreamOptions::None);
+			co_await speechStream.ReadAsync(result->buffer, size, InputStreamOptions::None);
 			// Data has been read from the speech stream.
 			// Pass it to the callback.
-			BYTE* bytes = buffer.data();
-			callback(bytes, buffer.Length(), markersStr.c_str());
-		} catch (hresult_error const& e) {
-			LOG_ERROR(L"Error " << e.code() << L": " << e.message().c_str());
-			callback(nullptr, 0, nullptr);
+			protectedCallback_(originToken, result, cb);
+			co_return;
 		}
-	} catch (...) {
-		LOG_ERROR(L"Unexpected error in OcSpeech::speak");
+		catch (winrt::hresult_error const& e) {
+			LOG_ERROR(L"Error " << e.code() << L": " << e.message().c_str());
+			protectedCallback_(originToken, std::optional<SpeakResult>(), cb);
+			co_return;
+		}
+	}
+	catch (winrt::hresult_error const& e) {
+		LOG_ERROR(L"hresult error in OcSpeech::speak: " << e.code() << L": " << e.message().c_str());
+	}
+	catch (std::exception const& e) {
+		LOG_ERROR(L"Exception in OcSpeech::speak: " << e.what());
+	}
+	catch (...) {
+		LOG_ERROR(L"Unexpected error in speak");
 	}
 }
 
-void __stdcall ocSpeech_speak(OcSpeech* instance, wchar_t* text) {
-	instance->speak(text);
+void __stdcall ocSpeech_speak(void* token, wchar_t* text) {
+	if (!g_state.isTokenValid(token)) {
+		LOG_ERROR(L"speak error: invalid token" << token);
+		return;
+	}
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"speak error: synth not valid.");
+		return;
+	}
+	auto cb = g_state.getCB();
+	if (!cb) {
+		LOG_ERROR(L"speak error: call back not valid");
+		return;
+	}
+	speak(token, text, synth, cb);
 }
 
-wstring OcSpeech::getVoices() {
-	wstring voices;
-	auto const& allVoices = synth.AllVoices();
+// We use BSTR because we need the string to stay around until the caller is done with it
+// but the caller then needs to free it.
+// We can't just use malloc because the caller might be using a different CRT
+// and calling malloc and free from different CRTs isn't safe.
+BSTR __stdcall ocSpeech_getVoices(void* token) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"voices error");
+		return SysAllocString(L"");
+	}
+	std::wstring voices;
+	auto const& allVoices = synth->AllVoices();
 	for (unsigned int i = 0; i < allVoices.Size(); ++i) {
 		VoiceInformation const& voiceInfo = allVoices.GetAt(i);
 		voices += voiceInfo.Id();
@@ -126,85 +419,111 @@ wstring OcSpeech::getVoices() {
 			voices += L"|";
 		}
 	}
-	return voices;
+	return SysAllocString(voices.c_str());
 }
 
-// We use BSTR because we need the string to stay around until the caller is done with it
-// but the caller then needs to free it.
-// We can't just use malloc because the caller might be using a different CRT
-// and calling malloc and free from different CRTs isn't safe.
-BSTR __stdcall ocSpeech_getVoices(OcSpeech* instance) {
-	return SysAllocString(instance->getVoices().c_str());
+
+bool isUniversalApiContractVersion_(const int major, const int minor) {
+	constexpr auto contract_name{ L"Windows.Foundation.UniversalApiContract" };
+	return ApiInformation::IsApiContractPresent(
+		winrt::hstring{ contract_name },
+		major,
+		minor
+	);
 }
 
-hstring OcSpeech::getCurrentVoiceId() {
-	return synth.Voice().Id();
+
+void preventEndUtteranceSilence_(std::shared_ptr<winrtSynth> synth) {
+	// By default, OneCore speech appends a  large annoying chunk of silence at the end of every utterance.
+	// Newer versions of OneCore speech allow disabling this feature, so turn it off where possible.
+	const bool isAppendSilenceAvailable = isUniversalApiContractVersion_(6, 0);
+	if (isAppendSilenceAvailable) {
+		synth->Options().AppendedSilence(SpeechAppendedSilence::Min);
+		LOG_INFO(L"AppendedSilence supported");
+	}
+	else {
+		LOG_INFO(L"AppendedSilence not supported");
+	}
 }
 
-const wchar_t* __stdcall ocSpeech_getCurrentVoiceId(OcSpeech* instance) {
-	return instance->getCurrentVoiceId().c_str();
+const wchar_t* __stdcall ocSpeech_getCurrentVoiceId(void* token) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_getCurrentVoiceId error");
+		return L"";
+	}
+	winrt::hstring voiceId = synth->Voice().Id();
+	return voiceId.c_str();
 }
 
-void OcSpeech::setVoice(int index) {
-	synth.Voice(synth.AllVoices().GetAt(index));
+void __stdcall ocSpeech_setVoice(void* token, int index) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_setVoice error");
+		return;
+	}
+	synth->Voice(synth->AllVoices().GetAt(index));
 }
 
-void __stdcall ocSpeech_setVoice(OcSpeech* instance, int index) {
-	instance->setVoice(index);
+const wchar_t* __stdcall ocSpeech_getCurrentVoiceLanguage(void* token) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_getCurrentVoiceLanguage error");
+		return L"";
+	}
+	return synth->Voice().Language().c_str();
 }
 
-hstring OcSpeech::getCurrentVoiceLanguage() {
-	return synth.Voice().Language();
+double __stdcall ocSpeech_getPitch(void* token) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_getPitch error");
+		return 0.0;
+	}
+	return synth->Options().AudioPitch();
 }
 
-const wchar_t* __stdcall ocSpeech_getCurrentVoiceLanguage(OcSpeech* instance) {
-	return instance->getCurrentVoiceLanguage().c_str();
+void __stdcall ocSpeech_setPitch(void* token, double pitch) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_setPitch error");
+		return;
+	}
+	synth->Options().AudioPitch(pitch);
 }
 
-double OcSpeech::getPitch() {
-	return synth.Options().AudioPitch();
+double __stdcall ocSpeech_getVolume(void* token) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_getVolume error");
+		return 0.0;
+	}
+	return synth->Options().AudioVolume();
 }
 
-double __stdcall ocSpeech_getPitch(OcSpeech* instance) {
-	return instance->getPitch();
+void __stdcall ocSpeech_setVolume(void* token, double volume) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_setVolume error");
+		return;
+	}
+	synth->Options().AudioVolume(volume);
 }
 
-void OcSpeech::setPitch(double pitch) {
-	synth.Options().AudioPitch(pitch);
+double __stdcall ocSpeech_getRate(void* token) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_getRate error");
+		return 0.0;
+	}
+	return synth->Options().SpeakingRate();
 }
 
-void __stdcall ocSpeech_setPitch(OcSpeech* instance, double pitch) {
-	instance->setPitch(pitch);
-}
-
-double OcSpeech::getVolume() {
-	return synth.Options().AudioVolume();
-}
-
-double __stdcall ocSpeech_getVolume(OcSpeech* instance) {
-	return instance->getVolume();
-}
-
-void OcSpeech::setVolume(double volume) {
-	synth.Options().AudioVolume(volume);
-}
-
-void __stdcall ocSpeech_setVolume(OcSpeech* instance, double volume) {
-	instance->setVolume(volume);
-}
-
-double OcSpeech::getRate() {
-	return synth.Options().SpeakingRate();
-}
-
-double __stdcall ocSpeech_getRate(OcSpeech* instance) {
-	return instance->getRate();
-}
-
-void OcSpeech::setRate(double rate) {
-	synth.Options().SpeakingRate(rate);
-}
-
-void __stdcall ocSpeech_setRate(OcSpeech* instance, double rate) {
-	instance->setRate(rate);
+void __stdcall ocSpeech_setRate(void* token, double rate) {
+	auto synth = g_state.getSynth(token);
+	if (!synth) {
+		LOG_ERROR(L"ocSpeech_setRate error");
+		return;
+	}
+	synth->Options().SpeakingRate(rate);
 }

--- a/nvdaHelper/localWin10/oneCoreSpeech.h
+++ b/nvdaHelper/localWin10/oneCoreSpeech.h
@@ -1,58 +1,67 @@
 /*
-Header for C dll bridge to Windows OneCore voices.
-This file is a part of the NVDA project.
-URL: http://www.nvaccess.org/
-Copyright 2016-2017 Tyler Spivey, NV Access Limited.
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.0, as published by
-    the Free Software Foundation.
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-This license can be found at:
-http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ Copyright (C) 2016-2022 NV Access Limited, Tyler Spivey
+ This file may be used under the terms of the GNU General Public License, version 2 or later.
+ For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+ Windows OneCore voices
+
+ Expected to be used serially (E.G. from python with GIL).
+ The token returned from initialize allows error checking on all methods,
+ to ensure terminate has not yet been called
+
+ Notes on the approach:
+ - Internal function 'speak' is run asynchronously using Windows thread pool.
+   Results are passed back to NVDA via a callback, which must still be valid when the results are ready.
+   However, terminate will invalidate the callback.
+   To protect against this, locking strategy is used.
+   Before the callback is executed a shared_lock is acquired on the mutex, this allows other shared locks
+   to be acquired, but prevents unique locks from acquiring the mutex.
+
+ - The lifetime of the winrtSynth instance is managed with a shared_ptr.
+   This allows it to be abandoned in terminate, while remaining valid for the duration of 'speak'.
+   To debug life-cycle management weak_ptrs are used to observe the reference count.
 */
 
 #pragma once
 #define export __declspec(dllexport)
 
-typedef void (*ocSpeech_Callback)(byte* data, int length, const wchar_t* markers);
-
-class OcSpeech {
-private:
-	winrt::Windows::Media::SpeechSynthesis::SpeechSynthesizer synth{ nullptr };
-	ocSpeech_Callback callback;
-
-public:
-	OcSpeech();
-	winrt::fire_and_forget speak(winrt::hstring text);
-	void setCallback(ocSpeech_Callback fn);
-	std::wstring getVoices();
-	winrt::hstring getCurrentVoiceId();
-	void setVoice(int index);
-	winrt::hstring getCurrentVoiceLanguage();
-	double getPitch();
-	void setPitch(double pitch);
-	double getVolume();
-	void setVolume(double volume);
-	double getRate();
-	void setRate(double rate);
-};
+typedef void (*ocSpeech_Callback)(BYTE* data, int length, const wchar_t* markers);
 
 extern "C" {
 	export bool __stdcall ocSpeech_supportsProsodyOptions();
-	export OcSpeech* __stdcall ocSpeech_initialize();
-	export void __stdcall ocSpeech_terminate(OcSpeech* instance);
-	export void __stdcall ocSpeech_setCallback(OcSpeech* instance, ocSpeech_Callback fn);
-	export void __stdcall ocSpeech_speak(OcSpeech* instance, wchar_t* text);
-	export BSTR __stdcall ocSpeech_getVoices(OcSpeech* instance);
-	export const wchar_t* __stdcall ocSpeech_getCurrentVoiceId(OcSpeech* instance);
-	export void __stdcall ocSpeech_setVoice(OcSpeech* instance, int index);
-	export const wchar_t* __stdcall ocSpeech_getCurrentVoiceLanguage(OcSpeech* instance);
-	export double __stdcall ocSpeech_getPitch(OcSpeech* instance);
-	export void __stdcall ocSpeech_setPitch(OcSpeech* instance, double pitch);
-	export double __stdcall ocSpeech_getVolume(OcSpeech* instance);
-	export void __stdcall ocSpeech_setVolume(OcSpeech* instance, double volume);
-	export double __stdcall ocSpeech_getRate(OcSpeech* instance);
-	export void __stdcall ocSpeech_setRate(OcSpeech* instance, double rate);
+
+	/* Initialize the ocSpeech system. The token returned is used to debug the life cycles of the ocSpeech system.
+	* Only one token may be active at a time.
+	* @return A token value that should be kept and passed to all ocSpeech functions.
+	* Used to verify client and DLL states are aligned.
+	*/
+	export void* __stdcall ocSpeech_initialize(ocSpeech_Callback fn);
+
+	/* Terminate the ocSpeech system. The given token becomes invalid.
+	* Terminate may block while a callback completes.
+	* To ensure terminate gets a chance to run, ensure that the callback does not
+	* call ocSpeech_speak. Doing so may result in more callbacks before terminate is unblocked.
+	* When terminate returns the token should be discarded and the callback will not be called.
+	@param token Used to verify dll and client state. Allows detection of synchronization errors.
+	*/
+	export void __stdcall ocSpeech_terminate(void* token);
+
+	/*
+	Send speech text to OneCore, call back to NVDA with synthesized speech.
+	@remarks The work is done asynchronously on a background thread.
+	@param token Used to verify dll and client state. Allows detection of synchronization errors.
+	@param text The text to synthesize.
+	*/
+	export void __stdcall ocSpeech_speak(void* token, wchar_t* text);
+
+	export BSTR __stdcall ocSpeech_getVoices(void* token);
+	export const wchar_t* __stdcall ocSpeech_getCurrentVoiceId(void* token);
+	export void __stdcall ocSpeech_setVoice(void* token, int index);
+	export const wchar_t* __stdcall ocSpeech_getCurrentVoiceLanguage(void* token);
+	export double __stdcall ocSpeech_getPitch(void* token);
+	export void __stdcall ocSpeech_setPitch(void* token, double pitch);
+	export double __stdcall ocSpeech_getVolume(void* token);
+	export void __stdcall ocSpeech_setVolume(void* token, double volume);
+	export double __stdcall ocSpeech_getRate(void* token);
+	export void __stdcall ocSpeech_setRate(void* token, double rate);
 }

--- a/nvdaHelper/localWin10/oneCoreSpeech.h
+++ b/nvdaHelper/localWin10/oneCoreSpeech.h
@@ -13,7 +13,7 @@
  - Internal function 'speak' is run asynchronously using Windows thread pool.
    Results are passed back to NVDA via a callback, which must still be valid when the results are ready.
    However, terminate will invalidate the callback.
-   To protect against this, locking strategy is used.
+   To protect against this, a locking strategy is used.
    Before the callback is executed a shared_lock is acquired on the mutex, this allows other shared locks
    to be acquired, but prevents unique locks from acquiring the mutex.
 

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -72,7 +72,7 @@ def findScript(gesture):
 
 	globalMapScripts = []
 	globalMaps = [inputCore.manager.userGestureMap, inputCore.manager.localeGestureMap]
-	globalMap = braille.handler.display.gestureMap
+	globalMap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None
 	if globalMap:
 		globalMaps.append(globalMap)
 	for globalMap in globalMaps:
@@ -100,17 +100,21 @@ def findScript(gesture):
 			return func
 
 	# Braille display level
-	if isinstance(braille.handler.display, baseObject.ScriptableObject):
+	if (
+		braille.handler
+		and isinstance(braille.handler.display, baseObject.ScriptableObject)
+	):
 		func = _getObjScript(braille.handler.display, gesture, globalMapScripts)
 		if func:
 			return func
 
 	# Vision enhancement provider level
-	for provider in vision.handler.getActiveProviderInstances():
-		if isinstance(provider, baseObject.ScriptableObject):
-			func = _getObjScript(provider, gesture, globalMapScripts)
-			if func:
-				return func
+	if vision.handler:
+		for provider in vision.handler.getActiveProviderInstances():
+			if isinstance(provider, baseObject.ScriptableObject):
+				func = _getObjScript(provider, gesture, globalMapScripts)
+				if func:
+					return func
 
 	# Tree interceptor level.
 	treeInterceptor = focus.treeInterceptor

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -445,6 +445,7 @@ def setSynth(name: Optional[str], isFallback: bool = False):
 	asDefault = False
 	global _curSynth, _audioOutputDevice
 	if name is None:
+		_curSynth.cancel()
 		_curSynth.terminate()
 		_curSynth = None
 		return True

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -89,6 +89,7 @@ Note:
 - Fixed a bug where selecting the Papenmeier Braille Display Driver caused NVDA to crash. (#13348)
 - In Microsoft word with UIA: page number and other formatting is no longer inappropriately announced when moving from a blank table cell to a cell with content, or from the end of the document into existing content. (#13458, #13459)
 - NVDA will no longer fail to report the page title and start automatically reading, when a page loads in Google chrome 100. (#13571)
+- NVDA no longer crashes when resetting the NVDA configuration to factory defaults while speak command keys is on. (#13634)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Supersedes https://github.com/nvaccess/nvda/pull/13569

### Summary of the issue:
NVDA was crashing when resetting the configuration to factory defaults.
NVDA terminates the ocSpeech native module when resetting the config, however there is a pending callback to a now deleted python function.

Steps to reproduce:
1. Run NVDA
1. In the Keyboard section of the Preferences dialog, turn "Speak command keys" on.
1. Reset your configuration to factory defaults
1. Note that NVDA crashes

### Description of how this pull request fixes the issue:

- Changes the design of the ocSpeech module.
- Both initialization and termination are blocked if a callback is about to happen.
  The "tokens" for prior initialization of ocSpeech are collected by the ocSpeech system.
  When an async task reaches completion, the origin token is checked for validity, the callback is not called for a now invalid token.
- Initialization now requires the callback to be specified.

### Testing strategy:

Manual testing

1. Run NVDA
1. In the Keyboard section of the Preferences dialog, turn "Speak command keys" on.
1. Reset your configuration to factory defaults
1. Note that NVDA does not crash.

### Known issues with pull request:
Other errors are logged during config reset See: #13580

### Change log entries:
Bug fixes
```t2t
- NVDA no longer crashes when resetting the NVDA configuration to factory defaults while speak command keys is on. ()
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
