### PR TITLE
Further change log fixes for 2022.2

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -52,7 +52,7 @@ LibLouis has been updated, which includes a new German braille table.
   - Fix braille output when navigating certain text in Mozilla rich edit controls, such as drafting a message in Thunderbird. (#12542)
   - When braille is tethered automatically and the mouse is moved with mouse tracking enabled,
    text review commands now update the braille display with the spoken content. (#11519)
-  - It is now possible to pan the braille display through content after use of the text review commands. (#8682)
+  - It is now possible to pan the braille display through content after use of text review commands. (#8682)
   -
 - The NVDA installer can now run from directories with special characters. (#13270)
 - In Firefox, NVDA no longer fails to report items in web pages when aria-rowindex, aria-colindex, aria-rowcount or aria-colcount attributes are invalid. (#13405)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,7 +39,7 @@ LibLouis has been updated, which includes a new German braille table.
 
 == Bug Fixes ==
 - Fixes for Java based applications:
-  - NVDA will now announce readonly state. (#13692)
+  - NVDA will now announce read-only state. (#13692)
   - NVDA will now announce disabled/enabled state correctly. (#10993)
   - NVDA will now announce function key shortcuts. (#13643)
   - NVDA can now beep or speak on progress bars. (#13594)


### PR DESCRIPTION
Must be merged before the translation freeze is introduced, but can be left open until changes have been aggregated for another beta release.