### PR TITLE
Review Changes and Release Blurb for 2022.2

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -197,7 +197,7 @@ After this point, discussion is again more general.
 ++ Basics of an App Module ++
 App Module files have a .py extension, and in most cases should be named the same as either the main executable of the application for which you wish them to be used or the package inside a host executable.
 For example, an App Module for notepad would be called notepad.py, as notepad's main executable is called notepad.exe.
-If you want to use a single App Module for multiple executables, or the name of the executable conflicts with the standard Python import rules read [Associating App Modules with an executable #AssociatingAppModule].
+To map a single App Module for multiple executables, or handle when an executable name violates the Python import rules, refer to [Associating App Modules with an executable #AssociatingAppModule].
 For apps hosted inside host executables, see the section on app modules for hosted apps.
 
 App Module files must be placed in the appModules subdirectory of an add-on, or of the scratchpad directory of the NVDA user configuration directory.
@@ -212,7 +212,7 @@ The App Module is unloaded once the application is closed or when NVDA is exitin
 ++ Associating App Modules with an executable ++[AssociatingAppModule]
 As explained above, sometimes the default way of associating an App Module with an application is not flexible enough. Examples include:
 - You want to use a single App Module for various binaries (perhaps both stable and preview versions of the application should have the same accessibility enhancements)
-- The executable file is named in a way which conflicts with the Python naming rules. I.e. for an application named "time", naming the App Module "time.py" would conflict with the built-in module from the standard library
+- The executable file is named in a way which conflicts with the Python naming rules. i.e. for an application named "time", naming the App Module "time.py" would conflict with the built-in module from the standard library
 -
 
 In such cases you can distribute a small global plugin along with your App Module which maps it to the executable.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,11 +5,11 @@ What's New in NVDA
 
 = 2022.2 =
 This release includes many bug fixes.
-Notably, there are siginifcant improvements for Java based applications, braille displays and Windows features.
+Notably, there are significant improvements for Java based applications, braille displays and Windows features.
 
 New table navigation commands have been introduced.
 Unicode CLDR has been updated.
-Liblouis has been updated, which includes a new German braille table.
+LibLouis has been updated, which includes a new German braille table.
 
 == New Features ==
 - Support for interacting with Microsoft Loop Components in Microsoft Office products. (#13617)
@@ -23,7 +23,7 @@ Liblouis has been updated, which includes a new German braille table.
 == Changes ==
 - NSIS has been updated to version 3.08. (#9134)
 - CLDR has been updated to version 41.0. (#13582)
-- Updated liblouis braille translator to [3.22.0 https://github.com/liblouis/liblouis/releases/tag/v3.22.0]. (#13775)
+- Updated LibLouis braille translator to [3.22.0 https://github.com/liblouis/liblouis/releases/tag/v3.22.0]. (#13775)
   - New braille table: German grade 2 (detailed)
   -
 - Added new role for "busy indicator" controls. (#10644)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,12 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2022.2 =
+This release includes many bug fixes.
+Notably, there are siginifcant improvements for Java based applications, braille displays and Windows features.
+
+New table navigation commands have been introduced.
+Unicode CLDR has been updated.
+Liblouis has been updated, which includes a new German braille table.
 
 == New Features ==
 - Support for interacting with Microsoft Loop Components in Microsoft Office products. (#13617)
@@ -44,7 +50,8 @@ What's New in NVDA
   -
 - Braille fixes:
   - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
-  - When braille is tethered automatically and the mouse is moved with mouse tracking enabled, text review commands now update the braille display with the spoken content. (#11519)
+  - When braille is tethered automatically and the mouse is moved with mouse tracking enabled
+   text review commands now update the braille display with the spoken content. (#11519)
   - It is now possible to pan the braille display through content after use of the text review commands. (#8682)
   -
 - The NVDA installer can now run from directories with special characters. (#13270)
@@ -58,8 +65,10 @@ What's New in NVDA
   -
 - Visual Studio now correctly reports line indentation. (#13574)
 - NVDA will once again announce Start menu search result details in recent Windows 10 and 11 releases. (#13544)
-- In Windows 10 and 11 Calculator version 10.1908 and later, NVDA will announce results when more commands are pressed, such as commands from scientific mode. (#13386)
-- In Windows 11, it is again possible to navigate and interact with user interface elements such as Taskbar and Task View using mouse and touch interaction. (#13508)
+- In Windows 10 and 11 Calculator version 10.1908 and later,
+NVDA will announce results when more commands are pressed, such as commands from scientific mode. (#13386)
+- In Windows 11, it is again possible to navigate and interact with user interface elements,
+such as Taskbar and Task View using mouse and touch interaction. (#13508)
 - Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 - NVDA will announce status bar content in Windows 11 Notepad. (#13386)
 - Navigator object highlighting now shows up immediately upon activation of the feature. (#13641)
@@ -70,8 +79,10 @@ What's New in NVDA
 
 
 == Changes for Developers ==
-- Compiling NVDA dependencies with Visual Studio 2022 (17.0) is now supported. For development and release builds, Visual Studio 2019 is still used. (#13033)
-- When retrieving the count of selected children via accSelection, the case where a negative child ID or an IDispatch is returned by IAccessible::get_accSelection is now handled properly. (#13276)
+- Compiling NVDA dependencies with Visual Studio 2022 (17.0) is now supported.
+For development and release builds, Visual Studio 2019 is still used. (#13033)
+- When retrieving the count of selected children via accSelection,
+the case where a negative child ID or an IDispatch is returned by ``IAccessible::get_accSelection`` is now handled properly. (#13276)
 - New convenience functions ``registerExecutableWithAppModule`` and ``unregisterExecutable`` were added to the ``appModuleHandler`` module.
 They can be used to use a single App Module with multiple executables. (#13366)
 -

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,7 +50,7 @@ Liblouis has been updated, which includes a new German braille table.
   -
 - Braille fixes:
   - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
-  - When braille is tethered automatically and the mouse is moved with mouse tracking enabled
+  - When braille is tethered automatically and the mouse is moved with mouse tracking enabled,
    text review commands now update the braille display with the spoken content. (#11519)
   - It is now possible to pan the braille display through content after use of the text review commands. (#8682)
   -


### PR DESCRIPTION
- Changes file: [*.t2t](https://github.com/nvaccess/nvda/blob/changeLogFor2022.2/user_docs/en/changes.t2t)
- User guide file: [*.t2t](https://github.com/nvaccess/nvda/blob/changeLogFor2022.2/user_docs/en/userGuide.t2t)
   - Many changes, notably to secure mode and secure screens documentation.
- Developer guide file: [*.t2t](https://github.com/nvaccess/nvda/blob/changeLogFor2022.2/devDocs/developerGuide.t2t)
    - Changes to 3.3, 3.4
- HTML docs: [docs (2).zip](https://github.com/nvaccess/nvda/files/8896215/docs.2.zip)
- Diff command: `git diff --stat release-2022.1...changeLogFor2022.2 -- "**/en/*.t2t" "**/developerGuide.t2t"`


Review checklist:
- [x] Release blurb reads well and is an accurate summary
     >This release includes many bug fixes.
      > Notably, there are significant improvements for Java based applications, braille displays and Windows features.
      > 
      > New table navigation commands have been introduced.
      > Unicode CLDR has been updated.
      > LibLouis has been updated, which includes a new German braille table.
- [x] Developer Guide (refer to common mistakes in *.t2t and review HTML file)
- [x] Change log (refer to common mistakes in *.t2t and review HTML file)
- [x] User Guide  (refer to common mistakes in *.t2t and review HTML file)

Common mistakes to look for:
- Incorrect spelling.
- Lists not terminated with a final - on a new line, matching indentation
- List items not indented by a multiple of 2 spaces
- Single grave marks ` instead of double grave marks ``
- Shortcuts added without code markdown, use two 'grave' characters (``NVDA+d``)
- Double spaces
- Inconsistent use of single vs double quote.