### PR TITLE
Improve pronunciation of : * / inside German words

### DIFF
--- a/source/locale/de/symbols.dic
+++ b/source/locale/de/symbols.dic
@@ -16,6 +16,9 @@ complexSymbols:
 Dezimaltrennzeichen	(?<![^\d -])\,(?=\d)
 ' im Wort	(?<=[^\W_])['’]
 - im Wort	(?<=[^\W_])[-]
+* im Wort	(?<=[^\W_])[\*]
+: im Wort	(?<=[^\W_])[\:]
+/ im Wort	(?<=[^\W_])[/]
 Negative Ziffer	(?<!\w)[-−]{1}(?=[$£€¥.]?\d)
 Tausendertrennzeichen	(?<![^\d -])\.(?=\d{3}(\D|$))
 Datumstrennzeichen	(?<=\d\d)\.(?=\d\d)
@@ -31,6 +34,9 @@ symbols:
 : phrase ending	Doppelpunkt	most	always
 Dezimaltrennzeichen		none	always
 ' im Wort	Apostroph	all	norep
+* im Wort		none	norep
+: im Wort		none	norep
+/ im Wort		none	norep
 Negative Ziffer	Minus	none	norep
 - im Wort	Bindestrich	all	norep
 ... sentence ending	Auslassungspunkte	all	always


### PR DESCRIPTION
In contemporary German, there are multiple ways to indicate that a noun refers to all genders, e.g. users could be referred to as:

Nutzer_innen
NutzerInnen
Nutzer*innen
Nutzer:innen
Nutzer/innen
Nutzer/-innen

The common pronunciation is to use a glottal stop before the suffix. NVDA (with the default OneCore voices) does the right thing for _ and the capital I, but either uses a long pause (with : ), or reads out the character in default settings. This is distracting to the user when encountering texts using one of the other forms.

This patch fixes all the above cases to use a short pause, most closely resembling a glottal stop.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

No issue, seems like a small enough change.

### Summary of the issue:

Some contemporary forms of expressing that a noun refers to all genders in German are pronounced incorrectly, such as "Nutzer*innen", "Nutzer_innen" or "Nutzer/innen".

### Description of how this pull request fixes the issue:

Rules are added to detect * _ and / inside words, and replace them with spaces before sending them to the TTS subsystem.

### Testing strategy:

Paste the above examples into notepad. They all should have identical pronunciation.

### Known issues with pull request:

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
