### PR TITLE
Fix-up of #13366: Replace dots with underscores before trying to check if the given App Module exists to work around bug in the Python import system

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -156,7 +156,12 @@ def _getPossibleAppModuleNamesForExecutable(executableName: str) -> Tuple[str, .
 	return tuple(
 		aliasName for aliasName in (
 			_executableNamesToAppModsAddons.get(executableName),
-			executableName,
+			# #5323: Certain executables contain dots as part of their file names.
+			# Since Python threats dot as a package separator we replace it with undescore
+			# in the name of the Python module.
+			# For new App Modules consider adding an alias to `appModule.EXECUTABLE_NAMES_TO_APP_MODS`
+			# rather than rely on the fact that dots are replaced.
+			executableName.replace(".", "_"),
 			appModules.EXECUTABLE_NAMES_TO_APP_MODS.get(executableName)
 		) if aliasName is not None
 	)
@@ -254,8 +259,7 @@ def getAppModuleFromProcessID(processID: int) -> AppModule:
 	with _getAppModuleLock:
 		mod=runningTable.get(processID)
 		if not mod:
-			# #5323: Certain executables contain dots as part of their file names.
-			appName=getAppNameFromProcessID(processID).replace(".","_")
+			appName = getAppNameFromProcessID(processID)
 			mod=fetchAppModule(processID,appName)
 			if not mod:
 				raise RuntimeError("error fetching default appModule")


### PR DESCRIPTION

Opened against beta since this fixes regression introduced during 2022.2 development cycle.
### Link to issue number:
Fix-up of #13366
Fixes #13813
### Summary of the issue:
As part of PR #13366 I've modified the code responsible for retrieving application name from process id so that it no longer tries to import an App Module for a hosting process if it does not exist. Unfortunately Python `find_Module` method seems to have a bug - it returns a module when the provided string contains dots and the file named exactly like the last segment of the provided name exists in the package. For example if you have module named `qq` in the package, and you would like to check if the module named `6.5.qq` exists `True` is returned even though there is no such module. I haven't yet tested how this behaves with more recent versions of Python nor opened an issue against them.

### Description of user facing changes
NVDA no longer fails to work in applications containing dots in their file names in cases where you have an App Module for an application named exactly like the last segment of the application name.
### Description of development approach
Dots are normalized to underscores before checking if the given module exists. While we did this already before trying to import a standard App Module this has not been done before trying to get module for a hosting process.
### Testing strategy:
- Performed steps from #13813 
- Tested that an App Module for AZARDI (it binary file contains dot in the file name) is loaded successfully
- Tested that the correct name is retrieved for a Java application from its hosting process
### Known issues with pull request:
None known
### Change log entries:
None needed - unreleased regression.
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
