### PR TITLE
Announce readonly state for Java text controls

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -312,6 +312,8 @@ class JAB(Window):
 		for state in stateStrings:
 			if state in JABStatesToNVDAStates:
 				stateSet.add(JABStatesToNVDAStates[state])
+		if "editable" not in stateStrings and self._JABAccContextInfo.accessibleText:
+			stateSet.add(controlTypes.State.READONLY)
 		if "visible" not in stateStrings:
 			stateSet.add(controlTypes.State.INVISIBLE)
 		if "showing" not in stateStrings:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -46,6 +46,7 @@ What's New in NVDA
 - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 - NVDA will announce status bar content in Windows 11 Notepad. (#13386)
+- NVDA will announce readonly state for Java applications. (#13692)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #13692 
### Summary of the issue:
In a Java swing application NVDA does not announce a read only text control as being read only.
### Description of how this pull request fixes the issue:
Java Access Bridge does not apply the editable state to read only controls. So when mapping JAB states to NVDA states check whether the control is a text control and whether it lacks the editable state, applying the read only state accordingly.
### Testing strategy:
Manual testing.
### Known issues with pull request:
None known.
### Change log entries:
New features
Changes
Bug fixes
Fixes issue where read only state of text controls not spoken in applications using the Java Access Bridge.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests None added but current tests pass.
  - System (end to end) tests None added, not sure how to add Java tests.
  - Manual testing Done.
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation No changes needed.
  - Developer / Technical Documentation No changes needed
  - Context sensitive help for GUI changes No changes needed.
- [x] UX of all users considered:
  - Speech  Yes
  - Braille Yes
  - Low Visio Yesn
  - Different web N/A browsers
  - Localization in other languages / culture than English Yes
