### PR TITLE
No longer rely on star imports in NVDAObjects.IAccessible.winword

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -4,32 +4,32 @@
 #See the file COPYING for more details.
 
 from comtypes import COMError
-import comtypes.automation
-import comtypes.client
 import ctypes
-import NVDAHelper
+import operator
+import uuid
 from logHandler import log
-import oleacc
 import winUser
 import speech
+import braille
 import controlTypes
+import config
+import tableUtils
 import textInfos
 import eventHandler
 import scriptHandler
+import ui
 from . import IAccessible
 from displayModel import EditableTextDisplayModelTextInfo
-from NVDAObjects.window import DisplayModelEditableText
 from ..behaviors import EditableTextWithoutAutoSelectDetection
-from NVDAObjects.window.winword import *
-from NVDAObjects.window.winword import WordDocumentTreeInterceptor
+import NVDAObjects.window.winword as winWordWindowModule
 from speech import sayAll
 
 
-class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocument):
- 
-	treeInterceptorClass=WordDocumentTreeInterceptor
+class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordWindowModule.WordDocument):
+
+	treeInterceptorClass = winWordWindowModule.WordDocumentTreeInterceptor
 	shouldCreateTreeInterceptor=False
-	TextInfo=WordDocumentTextInfo
+	TextInfo = winWordWindowModule.WordDocumentTextInfo
 
 	def _get_ignoreEditorRevisions(self):
 		try:
@@ -112,7 +112,7 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 		except (COMError, AttributeError):
 			tableRangesEqual=False
 		if not tableRangesEqual:
-			self._curHeaderCellTracker=HeaderCellTracker()
+			self._curHeaderCellTracker = tableUtils.HeaderCellTracker()
 			self.populateHeaderCellTrackerFromBookmarks(self._curHeaderCellTracker,tableRange.bookmarks)
 			self.populateHeaderCellTrackerFromHeaderRows(self._curHeaderCellTracker,table)
 			self._curHeaderCellTrackerTable=table
@@ -140,7 +140,7 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 			name="ColumnTitle_"
 		else:
 			raise ValueError("One or both of isColumnHeader or isRowHeader must be True")
-		name+=uuid.uuid4().hex
+		name += uuid.uuid4().hex
 		if oldInfo:
 			self.WinwordDocumentObject.bookmarks[oldInfo.name].delete()
 			oldInfo.name=name
@@ -323,8 +323,8 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 		thisIndex=rowNumber if row else columnNumber
 		otherIndex=columnNumber if row else rowNumber
 		thisLimit=(rowCount if row else columnCount) if forward else 1
-		limitOp=operator.le if forward else operator.ge
-		incdecFunc=operator.add if forward else operator.sub
+		limitOp = operator.le if forward else operator.ge
+		incdecFunc = operator.add if forward else operator.sub
 		foundCell=None
 		curOtherIndex=otherIndex
 		while curOtherIndex>0:
@@ -341,7 +341,9 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 		if not foundCell:
 			ui.message(_("Edge of table"))
 			return False
-		newInfo=WordDocumentTextInfo(self,textInfos.POSITION_CARET,_rangeObj=foundCell)
+		newInfo = winWordWindowModule.WordDocumentTextInfo(
+			self, textInfos.POSITION_CARET, _rangeObj=foundCell
+		)
 		speech.speakTextInfo(newInfo, reason=controlTypes.OutputReason.CARET, unit=textInfos.UNIT_CELL)
 		newInfo.collapse()
 		newInfo.updateCaret()
@@ -362,15 +364,15 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 	def script_nextParagraph(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
 		# #4375: can't use self.move here as it may check document.chracters.count which can take for ever on large documents.
-		info._rangeObj.move(wdParagraph,1)
+		info._rangeObj.move(winWordWindowModule.wdParagraph, 1)
 		info.updateCaret()
 		self._caretScriptPostMovedHelper(textInfos.UNIT_PARAGRAPH,gesture,None)
 	script_nextParagraph.resumeSayAllMode = sayAll.CURSOR.CARET
 
 	def script_previousParagraph(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
-		# #4375: keeping cemetrical with nextParagraph script. 
-		info._rangeObj.move(wdParagraph,-1)
+		# #4375: keeping symmetrical with nextParagraph script.
+		info._rangeObj.move(winWordWindowModule.wdParagraph, -1)
 		info.updateCaret()
 		self._caretScriptPostMovedHelper(textInfos.UNIT_PARAGRAPH,gesture,None)
 	script_previousParagraph.resumeSayAllMode = sayAll.CURSOR.CARET
@@ -398,7 +400,8 @@ class WordDocument(IAccessible,EditableTextWithoutAutoSelectDetection,WordDocume
 		"kb:NVDA+alt+c":"reportCurrentComment",
 	}
 
-class SpellCheckErrorField(IAccessible,WordDocument_WwN):
+
+class SpellCheckErrorField(IAccessible, winWordWindowModule.WordDocument_WwN):
 
 	parentSDMCanOverrideName=False
 	ignoreFormatting=True
@@ -460,8 +463,8 @@ class ProtectedDocumentPane(IAccessible):
 		document=next((x for x in self.children if isinstance(x,WordDocument)), None)  
 		if document:
 			curThreadID=ctypes.windll.kernel32.GetCurrentThreadId()
-			ctypes.windll.user32.AttachThreadInput(curThreadID,document.windowThreadID,True)
-			ctypes.windll.user32.SetFocus(document.windowHandle)
-			ctypes.windll.user32.AttachThreadInput(curThreadID,document.windowThreadID,False)
+			winUser.user32.AttachThreadInput(curThreadID, document.windowThreadID, True)
+			winUser.user32.SetFocus(document.windowHandle)
+			winUser.user32.AttachThreadInput(curThreadID, document.windowThreadID, False)
 			if not document.WinwordWindowObject.active:
 				document.WinwordWindowObject.activate()


### PR DESCRIPTION
### Link to issue number:
None, found when testing code from PR #13575

### Summary of the issue:
`NVDAObjects.IAccessible.winword` star imports everything from `NVDAObjects.window.winword`. This may cause issues when removing imports from `NVDAObjects.window.winword`, it is also better to be explicit.
### Description of how this pull request fixes the issue:
`NVDAObjects.IAccessible.winword` now imports all used modules explicitly.
### Testing strategy:
- Executed Flake8 on the entire `NVDAObjects.IAccessible.winword` module - made sure no undefined names show up
- Smoke tested document and table navigation in MS Word with UIA disabled.
### Known issues with pull request:
None known
### Change log entries:
None needed
### Code Review Checklist:



- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
