### PR TITLE
Improve versatility of System Test Framework, introduce `ensure_speech_did_not_occur`

### DIFF
--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -372,18 +372,16 @@ class NVDASpyLib:
 	def ensure_speech_did_not_occur(
 			self,
 			speech: str,
-			maxWaitSeconds: float,
 			afterIndex: Optional[int] = None,
+			maxWaitSeconds: float = SPEECH_HAS_FINISHED_SECONDS,
 			intervalBetweenSeconds: float = 0.1,
 	) -> None:
 		"""
 		@param speech: The speech to check for.
+		@param afterIndex: Check for speech after this index. The index is exclusive.
 		@param maxWaitSeconds: The amount of time to wait in seconds.
 		As this is the expected path, this will cause a successful test run to be delayed the time provided.
-		The default for the converse, `wait_for_specific_speech`, is 5s,
-		to make sure the application / OS is working fine.
-		It can be longer as it will only occur when a test fails.
-		@param afterIndex: Check for speech after this index. The index is exclusive.
+		The default is SPEECH_HAS_FINISHED_SECONDS to allow for delays from the application / OS.
 		@param intervalBetweenSeconds: The amount of time to wait between checking speech, in seconds.
 		"""
 		success, _speechIndex = self._has_speech_occurred_before_timeout(

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -372,14 +372,18 @@ class NVDASpyLib:
 	def ensure_speech_did_not_occur(
 			self,
 			speech: str,
+			maxWaitSeconds: float,
 			afterIndex: Optional[int] = None,
-			maxWaitSeconds: float = 5.0,
 			intervalBetweenSeconds: float = 0.1,
 	) -> None:
 		"""
 		@param speech: The speech to check for.
-		@param afterIndex: Check for speech after this index. The index is exclusive.
 		@param maxWaitSeconds: The amount of time to wait in seconds.
+		As this is the expected path, this will cause a successful test run to be delayed the time provided.
+		The default for the converse, `wait_for_specific_speech`, is 5s,
+		to make sure the application / OS is working fine.
+		It can be longer as it will only occur when a test fails.
+		@param afterIndex: Check for speech after this index. The index is exclusive.
 		@param intervalBetweenSeconds: The amount of time to wait between checking speech, in seconds.
 		"""
 		success, _speechIndex = self._has_speech_occurred_before_timeout(

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018 NV Access Limited
+# Copyright (C) 2018-2022 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -321,25 +321,31 @@ class NVDASpyLib:
 			speech: str,
 			afterIndex: Optional[int] = None,
 			maxWaitSeconds: int = 5,
+			intervalBetweenSeconds: float = 0.1,
+			expectedFailure: bool = False,
 	) -> int:
 		"""
 		@param speech: The speech to expect.
 		@param afterIndex: The speech should come after this index. The index is exclusive.
 		@param maxWaitSeconds: The amount of time to wait in seconds.
+		@param intervalBetweenSeconds: The amount of time to wait between checking speech, in seconds.
+		@param expectedFailure: If the wait condition is expected to fail.
 		@return: the index of the speech.
 		"""
 		success, speechIndex = _blockUntilConditionMet(
 			getValue=lambda: self._getIndexOfSpeech(speech, afterIndex),
 			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),
 			shouldStopEvaluator=lambda indexFound: indexFound >= (afterIndex if afterIndex else 0),
-			intervalBetweenSeconds=0.1,
+			intervalBetweenSeconds=intervalBetweenSeconds,
 			errorMessage=None
 		)
-		if not success:
+		if success == expectedFailure:
+			# Robot framework prevents you from catching AssertionErrors, so a failureExpected flag is required
 			self.dump_speech_to_log()
+			problemMsg = "occurred unexpectedly" if success else "did not occur"
 			raise AssertionError(
-				"Specific speech did not occur before timeout: {}\n"
-				"See NVDA log for dump of all speech.".format(speech)
+				f"Specific speech {problemMsg} before timeout: {speech}\n"
+				"See NVDA log for dump of all speech."
 			)
 		return speechIndex
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
While working on a separate PR, system tests were needed which changed the interval of checking speech, and to expect a failure.
This led to the contributor writing duplicate code to handle these cases, instead of improving the system test API.

That PR no longer requires this change, but the situation is generic enough to keep the API changes to make contributions easier in future.

### Description of user facing changes
`wait_for_specific_speech` now accepts a parameter to change the checking interval.

A new function `ensure_speech_did_not_occur` has been introduced.

### Description of development approach
N/A

### Testing strategy:
Tested when working on #13550 

### Known issues with pull request:
N/A

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
