### PR TITLE
Prevent error if no matching index found after Input Gestures filter

### DIFF
--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -636,6 +636,7 @@ class InputGesturesDialog(SettingsDialog):
 		super()._onWindowDestroy(evt)
 
 	def onFilterChange(self, evt):
+		self.tree.Unselect()
 		filterText = evt.GetEventObject().GetValue()
 		self.filter(filterText)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -46,6 +46,7 @@ This will improve performance for some Java applications including IntelliJ IDEA
 - Announcement of selected cells for LibreOffice Calc is more efficient and no longer results in a Calc freeze when many cells are selected. (#13232)
 - When running under a different user, Microsoft Edge is no longer inaccessible. (#13032)
 - When rate boost is off, eSpeak's rate does not drop anymore between rates 99% and 100%. (#13876)
+- Fix bug which allowed 2 Input Gestures dialogs to open. (#13854)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13854 

### Summary of the issue:
When a tree item in the input gestures dialog is selected, then a filter event happens which makes the index no longer valid, an unhandled exception occurs.
This causes multiple Input Gestures to be able to be opened.

STR
1. Open input gestures dialog.
1. Arrow down to the 4th category (Configuration Profiles)
1. Press `Shift+Tab` to move to "filter by" edit field and type "z"
1. The dialog should refresh with 3 categories
1. Note an ERROR is logged, as the selected index (4) is larger than the number of categories
1. Close the Input Gestures dialog (press escape)
1. Open the Input Gestures dialog
1. Open a second Input Gestures dialog

### Description of user facing changes
2 input gesture dialogs can no longer be opened.

### Description of development approach
Unselect items when the input gesture filter is updated.

### Testing strategy:
Test STR

### Known issues with pull request:
None

### Change log entries:
Changes
```
- Fix bug which allowed 2 Input Gestures dialogs to open. (#13854)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
