### PR TITLE
Change directory to package symbols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,11 @@ build_script:
  - scons source %sconsArgs%
  - scons %sconsOutTargets% %sconsArgs%
  - ps: appveyor\scripts\buildSymbolStore.ps1
- - 7z a -tzip -r output\symbols.zip symbols\*.dl_ symbols\*.ex_ symbols\*.pd_
+ # The server expects the symbols archive to be structured as ./*.ex_ not ./symbols/*.ex_.
+ # Change directory to package, as 7z will structure the archive using the relative path.
+ - cd symbols
+ - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
+ - cd ..
 
 before_test:
  - ps: appveyor\scripts\tests\beforeTests.ps1


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Follow up of #12540 

### Summary of the issue:

The server expects the symbols archive to be structured as `./*.ex_` not `./symbols/*.ex_`.
Due to changes in #12540, the symbols archive has been restructured to `./symbols/*.ex_`.
This is because 7zip structures the archive based on relative paths.

### Description of how this pull request fixes the issue:

Reverts the 7zip symbol build to the old behaviour

### Testing strategy:

Compare the output of this build's symbols.zip to the latest alpha

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
