### PR TITLE
Feature flag for custom options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,10 @@ py2exe==0.11.1.0
 sphinx==3.4.1
 sphinx_rtd_theme
 
+# Requirements for type checking.
+# typing_extensions is incorporated in py3.8+, also available via mypy
+typing_extensions==4.2.0
+
 # Requirements for automated linting
 flake8 ~= 3.7.7
 flake8-tabs == 2.1.0

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -543,7 +543,7 @@ class ConfigManager(object):
 		#: Whether profile triggers are enabled (read-only).
 		self.profileTriggersEnabled: bool = True
 		self.validator: Validator = Validator({
-			"featureFlag": _validateConfig_featureFlag
+			"_featureFlag": _validateConfig_featureFlag
 		})
 		self.rootSection: Optional[AggregatedSection] = None
 		self._shouldHandleProfileSwitch: bool = True

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -174,7 +174,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	trapNonCommandGestures = boolean(default=true)
 	enableOnPageLoad = boolean(default=true)
 	autoFocusFocusableElements = boolean(default=False)
-	loadChromiumVBufOnBusyState = featureFlag(behaviorOfDefault="enabled")
+	loadChromiumVBufOnBusyState = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 
 [touch]
 	enabled = boolean(default=true)

--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -52,7 +52,7 @@ class FeatureFlag(typing.Generic[FlagValueEnum]):
 
 	def __bool__(self) -> bool:
 		if not isinstance(self.value, BoolFlag):
-			raise NotImplemented(
+			raise NotImplementedError(
 				"Only BoolFlag supported. For other types use explicit checks"
 			)
 		if self.isDefault():

--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -45,6 +45,8 @@ class FeatureFlag(typing.Generic[FlagValueEnum]):
 			behaviorOfDefault: FlagValueEnum
 	):
 		self.value = value
+		self.enumClassType: typing.Type[FlagValueEnum] = type(value)
+		assert self.enumClassType == type(behaviorOfDefault)
 		assert behaviorOfDefault != value.DEFAULT
 		self.behaviorOfDefault = behaviorOfDefault
 
@@ -68,9 +70,9 @@ class FeatureFlag(typing.Generic[FlagValueEnum]):
 	def __eq__(self, other: typing.Union["FeatureFlag", FlagValueEnum]):
 		if isinstance(other, type(self.value)):
 			other = FeatureFlag(other, behaviorOfDefault=self.behaviorOfDefault)
