### PR TITLE
Load Chromium virtual buffer on state_system_busy

### DIFF
--- a/devDocs/featureFlags.md
+++ b/devDocs/featureFlags.md
@@ -1,0 +1,144 @@
+# Feature Flags
+
+NVDA makes judicious use of feature flags to enable and disable features that are in early development.
+The following are provided to streamline the creation of new feature flags:
+- A config spec type
+- A GUI control type
+
+## Background
+When providing a feature flag it is important to understand the importance of providing a "default" state.
+A boolean feature, must have 3 states selectable by the user:
+- `True`
+- `False`
+- `Default` (NVDA developer recommendation)
+
+This allows a choice between the following use-cases to be made at any point in time:
+- **Explicitly opt-in** to the feature, regardless of the default behavior. 
+An early adopter may choose to do this to test the feature and provide feedback.
+- **Explicitly opt-out** of the feature, regardless of the default behavior.
+A user may find the pre-existing behavior acceptable, and wants the maximum delay to adopt the new feature.
+They may be prioritising stability, or anticipating this feature flag receives a permanent home in NVDA settings.
+- **Explicitly choose the default** (NVDA developer recommended) behavior.
+Noting, that in this case it is important that the user must be able to select one of the other options first,
+and return to the default behavior at any point in time.
+
+This should be possible while still allowing developers to change the behaviour
+of the default option.
+The development process might require that initially NVDA is released with
+the feature disabled by default.
+In this case only testers, or the most curious users are expected to opt-in temporarily.
+As the feature improves, bugs are fixed, edge cases are handled, and the UX is improved,
+developers may wish to change the behavior of the default option to enable the feature.
+This change shouldn't affect those who have already explicitly opted out of the feature.
+Only those who maybe haven't tried the feature, because they were using the prior default behaviour, or
+those who have tried and found the feature to be unstable and decided they would wait for it to become
+stable.
+
+## Feature Flag Enum
+To aid static typing in NVDA, `enum` classes are used.
+`BoolFlag` is provided, the majority of feature flags are expected to use this.
+However, if more values are required (E.G. `AllowUiaInMSWord` has options `WHEN_NECESSARY`, `WHERE_SUITABLE`, `ALWAYS`, in addition to `DEFAULT`), then a new `enum` class can be defined.
+Adding the enum class to the `featureFlagEnums.py` file will automatically expose it for use in the config spec (see the next section).
+Example new `enum` class:
+
+```python
+
+class AllowUiaInMSWordFlag(DisplayStringEnum):
+	"""Feature flag for UIA in MS Word.
+	The explicit DEFAULT option allows developers to differentiate between a value set that happens to be
+	the current default, and a value that has been returned to the "default" explicitly.
+	"""
+
+	@property
+	def _displayStringLabels(self):
+		""" These labels will be used in the GUI when displaying the options.
+		"""
+		# To prevent duplication, self.DEFAULT is not included here.
+		return {
+			# Translators: Label for an option in NVDA settings.
+			self.WHEN_NECESSARY: _("Only when necessary"),
+			# Translators: Label for an option in NVDA settings.
+			self.WHERE_SUITABLE: _("Where suitable"),
+			# Translators: Label for an option in NVDA settings.
+			self.ALWAYS: _("ALWAYS"),
+		}
+
+	DEFAULT = enum.auto()
+	WHEN_NECESSARY = enum.auto()
+	WHERE_SUITABLE = enum.auto()
+	ALWAYS = enum.auto()
+```
+
+## Config Spec
+In `configSpec.py` specify the new config key, ideally in the category that is most relevant to the feature.
+Placing it in a category rather than a catch-all feature flags category, allows for the option to become
+permanent without having to write config upgrade code to move it from section to another.
+
+```ini
+[virtualBuffers]
+    newOptionForUsers = featureFlag(optionsEnum="BoolFlag", behaviourOfDefault="disabled")
+    anotherOptionForUsers = featureFlag(optionsEnum="AllowUiaInMSWordFlag", behaviourOfDefault="WHERE_SUITABLE")
+```
+
+The `featureFlag` type is a custom spec type.
+It will produce a `config.FeatureFlag` class instance when the key is accessed.
+```python
+newFlagValue: config.FeatureFlag = config.conf["virtualBuffers"]["newOptionForUsers"]
+
+# BoolFlag converts to bool automatically, taking into account 'behaviorOfDefault'
+if newFlagValue:
+    print("The new option is enabled")
+
+anotherFlagValue: config.FeatureFlag = config.conf["virtualBuffers"]["anotherOptionForUsers"]
+
+# Other "optionsEnum" types can compare with the value, the 'behaviorOfDefault' is taken into account.
+if flagValue == AllowUiaInMSWordFlag.ALWAYS:
+    print("Another option is enabled")
+```
+
+## GUI
+A control (`gui.nvdaControls.FeatureFlagCombo`) is provided to simplify exposing the feature flag to the user.
+
+### Usage:
+Note the comments in the example:
+- `creation`
+- `is default`
+- `reset to default value`
+- `save GUI value to config`
+
+
+```python
+import collections
+from gui import nvdaControls, guiHelper
+import config
+import wx
+
+sHelper = guiHelper.BoxSizerHelper(self, sizer=wx.BoxSizer(wx.HORIZONTAL))
+
+# Translators: Explanation for the group name
+label = _("Virtual Buffers")
+vbufSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+vbufGroup = guiHelper.BoxSizerHelper(vbufSizer, sizer=vbufSizer)
+sHelper.addItem(vbufGroup)
+
+# creation
+self.newOptionForUsersCombo: nvdaControls.FeatureFlagCombo = vbufGroup.addLabeledControl(
+    labelText=_(
+        # Translators: Explanation of what the control does and where it is used.
+        "New option for users"
+    ),
+    wxCtrlClass=nvdaControls.FeatureFlagCombo,
+    keyPath=["virtualBuffers", "newOptionForUsers"], # The path of keys, see config spec.
+    conf=config.conf, # The configObj instance, allows getting / setting the value
+)
+...
+# is default
+# Checking if the user has a saved (non-default) value
+self.loadChromeVbufWhenBusyCombo.isValueConfigSpecDefault()
+...
+# reset to default value:
+self.loadChromeVbufWhenBusyCombo.resetToConfigSpecDefault()
+...
+# save GUI value to config:
+self.loadChromeVbufWhenBusyCombo.saveCurrentValueToConf()
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,10 @@ py2exe==0.11.1.0
 sphinx==3.4.1
 sphinx_rtd_theme
 
+# Requirements for type checking.
+# typing_extensions is incorporated in py3.8+, also available via mypy
+typing_extensions==4.3.0
+
 # Requirements for automated linting
 flake8 ~= 3.7.7
 flake8-tabs == 2.1.0

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -90,7 +90,7 @@ class Document(ia2Web.Document):
 
 	def _get_treeInterceptorClass(self) -> typing.Type["TreeInterceptor"]:
 		shouldLoadVBufOnBusyFeatureFlag = bool(
-			config.conf["virtualBuffers"]["loadChromiumVbufOnBusyState"]
+			config.conf["virtualBuffers"]["loadChromiumVBufOnBusyState"]
 		)
 		vBufUnavailableStates = {  # if any of these are in states, don't return ChromeVBuf
 			controlTypes.State.EDITABLE,

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -5,15 +5,21 @@
 
 """NVDAObjects for the Chromium browser project
 """
-
+import typing
 from typing import Dict, Optional
 from comtypes import COMError
+
+import config
 import controlTypes
 from NVDAObjects.IAccessible import IAccessible
 from virtualBuffers.gecko_ia2 import Gecko_ia2 as GeckoVBuf, Gecko_ia2_TextInfo as GeckoVBufTextInfo
 from . import ia2Web
 from logHandler import log
 
+if typing.TYPE_CHECKING:
+	# F401 imported but unused, actually used as a string within type annotation (to avoid having to import
+	# at run time)
+	from treeInterceptorHandler import TreeInterceptor  # noqa: F401
 
 supportedAriaDetailsRoles: Dict[str, Optional[controlTypes.Role]] = {
 	"comment": controlTypes.Role.COMMENT,
@@ -82,11 +88,28 @@ class ChromeVBuf(GeckoVBuf):
 
 class Document(ia2Web.Document):
 
-	def _get_treeInterceptorClass(self):
-		states = self.states
-		if controlTypes.State.EDITABLE not in states and controlTypes.State.BUSY not in states:
-			return ChromeVBuf
-		return super(Document, self).treeInterceptorClass
+	def _get_treeInterceptorClass(self) -> typing.Type["TreeInterceptor"]:
+		shouldLoadVBufOnBusyFeatureFlag = bool(
+			config.conf["virtualBuffers"]["loadChromiumVbufOnBusyState"]
+		)
+		vBufUnavailableStates = {  # if any of these are in states, don't return ChromeVBuf
+			controlTypes.State.EDITABLE,
+		}
+		if not shouldLoadVBufOnBusyFeatureFlag:
+			log.debug(
+				f"loadChromiumVBufOnBusyState feature flag is {shouldLoadVBufOnBusyFeatureFlag},"
+				" vBuf WILL NOT be loaded when state of the document is busy."
+			)
+			vBufUnavailableStates.add(controlTypes.State.BUSY)
+		else:
+			log.debug(
+				f"loadChromiumVBufOnBusyState feature flag is {shouldLoadVBufOnBusyFeatureFlag},"
+				" vBuf WILL be loaded when state of the document is busy."
+			)
+		if self.states.intersection(vBufUnavailableStates):
+			return super().treeInterceptorClass
+		return ChromeVBuf
+
 
 class ComboboxListItem(IAccessible):
 	"""

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -26,6 +26,9 @@ import config
 import controlTypes
 import appModuleHandler
 import treeInterceptorHandler
+from treeInterceptorHandler import (
+	TreeInterceptor,
+)
 import braille
 import vision
 import globalPluginHandler
@@ -352,10 +355,15 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 
 	focusRedirect=None #: Another object which should be treeted as the focus if focus is ever given to this object.
 
-	def _get_treeInterceptorClass(self):
+	treeInterceptorClass: typing.Type[TreeInterceptor]
+	"""Type definition for auto prop '_get_treeInterceptorClass'"""
+
+	def _get_treeInterceptorClass(self) -> typing.Type[TreeInterceptor]:
 		"""
-		If this NVDAObject should use a treeInterceptor, then this property provides the L{treeInterceptorHandler.TreeInterceptor} class it should use. 
+		If this NVDAObject should use a treeInterceptor, then this property
+		provides the L{treeInterceptorHandler.TreeInterceptor} class it should use.
 		If not then it should be not implemented.
+		@raises NotImplementedError when no TreeInterceptor class is available.
 		"""
 		raise NotImplementedError
 
@@ -368,10 +376,10 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	#: @type: bool
 	shouldCreateTreeInterceptor = True
 
-	#: Type definition for auto prop '_get_treeInterceptor'
-	treeInterceptor: treeInterceptorHandler.TreeInterceptor
+	treeInterceptor: typing.Optional[TreeInterceptor]
+	"""Type definition for auto prop '_get_treeInterceptor'"""
 
-	def _get_treeInterceptor(self) -> treeInterceptorHandler.TreeInterceptor:
+	def _get_treeInterceptor(self) -> typing.Optional[TreeInterceptor]:
 		"""Retrieves the treeInterceptor associated with this object.
 		If a treeInterceptor has not been specifically set,
 		the L{treeInterceptorHandler} is asked if it can find a treeInterceptor containing this object.
@@ -392,7 +400,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 				self._treeInterceptor=weakref.ref(ti)
 			return ti
 
-	def _set_treeInterceptor(self,obj):
+	def _set_treeInterceptor(self, obj: typing.Optional[TreeInterceptor]):
 		"""Specifically sets a treeInterceptor to be associated with this object.
 		"""
 		if obj:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -34,6 +34,10 @@ from fileUtils import FaultTolerantFile
 import extensionPoints
 from . import profileUpgrader
 from .configSpec import confspec
+from .featureFlag import (
+	_transformSpec_AddFeatureFlagDefault,
+	_validateConfig_featureFlag,
+)
 from typing import Any, Dict, List, Optional, Set
 
 #: True if NVDA is running as a Windows Store Desktop Bridge application
@@ -496,6 +500,20 @@ def addConfigDirsToPythonPackagePath(module, subdir=None):
 	pathList.extend(module.__path__)
 	module.__path__=pathList
 
+
+def _transformSpec(spec: ConfigObj):
+	"""To make the spec less verbose, transform the spec:
+	- Add default="default" to all featureFlag items. This is required so that the key can be read,
+	even if it is missing from the config.
+	"""
+	spec.configspec = spec
+	spec.validate(
+		Validator({
+			"featureFlag": _transformSpec_AddFeatureFlagDefault,
+		}), preserve_errors=True,
+	)
+
+
 class ConfigManager(object):
 	"""Manages and provides access to configuration.
 	In addition to the base configuration, there can be multiple active configuration profiles.
@@ -517,13 +535,16 @@ class ConfigManager(object):
 
 	def __init__(self):
 		self.spec = confspec
+		_transformSpec(self.spec)
 		#: All loaded profiles by name.
 		self._profileCache: Optional[Dict[Optional[str], ConfigObj]] = {}
 		#: The active profiles.
 		self.profiles: List[ConfigObj] = []
 		#: Whether profile triggers are enabled (read-only).
 		self.profileTriggersEnabled: bool = True
-		self.validator: Validator = Validator()
+		self.validator: Validator = Validator({
+			"_featureFlag": _validateConfig_featureFlag
+		})
 		self.rootSection: Optional[AggregatedSection] = None
 		self._shouldHandleProfileSwitch: bool = True
 		self._pendingHandleProfileSwitch: bool = False

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -174,7 +174,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	trapNonCommandGestures = boolean(default=true)
 	enableOnPageLoad = boolean(default=true)
 	autoFocusFocusableElements = boolean(default=False)
-	loadChromiumVbufOnBusyState = boolean(default=True)
+	loadChromiumVBufOnBusyState = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 
 [touch]
 	enabled = boolean(default=true)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -174,6 +174,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	trapNonCommandGestures = boolean(default=true)
 	enableOnPageLoad = boolean(default=true)
 	autoFocusFocusableElements = boolean(default=False)
+	loadChromiumVbufOnBusyState = boolean(default=True)
 
 [touch]
 	enabled = boolean(default=true)

--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -1,0 +1,226 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Manages NVDA configuration.
+Provides utility classes to make handling featureFlags easier.
+"""
+import enum
+import typing
+
+from . import featureFlagEnums
+from .featureFlagEnums import (
+	BoolFlag,
+	FlagValueEnum,
+)
+from typing import (
+	Optional,
+)
+from configobj.validate import (
+	ValidateError,
+	VdtParamError,
+)
+from logHandler import log
+
+
+class FeatureFlag:
+	"""A FeatureFlag allows the selection of a preference for behavior or its default state.
+	It's typically used to introduce a feature that isn't expected to handle all use-cases well
+	when initially introduced.
+	The feature can be disabled initially, some users can manually enable and try the feature
+	giving feedback.
+	Once developers have confidence in the feature, the default behavior is changed.
+	This change in default behavior should not have any impact on users who have already tried the feature,
+	and perhaps disagreed in principle with it (I.E. wished to disable the feature, not because it is buggy,
+	but because even if it works perfectly it is not their preference).
+	The default option allows users to explicitly defer to the NVDA default behaviour.
+	The default behaviour can change, without affecting a user's preference.
+	"""
+	def __init__(
+			self,
+			value: FlagValueEnum,
+			behaviorOfDefault: FlagValueEnum
+	):
+		self.value = value
+		self.enumClassType: typing.Type[FlagValueEnum] = type(value)
+		assert self.enumClassType == type(behaviorOfDefault)
+		assert behaviorOfDefault != value.DEFAULT
+		self.behaviorOfDefault = behaviorOfDefault
+
+	def __bool__(self) -> bool:
+		if not isinstance(self.value, BoolFlag):
+			raise NotImplementedError(
+				"Only BoolFlag supported. For other types use explicit checks"
+			)
+		if self.isDefault():
+			return bool(self.behaviorOfDefault)
+		return bool(self.value)
+
+	def isDefault(self) -> bool:
+		return self.value == self.value.DEFAULT
+
+	def calculated(self) -> FlagValueEnum:
+		if self.isDefault():
+			return self.behaviorOfDefault
+		return self.value
+
+	def __eq__(self, other: typing.Union["FeatureFlag", FlagValueEnum]):
+		if isinstance(other, type(self.value)):
+			other = FeatureFlag(other, behaviorOfDefault=self.behaviorOfDefault)
+		if isinstance(other, FeatureFlag):
+			return self.calculated() == other.calculated()
+		return super().__eq__(other)
+
+	def __str__(self) -> str:
+		"""So that the value can be saved to the ini file.
+		"""
+		return self.value.name
+
+
+def _validateConfig_featureFlag(
+		value: Optional[str],
+		optionsEnum: str,
+		behaviorOfDefault: str
+) -> FeatureFlag:
+	""" Used in conjunction with configObj.Validator
+	param value: The value to be validated / converted to a FeatureFlag object.
+	Expected: "enabled", "disabled", "default"
+	param behaviorOfDefault: Required, the default behavior of the flag, should be "enabled" or "disabled".
+	"""
+	log.debug(
+		f"Validating feature flag: {value}"
+		f", optionsEnum: {optionsEnum}"
+		f", behaviorOfDefault: {behaviorOfDefault}"
+	)
+	if not isinstance(optionsEnum, str):
+		raise ValidateError(
+			'Spec Error: optionsEnum must be specified as a string'
+			f" (got type {type(optionsEnum)} with value: {optionsEnum})"
+		)
+	try:
+		OptionsEnumClass = dict(featureFlagEnums.getAvailableEnums())[optionsEnum]
+	except KeyError:
+		raise ValidateError(
+			"Spec Error: optionsEnum must be an enum defined in the config.featureFlagEnums module."
+			f" (got {optionsEnum})"
+		)
+
+	if not isinstance(behaviorOfDefault, str):
+		raise ValidateError(
+			'Spec Error: behaviorOfDefault must be specified as a valid'
+			f' {OptionsEnumClass.__qualname__} member string'
+			f" (got type {type(behaviorOfDefault)} with value: {behaviorOfDefault})"
+		)
+	try:
+		behaviorOfDefault = OptionsEnumClass[behaviorOfDefault.upper()]
+	except KeyError:
+		raise ValidateError(
+			"Spec Error: behaviorOfDefault must be specified as a valid enum member string for enum class "
+			f"{OptionsEnumClass.__qualname__} (got {behaviorOfDefault})"
+		)
+	if behaviorOfDefault == OptionsEnumClass.DEFAULT:
+		raise ValidateError("Spec Error: behaviorOfDefault must not be 'default'/'DEFAULT'")
+
+	if not isinstance(value, str):
+		raise ValidateError(
+			'Expected a featureFlag value in the form of a string. EG "disabled", "enabled", or "default".'
+			f" Got {type(value)} with value: {value} instead."
+		)
+
+	try:
+		value = OptionsEnumClass[value.upper()]
+	except KeyError:
+		raise ValidateError(
+			"FeatureFlag value must be specified as a valid enum member string for enum class "
+			f"{OptionsEnumClass.__qualname__} (got {value})"
+		)
+
+	return FeatureFlag(value, behaviorOfDefault)
+
+
+def _transformSpec_AddFeatureFlagDefault(specString: str, **kwargs) -> str:
+	""" Ensure that default is specified for featureFlag used in configSpec.
+	Param examples based on the following spec string in configSpec:
+		loadChromiumVBufOnBusyState = featureFlag(behaviorOfDefault="enabled", optionsEnum="BoolFlag")
+	@param specString: EG 'featureFlag(behaviorOfDefault="enabled", optionsEnum="BoolFlag")'
+	@param kwargs: EG {'behaviorOfDefault': 'enabled', 'optionsEnum':'BoolFlag'}
+	@return 'featureFlag(behaviorOfDefault="ENABLED", optionsEnum="BoolFlag", default="DEFAULT")'
+	@remarks Manually specifying 'default' in the configSpec string (for featureFlag) will result in a
+		VdtParamError. Required params:
+		- 'behaviorOfDefault'
+		- 'optionsEnum'
+	"""
+	log.info(f"specString: {specString}, kwargs: {kwargs}")
+	usage = 'Usage: featureFlag(behaviorOfDefault="enabled"|"disabled", optionsEnum="BoolFlag")'
+	if "default=" in specString:
+		raise VdtParamError(
+			name_or_msg=f"Param 'default' not expected. {usage}",
+			value=specString
+		)
+
+	optionsEnumKey = "optionsEnum"
+	if optionsEnumKey not in kwargs:
+		raise VdtParamError(
+			name_or_msg=f"Param '{optionsEnumKey}' missing. {usage}",
+			value=specString
+		)
+	optionsEnumVal = kwargs[optionsEnumKey]
+	if not isinstance(optionsEnumVal, str):
+		raise VdtParamError(
+			name_or_msg=(
+				f"Param '{optionsEnumKey}' should have a string value"
+				f" but got {type(optionsEnumVal)}. {usage}"),
+			value=specString
+		)
+	availableEnums = dict(featureFlagEnums.getAvailableEnums())
+	if optionsEnumVal not in availableEnums:
+		raise VdtParamError(
+			name_or_msg=(
+				f"Param '{optionsEnumKey}' should be an enum defined in featureFlagEnums,"
+				f" but was {optionsEnumVal}. Currently available: {availableEnums.keys()} "
+			),
+			value=specString
+		)
+	OptionsEnumClass: enum.EnumMeta = availableEnums[optionsEnumVal]
+	behaviorOfDefaultKey = "behaviorOfDefault"
+	if behaviorOfDefaultKey not in kwargs:
+		raise VdtParamError(
+			name_or_msg=f"Param '{behaviorOfDefaultKey}' missing. {usage}",
+			value=specString
+		)
+	behaviorOfDefaultVal = kwargs[behaviorOfDefaultKey]
+	if not isinstance(behaviorOfDefaultVal, str):
+		raise VdtParamError(
+			name_or_msg=(
+				f"Param '{behaviorOfDefaultKey}' should have a string value"
+				f" but got {type(behaviorOfDefaultVal)}. {usage}"),
+			value=specString
+		)
+	behaviorOfDefaultVal = behaviorOfDefaultVal.upper()
+	try:
+		OptionsEnumClass[behaviorOfDefaultVal]
+	except KeyError:
+		raise VdtParamError(
+			name_or_msg=(
+				f"Param '{behaviorOfDefaultKey}' should be one of: {[o.name for o in OptionsEnumClass]}"
+				f" but was {behaviorOfDefaultVal}. {usage}"
+			),
+			value=specString
+		)
+	if len(kwargs) != 2:
+		raise VdtParamError(
+			name_or_msg=(
+				"Unexpected number of params."
+				f" Got {kwargs}. {usage}"
+			),
+			value=specString
+		)
+	# ensure there is the expected default
+	retString = (
+		'_featureFlag('
+		f'{optionsEnumKey}="{optionsEnumVal}"'
+		f', {behaviorOfDefaultKey}="{behaviorOfDefaultVal}"'
+		f', default="DEFAULT")'
+	)
+	return retString

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -1,0 +1,77 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""
+Feature flag value enumerations.
+Some feature flags require feature specific options, this file defines those options.
+All feature flags enums should
+- inherit from DisplayStringEnum and implement _displayStringLabels (for the 'displayString' property)
+- have a 'DEFAULT' member.
+"""
+import enum
+import typing
+
+from utils.displayString import (
+	DisplayStringEnum,
+	_DisplayStringEnumMixin,
+)
+
+from typing_extensions import (
+	Protocol,  # Python 3.8 adds native support
+)
+
+
+class FeatureFlagEnumProtocol(Protocol, typing.Collection):
+	""" All feature flags are expected to have a "DEFAULT" value.
+	This definition is provided only for type annotations
+	"""
+	DEFAULT: enum.Enum  # Required enum member
+	name: str  # comes from enum.Enum
+	value: str  # comes from enum.Enum
+
+
+class FlagValueEnum(enum.EnumMeta, _DisplayStringEnumMixin, FeatureFlagEnumProtocol):
+	"""Provided only for type annotations.
+	"""
+	pass
+
+
+class BoolFlag(DisplayStringEnum):
+	"""Generic logically bool feature flag.
+	The explicit DEFAULT option allows developers to differentiate between a value set that happens to be
+	the current default, and a value that has been returned to the "default" explicitly.
+	"""
+
+	@property
+	def _displayStringLabels(self):
+		# To prevent duplication, self.DEFAULT is not included here.
+		return {
+			# Translators: Label for an option in NVDA settings.
+			self.DISABLED: _("Disabled"),
+			# Translators: Label for an option in NVDA settings.
+			self.ENABLED: _("Enabled"),
+		}
+
+	DEFAULT = enum.auto()
+	DISABLED = enum.auto()
+	ENABLED = enum.auto()
+
+	def __bool__(self):
+		if self == BoolFlag.DEFAULT:
+			raise ValueError(
+				"Only ENABLED or DISABLED are valid bool values"
+				", DEFAULT must be combined with a 'behavior for default' to be Truthy or Falsy"
+			)
+		return self == BoolFlag.ENABLED
+
+
+def getAvailableEnums() -> typing.Generator[typing.Tuple[str, FlagValueEnum], None, None]:
+	for name, value in globals().items():
+		if (
+			isinstance(value, type)  # is a class
+			and issubclass(value, DisplayStringEnum)  # inherits from DisplayStringEnum
+			and value != DisplayStringEnum  # but isn't DisplayStringEnum
+		):
+			yield name, value

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -3,10 +3,24 @@
 # Copyright (C) 2016-2021 NV Access Limited, Derek Riemer
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+import collections
+import enum
+import typing
+from typing import (
+	List,
+	OrderedDict,
+	Type,
+)
 
 import wx
 from wx.lib import scrolledpanel
 from wx.lib.mixins import listctrl as listmix
+
+import config
+from config.featureFlag import (
+	FeatureFlag,
+	FlagValueEnum as FeatureFlagEnumT,
+)
 from .dpiScalingHelper import DpiScalingHelperMixin
 from . import guiHelper
 import winUser
@@ -391,3 +405,129 @@ class TabbableScrolledPanel(scrolledpanel.ScrolledPanel):
 		finally:
 			# ensure child.GetRect is reset properly even if super().ScrollChildIntoView throws an exception
 			child.GetRect = oldChildGetRectFunction
+
+
+class FeatureFlagCombo(wx.Choice):
+	"""Creates a combobox (wx.Choice) with a list of feature flags.
+	"""
+	def __init__(
+			self,
+			parent: wx.Window,
+			keyPath: List[str],
+			conf: config.ConfigManager,
+			pos=wx.DefaultPosition,
+			size=wx.DefaultSize,
+			style=0,
+			validator=wx.DefaultValidator,
+			name=wx.ChoiceNameStr,
+	):
+		"""
+		@param parent: The parent window.
+		@param keyPath: The list of keys required to get to the config value.
+		@param conf: The config.conf object.
+		@param pos: The position of the control. Forwarded to wx.Choice
+		@param size: The size of the control. Forwarded to wx.Choice
+		@param style: The style of the control. Forwarded to wx.Choice
+		@param validator: The validator for the control. Forwarded to wx.Choice
+		@param name: The name of the control. Forwarded to wx.Choice
+		"""
+		self._confPath = keyPath
+		self._conf = conf
+		configValue = self._getConfigValue()
+		self._optionsEnumClass: Type[FeatureFlagEnumT] = configValue.enumClassType
+		translatedOptions: typing.OrderedDict[FeatureFlagEnumT, str] = collections.OrderedDict({
+			value: value.displayString
+			for value in self._optionsEnumClass
+			if value != self._optionsEnumClass.DEFAULT
+		})
+		if self._optionsEnumClass.DEFAULT in translatedOptions:
+			raise ValueError(
+				f"The translatedOptions dictionary should not contain the key {self._optionsEnumClass.DEFAULT!r}"
+				" It will be added automatically. See _setDefaultOptionLabel"
+			)
+		self._translatedOptions = self._createOptionsDict(translatedOptions)
+		choices = list(self._translatedOptions.values())
+		super().__init__(
+			parent,
+			choices=choices,
+			pos=pos,
+			size=size,
+			style=style,
+			validator=validator,
+			name=name,
+		)
+
+		self.SetSelection(self._getChoiceIndex(self._getConfigValue().value))
+		self.defaultValue = self._getConfSpecDefaultValue()
+		"""The default value of the config spec. Not the "behavior of default".
+		This is provided to maintain compatibility with other controls in the
+		advanced settings dialog.
+		"""
+
+	def _getChoiceIndex(self, value: FeatureFlagEnumT) -> int:
+		return list(self._translatedOptions.keys()).index(value)
+
+	def _getConfSpecDefaultValue(self) -> FeatureFlagEnumT:
+		defaultValueFromSpec = self._conf.getConfigValidation(self._confPath).default
+		if not isinstance(defaultValueFromSpec, FeatureFlag):
+			raise ValueError(f"Default spec value is not a FeatureFlag, but {type(defaultValueFromSpec)}")
+		return defaultValueFromSpec.value
+
+	def _getConfigValue(self) -> FeatureFlag:
+		keyPath = self._confPath
+		if not keyPath or len(keyPath) < 1:
+			raise ValueError("Key path not provided")
+
+		conf = self._conf
+		for nextKey in keyPath:
+			conf = conf[nextKey]
+
+		if not isinstance(conf, FeatureFlag):
+			raise ValueError(f"Config value is not a FeatureFlag, but a {type(conf)}")
+		return conf
+
+	def isValueConfigSpecDefault(self) -> bool:
+		"""Does the current value of the control match the default value from the config spec?
+		This is not the same as the "behaviour of default".
+		"""
+		return self.GetSelection() == self.defaultValue
+
+	def resetToConfigSpecDefault(self) -> None:
+		"""Set the value of the control to the default value from the config spec.
+		"""
+		self.SetSelection(self._getChoiceIndex(self.defaultValue))
+
+	def saveCurrentValueToConf(self) -> None:
+		""" Set the config value to the current value of the control.
+		"""
+		flagValue: enum.Enum = list(self._translatedOptions.keys())[self.GetSelection()]
+		keyPath = self._confPath
+		if not keyPath or len(keyPath) < 1:
+			raise ValueError("Key path not provided")
+		lastIndex = len(keyPath) - 1
+
+		conf = self._conf
+		for index, nextKey in enumerate(keyPath):
+			if index == lastIndex:
+				conf[nextKey] = flagValue.name
+				return
+			else:
+				conf = conf[nextKey]
+
+	def _createOptionsDict(
+			self,
+			translatedOptions: OrderedDict[FeatureFlagEnumT, str]
+	) -> OrderedDict[enum.Enum, str]:
+		behaviorOfDefault = self._getConfigValue().behaviorOfDefault
+		translatedStringForBehaviorOfDefault = translatedOptions[behaviorOfDefault]
+		# Translators: Label for the default option for some feature-flag combo boxes
+		# Such as, in the Advanced settings panel option, 'Load Chromium virtual buffer when document busy.'
+		# The placeholder {} is replaced with the label of the option which describes current default behavior
+		# in NVDA. EG "Default (Yes)".
+		defaultOptionLabel: str = _("Default ({})").format(
+			translatedStringForBehaviorOfDefault
+		)
+		return collections.OrderedDict({
+			self._optionsEnumClass.DEFAULT: defaultOptionLabel,  # make sure default is the first option.
+			**translatedOptions
+		})

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -8,7 +8,6 @@
 # jakubl7545, mltony
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-
 import logging
 from abc import ABCMeta, abstractmethod
 import copy
@@ -17,6 +16,7 @@ from enum import IntEnum
 
 import typing
 import wx
+
 from vision.providerBase import VisionEnhancementProviderSettings
 from wx.lib.expando import ExpandoTextCtrl
 import wx.lib.newevent
@@ -2892,6 +2892,23 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
+		label = _("Virtual Buffers")
+		vBufSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		vBufGroup = guiHelper.BoxSizerHelper(vBufSizer, sizer=vBufSizer)
+		sHelper.addItem(vBufGroup)
+
+		self.loadChromeVBufWhenBusyCombo: nvdaControls.FeatureFlagCombo = vBufGroup.addLabeledControl(
+			labelText=_(
+				# Translators: This is the label for a combo-box in the Advanced settings panel.
+				"Load Chromium virtual buffer when document busy."
+			),
+			wxCtrlClass=nvdaControls.FeatureFlagCombo,
+			keyPath=["virtualBuffers", "loadChromiumVBufOnBusyState"],
+			conf=config.conf,
+		)
+
+		# Translators: This is the label for a group of advanced options in the
+		#  Advanced settings panel
 		label = _("Editable Text")
 		editableSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
 		editableTextGroup = guiHelper.BoxSizerHelper(editableSizer, sizer=editableSizer)
@@ -3016,6 +3033,7 @@ class AdvancedPanelControls(
 			and self.annotationsDetailsCheckBox.IsChecked() == self.annotationsDetailsCheckBox.defaultValue
 			and self.ariaDescCheckBox.IsChecked() == self.ariaDescCheckBox.defaultValue
 			and self.supportHidBrailleCombo.GetSelection() == self.supportHidBrailleCombo.defaultValue
+			and self.loadChromeVBufWhenBusyCombo.isValueConfigSpecDefault()
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -3036,6 +3054,7 @@ class AdvancedPanelControls(
 		self.supportHidBrailleCombo.SetSelection(self.supportHidBrailleCombo.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
+		self.loadChromeVBufWhenBusyCombo.resetToConfigSpecDefault()
 		self._defaultsRestored = True
 
 	def onSave(self):
@@ -3063,6 +3082,7 @@ class AdvancedPanelControls(
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
 		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCombo.GetSelection()
+		self.loadChromeVBufWhenBusyCombo.saveCurrentValueToConf()
 
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,344 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2022 NV Access Limited
+import enum
+import typing
+import unittest
+
+import configobj
+import configobj.validate
+
+from config import featureFlag
+from config.featureFlag import (
+	FeatureFlag,
+)
+from config.featureFlagEnums import (
+	getAvailableEnums,
+	BoolFlag,
+)
+from utils.displayString import (
+	DisplayStringEnum
+)
+
+
+class Config_FeatureFlagEnums_getAvailableEnums(unittest.TestCase):
+
+	def test_knownEnumsReturned(self):
+		self.assertTrue(
+			set(getAvailableEnums()).issuperset({
+				("BoolFlag", BoolFlag),
+			}
+		))
+
+	def test_allEnumsHaveDefault(self):
+		noDefault = []
+		for name, klass in getAvailableEnums():
+			if not hasattr(klass, "DEFAULT"):
+				noDefault.append((name, klass))
+		self.assertEqual(noDefault, [])
+
+
+class Config_FeatureFlag_specTransform(unittest.TestCase):
+
+	def test_defaultGetsAdded(self):
+		self.assertEqual(
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="disabled", optionsEnum="BoolFlag")',
+				behaviorOfDefault="disabled",
+				optionsEnum="BoolFlag",
+				# note: configObj treats param 'default' specially, it isn't passed through as a kwarg.
+			),
+			'_featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="DISABLED", default="DEFAULT")'
+		)
+
+	def test_behaviorOfDefaultGetsKept(self):
+		self.assertEqual(
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="enabled", optionsEnum="BoolFlag")',
+				behaviorOfDefault="enabled",
+				optionsEnum="BoolFlag",
+			),
+			'_featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="ENABLED", default="DEFAULT")'
+		)
+
+	def test_paramDefaultIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="disabled", optionsEnum="BoolFlag", default="enabled")',
+				behaviorOfDefault="disabled",
+				optionsEnum="BoolFlag",
+				# note: configObj treats param 'default' specially, it isn't passed through as a kwarg.
+			)
+
+	def test_behaviorOfDefaultMissingIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(optionsEnum="BoolFlag")',
+				optionsEnum="BoolFlag",
+			)
+
+	def test_optionsEnumMissingIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="enabled")',
+				behaviorOfDefault="enabled",
+			)
+
+	def test_argsMissingIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag()',
+			)
+
+	def test_behaviorOfDefaultTypeMustBeStr(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault=True, optionsEnum="BoolFlag")',
+				behaviorOfDefault=True,
+				optionsEnum="BoolFlag",
+			)
+
+	def test_tooManyParamsIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="enabled", optionsEnum="BoolFlag", someOther=True)',
+				behaviorOfDefault="enabled",
+				optionsEnum="BoolFlag",
+				someOther=True
+			)
+
+	def test_optionsEnumMustBeKnown(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="enabled", optionsEnum="UnknownEnumClass", someOther=True)',
+				behaviorOfDefault="enabled",
+				optionsEnum="UnknownEnumClass",
+				someOther=True
+			)
+
+
+class Config_FeatureFlag_validateFeatureFlag(unittest.TestCase):
+
+	def assertFeatureFlagState(
+			self,
+			flag: FeatureFlag,
+			enumType: typing.Type,
+			value: enum.Enum,
+			behaviorOfDefault: enum.Enum,
+			calculatedValue: bool
+	) -> None:
+		self.assertIsInstance(flag.value, enumType, msg="Wrong enum type created")
+		self.assertIsInstance(value, enumType, msg="Test error: wrong enum type for checking value")
+		self.assertIsInstance(
+			behaviorOfDefault,
+			enumType,
+			msg="Test error: wrong enum type for checking behaviorOfDefault"
+		)
+
+		self.assertEqual(bool(flag), calculatedValue, msg="Calculated value for behaviour is unexpected")
+		self.assertEqual(flag.value, value, msg="Flag value is unexpected")
+		self.assertEqual(
+			flag.behaviorOfDefault,
+			behaviorOfDefault,
+			msg="Flag behaviorOfDefault value is unexpected"
+		)
+		self.assertEqual(
+			str(flag),  # conversion to string required to save to config.
+			value.name.upper(),
+			msg="Flag string conversion not as expected"
+		)
+
+	def test_enabled_lower(self):
+		flag = featureFlag._validateConfig_featureFlag(
+			"enabled",
+			behaviorOfDefault="disabled",
+			optionsEnum=BoolFlag.__name__
+		)
+		self.assertFeatureFlagState(
+			flag,
+			enumType=BoolFlag,
+			value=BoolFlag.ENABLED,
+			behaviorOfDefault=BoolFlag.DISABLED,
+			calculatedValue=True
+		)
+
+	def test_enabled_upper(self):
+		flag = featureFlag._validateConfig_featureFlag(
+			"ENABLED",
+			behaviorOfDefault="disabled",
+			optionsEnum=BoolFlag.__name__
+		)
+		self.assertFeatureFlagState(
+			flag,
+			enumType=BoolFlag,
+			value=BoolFlag.ENABLED,
+			behaviorOfDefault=BoolFlag.DISABLED,
+			calculatedValue=True
+		)
+
+	def test_disabled_lower(self):
+		flag = featureFlag._validateConfig_featureFlag(
+			"disabled",
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
+		)
+		self.assertFeatureFlagState(
+			flag,
+			enumType=BoolFlag,
+			value=BoolFlag.DISABLED,
+			behaviorOfDefault=BoolFlag.ENABLED,
+			calculatedValue=False
+		)
+
+	def test_disabled_upper(self):
+		flag = featureFlag._validateConfig_featureFlag(
+			"DISABLED",
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
+		)
+		self.assertFeatureFlagState(
+			flag,
+			enumType=BoolFlag,
+			value=BoolFlag.DISABLED,
+			behaviorOfDefault=BoolFlag.ENABLED,
+			calculatedValue=False
+		)
+
+	def test_default_lower(self):
+		flag = featureFlag._validateConfig_featureFlag(
+			"default",
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
+		)
+		self.assertFeatureFlagState(
+			flag,
+			enumType=BoolFlag,
+			value=BoolFlag.DEFAULT,
+			behaviorOfDefault=BoolFlag.ENABLED,
+			calculatedValue=True
+		)
+
+	def test_default_upper(self):
+		flag = featureFlag._validateConfig_featureFlag(
+			"DEFAULT",
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
+		)
+		self.assertFeatureFlagState(
+			flag,
+			enumType=BoolFlag,
+			value=BoolFlag.DEFAULT,
+			behaviorOfDefault=BoolFlag.ENABLED,
+			calculatedValue=True
+		)
+
+	def test_empty_raises(self):
+		with self.assertRaises(configobj.validate.ValidateError):
+			featureFlag._validateConfig_featureFlag(
+				"",  # Given our usage of ConfigObj, this situation is unexpected.
+				behaviorOfDefault="disabled",
+				optionsEnum=BoolFlag.__name__
+			)
+
+	def test_None_raises(self):
+		with self.assertRaises(configobj.validate.ValidateError):
+			featureFlag._validateConfig_featureFlag(
+				None,  # Given our usage of ConfigObj, this situation is unexpected.
+				behaviorOfDefault="disabled",
+				optionsEnum=BoolFlag.__name__
+			)
+
+	def test_invalid_raises(self):
+		with self.assertRaises(configobj.validate.ValidateError):
+			featureFlag._validateConfig_featureFlag(
+				"invalid",  # must be a valid member of BoolFlag
+				behaviorOfDefault="disabled",
+				optionsEnum=BoolFlag.__name__
+			)
+
+
+class Config_FeatureFlag_with_BoolFlag(unittest.TestCase):
+
+	def test_Enabled_DisabledByDefault(self):
+		f = FeatureFlag(value=BoolFlag.ENABLED, behaviorOfDefault=BoolFlag.DISABLED)
+		self.assertEqual(True, bool(f))
+		self.assertEqual(BoolFlag.ENABLED, f.calculated())
+		self.assertTrue(f == BoolFlag.ENABLED)  # overloaded operator ==
+		self.assertEqual(f.enumClassType, BoolFlag)
+
+	def test_Enabled_EnabledByDefault(self):
+		f = FeatureFlag(value=BoolFlag.ENABLED, behaviorOfDefault=BoolFlag.ENABLED)
+		self.assertEqual(True, bool(f))
+		self.assertEqual(BoolFlag.ENABLED, f.calculated())
+		self.assertTrue(f == BoolFlag.ENABLED)  # overloaded operator ==
+		self.assertEqual(f.enumClassType, BoolFlag)
+
+	def test_Disabled_DisabledByDefault(self):
+		f = FeatureFlag(value=BoolFlag.DISABLED, behaviorOfDefault=BoolFlag.DISABLED)
+		self.assertEqual(False, bool(f))
+		self.assertEqual(BoolFlag.DISABLED, f.calculated())
+		self.assertTrue(f == BoolFlag.DISABLED)  # overloaded operator ==
+		self.assertEqual(f.enumClassType, BoolFlag)
+
+	def test_Disabled_EnabledByDefault(self):
+		f = FeatureFlag(value=BoolFlag.DISABLED, behaviorOfDefault=BoolFlag.ENABLED)
+		self.assertEqual(False, bool(f))
+		self.assertEqual(BoolFlag.DISABLED, f.calculated())
+		self.assertTrue(f == BoolFlag.DISABLED)  # overloaded operator ==
+		self.assertEqual(f.enumClassType, BoolFlag)
+
+	def test_Default_EnabledByDefault(self):
+		f = FeatureFlag(value=BoolFlag.DEFAULT, behaviorOfDefault=BoolFlag.ENABLED)
+		self.assertEqual(True, bool(f))
+		self.assertEqual(BoolFlag.ENABLED, f.calculated())
+		self.assertTrue(f == BoolFlag.ENABLED)  # overloaded operator ==
+		self.assertEqual(f.enumClassType, BoolFlag)
+
+	def test_Default_DisabledByDefault(self):
+		f = FeatureFlag(value=BoolFlag.DEFAULT, behaviorOfDefault=BoolFlag.DISABLED)
+		self.assertEqual(False, bool(f))
+		self.assertEqual(BoolFlag.DISABLED, f.calculated())
+		self.assertTrue(f == BoolFlag.DISABLED)  # overloaded operator ==
+		self.assertEqual(f.enumClassType, BoolFlag)
+
+	def test_DefaultBehaviorOfDefault_Raises(self):
+		with self.assertRaises(AssertionError):
+			FeatureFlag(value=BoolFlag.DEFAULT, behaviorOfDefault=BoolFlag.DEFAULT)
+
+
+class CustomEnum(DisplayStringEnum):
+	DEFAULT = enum.auto()
+	ALWAYS = enum.auto()
+	WHEN_REQUIRED = enum.auto()
+	NEVER = enum.auto()
+
+	def _displayStringLabels(self) -> typing.Dict[enum.Enum, str]:
+		return {}
+
+
+class Config_FeatureFlag_with_CustomEnum(unittest.TestCase):
+	def test_CustomEnum_boolRaises(self):
+		f = FeatureFlag(value=CustomEnum.ALWAYS, behaviorOfDefault=CustomEnum.NEVER)
+		with self.assertRaises(NotImplementedError):
+			bool(f)
+
+	def test_CustomEnum_equalsOp(self):
+		always = FeatureFlag(value=CustomEnum.ALWAYS, behaviorOfDefault=CustomEnum.NEVER)
+
+		alsoAlways = FeatureFlag(value=CustomEnum.ALWAYS, behaviorOfDefault=CustomEnum.NEVER)
+		whenRequired = FeatureFlag(value=CustomEnum.WHEN_REQUIRED, behaviorOfDefault=CustomEnum.NEVER)
+		defaultAlways = FeatureFlag(value=CustomEnum.DEFAULT, behaviorOfDefault=CustomEnum.ALWAYS)
+		defaultNever = FeatureFlag(value=CustomEnum.DEFAULT, behaviorOfDefault=CustomEnum.NEVER)
+
+		self.assertFalse(always.isDefault())
+		self.assertTrue(defaultAlways.isDefault())
+
+		# overloaded operator == accepts enum or featureFlag
+		self.assertTrue(always == CustomEnum.ALWAYS)
+		self.assertTrue(always == alsoAlways)
+		self.assertTrue(whenRequired == CustomEnum.WHEN_REQUIRED)
+		self.assertTrue(whenRequired != alsoAlways)
+		self.assertTrue(defaultAlways == CustomEnum.ALWAYS)
+		self.assertTrue(defaultAlways == always)
+		self.assertTrue(defaultNever == CustomEnum.NEVER)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ This will improve performance for some Java applications including IntelliJ IDEA
   - To find your Windows Console's NVDA API level, set "Windows Console support" to "UIA when available", then check the NVDA+F1 log opened from a running Windows Console instance.
   -
 - The Chromium virtual buffer is now loaded even when the document object has the MSAA ``STATE_SYSTEM_BUSY`` exposed via IA2. (#13306)
+- A config spec type ``featureFlag`` has been created for use with experimental features in NVDA. See ``devDocs/featureFlag.md`` for more information. (#13859)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,6 +44,7 @@ This will improve performance for some Java applications including IntelliJ IDEA
   - This can be overridden by changing the "Windows Console support" setting in NVDA's advanced settings panel.
   - To find your Windows Console's NVDA API level, set "Windows Console support" to "UIA when available", then check the NVDA+F1 log opened from a running Windows Console instance.
   -
+- The Chromium virtual buffer is now loaded even when the document object has the MSAA ``STATE_SYSTEM_BUSY`` exposed via IA2. (#13306)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes: #13306 

### Summary of the issue:
Chromium devs wish to be able to communicate that a document is loading via [MSAA `STATE_SYSTEM_BUSY`](https://docs.microsoft.com/en-us/windows/win32/winauto/object-state-constants) [exposed via IA2](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_states_8idl.html#aafecbfb195aaf7050dc8f75a7833bd5f)

This prevents NVDA from loading a virtual buffer until the document is no longer considered busy. The definition of `STATE_SYSTEM_BUSY` is:
>The control cannot accept input at this time.

This will introduce special handling for Chromium based browsers, but will match the existing behavior for Firefox.

### Description of user facing changes
There should be no observable change in the behavior of NVDA when used with Chrome.

### Description of development approach
- Return a valid `TreeInterceptor` class from `_get_treeInterceptorClass` even when the document has `STATE_SYSTEM_BUSY`.
- Introduce a feature flag to allow disabling this behavior.
- Streamline the process of creating new feature flags. Provide reusable classes to help future flags be more consistent.

### Testing strategy:
- Ask Chromium devs to test with an NVDA try build.
- Allow users to test when the change is introduced to Chromium in the future (after this change reaches a majority of NVDA users)
- Rely on the feature flag for users to be able to disable this if there are problems.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
