### PR TITLE
Support non-interactive use of ensureVenv script

### DIFF
--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -25,24 +25,26 @@ venv_python_version_path: str = os.path.join(venv_path, "python_version")
 isInteractive = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
 
 
-def askYesNoQuestion(message: str, default: bool = True) -> bool:
+def askYesNoQuestion(message: str) -> bool:
 	"""
 	Displays the given message to the user and accepts y or n as input.
 	Any other input causes the question to be asked again.
-	If isInteractive is False, the default is always returned.
+	If isInteractive is False, y is assumed and True is returned.
 	@returns: True for y and False for n.
 	"""
-	while isInteractive:
-		answer = input(
-			message + " [y/n]: "
-		)
+	question: str = f"{message} [y/n]: "
+	while True:
+		if isInteractive:
+			answer = input(question)
+		else:
+			answer = "y"
+			print(f"{question}{answer} (answered non-interactively)")
 		if answer == 'n':
 			return False
 		elif answer == 'y':
 			return True
 		else:
 			continue  # ask again
-	return default
 
 
 def fetchRequirementsSet(path: str) -> Set[str]:

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -24,7 +24,10 @@ venv_python_version_path: str = os.path.join(venv_path, "python_version")
 #: Value is True if interactive (i.e. stdout is attached to a terminal), False otherwise.
 isInteractive = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
 if not isInteractive:
-	print("Warning: Running in non-interactive mode. Defaults are assumed for prompts, if applicable", flush=True)
+	print(
+		"Warning: Running in non-interactive mode. Defaults are assumed for prompts, if applicable",
+		flush=True
+	)
 
 
 def askYesNoQuestion(message: str, default: bool) -> bool:

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -19,15 +19,20 @@ venv_path: str = os.path.join(top_dir, ".venv")
 requirements_path: str = os.path.join(top_dir, "requirements.txt")
 venv_orig_requirements_path: str = os.path.join(venv_path, "_requirements.txt")
 venv_python_version_path: str = os.path.join(venv_path, "python_version")
+#: Whether this script is run interactively,
+#: i.e. whether user input is possible to answer questions.
+#: Value is True if interactive (i.e. stdout is attached to a terminal), False otherwise.
+isInteractive = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
 
 
-def askYesNoQuestion(message: str) -> bool:
+def askYesNoQuestion(message: str, default: bool = True) -> bool:
 	"""
 	Displays the given message to the user and accepts y or n as input.
 	Any other input causes the question to be asked again.
-	@returns: True for y and n for False.
+	If isInteractive is False, the default is always returned.
+	@returns: True for y and False for n.
 	"""
-	while True:
+	while isInteractive:
 		answer = input(
 			message + " [y/n]: "
 		)
@@ -37,6 +42,7 @@ def askYesNoQuestion(message: str) -> bool:
 			return True
 		else:
 			continue  # ask again
+	return default
 
 
 def fetchRequirementsSet(path: str) -> Set[str]:

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -23,13 +23,17 @@ venv_python_version_path: str = os.path.join(venv_path, "python_version")
 #: i.e. whether user input is possible to answer questions.
 #: Value is True if interactive (i.e. stdout is attached to a terminal), False otherwise.
 isInteractive = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+if not isInteractive:
+	print("Warning: Running in non-interactive mode. Defaults are assumed for prompts, if applicable", flush=True)
 
 
-def askYesNoQuestion(message: str) -> bool:
+def askYesNoQuestion(message: str, default: bool) -> bool:
 	"""
 	Displays the given message to the user and accepts y or n as input.
 	Any other input causes the question to be asked again.
-	If isInteractive is False, y is assumed and True is returned.
+	If isInteractive is False, the default is always returned, the question and outcome
+	will still be sent to stdout for inspection of the build.
+	@param default: the return value when the user can not be prompted.
 	@returns: True for y and False for n.
 	"""
 	question: str = f"{message} [y/n]: "
@@ -37,7 +41,7 @@ def askYesNoQuestion(message: str) -> bool:
 		if isInteractive:
 			answer = input(question)
 		else:
-			answer = "y"
+			answer = "y" if default else "n"
 			print(f"{question}{answer} (answered non-interactively)")
 		if answer == 'n':
 			return False
@@ -129,7 +133,8 @@ def ensureVenvAndRequirements():
 	):
 		if askYesNoQuestion(
 			f"Virtual environment at {venv_path} probably not created by NVDA. "
-			"This directory must be removed before continuing. Should it be removed?"
+			"This directory must be removed before continuing. Should it be removed?",
+			default=True
 		):
 			return createVenvAndPopulate()
 		else:
@@ -149,7 +154,8 @@ def ensureVenvAndRequirements():
 			"If you choose no, the new requirements will be installed without recreating. "
 			"This means that transitive dependencies can get out of sync "
 			"with those used in automated builds. "
-			"Would you like to continue recreating the environment?"
+			"Would you like to continue recreating the environment?",
+			default=True
 		):
 			return createVenvAndPopulate()
 		return populate()


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/pull/13048#issuecomment-1178807953

### Summary of the issue:
#13048 introduced another prompt to adres when dependencies in requirements.txt have changed. This blocks non-interactive use of the ensureVenv script, e.g. when running "scons source" non-interactively.

### Description of user facing changes
As proposed by @feerrenrut in https://github.com/nvaccess/nvda/pull/13048#issuecomment-1178807953, just use defaults when running in non-interactive mode.

### Description of development approach
See https://github.com/nvaccess/nvda/pull/13048#issuecomment-1178807953. Note that isatty is not always avaliable on sys.stdout, e.g. when it is set to the NVDA python console.

### Testing strategy:
Tested running `scons source > d:\output` and observed that the venv was dropped and recreated.

### Known issues with pull request:
Do we want to present the question and also print that the question has been answered as default due to running in non-interactive, I figured it would be a bit overkill for that purpose.

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
