### PR TITLE
Fix say-all with oneCore synth

### DIFF
--- a/nvdaHelper/localWin10/oneCoreSpeech.cpp
+++ b/nvdaHelper/localWin10/oneCoreSpeech.cpp
@@ -302,7 +302,7 @@ std::wstring createMarkersString_(IVectorView<IMediaMarker> markers) {
 			markersStr += L"|";
 		}
 		else {
-			firstComplete = false;
+			firstComplete = true;
 		}
 		markersStr += marker.Text();
 		markersStr += L":";


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13651

### Summary of the issue:
Starting say-all with synth set to onecore fails with an error.

A logic error in the change: https://github.com/nvaccess/nvda/pull/13634
Causes the "markerStr" to be constructed incorectly. The `|` character expected to separate entries was missing.

Example string: `20:1437521:18864375`
Should be instead: `20:14375|21:18864375`

### Description of how this pull request fixes the issue:
Fix the logic error, every entry after the first should start with a `|` character.

### Testing strategy:
Tested say all in edge with synth set to oneCore.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