-		if not isinstance(other, FeatureFlag):
-			raise NotImplementedError()
-		return self.calculated() == other.calculated()
+		if isinstance(other, FeatureFlag):
+			return self.calculated() == other.calculated()
+		return super().__eq__(other)
 
 	def __str__(self):
 		"""So that the value can be saved to the ini file.

--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -11,8 +11,8 @@ import typing
 
 from . import featureFlagEnums
 from .featureFlagEnums import (
-	FeatureFlagEnumProtocol,
 	BoolFlag,
+	FlagValueEnum,
 )
 from typing import (
 	Optional,
@@ -23,10 +23,8 @@ from configobj.validate import (
 )
 from logHandler import log
 
-FlagValueEnum = typing.TypeVar('FlagValueEnum', bound=FeatureFlagEnumProtocol)
 
-
-class FeatureFlag(typing.Generic[FlagValueEnum]):
+class FeatureFlag:
 	"""A FeatureFlag allows the selection of a preference for behavior or its default state.
 	It's typically used to introduce a feature that isn't expected to handle all use-cases well
 	when initially introduced.

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -1,0 +1,49 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""
+Feature flag value enumerations.
+Some feature flags require feature specific options, this file defines those options.
+All feature flags enums must have a 'DEFAULT'
+"""
+import enum
+import logging
+import sys
+import typing
+
+from typing_extensions import Protocol  # Python 3.8 adds native support
+
+
+class FeatureFlagEnumProtocol(Protocol):
+	""" All feature flags are expected to have a "DEFAULT" value.
+	"""
+	DEFAULT: enum.Enum
+	name: str
+	value: typing.Type
+
+
+class BoolFlag(enum.Enum):
+	"""Generic logically bool feature flag.
+	The explicit DEFAULT option allows developers to differentiate between a value set that happens to be
+	the current default, and a value that has been returned to the "default" explicitly.
+	"""
+	DEFAULT = enum.auto()
+	DISABLED = enum.auto()
+	ENABLED = enum.auto()
+
+	def __bool__(self):
+		if self == BoolFlag.DEFAULT:
+			raise ValueError(
+				"Only ENABLED or DISABLED are valid bool values"
+				", DEFAULT must be combined with a 'behavior for default' to be Truthy or Falsy"
+			)
+		return self == BoolFlag.ENABLED
+
+
+def getAvailableEnums() -> typing.Generator[typing.Tuple[str, enum.EnumMeta], None, None]:
+	for name, value in globals().items():
+		logging.debug(f"Found Enum class: {name}:{value}")
+		if isinstance(value, enum.EnumMeta) and hasattr(value, "DEFAULT"):
+			yield name, value

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -19,14 +19,16 @@ from utils.displayString import (
 
 from typing_extensions import Protocol  # Python 3.8 adds native support
 
+_displayString = typing.TypeVar("_displayString", bound=DisplayStringEnum)
+
 
 class FeatureFlagEnumProtocol(Protocol):
 	""" All feature flags are expected to have a "DEFAULT" value.
 	"""
 	DEFAULT: enum.Enum  # Required enum member
-	name: str  # from Enum
-	value: typing.Type  # from Enum
-	displayString: str  # from utils.displayString._DisplayStringEnumMixin
+
+
+FlagValueEnum = typing.Union[FeatureFlagEnumProtocol, _displayString]
 
 
 class BoolFlag(DisplayStringEnum):
@@ -58,7 +60,11 @@ class BoolFlag(DisplayStringEnum):
 		return self == BoolFlag.ENABLED
 
 
-def getAvailableEnums() -> typing.Generator[typing.Tuple[str, enum.EnumMeta], None, None]:
+def getAvailableEnums() -> typing.Generator[typing.Tuple[str, DisplayStringEnum], None, None]:
 	for name, value in globals().items():
-		if isinstance(value, enum.EnumMeta) and hasattr(value, "DEFAULT"):
+		if (
+			isinstance(value, type)  # is a class
+			and issubclass(value, DisplayStringEnum)  # inherits from DisplayStringEnum
+			and value != DisplayStringEnum  # but isn't DisplayStringEnum
+		):
 			yield name, value

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -6,12 +6,17 @@
 """
 Feature flag value enumerations.
 Some feature flags require feature specific options, this file defines those options.
-All feature flags enums must have a 'DEFAULT'
+All feature flags enums should
+- inherit from DisplayStringEnum and implement _displayStringLabels (for the 'displayString' property)
+- have a 'DEFAULT' member.
 """
 import enum
 import logging
-import sys
 import typing
+
+from utils.displayString import (
+	DisplayStringEnum
+)
 
 from typing_extensions import Protocol  # Python 3.8 adds native support
 
@@ -19,16 +24,28 @@ from typing_extensions import Protocol  # Python 3.8 adds native support
 class FeatureFlagEnumProtocol(Protocol):
 	""" All feature flags are expected to have a "DEFAULT" value.
 	"""
-	DEFAULT: enum.Enum
-	name: str
-	value: typing.Type
+	DEFAULT: enum.Enum  # Required enum member
+	name: str  # from Enum
+	value: typing.Type  # from Enum
+	displayString: str  # from utils.displayString._DisplayStringEnumMixin
 
 
-class BoolFlag(enum.Enum):
+class BoolFlag(DisplayStringEnum):
 	"""Generic logically bool feature flag.
 	The explicit DEFAULT option allows developers to differentiate between a value set that happens to be
 	the current default, and a value that has been returned to the "default" explicitly.
 	"""
+
+	@property
+	def _displayStringLabels(self):
+		# To prevent duplication, self.DEFAULT is not included here.
+		return {
+			# Translators: Label for an option in NVDA settings.
+			self.DISABLED: _("Disabled"),
+			# Translators: Label for an option in NVDA settings.
+			self.ENABLED: _("Enabled"),
+		}
+
 	DEFAULT = enum.auto()
 	DISABLED = enum.auto()
 	ENABLED = enum.auto()

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -11,7 +11,6 @@ All feature flags enums should
 - have a 'DEFAULT' member.
 """
 import enum
