### PR TITLE
Fix-up eSpeak.md formatting

### DIFF
--- a/include/espeak.md
+++ b/include/espeak.md
@@ -42,6 +42,18 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
       - Diff `src/windows/config.h` with the previous commit.
    1. Update NVDA [`readme.md`](../readme.md) with eSpeak version and commit.
    1. Build NVDA: `scons source`
+      - Expected warnings from eSpeak compilation:
+         - On the first build after changes, all languages may show this warning.
+         Our build intentionally compiles using the `phonemetable`.
+         ```log
+         espeak_compileDict_buildAction(["include\espeak\espeak-ng-data\uz_dict"], ["include\espeak\dictsource\uz_list", "include\espeak\dictsource\uz_rules"])
+         Can't read dictionary file: 'C:\Users\sean\projects\nvda\include\espeak/espeak-ng-data\uz_dict'
+         Using phonemetable: 'uz'
+         Compiling: 'C:\Users\sean\projects\nvda\include\espeak\dictsource/uz_list'
+               121 entries
+         Compiling: 'C:\Users\sean\projects\nvda\include\espeak\dictsource/uz_rules'
+               35 rules, 26 groups (0)
+         ```
 1. Run NVDA (set eSpeak-ng as the synthesizer) and test.
 1. Ensure that the log file contains the new version number for eSpeak-NG
 

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -38,7 +38,8 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
    1. Update the `/DPACKAGE_VERSION` in [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript)
       - The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
       - [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
-      - Compare to espeak source info: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
+      - Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
+      - Diff `src/windows/config.h` with the previous commit.
    1. Update NVDA [`readme.md`](../readme.md) with eSpeak version and commit.
    1. Build NVDA: `scons source`
 1. Run NVDA (set eSpeak-ng as the synthesizer) and test.

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -1,17 +1,17 @@
-# Espeak-ng submodule
+# eSpeak-ng submodule
 
-The submodule contained in the espeak directory is a cross platform open source speech synthesizer.
+The submodule contained in the `espeak` directory is a cross platform open source speech synthesizer.
 
 ## Building
-NVDA has a custom build of ESpeak because not all components are required.
+NVDA has a custom build of eSpeak because not all components are required.
 
 ### Background
-The main authority on build requirements should be `<nvda repo root>/include/espeak/Makefile.am`.
-The `*.vcxproj` files in `<nvda repo root>/include/espeak/src/windows/` can also be considered,
+The main authority on build requirements should be [`include/espeak/Makefile.am`](./espeak/Makefile.am).
+The `*.vcxproj` files in [`/include/espeak/src/windows/`](./espeak/src/windows/) can also be considered,
 however these are not always kept up to date.
 
-We don't use the auto make files or the visual studio files, we maintain our own method of building espeak.
-Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
+We don't use the auto make files or the visual studio files, we maintain our own method of building eSpeak.
+Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak)
 * `sconscript` for the build process.
 * `config.h` to set the eSpeak-ng version that NVDA outputs to the log file.
 
@@ -32,15 +32,15 @@ Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
    1. Changes to Dictionary compilation should be reflected in `espeakDictionaryCompileList`
    1. Some modules are intentionally excluded from the build.
       If unsure, err on the side of including it and raise it as a question when submitting a PR.
-   1. Modify the `<nvda repo root>/nvdaHelper/espeak/config.h` file as required.
+   1. Modify the [`/nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) file as required.
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
-   1. Update the `/DPACKAGE_VERSION` in `espeak/sconscript`
-      - The preprocessor definition is used to supply these definitions instead of `<nvda repo root>/nvdaHelper/espeak/config.h`
-      - `<nvda repo root>/nvdaHelper/espeak/config.h` must exist (despite being empty) since a "config.h" is included within espeak.
-      - Compare to espeak source info: `<nvda repo root>/include/espeak/src/windows/config.h`.
-   1. Update NVDA `readme.md` with espeak version and commit.
-   1. Build NVDA
+   1. Update the `/DPACKAGE_VERSION` in [`espeak/sconscript`](../nvdaHelper/espeak/sconscript)
+      - The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
+      - [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
+      - Compare to espeak source info: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
+   1. Update NVDA [`readme.md`](../readme.md) with eSpeak version and commit.
+   1. Build NVDA: `scons source`
 1. Run NVDA (set eSpeak-ng as the synthesizer) and test.
 1. Ensure that the log file contains the new version number for eSpeak-NG
 
@@ -48,7 +48,7 @@ Modifications will need to be made in `<nvda repo root>/nvdaHelper/espeak`
 
 If python crashes while building, check the log.
 If the last thing is compiling some dictionary try excluding it.
-This can be done in `<nvda repo root>/nvdaHelper/espeak/sconscript`.
+This can be done in [`/nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript).
 Remember to report this to the eSpeak-ng project.
 
 If the build fails, take note of the error, compare the diff of the `Makefile.am` file and mirror 
