### PR TITLE
Extend the life of deprecated aliases

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -89,7 +89,7 @@ def __getattr__(attrName: str) -> Any:
 	since add-ons are initialized before `appModuleHandler`
 	and when `appModuleHandler` was not yet initialized the variable was set to `None`.
 	"""
-	if attrName == "NVDAProcessID":
+	if attrName == "NVDAProcessID" and globalVars._useDeprecatedAPI:
 		log.warning("appModuleHandler.NVDAProcessID is deprecated, use globalVars.appPid instead.")
 		if initialize._alreadyInitialized:
 			return globalVars.appPid
@@ -112,12 +112,14 @@ def _warnDeprecatedAliasAppModule() -> None:
 	except KeyError:
 		raise RuntimeError("This function can be executed only inside an alias App Module.") from None
 	else:
-		log.warning(
-			(
-				f"Importing from appModules.{currModName} is deprecated,"
-				f" you should import from appModules.{replacementModName}."
-			)
+		importFailMsg = (
+			f"Importing appModules.{currModName} is deprecated,"
+			f" instead, import appModules.{replacementModName}."
 		)
+		if globalVars._useDeprecatedAPI:
+			log.warning(importFailMsg)
+		else:
+			raise ImportError(importFailMsg)
 
 
 def registerExecutableWithAppModule(executableName: str, appModName: str) -> None:

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -114,12 +114,12 @@ def _warnDeprecatedAliasAppModule() -> None:
 	else:
 		importFailMsg = (
 			f"Importing appModules.{currModName} is deprecated,"
-			f" instead, import appModules.{replacementModName}."
+			f" instead import appModules.{replacementModName}."
 		)
 		if globalVars._useDeprecatedAPI:
 			log.warning(importFailMsg)
 		else:
-			raise ImportError(importFailMsg)
+			raise ModuleNotFoundError(importFailMsg)
 
 
 def registerExecutableWithAppModule(executableName: str, appModName: str) -> None:

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -89,7 +89,7 @@ def __getattr__(attrName: str) -> Any:
 	since add-ons are initialized before `appModuleHandler`
 	and when `appModuleHandler` was not yet initialized the variable was set to `None`.
 	"""
-	if attrName == "NVDAProcessID" and globalVars._useDeprecatedAPI:
+	if attrName == "NVDAProcessID" and globalVars._allowDeprecatedAPI:
 		log.warning("appModuleHandler.NVDAProcessID is deprecated, use globalVars.appPid instead.")
 		if initialize._alreadyInitialized:
 			return globalVars.appPid
@@ -112,14 +112,13 @@ def _warnDeprecatedAliasAppModule() -> None:
 	except KeyError:
 		raise RuntimeError("This function can be executed only inside an alias App Module.") from None
 	else:
