### PR TITLE
Fix UIATextInfo and MSHTMLTextInfo, updateCaret without selecting text

### DIFF
--- a/source/NVDAObjects/IAccessible/MSHTML.py
+++ b/source/NVDAObjects/IAccessible/MSHTML.py
@@ -402,7 +402,9 @@ class MSHTMLTextInfo(textInfos.TextInfo):
 		return res
 
 	def updateCaret(self):
-		self._rangeObj.select()
+		copyTextInfo = self.copy()
+		copyTextInfo.collapse()
+		copyTextInfo._rangeObj.select()
 
 	def updateSelection(self):
 		self._rangeObj.select()

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -923,7 +923,11 @@ class UIATextInfo(textInfos.TextInfo):
 	def updateSelection(self):
 		self._rangeObj.Select()
 
-	updateCaret = updateSelection
+	def updateCaret(self) -> None:
+		copyTextInfo = self.copy()
+		copyTextInfo.collapse()
+		copyTextInfo.updateSelection()
+
 
 class UIA(Window):
 	_UIACustomProps = UIAHandler.customProps.CustomPropertiesCommon.get()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13899 

### Summary of the issue:
Using Notepad on Windows 11, performing Say All (``nvda+downArrow|nvda+a``) selects each line of text.

This is because `UIATextInfo.updateCaret = UIATextInfo.updateSelection`, so updating the caret sets the selection.

The same problem exists with `MSHTMLTextInfo`

### Description of user facing changes
Say All no longer highlights each line of text.

### Description of development approach
1. Copy the text info
2. Collapse the new text info (e.g the range endpoints become (start, start))
3. Set the selection on the new range

### Testing strategy:
Test with STR in #13899 with Notepad
Test Say All with Internet Explorer as well.

### Known issues with pull request:

### Change log entries:
Fixes unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
