### PR TITLE
appModules/calculator: focus.appModule.productVersion -> self.productVersion

### DIFF
--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -125,7 +125,7 @@ class AppModule(appModuleHandler.AppModule):
 		# #13383: later Calculator releases use UIA notification event to announce results.
 		# While the exact version that introduced UIA notification event cannot be found easily,
 		# it is definitely used in version 10.1908 and later.
-		calculatorVersion = [int(version) for version in focus.appModule.productVersion.split(".")[:2]]
+		calculatorVersion = [int(version) for version in self.productVersion.split(".")[:2]]
 		if calculatorVersion >= [10, 1908]:
 			return
 		# In redstone, calculator result keeps firing name change,


### PR DESCRIPTION
Hi,

Forgot to do this while fixing #13386 

### Link to issue number:
Follow-up to #13383 

### Summary of the issue:
Cosmetics: focus.appModule.productVersion -> self.productVersion for consistency.

### Description of how this pull request fixes the issue:
Changes focus.appModule.productVersion to self.productVersion in Calculator results script. No changes to functionality whatsoever.

### Testing strategy:
Manual testing, see #13383.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
