### PR TITLE
Add helperLocalBindingHandle to NVDAObject appModule devInfo

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1328,25 +1328,11 @@ This code is executed if a gain focus event is received by this object.
 			ret = "exception: %s" % e
 		info.append("value: %s" % ret)
 		try:
-			ret = repr(self.appModule)
-		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule: %s" % ret)
-		try:
-			ret = repr(self.appModule.productName)
-		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule.productName: %s" % ret)
-		try:
-			ret = repr(self.appModule.productVersion)
-		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule.productVersion: %s" % ret)
-		try:
 			ret = repr(self.TextInfo)
 		except Exception as e:
 			ret = "exception: %s" % e
 		info.append("TextInfo: %s" % ret)
+		info.extend(self.appModule.devInfo)
 		return info
 
 	def _get_sleepMode(self):

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -746,6 +746,37 @@ class AppModule(baseObject.ScriptableObject):
 		"""
 		raise NotImplementedError()
 
+	devInfo: List[str]
+	"""Information about this appModule useful to developers."""
+
+	def _get_devInfo(self) -> List[str]:
+		"""Information about this appModule useful to developers.
+		For an NVDAObject, its appModule devInfo is appended to NVDAObject.devInfo.
+		Subclasses may extend this, calling the superclass property first.
+		@return: A list of text strings providing information about this appModule useful to developers.
+		"""
+		info = []
+		try:
+			ret = repr(self)
+		except Exception as e:
+			ret = "exception: %s" % e
+		info.append("appModule: %s" % ret)
+		try:
+			ret = repr(self.productName)
+		except Exception as e:
+			ret = "exception: %s" % e
+		info.append("appModule.productName: %s" % ret)
+		try:
+			ret = repr(self.productVersion)
+		except Exception as e:
+			ret = "exception: %s" % e
+		info.append("appModule.productVersion: %s" % ret)
+		try:
+			ret = repr(self.helperLocalBindingHandle)
+		except Exception as e:
+			ret = "exception: %s" % e
+		info.append("appModule.helperLocalBindingHandle: %s" % ret)
+		return info
 
 class AppProfileTrigger(config.ProfileTrigger):
 	"""A configuration profile trigger for when a particular application has focus.

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -759,23 +759,23 @@ class AppModule(baseObject.ScriptableObject):
 		try:
 			ret = repr(self)
 		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule: %s" % ret)
+			ret = f"exception: {e}"
+		info.append(f"appModule: {ret}")
 		try:
 			ret = repr(self.productName)
 		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule.productName: %s" % ret)
+			ret = f"exception: {e}"
+		info.append(f"appModule.productName: {ret}")
 		try:
 			ret = repr(self.productVersion)
 		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule.productVersion: %s" % ret)
+			ret = f"exception: {e}"
+		info.append(f"appModule.productVersion: {ret}")
 		try:
 			ret = repr(self.helperLocalBindingHandle)
 		except Exception as e:
-			ret = "exception: %s" % e
-		info.append("appModule.helperLocalBindingHandle: %s" % ret)
+			ret = f"exception: {e}"
+		info.append(f"appModule.helperLocalBindingHandle: {ret}")
 		return info
 
 class AppProfileTrigger(config.ProfileTrigger):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
When developing #13657, logging `NVDAObject.appModule.helperLocalBindingHandle` was helpful.
`NVDAObject._get_devInfo` is considered too complex, and should aim to be shortened.

### Description of how this pull request fixes the issue:
Moves the appModule devInfo logging out of `NVDAObject._get_devInfo` into `AppModule.get_devInfo`.
Adds `appModule.helperLocalBindingHandle` to the log info for an NVDAObject.

### Testing strategy:

Test with `NVDA+F1` on various NVDAObjects.

### Known issues with pull request:
None

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
