### PR TITLE
Fix-up of PR 13805: No longer rely on star imports in appModule for MS Outlook

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -508,7 +508,7 @@ the NVDAObject for IAccessible
 				from .winword import SpellCheckErrorField
 				clsList.append(SpellCheckErrorField)
 			else:
-				from .winword import WordDocument_WwN
+				from NVDAObjects.window.winword import WordDocument_WwN
 				clsList.append(WordDocument_WwN)
 		elif windowClassName=="DirectUIHWND" and role==oleacc.ROLE_SYSTEM_TOOLBAR:
 			parentWindow=winUser.getAncestor(self.windowHandle,winUser.GA_PARENT)

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -30,8 +30,13 @@ import speech
 import ui
 from NVDAObjects.IAccessible import IAccessible
 from NVDAObjects.window import Window
-from NVDAObjects.window.winword import WordDocument as BaseWordDocument
-from NVDAObjects.IAccessible.winword import WordDocument, WordDocumentTreeInterceptor, BrowseModeWordDocumentTextInfo, WordDocumentTextInfo
+from NVDAObjects.window.winword import (
+	WordDocument as BaseWordDocument,
+	WordDocumentTreeInterceptor,
+	BrowseModeWordDocumentTextInfo,
+	WordDocumentTextInfo,
+)
+from NVDAObjects.IAccessible.winword import WordDocument
 from NVDAObjects.IAccessible.MSHTML import MSHTML
 from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA


### PR DESCRIPTION
### Link to issue number:
Fixes #13810 
### Summary of the issue:
PR #13805 removed star imports from `NVDAObjects.IAccessible.winword`. Unfortunately the appModule for MS Outlook relied on some of the stuff star imported there. 
### Description of user facing changes
MS Outlook can once again be used with Alpha versions of NVDA.
### Description of development approach
Inspected all imports from `NVDAObjects.IAccessible.winword` - - where they imported stuff which is actually defined in `NVDAObjects.window.winword` the imports were made explicit.
### Testing strategy:
Made sure that MS Outlook can once again be used 
### Known issues with pull request:
None known
### Change log entries:
None needed - unreleased regression.

### Code Review Checklist:



- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
