### PR TITLE
Update liblouis to 3.22.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 7e5457f91e10
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
-* [liblouis](http://www.liblouis.org/), version 3.21.0
+* [liblouis](http://www.liblouis.org/), version 3.22.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 41.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -188,6 +188,9 @@ addTable("de-g1-detailed.ctb", _("German grade 1 (detailed)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("de-g2.ctb", _("German grade 2"), contracted=True, input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("de-g2-detailed.ctb", _("German grade 2 (detailed)"), contracted=True, input=False)
 
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,9 @@ What's New in NVDA
 == Changes ==
 - NSIS has been updated to version 3.08. (#9134)
 - CLDR has been updated to version 41.0. (#13582)
+- Updated liblouis braille translator to [3.22.0 https://github.com/liblouis/liblouis/releases/tag/v3.22.0]. (#13775)
+  - New braille table: German grade 2 (detailed)
+  -
 - Added new role for "busy indicator" controls. (#10644)
 - NVDA now announces when an NVDA action cannot be performed. (#13500)
   - This includes when:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Liblouis 3.22.0 has been released.

### Description of how this pull request fixes the issue:
Updates liblouis to 3.22.0. [Changelog](https://github.com/liblouis/liblouis/releases/tag/v3.22.0).

### Testing strategy:
Ran from sources and loaded the new braille table. Works as it should.

### Known issues with pull request:
None

### Change log entries:
Section: Changes

```
- Updated liblouis braille translator to [3.22.0 https://github.com/liblouis/liblouis/releases/tag/v3.22.0]. (#13775)
  - New braille table: German grade 2 (detailed)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
