### PR TITLE
Use automatic width for License Agreement text

### DIFF
--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -1,20 +1,27 @@
 # -*- coding: UTF-8 -*-
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2018 NV Access Limited
+#Copyright (C) 2018-2022 NV Access Limited
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-from typing import Optional, Any, Callable
+from typing import Optional, Any, Callable, Tuple, Union
 
 
-def scaleSize(scaleFactor, size):
+_FloatInt = Union[int, float] 
+_Size = Union[Tuple[_FloatInt, _FloatInt], _FloatInt]
+_ScaledSize = Union[Tuple[float, float], float]
+
+
+def scaleSize(scaleFactor: float, size: _Size) -> _ScaledSize:
 	"""Helper method to scale a size using the logical DPI
-	@param size: The size (x,y) as a tuple or a single numerical type to scale
-	@returns: The scaled size, returned as the same type"""
+	@param size: The size (x, y) as a tuple or a single numerical type to scale
+	@returns: The scaled size, as a float or tuple of floats.
+	"""
 	if isinstance(size, tuple):
 		return (scaleFactor * size[0], scaleFactor * size[1])
 	return scaleFactor * size
 
-def getScaleFactor(windowHandle):
+
+def getScaleFactor(windowHandle: int) -> float:
 	"""Helper method to get the window scale factor. The window needs to be constructed first, in
 	order to get the window handle, this likely means calling the wx.window __init__ method prior
 	to calling self.GetHandle()"""
@@ -27,10 +34,10 @@ class DpiScalingHelperMixin(object):
 			Sub-classes are responsible for calling wx.Window init
 	"""
 
-	def __init__(self, windowHandle):
+	def __init__(self, windowHandle: int):
 		self._scaleFactor = getScaleFactor(windowHandle)
 
-	def scaleSize(self, size):
+	def scaleSize(self, size: _Size) -> _ScaledSize:
 		assert getattr(self, u"_scaleFactor", None)
 		return scaleSize(self._scaleFactor, size)
 
@@ -42,7 +49,7 @@ class DpiScalingHelperMixinWithoutInit:
 	GetHandle: Callable[[], Any]  # Should be provided by wx.Window
 	_scaleFactor: Optional[float] = None
 
-	def scaleSize(self, size):
+	def scaleSize(self, size: _Size) -> _ScaledSize:
 		if self._scaleFactor is None:
 			windowHandle = self.GetHandle()
 			self._scaleFactor = getScaleFactor(windowHandle)

--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -1,12 +1,12 @@
 # -*- coding: UTF-8 -*-
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2018-2022 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2018-2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 from typing import Optional, Any, Callable, Tuple, Union
 
 
-_FloatInt = Union[int, float] 
+_FloatInt = Union[int, float]
 _Size = Union[Tuple[_FloatInt, _FloatInt], _FloatInt]
 _ScaledSize = Union[Tuple[float, float], float]
 

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -153,9 +153,17 @@ class LauncherDialog(
 		groupLabel = _("License Agreement")
 		sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=groupLabel)
 		sHelper.addItem(sizer)
-		licenseTextCtrl = wx.TextCtrl(self, size=(500, 400), style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH)
+		licenseTextCtrl = wx.TextCtrl(
+			self,
+			size=(-1, 500),  # -1 uses default width
+			style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH,
+		)
 		licenseTextCtrl.Value = open(getDocFilePath("copying.txt", False), "r", encoding="UTF-8").read()
-		sizer.Add(licenseTextCtrl)
+		sizer.Add(
+			licenseTextCtrl,
+			flag=wx.EXPAND,
+			proportion=1,
+		)
 
 		# Translators: The label for a checkbox in NvDA installation program to agree to the license agreement.
 		agreeText = _("I &agree")

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -154,28 +154,7 @@ class LauncherDialog(
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
-		# Translators: The label of the license text which will be shown when NVDA installation program starts.
-		groupLabel = _("License Agreement")
-		sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=groupLabel)
-		sHelper.addItem(sizer)
-		# Create a fake text control to determine appropriate width of license text box
-		_fakeTextCtrl = wx.StaticText(
-			self,
-			label="a" * 80,  # The GPL2 text of copying.txt wraps sentences at 80 characters
-		)
-		widthOfLicenseText = _fakeTextCtrl.Size[0]
-		_fakeTextCtrl.Destroy()
-		licenseTextCtrl = wx.TextCtrl(
-			self,
-			size=(widthOfLicenseText, self.scaleSize(300)),
-			style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH,
-		)
-		licenseTextCtrl.Value = open(getDocFilePath("copying.txt", False), "r", encoding="UTF-8").read()
-		sizer.Add(
-			licenseTextCtrl,
-			flag=wx.EXPAND,
-			proportion=1,
-		)
+		sHelper.addItem(self._createLicenseAgreementGroup())
 
 		# Translators: The label for a checkbox in NvDA installation program to agree to the license agreement.
 		agreeText = _("I &agree")
