### PR TITLE
Change input help documentation for move to first/last row scripts of fake table navigation in list views

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -601,6 +601,12 @@ class RowWithFakeNavigation(NVDAObject):
 		cell = self.getChild(child)
 		self._moveToColumn(cell)
 
+	@script(
+		# Translators: The description of an NVDA command.
+		description=_("Moves the navigator object to the next column"),
+		gesture="kb:control+alt+rightArrow",
+		canPropagate=True,
+	)
 	def script_moveToNextColumn(self, gesture):
 		cur = api.getNavigatorObject()
 		if cur == self:
@@ -613,10 +619,13 @@ class RowWithFakeNavigation(NVDAObject):
 		while new and new.location and new.location.width == 0:
 			new = new.next
 		self._moveToColumn(new)
-	script_moveToNextColumn.canPropagate = True
-	# Translators: The description of an NVDA command.
-	script_moveToNextColumn.__doc__ = _("Moves the navigator object to the next column")
 
+	@script(
+		# Translators: The description of an NVDA command.
+		description=_("Moves the navigator object to the previous column"),
+		gesture="kb:control+alt+leftArrow",
+		canPropagate=True,
+	)
 	def script_moveToPreviousColumn(self, gesture):
 		cur = api.getNavigatorObject()
 		if cur == self:
@@ -628,9 +637,6 @@ class RowWithFakeNavigation(NVDAObject):
 			while new and new.location and new.location.width == 0:
 				new = new.previous
 		self._moveToColumn(new)
-	script_moveToPreviousColumn.canPropagate = True
-	# Translators: The description of an NVDA command.
-	script_moveToPreviousColumn.__doc__ = _("Moves the navigator object to the previous column")
 
 	def reportFocus(self):
 		col = self._savedColumnNumber
@@ -647,17 +653,23 @@ class RowWithFakeNavigation(NVDAObject):
 			self.__class__._savedColumnNumber = nav.columnNumber
 		row.setFocus()
 
+	@script(
+		# Translators: The description of an NVDA command.
+		description=_("Moves the navigator object and focus to the next row"),
+		gesture="kb:control+alt+downArrow",
+		canPropagate=True,
+	)
 	def script_moveToNextRow(self, gesture):
 		self._moveToRow(self.next)
-	script_moveToNextRow.canPropagate = True
-	# Translators: The description of an NVDA command.
-	script_moveToNextRow.__doc__ = _("Moves the navigator object and focus to the next row")
 
+	@script(
+		# Translators: The description of an NVDA command.
+		description=_("Moves the navigator object and focus to the previous row"),
+		gesture="kb:control+alt+upArrow",
+		canPropagate=True,
+	)
 	def script_moveToPreviousRow(self, gesture):
 		self._moveToRow(self.previous)
-	script_moveToPreviousRow.canPropagate = True
-	# Translators: The description of an NVDA command.
-	script_moveToPreviousRow.__doc__ = _("Moves the navigator object and focus to the previous row")
 
 	@script(
 		description=_(
@@ -693,7 +705,7 @@ class RowWithFakeNavigation(NVDAObject):
 	@script(
 		description=_(
 			# Translators: The description of an NVDA command.
-			"Moves the navigator object to the first row"
+			"Moves the navigator object and focus to the first row"
 		),
 		gesture="kb:Control+Alt+PageUp",
 		canPropagate=True,
@@ -704,7 +716,7 @@ class RowWithFakeNavigation(NVDAObject):
 	@script(
 		description=_(
 			# Translators: The description of an NVDA command.
-			"Moves the navigator object to the last row"
+			"Moves the navigator object and focus to the last row"
 		),
 		gesture="kb:Control+Alt+PageDown",
 		canPropagate=True,
@@ -712,12 +724,6 @@ class RowWithFakeNavigation(NVDAObject):
 	def script_moveToLastRow(self, gesture):
 		self._moveToRow(self.parent.lastChild)
 
-	__gestures = {
-		"kb:control+alt+rightArrow": "moveToNextColumn",
-		"kb:control+alt+leftArrow": "moveToPreviousColumn",
-		"kb:control+alt+downArrow": "moveToNextRow",
-		"kb:control+alt+upArrow": "moveToPreviousRow",
-	}
 
 class RowWithoutCellObjects(NVDAObject):
 	"""An abstract class which creates cell objects for table rows which don't natively expose them.


### PR DESCRIPTION
Issue found while translating NVDA.
### Link to issue number:
Follow-up of #13435.
### Summary of the issue:

In fake table navigation in list views, horizontal movements only move the navigator object, whereas vertical movements move the navigator object but also the focus. This was not reflected in input help for the newly introduced commands to jump to first/last row.

### Description of how this pull request fixes the issue:
* Updated the two scripts documentation.
* While at it, I have also converted remaining fake table navigation scripts to syntax with decorator.

### Testing strategy:
Manual tests:
* Checked input help
* Checked that all fake table navigation still work in the detailed view of processes in the task manager.

### Known issues with pull request:
None
### Change log entries:
Not needed (fix in dev stage).

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
