### PR TITLE
Add NVDA estimated size to add/remove programs

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -259,10 +259,9 @@ def registerInstallation(
 		startOnLogonScreen: bool,
 		configInLocalAppData: bool = False
 ):
-	calculatedUninstallerRegInfo = uninstallerRegInfo + {
-		# EstimatedSize is in KiB
-		"EstimatedSize": getDirectorySize(installDir) / 1024
-	}
+	calculatedUninstallerRegInfo = uninstallerRegInfo.copy()
+	# EstimatedSize is in KiB
+	calculatedUninstallerRegInfo.update(EstimatedSize=getDirectorySize(installDir) / 1024)
 	with winreg.CreateKeyEx(
 		winreg.HKEY_LOCAL_MACHINE,
 		r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA",

--- a/source/installer.py
+++ b/source/installer.py
@@ -226,21 +226,66 @@ def removeOldProgramFiles(destPath):
 				except RetriableFailure:
 					log.warning(f"Couldn't remove file: {path!r}")
 
-uninstallerRegInfo={
-	"DisplayName":versionInfo.name,
-	"DisplayVersion":versionInfo.version,
-	"DisplayIcon":u"{installDir}\\images\\nvda.ico",
-	"InstallDir":u"{installDir}",
-	"Publisher":versionInfo.publisher,
-	"UninstallDirectory":u"{installDir}",
-	"UninstallString":u"{installDir}\\uninstall.exe",
-	"URLInfoAbout":versionInfo.url,
+
+uninstallerRegInfo = {
+	"DisplayName": versionInfo.name,
+	"DisplayVersion": versionInfo.version,
+	"DisplayIcon": u"{installDir}\\images\\nvda.ico",
+	"InstallDir": u"{installDir}",
+	"Publisher": versionInfo.publisher,
+	"UninstallDirectory": u"{installDir}",
+	"UninstallString": u"{installDir}\\uninstall.exe",
+	"URLInfoAbout": versionInfo.url,
 }
 
-def registerInstallation(installDir,startMenuFolder,shouldCreateDesktopShortcut,startOnLogonScreen,configInLocalAppData=False):
-	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NVDA",0,winreg.KEY_WRITE) as k:
-		for name,value in uninstallerRegInfo.items(): 
-			winreg.SetValueEx(k,name,None,winreg.REG_SZ,value.format(installDir=installDir))
+
+def getDirectorySize(path: str) -> int:
+	"""Calculates the size of a directory in bytes.
+	"""
+	total = 0
+	with os.scandir(path) as iterator:
+		for entry in iterator:
+			if entry.is_file():
+				total += entry.stat().st_size
+			elif entry.is_dir():
+				total += getDirectorySize(entry.path)
+	return total
+
+
+def registerInstallation(
+		installDir: str,
+		startMenuFolder: str,
+		shouldCreateDesktopShortcut: bool,
+		startOnLogonScreen: bool,
+		configInLocalAppData: bool = False
+):
+	calculatedUninstallerRegInfo = uninstallerRegInfo + {
+		# EstimatedSize is in KiB
+		"EstimatedSize": getDirectorySize(installDir) / 1024
+	}
+	with winreg.CreateKeyEx(
+		winreg.HKEY_LOCAL_MACHINE,
+		r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA",
+		0,
+		winreg.KEY_WRITE
+	) as k:
+		for name, value in calculatedUninstallerRegInfo.items():
+			if isinstance(value, int):
+				winreg.SetValueEx(
+					k,
+					name,
+					None,
+					winreg.REG_DWORD,
+					value
+				)
+			else:
+				winreg.SetValueEx(
+					k,
+					name,
+					None,
+					winreg.REG_SZ,
+					value.format(installDir=installDir)
+				)
 	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\nvda.exe",0,winreg.KEY_WRITE) as k:
 		winreg.SetValueEx(k,"",None,winreg.REG_SZ,os.path.join(installDir,"nvda.exe"))
 	with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE, config.RegistryKey.NVDA.value, 0, winreg.KEY_WRITE) as k:
@@ -584,8 +629,14 @@ def install(shouldCreateDesktopShortcut=True,shouldRunAtLogon=True):
 			break
 	else:
 		raise RuntimeError("No available executable to use as nvda.exe")
-	registerInstallation(installDir,startMenuFolder,shouldCreateDesktopShortcut,shouldRunAtLogon,configInLocalAppData)
-	removeOldLibFiles(installDir,rebootOK=True)
+	removeOldLibFiles(installDir, rebootOK=True)
+	registerInstallation(
+		installDir,
+		startMenuFolder,
+		shouldCreateDesktopShortcut,
+		shouldRunAtLogon,
+		configInLocalAppData
+	)
 	COMRegistrationFixes.fixCOMRegistrations()
 
 def removeOldLoggedFiles(installPath):

--- a/source/installer.py
+++ b/source/installer.py
@@ -261,7 +261,7 @@ def registerInstallation(
 ):
 	calculatedUninstallerRegInfo = uninstallerRegInfo.copy()
 	# EstimatedSize is in KiB
-	calculatedUninstallerRegInfo.update(EstimatedSize=getDirectorySize(installDir) / 1024)
+	calculatedUninstallerRegInfo.update(EstimatedSize=getDirectorySize(installDir) // 1024)
 	with winreg.CreateKeyEx(
 		winreg.HKEY_LOCAL_MACHINE,
 		r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA",

--- a/source/installer.py
+++ b/source/installer.py
@@ -227,15 +227,15 @@ def removeOldProgramFiles(destPath):
 					log.warning(f"Couldn't remove file: {path!r}")
 
 
-uninstallerRegInfo = {
-	"DisplayName": versionInfo.name,
-	"DisplayVersion": versionInfo.version,
-	"DisplayIcon": u"{installDir}\\images\\nvda.ico",
-	"InstallDir": u"{installDir}",
-	"Publisher": versionInfo.publisher,
-	"UninstallDirectory": u"{installDir}",
-	"UninstallString": u"{installDir}\\uninstall.exe",
-	"URLInfoAbout": versionInfo.url,
+uninstallerRegInfo={
+	"DisplayName":versionInfo.name,
+	"DisplayVersion":versionInfo.version,
+	"DisplayIcon":u"{installDir}\\images\\nvda.ico",
+	"InstallDir":u"{installDir}",
+	"Publisher":versionInfo.publisher,
+	"UninstallDirectory":u"{installDir}",
+	"UninstallString":u"{installDir}\\uninstall.exe",
+	"URLInfoAbout":versionInfo.url,
 }
 
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -258,10 +258,12 @@ def registerInstallation(
 		shouldCreateDesktopShortcut: bool,
 		startOnLogonScreen: bool,
 		configInLocalAppData: bool = False
-):
+) -> None:
 	calculatedUninstallerRegInfo = uninstallerRegInfo.copy()
 	# EstimatedSize is in KiB
-	calculatedUninstallerRegInfo.update(EstimatedSize=getDirectorySize(installDir) // 1024)
+	estimatedSize = getDirectorySize(installDir)
+	log.debug(f"Estimated install size {estimatedSize}")
+	calculatedUninstallerRegInfo.update(EstimatedSize=estimatedSize // 1024)
 	with winreg.CreateKeyEx(
 		winreg.HKEY_LOCAL_MACHINE,
 		r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,6 +33,7 @@ It can be re-enabled in NVDA's advanced settings panel. (#11554)
   -
 - When using UI Automation to access Microsoft Excel spreadsheet controls, NVDA is now able to report when a cell is merged. (#12843)
 - Instead of reporting "has details" the purpose of details is included where possible, for example "has comment". (#13649)
+- The installation size of NVDA is now shown in Windows Programs and Feature section. (#13909)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In Windows Add/remove programs, there is a column that displays the estimated installation size of a product. This column is empty for NVDA.

### Description of user facing changes
Calculate install size of the NVDA program files folder, and add it to the registry. This will be visible in Add/remove programs.

### Description of development approach
I decided to calculate estimated size during installation. This takes the SystemConfig into account as that is part of the program files directory. This means that the estimated size is also based on the system config. I think this is OK, because when removing NVDA from Add/remove programs, the systemConfig dir is removed as well. Long story short, the estimated size is the best estimate we could get at time of installation

### Testing strategy:
installed the build from appveyor. Verified that the estimated size is visible in add/remove programs and equal to the size of C:\Program Files (x86)\NVDA

### Known issues with pull request:
None known

### Change log entries:
Changes
- The installation size of NVDA is now shown in Windows' Programs and Feature section.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
