### PR TITLE
Update eSpeak to 1.52-dev commit dc153592

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -92,7 +92,7 @@ env.Append(
 		# Ignore all warnings as the code is not ours.
 		'/W0',
 		# Preprocessor definitions. Migrated from 'nvdaHelper/espeak/config.h'
-		'/DPACKAGE_VERSION=\\"1.51-dev\\"',  # See 'include/espeak/src/windows/config.h'
+		'/DPACKAGE_VERSION=\\"1.52-dev\\"',  # See 'include/espeak/src/windows/config.h'
 		'/DHAVE_STDINT_H=1',
 		'/D__WIN32__#1',
 		'/DLIBESPEAK_NG_EXPORT',

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -136,6 +136,18 @@ def espeak_compilePhonemeData_buildAction(target,source,env):
 	espeak.espeak_ng_CompilePhonemeData(22050,None,None)
 	espeak.espeak_Terminate()
 
+
+# refer to CLEANFILES in include\espeak\Makefile.am 
+for f in (
+		os.path.join(espeakRepo.abspath, "dictsource", "ru_listx"),
+		os.path.join(espeakRepo.abspath, "dictsource", "cmn_listx"),
+		os.path.join(espeakRepo.abspath, "dictsource", "yue_listx"),
+	):
+	if os.path.exists(f):
+		print(f"Removing listx file: {f}")
+		os.remove(f)
+
+
 env['BUILDERS']['espeak_compilePhonemeData']=Builder(action=env.Action(espeak_compilePhonemeData_buildAction,"Compiling phoneme data"),emitter=espeak_compilePhonemeData_buildEmitter)
 
 #: See dictionaries section of /include/espeak/Makefile.am
@@ -150,6 +162,7 @@ espeakDictionaryCompileList: typing.Dict[
 	"as_dict": ("as", ["as_list", "as_rules", ]),
 	"az_dict": ("az", ["az_list", "az_rules", ]),
 	"ba_dict": ("ba", ["ba_list", "ba_rules", ]),
+	"be_dict": ("be", ["be_list", "be_rules", ]),
 	"bg_dict": ("bg", ["bg_listx", "bg_list", "bg_rules"]),
 	"bn_dict": ("bn", ["bn_list", "bn_rules", ]),
 	"bpy_dict": ("bpy", ["bpy_list", "bpy_rules", ]),
@@ -200,6 +213,7 @@ espeakDictionaryCompileList: typing.Dict[
 	"ku_dict": ("ku", ["ku_list", "ku_rules", ]),
 	"ky_dict": ("ky", ["ky_list", "ky_rules", ]),
 	"la_dict": ("la", ["la_list", "la_rules", ]),
+	"lb_dict": ("lb", ["lb_list", "lb_rules", ]),
 	"lfn_dict": ("lfn", ["lfn_list", "lfn_rules", ]),
 	"lt_dict": ("lt", ["lt_list", "lt_rules", ]),
 	"lv_dict": ("lv", ["lv_list", "lv_rules", ]),
@@ -209,6 +223,7 @@ espeakDictionaryCompileList: typing.Dict[
 	"mr_dict": ("mr", ["mr_list", "mr_rules", ]),
 	"ms_dict": ("ms", ["ms_list", "ms_rules", ]),
 	"mt_dict": ("mt", ["mt_list", "mt_rules", ]),
+	"mto_dict": ("mto", ["mto_list", "mto_rules", ]),
 	"my_dict": ("my", ["my_list", "my_rules", ]),
 	"nci_dict": ("nci", ["nci_list", "nci_rules", ]),
 	"ne_dict": ("ne", ["ne_list", "ne_rules", ]),
@@ -316,7 +331,7 @@ def espeak_compileDict_buildAction(
 		# returns: espeak_ng_STATUS
 		compileDictResult = espeak.espeak_ng_CompileDictionary(
 			rulesPathEncoded,  # const char *dsource
-			None,  # const char *dict_name
+			bytes(lang, encoding="ascii"),  # const char *dict_name
 			None,  # FILE *log
 			0,  # int flags
 			None,  # espeak_ng_ERROR_CONTEXT *context
@@ -417,8 +432,12 @@ env.Install(
 	env.Glob(os.path.join(espeakRepo.abspath, 'dictsource', 'extra', '*'))
 )
 
-#Compile all dictionaries
-excludeLangs: typing.List[str] = [] # Use to exclude languages which don't compile.
+excludeLangs: typing.List[str] = [
+]
+"""Used to exclude languages which don't compile.
+"""
+
+# Compile all dictionaries
 dictSourcePath: SCons.Node.FS.Dir = espeakRepo.Dir('dictsource')
 
 # Remove emoji files before compiling dictionaries.

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -137,15 +137,35 @@ def espeak_compilePhonemeData_buildAction(target,source,env):
 	espeak.espeak_Terminate()
 
 
-# refer to CLEANFILES in include\espeak\Makefile.am 
-for f in (
-		os.path.join(espeakRepo.abspath, "dictsource", "ru_listx"),
-		os.path.join(espeakRepo.abspath, "dictsource", "cmn_listx"),
-		os.path.join(espeakRepo.abspath, "dictsource", "yue_listx"),
-	):
-	if os.path.exists(f):
-		print(f"Removing listx file: {f}")
+def removeEmoji():
+	"""
+	Remove emoji files before compiling dictionaries.
+	Currently many of these simply crash eSpeak at runtime.
+	Also, our own emoji processing using CLDR data is preferred.
+	"""
+	emojiGlob = os.path.join(espeakRepo.abspath, 'dictsource', '*_emoji')
+	for f in glob(emojiGlob):
+		print(f"Removing emoji file: {f}")
 		os.remove(f)
+
+
+def cleanFiles_preBuildAction(target, source, env):
+	"""
+	Before compiling eSpeak, removes:
+	 - emoji files
+	 - dictionary artifacts listed in CLEANFILES
+	"""
+	removeEmoji()
+	# refer to CLEANFILES in include\espeak\Makefile.am 
+	for f in (
+			# These files are created when we moved them from espeak/dictsource/extra/*_*.
+			os.path.join(espeakRepo.abspath, "dictsource", "ru_listx"),
+			os.path.join(espeakRepo.abspath, "dictsource", "cmn_listx"),
+			os.path.join(espeakRepo.abspath, "dictsource", "yue_listx"),
+		):
+		if os.path.exists(f):
+			print(f"Removing listx file: {f}")
+			os.remove(f)
 
 
 env['BUILDERS']['espeak_compilePhonemeData']=Builder(action=env.Action(espeak_compilePhonemeData_buildAction,"Compiling phoneme data"),emitter=espeak_compilePhonemeData_buildEmitter)
@@ -426,10 +446,14 @@ for i in phonemeData:
 	fileName = i.abspath[l:]
 	env.InstallAs(os.path.join(synthDriversDir.Dir('espeak-ng-data').abspath, fileName), i)
 
+
+# Removes files that are created when installing from dictsource/extra/*_* to dictsource.
+# Also removes emoji files from dictsource compilation, refer to cleanEmoji for justification.
+env.AddPreAction(espeakLib, env.Action(cleanFiles_preBuildAction))
 # Move any extra dictionaries into dictsource for compilation
 env.Install(
 	espeakRepo.Dir('dictsource'),
-	env.Glob(os.path.join(espeakRepo.abspath, 'dictsource', 'extra', '*'))
+	env.Glob(os.path.join(espeakRepo.abspath, 'dictsource', 'extra', '*_*'))
 )
 
 excludeLangs: typing.List[str] = [
@@ -440,13 +464,6 @@ excludeLangs: typing.List[str] = [
 # Compile all dictionaries
 dictSourcePath: SCons.Node.FS.Dir = espeakRepo.Dir('dictsource')
 
-# Remove emoji files before compiling dictionaries.
-# Currently many of these simply crash eSpeak at runtime.
-# Also, our own emoji processing using CLDR data is preferred.
-emojiGlob = os.path.join(espeakRepo.abspath,'dictsource','*_emoji')
-for f in glob(emojiGlob):
-	print(f"Removing emoji file: {f}")
-	os.remove(f)
 
 # Create compile commands for all languages
 for dictFileName, (langCode, inputFiles) in espeakDictionaryCompileList.items():

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -31,7 +31,8 @@ class espeak_ERROR(enum.IntEnum):
 	EE_BUFFER_FULL = 1
 	EE_NOT_FOUND = 2
 
-class espeak_ng_STATUS(enum.IntEnum):
+
+class espeak_ng_STATUS(enum.IntFlag):
 	ENS_GROUP_MASK = 0x70000000
 	ENS_GROUP_ERRNO = 0x00000000  # Values 0 - 255 map to errno error codes.
 	ENS_GROUP_ESPEAK_NG = 0x10000000  # eSpeak NG error codes.

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -399,7 +399,11 @@ espeakLib=env.SharedLibrary(
 	LIBS=['advapi32'],
 )
 
-phonemeData=env.espeak_compilePhonemeData(espeakRepo.Dir('espeak-ng-data'),espeakRepo.Dir('phsource'))
+
+phonemeData = env.espeak_compilePhonemeData(
+	espeakRepo.Dir('espeak-ng-data'),
+	espeakRepo.Dir('phsource')
+)
 env.Depends(phonemeData,espeakLib)
 for i in phonemeData:
 	iDir = espeakRepo.Dir('espeak-ng-data').abspath
@@ -408,7 +412,10 @@ for i in phonemeData:
 	env.InstallAs(os.path.join(synthDriversDir.Dir('espeak-ng-data').abspath, fileName), i)
 
 # Move any extra dictionaries into dictsource for compilation
-env.Install(espeakRepo.Dir('dictsource'),env.Glob(os.path.join(espeakRepo.abspath,'dictsource','extra','*_*')))
+env.Install(
+	espeakRepo.Dir('dictsource'),
+	env.Glob(os.path.join(espeakRepo.abspath, 'dictsource', 'extra', '*'))
+)
 
 #Compile all dictionaries
 excludeLangs: typing.List[str] = [] # Use to exclude languages which don't compile.
@@ -419,7 +426,7 @@ dictSourcePath: SCons.Node.FS.Dir = espeakRepo.Dir('dictsource')
 # Also, our own emoji processing using CLDR data is preferred.
 emojiGlob = os.path.join(espeakRepo.abspath,'dictsource','*_emoji')
 for f in glob(emojiGlob):
-	print("Removing emoji file: %s"%f)
+	print(f"Removing emoji file: {f}")
 	os.remove(f)
 
 # Create compile commands for all languages

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit dc153592
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit 9de65fcb
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.22.0

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit e57e68fc
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit 0b44ab73c7
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.22.0

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit 0b44ab73c7
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit dc153592
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.22.0

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.51-dev commit 7e5457f91e10
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit e57e68fc
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.22.0

--- a/tests/unit/test_synthDrivers/test_espeak.py
+++ b/tests/unit/test_synthDrivers/test_espeak.py
@@ -109,7 +109,7 @@ class TestSynthDriver_Integration(unittest.TestCase):
 			expectedUnsupportedMappedLanguages,
 			unsupportedLanguagesWithoutLocale,
 			msg=(
-				"eSpeak has a language with locale supported"
+				"eSpeak has a language with locale supported "
 				"but the language without locale is unsupported."
 				"Update _defaultLangToLocale to include a new mapping."
 			)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -18,7 +18,7 @@ It can be re-enabled in NVDA's advanced settings panel. (#11554)
 
 
 == Changes ==
-- eSpeak NG has been updated to 1.52-dev commit ``dc153592``. (#13295)
+- eSpeak NG has been updated to 1.52-dev commit ``9de65fcb``. (#13295)
   - Added languages:
     - Belarusian
     - Luxembourgish

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,13 @@ It can be re-enabled in NVDA's advanced settings panel. (#11554)
 
 == Changes ==
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA is now able to report when a cell is merged. (#12843)
+- eSpeak NG has been updated to 1.52-dev commit ``0b44ab73c7``. (#13295)
+  - Added languages:
+    - Belarusian
+    - Luxembourgish
+    - Totontepec Mixe
+    -
+  -
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,7 +19,7 @@ It can be re-enabled in NVDA's advanced settings panel. (#11554)
 
 == Changes ==
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA is now able to report when a cell is merged. (#12843)
-- eSpeak NG has been updated to 1.52-dev commit ``0b44ab73c7``. (#13295)
+- eSpeak NG has been updated to 1.52-dev commit ``dc153592``. (#13295)
   - Added languages:
     - Belarusian
     - Luxembourgish


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #13295 

### Summary of the issue:

eSpeak is updated using the steps outlined in [espeak.md](https://github.com/nvaccess/nvda/blob/master/include/espeak.md).

Build issues fixed:
1. When a language dictionary fails to compile, an `errno` is raised. our `IntEnum` implementation of `espeak_ng_STATUS` doesn't correctly capture `errno`. Usage of `IntFlag` is required.
1. The dictionary compilation action did not specify the name of the language.
This used to be handled by eSpeak implicitly through getting a mapping using the rules path.
This is no longer the case for some languages.
1. eSpeak added `CLEANFILES` for certain language dictionary components. This can be mirrored by `env.Clean` or `os.remove`.
1. A PR to eSpeak was created to fix building Malay (ms) https://github.com/espeak-ng/espeak-ng/pull/1225.

### Description of user facing changes

Added languages:
  - Belarusian
  - Luxembourgish
  - Totontepec Mixe

### Description of development approach

New languages were added to the compile dictionary.

An annotated diff of Makefile.am can be checked to confirm the changes are implemented correctly into the build system: [makefile.diff](https://github.com/nvaccess/nvda/files/8998019/makefile.diff.txt). `ctrl+f` "`_CHANGES`" to find annotations.

### Testing strategy:

#### Fix 1 - Manual testing

Tested capturing `errno` (where `errno = 2`) when running `scons source`.
This required a dictionary that would fail to compile (when reproducing Issue 2).
These are logged as follows:
```log
Failed to compile dictionary: 'include\espeak\espeak-ng-data\ms_dict'
 rulesPath: b'C:\\Users\\sean\\projects\\nvda\\include\\espeak\\dictsource/'
 language: 'ms'
 result: espeak_ng_STATUS.2
```

#### General manual testing for Fix 2 and 3

Run `scons source`, check output.

Read text running from source
- using newly added eSpeak languages.
- using eSpeak Spanish, English, French (smoke test).

#### Fix 4

Tested reading Malay text with Malay language using 2022.1 to compare.
Build log shows build with "ms" as expcted.

this pr: https://ci.appveyor.com/project/NVAccess/nvda/builds/44017834?fullLog=true
```py
espeak_compileDict_buildAction(["include\espeak\espeak-ng-data\ms_dict"], ["include\espeak\dictsource\ms_list", "include\espeak\dictsource\ms_rules"])
Error: The requested functionality has not been built into espeak-ng.
Using phonemetable: 'ms'
Compiling: 'C:\projects\nvda\include\espeak\dictsource/ms_list'
	703 entries
Compiling: 'C:\projects\nvda\include\espeak\dictsource/ms_rules'
	125 rules, 27 groups (0)
Install file: "include\espeak\espeak-ng-data\ms_dict" as "source\synthDrivers\espeak-ng-data\ms_dict"
```


Alpha: https://ci.appveyor.com/project/NVAccess/nvda/builds/44005620?fullLog=true
```py
espeak_compileDict_buildAction(["include\espeak\espeak-ng-data\ms_dict"], ["include\espeak\dictsource\ms_list", "include\espeak\dictsource\ms_rules"])
Error: The requested functionality has not been built into espeak-ng.
Can't read dictionary file: 'C:\projects\nvda\include\espeak/espeak-ng-data\ms_dict'
Using phonemetable: 'id'
Compiling: 'C:\projects\nvda\include\espeak\dictsource/ms_list'
	703 entries
Compiling: 'C:\projects\nvda\include\espeak\dictsource/ms_rules'
	125 rules, 27 groups (0)
Install file: "include\espeak\espeak-ng-data\ms_dict" as "source\synthDrivers\espeak-ng-data\ms_dict"
```

### Known issues with pull request:
None

### Change log entries:
Refer to PR diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
