### PR TITLE
Drop unsupported language switching commands for OneCore

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -331,15 +331,6 @@ class SpeechManager(object):
 
 		outSeq = []
 		for command in inSeq:
-			if isinstance(command, LangChangeCommand) and currentSynth.name == 'oneCore':
-				langCode = command.lang.split('_')[0]
-				langSupported = False
-				currentSynthLanguages = currentSynth.availableLanguages
-				for lang in currentSynthLanguages:
-					if lang and normalizeLanguage(lang).split('_')[0] == langCode:
-						langSupported = True
-				if not langSupported:
-					log.warning(f"Language {command.lang} not supported by {currentSynth.name} ({currentSynthLanguages})")
 			if isinstance(command, BaseCallbackCommand):
 				# When the synth reaches this point, we want to call the callback.
 				speechIndex = next(self._indexCounter)

--- a/source/speechXml.py
+++ b/source/speechXml.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2021 NV Access Limited
+# Copyright (C) 2016-2022 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -14,7 +14,7 @@ from collections import namedtuple, OrderedDict
 import re
 import speech
 import textUtils
-from speech.commands import SpeechCommand
+from speech.commands import LangChangeCommand, SpeechCommand
 from logHandler import log
 
 XML_ESCAPES = {
@@ -49,7 +49,8 @@ def _buildInvalidXmlRegexp():
 RE_INVALID_XML_CHARS = _buildInvalidXmlRegexp()
 REPLACEMENT_CHAR = textUtils.REPLACEMENT_CHAR
 
-def toXmlLang(nvdaLang):
+
+def toXmlLang(nvdaLang: str) -> str:
 	"""Convert an NVDA language to an XML language.
 	"""
 	return nvdaLang.replace("_", "-")
@@ -153,7 +154,7 @@ class XmlBalancer(object):
 			self._openTags.append(tag)
 		self._tagsChanged = False
 
-	def generateXml(self, commands):
+	def generateXml(self, commands) -> str:
 		"""Generate XML from a sequence of balancer commands and text.
 		"""
 		for command in commands:
@@ -235,7 +236,7 @@ class SsmlConverter(SpeechXmlConverter):
 	"""Converts an NVDA speech sequence to SSML.
 	"""
 
-	def __init__(self, defaultLanguage):
+	def __init__(self, defaultLanguage: str):
 		self.defaultLanguage = toXmlLang(defaultLanguage)
 
 	def generateBalancerCommands(self, speechSequence):
@@ -254,7 +255,7 @@ class SsmlConverter(SpeechXmlConverter):
 		else:
 			return StopEnclosingTextCommand()
 
-	def convertLangChangeCommand(self, command):
+	def convertLangChangeCommand(self, command: LangChangeCommand) -> SetAttrCommand:
 		lang = command.lang or self.defaultLanguage
 		lang = toXmlLang(lang)
 		return SetAttrCommand("voice", "xml:lang", lang)

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -54,7 +54,9 @@ class _OcSsmlConverter(speechXml.SsmlConverter):
 			availableLanguages: Set[str],
 	):
 		self.lowerCaseAvailableLanguages = {language.lower() for language in availableLanguages}
-		self.availableLanguagesWithoutLocale = {language.split("_")[0] for language in self.lowerCaseAvailableLanguages}
+		self.availableLanguagesWithoutLocale = {
+			language.split("_")[0] for language in self.lowerCaseAvailableLanguages
+		}
 		super().__init__(defaultLanguage)
 
 	def _convertProsody(self, command, attr, default, base=None):
@@ -488,18 +490,22 @@ class OneCoreSynthDriver(SynthDriver):
 		@returns: True if the voice is valid, False otherwise.
 
 		OneCore keeps specific registry caches of OneCore for AT applications.
-		NVDA's OneCore cache is: `HKEY_CURRENT_USER\Software\Microsoft\Speech_OneCore\Isolated\Ny37kw9G-o42UiJ1z6Qc_sszEKkCNywTlrTOG0QKVB4`.
-		The caches contain a subtree which is meant to mirror the path `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\*`.
+		NVDA's OneCore cache is:
+		`HKEY_CURRENT_USER\Software\Microsoft\Speech_OneCore\Isolated\Ny37kw9G-o42UiJ1z6Qc_sszEKkCNywTlrTOG0QKVB4`.
+		The caches contain a subtree which is meant to mirror the path
+		`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\*`.
 
 		For example
 		`HKEY_CURRENT_USER\Software\Microsoft\Speech_OneCore\Isolated\Ny37kw9G-o42UiJ1z6Qc_sszEKkCNywTlrTOG0QKVB4\
 		HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\Voices\Tokens\MSTTS_V110_enUS_MarkM`
 		refers to `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\Voices\Tokens\MSTTS_V110_enUS_MarkM`.
 
-		Languages which have been used by an installed copy of NVDA, but uninstalled from the system are kept in the cache.
+		Languages which have been used by an installed copy of NVDA,
+		but uninstalled from the system are kept in the cache.
 		OneCore will still attempt to use these languages, so we must check if they are valid first.
 
