### PR TITLE
appModules/explorer: do not treat IAccessible Start button class as UIA element

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -531,7 +531,10 @@ class AppModule(appModuleHandler.AppModule):
 				"XamlExplorerHostIslandWindow",  # Task View and Snap Layouts
 			)
 		):
-			return True
+			# #13717: on some systems, Windows 11 shell elements are reported as IAccessible,
+			# notably Start button, causing IAccessible handler to report attribute error when handling events.
+			if winUser.getClassName(hwnd) != "Start":
+				return True
 		return False
 
 	def event_UIA_window_windowOpen(self, obj, nextHandler):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -530,11 +530,11 @@ class AppModule(appModuleHandler.AppModule):
 				"Shell_InputSwitchTopLevelWindow",  # Language switcher
 				"XamlExplorerHostIslandWindow",  # Task View and Snap Layouts
 			)
-		):
 			# #13717: on some systems, Windows 11 shell elements are reported as IAccessible,
 			# notably Start button, causing IAccessible handler to report attribute error when handling events.
-			if winUser.getClassName(hwnd) != "Start":
-				return True
+			and winUser.getClassName(hwnd) != "Start"
+		):
+			return True
 		return False
 
 	def event_UIA_window_windowOpen(self, obj, nextHandler):


### PR DESCRIPTION
### Link to issue number:
Fixes a possible regression from #13691 
Follow-up to #13506 
Fixes #13717 

### Summary of the issue:
On some Windows 11 systems, Start button is seen as IAccessible object rather than UIA element. This causes IAccessible handler to report attribute error when handling events as an attribute is not present in UIA elements.

### Description of how this pull request fixes the issue:
On the surface, Start button window class name (Start) should be classified as a bad UIA window. However, when handling events from UIA handler thread, good UIA windows are checked before looking for bad UIA window class names. Because File Explorer's good UIA window method checks for the root element (the element being the ancestor of Start button), bad UIA window class name will not et a chance to detect IAccessible Start button. Therefore edit good UIA window method instead by checking for the specific class name in Windows 11.

### Testing strategy:
Manual testing:

Prerequisites: Windows 11 Version 21H2 or later (test systems are running Version 22H2 preview (build 22621 beta):
1. Run a build from this branch.
2. Press Windows+D to show Desktop.
3. Press Tab to move through shell elements such as Start button, Task View button, Taskbar, notification area, and back to Desktop.
4. While performing step 3, make sure NVDA is saying something.

For detailed debug output, enable IAccessible and UIA debugging from Advanced settings panel, restart NVDA with debug logging enabled, then perform steps 2 through 4 from aboveabove. Then open the log and see what IAccessible and UIA handlers are saying about focus events.

### Known issues with pull request:
None, although it might be possible that there are other Windows 11 shell elements that are showing as IAccessible as opposed to UIA.

### Change log entries:
None needed as this is a follow-up to #13691.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English

### Additional possibilities and context:
This issue occurs regardless of whether or not add-ons are on or off. Also, since Windows 11 shell is a UIA universe by default (checked many times after installing Windows 11 from scratch), it might be possible that something other than #13691 might be causing shell elements to be shown as IAccessible (perhaps a shell overlay or a Windows setting).
