### PR TITLE
Use importlib.util.find_spec when checking if the given appModule exists to workaround issues in find_module and for forward compatibility.

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -22,13 +22,11 @@ from typing import (
 	List,
 	Optional,
 	Tuple,
-	Union,
 )
-import zipimport
 
 import winVersion
-import pkgutil
 import importlib
+import importlib.util
 import threading
 import tempfile
 import comtypes.client
@@ -46,11 +44,9 @@ from fileUtils import getFileVersionInfo
 import globalVars
 
 
-_KNOWN_IMPORTERS_T = Union[importlib.machinery.FileFinder, zipimport.zipimporter]
 # Dictionary of processID:appModule pairs used to hold the currently running modules
 runningTable: Dict[int, AppModule] = {}
 _CORE_APP_MODULES_PATH: os.PathLike = appModules.__path__[0]
-_importers: Optional[List[_KNOWN_IMPORTERS_T]] = None
 _getAppModuleLock=threading.RLock()
 #: Notifies when another application is taking foreground.
 #: This allows components to react upon application switches.
@@ -136,16 +132,6 @@ def unregisterExecutable(executableName: str) -> None:
 		log.error(f"Executable {executableName} was not previously registered.")
 
 
-def _getPathFromImporter(importer: _KNOWN_IMPORTERS_T) -> os.PathLike:
-	try:  # Standard `FileFinder` instance
-		return importer.path
-	except AttributeError:
-		try:  # Special case for `zipimporter`
-			return os.path.normpath(os.path.join(importer.archive, importer.prefix))
-		except AttributeError:
-			raise TypeError(f"Cannot retrieve path from {repr(importer)}") from None
-
-
 def _getPossibleAppModuleNamesForExecutable(executableName: str) -> Tuple[str, ...]:
 	"""Returns list of the appModule names for a given executable.
 	The names in the tuple are placed in order in which import of these aliases should be attempted that is:
@@ -172,27 +158,29 @@ def doesAppModuleExist(name: str, ignoreDeprecatedAliases: bool = False) -> bool
 	:param ignoreDeprecatedAliases: used for backward compatibility, so that by default alias modules
 	are not excluded.
 	"""
-	for importer in _importers:
-		modExists = importer.find_module(f"appModules.{name}")
-		if modExists:
-			# While the module has been found it is possible tis is just a deprecated alias.
-			# Before PR #13366 the only possibility to map a single app module to multiple executables
-			# was to create a alias app module and import everything from the main module into it.
-			# Now the preferred solution is to add an entry into `appModules.EXECUTABLE_NAMES_TO_APP_MODS`,
-			# but old alias modules have to stay to preserve backwards compatibility.
-			# We cannot import the alias module since they show a deprecation warning on import.
-			# To determine if the module should be imported or not we check if:
-			# - it is placed in the core appModules package, and
-			# - it has an alias defined in `appModules.EXECUTABLE_NAMES_TO_APP_MODS`.
-			# If both of these are true the module should not be imported in core.
-			if (
-				ignoreDeprecatedAliases
-				and name in appModules.EXECUTABLE_NAMES_TO_APP_MODS
-				and _getPathFromImporter(importer) == _CORE_APP_MODULES_PATH
-			):
-				continue
-			return True
-	return False  # None of the aliases exists
+	try:
+		modSpec = importlib.util.find_spec(f"appModules.{name}", package=appModules)
+	except ImportError:
+		modSpec = None
+	if modSpec is None:
+		return False
+	# While the module has been found it is possible tis is just a deprecated alias.
+	# Before PR #13366 the only possibility to map a single app module to multiple executables
+	# was to create a alias app module and import everything from the main module into it.
+	# Now the preferred solution is to add an entry into `appModules.EXECUTABLE_NAMES_TO_APP_MODS`,
+	# but old alias modules have to stay to preserve backwards compatibility.
+	# We cannot import the alias module since they show a deprecation warning on import.
+	# To determine if the module should be imported or not we check if:
+	# - it is placed in the core appModules package, and
+	# - it has an alias defined in `appModules.EXECUTABLE_NAMES_TO_APP_MODS`.
+	# If both of these are true the module should not be imported in core.
+	if (
+		ignoreDeprecatedAliases
+		and name in appModules.EXECUTABLE_NAMES_TO_APP_MODS
+		and os.path.dirname(modSpec.origin) == _CORE_APP_MODULES_PATH
+	):
+		return False
+	return True
 
 
 def _importAppModuleForExecutable(executableName: str) -> Optional[ModuleType]:
@@ -371,9 +359,7 @@ def reloadAppModules():
 def initialize():
 	"""Initializes the appModule subsystem. 
 	"""
-	global _importers
 	config.addConfigDirsToPythonPackagePath(appModules)
-	_importers=list(pkgutil.iter_importers("appModules.__init__"))
 	if not initialize._alreadyInitialized:
 		initialize._alreadyInitialized = True
 

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -143,7 +143,7 @@ def _getPossibleAppModuleNamesForExecutable(executableName: str) -> Tuple[str, .
 		aliasName for aliasName in (
 			_executableNamesToAppModsAddons.get(executableName),
 			# #5323: Certain executables contain dots as part of their file names.
-			# Since Python threats dot as a package separator we replace it with undescore
+			# Since Python treats dot as a package separator we replace it with an underscore
 			# in the name of the Python module.
 			# For new App Modules consider adding an alias to `appModule.EXECUTABLE_NAMES_TO_APP_MODS`
 			# rather than rely on the fact that dots are replaced.
@@ -164,9 +164,9 @@ def doesAppModuleExist(name: str, ignoreDeprecatedAliases: bool = False) -> bool
 		modSpec = None
 	if modSpec is None:
 		return False
-	# While the module has been found it is possible tis is just a deprecated alias.
+	# While the module has been found it is possible this is a deprecated alias.
 	# Before PR #13366 the only possibility to map a single app module to multiple executables
-	# was to create a alias app module and import everything from the main module into it.
+	# was to create an alias app module and import everything from the main module into it.
 	# Now the preferred solution is to add an entry into `appModules.EXECUTABLE_NAMES_TO_APP_MODS`,
 	# but old alias modules have to stay to preserve backwards compatibility.
 	# We cannot import the alias module since they show a deprecation warning on import.


### PR DESCRIPTION
### Link to issue number:
None, discussion in PR #13814

### Summary of the issue:

As mentioned in https://github.com/nvaccess/nvda/pull/13814#issuecomment-1159850266 `FileFinder.find_module` is deprecated. `find_spec` is the recommended replacement method.
As noted in https://github.com/nvaccess/nvda/pull/13814#issuecomment-1159899811, using either `find_spec` or `find_module` with `pkgutil.iter_importers` results in paths containing "." being incorrectly treated as python packages, causing #13813

### Description of development approach

### Description of user facing changes
No user facing change
### Description of development approach
When checking if the given appModule exists, instead use `importlib.util.find_spec`, which does not have the same problematic behaviour as `pkgutil.iter_importers`.

### Testing strategy:
- Made sure that #13813 has not been reintroduced
- Made sure that alias appModules are not imported
- Made sure that right module is imported for Firefox and Notepad++

### Known issues with pull request:
None known
### Change log entries:
None needed - internal change
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