-		Refer to https://github.com/nvaccess/nvda/issues/13732#issuecomment-1149386711 for more information.
+		For more information, refer to:
+		https://github.com/nvaccess/nvda/issues/13732#issuecomment-1149386711
 		"""
 		IDParts = ID.split('\\')
 		rootKey = getattr(winreg, IDParts[0])

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -469,7 +469,7 @@ class OneCoreSynthDriver(SynthDriver):
 
 	def _getAvailableVoices(self):
 		voices = OrderedDict()
-		# Fetch the full list of voices that Onecore speech knows about.
+		# Fetch the full list of voices that OneCore speech knows about.
 		# Note that it may give back voices that are uninstalled or broken.
 		# Refer to _isVoiceValid for information on uninstalled or broken voices.
 		voicesStr = self._dll.ocSpeech_getVoices(self._ocSpeechToken).split('|')
@@ -490,19 +490,22 @@ class OneCoreSynthDriver(SynthDriver):
 		@returns: True if the voice is valid, False otherwise.
 
 		OneCore keeps specific registry caches of OneCore for AT applications.
-		NVDA's OneCore cache is:
+		Installed copies of NVDA have a OneCore cache in:
 		`HKEY_CURRENT_USER\Software\Microsoft\Speech_OneCore\Isolated\Ny37kw9G-o42UiJ1z6Qc_sszEKkCNywTlrTOG0QKVB4`.
-		The caches contain a subtree which is meant to mirror the path
+		The caches contain a subtree which is meant to mirror the path:
 		`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\*`.
 
-		For example
+		For example:
 		`HKEY_CURRENT_USER\Software\Microsoft\Speech_OneCore\Isolated\Ny37kw9G-o42UiJ1z6Qc_sszEKkCNywTlrTOG0QKVB4\
 		HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\Voices\Tokens\MSTTS_V110_enUS_MarkM`
 		refers to `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\Voices\Tokens\MSTTS_V110_enUS_MarkM`.
 
 		Languages which have been used by an installed copy of NVDA,
 		but uninstalled from the system are kept in the cache.
-		OneCore will still attempt to use these languages, so we must check if they are valid first.
+		For installed copies of NVDA, OneCore will still attempt to use these languages,
+		so we must check if they are valid first.
+		For portable copies, the cache is bypassed and `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech_OneCore\`
+		is read directly.
 
 		For more information, refer to:
 		https://github.com/nvaccess/nvda/issues/13732#issuecomment-1149386711

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -54,6 +54,7 @@ class _OcSsmlConverter(speechXml.SsmlConverter):
 			availableLanguages: Set[str],
 	):
 		self.lowerCaseAvailableLanguages = {language.lower() for language in availableLanguages}
+		self.availableLanguagesWithoutLocale = {language.split("_")[0] for language in self.lowerCaseAvailableLanguages}
 		super().__init__(defaultLanguage)
 
 	def _convertProsody(self, command, attr, default, base=None):
@@ -88,8 +89,13 @@ class _OcSsmlConverter(speechXml.SsmlConverter):
 			log.debugWarning(f"Invalid language: {command.lang}")
 			return None
 
-		if command.lang.lower().replace("-", "_") not in self.lowerCaseAvailableLanguages:
-			log.warning(f"Language {command.lang} not supported ({self.availableLanguages})")
+		normalizedLanguage = command.lang.lower().replace("-", "_")
+		normalizedLanguageWithoutLocale = normalizedLanguage.split("_")[0]
+		if (
+			normalizedLanguage not in self.lowerCaseAvailableLanguages
+			and normalizedLanguageWithoutLocale not in self.availableLanguagesWithoutLocale
+		):
+			log.warning(f"Language {command.lang} not supported ({self.lowerCaseAvailableLanguages})")
 			return None
 
 		return super().convertLangChangeCommand(command)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -60,6 +60,7 @@ What's New in NVDA
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 - NVDA will announce status bar content in Windows 11 Notepad. (#13386)
 - Navigator object highlighting now shows up immediately upon activation of the feature. (#13641)
+- Fix automatic language switching failing with OneCore when trying to switch to a formerly installed language. (#13732)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13732 

### Summary of the issue:
OneCore keeps a cache of voices for NVDA in the registry.
OneCore fails to automatic language switch when remnants of a previously installed OneCore language exist in the cache.
This causes speech to not be announced.

This is only an issue for installed copies, as portable copies bypass the NVDA OneCore cache.

### Description of how this pull request fixes the issue:
Drop the language change command if a given language is unsupported by OneCore.

### Testing strategy:

#### Manual testing

Using the following HTML sample, test language switching. 
Replace the language code "zh" as appropriate.

`data:text/html,<p>Hello</p><p lang="zh">world</p>`.

Using installed oneCore languages `'en_au', 'fr_fr', 'en_us', 'zh_hk'`

Automatic language switching is successful for the following language codes:
- "en" (to en_US)
- "en_AU"
- "en-AU"
- "en-au"
- "en_AU"
- "fr-fr"
- "fr" (to fr_FR)
- "zh" (to zh_hk)
- "zh_hk"

Automatic language switching reverts to the default voice for the following language codes:
- "FakeLang_fakeLocale" (illegitimate language)
- "en-CA" (unsupported locale)
- "ta" (unsupported language)

### Known issues with pull request:
None

### Change log entries:
Bug fixes
```t2t
- Fix automatic language switching failing with OneCore when trying to switch to a formerly installed language. (#13732)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
