### PR TITLE
Windows 11 Notepad: announce status bar if shown

### DIFF
--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -24,7 +24,9 @@ class AppModule(appModuleHandler.AppModule):
 		if api.getFocusObject().windowClassName != "RichEditD2DPT":
 			raise NotImplementedError()
 		# Look for a specific child as some children report the same UIA properties such as class name.
-		statusBar = api.getForegroundObject().children[7].firstChild
+		# Make sure to look for a foreground UIA element which hosts status bar content if visible.
+		notepadStatusBarIndex = 7
+		statusBar = api.getForegroundObject().children[notepadStatusBarIndex].firstChild
 		# No location for a disabled status bar i.e. location is 0 (x, y, width, height).
 		if not any(statusBar.location):
 			raise NotImplementedError()

--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -21,6 +21,7 @@ class AppModule(appModuleHandler.AppModule):
 		If visible, a child of the foreground window hosts the status bar elements.
 		Status bar child position must be checked whenever Notepad is updated on stable Windows 11 releases
 		as Notepad is updated through Microsoft Store as opposed to tied to specific Windows releases.
+		L{api.getStatusBar} will resort to position lookup if C{NotImplementedError} is raised.
 		"""
 		# #13688: Notepad 11 uses Windows 11 user interface, therefore status bar is harder to obtain.
 		# This does not affect earlier versions.

--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -1,0 +1,31 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""App module for Windows Notepad.
+While this app module also covers older Notepad releases,
+this module provides workarounds for Windows 11 Notepad."""
+
+import appModuleHandler
+import api
+
+
+class AppModule(appModuleHandler.AppModule):
+
+	def _get_statusBar(self):
+		# #13688: Notepad 11 uses Windows 11 user interface, therefore status bar is harder to obtain.
+		# This does not affect earlier versions.
+		notepadVersion = int(self.productVersion.split(".")[0])
+		if notepadVersion < 11:
+			raise NotImplementedError()
+		# And no, status bar is shown when editing documents.
+		# Thankfully, of all the UIA objects encountered, document window has a unique window class name.
+		if api.getFocusObject().windowClassName != "RichEditD2DPT":
+			raise NotImplementedError()
+		# Look for a specific child as some children report the same UIA properties such as class name.
+		statusBar = api.getForegroundObject().children[7].firstChild
+		# No location for a disabled status bar i.e. location is 0 (x, y, width, height).
+		if not any(statusBar.location):
+			raise NotImplementedError()
+		return statusBar

--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -14,6 +14,14 @@ import api
 class AppModule(appModuleHandler.AppModule):
 
 	def _get_statusBar(self):
+		"""Retrieves Windows 11 Notepad status bar.
+		In Windows 10 and earlier, status bar can be obtained by looking at the bottom of the screen.
+		Windows 11 Notepad uses Windows 11 UI design (top-level window is labeled "DesktopWindowXamlSource",
+		therefore status bar cannot be obtained by position alone.
+		If visible, a child of the foreground window hosts the status bar elements.
+		Status bar child position must be checked whenever Notepad is updated on stable Windows 11 releases
+		as Notepad is updated through Microsoft Store as opposed to tied to specific Windows releases.
+		"""
 		# #13688: Notepad 11 uses Windows 11 user interface, therefore status bar is harder to obtain.
 		# This does not affect earlier versions.
 		notepadVersion = int(self.productVersion.split(".")[0])

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ What's New in NVDA
 - In Windows 10 and 11 Calculator version 10.1908 and later, NVDA will announce results when more commands are pressed, such as commands from scientific mode. (#13386)
 - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
+- NVDA will announce status bar content in Windows 11 Notepad. (#13386)
 -
 
 


### PR DESCRIPTION

### Link to issue number:
Fixes #13688 

### Summary of the issue:
With the redesigned Windows 11 Notepad, users cannot obtain statsu bar information.

### Description of how this pull request fixes the issue:
Introduce a new Windows 11 Notepad app module (notepad.exe). With the new UI design, status bar cannot be obtained as in prior Notepad releases. Thankfully it is possible to traverse the UIA tree to obtain the status bar object from a specific child element position (this is because child elements have the same UIA class name). Also, status bar is shown if focused on the document window (rich edit) and enabled from view menu.

### Testing strategy:
Manual testing:

1. With Windows 11 installed, install Notepad 11.2203 or later.
2. Open Notepad.
3. Select View/status bar.
4. Type text.
5. Perform status bar command (NVDA+End in desktop layout/NVDA+Shift+End in laptop layout).

### Known issues with pull request:
None, although status bar position may need to be changed if Microsoft updates Notepad interface in future releases.

### Change log entries:
Bug fixes:

NVDA will announce status bar content in Windows 11 Notepad. (#13386 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
