### PR TITLE
For single column SysListViews, ignore column order array as it is not required

### DIFF
--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -217,7 +217,10 @@ class List(List):
 	def _get_rowCount(self):
 		return watchdog.cancellableSendMessage(self.windowHandle, LVM_GETITEMCOUNT, 0, 0)
 
-	def _get_columnCount(self):
+	columnCount: int
+	"""Typing information for auto-property: _get_columnCount"""
+
+	def _get_columnCount(self) -> int:
 		if not self.isMultiColumn:
 			return 0
 		headerHwnd= watchdog.cancellableSendMessage(self.windowHandle,LVM_GETHEADER,0,0)
@@ -288,14 +291,13 @@ class List(List):
 		return self._getColumnOrderArrayRawInProc(columnCount)
 
 	def _getColumn(self, column: int) -> Optional[int]:
+		if column == 1 and self.columnCount == 1:
+			# Use an implied default column mapping for single column list views
+			return 0
 		columnOrderArray = self._getColumnOrderArrayRaw(self.columnCount)
 		if columnOrderArray is None:
-			if column == 1:
-				log.debug("Using an implied default column mapping for single column list views")
-				return 0
-			else:
-				log.error("Cannot fetch column as column order array is unknown")
-				return None
+			log.error("Cannot fetch column as column order array is unknown")
+			return None
 		return columnOrderArray[column - 1]
 
 

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -296,9 +296,12 @@ class List(List):
 		To keep a consistent internal mapping, a column order array is used
 		to map a presentation index to a consistent internal index.
 		For single-column SysListViews, the mapping is not necessary.
-
-		If the column order array cannot be fetched from a multi-column SysListView ,
-		returns None as a mapped column cannot be determined.
+		If the column order array cannot be fetched from a multi-column SysListView,
+		this returns None.
+	
+		@param presentationIndex: One based index for the column as presented to the user.
+		@return: The internal / logical column zero based index for the column.
+		None if the mapped column cannot be determined.
 		"""
 		if presentationIndex == 1 and self.columnCount == 1:
 			# Use an implied default column mapping for single column list views

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -290,15 +290,24 @@ class List(List):
 			return self._getColumnOrderArrayRawOutProc(columnCount)
 		return self._getColumnOrderArrayRawInProc(columnCount)
 
-	def _getColumn(self, column: int) -> Optional[int]:
-		if column == 1 and self.columnCount == 1:
+	def _getMappedColumn(self, presentationIndex: int) -> Optional[int]:
+		"""
+		Multi-column SysListViews can have their columns re-ordered.
+		To keep a consistent internal mapping, a column order array is used
+		to map a presentation index to a consistent internal index.
+		For single-column SysListViews, the mapping is not necessary.
+
+		If the column order array cannot be fetched from a multi-column SysListView ,
+		returns None as a mapped column cannot be determined.
+		"""
+		if presentationIndex == 1 and self.columnCount == 1:
 			# Use an implied default column mapping for single column list views
 			return 0
 		columnOrderArray = self._getColumnOrderArrayRaw(self.columnCount)
 		if columnOrderArray is None:
 			log.error("Cannot fetch column as column order array is unknown")
 			return None
-		return columnOrderArray[column - 1]
+		return columnOrderArray[presentationIndex - 1]
 
 
 class GroupingItem(Window):
@@ -462,7 +471,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return RectLTRB(left, top, right, bottom).toScreen(self.windowHandle).toLTWH()
 
 	def _getColumnLocation(self, column: int) -> Optional[RectLTRB]:
-		mappedColumn = self.parent._getColumn(column)
+		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None
 		return self._getColumnLocationRaw(mappedColumn)
@@ -518,7 +527,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return self._getColumnContentRawInProc(index)
 
 	def _getColumnContent(self, column: int) -> Optional[str]:
-		mappedColumn = self.parent._getColumn(column)
+		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None
 		return self._getColumnContentRaw(mappedColumn)
@@ -538,7 +547,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return item.iImage
 
 	def _getColumnImageID(self, column):
-		mappedColumn = self.parent._getColumn(column)
+		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None
 		return self._getColumnImageIDRaw(mappedColumn)
@@ -592,7 +601,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return self._getColumnHeaderRawInProc(index)
 
 	def _getColumnHeader(self, column: int) -> Optional[str]:
-		mappedColumn = self.parent._getColumn(column)
+		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None
 		return self._getColumnHeaderRaw(mappedColumn)

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -287,10 +287,16 @@ class List(List):
 			return self._getColumnOrderArrayRawOutProc(columnCount)
 		return self._getColumnOrderArrayRawInProc(columnCount)
 
-	_columnOrderArray: Optional[ctypes.Array]
-
-	def _get__columnOrderArray(self) -> Optional[ctypes.Array]:
-		return self._getColumnOrderArrayRaw(self.columnCount)
+	def _getColumn(self, column: int) -> Optional[int]:
+		columnOrderArray = self._getColumnOrderArrayRaw(self.columnCount)
+		if columnOrderArray is None:
+			if column == 1:
+				log.debug("Using an implied default column mapping for single column list views")
+				return 0
+			else:
+				log.error("Cannot fetch column as column order array is unknown")
+				return None
+		return columnOrderArray[column - 1]
 
 
 class GroupingItem(Window):
@@ -454,10 +460,10 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return RectLTRB(left, top, right, bottom).toScreen(self.windowHandle).toLTWH()
 
 	def _getColumnLocation(self, column: int) -> Optional[RectLTRB]:
-		if self.parent._columnOrderArray is None:
-			log.debugWarning("Cannot fetch column location as column order array is unknown")
+		mappedColumn = self.parent._getColumn(column)
+		if mappedColumn is None:
 			return None
-		return self._getColumnLocationRaw(self.parent._columnOrderArray[column - 1])
+		return self._getColumnLocationRaw(mappedColumn)
 
 	def _getColumnContentRawInProc(self, index: int) -> Optional[str]:
 		"""Retrieves text for a given column.
