### PR TITLE
Start 2022.3 dev cycle

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -66,7 +66,7 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2022
-version_major = 2
+version_major = 3
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,29 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.3 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+
+
+=== Deprecations ===
+These are proposed API breaking changes.
+The deprecated part of the API will continue to be available until the specified release.
+If no release is specified, the plan for removal has not been determined.
+Note, the roadmap for removals is 'best effort' and may be subject to change.
+Please test the new API and provide feedback.
+For add-on authors, please open a GitHub issue if these changes stop the API from meeting your needs.
+
+
 = 2022.2 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for the 2022.3 release.
This won't be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`

On merge:
- [x] Update auto milestone ID