### PR TITLE
Windows 11 shell (appModules/explorer): classify certain windows as UIA to allow mouse and touch navigation to work while interacting with shell elements

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -506,9 +506,10 @@ class AppModule(appModuleHandler.AppModule):
 		nextHandler()
 
 	def isGoodUIAWindow(self, hwnd):
+		currentWinVer = winVersion.getWinVer()
 		# #9204: shell raises window open event for emoji panel in build 18305 and later.
 		if (
-			winVersion.getWinVer() >= winVersion.WIN10_1903
+			currentWinVer >= winVersion.WIN10_1903
 			and winUser.getClassName(hwnd) == "ApplicationFrameWindow"
 		):
 			return True
@@ -517,7 +518,7 @@ class AppModule(appModuleHandler.AppModule):
 		# notably when interacting with windows labeled "DesktopWindowXamlSource".
 		# WORKAROUND UNTIL A PERMANENT FIX IS FOUND ACROSS APPS
 		if (
-			winVersion.getWinVer() >= winVersion.WIN11
+			currentWinVer >= winVersion.WIN11
 			# Traverse parents until arriving at the top-level window with the below class names.
 			# This is more so for the shell root (first class name), and for others, class name check would work
 			# since they are top-level windows for windows shown on screen such as Task View.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -518,7 +518,11 @@ class AppModule(appModuleHandler.AppModule):
 		# WORKAROUND UNTIL A PERMANENT FIX IS FOUND ACROSS APPS
 		if (
 			winVersion.getWinVer() >= winVersion.WIN11
-			and winUser.getClassName(hwnd) in (
+			# Traverse parents until arriving at the top-level window with the below class names.
+			# This is more so for the shell root (first class name), and for others, class name check would work
+			# since they are top-level windows for windows shown on screen such as Task View.
+			# However, look for the ancestor for consistency.
+			and winUser.getClassName(winUser.getAncestor(hwnd, winUser.GA_ROOT)) in (
 				# Windows 11 shell UI root, housing various shell elements shown on screen if enabled.
 				"Shell_TrayWnd",  # Start, Search, Widgets, other shell elements
 				# Top-level window class names from Windows 11 shell features

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -512,6 +512,21 @@ class AppModule(appModuleHandler.AppModule):
 			and winUser.getClassName(hwnd) == "ApplicationFrameWindow"
 		):
 			return True
+		# #13506: Windows 11 UI elements such as Taskbar should be reclassified as UIA windows,
+		# letting NVDA announce shell elements when navigating with mouse and/or touch,
+		# notably when interacting with windows labeled "DesktopWindowXamlSource".
+		# WORKAROUND UNTIL A PERMANENT FIX IS FOUND ACROSS APPS
+		if (
+			winVersion.getWinVer() >= winVersion.WIN11
+			and winUser.getClassName(hwnd) in (
+				# Windows 11 shell UI root, housing various shell elements shown on screen if enabled.
+				"Shell_TrayWnd",  # Start, Search, Widgets, other shell elements
+				# Top-level window class names from Windows 11 shell features
+				"Shell_InputSwitchTopLevelWindow",  # Language switcher
+				"XamlExplorerHostIslandWindow",  # Task View and Snap Layouts
+			)
+		):
+			return True
 		return False
 
 	def event_UIA_window_windowOpen(self, obj, nextHandler):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ What's New in NVDA
 - NVDA will once again announce Start menu search result details in recent Windows 10 and 11 releases. (#13544)
 - In Windows 10 and 11 Calculator version 10.1908 and later, NVDA will announce results when more commands are pressed, such as commands from scientific mode. (#13386)
 - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
+- In Windows 11, it is again possible to navigate and interact with user interface elements such as Taskbar and Task View using mouse and touch interaction. (#13508)
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 -
 


### PR DESCRIPTION
### Link to issue number:
#13506 (partial)

### Summary of the issue:
Windows 11 UI (shell) elements such as taskbar, notification area, TaskView, Snap layouts, and buttons such as Search and Chat cannot be navigated to and interacted with mosue and touchscreens.

### Description of how this pull request fixes the issue:
Reclassifies the following windows as UIA windows:

* Shell_TrayWnd: Start, Search, Widgets, other shell elements nadi s the rot shell elements window (not to be conrused with desktop window)
* Shell_InputSwitchTopLevelWindow: language switcher
* XamlExplorerHostIslandWindow: Task View and Snap Layouts

Most of these have the label of "DesktopWindowXamlSource". The "isGoodUIAWindow" in File Explorer app module was edited to treat these windows as UIA elements provided that they are the ancestors (top-level windows) of windows passed into that method. This is more so for the first window class name (shell root) whereas others can go through just a class name check, but cal winUser.getAncestor with GA_ROOT (2) flag for all windows for consistency.

### Testing strategy:
Manual testing (system tests cannot be added until Appveyor uses a server version based on Windows 11):

1. With Windows 11 (21H2 and 22H2 preview) installed, use the mouse to navigate shell elements (bottom elements).
2. Make sure element labels are announced.
3. Perform the same test with touchscreen gestures.
4. Press Windows+Tab to open Task View and make sure mouse and touch navigation works.

To check that mosue and touch navigation works, make sure you don't hear "DesktopWindowXamlSource" for the scenarios described (there might be other windows with this label but are out of scope of this PR).

### Known issues with pull request:
This solution is specific to Windows 11 shell. There are desktop apps that embed XAML controls, hence the class name of "DesktopWindowXamlSource", and other app examples include Notepad, Windows Terminal, and This PC (file browser part of File Explorer). A general solution that works across apps is preferred.

### Change log entries:
Bug fixes:

In Windows 11, it is again possible to navigate and interact with user interface elements such as Taskbar and Task View using mouse and touch interaction. (#13508 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
