### PR TITLE
Word with UIA: Fix case where comment contents don't read

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -102,7 +102,14 @@ def getCommentInfoFromPosition(position):
 		typeID = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAnnotationTypeIdPropertyId)
 		# Use Annotation Type Comment if available
 		if typeID == UIAHandler.AnnotationType_Comment:
-			comment = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_NamePropertyId)
+			# Newer versions of Word present the comment text in the FullDescription property
+			try:
+				comment = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA.UIA_FullDescriptionPropertyId)
+			except COMError:
+				comment = None
+			if not comment:
+				# Fall back to the name of the UIAElement
+				comment = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA.UIA_NamePropertyId)
 			author = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationAuthorPropertyId)
 			date = UIAElement.GetCurrentPropertyValue(UIAHandler.UIA_AnnotationDateTimePropertyId)
 			return dict(comment=comment, author=author, date=date)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When playing with comments in Word 16.0.15225.20204 lately, I discovered that NVDA was unable to show the comment contents in the elements list or when pressing NVDA+Alt+C

### Description of how this pull request fixes the issue:
Somehow, Microsoft decided to describe the comment thread in the name property and moved the contents of the comment to the Full Description property.

### Testing strategy:
Created a new document, added a comment. Checked in both the elements list and when pressing alt+NVDA+C that the comment read correctly.

### Known issues with pull request:
I'm not sure whether my assumption is correct that Microsoft really changed something here, but given this seems to have worked before, I guess that this is the case. Therefore I built a workaround that should fallback to the name of the comment UIAElement if the FullDescription is empty, however I'm unable to test this for older versions of Word. it would really help if Microsoft would clarify things here.

### Change log entries:
Bug fixes
- NVDA is no longer unable to read the contents of a comment in newer versions of MS Word when UIA is used.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
