### PR TITLE
Use EditTextInfo for RichEdit50 controls

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -3,38 +3,32 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import locale
 from typing import (
 	Dict,
 	Optional,
+	Type,
 )
 
 import comtypes.client
-import struct
 import ctypes
 from comtypes import COMError
 import oleTypes
 import colors
-import globalVars
 import NVDAHelper
 import eventHandler
 import comInterfaces.tom
 from logHandler import log
 import languageHandler
 import config
-import speech
 import winKernel
 import api
 import winUser
 import textInfos.offsets
-from keyboardHandler import KeyboardInputGesture
-from scriptHandler import isScriptWaiting
 import controlTypes
 from controlTypes import TextPosition
 from . import Window
 from .. import NVDAObjectTextInfo
 from ..behaviors import EditableTextWithAutoSelectDetection
-import braille
 import watchdog
 import locationHelper
 import textUtils
@@ -799,8 +793,14 @@ class Edit(EditableTextWithAutoSelectDetection, Window):
 	editAPIVersion=0
 	editValueUnit=textInfos.UNIT_LINE
 
-	def _get_TextInfo(self):
-		if self.editAPIVersion!=0 and self.ITextDocumentObject:
+	def _get_TextInfo(self) -> Type["textInfos.TextInfo"]:
+		if (
+			self.editAPIVersion not in {
+				0,
+				5,  # wx RichEdit50 controls do not work with ITextDocumentTextInfo #13420
+			}
+			and self.ITextDocumentObject
+		):
 			return ITextDocumentTextInfo
 		else:
 			return EditTextInfo


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

Opening draft PR to start build

### Link to issue number:
Fixes #13420, #13927

### Summary of the issue:
TODO

### Description of user facing changes
Review cursor and system cursor tracking fixed for RichEdit50 controls (e.g. NVDA log viewer, Bookworm).

### Description of development approach
Use EditTextInfo for RichEdit50 controls.

### Testing strategy:
TODO

### Known issues with pull request:
Bookworm sayAll stops after each page. This is different behaviour to 2022.2, where sayAll continues on the new page.
This is better than the current behaviour on master, which causes sayAll to be caught in an infinite loop scrolling at the bottom of the last page.

### Change log entries:
Bug fixes


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
