### PR TITLE
specify explicit encoding(UTF-8) for the calls in sconstruct and checkPot.py

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -470,7 +470,7 @@ def makePot(target, source, env):
 	# Tweak the headers.
 	potFn = str(target[0])
 	tmpFn = "%s.tmp" % potFn
-	with open(potFn, "rt") as inp, open(tmpFn, "wt") as out:
+	with open(potFn, "rt", encoding="utf-8") as inp, open(tmpFn, "wt") as out:
 		for lineNum, line in enumerate(inp):
 			if lineNum == 1:
 				line = "# %s\n" % versionInfo.copyright

--- a/sconstruct
+++ b/sconstruct
@@ -470,7 +470,7 @@ def makePot(target, source, env):
 	# Tweak the headers.
 	potFn = str(target[0])
 	tmpFn = "%s.tmp" % potFn
-	with open(potFn, "rt", encoding="utf-8") as inp, open(tmpFn, "wt") as out:
+	with open(potFn, "rt", encoding="utf-8") as inp, open(tmpFn, "wt", encoding="utf-8") as out:
 		for lineNum, line in enumerate(inp):
 			if lineNum == 1:
 				line = "# %s\n" % versionInfo.copyright

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -116,7 +116,7 @@ def checkPot(fileName):
 	expectedErrors = 0
 	unexpectedSuccesses = 0
 	foundMessagesWithOutComments: Set[str] = set()
-	with open(fileName, "rt") as pot:
+	with open(fileName, "rt", encoding="utf-8") as pot:
 		passedHeader = False
 		for line in pot:
 			line = line.rstrip()


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
As a change required by #13675 

### Description of how this pull request fixes the issue:
According to [this comment][1] by @lukaszgo1 in #13675 

Because Python function opens the text files using the default ANSI code page on Windows and the ANSI code page on system (and on AppVeyor) cannot correctly decode utf-8 text.
To fix this we need to specify explicit encoding(UTF-8) for the calls in sconstruct and test/checkPot.py
### Testing strategy:
Execute scons pot to test

### Known issues with pull request:
None
### Change log entries:
New features
Changes: specify explicit encoding for the calls in sconstruct and checkPot.py
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English

[1]: https://github.com/nvaccess/nvda/pull/13675#issuecomment-1124160470