### PR TITLE
Incompatible add-on dialog messages updated to be more end-user friendly

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -608,11 +608,12 @@ def handleRemoteAddonInstall(addonPath):
 
 
 def _showAddonRequiresNVDAUpdateDialog(parent, bundle):
-	incompatibleMessage = _(
+	incompatibleReasonMessage = _(
 		# Translators: The message displayed when installing an add-on package is prohibited,
-		# because it requires a later version of NVDA than is currently installed.
-		"Installation of {summary} {version} has been blocked. The minimum NVDA version required for "
-		"this add-on is {minimumNVDAVersion}, your current NVDA version is {NVDAVersion}"
+		# because it requires a newer version of NVDA than is currently in use.
+		"Installation of this add-on has been blocked. Your version of NVDA ({NVDAVersion}) "
+		"is too old to support {summary} version {version}.\n"
+		"Please update NVDA to at least version {minimumNVDAVersion}, to use this version of {summary}."
 	).format(
 		summary=bundle.manifest['summary'],
 		version=bundle.manifest['version'],
@@ -623,27 +624,25 @@ def _showAddonRequiresNVDAUpdateDialog(parent, bundle):
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=_("Add-on not compatible"),
-		message=incompatibleMessage,
+		message=incompatibleReasonMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(bundle)
 	).ShowModal()
 
 
 def _showAddonTooOldDialog(parent, bundle):
-	confirmInstallMessage = _(
-		# Translators: A message informing the user that this addon can not be installed
-		# because it is not compatible.
-		"Installation of {summary} {version} has been blocked."
-		" An updated version of this add-on is required,"
-		" the minimum add-on API supported by this version of NVDA is {backCompatToAPIVersion}"
-	).format(
-		backCompatToAPIVersion=addonAPIVersion.formatForGUI(addonAPIVersion.BACK_COMPAT_TO),
-		**bundle.manifest
-	)
+	incompatibleReasonMessage = _(
+		# Translators: The message displayed when installing an add-on package is prohibited,
+		# because it requires an older version of NVDA than is currently in use.
+		"Installation of this add-on has been blocked. {summary} version {version} "
+		"is too old to work with your version of NVDA.\n"
+		"The add-on is only compatible through the {lastTestedNVDAVersion[0]} NVDA series. "
+		"Please download a newer version, or contact the add-on's author: {author}, to ask for an update."
+	).format(**bundle.manifest)
 	return ErrorAddonInstallDialog(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=_("Add-on not compatible"),
-		message=confirmInstallMessage,
+		message=incompatibleReasonMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(bundle)
 	).ShowModal()
 


### PR DESCRIPTION
Note to Reef/Sean: the commit should be complete for merging, without needing the text of the PR pasted in.

### Link to issue number:

Closes #13632 

### Summary of the issue:

It was thought by some users and developers, that the messages shown when an add-on can not be installed because of being too young or old for the current NVDA version (by indicating API version), were overly developer centric.

Specifically, one of the messages had the potential, if not read with great care and some understanding of NVDA internals, to make users think that the add-on was compatible with the current version of NVDA, even though it wasn't, thus causing confusion as to why it wasn't installable.

### Description of how this pull request fixes the issue:

The messages have been updated to present more end-user friendly information, although at the cost of exactitude in the case of the add-on too old message.

#### Sample of the revised add-on too old for NVDA dialog:

```
Installation of this add-on has been blocked. Add-on Name version #.# is too
old to work with your version of NVDA.
The add-on is only compatible through the 2021 NVDA series. Please
download a newer version, or contact the add-on's author: Firstname Lastname
<email>, to ask for an update.
```

#### Sample of the revised add-on too new for NVDA dialog:

```
Installation of this add-on has been blocked. Your version of NVDA (2022.2)
is too old to support Add-on Name version #.#.
Please update NVDA to at least version 2025.1, to use this version of
Add-on Name.
```

### Testing strategy:

* Attempted to install an add-on which was too old for the current NVDA version. Sample: [Dev Helper 1.4](https://addons.nvda-project.org/files/get.php?file=debughelper).
* Created, and attempted to install, a version of the Numpad Nav Mode add-on, configured for a version of NVDA which does not yet exist. [Available here](https://ci.appveyor.com/api/buildjobs/krq1njgobtuhakn1/artifacts/numpadNavMode-999.nvda-addon).

### Known issues with pull request:

Regarding the add-on too old for NVDA dialog: I am not really satisfied with the presentation of the last supporting NVDA version by year only. However, without a map of NVDA versions to API supported versions being carried somewhere in core, there seems no convenient way to provide an exact final version.

Naturally, such a mapping could be created, but then it must be maintained. I don't think that is desirable. If the current pattern of only breaking API compat on year.1 versions continues, this should only prove incorrect for 2019.3.1 situations, and we're far past that.

### Change log entries:
Changes

The dialogs shown when an add-on can not be installed because it is incompatible, have been revised so they are easier to understand by end users. (#13632)

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
