### PR TITLE
Fixup #13131, ensure speech doesn't interrupt when scrolling braille display

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2778,12 +2778,12 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 		return self.id.split("+")
 
 	def _get_speechEffectWhenExecuted(self) -> Optional[str]:
-		from globalCommands import GlobalCommands
+		from globalCommands import commands
 		if (
 			not config.conf["braille"]["interruptSpeechWhileScrolling"]
 			and self.script in {
-				GlobalCommands.script_braille_scrollBack,
-				GlobalCommands.script_braille_scrollForward,
+				commands.script_braille_scrollBack,
+				commands.script_braille_scrollForward,
 			}
 		):
 			return None
@@ -2819,6 +2819,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 			return description, key
 
 inputCore.registerGestureSource("br", BrailleDisplayGesture)
+# inputCore.registerGestureSource("kb", BrailleDisplayGesture)
 
 
 def getSerialPorts(filterFunc=None) -> typing.Iterator[typing.Tuple[str, str]]:

--- a/source/braille.py
+++ b/source/braille.py
@@ -2819,7 +2819,6 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 			return description, key
 
 inputCore.registerGestureSource("br", BrailleDisplayGesture)
-# inputCore.registerGestureSource("kb", BrailleDisplayGesture)
 
 
 def getSerialPorts(filterFunc=None) -> typing.Iterator[typing.Tuple[str, str]]:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixup of #13131 
### Summary of the issue:
#13131 incorrectly checks the script commands. The initial PR did not use the correct instance of global commands, rather references to the class methods.

### Description of user facing changes
#13131 works as intended.

### Description of development approach

### Testing strategy:
Get a braille user to test the PR build

This patch scrolls the braille viewer display forward every 2 seconds once opened. 
Confirmed speech wasn't interrupted.
```diff
diff --git a/source/brailleViewer/brailleViewerGui.py b/source/brailleViewer/brailleViewerGui.py
index 33f3ead0a..a8bf947dc 100644
--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -451,6 +451,9 @@ class BrailleViewerFrame(
 			self._newCellCount = currentCellCount
 
 		self._triggerGuiUpdate()
+		import core
+		from globalCommands import commands
+		core.callLater(2000, commands.script_braille_scrollForward, "")
 
 	def _triggerGuiUpdate(self):
 		continuousTimerRunning = self._timer.IsRunning() and not self._timer.IsOneShot()
```

### Known issues with pull request:
None
### Change log entries:
None - Unreleased feature

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