@@ -212,6 +191,30 @@ class LauncherDialog(
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.CentreOnScreen()
+
+	def _createLicenseAgreementGroup(self) -> wx.StaticBoxSizer:
+		# Translators: The label of the license text which will be shown when NVDA installation program starts.
+		groupLabel = _("License Agreement")
+		sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=groupLabel)
+		# Create a fake text control to determine appropriate width of license text box
+		_fakeTextCtrl = wx.StaticText(
+			self,
+			label="a" * 80,  # The GPL2 text of copying.txt wraps sentences at 80 characters
+		)
+		widthOfLicenseText = _fakeTextCtrl.Size[0]
+		_fakeTextCtrl.Destroy()
+		licenseTextCtrl = wx.TextCtrl(
+			self,
+			size=(widthOfLicenseText, self.scaleSize(300)),
+			style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH,
+		)
+		licenseTextCtrl.Value = open(getDocFilePath("copying.txt", False), "r", encoding="UTF-8").read()
+		sizer.Add(
+			licenseTextCtrl,
+			flag=wx.EXPAND,
+			proportion=1,
+		)
+		return sizer
 
 	def onLicenseAgree(self, evt):
 		for ctrl in self.actionButtons:

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -136,7 +136,7 @@ class WelcomeDialog(
 
 
 class LauncherDialog(
-		DpiScalingHelperMixinWithoutInit, 
+		DpiScalingHelperMixinWithoutInit,
 		gui.contextHelp.ContextHelpMixin,
 		wx.Dialog  # wxPython does not seem to call base class initializer, put last in MRO
 ):

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -101,7 +101,9 @@ DEFAULT_DPI_LEVEL = 96.0
 # The constant (defined in winGdi.h) to get the number of logical pixels per inch on the x axis
 # via the GetDeviceCaps function.
 LOGPIXELSX = 88
-def getWindowScalingFactor(window):
+
+
+def getWindowScalingFactor(window: int) -> float:
 	"""Gets the logical scaling factor used for the given window handle. This is based off the Dpi reported by windows
 	for the given window handle / divided by the "base" DPI level of 96. Typically this is a result of using the scaling
 	percentage in the windows display settings. 100% is typically 96 DPI, 150% is typically 144 DPI.
@@ -109,11 +111,11 @@ def getWindowScalingFactor(window):
 	@returns the logical scaling factor. EG. 1.0 if the window DPI level is 96, 1.5 if the window DPI level is 144"""
 	user32 = ctypes.windll.user32
 	try:
-		winDpi = user32.GetDpiForWindow(window)
+		winDpi: int = user32.GetDpiForWindow(window)
 	except:
 		log.debug("GetDpiForWindow failed, using GetDeviceCaps instead")
 		dc = user32.GetDC(window)
-		winDpi = ctypes.windll.gdi32.GetDeviceCaps(dc, LOGPIXELSX)
+		winDpi: int = ctypes.windll.gdi32.GetDeviceCaps(dc, LOGPIXELSX)
 		ret = user32.ReleaseDC(window, dc)
 		if ret != 1:
 			log.error("Unable to release the device context.")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:

The width of the License Agreement was fixed, however the outer dialog scales with DPI.
This causes inconsistent behaviour for the License Agreement text sizing within the Launcher dialog.

Examples refer to a machine with high DPI and 200% scaling

For example, the width of the license agreement text for my machine display setting is roughly 2/3rds of the dialog.
![image](https://user-images.githubusercontent.com/7090342/177077116-5c06616c-be1a-4a3f-a4bd-36c68ae0ba04.png)

Additionally, the GPL2 license text is manually wrapped wraps at different line lengths, with 80 being the most common.
Longer lines exist for custom changes to the GPL2 license.

### Description of user facing changes

Makes the width of the license text dialog fit 80 characters of text comfortably.
Also changes the height of the dialog by ~100px (scaled) for readability.

Example with same display settings:
![image](https://user-images.githubusercontent.com/7090342/177263234-6f751ec7-fa83-4a48-8b32-ada403abe6bf.png)

### Description of development approach
Get a the width of a line of license text by creating and destroying a hidden text control.
Use that to set the scaled size of the license text.

### Testing strategy:
**Manual testing**

Visually checking the installer dialog when running the launcher created with `scons source` and this PR build.

Opening the installer dialog from the python console, when running from source:
```py
import gui
from gui.startupDialogs import LauncherDialog
x = LauncherDialog(gui.mainFrame)
x.run()
```

### Known issues with pull request:
The license text in `copying.txt` is wrapped inconsistently.
It should be considered to reformat the file so that all sentences and only sentences end in a new line.

### Change log entries:
Not worth a changelog entry IMO

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
