### PR TITLE
Windows versions: recognize build 22621 as Windows 11 22H2

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -24,7 +24,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.18990.0" 
-			MaxVersionTested="10.0.19044.0" 
+			MaxVersionTested="10.0.22621.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -35,6 +35,7 @@ _BUILDS_TO_RELEASE_NAMES = {
 	19045: "Windows 10 22H2",
 	20348: "Windows Server 2022",
 	22000: "Windows 11 21H2",
+	22621: "Windows 11 22H2",
 }
 
 
@@ -156,6 +157,7 @@ WIN10_21H2 = WinVersion(major=10, minor=0, build=19044)
 WIN10_22H2 = WinVersion(major=10, minor=0, build=19045)
 WINSERVER_2022 = WinVersion(major=10, minor=0, build=20348)
 WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
+WIN11_22H2 = WinVersion(major=10, minor=0, build=22621)
 
 
 @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
### Link to issue number:
Closes parts of #13845 

### Summary of the issue:
Recognize Windows 22H2 releases. In part 1 (this pull request), recognize 10.0.22621 as Windows 11 Version 22H2 (Nickel/Sun Valley 2).

### Description of user facing changes
No user facing changes

### Description of development approach
Verified that the following builds will be tied to upcoming Windows feature updates:

* 19045: Windows 10 22H2 (see additional context as this is out of scope for this PR)
* 22621: Windows 11 22H2

Build 22621 is available to release preview Windows Insiders, build 19045 forthcoming.

### Testing strategy:
Manual testing (ideally on virtual machines):

1. Install Windows 11 22H2 (release preview).
2. With NVDA running, open Python Console (`Control+NVDA+Z`) and type "import winVersion; winVersion.getWinVer()" without quotes. Verify that version returned is "Windows 11 22H2".
3. Verify that the version returned also matches winVersion.WIN11_22H2 object and that it is newer (higher build number) than winVersion.WIN11.
4. Repeat steps 1 through 3 when Windows 10 22H2 is released to Windows Insiders but compare the version returned with winVersion.WIN10_22H2 and make sure winVersion.WIN10_21H2 < winVersion.WIN10_22H2 < winVersion.WINSERVER_2022 (deferred to a later PR).

### Known issues with pull request:
Although it is highly unlikely, Windows 10 22H2's build number could change in the future. The sure sign is which build will be released to Windows Insiders, and indication is that it will be 19045.

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English

## Additional context:
Originally this PR added winVersion entry for Windows 10 Version 22H2 but is deferred to a later PR.
