### PR TITLE
Revert "Ignore hidden text in richEdit controls accessed with ITextDocument (PR #13618)"

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -684,17 +684,16 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			formatConfig=config.conf["documentFormatting"]
 		textRange=self._rangeObj.duplicate
 		textRange.collapse(True)
+		if not formatConfig["detectFormatAfterCursor"]:
+			textRange.expand(comInterfaces.tom.tomCharacter)
+			return [textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(textRange, formatConfig)),
+				self._getTextAtRange(self._rangeObj)]
 		commandList=[]
 		endLimit=self._rangeObj.end
 		while textRange.end<endLimit:
 			self._expandFormatRange(textRange, formatConfig)
-			# Only add formatting and text if it is not marked as hidden.
-			# e.g. hyperLinks have hidden text at their beginning.
-			if not textRange.font.hidden:
-				commandList.append(
-					textInfos.FieldCommand("formatChange", self._getFormatFieldAtRange(textRange, formatConfig))
-				)
-				commandList.append(self._getTextAtRange(textRange))
+			commandList.append(textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(textRange, formatConfig)))
+			commandList.append(self._getTextAtRange(textRange))
 			end = textRange.end
 			textRange.start = end
 			#Trying to set the start past the end of the document forces both start and end back to the previous offset, so catch this
@@ -772,13 +771,6 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		else:
 			moveFunc=self._rangeObj.Move
 		res=moveFunc(unit,direction)
-		if not endPoint:
-			# For a normal move, I.e. not moving just one end,
-			# skip over any hidden text.
-			# E.g. hyperlinks have some hidden text at their beginning.
-			# So that the review cursor does not navigate through this text.
-			while res and self._rangeObj.font.hidden:
-				res = moveFunc(unit, 1 if direction > 0 else -1)
 		return res
 
 	def _get_bookmark(self):

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -686,13 +686,21 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		textRange.collapse(True)
 		if not formatConfig["detectFormatAfterCursor"]:
 			textRange.expand(comInterfaces.tom.tomCharacter)
-			return [textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(textRange, formatConfig)),
-				self._getTextAtRange(self._rangeObj)]
+			return [
+				textInfos.FieldCommand(
+					"formatChange",
+					self._getFormatFieldAtRange(textRange, formatConfig)
+				),
+				self._getTextAtRange(self._rangeObj)
+			]
 		commandList=[]
 		endLimit=self._rangeObj.end
 		while textRange.end<endLimit:
 			self._expandFormatRange(textRange, formatConfig)
-			commandList.append(textInfos.FieldCommand("formatChange",self._getFormatFieldAtRange(textRange, formatConfig)))
+			commandList.append(textInfos.FieldCommand(
+				"formatChange",
+				self._getFormatFieldAtRange(textRange, formatConfig)
+			))
 			commandList.append(self._getTextAtRange(textRange))
 			end = textRange.end
 			textRange.start = end

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -69,7 +69,6 @@ LibLouis has been updated, which includes a new German braille table.
 NVDA will announce results when more commands are pressed, such as commands from scientific mode. (#13383)
 - In Windows 11, it is again possible to navigate and interact with user interface elements,
 such as Taskbar and Task View using mouse and touch interaction. (#13506)
-- Hidden text is no longer announced in Wordpad and other ``richEdit`` controls. (#13618)
 - NVDA will announce status bar content in Windows 11 Notepad. (#13688)
 - Navigator object highlighting now shows up immediately upon activation of the feature. (#13641)
 - Fix reading single column list view items. (#13659, #13735)


### PR DESCRIPTION
This reverts commit c59130906ead301f7e7bc9d0fc600a138c1163da.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

Fixes #13826, reverts #13618

### Summary of the issue:
#13618 causes a regression - #13826.
The PR needs to be reverted for 2022.2, and a new attempt at #13618 can be taken for 2022.3.

### Description of user facing changes
#13618 is reverted: Hidden text will now be announced again in Wordpad and other ``richEdit`` controls.

### Description of development approach
Note: another translation freeze may need to be announced.
The only translation changes is remove a line from changes.t2t.

### Testing strategy:
- [x] Manual testing to confirm this fixes #13826


Using a [copy paste article from wikipedia.brh.txt](https://github.com/nvaccess/nvda/files/9025011/copy.paste.article.from.wikipedia.brh.txt) opened in Baraha version 10.10.400 (64bit) and NVDA 2022.2beta2, #13826 was reproduced.

`ctrl+downArrow` and `ctrl+upArrow` lags between 0.5-1s on long paragraphs.

The PR build from this PR does not lag when navigating the same paragraphs.

### Known issues with pull request:
None

### Change log entries:
refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
I reproduced https://github.com/nvaccess/nvda/issues/13826 with a [copy paste article from wikipedia.brh.txt](https://github.com/nvaccess/nvda/files/9025011/copy.paste.article.from.wikipedia.brh.txt) opened in Baraha version 10.10.400 (64bit) and NVDA 2022.2beta2.

ctrl+downArrow and ctrl+upArrow lags between 0.5-1s on long paragraphs.

The PR build from this PR does not lag when navigating the same paragraphs.