### PR TITLE
NVDA should report Java controls which are disabled as unavailable

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -328,6 +328,8 @@ class JAB(Window):
 			stateSet.add(controlTypes.State.OFFSCREEN)
 		if "expandable" not in stateStrings:
 			stateSet.discard(controlTypes.State.COLLAPSED)
+		if "enabled" not in stateStrings:
+			stateSet.add(controlTypes.State.UNAVAILABLE)
 		return stateSet
 
 	def _get_value(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -32,7 +32,6 @@ What's New in NVDA
 - The NVDA installer can now run from directories with special characters. (#13270)
 - In Firefox, NVDA no longer fails to report items in web pages when aria-rowindex, aria-colindex, aria-rowcount or aria-colcount attributes are invalid. (#13405)
 - The cursor does not switch row or column anymore when using table navigation to navigate through merged cells. (#7278)
--  NVDA will no longer incorrectly remove text from Java widgets when presenting to the user. (#13102)
 - When reading non-interactive PDFs in Adobe Reader, the type and state of form fields (such as checkboxes and radio buttons) are now reported. (#13285)
 - "Reset configuration to factory defaults" is now accessible in the NVDA menu during secure mode. (#13547)
 - Any locked mouse keys will be unlocked when NVDA exits, previously the mouse button would remain locked. (#13410)
@@ -40,15 +39,19 @@ What's New in NVDA
   - Note that for line number reporting to work, showing line numbers must be enabled in Visual Studio and NVDA.
   -
 - Visual Studio now correctly reports line indentation. (#13574)
-- NVDA can now beep or speak on Java application progress bars (#13594)
-- Fix issue where function key shortcuts were not announced in Java Swing applications. (#13643)
+- Fixes for Java based applications:
+  - NVDA will now announce readonly state. (#13692)
+  - NVDA will now announce disabled/enabled state correctly. (#10993)
+  - NVDA will now announce function key shortcuts. (#13643)
+  - NVDA can now beep or speak on progress bars. (#13594)
+  - NVDA will no longer incorrectly remove text from widgets when presenting to the user. (#13102)
+  -
 - NVDA will once again announce Start menu search result details in recent Windows 10 and 11 releases. (#13544)
 - In Windows 10 and 11 Calculator version 10.1908 and later, NVDA will announce results when more commands are pressed, such as commands from scientific mode. (#13386)
 - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
 - In Windows 11, it is again possible to navigate and interact with user interface elements such as Taskbar and Task View using mouse and touch interaction. (#13508)
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 - NVDA will announce status bar content in Windows 11 Notepad. (#13386)
-- NVDA will announce readonly state for Java applications. (#13692)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #10993
### Summary of the issue:
Controls in Java applications which do not have the enabled state are not being spoken as unavailable by NVDA.
### Description of how this pull request fixes the issue:
Java accessibility API states that controls lacking the enabled state cannot be manipulated and normally are shown as greyed out. I understand lacking the enabled state to map to unavailable in NVDA and so this pull request checks if enabled is not present and sets the unavailable state accordingly.
In the (java documentation at https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/accessibility/AccessibleState.html it says the following for the enabled state:
public static final AccessibleState ENABLED
Indicates this object is enabled. The absence of this state from an object's state set indicates this object is not enabled. An object that is not enabled cannot be manipulated by the user. In a graphical display, it is usually grayed out.
### Testing strategy:
Manual testing.
### Known issues with pull request:
The original issue referenced describes this for menus. It appears that (java Swing applications do not set focus to unavailable menu items and object review filters out unavailable menu items. So the example in the referenced issue cannot be used for testing, other examples may be needed.
### Change log entries:
New features
Changes
Bug fixes
Fix NVDA not reporting disabled/enabled state correctly for controls exposed through (java Access Bridge.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests None added, no breakage.
  - System (end to end) tests None added.
  - Manual testing Done.
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation N/A
  - Developer / Technical Documentation N/A
  - Context sensitive help for GUI changes N/A
- [x] UX of all users considered:
  - Speech  Yes
  - Braille Yes
  - Low Vision Yes
  - Different web browsers N/A
  - Localization in other languages / culture than English Yes