@@ -57,13 +57,13 @@ any changes in our `sconscript` file.
 ### Known issues
 Due to problems with emoji support (causing crashes), emoji dictionary files are being excluded
 from the build, they are deleted prior to compiling the dictionaries in the
-`<nvda repo root>/nvdaHelper/espeak/sconscript` file.
+[`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript) file.
 
-## Manually testing Espeak-ng
+## Manually testing eSpeak-ng
 If you wish to test eSpeak-ng directly, perhaps to create steps to reproduce when raising an issue for the eSpeak-ng project, consider feeding SSML directly to the executable provided by the project.
 
-The [espeak docs](https://github.com/espeak-ng/espeak-ng/blob/master/docs/index.md) are worth reading.
-They describe the various [(espeak-ng) command line arguments](https://github.com/espeak-ng/espeak-ng/blob/master/src/espeak-ng.1.ronn) (note also [speak-ng command line](https://github.com/espeak-ng/espeak-ng/blob/master/src/speak-ng.1.ronn)), and [insturctions to build](https://github.com/espeak-ng/espeak-ng/blob/master/docs/building.md#windows) an `.exe` from a commit of eSpeak, locally on Windows.
+The [eSpeak docs](https://github.com/espeak-ng/espeak-ng/blob/master/docs/index.md) are worth reading.
+They describe the various [(eSpeak-ng) command line arguments](https://github.com/espeak-ng/espeak-ng/blob/master/src/espeak-ng.1.ronn) (note also [speak-ng command line](https://github.com/espeak-ng/espeak-ng/blob/master/src/speak-ng.1.ronn)), and [instructions to build](https://github.com/espeak-ng/espeak-ng/blob/master/docs/building.md#windows) an `.exe` from a commit of eSpeak, locally on Windows.
 However, historically the Windows build for espeak-ng hasn't been well maintained, with periods of build failures.
 It is also different from the build approach within NVDA.
 

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -35,7 +35,7 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
    1. Modify the [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) file as required.
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
-   1. Update the `/DPACKAGE_VERSION` in [`espeak/sconscript`](../nvdaHelper/espeak/sconscript)
+   1. Update the `/DPACKAGE_VERSION` in [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript)
       - The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
       - [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
       - Compare to espeak source info: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -7,7 +7,7 @@ NVDA has a custom build of eSpeak because not all components are required.
 
 ### Background
 The main authority on build requirements should be [`include/espeak/Makefile.am`](./espeak/Makefile.am).
-The `*.vcxproj` files in [`/include/espeak/src/windows/`](./espeak/src/windows/) can also be considered,
+The `*.vcxproj` files in [`include/espeak/src/windows/`](./espeak/src/windows/) can also be considered,
 however these are not always kept up to date.
 
 We don't use the auto make files or the visual studio files, we maintain our own method of building eSpeak.
@@ -32,7 +32,7 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
    1. Changes to Dictionary compilation should be reflected in `espeakDictionaryCompileList`
    1. Some modules are intentionally excluded from the build.
       If unsure, err on the side of including it and raise it as a question when submitting a PR.
-   1. Modify the [`/nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) file as required.
+   1. Modify the [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) file as required.
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
    1. Update the `/DPACKAGE_VERSION` in [`espeak/sconscript`](../nvdaHelper/espeak/sconscript)
@@ -48,7 +48,7 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
 
 If python crashes while building, check the log.
 If the last thing is compiling some dictionary try excluding it.
-This can be done in [`/nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript).
+This can be done in [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript).
 Remember to report this to the eSpeak-ng project.
 
 If the build fails, take note of the error, compare the diff of the `Makefile.am` file and mirror 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None
### Summary of the issue:
Minor formatting issues with eSpeak.md file

### Description of user facing changes

1. Normalize capitalization to `eSpeak`
1. Normalize paths to NVDA root, link to them where possible
1. Added instruction to diff config file
1. Added example of expected build warnings

### Description of development approach
N/A
### Testing strategy:
N/A
### Known issues with pull request:
N/A
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
