### PR TITLE
Add a script to cycle through language switching modes.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -899,6 +899,29 @@ class GlobalCommands(ScriptableObject):
 		ui.message(state)
 
 	@script(
+		# Translators: Input help mode message for cycle through automatic language switching mode command.
+		description=_("Cycles through speech automatic language switching modes off, language only and language and dialect."),
+		category=SCRCAT_SPEECH,
+	)
+	def script_cycleSpeechAutomaticLanguageSwitching(self,gesture):
+		if config.conf["speech"]["autoLanguageSwitching"]:
+			if config.conf["speech"]["autoDialectSwitching"]:
+				# Translators: A message reported when executing the cycle automatic language switching mode command.
+				state = _("Automatic language switching off")
+				config.conf["speech"]["autoLanguageSwitching"]=False
+				config.conf["speech"]["autoDialectSwitching"] = False
+			else:
+				# Translators: A message reported when executing the cycle automatic language switching mode command.
+				state = _("Automatic language and dialect switching on")
+				config.conf["speech"]["autoDialectSwitching"] = True
+		else:
+			# Translators: A message reported when executing the cycle automatic language switching mode command.
+			state = _("Automatic language switching on")
+			config.conf["speech"]["autoLanguageSwitching"]=True
+			config.conf["speech"]["autoDialectSwitching"] = False
+		ui.message(state)
+
+	@script(
 		# Translators: Input help mode message for cycle speech symbol level command.
 		description=_("Cycles through speech symbol levels which determine what symbols are spoken"),
 		category=SCRCAT_SPEECH,

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -899,16 +899,18 @@ class GlobalCommands(ScriptableObject):
 		ui.message(state)
 
 	@script(
-		# Translators: Input help mode message for cycle through automatic language switching mode command.
-		description=_("Cycles through speech automatic language switching modes off, language only and language and dialect."),
+		description=_(
+			# Translators: Input help mode message for cycle through automatic language switching mode command.
+			"Cycles through speech automatic language switching modes off, language only and language and dialect."
+		),
 		category=SCRCAT_SPEECH,
 	)
-	def script_cycleSpeechAutomaticLanguageSwitching(self,gesture):
+	def script_cycleSpeechAutomaticLanguageSwitching(self, gesture):
 		if config.conf["speech"]["autoLanguageSwitching"]:
 			if config.conf["speech"]["autoDialectSwitching"]:
 				# Translators: A message reported when executing the cycle automatic language switching mode command.
 				state = _("Automatic language switching off")
-				config.conf["speech"]["autoLanguageSwitching"]=False
+				config.conf["speech"]["autoLanguageSwitching"] = False
 				config.conf["speech"]["autoDialectSwitching"] = False
 			else:
 				# Translators: A message reported when executing the cycle automatic language switching mode command.
@@ -917,7 +919,7 @@ class GlobalCommands(ScriptableObject):
 		else:
 			# Translators: A message reported when executing the cycle automatic language switching mode command.
 			state = _("Automatic language switching on")
-			config.conf["speech"]["autoLanguageSwitching"]=True
+			config.conf["speech"]["autoLanguageSwitching"] = True
 			config.conf["speech"]["autoDialectSwitching"] = False
 		ui.message(state)
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -901,7 +901,8 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for cycle through automatic language switching mode command.
-			"Cycles through speech automatic language switching modes off, language only and language and dialect."
+			"Cycles through speech modes for automatic language switching: "
+			"off, language only and language and dialect."
 		),
 		category=SCRCAT_SPEECH,
 	)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,7 @@ What's New in NVDA
  - ``control+alt+home/end`` to jump to first/last column.
  - ``control+alt+pageUp/pageDown`` to jump to first/last row.
  -
+- An unassigned script to cycle through language and dialect switching modes has been added. (#10253)
 -
 
 == Changes ==


### PR DESCRIPTION
### Link to issue number:

Fixes #10253

### Summary of the issue:

A gesture is missing to control automatic language switching and automatic dialect switching options.

### Description of how this pull request fixes the issue:
Add an unassigned script that cycles through the 3 following automatic language and dialect switching modes:
* Language and dialect switching off
* Language switching on, dialect switching off
• Language and dialect switching on

Note that the 4th possible state (language switching off and dialect switching on) does not make sense.

### Testing strategy:

* Called the script many times and checked the result in the Speech Settings panel after each call
* Tested with eSpeak in French (Franche) the text on this test page: [ExamplePageWithLangTag.html.txt](https://github.com/nvaccess/nvda/files/8665023/ExamplePageWithLangTag.html.txt)
  Note: The number 70 is said to be "soixante-dix" in French from France and "septante" in French from Belgium. Hence the easy test to distinguish one dialect from another.

 ### Known issues with pull request:

In #10253, the alternative solution to include this toggle in the synth setting ring was suggested by @JulienCochuyt.
Since the synth settings ring already contains many parameters, I have not retained this solution. Should #7747 be implemented, we can re-discuss it at that time.
Also a dedicated gesture is faster than the ring and thus would fulfill the expectations of https://github.com/nvaccess/nvda/issues/10253#issuecomment-1122387480.

### Change log entries:
New features
`An unassigned script to cycle through language and dialect switching modes have been added. (#10253)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
