### PR TITLE
Cherry-pick f90caa92: Improve logging and typing for sysListView32 (#13657)

### DIFF
--- a/nvdaHelper/remote/sysListView32.cpp
+++ b/nvdaHelper/remote/sysListView32.cpp
@@ -162,14 +162,19 @@ error_status_t nvdaInProcUtils_sysListView32_getColumnOrderArray(handle_t bindin
 	// ListView_GetColumnOrderArray macro has no return value, using SendMessage directly so errors are caught.
 	// The meaning of the return value depends on the message sent, for LVM_GETCOLUMNORDERARRAY,
 	// it returns nonzero if successful, or 0 otherwise.
+	// https://docs.microsoft.com/en-us/windows/win32/controls/lvm-getcolumnorderarray#return-value
 	const auto sendMsgRes = SendMessage(
 		static_cast<HWND>(UlongToHandle(windowHandle)),
 		LVM_GETCOLUMNORDERARRAY,
 		static_cast<WPARAM>(columnCount),
 		reinterpret_cast<LPARAM>(columnOrderArray)
 	);
-	if (TRUE != sendMsgRes) {
-		LOG_DEBUGWARNING(L"LVM_GETCOLUMNORDERARRAY failed");
+	if (FALSE == sendMsgRes) {
+		LOG_DEBUGWARNING(
+			L"LVM_GETCOLUMNORDERARRAY failed. " <<
+			L"Windows Error: " << GetLastError() <<
+			L", Window Handle: " << windowHandle
+		);
 		return ERROR_INVALID_FUNCTION;
 	}
 	return ERROR_SUCCESS;


### PR DESCRIPTION
This is a cherry-pick of #13657 from master that should have been included in 2022.1. It will be included in 2022.1.1

Closes: #13735 

**Note: Should me a merge commit not a squash merge**

Original commit:

---

Fix up of #13560, #13271

Summary of the issue:

When out-of-process failed, an empty array was returned instead of None.
This could have led to incorrect reporting of list items.
For example, trying to get the contents of the second column of the list/table/report, the array is initialized with all values of zero, if used without being filled with valid data all columns will report the same thing.

#13271 notes:
>How likely are cases where injection doesn't work and the outproc variants succeed? I guess this is pretty unlikely, unless we're running under Windows Store.

- If injection doesn't work there will be no `helperLocalBindingHandle`, out of process approach will be tried.
- If an application like StartIsBack/StartAllBack doesn't handle the Windows Message properly then it doesn't matter if the message is sent in-process or out-of-process.

Description of how this pull request fixes the issue:

- When possible, use in process approach to get the column order array. It should be possible if there is a `helperLocalBindingHandle`
- Don't return an array filled with zeros, return None when out-of-process fails.
