### PR TITLE
Review changelog and documentation changes for 2022.3

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,7 +16,7 @@ eSpeak has been updated, which introduces 3 new languages: Belarusian, Luxembour
 - In the Windows Console Host used by Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 11 version 22H2 (Sun Valley 2) and later:
   - Vastly improved performance and stability. (#10964)
   - When pressing ``control+f`` to find text, the review cursor position is updated to follow the found term. (#11172)
-  - Reporting of typed text that does not appear onscreen (such as passwords) is disabled by default.
+  - Reporting of typed text that does not appear on-screen (such as passwords) is disabled by default.
 It can be re-enabled in NVDA's advanced settings panel. (#11554)
   - Text that has scrolled offscreen can be reviewed without scrolling the console window. (#12669)
   - More detailed text formatting information is available. ([microsoft/terminal PR 10336 https://github.com/microsoft/terminal/pull/10336])

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,13 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2022.3 =
+A significant amount of this release was contributed by the NVDA development community.
+This includes table say all commands, delayed character descriptions, and improved Windows Console behaviour.
+
+This release also includes several bug fixes.
+Notably, up-to-date versions of Adobe Acrobat/Reader will no longer crash when reading a PDF document.
+
+eSpeak has been updated, which introduces 3 new languages: Belarusian, Luxembourgish and Totontepec Mixe.
 
 == New Features ==
 - In the Windows Console Host used by Command Prompt, PowerShell, and the Windows Subsystem for Linux on Windows 11 version 22H2 (Sun Valley 2) and later:
@@ -65,12 +72,7 @@ This will improve performance for some Java applications including IntelliJ IDEA
 
 
 === Deprecations ===
-These are proposed API breaking changes.
-The deprecated part of the API will continue to be available until the specified release.
-If no release is specified, the plan for removal has not been determined.
-Note, the roadmap for removals is 'best effort' and may be subject to change.
-Please test the new API and provide feedback.
-For add-on authors, please open a GitHub issue if these changes stop the API from meeting your needs.
+There are no deprecations proposed in 2022.3.
 
 
 = 2022.2 =

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,7 +5,7 @@ What's New in NVDA
 
 = 2022.3 =
 A significant amount of this release was contributed by the NVDA development community.
-This includes table say all commands, delayed character descriptions, and improved Windows Console behaviour.
+This includes table say all commands, delayed character descriptions, and improved Windows Console support.
 
 This release also includes several bug fixes.
 Notably, up-to-date versions of Adobe Acrobat/Reader will no longer crash when reading a PDF document.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1923,6 +1923,12 @@ This setting contains the following values:
 -
 
 ==== Windows Console support ====[AdvancedSettingsConsoleUIA]
+: Default
+  Automatic
+: Options
+  Automatic, UIA when available, Legacy
+:
+
 This option selects how NVDA interacts with the Windows Console used by command prompt, PowerShell, and the Windows Subsystem for Linux.
 It does not affect the modern Windows Terminal.
 In Windows 10 version 1709, Microsoft [added support for its UI Automation API to the console https://devblogs.microsoft.com/commandline/whats-new-in-windows-console-in-windows-10-fall-creators-update/], bringing vastly improved performance and stability for screen readers that support it.


### PR DESCRIPTION
**Must be squash merge**

Comparison command:
`git diff release-2022.2...origin/branchBeta2022.3 -- "**/en/*.t2t" "**/developerGuide.t2t" `

Common mistakes to look for:

- Issue/PR reference is incorrect
- Incorrect spelling.
- Lists not terminated with a final - on a new line, matching indentation
- List items not indented by a multiple of 2 spaces
- Single grave marks ` instead of double grave marks ``
- Shortcuts added without code markdown, use two 'grave' characters (``NVDA+d``)
- Double spaces
- Inconsistent use of single vs double quote