-		importFailMsg = (
+		deprecatedImportWarning = (
 			f"Importing appModules.{currModName} is deprecated,"
 			f" instead import appModules.{replacementModName}."
 		)
-		if globalVars._useDeprecatedAPI:
-			log.warning(importFailMsg)
-		else:
-			raise ModuleNotFoundError(importFailMsg)
+		log.warning(deprecatedImportWarning)
+		if not globalVars._allowDeprecatedAPI:
+			raise ModuleNotFoundError(deprecatedImportWarning)
 
 
 def registerExecutableWithAppModule(executableName: str, appModName: str) -> None:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -10,8 +10,6 @@ In addition, this module provides three actions: profile switch notifier, an act
 For the latter two actions, one can perform actions prior to and/or after they take place.
 """
 
-
-from buildVersion import version_year
 from enum import Enum
 import globalVars
 import winreg
@@ -88,17 +86,15 @@ class RegistryKey(str, Enum):
 	"""
 
 
-if version_year < 2023:
+if globalVars._useDeprecatedAPI:
 	RUN_REGKEY = RegistryKey.RUN.value
 	"""
-	Deprecated, for removal in 2023.
-	Use L{RegistryKey.RUN} instead.
+	Deprecated, use L{RegistryKey.RUN} instead.
 	"""
 
 	NVDA_REGKEY = RegistryKey.NVDA.value
 	"""
-	Deprecated, for removal in 2023.
-	Use L{RegistryKey.NVDA} instead.
+	Deprecated, use L{RegistryKey.NVDA} instead.
 	"""
 
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -59,6 +59,18 @@ post_configSave = extensionPoints.Action()
 pre_configReset = extensionPoints.Action()
 post_configReset = extensionPoints.Action()
 
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "NVDA_REGKEY" and globalVars._allowDeprecatedAPI:
+		log.warning("NVDA_REGKEY is deprecated, use RegistryKey.NVDA instead.")
+		return RegistryKey.NVDA.value
+	if attrName == "RUN_REGKEY" and globalVars._allowDeprecatedAPI:
+		log.warning("RUN_REGKEY is deprecated, use RegistryKey.RUN instead.")
+		return RegistryKey.RUN.value
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
+
 def initialize():
 	global conf
 	conf = ConfigManager()
@@ -83,18 +95,6 @@ class RegistryKey(str, Enum):
 	The name of the registry key stored under HKEY_LOCAL_MACHINE where system wide NVDA settings are stored.
 	Note that NVDA is a 32-bit application, so on X64 systems,
 	this will evaluate to `r"SOFTWARE\WOW6432Node\nvda"`
-	"""
-
-
-if globalVars._useDeprecatedAPI:
-	RUN_REGKEY = RegistryKey.RUN.value
-	"""
-	Deprecated, use L{RegistryKey.RUN} instead.
-	"""
-
-	NVDA_REGKEY = RegistryKey.NVDA.value
-	"""
-	Deprecated, use L{RegistryKey.NVDA} instead.
 	"""
 
 

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -7,7 +7,7 @@
 """
 
 from enum import Enum, IntEnum
-from typing import List
+from typing import Any, List
 
 import globalVars
 from logHandler import log
@@ -21,6 +21,20 @@ canConfigTerminateOnDesktopSwitch: bool = winVersion.getWinVer() >= winVersion.W
 _APP_KEY_NAME = "nvda_nvda_v1"
 
 
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "ROOT_KEY" and globalVars._allowDeprecatedAPI:
+		log.warning("ROOT_KEY is deprecated, use RegistryKey.ROOT instead.")
+		return RegistryKey.ROOT.value
+	if attrName == "APP_KEY_PATH" and globalVars._allowDeprecatedAPI:
+		log.warning("APP_KEY_PATH is deprecated, use RegistryKey.APP instead.")
+		return RegistryKey.APP.value
+	if attrName == "APP_KEY_NAME" and globalVars._allowDeprecatedAPI:
+		log.warning("APP_KEY_NAME is deprecated.")
+		return _APP_KEY_NAME
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
+
 class RegistryKey(str, Enum):
 	ROOT = r"Software\Microsoft\Windows NT\CurrentVersion\Accessibility"
 	TEMP = r"Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp"
@@ -31,21 +45,6 @@ class AutoStartContext(IntEnum):
 	"""Registry HKEY used for tracking when NVDA starts automatically"""
 	ON_LOGON_SCREEN = winreg.HKEY_LOCAL_MACHINE
 	AFTER_LOGON = winreg.HKEY_CURRENT_USER
-
-
-if globalVars._useDeprecatedAPI:
-	ROOT_KEY = RegistryKey.ROOT.value
-	"""
-	Deprecated, use L{RegistryKey.ROOT} instead.
-	"""
-
-	APP_KEY_NAME = _APP_KEY_NAME
-	"""Deprecated for removal"""
-
-	APP_KEY_PATH = RegistryKey.APP.value
-	"""
-	Deprecated, use L{RegistryKey.APP} instead.
-	"""
 
 
 def isRegistered() -> bool:

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -6,9 +6,10 @@
 """Utilities for working with the Windows Ease of Access Center.
 """
 
-from buildVersion import version_year
 from enum import Enum, IntEnum
 from typing import List
+
+import globalVars
 from logHandler import log
 import winreg
 import winUser
@@ -32,20 +33,18 @@ class AutoStartContext(IntEnum):
 	AFTER_LOGON = winreg.HKEY_CURRENT_USER
 
 
-if version_year < 2023:
+if globalVars._useDeprecatedAPI:
 	ROOT_KEY = RegistryKey.ROOT.value
 	"""
-	Deprecated, for removal in 2023.
-	Use L{RegistryKey.ROOT} instead.
+	Deprecated, use L{RegistryKey.ROOT} instead.
 	"""
 
 	APP_KEY_NAME = _APP_KEY_NAME
-	"""Deprecated, for removal in 2023"""
+	"""Deprecated for removal"""
 
 	APP_KEY_PATH = RegistryKey.APP.value
 	"""
-	Deprecated, for removal in 2023.
-	Use L{RegistryKey.APP} instead.
+	Deprecated, use L{RegistryKey.APP} instead.
 	"""
 
 

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -70,7 +70,7 @@ appPid: int = 0
 """The process ID of NVDA itself.
 """
 
-_useDeprecatedAPI: bool = True
+_allowDeprecatedAPI: bool = True
 """
 Used for marking code as deprecated.
 This should never be False in released code.

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -69,3 +69,15 @@ exitCode=0
 appPid: int = 0
 """The process ID of NVDA itself.
 """
+
+_useDeprecatedAPI: bool = True
+"""
+Used for marking code as deprecated.
+This should never be False in released code.
+
+Making this False may be useful for testing if code
+is compliant without using deprecated APIs.
+Note that deprecated code may be imported at runtime,
+and as such, this value cannot be changed at runtime
+to test compliance. 
+"""

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -75,9 +75,7 @@ _useDeprecatedAPI: bool = True
 Used for marking code as deprecated.
 This should never be False in released code.
 
-Making this False may be useful for testing if code
-is compliant without using deprecated APIs.
+Making this False may be useful for testing if code is compliant without using deprecated APIs.
 Note that deprecated code may be imported at runtime,
-and as such, this value cannot be changed at runtime
-to test compliance. 
+and as such, this value cannot be changed at runtime to test compliance.
 """

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -46,14 +46,12 @@ from . import logViewer
 import speechViewer
 import winUser
 import api
-from buildVersion import version_year
 
 
-if version_year < 2023:
+if globalVars._useDeprecatedAPI:
 	def quit():
 		"""
-		Deprecated, for removal in 2023.1.
-		Use `wx.CallAfter(mainFrame.onExitCommand, None)` directly instead.
+		Deprecated, use `wx.CallAfter(mainFrame.onExitCommand, None)` directly instead.
 		"""
 		log.debugWarning("Deprecated function called: gui.quit", stack_info=True)
 		wx.CallAfter(mainFrame.onExitCommand, None)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -48,7 +48,7 @@ import winUser
 import api
 
 
-if globalVars._useDeprecatedAPI:
+if globalVars._allowDeprecatedAPI:
 	def quit():
 		"""
 		Deprecated, use `wx.CallAfter(mainFrame.onExitCommand, None)` directly instead.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -85,12 +85,11 @@ Please test the new API and provide feedback.
 For add-on authors, please open a GitHub issue if these changes stop the API from meeting your needs.
 
 
-- ``appModuleHandler.NVDAProcessID`` is deprecated - use ``globalVars.appPid`` instead. (#13646)
-- ``gui.quit`` has been deprecated for removal in 2023.1. (#13498)
-  - Use ``wx.CallAfter(mainFrame.onExitCommand, None)`` directly instead.
+- ``appModuleHandler.NVDAProcessID`` is deprecated, use ``globalVars.appPid`` instead. (#13646)
+- ``gui.quit`` is deprecated, use ``wx.CallAfter(mainFrame.onExitCommand, None)`` instead. (#13498)
   -
 % Insert new list items here as the alias appModule table should be kept at the bottom of this list
-- Some alias appModules are marked as deprecated and will be removed in 2023.1.
+- Some alias appModules are marked as deprecated.
 Code which imports from one of them, should instead import from the replacement module.  (#13366)
 -
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
For deprecated aliases, there is no need to remove them, as they have a minimum maintenance burden.
Add-on authors and contributors have requested we keep aliases where possible.

However, without marking code for removal, it can be hard to find deprecations.
Core contributors and add-on authors may want to avoid deprecated APIs.
As such, a way to test the deprecated API being removed is needed.

### Description of how this pull request fixes the issue:

Extends the life of all currently deprecated aliases.
Warnings will be logged when attempting to use deprecated aliases (except for controlTypes, due to the noise of this).
Adds a global variable to mark code as deprecated, which allows developers to test NVDA with deprecated APIs removed.

As a result, there is currently no API breakages staged for 2023.1

### Testing strategy:

Manual testing:

**Test Steps 1:**
1. Run NVDA and open the Python console.
1.  Try importing deprecated aliases, ensure they are imported successfully but a warning is logged:
     - `import appModules.calculatorapp`
     - `from gui import quit; quit()` (calling quit should trigger the log warning)
     - `from appModuleHandler import NVDAProcessID`
     - `from easeOfAccess import ROOT_KEY`

**Test Steps 2:**
1. From NVDA source, change `globalVars._allowDeprecatedAPI = False`
1. Run NVDA from source and open the Python console.
1.  Try importing deprecated aliases, ensure they all raise a `ModuleNotFoundError`/`ImportError`:
     - `import appModules.calculatorapp`
     - `from gui import quit`
     - `from appModuleHandler import NVDAProcessID`
     - `from easeOfAccess import ROOT_KEY`
   
### Known issues with pull request:
None

### Change log entries:
Included in PR

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
