### PR TITLE
Implement BreakCommand for SAPI4, fix eSpeak

### DIFF
--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -157,15 +157,15 @@ class BreakCommand(SynthCommand):
 	"""Insert a break between words.
 	"""
 
-	def __init__(self, time=0):
+	def __init__(self, time: int = 0):
 		"""
 		@param time: The duration of the pause to be inserted in milliseconds.
-		@param time: int
 		"""
 		self.time = time
+		"""Time in milliseconds"""
 
 	def __repr__(self):
-		return "BreakCommand(time=%d)" % self.time
+		return f"BreakCommand(time={self.time})"
 
 class EndUtteranceCommand(SpeechCommand):
 	"""End the current utterance at this point in the speech.

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -10,7 +10,9 @@ Commands that can be embedded in a speech sequence for changing synth parameters
 """
  
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Callable
+from typing import (
+	Optional,
+)
 
 import config
 from synthDriverHandler import getSynth

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -6,7 +6,7 @@
 
 import os
 from collections import OrderedDict
-from typing import Optional, Set
+from typing import Dict, List, Optional, Set
 
 from . import _espeak
 from languageHandler import (
@@ -311,9 +311,9 @@ class SynthDriver(SynthDriver):
 	# Note: when working on speak, look for opportunities to simplify
 	# and move logic out into smaller helper functions.
 	def speak(self, speechSequence: SpeechSequence):  # noqa: C901
-		textList=[]
-		langChanged=False
-		prosody={}
+		textList: List[str] = []
+		langChanged = False
+		prosody: Dict[str, int] = {}
 		# We output malformed XML, as we might close an outer tag after opening an inner one; e.g.
 		# <voice><prosody></voice></prosody>.
 		# However, eSpeak doesn't seem to mind.
@@ -329,7 +329,9 @@ class SynthDriver(SynthDriver):
 				textList.append(langChangeXML)
 				langChanged = True
 			elif isinstance(item, BreakCommand):
-				textList.append('<break time="%dms" />' % item.time)
+				# Break commands are ignored at the start of speech unless strength is specified.
+				# Refer to eSpeak issue: https://github.com/espeak-ng/espeak-ng/issues/1232
+				textList.append(f'<break time="{item.time}ms" strength="1" />')
 			elif type(item) in self.PROSODY_ATTRS:
 				if prosody:
 					# Close previous prosody tag.

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -6,7 +6,12 @@
 
 import os
 from collections import OrderedDict
-from typing import Dict, List, Optional, Set
+from typing import (
+	Dict,
+	List,
+	Optional,
+	Set,
+)
 
 from . import _espeak
 from languageHandler import (

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -1,8 +1,7 @@
-#synthDrivers/sapi4.py
-#A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import locale
 from collections import OrderedDict

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -38,8 +38,13 @@ import config
 import nvwave
 import weakref
 
-from speech.commands import PitchCommand
-from speech.commands import IndexCommand, SpeechCommand, CharacterModeCommand
+from speech.commands import (
+	IndexCommand,
+	SpeechCommand,
+	CharacterModeCommand,
+	BreakCommand,
+	PitchCommand,
+)
 
 class SynthDriverBufSink(COMObject):
 	_com_interfaces_ = [ITTSBufNotifySink]
@@ -129,6 +134,8 @@ class SynthDriver(SynthDriver):
 			elif isinstance(item, CharacterModeCommand):
 				textList.append("\\RmS=1\\" if item.state else "\\RmS=0\\")
 				charMode=item.state
+			elif isinstance(item, BreakCommand):
+				textList.append(f"\\Pau={item.time}\\")
 			elif isinstance(item, PitchCommand):
 				offset = int(config.conf["speech"]['sapi4']["capPitchChange"])
 				offset = int((self._maxPitch - self._minPitch) * offset / 100)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
The `BreakCommand` is not implemented with SAPI4.
There is also a known issue with eSpeak not supporting the `break` SSML tag correctly.

### Description of user facing changes

Fix pauses being announced correctly when using MathPlayer and SAPI4 or eSpeak.

### Description of development approach

For SAPI5 the [`Pau`](http://www.tapiex.com/ES_Help/SctrlTags.htm#Pau) tag is used to implement the pause.

There is a known issue with eSpeak and the `break` SSML tag, which has been fixed with a workaround, adding the `strength` attribute, while we wait for https://github.com/espeak-ng/espeak-ng/issues/1232 to be fixed.

### Testing strategy:

Manual testing

Running the following code in the Python console using

- [x] SAPI5
- [x] eSpeak
- [x] OneCore
- [x] SAPI 4

```py
import core
from synthDriverHandler import getSynth
from speech.commands import BreakCommand
# returning None suppresses NVDA from announcing the return object CallLater
# which makes it harder to confirm the timed delay
s = lambda x: None if core.callLater(1, getSynth().speak, [BreakCommand(x), "test"]) else None
```
```py
s(100)  # 100ms
# wait and test the next value
s(1000) # 1s
# wait and test the next value
s(5000) # 5s
```

### Known issues with pull request:
None

### Change log entries:
```t2t
New features
Changes
- Improve eSpeak and SAPI 4 pause lengths when encountering commas and breaks using MathPlayer. 
Bug fixes
For Developers
- The SAPI 4 Synth Driver now supports ``BreakCommand``.

```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
