### PR TITLE
Java Access Bridge announcement fixes: toggle buttons, window titles, position information

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -384,7 +384,7 @@ class JAB(Window):
 				return info
 
 		parent=self.parent
-		if isinstance(parent,JAB) and self.role in (controlTypes.Role.TREEVIEWITEM,controlTypes.Role.LISTITEM):
+		if isinstance(parent,JAB) and self.role in (controlTypes.Role.TREEVIEWITEM,controlTypes.Role.LISTITEM, controlTypes.Role.TAB):
 			index=self._JABAccContextInfo.indexInParent+1
 			childCount=parent._JABAccContextInfo.childrenCount
 			info['indexInGroup']=index

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -100,7 +100,7 @@ JABStatesToNVDAStates={
 re_simpleXmlTag = re.compile(r"(\<[^>]+\>)+")
 
 
-def _subHtmlTag(match):
+def _subHtmlTag(match: re.match) -> str:
 	startIndex, endIndex = match.span()
 	return "" if startIndex == 0 or match.string[startIndex - 1].isspace() \
 	or endIndex == len(match.string) or match.string[endIndex].isspace() else " "

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -105,7 +105,7 @@ def _subHtmlTag(match: re.match) -> str:
 	return "" if startIndex == 0 or match.string[startIndex - 1].isspace() \
 	or endIndex == len(match.string) or match.string[endIndex].isspace() else " "
 
-def _processHtml(text):
+def _processHtml(text: str) -> str:
 	""" Strips HTML tags from text if it is HTML """
 	return re_simpleXmlTag.sub(_subHtmlTag, text) if text.startswith("<html>") else text
 

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -340,12 +340,15 @@ class JAB(Window):
 		return stateSet
 
 	def _get_value(self):
-		if self.role not in [
-			controlTypes.Role.TOGGLEBUTTON, controlTypes.Role.CHECKBOX,
-			controlTypes.Role.MENU, controlTypes.Role.MENUITEM,
-			controlTypes.Role.RADIOBUTTON, controlTypes.Role.BUTTON] \
-		and self._JABAccContextInfo.accessibleValue \
-		and not self._JABAccContextInfo.accessibleText:
+		if (
+			self.role not in [
+				controlTypes.Role.TOGGLEBUTTON, controlTypes.Role.CHECKBOX,
+				controlTypes.Role.MENU, controlTypes.Role.MENUITEM,
+				controlTypes.Role.RADIOBUTTON, controlTypes.Role.BUTTON
+			]
+			and self._JABAccContextInfo.accessibleValue
+			and not self._JABAccContextInfo.accessibleText
+		):
 			return self.jabContext.getCurrentAccessibleValueFromContext()
 
 	def _get_description(self):

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -384,8 +384,14 @@ class JAB(Window):
 				return info
 
 		parent=self.parent
-		if isinstance(parent, JAB) and self.role in (
-			controlTypes.Role.TREEVIEWITEM, controlTypes.Role.LISTITEM, controlTypes.Role.TAB):
+		if (
+			isinstance(parent, JAB)
+			and self.role in (
+				controlTypes.Role.TREEVIEWITEM,
+				controlTypes.Role.LISTITEM,
+				controlTypes.Role.TAB
+			)
+		):
 			index=self._JABAccContextInfo.indexInParent+1
 			childCount=parent._JABAccContextInfo.childrenCount
 			info['indexInGroup']=index

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -97,13 +97,13 @@ JABStatesToNVDAStates={
 }
 
 
-
-re_simpleXmlTag=re.compile(r"(\<[^>]+\>)+")
+re_simpleXmlTag = re.compile(r"(\<[^>]+\>)+")
 
 
 def _subHtmlTag(match):
 	startIndex, endIndex = match.span()
-	return "" if startIndex == 0 or match.string[startIndex - 1].isspace() or endIndex == len(match.string) or match.string[endIndex].isspace() else " "
+	return "" if startIndex == 0 or match.string[startIndex - 1].isspace() \
+	or endIndex == len(match.string) or match.string[endIndex].isspace() else " "
 
 def _processHtml(text):
 	""" Strips HTML tags from text if it is HTML """
@@ -384,7 +384,8 @@ class JAB(Window):
 				return info
 
 		parent=self.parent
-		if isinstance(parent,JAB) and self.role in (controlTypes.Role.TREEVIEWITEM,controlTypes.Role.LISTITEM, controlTypes.Role.TAB):
+		if isinstance(parent, JAB) and self.role in (
+			controlTypes.Role.TREEVIEWITEM, controlTypes.Role.LISTITEM, controlTypes.Role.TAB):
 			index=self._JABAccContextInfo.indexInParent+1
 			childCount=parent._JABAccContextInfo.childrenCount
 			info['indexInGroup']=index

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -101,9 +101,13 @@ re_simpleXmlTag = re.compile(r"(\<[^>]+\>)+")
 
 
 def _subHtmlTag(match: re.match) -> str:
+	""" Determines whether to replace the tag with a space or to just remove it. """
 	startIndex, endIndex = match.span()
-	return "" if startIndex == 0 or match.string[startIndex - 1].isspace() \
-	or endIndex == len(match.string) or match.string[endIndex].isspace() else " "
+	return "" if (
+		startIndex == 0 or match.string[startIndex - 1].isspace()
+		or endIndex == len(match.string) or match.string[endIndex].isspace()
+	) else " "
+
 
 def _processHtml(text: str) -> str:
 	""" Strips HTML tags from text if it is HTML """

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -397,7 +397,7 @@ class JAB(Window):
 	def _get_parent(self):
 		if not hasattr(self,'_parent'):
 			jabContext=self.jabContext.getAccessibleParentFromContext()
-			if jabContext:
+			if jabContext and self.indexInParent is not None:
 				self._parent=JAB(jabContext=jabContext)
 			else:
 				self._parent=super(JAB,self).parent

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -320,6 +320,9 @@ class JAB(Window):
 		for state in stateStrings:
 			if state in JABStatesToNVDAStates:
 				stateSet.add(JABStatesToNVDAStates[state])
+		if self.role is controlTypes.Role.TOGGLEBUTTON and controlTypes.State.CHECKED in stateSet:
+			stateSet.discard(controlTypes.State.CHECKED)
+			stateSet.add(controlTypes.State.PRESSED)
 		if "editable" not in stateStrings and self._JABAccContextInfo.accessibleText:
 			stateSet.add(controlTypes.State.READONLY)
 		if "visible" not in stateStrings:
@@ -333,7 +336,12 @@ class JAB(Window):
 		return stateSet
 
 	def _get_value(self):
-		if self.role not in [controlTypes.Role.CHECKBOX,controlTypes.Role.MENU,controlTypes.Role.MENUITEM,controlTypes.Role.RADIOBUTTON,controlTypes.Role.BUTTON] and self._JABAccContextInfo.accessibleValue and not self._JABAccContextInfo.accessibleText:
+		if self.role not in [
+			controlTypes.Role.TOGGLEBUTTON, controlTypes.Role.CHECKBOX,
+			controlTypes.Role.MENU, controlTypes.Role.MENUITEM,
+			controlTypes.Role.RADIOBUTTON, controlTypes.Role.BUTTON] \
+		and self._JABAccContextInfo.accessibleValue \
+		and not self._JABAccContextInfo.accessibleText:
 			return self.jabContext.getCurrentAccessibleValueFromContext()
 
 	def _get_description(self):

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -98,12 +98,16 @@ JABStatesToNVDAStates={
 
 
 
-re_simpleXmlTag=re.compile(r"\<[^>]+\>")
+re_simpleXmlTag=re.compile(r"(\<[^>]+\>)+")
 
+
+def _subHtmlTag(match):
+	startIndex, endIndex = match.span()
+	return "" if startIndex == 0 or match.string[startIndex - 1].isspace() or endIndex == len(match.string) or match.string[endIndex].isspace() else " "
 
 def _processHtml(text):
 	""" Strips HTML tags from text if it is HTML """
-	return re_simpleXmlTag.sub(" ", text) if text.startswith("<html>") else text
+	return re_simpleXmlTag.sub(_subHtmlTag, text) if text.startswith("<html>") else text
 
 
 class JABTextInfo(textInfos.offsets.OffsetsTextInfo):

--- a/tests/unit/test_javaAccessBridge.py
+++ b/tests/unit/test_javaAccessBridge.py
@@ -25,8 +25,8 @@ class TestJavaAccessBridge(unittest.TestCase):
 		self.assertEqual(regexStr, JAB._processHtml(regexStr))
 
 	def test_htmlStringHasTagsRemoved(self):
-		htmlStr = "<html><body><p>Some <b>bold</b> text.</p></body></html>"
-		expected = "   Some  bold  text.   "
+		htmlStr = "<html><body><p>Some <b>bold</b> <i>text</i>.</p></body></html>"
+		expected = "Some bold text ."
 		self.assertEqual(expected, JAB._processHtml(htmlStr))
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -35,6 +35,9 @@ What's New in NVDA
   - NVDA will now announce function key shortcuts. (#13643)
   - NVDA can now beep or speak on progress bars. (#13594)
   - NVDA will no longer incorrectly remove text from widgets when presenting to the user. (#13102)
+  - NVDA will now announce the state of toggle buttons. (#9728)
+  - NVDA will now identify the window in a Java application with multiple windows. (#9184)
+  - NVDA will now announce position information for tab controls. (#13744)
   -
 - Braille fixes:
   - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #9184 and fixes #9728 
### Summary of the issue:
A number of features in Java Access Bridge were not working optimally.
1. Various commands like read window and read window title were not working when Java applications have multiple windows. (#9184)
1. Toggle buttons were not read correctly. (#9728)
1. Unnecessary spaces when HTML tags removed from Java controls. (#9728)
1. Provide position information for Java tab controls. (#9728)

### Description of how this pull request fixes the issue:
1. According to [Java documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/accessibility/AccessibleContext.html#getAccessibleIndexInParent\(\)) when getAccessibleIndexInParent returns -1 there is no parent. So in NVDA if indexInParent is None we should treat it as if parent is not set.
1. Java toggle buttons use the checked state for pressed, correctly map this. The value should be ignored for a toggle button.
1. Updated the regular expression processing for HTML tags to check if the tags are at the start or end or have surrounding whitespace, in which case the tag is stripped. If there is only non-whitespace characters around the tag then replace the tag with a space to prevent words being joined.
1. For Java controls with Role.TAB use indexInParent and parent.childCount to find the position information.

### Testing strategy:
Manual following steps in issue #9728 and unit tests for HTML processing.
### Known issues with pull request:
None known.
### Change log entries:
New features

Changes
* NVDA now announces position information for tab controls in Java applications.

Bug fixes
* Correctly report state of Java toggle buttons.
* Correctly identify the window in a Java application with multiple windows.

For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests Not sure how to do such tests for java applications.
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
