### PR TITLE
Fix SAPI5 Audio Ducking Crash on Slow startup

### DIFF
--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -178,7 +178,7 @@ def isAudioDuckingSupported():
 		) and hasattr(oledll.oleacc, 'AccSetRunningUtilityState')
 		_isAudioDuckingSupported &= systemUtils.hasUiAccess()
 		# If the wx.App has not been initialized, audio ducking callbacks
-		# will fail as they use the wx event loop
+		# will fail as they rely on wx.CallLater/wx.CallAfter
 		_isAudioDuckingSupported &= wx.GetApp() is not None
 	return _isAudioDuckingSupported
 

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -171,11 +171,15 @@ _isAudioDuckingSupported=None
 def isAudioDuckingSupported():
 	global _isAudioDuckingSupported
 	if _isAudioDuckingSupported is None:
+		import wx
 		_isAudioDuckingSupported = (
 			config.isInstalledCopy()
 			or config.isAppX
 		) and hasattr(oledll.oleacc, 'AccSetRunningUtilityState')
 		_isAudioDuckingSupported &= systemUtils.hasUiAccess()
+		# If the wx.App has not been initialized, audio ducking callbacks
+		# will fail as they use the wx event loop
+		_isAudioDuckingSupported &= wx.GetApp() is not None
 	return _isAudioDuckingSupported
 
 

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -130,7 +130,7 @@ def _unensureDucked(delay=True):
 		except core.NVDANotInitializedError:
 			# If the wx.App has not been initialized, audio ducking callbacks
 			# will fail as they rely on wx.CallLater/wx.CallAfter
-			log.debugWarning("wx App not initialized, cannot delay audio un-duck")
+			log.debugWarning("wx App not initialized, unducking immediately")
 	with _duckingRefCountLock:
 		_duckingRefCount-=1
 		if _isDebug():

--- a/source/core.py
+++ b/source/core.py
@@ -479,10 +479,12 @@ def main():
 	import mathPres
 	log.debug("Initializing MathPlayer")
 	mathPres.initialize()
+	time.sleep(5)
 	if not globalVars.appArgs.minimal and (time.time()-globalVars.startTime)>5:
 		log.debugWarning("Slow starting core (%.2f sec)" % (time.time()-globalVars.startTime))
 		# Translators: This is spoken when NVDA is starting.
 		speech.speakMessage(_("Loading NVDA. Please wait..."))
+	time.sleep(2)
 	import wx
 	import six
 	log.info("Using wx version %s with six version %s"%(wx.version(), six.__version__))

--- a/source/core.py
+++ b/source/core.py
@@ -479,12 +479,10 @@ def main():
 	import mathPres
 	log.debug("Initializing MathPlayer")
 	mathPres.initialize()
-	time.sleep(5)
 	if not globalVars.appArgs.minimal and (time.time()-globalVars.startTime)>5:
 		log.debugWarning("Slow starting core (%.2f sec)" % (time.time()-globalVars.startTime))
 		# Translators: This is spoken when NVDA is starting.
 		speech.speakMessage(_("Loading NVDA. Please wait..."))
-	time.sleep(2)
 	import wx
 	import six
 	log.info("Using wx version %s with six version %s"%(wx.version(), six.__version__))

--- a/source/core.py
+++ b/source/core.py
@@ -866,13 +866,22 @@ def requestPump():
 	import wx
 	wx.CallAfter(_pump.Start,PUMP_MAX_DELAY, True)
 
+
+class NVDANotInitializedError(Exception):
+	pass
+
+
 def callLater(delay, callable, *args, **kwargs):
 	"""Call a callable once after the specified number of milliseconds.
 	As the call is executed within NVDA's core queue, it is possible that execution will take place slightly after the requested time.
 	This function should never be used to execute code that brings up a modal UI as it will cause NVDA's core to block.
-	This function can be safely called from any thread.
+	This function can be safely called from any thread once NVDA has been initialized.
 	"""
 	import wx
+	if wx.GetApp() is None:
+		# If NVDA has not fully initialized yet, the wxApp may not be initialized.
+		# wx.CallLater and wx.CallAfter requires the wxApp to be initialized.
+		raise NVDANotInitializedError("NVDA has not initialized, cannot schedule callable")
 	if threading.get_ident() == mainThreadId:
 		return wx.CallLater(delay, _callLaterExec, callable, args, kwargs)
 	else:

--- a/source/core.py
+++ b/source/core.py
@@ -881,7 +881,7 @@ def callLater(delay, callable, *args, **kwargs):
 	if wx.GetApp() is None:
 		# If NVDA has not fully initialized yet, the wxApp may not be initialized.
 		# wx.CallLater and wx.CallAfter requires the wxApp to be initialized.
-		raise NVDANotInitializedError("NVDA has not initialized, cannot schedule callable")
+		raise NVDANotInitializedError("Cannot schedule callable, wx.App is not initialized")
 	if threading.get_ident() == mainThreadId:
 		return wx.CallLater(delay, _callLaterExec, callable, args, kwargs)
 	else:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #13694 

### Summary of the issue:

- NVDA start up is slow.
- Speech is announced during start up to warn the user that start up is slow.
- If using SAPI5 and audioducking is enabled, SAPI5 will try to duck the audio using wx callbacks
- The wxWidgets App has not beeing initialized, so the callback fails and NVDA crashes.

### Description of how this pull request fixes the issue:

Throw a known exception if NVDA is not ready when callLater is called.
If this exception occurs when audio ducking, force audio ducking to unduck immediately instead of delay

### Testing strategy:

Manual testing:

**Using NVDA 2022.1rc1 with audio ducking enabled and SAPI5.**
- emulate a slow start up and reproduce the crash.

**Using a try build from this PR with audio ducking enabled and SAPI5.**
- [emulate a slow start up](https://stackoverflow.com/a/28341146)
- Note that the warning message that announces that NVDA start up is slow doesn't duck audio
- Note that NVDA starts successfully
- Confirm that audio ducking works as expected once NVDA has started
- Note the following log
```py
WARNING - mathPres.initialize (12:46:35.192) - MainThread (6344):
MathPlayer 4 not available
DEBUGWARNING - core.main (12:46:40.207) - MainThread (6344):
Slow starting core (6.88 sec)
IO - speech.speech.speak (12:46:40.207) - MainThread (6344):
Speaking [LangChangeCommand ('en_US'), 'Loading NVDA. Please wait...']
DEBUGWARNING - characterProcessing._getSpeechSymbolsForLocale (12:46:40.208) - MainThread (6344):
No CLDR data for locale en_US
DEBUGWARNING - synthDrivers.sapi5.SynthDriver.speak (12:46:40.344) - MainThread (6344):
Unsupported speech command: LangChangeCommand ('en_US')
DEBUGWARNING - audioDucking._unensureDucked (12:46:40.349) - MainThread (6344):
wx App not initialized, cannot delay audio un-duck
INFO - core.main (12:46:40.349) - MainThread (6344):
Using wx version 4.1.1 msw (phoenix) wxWidgets 3.1.5 with six version 1.16.0
```

### Known issues with pull request:
None

### Change log entries:
Fixes an unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
e