### PR TITLE
Only close seika connection if initialized

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -6,7 +6,6 @@
 
 import itertools
 import os
-from sys import exc_info
 import typing
 from typing import Iterable, Union, Tuple, List, Optional
 from locale import strxfrm

--- a/source/braille.py
+++ b/source/braille.py
@@ -6,6 +6,7 @@
 
 import itertools
 import os
+from sys import exc_info
 import typing
 from typing import Iterable, Union, Tuple, List, Optional
 from locale import strxfrm
@@ -2428,9 +2429,9 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		# Clear the display.
 		try:
 			self.display([0] * self.numCells)
-		except Exception as e:
+		except Exception:
 			# The display driver seems to be failing, but we're terminating anyway, so just ignore it.
-			log.debugWarning(f"Display driver {self} is failing while terminating. {e}")
+			log.error(f"Display driver {self} failed to display while terminating.", exc_info=True)
 
 	#: typing information for autoproperty _get_numCells
 	numCells: int

--- a/source/braille.py
+++ b/source/braille.py
@@ -2424,13 +2424,13 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		Subclasses should call the superclass method first.
 		@postcondition: This instance can no longer be used unless it is constructed again.
 		"""
-		super(BrailleDisplayDriver,self).terminate()
+		super().terminate()
 		# Clear the display.
 		try:
 			self.display([0] * self.numCells)
-		except:
+		except Exception as e:
 			# The display driver seems to be failing, but we're terminating anyway, so just ignore it.
-			pass
+			log.debugWarning(f"Display driver {self} is failing while terminating. {e}")
 
 	#: typing information for autoproperty _get_numCells
 	numCells: int

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -97,7 +97,6 @@ def isSeikaBluetoothDeviceMatch(match: DeviceMatch) -> bool:
 
 
 class BrailleDisplayDriver(braille.BrailleDisplayDriver):
-	_dev: Optional[hwIo.IoBase] = None
 	name = SEIKA_NAME
 	# Translators: Name of a braille display.
 	description = _("Seika Notetaker")
@@ -118,6 +117,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self._hidBuffer = b""
 		self._command: typing.Optional[bytes] = None
 		self._argsLen: typing.Optional[int] = None
+		self._dev: Optional[hwIo.IoBase] = None
 
 		log.debug(f"Seika Notetaker braille driver: ({port!r})")
 		dev: typing.Optional[typing.Union[hwIo.Hid, hwIo.Serial]] = None

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -185,17 +185,17 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		return False
 
 	def terminate(self):
-		if self._dev is None:
-			log.error("Seika Notetaker driver not initialized")
-			return
 		try:
 			super().terminate()
 		finally:
+			if self._dev is None:
+				log.debugWarning("Seika Notetaker driver not initialized when attempting to terminate")
+				return
 			self._dev.close()
 
 	def display(self, cells: List[int]):
 		if self._dev is None:
-			log.error("Seika Notetaker driver not initialized")
+			log.debugWarning("Seika Notetaker driver not initialized when attempting to display")
 			return
 		# cells will already be padded up to numCells.
 		cellBytes = SEIKA_SEND_TEXT + bytes([self.numCells]) + bytes(cells)

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -188,7 +188,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		try:
 			super().terminate()
 		finally:
-			self._dev.close()
+			if self._dev:
+				# Check if initialized
+				self._dev.close()
 
 	def display(self, cells: List[int]):
 		# cells will already be padded up to numCells.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Closes part of #13679

### Summary of the issue:

It appears that when resetting a config, the seika notetaker driver can be terminated before it has been initialized.

### Description of how this pull request fixes the issue:

Only terminate the notetaker driver if it has been initialized.

### Testing strategy:

- [x] @cary-rowen to test a build of this PR

### Known issues with pull request:

Another issue is highlighted in #13679. While terminating/initializing during a config change, the braille.handler is attempted to be used when handling events on NVDA objects.
This is a more complex problem and needs a braille device to reproduce and test.

### Change log entries:
Fixes an unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
