### PR TITLE
Logging: No longer mark log messages from nvda.pyw as coming from external code when running from sources

### DIFF
--- a/runlint.bat
+++ b/runlint.bat
@@ -1,9 +1,15 @@
 @echo off
 rem runlint <base commit> [<output file>]
 rem Lints any changes after base commit up to and including current HEAD, plus any uncommitted changes.
-call "%~dp0\venvUtils\venvCmd.bat" py "%~dp0\tests\lint\genDiff.py" %1 "%~dp0\tests\lint\_lint.diff"
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%\venvUtils
+set lintFilesPath=%here%\tests\lint
+
+call "%scriptsDir%\venvCmd.bat" py "%lintFilesPath%\genDiff.py" %1 "%lintFilesPath%\_lint.diff"
   if ERRORLEVEL 1 exit /b %ERRORLEVEL%
-  set flake8Args=--diff --config="%~dp0\tests\lint\flake8.ini"
+  set flake8Args=--diff --config="%lintFilesPath%\flake8.ini"
   if "%2" NEQ "" set flake8Args=%flake8Args%  --tee --output-file=%2
-  type "%~dp0\tests\lint\_lint.diff" | call "%~dp0\venvUtils\venvCmd.bat" py -Xutf8 -m flake8 %flake8Args%
+  type "%lintFilesPath%\_lint.diff" | call "%scriptsDir%\venvCmd.bat" py -Xutf8 -m flake8 %flake8Args%
   

--- a/runnvda.bat
+++ b/runnvda.bat
@@ -1,2 +1,8 @@
 @echo off
-call "%~dp0\venvUtils\venvCmd.bat" start pyw "%~dp0\source\nvda.pyw" %*
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%\venvUtils
+set sourceDirPath=%here%\source
+
+call "%scriptsDir%\venvCmd.bat" start pyw "%sourceDirPath%\nvda.pyw" %*

--- a/runsettingsdiff.bat
+++ b/runsettingsdiff.bat
@@ -1,2 +1,8 @@
 @echo off
-call "%~dp0\venvUtils\venvCmd.bat" py -m robot --argumentfile "%~dp0\tests\system\guiDiff.robot" %* "%~dp0\tests\system\robot"
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%\venvUtils
+set systemTestsPath=%here%\tests\system
+
+call "%scriptsDir%\venvCmd.bat" py -m robot --argumentfile "%systemTestsPath%\guiDiff.robot" %* "%systemTestsPath%\robot"

--- a/runsystemtests.bat
+++ b/runsystemtests.bat
@@ -1,3 +1,8 @@
 @echo off
-call "%~dp0\venvUtils\venvCmd.bat" py -m robot --argumentfile "%~dp0\tests\system\robotArgs.robot" %* "%~dp0\tests\system\robot"
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%\venvUtils
+set systemTestsPath=%here%\tests\system
 
+call "%scriptsDir%\venvCmd.bat" py -m robot --argumentfile "%systemTestsPath%\robotArgs.robot" %* "%systemTestsPath%\robot"

--- a/rununittests.bat
+++ b/rununittests.bat
@@ -1,2 +1,8 @@
 @echo off
-call "%~dp0\venvUtils\venvCmd.bat" py -m nose -sv --traverse-namespace -w "%~dp0\tests\unit" %*
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%\venvUtils
+set unitTestsPath=%here%\tests\unit
+
+call "%scriptsDir%\venvCmd.bat" py -m nose -sv --traverse-namespace -w "%unitTestsPath%" %*

--- a/scons.bat
+++ b/scons.bat
@@ -1,3 +1,7 @@
 @echo off
 rem Executes SScons within the NVDA build system's Python virtual environment.
-call "%~dp0\venvUtils\venvCmd.bat" py -m SCons %*
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%\venvUtils
+call "%scriptsDir%\venvCmd.bat" py -m SCons %*

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -30,9 +30,14 @@ CO_E_OBJNOTCONNECTED = -2147220995
 EVENT_E_ALL_SUBSCRIBERS_FAILED = -2147220991
 LOAD_WITH_ALTERED_SEARCH_PATH=0x8
 
