### PR TITLE
Create typing hints for IUIAutomationTextRange

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -10,9 +10,6 @@ from ctypes import (
 	oledll,
 	windll,
 )
-from enum import (
-	Enum,
-)
 
 import comtypes.client
 from comtypes.automation import VT_EMPTY

--- a/source/UIAHandler/types.py
+++ b/source/UIAHandler/types.py
@@ -14,6 +14,9 @@ from comInterfaces.UIAutomationClient import IUIAutomationTextRange
 
 
 class _IUIAutomationTextRangeT(Protocol):
+	# Based on IUIAutomationTextRange
+	# https://docs.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationtextrange
+
 	def findText(self) -> "IUIAutomationTextRangeT":
 		...
 

--- a/source/UIAHandler/types.py
+++ b/source/UIAHandler/types.py
@@ -1,0 +1,62 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from typing import (
+	Any,
+)
+from typing_extensions import (
+	Protocol,
+)
+
+from comInterfaces.UIAutomationClient import IUIAutomationTextRange
+
+
+class _IUIAutomationTextRangeT(Protocol):
+	def findText(self) -> "IUIAutomationTextRangeT":
+		...
+
+	def clone(self) -> "IUIAutomationTextRangeT":
+		...
+
+	def MoveEndpointByRange(
+			self,
+			source: int,
+			rangeObject: "IUIAutomationTextRangeT",
+			target: int
+	) -> None:
+		...
+
+	def CompareEndpoints(
+			self,
+			source: int,
+			rangeObject: "IUIAutomationTextRangeT",
+			target: int
+	) -> Any:
+		...
+
+	def compare(self, other: "IUIAutomationTextRangeT") -> Any:
+		...
+
+	def getText(self, index: int) -> str:
+		...
+
+	def Select(self) -> None:
+		...
+
+	def MoveEndpointByUnit(self, endPoint: int, unit: int, direction: int) -> None:
+		...
+
+	def Move(self, unit: int, direction: int) -> None:
+		...
+
+	def ExpandToEnclosingUnit(self, unit: int) -> None:
+		...
+
+	def GetBoundingRectangles(self) -> Any:
+		...
+
+
+class IUIAutomationTextRangeT(type(IUIAutomationTextRange), _IUIAutomationTextRangeT):
+	pass

--- a/source/UIAHandler/types.py
+++ b/source/UIAHandler/types.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 from typing import (
-	Any,
+	List,
 )
 from typing_extensions import (
 	Protocol,
@@ -36,10 +36,10 @@ class _IUIAutomationTextRangeT(Protocol):
 			source: int,
 			rangeObject: "IUIAutomationTextRangeT",
 			target: int
-	) -> Any:
+	) -> int:
 		...
 
-	def compare(self, other: "IUIAutomationTextRangeT") -> Any:
+	def compare(self, other: "IUIAutomationTextRangeT") -> bool:
 		...
 
 	def getText(self, index: int) -> str:
@@ -57,7 +57,7 @@ class _IUIAutomationTextRangeT(Protocol):
 	def ExpandToEnclosingUnit(self, unit: int) -> None:
 		...
 
-	def GetBoundingRectangles(self) -> Any:
+	def GetBoundingRectangles(self) -> List:
 		...
 
 

--- a/source/UIAHandler/types.py
+++ b/source/UIAHandler/types.py
@@ -16,19 +16,12 @@ from comInterfaces.UIAutomationClient import IUIAutomationTextRange
 class _IUIAutomationTextRangeT(Protocol):
 	# Based on IUIAutomationTextRange
 	# https://docs.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationtextrange
-
-	def findText(self) -> "IUIAutomationTextRangeT":
-		...
+	# Currently incomplete.
 
 	def clone(self) -> "IUIAutomationTextRangeT":
 		...
 
-	def MoveEndpointByRange(
-			self,
-			source: int,
-			rangeObject: "IUIAutomationTextRangeT",
-			target: int
-	) -> None:
+	def compare(self, other: "IUIAutomationTextRangeT") -> bool:
 		...
 
 	def CompareEndpoints(
@@ -39,25 +32,33 @@ class _IUIAutomationTextRangeT(Protocol):
 	) -> int:
 		...
 
-	def compare(self, other: "IUIAutomationTextRangeT") -> bool:
+	def ExpandToEnclosingUnit(self, unit: int) -> None:
+		...
+
+	def findText(self) -> "IUIAutomationTextRangeT":
+		...
+
+	def GetBoundingRectangles(self) -> List:
 		...
 
 	def getText(self, index: int) -> str:
 		...
 
-	def Select(self) -> None:
+	def Move(self, unit: int, direction: int) -> None:
+		...
+
+	def MoveEndpointByRange(
+			self,
+			source: int,
+			rangeObject: "IUIAutomationTextRangeT",
+			target: int
+	) -> None:
 		...
 
 	def MoveEndpointByUnit(self, endPoint: int, unit: int, direction: int) -> None:
 		...
 
-	def Move(self, unit: int, direction: int) -> None:
-		...
-
-	def ExpandToEnclosingUnit(self, unit: int) -> None:
-		...
-
-	def GetBoundingRectangles(self) -> List:
+	def Select(self) -> None:
 		...
 
 

--- a/source/api.py
+++ b/source/api.py
@@ -253,18 +253,15 @@ def getReviewPosition() -> textInfos.TextInfo:
 
 def setReviewPosition(
 		reviewPosition,
-		clearNavigatorObject=True,
-		isCaret=False,
-		isMouse=False
-):
+		clearNavigatorObject: bool = True,
+		isCaret: bool = False,
+		isMouse: bool = False,
+) -> None:
 	"""Sets a TextInfo instance as the review position.
-	@param clearNavigatorObject: if  true, It sets the current navigator object to C{None}.
+	@param clearNavigatorObject: If True, it sets the current navigator object to C{None}.
 		In that case, the next time the navigator object is asked for it fetches it from the review position.
-	@type clearNavigatorObject: bool
 	@param isCaret: Whether the review position is changed due to caret following.
-	@type isCaret: bool
 	@param isMouse: Whether the review position is changed due to mouse following.
-	@type isMouse: bool
 	"""
 	globalVars.reviewPosition=reviewPosition.copy()
 	globalVars.reviewPositionObj=reviewPosition.obj

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -298,7 +298,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 	_cache__storyFieldsAndRects = True
 
 	def _get__storyFieldsAndRects(self) -> Tuple[
-		List[Union[str, textInfos.FieldCommand]],
+		List[textInfos.TextInfo.TextOrFieldsT],
 		List[RectLTRB],
 		List[int],
 		List[int]

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -360,7 +360,8 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
-	TextWithFieldsT = List[Union[str, FieldCommand]]
+	TextOrFieldsT = Union[str, FieldCommand]
+	TextWithFieldsT = List[TextOrFieldsT]
 
 	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> "TextInfo.TextWithFieldsT":
 		"""Retrieves the text in this range, as well as any control/format fields associated therewith.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

### Summary of the issue:
Objects from `comInterfaces` generally do not have helpful type hints.

### Description of user facing changes
When a variable is type hinted with `IUIAutomationTextRangeT` supported functions will appear as type hints. 

### Description of development approach
Implements methods found in https://docs.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationtextrange, checked against usages in NVDA code.

### Testing strategy:

### Known issues with pull request:

### Change log entries:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
