### PR TITLE
Remove `typing.Collection` from MRO of `FlagValueEnum`

### DIFF
--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -23,7 +23,7 @@ from typing_extensions import (
 )
 
 
-class FeatureFlagEnumProtocol(Protocol, typing.Collection):
+class FeatureFlagEnumProtocol(Protocol):
 	""" All feature flags are expected to have a "DEFAULT" value.
 	This definition is provided only for type annotations
 	"""


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13923 

### Summary of the issue:
Performing type checks for collections fail 

The following code raises an error when FlagValueEnum is defined as

```py
FlagValueEnum(enum.EnumMeta, _DisplayStringEnumMixin, FeatureFlagEnumProtocol): pass
```

In the NVDA python console
```py
>>>import collections.abc
>>>isinstance(12, collections.abc.Sized)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "C:\Users\sean\AppData\Local\Programs\Python\Python37-32\lib\abc.py", line 139, in __instancecheck__
    return _abc_instancecheck(cls, instance)
  File "C:\Users\sean\AppData\Local\Programs\Python\Python37-32\lib\abc.py", line 143, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
  File "C:\Users\sean\AppData\Local\Programs\Python\Python37-32\lib\abc.py", line 143, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
  File "C:\Users\sean\AppData\Local\Programs\Python\Python37-32\lib\abc.py", line 143, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
  [Previous line repeated 1 more time]
TypeError: descriptor '__subclasses__' of 'type' object needs an argument
```


### Description of user facing changes
API is fixed for performing type checks in `collections`.

### Description of development approach

Removing `typing.Collection` or `enum.EnumMeta` from the MRO both resolve the python console / API bug.
As a result, I assume the bug is some sort of class conflict between `typing.Collection` and `enum.EnumMeta` .
We could resolve this by creating a metaclass.
However, I believe the already included EnumMeta class should cover what we wanted in type hinting `typing.Collection`.

>The EnumMeta metaclass is responsible for providing the `__contains__(), __dir__(), __iter__()` and other methods that allow one to do things with an [Enum](https://docs.python.org/3/library/enum.html#enum.Enum) class that fail on a typical class, such as` list(Color)` or some_enum_var in Color. EnumMeta is responsible for ensuring that various other methods on the final [Enum](https://docs.python.org/3/library/enum.html#enum.Enum) class are correct (such as `__new__(), __getnewargs__(), __str__() and __repr__()`).

https://docs.python.org/3/library/enum.html#enum-classes.

### Testing strategy:
Tested with add-on and python console.

### Known issues with pull request:
None

### Change log entries:
Unreleased regressions

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