-def isPathExternalToNVDA(path):
+
+def isPathExternalToNVDA(path: str) -> bool:
 	""" Checks if the given path is external to NVDA (I.e. not pointing to built-in code). """
-	if path[0] != "<" and os.path.isabs(path) and not path.startswith(sys.path[0] + "\\"):
+	if(
+		path[0] != "<"
+		and os.path.isabs(path)
+		and not os.path.normpath(path).startswith(sys.path[0] + "\\")
+	):
 		# This module is external because:
 		# the code comes from a file (fn doesn't begin with "<");
 		# it has an absolute file path (code bundled in binary builds reports relative paths); and

--- a/venvUtils/ensureAndActivate.bat
+++ b/venvUtils/ensureAndActivate.bat
@@ -2,9 +2,14 @@
 rem this script ensures the NVDA build system Python virtual environment is created and up to date,
 rem and then activates it.
 rem This is an internal script and should not be used directly.
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%
+set venvLocation=%here%\..\.venv
 
 rem Ensure the environment is created and up to date
-py -3.7-32 "%~dp0\ensureVenv.py"
+py -3.7-32 "%scriptsDir%\ensureVenv.py"
 if ERRORLEVEL 1 goto :EOF
 
 rem Set the necessary environment variables to have Python use this virtual environment.
@@ -18,7 +23,7 @@ rem set the VIRTUAL_ENV variable instructing Python to use a virtual environment
 rem py.exe will honor VIRTUAL_ENV and launch the python.exe that it finds in %VIRTUAL_ENV%\scripts.
 rem %VIRTUAL_ENV%\scripts\python.exe will find pyvenv.cfg in its parent directory,
 rem which is actually what then causes Python to use the site-packages found in this virtual environment.
-set VIRTUAL_ENV=%~dp0..\.venv
+set VIRTUAL_ENV=%venvLocation%
 rem Add the virtual environment's scripts directory to the path
 set PATH=%VIRTUAL_ENV%\scripts;%PATH%
 rem Set an NVDA-specific variable to identify this official NVDA virtual environment from other 3rd party ones

--- a/venvUtils/exportPackageList.bat
+++ b/venvUtils/exportPackageList.bat
@@ -1,7 +1,12 @@
 @echo off
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%
+
 setlocal
 if "%VIRTUAL_ENV%" == "" (
-	call "%~dp0\ensureAndActivate.bat"
+	call "%scriptsDir%\ensureAndActivate.bat"
 	if ERRORLEVEL 1 goto :EOF
 )
 py -m pip freeze >%1

--- a/venvUtils/venvCmd.bat
+++ b/venvUtils/venvCmd.bat
@@ -15,12 +15,16 @@ if "%VIRTUAL_ENV%" NEQ "" (
 	call %*
 	goto :EOF
 )
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+set scriptsDir=%here%
 
 rem call setlocal to make sure that any environment variable changes made by activating the virtual environment
 rem can be completely undone when endlocal is called or this script exits.
 setlocal
 echo Ensuring NVDA Python virtual environment
-call "%~dp0\ensureAndActivate.bat"
+call "%scriptsDir%\ensureAndActivate.bat"
 if ERRORLEVEL 1 goto :EOF
 echo call %*
 call %*


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When starting NVDA from sources messages logged from nvda.pyw are shown as external. Example message:
```
INFO - external:__main__ (17:20:02.477) - MainThread (4316):
Starting NVDA version source-master-b817b03

```
This is clearly wrong. The problem is caused by the trailing backslash added in bat scripts (`%~dp0` is already terminated with one and adding a second backslash causes `logHandler.isPathExternalToNVDA` to think that the path is external).
### Description of user facing changes
Log messages from nvda.pyw are no longer marked as external.
### Description of development approach
All usages of `%~dp0` are inspected and trailing backslash is no longer added to the paths. To make `logHandler.isPathExternalToNVDA` more resilient to invalid paths the path is normalized before checking if it is the same as `sys.path`.
### Testing strategy:
- Tested that messages logged from nvda.pyw are no longer marked as external.
- Smoke tested modified scripts.
### Known issues with pull request:
None known
### Change log entries:
None needed - affects only logging from source copies.

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