-import logging
 import typing
 
 from utils.displayString import (

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -61,6 +61,5 @@ class BoolFlag(DisplayStringEnum):
 
 def getAvailableEnums() -> typing.Generator[typing.Tuple[str, enum.EnumMeta], None, None]:
 	for name, value in globals().items():
-		logging.debug(f"Found Enum class: {name}:{value}")
 		if isinstance(value, enum.EnumMeta) and hasattr(value, "DEFAULT"):
 			yield name, value

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -10,21 +10,16 @@ from typing import (
 	List,
 	OrderedDict,
 	Type,
-	Union,
 )
 
 import wx
 from wx.lib import scrolledpanel
 from wx.lib.mixins import listctrl as listmix
 
-from utils.displayString import (
-	DisplayStringEnum
-)
 from config.featureFlag import (
 	FeatureFlag,
 )
 from config.featureFlagEnums import (
-	BoolFlag,
 	FeatureFlagEnumProtocol
 )
 from .dpiScalingHelper import DpiScalingHelperMixin

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -18,9 +18,7 @@ from wx.lib.mixins import listctrl as listmix
 
 from config.featureFlag import (
 	FeatureFlag,
-)
-from config.featureFlagEnums import (
-	FeatureFlagEnumProtocol
+	FlagValueEnum as FeatureFlagEnumT,
 )
 from .dpiScalingHelper import DpiScalingHelperMixin
 from . import guiHelper
@@ -408,10 +406,7 @@ class TabbableScrolledPanel(scrolledpanel.ScrolledPanel):
 			child.GetRect = oldChildGetRectFunction
 
 
-FeatureFlagEnumT = typing.TypeVar("FeatureFlagEnumT", bound=FeatureFlagEnumProtocol)
-
-
-class FeatureFlagCombo(wx.Choice, typing.Generic[FeatureFlagEnumT]):
+class FeatureFlagCombo(wx.Choice):
 	"""Creates a combobox (wx.Choice) with a list of feature flags.
 	"""
 	def __init__(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2909,15 +2909,6 @@ class AdvancedPanelControls(
 			wxCtrlClass=nvdaControls.FeatureFlagCombo,
 			keyPath=["virtualBuffers", "loadChromiumVBufOnBusyState"],
 			conf=config.conf,
-			optionsEnumClass=BoolFlag,
-			translatedOptions=collections.OrderedDict({
-				# Translators: Label for option in the 'Load Chromium virtual buffer when document busy.'
-				# combobox in the Advanced settings panel.
-				BoolFlag.ENABLED: _("Yes"),
-				# Translators: Label for option in the 'Load Chromium virtual buffer when document busy.'
-				# combobox in the Advanced settings panel.
-				BoolFlag.DISABLED: _("No"),
-			})
 		)
 
 		# Translators: This is the label for a group of advanced options in the

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -27,7 +27,7 @@ import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 from config.featureFlag import (
-	FeatureFlagValue,
+	BoolFlag,
 )
 import languageHandler
 import speech
@@ -2909,13 +2909,14 @@ class AdvancedPanelControls(
 			wxCtrlClass=nvdaControls.FeatureFlagCombo,
 			keyPath=["virtualBuffers", "loadChromiumVBufOnBusyState"],
 			conf=config.conf,
+			optionsEnumClass=BoolFlag,
 			translatedOptions=collections.OrderedDict({
 				# Translators: Label for option in the 'Load Chromium virtual buffer when document busy.'
 				# combobox in the Advanced settings panel.
-				FeatureFlagValue.ENABLED: _("Yes"),
+				BoolFlag.ENABLED: _("Yes"),
 				# Translators: Label for option in the 'Load Chromium virtual buffer when document busy.'
 				# combobox in the Advanced settings panel.
-				FeatureFlagValue.DISABLED: _("No"),
+				BoolFlag.DISABLED: _("No"),
 			})
 		)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -8,7 +8,6 @@
 # jakubl7545, mltony
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-import collections
 import logging
 from abc import ABCMeta, abstractmethod
 import copy
@@ -26,9 +25,6 @@ import logHandler
 import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
-from config.featureFlag import (
-	BoolFlag,
-)
 import languageHandler
 import speech
 import gui

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,8 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2022 NV Access Limited
-
+import enum
+import typing
 import unittest
 
 import configobj
@@ -11,8 +12,22 @@ import configobj.validate
 from config import featureFlag
 from config.featureFlag import (
 	FeatureFlag,
-	FeatureFlagValue,
 )
+from config.featureFlagEnums import (
+	getAvailableEnums,
+	BoolFlag,
+)
+
+
+class Config_FeatureFlagEnums_getAvailableEnums(unittest.TestCase):
+
+	def test_knownEnumsReturned(self):
+		self.assertEqual(
+			dict(getAvailableEnums()),
+			{
+				"BoolFlag": BoolFlag,
+			}
+		)
 
 
 class Config_FeatureFlag_specTransform(unittest.TestCase):
@@ -20,29 +35,48 @@ class Config_FeatureFlag_specTransform(unittest.TestCase):
 	def test_defaultGetsAdded(self):
 		self.assertEqual(
 			featureFlag._transformSpec_AddFeatureFlagDefault(
-				'featureFlag(behaviorOfDefault="disabled")',
-				behaviorOfDefault="disabled"
+				'featureFlag(behaviorOfDefault="disabled", optionsEnum="BoolFlag")',
+				behaviorOfDefault="disabled",
+				optionsEnum="BoolFlag",
+				# note: configObj treats param 'default' specially, it isn't passed through as a kwarg.
 			),
-			'featureFlag(behaviorOfDefault="disabled", default="default")'
+			'_featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="DISABLED", default="DEFAULT")'
 		)
 
 	def test_behaviorOfDefaultGetsKept(self):
 		self.assertEqual(
 			featureFlag._transformSpec_AddFeatureFlagDefault(
-				'featureFlag(behaviorOfDefault="enabled")',
-				behaviorOfDefault="enabled"
+				'featureFlag(behaviorOfDefault="enabled", optionsEnum="BoolFlag")',
+				behaviorOfDefault="enabled",
+				optionsEnum="BoolFlag",
 			),
-			'featureFlag(behaviorOfDefault="enabled", default="default")'
+			'_featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="ENABLED", default="DEFAULT")'
 		)
 
 	def test_paramDefaultIsError(self):
 		with self.assertRaises(configobj.validate.VdtParamError):
 			featureFlag._transformSpec_AddFeatureFlagDefault(
-				'featureFlag(behaviorOfDefault="disabled", default="enabled")',
-				behaviorOfDefault="disabled"
+				'featureFlag(behaviorOfDefault="disabled", optionsEnum="BoolFlag", default="enabled")',
+				behaviorOfDefault="disabled",
+				optionsEnum="BoolFlag",
+				# note: configObj treats param 'default' specially, it isn't passed through as a kwarg.
 			)
 
 	def test_behaviorOfDefaultMissingIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(optionsEnum="BoolFlag")',
+				optionsEnum="BoolFlag",
+			)
+
+	def test_optionsEnumMissingIsError(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="enabled")',
+				behaviorOfDefault="enabled",
+			)
+
+	def test_argsMissingIsError(self):
 		with self.assertRaises(configobj.validate.VdtParamError):
 			featureFlag._transformSpec_AddFeatureFlagDefault(
 				'featureFlag()',
@@ -51,15 +85,26 @@ class Config_FeatureFlag_specTransform(unittest.TestCase):
 	def test_behaviorOfDefaultTypeMustBeStr(self):
 		with self.assertRaises(configobj.validate.VdtParamError):
 			featureFlag._transformSpec_AddFeatureFlagDefault(
-				'featureFlag(behaviorOfDefault=True)',
-				behaviorOfDefault=True
+				'featureFlag(behaviorOfDefault=True, optionsEnum="BoolFlag")',
+				behaviorOfDefault=True,
+				optionsEnum="BoolFlag",
 			)
 
 	def test_tooManyParamsIsError(self):
 		with self.assertRaises(configobj.validate.VdtParamError):
 			featureFlag._transformSpec_AddFeatureFlagDefault(
-				'featureFlag(behaviorOfDefault="enabled", someOther=True)',
-				behaviorOfDefault=True,
+				'featureFlag(behaviorOfDefault="enabled", optionsEnum="BoolFlag", someOther=True)',
+				behaviorOfDefault="enabled",
+				optionsEnum="BoolFlag",
+				someOther=True
+			)
+
+	def test_optionsEnumMustBeKnown(self):
+		with self.assertRaises(configobj.validate.VdtParamError):
+			featureFlag._transformSpec_AddFeatureFlagDefault(
+				'featureFlag(behaviorOfDefault="enabled", optionsEnum="UnknownEnumClass", someOther=True)',
+				behaviorOfDefault="enabled",
+				optionsEnum="UnknownEnumClass",
 				someOther=True
 			)
 
@@ -69,10 +114,19 @@ class Config_FeatureFlag_validateFeatureFlag(unittest.TestCase):
 	def assertFeatureFlagState(
 			self,
 			flag: FeatureFlag,
-			value: FeatureFlagValue,
-			behaviorOfDefault: FeatureFlagValue,
+			enumType: typing.Type,
+			value: enum.Enum,
+			behaviorOfDefault: enum.Enum,
 			calculatedValue: bool
-	):
+	) -> None:
+		self.assertIsInstance(flag.value, enumType, msg="Wrong enum type created")
+		self.assertIsInstance(value, enumType, msg="Test error: wrong enum type for checking value")
+		self.assertIsInstance(
+			behaviorOfDefault,
+			enumType,
+			msg="Test error: wrong enum type for checking behaviorOfDefault"
+		)
+
 		self.assertEqual(bool(flag), calculatedValue, msg="Calculated value for behaviour is unexpected")
 		self.assertEqual(flag.value, value, msg="Flag value is unexpected")
 		self.assertEqual(
@@ -89,72 +143,84 @@ class Config_FeatureFlag_validateFeatureFlag(unittest.TestCase):
 	def test_enabled_lower(self):
 		flag = featureFlag._validateConfig_featureFlag(
 			"enabled",
-			behaviorOfDefault="disabled"
+			behaviorOfDefault="disabled",
+			optionsEnum=BoolFlag.__name__
 		)
 		self.assertFeatureFlagState(
 			flag,
-			value=FeatureFlagValue.ENABLED,
-			behaviorOfDefault=FeatureFlagValue.DISABLED,
+			enumType=BoolFlag,
+			value=BoolFlag.ENABLED,
+			behaviorOfDefault=BoolFlag.DISABLED,
 			calculatedValue=True
 		)
 
 	def test_enabled_upper(self):
 		flag = featureFlag._validateConfig_featureFlag(
 			"ENABLED",
-			behaviorOfDefault="disabled"
+			behaviorOfDefault="disabled",
+			optionsEnum=BoolFlag.__name__
 		)
 		self.assertFeatureFlagState(
 			flag,
-			value=FeatureFlagValue.ENABLED,
-			behaviorOfDefault=FeatureFlagValue.DISABLED,
+			enumType=BoolFlag,
+			value=BoolFlag.ENABLED,
+			behaviorOfDefault=BoolFlag.DISABLED,
 			calculatedValue=True
 		)
 
 	def test_disabled_lower(self):
 		flag = featureFlag._validateConfig_featureFlag(
 			"disabled",
-			behaviorOfDefault="enabled"
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
 		)
 		self.assertFeatureFlagState(
 			flag,
-			value=FeatureFlagValue.DISABLED,
-			behaviorOfDefault=FeatureFlagValue.ENABLED,
+			enumType=BoolFlag,
+			value=BoolFlag.DISABLED,
+			behaviorOfDefault=BoolFlag.ENABLED,
 			calculatedValue=False
 		)
 
 	def test_disabled_upper(self):
 		flag = featureFlag._validateConfig_featureFlag(
 			"DISABLED",
-			behaviorOfDefault="enabled"
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
 		)
 		self.assertFeatureFlagState(
 			flag,
-			value=FeatureFlagValue.DISABLED,
-			behaviorOfDefault=FeatureFlagValue.ENABLED,
+			enumType=BoolFlag,
+			value=BoolFlag.DISABLED,
+			behaviorOfDefault=BoolFlag.ENABLED,
 			calculatedValue=False
 		)
 
 	def test_default_lower(self):
 		flag = featureFlag._validateConfig_featureFlag(
 			"default",
-			behaviorOfDefault="enabled"
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
 		)
 		self.assertFeatureFlagState(
 			flag,
-			value=FeatureFlagValue.DEFAULT,
-			behaviorOfDefault=FeatureFlagValue.ENABLED,
+			enumType=BoolFlag,
+			value=BoolFlag.DEFAULT,
+			behaviorOfDefault=BoolFlag.ENABLED,
 			calculatedValue=True
 		)
 
 	def test_default_upper(self):
 		flag = featureFlag._validateConfig_featureFlag(
 			"DEFAULT",
-			behaviorOfDefault="enabled"
+			behaviorOfDefault="enabled",
+			optionsEnum=BoolFlag.__name__
 		)
 		self.assertFeatureFlagState(
 			flag,
-			value=FeatureFlagValue.DEFAULT,
-			behaviorOfDefault=FeatureFlagValue.ENABLED,
+			enumType=BoolFlag,
+			value=BoolFlag.DEFAULT,
+			behaviorOfDefault=BoolFlag.ENABLED,
 			calculatedValue=True
 		)
 
@@ -162,12 +228,22 @@ class Config_FeatureFlag_validateFeatureFlag(unittest.TestCase):
 		with self.assertRaises(configobj.validate.ValidateError):
 			featureFlag._validateConfig_featureFlag(
 				"",  # Given our usage of ConfigObj, this situation is unexpected.
-				behaviorOfDefault="disabled"
+				behaviorOfDefault="disabled",
+				optionsEnum=BoolFlag.__name__
 			)
 
 	def test_None_raises(self):
 		with self.assertRaises(configobj.validate.ValidateError):
 			featureFlag._validateConfig_featureFlag(
 				None,  # Given our usage of ConfigObj, this situation is unexpected.
-				behaviorOfDefault="disabled"
+				behaviorOfDefault="disabled",
+				optionsEnum=BoolFlag.__name__
+			)
+
+	def test_invalid_raises(self):
+		with self.assertRaises(configobj.validate.ValidateError):
+			featureFlag._validateConfig_featureFlag(
+				"invalid",  # must be a valid member of BoolFlag
+				behaviorOfDefault="disabled",
+				optionsEnum=BoolFlag.__name__
 			)


### PR DESCRIPTION
### Link to issue number:
Extension of #13859 as per discussion: https://github.com/nvaccess/nvda/pull/13859#discussion_r910969388

### Summary of the issue:
Some feature flags require more than just a Boolean enabled/disabled outcome (in addition to 'default'), E.G.:
- AllowUiaInMSWord [WHEN_NECESSARY, WHERE_SUITABLE, ALWAYS]
- AllowUiaInChromium [WHEN_NECESSARY, YES, NO]

Several approaches have been tried:
- Store integers in the config that match with enum values, as per (AllowUiaInMSWord and AllowUiaInChromium)
- Use "options" in config (several string values). Literal strings in code to compare refer to these.

These approaches can hide errors:
- Looking at the config, what are the valid values when an integer is used.
- Using string "options":
  - what are the valid options?
  - how do you find all usages?
  - Change the strategy for default?
- For both, when looking at the config or configSpec, how can the behavior of default be determined?

### Description of user facing changes
Where the user is a developer adding a new feature flag:
- Define a new enum in `featureFlagEnums.py` (include a `DEFAULT` member) E.G.: `MyNewFeature`
- Add the entry to the `configSpec.py` E.G. `shouldUseMyNewFeature = featureFlag(optionsEnumClass="MyNewFeature", behaviorOfDefault="ON_WEEKENDS")`
- Add a GUI option for it, using `FeatureFlagCombo`
- Wrap the code for the feature with `config.conf["section"]["shouldUseMyNewFeature "] == MyNewFeature.ON_WEEKENDS`

### Description of development approach
- The `configSpec` explicitly defines what the behavior of default is.
- The enum class that backs the config is defined, allowing for type / value checking.
- Existing flags have not been upgraded, these would require upgrade code for the config, this introduces unnecessary complexity.

### Testing strategy:

### Known issues with pull request:

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