@@ -510,10 +516,10 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return self._getColumnContentRawInProc(index)
 
 	def _getColumnContent(self, column: int) -> Optional[str]:
-		if self.parent._columnOrderArray is None:
-			log.debugWarning("Cannot fetch column content as column order array is unknown")
+		mappedColumn = self.parent._getColumn(column)
+		if mappedColumn is None:
 			return None
-		return self._getColumnContentRaw(self.parent._columnOrderArray[column - 1])
+		return self._getColumnContentRaw(mappedColumn)
 
 	def _getColumnImageIDRaw(self, index):
 		processHandle=self.processHandle
@@ -530,10 +536,10 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return item.iImage
 
 	def _getColumnImageID(self, column):
-		if self.parent._columnOrderArray is None:
-			log.debugWarning("Cannot fetch column image ID as column order array is unknown")
+		mappedColumn = self.parent._getColumn(column)
+		if mappedColumn is None:
 			return None
-		return self._getColumnImageIDRaw(self.parent._columnOrderArray[column - 1])
+		return self._getColumnImageIDRaw(mappedColumn)
 
 	def _getColumnHeaderRawOutProc(self, index: int) -> Optional[str]:
 		"""Retrieves text of the header for the given column.
@@ -584,10 +590,10 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 		return self._getColumnHeaderRawInProc(index)
 
 	def _getColumnHeader(self, column: int) -> Optional[str]:
-		if self.parent._columnOrderArray is None:
-			log.debugWarning("Cannot fetch column header as column order array is unknown")
+		mappedColumn = self.parent._getColumn(column)
+		if mappedColumn is None:
 			return None
-		return self._getColumnHeaderRaw(self.parent._columnOrderArray[column - 1])
+		return self._getColumnHeaderRaw(mappedColumn)
 
 	def _get_name(self):
 		parent = self.parent

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -298,7 +298,7 @@ class List(List):
 		For single-column SysListViews, the mapping is not necessary.
 		If the column order array cannot be fetched from a multi-column SysListView,
 		this returns None.
-	
+
 		@param presentationIndex: One based index for the column as presented to the user.
 		@return: The internal / logical column zero based index for the column.
 		None if the mapped column cannot be determined.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -60,6 +60,7 @@ What's New in NVDA
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 - NVDA will announce status bar content in Windows 11 Notepad. (#13386)
 - Navigator object highlighting now shows up immediately upon activation of the feature. (#13641)
+- Fix reading single column list view items. (#13659, #13735)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13659, #13735 

### Summary of the issue:

Certain applications don't provide a column order array. For the case of single column list views, a column order array is unnecessary, as a default mapping can be assumed.

### Description of how this pull request fixes the issue:

For single column list views, map the first column in the UX, to the first column index: i.e. `[0]` is the column order array. When fetching from a multi column list view, log an error if the column order array is unknown.

### Testing strategy:

Manual testing
- [x] Test reading start menu items with StartAllBack/StartIsBack (STR in #13659)
- [x] Test STR in #13735 (thanks @cary-rowen)

### Known issues with pull request:
None

### Change log entries:
Bug fixes:
```t2t
- Fix reading single column list view items. (#13659, #13735)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
