### PR TITLE
Introduce table sayAll commands

### DIFF
--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -10,6 +10,7 @@ from baseObject import AutoPropertyObject, ScriptableObject
 import config
 import textInfos
 import controlTypes
+from speech import sayAll
 
 _TableID = Union[int, Tuple, Any]
 """
@@ -45,6 +46,18 @@ class _TableSelection:
 	trueRow: int
 	rowSpan: int
 	trueCol: int
+	colSpan: int
+
+
+@dataclass
+class _TableCell:
+	"""
+	Contains information about a cell in the table with matching tableID
+	"""
+	tableID: _TableID
+	row: int
+	col: int
+	rowSpan: int
 	colSpan: int
 
 
@@ -100,13 +113,14 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 						layoutIDs.add(tableID)
 		return layoutIDs
 
-	def _getTableCellCoords(self, info):
+	def _getTableCellCoords(
+			self,
+			info: textInfos.TextInfo,
+	) -> _TableCell:
 		"""
 		Fetches information about the deepest table cell at the given position.
 		@param info:  the position where the table cell should be looked for.
-		@type info: L{textInfos.TextInfo}
-		@returns: a tuple of table ID, row number, column number, row span, and column span.
-		@rtype: tuple
+		@returns: Information about requested cell.
 		@raises: LookupError if there is no table cell at this position.
 		"""
 		if info.isCollapsed:
@@ -126,13 +140,52 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 				break
 		else:
 			raise LookupError("Not in a table cell")
-		return (
+		return _TableCell(
 			attrs["table-id"],
 			attrs["table-rownumber"],
 			attrs["table-columnnumber"],
 			attrs.get("table-rowsspanned", 1),
 			attrs.get("table-columnsspanned", 1),
 		)
+
+	def _getTableCellCoordsCached(
+			self,
+			info: textInfos.TextInfo,
+			axis: Optional[_Axis] = None,
+	) -> _TableCell:
+		cell = self._getTableCellCoords(info)
+
+		# The following lines check whether user has been issuing table navigation commands repeatedly.
+		# In this case, instead of using current column/row index, we used cached value
+		# to allow users being able to skip merged cells without affecting the initial column/row index.
+		# For more info see issue #11919 and #7278.
+		if (
+			self._lastTableSelection
+			and cell.row == self._lastTableSelection.lastRow
+			and cell.col == self._lastTableSelection.lastCol
+			and self._lastTableSelection.axis == axis
+		):
+			if axis == _Axis.ROW:
+				newCol = self._lastTableSelection.trueCol
+				newColSpan = self._lastTableSelection.colSpan
+				return _TableCell(
+					cell.tableID,
+					cell.row,
+					newCol,
+					cell.rowSpan,
+					newColSpan,
+				)
+			else:
+				newRow = self._lastTableSelection.trueRow
+				newRowSpan = self._lastTableSelection.rowSpan
+				return _TableCell(
+					cell.tableID,
+					newRow,
+					cell.col,
+					newRowSpan,
+					cell.colSpan,
+				)
+		return cell
 
 	def _getTableDimensions(self, info: textInfos.TextInfo) -> Tuple[int, int]:
 		"""
@@ -188,12 +241,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 
 	def _getNearestTableCell(
 			self,
-			tableID: _TableID,
 			startPos: textInfos.TextInfo,
-			origRow: int,
-			origCol: int,
-			origRowSpan: int,
-			origColSpan: int,
+			cell: _TableCell,
 			movement: _Movement,
 			axis: _Axis,
 	) -> textInfos.TextInfo:
@@ -201,26 +250,22 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		Locates the nearest table cell relative to another table cell in a given direction, given its coordinates.
 		For example, this is used to move to the cell in the next column, previous row, etc.
 		This method will skip over missing table cells (where L{_getTableCellAt} raises LookupError), up to the number of times set by _missingTableCellSearchLimit set on this instance.
-		@param tableID: the ID of the table
 		@param startPos: the position in the document to start searching from.
-		@param origRow: the row number of the starting cell
-		@param origCol: the column number  of the starting cell
-		@param origRowSpan: the row span of the row of the starting cell
-		@param origColSpan: the column span of the column of the starting cell
+		@param cell: the cell information of start position.
 		@param movement: the direction ("next" or "previous")
 		@param axis: the axis of movement ("row" or "column")
 		@returns: the position of the nearest table cell
 		"""
+		tableID = cell.tableID
 		if not axis:
 			raise ValueError("Axis must be row or column")
 
 		# Determine destination row and column.
-		destRow = origRow
-		destCol = origCol
+		destRow, destCol = cell.row, cell.col
 		if axis == _Axis.ROW:
-			destRow += origRowSpan if movement == _Movement.NEXT else -1
+			destRow += cell.rowSpan if movement == _Movement.NEXT else -1
 		elif axis == _Axis.COLUMN:
-			destCol += origColSpan if movement == _Movement.NEXT else -1
+			destCol += cell.colSpan if movement == _Movement.NEXT else -1
 
 		# Try and fetch the cell at these coordinates, though  if a  cell is missing, try  several more times moving the coordinates on by one cell each time
 		limit=self._missingTableCellSearchLimit
@@ -241,12 +286,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 
 	def _getFirstOrLastTableCell(
 			self,
-			tableID: _TableID,
 			startPos: textInfos.TextInfo,
-			origRow: int,
-			origCol: int,
-			origRowSpan: int,
-			origColSpan: int,
+			cell: _TableCell,
 			movement: _Movement,
 			axis: _Axis
 	) -> textInfos.TextInfo:
@@ -258,17 +299,13 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		After figuring out exact coordinates of the cell it will try to jump directly to that cell,
 		or if that fails (due to missing table cell), it will walk in the opposite direction skipping missing cells
 		up to the number of times set by _missingTableCellSearchLimit set on this instance.
-		@param tableID: the ID of the table
 		@param startPos: the position in the document to start searching from.
-		@param origRow: the row number of the starting cell
-		@param origCol: the column number  of the starting cell
-		@param origRowSpan: the row span of the row of the starting cell
-		@param origColSpan: the column span of the column of the starting cell
+		@param cell: the cell information of start position.
 		@param movement: the direction ("first" or "last")
 		@param axis: the axis of movement ("row" or "column")
 		@returns: the position of the destination table cell
 		"""
-		destRow, destCol = origRow, origCol
+		destRow, destCol = cell.row, cell.col
 		if movement == _Movement.FIRST:
 			if axis == _Axis.COLUMN:
 				destCol = 1
@@ -281,19 +318,83 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			else:
 				destRow = nRows
 		try:
-			return self._getTableCellAt(tableID, startPos, destRow, destCol)
+			return self._getTableCellAt(cell.tableID, startPos, destRow, destCol)
 		except LookupError:
 			oppositeMovement = _Movement.PREVIOUS if movement == _Movement.LAST else _Movement.NEXT
 			return self._getNearestTableCell(
-				tableID,
 				startPos,
-				destRow,
-				destCol,
-				origRowSpan=1,
-				origColSpan=1,
+				_TableCell(
+					cell.TableID,
+					destRow,
+					destCol,
+					rowSpan=1,
+					colSpan=1,
+				),
 				movement=oppositeMovement,
-				axis=axis
+				axis=axis,
 			)
+
+	def _tableFindNewCell(
+			self,
+			movement: Optional[_Movement] = None,
+			axis: Optional[_Axis] = None,
+			selection: Optional[textInfos.TextInfo] = None,
+			raiseOnEdge: bool = False,
+	) -> Tuple[_TableCell, textInfos.TextInfo, Optional[_TableSelection]]:
+		# documentBase is a core module and should not depend on these UI modules and so they are imported
+		import ui
+		if not selection:
+			selection = self.selection
+		try:
+			cell = self._getTableCellCoordsCached(selection, axis)
+		except LookupError as e:
+			# Translators: The message reported when a user attempts to use a table movement command
+			# when the cursor is not within a table.
+			ui.message(_("Not in a table cell"))
+			raise e
+
+		try:
+			if movement in {_Movement.PREVIOUS, _Movement.NEXT}:
+				info = self._getNearestTableCell(
+					self.selection,
+					cell,
+					movement,
+					axis,
+				)
+			elif movement in {_Movement.FIRST, _Movement.LAST}:
+				info = self._getFirstOrLastTableCell(
+					self.selection,
+					cell,
+					movement,
+					axis
+				)
+			elif movement is None:
+				info = self._getTableCellAt(cell.tableID, self.selection, cell.row, cell.col)
+			else:
+				raise ValueError(f"Unknown movement {movement}")
+			newCell = self._getTableCellCoords(info)
+		except LookupError as e:
+			if raiseOnEdge:
+				raise e
+			# Translators: The message reported when a user attempts to use a table movement command
+			# but the cursor can't be moved in that direction because it is at the edge of the table.
+			ui.message(_("Edge of table"))
+			# Retrieve the cell on which we started.
+			try:
+				info = self._getTableCellAt(cell.tableID, self.selection, cell.row, cell.col)
+			except LookupError as e:
+				raise RuntimeError("Unable to find current cell.", e)
+			newCell = self._getTableCellCoords(info)
+		tableSelection = _TableSelection(
+			lastRow=newCell.row,
+			lastCol=newCell.col,
+			axis=axis,
+			trueRow=cell.row if axis == _Axis.COLUMN else newCell.row,
+			rowSpan=cell.rowSpan if axis == _Axis.COLUMN else newCell.rowSpan,
+			trueCol=cell.col if axis == _Axis.ROW else newCell.col,
+			colSpan=cell.colSpan if axis == _Axis.ROW else newCell.colSpan,
+		) if movement is not None else None
+		return newCell, info, tableSelection
 
 	def _tableMovementScriptHelper(
 			self,
@@ -304,83 +405,66 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		# at run-time. (#12404)
 		from scriptHandler import isScriptWaiting
 		from speech import speakTextInfo
-		import ui
 
 		if isScriptWaiting():
 			return
+
 		formatConfig = config.conf["documentFormatting"].copy()
 		formatConfig["reportTables"] = True
 		try:
-			tableID, origRow, origCol, origRowSpan, origColSpan = self._getTableCellCoords(self.selection)
+			_cell, info, tableSelection = self._tableFindNewCell(
+				movement,
+				axis,
+			)
 		except LookupError:
-			# Translators: The message reported when a user attempts to use a table movement command
-			# when the cursor is not within a table.
-			ui.message(_("Not in a table cell"))
+			# _tableFindNewCell already spoke proper error message
 			return
-
-		# The following lines check whether user has been issuing table navigation commands repeatedly.
-		# In this case, instead of using current column/row index, we used cached value
-		# to allow users being able to skip merged cells without affecting the initial column/row index.
-		# For more info see issue #11919 and #7278.
-		if (
-			self._lastTableSelection
-			and origRow == self._lastTableSelection.lastRow
-			and origCol == self._lastTableSelection.lastCol
-			and self._lastTableSelection.axis == axis
-		):
-			if axis == _Axis.ROW:
-				origCol = self._lastTableSelection.trueCol
-				origColSpan = self._lastTableSelection.colSpan
-			else:
-				origRow = self._lastTableSelection.trueRow
-				origRowSpan = self._lastTableSelection.rowSpan
-
-		try:
-			if movement in {_Movement.PREVIOUS, _Movement.NEXT}:
-				info = self._getNearestTableCell(
-					tableID,
-					self.selection,
-					origRow,
-					origCol,
-					origRowSpan,
-					origColSpan,
-					movement,
-					axis
-				)
-			elif movement in {_Movement.FIRST, _Movement.LAST}:
-				info = self._getFirstOrLastTableCell(
-					tableID,
-					self.selection,
-					origRow,
-					origCol,
-					origRowSpan,
-					origColSpan,
-					movement,
-					axis
-				)
-			else:
-				raise ValueError(f"Unknown movement {movement}")
-			newTableID, newRow, newCol, newRowSpan, newColSpan = self._getTableCellCoords(info)
-		except LookupError:
-			# Translators: The message reported when a user attempts to use a table movement command
-			# but the cursor can't be moved in that direction because it is at the edge of the table.
-			ui.message(_("Edge of table"))
-			# Retrieve the cell on which we started.
-			info = self._getTableCellAt(tableID, self.selection, origRow, origCol)
-			newTableID, newRow, newCol, newRowSpan, newColSpan = self._getTableCellCoords(info)
 
 		speakTextInfo(info, formatConfig=formatConfig, reason=controlTypes.OutputReason.CARET)
 		info.collapse()
 		self.selection = info
+		self._lastTableSelection = tableSelection
+
+	def _tableSayAll(
+			self,
+			movement: _Movement,
+			axis: _Axis,
+			updateCaret: bool = True,
+	) -> None:
+		try:
+			cell, info, _tableSelection = self._tableFindNewCell(
+				movement if movement == _Movement.FIRST else None,
+				axis,
+			)
+		except LookupError:
+			# _tableFindNewCell already spoke proper error message
+			return
+
+		def nextLineFunc(info: textInfos.TextInfo) -> textInfos.TextInfo:
+			try:
+				_cell, newInfo, tableSelection = self._tableFindNewCell(
+					_Movement.NEXT,
+					axis,
+					selection=info,
+					raiseOnEdge=True,
+				)
+				self._lastTableSelection = tableSelection
+				return newInfo
+			except LookupError as e:
+				raise StopIteration(e)
+		oldSelection = self._lastTableSelection
+		bothAxesColumn = oldSelection is not None and axis == _Axis.COLUMN and axis == oldSelection.axis
+		bothAxesRow = oldSelection is not None and axis == _Axis.ROW and axis == oldSelection.axis
 		self._lastTableSelection = _TableSelection(
-			lastRow=newRow,
-			lastCol=newCol,
+			lastRow=cell.row,
+			lastCol=cell.col,
 			axis=axis,
-			trueRow=origRow,
-			rowSpan=origRow,
-			trueCol=origCol,
-			colSpan=origColSpan,
+			trueRow=oldSelection .trueRow if bothAxesColumn else cell.row,
+			rowSpan=oldSelection .rowSpan if bothAxesColumn else cell.rowSpan,
+			trueCol=oldSelection.trueCol if bothAxesRow else cell.col,
+			colSpan=oldSelection .colSpan if bothAxesRow else cell.colSpan,
 		)
+		sayAll.SayAllHandler.readText(sayAll.CURSOR.TABLE, info, nextLineFunc, updateCaret)
 
 	def script_nextRow(self, gesture):
 		self._tableMovementScriptHelper(axis=_Axis.ROW, movement=_Movement.NEXT)
@@ -422,6 +506,36 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 	# Translators: the description for the last table column script on browseMode documents.
 	script_lastColumn.__doc__ = _("moves to the last table column")
 
+	def script_sayAllRow(self, gesture):
+		self._tableSayAll(_Movement.NEXT, _Axis.COLUMN)
+	script_sayAllRow.__doc__ = _(
+		# Translators: the description for the sayAll row command
+		"Reads the row horizontally from the current cell rightwards to the last cell in the row."
+	)
+
+	def script_sayAllColumn(self, gesture):
+		self._tableSayAll(_Movement.NEXT, _Axis.ROW)
+	script_sayAllColumn.__doc__ = _(
+		# Translators: the description for the sayAll row command
+		"Reads the column vertically from the current cell downwards to the last cell in the column."
+	)
+
+	def script_speakRow(self, gesture):
+		self._tableSayAll(_Movement.FIRST, _Axis.COLUMN, updateCaret=False)
+	script_speakRow.__doc__ = _(
+		# Translators: the description for the speak row command
+		"Reads the current row horizontally from left to right "
+		"without moving the system caret."
+	)
+
+	def script_speakColumn(self, gesture):
+		self._tableSayAll(_Movement.FIRST, _Axis.ROW, updateCaret=False)
+	script_speakColumn.__doc__ = _(
+		# Translators: the description for the speak column command
+		"Reads the current column vertically from top to bottom "
+		"without moving the system caret."
+	)
+
 	def script_toggleIncludeLayoutTables(self,gesture):
 		# documentBase is a core module and should not depend on UI, so it is imported at run-time. (#12404)
 		import ui
@@ -444,6 +558,10 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		"kb:control+alt+leftArrow": "previousColumn",
 		"kb:control+alt+pageUp": "firstRow",
 		"kb:control+alt+pageDown": "lastRow",
-		"kb:control+alt+Home": "firstColumn",
-		"kb:control+alt+End": "lastColumn",
+		"kb:control+alt+home": "firstColumn",
+		"kb:control+alt+end": "lastColumn",
+		"kb:NVDA+control+alt+rightArrow": "sayAllRow",
+		"kb:NVDA+control+alt+downArrow": "sayAllColumn",
+		"kb:NVDA+control+alt+leftArrow": "speakRow",
+		"kb:NVDA+control+alt+upArrow": "speakColumn",
 	}

--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -4,8 +4,9 @@
 # Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt
 
+from abc import ABCMeta, abstractmethod
 from enum import IntEnum
-from typing import Callable, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING, Optional
 import weakref
 import garbageHandler
 from logHandler import log
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
 class CURSOR(IntEnum):
 	CARET = 0
 	REVIEW = 1
+	TABLE = 2
 
 
 SayAllHandler = None
@@ -95,10 +97,23 @@ class _SayAllHandler:
 		self._getActiveSayAll = weakref.ref(reader)
 		reader.next()
 
-	def readText(self, cursor: CURSOR):
+	def readText(
+			self,
+			cursor: CURSOR,
+			startPos: Optional[textInfos.TextInfo] = None,
+			nextLineFunc: Optional[Callable[[textInfos.TextInfo], textInfos.TextInfo]] = None,
+			shouldUpdateCaret: bool = True,
+	) -> None:
 		self.lastSayAllMode = cursor
 		try:
-			reader = _TextReader(self, cursor)
+			if cursor == CURSOR.CARET:
+				reader = _CaretTextReader(self)
+			elif cursor == CURSOR.REVIEW:
+				reader = _ReviewTextReader(self)
+			elif cursor == CURSOR.TABLE:
+				reader = _TableTextReader(self, startPos, nextLineFunc, shouldUpdateCaret)
+			else:
+				raise RuntimeError(f"Unknown cursor {cursor}")
 		except NotImplementedError:
 			log.debugWarning("Unable to make reader", exc_info=True)
 			return
@@ -145,7 +160,7 @@ class _ObjectsReader(garbageHandler.TrackedObject):
 		self.walker = None
 
 
-class _TextReader(garbageHandler.TrackedObject):
+class _TextReader(garbageHandler.TrackedObject, metaclass=ABCMeta):
 	"""Manages continuous reading of text.
 	This is intended for internal use only.
 
@@ -167,35 +182,41 @@ class _TextReader(garbageHandler.TrackedObject):
 	"""
 	MAX_BUFFERED_LINES = 10
 
-	def __init__(self, handler: _SayAllHandler, cursor: CURSOR):
+	def __init__(self, handler: _SayAllHandler):
 		self.handler = handler
-		self.cursor = cursor
 		self.trigger = SayAllProfileTrigger()
-		self.reader = None
-		# Start at the cursor.
-		if cursor == CURSOR.CARET:
-			try:
-				self.reader = api.getCaretObject().makeTextInfo(textInfos.POSITION_CARET)
-			except (NotImplementedError, RuntimeError) as e:
-				raise NotImplementedError("Unable to make TextInfo: " + str(e))
-		else:
-			self.reader = api.getReviewPosition()
+		self.reader = self.getInitialTextInfo()
 		# #10899: SayAll profile can't be activated earlier because they may not be anything to read
 		self.trigger.enter()
 		self.speakTextInfoState = SayAllHandler._makeSpeakTextInfoState(self.reader.obj)
 		self.numBufferedLines = 0
+		self.initialIteration = True
 
-	def nextLine(self):
-		if not self.reader:
-			log.debug("no self.reader")
-			# We were stopped.
-			return
-		if not self.reader.obj:
-			log.debug("no self.reader.obj")
-			# The object died, so we should too.
-			self.finish()
-			return
-		bookmark = self.reader.bookmark
+	@abstractmethod
+	def getInitialTextInfo(self) -> textInfos.TextInfo:
+		...
+
+	@abstractmethod
+	def updateCaret(self, updater: textInfos.TextInfo) -> None:
+		...
+
+	def shouldReadInitialPosition(self) -> bool:
+		return False
+
+	def nextLineImpl(self) -> bool:
+		"""
+		Advances cursor to the next reading chunk (e.g. paragraph).
+		@return: C{True} if advanced successfully, C{False} otherwise.
+		"""
+		# Collapse to the end of this line, ready to read the next.
+		try:
+			self.reader.collapse(end=True)
+		except RuntimeError:
+			# This occurs in Microsoft Word when the range covers the end of the document.
+			# without this exception to indicate that further collapsing is not possible,
+			# say all could enter an infinite loop.
+
+			return False
 		# Expand to the current line.
 		# We use move end rather than expand
 		# because the user might start in the middle of a line
@@ -211,8 +232,25 @@ class _TextReader(garbageHandler.TrackedObject):
 				self.handler.speechWithoutPausesInstance.speakWithoutPauses([cb, EndUtteranceCommand()])
 			else:
 				self.finish()
-			return
+			return False
+		return True
 
+	def nextLine(self):
+		if not self.reader:
+			log.debug("no self.reader")
+			# We were stopped.
+			return
+		if not self.reader.obj:
+			log.debug("no self.reader.obj")
+			# The object died, so we should too.
+			self.finish()
+			return
+		if not self.initialIteration or not self.shouldReadInitialPosition():
+			if not self.nextLineImpl():
+				self.finish()
+				return
+		self.initialIteration = False
+		bookmark = self.reader.bookmark
 		# Copy the speakTextInfoState so that speak callbackCommand
 		# and its associated callback are using a copy isolated to this specific line.
 		state = self.speakTextInfoState.copy()
@@ -244,15 +282,6 @@ class _TextReader(garbageHandler.TrackedObject):
 		# Update the textInfo state ready for when speaking the next line.
 		self.speakTextInfoState = state.copy()
 
-		# Collapse to the end of this line, ready to read the next.
-		try:
-			self.reader.collapse(end=True)
-		except RuntimeError:
-			# This occurs in Microsoft Word when the range covers the end of the document.
-			# without this exception to indicate that further collapsing is not possible,
-			# say all could enter an infinite loop.
-			self.finish()
-			return
 		if not spoke:
 			# This line didn't include a natural pause, so nothing was spoken.
 			self.numBufferedLines += 1
@@ -271,10 +300,7 @@ class _TextReader(garbageHandler.TrackedObject):
 		# We've just started speaking this line, so move the cursor there.
 		state.updateObj()
 		updater = obj.makeTextInfo(bookmark)
-		if self.cursor == CURSOR.CARET:
-			updater.updateCaret()
-		if self.cursor != CURSOR.CARET or config.conf["reviewCursor"]["followCaret"]:
-			api.setReviewPosition(updater, isCaret=self.cursor == CURSOR.CARET)
+		self.updateCaret(updater)
 		winKernel.SetThreadExecutionState(winKernel.ES_SYSTEM_REQUIRED)
 		if self.numBufferedLines == 0:
 			# This was the last line spoken, so move on.
@@ -315,6 +341,59 @@ class _TextReader(garbageHandler.TrackedObject):
 
 	def __del__(self):
 		self.stop()
+
+
+class _CaretTextReader(_TextReader):
+	def getInitialTextInfo(self) -> textInfos.TextInfo:
+		try:
+			return api.getCaretObject().makeTextInfo(textInfos.POSITION_CARET)
+		except (NotImplementedError, RuntimeError) as e:
+			raise NotImplementedError("Unable to make TextInfo: ", e)
+
+	def updateCaret(self, updater: textInfos.TextInfo) -> None:
+		updater.updateCaret()
+		if config.conf["reviewCursor"]["followCaret"]:
+			api.setReviewPosition(updater, isCaret=True)
+
+
+class _ReviewTextReader(_TextReader):
+	def getInitialTextInfo(self) -> textInfos.TextInfo:
+		return api.getReviewPosition()
+
+	def updateCaret(self, updater: textInfos.TextInfo) -> None:
+		api.setReviewPosition(updater, isCaret=False)
+
+
+class _TableTextReader(_CaretTextReader):
+	def __init__(
+			self,
+			handler: _SayAllHandler,
+			startPos: Optional[textInfos.TextInfo] = None,
+			nextLineFunc: Optional[Callable[[textInfos.TextInfo], textInfos.TextInfo]] = None,
+			shouldUpdateCaret: bool = True,
+	):
+		self.startPos = startPos
+		self.nextLineFunc = nextLineFunc
+		self.shouldUpdateCaret = shouldUpdateCaret
+		super().__init__(handler)
+
+	def getInitialTextInfo(self) -> textInfos.TextInfo:
+		return self.startPos or super().getInitialTextInfo()
+
+	def nextLineImpl(self) -> bool:
+		try:
+			self.reader = self.nextLineFunc(self.reader)
+			return True
+		except StopIteration:
+			return False
+
+	def shouldReadInitialPosition(self) -> bool:
+		return True
+
+	def updateCaret(self, updater: textInfos.TextInfo) -> None:
+		if self.shouldUpdateCaret:
+			return super().updateCaret(updater)
+
 
 class SayAllProfileTrigger(config.ProfileTrigger):
 	"""A configuration profile trigger for when say all is in progress.

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -38,6 +38,8 @@ import aria
 import treeInterceptorHandler
 import watchdog
 from abc import abstractmethod
+import documentBase
+
 
 VBufStorage_findDirection_forward=0
 VBufStorage_findDirection_back=1
@@ -640,15 +642,14 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	def _getNearestTableCell(
 			self,
-			tableID,
-			startPos,
-			origRow,
-			origCol,
-			origRowSpan,
-			origColSpan,
-			movement,
-			axis
-	):
+			startPos: textInfos.TextInfo,
+			cell: documentBase._TableCell,
+			movement: documentBase._Movement,
+			axis: documentBase._Axis,
+	) -> textInfos.TextInfo:
+		tableID, origRow, origCol, origRowSpan, origColSpan = (
+			cell.tableID, cell.row, cell.col, cell.rowSpan, cell.colSpan
+		)
 		# Determine destination row and column.
 		destRow = origRow
 		destCol = origCol

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -23,6 +23,7 @@ from comtypes import COMError
 import aria
 import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
+import documentBase
 
 
 def _getNormalizedCurrentAttrs(attrs: textInfos.ControlField) -> typing.Dict[str, typing.Any]:
@@ -548,26 +549,13 @@ class Gecko_ia2(VirtualBuffer):
 
 	def _getNearestTableCell(
 			self,
-			tableID,
-			startPos,
-			origRow,
-			origCol,
-			origRowSpan,
-			origColSpan,
-			movement,
-			axis,
-	):
+			startPos: textInfos.TextInfo,
+			cell: documentBase._TableCell,
+			movement: documentBase._Movement,
+			axis: documentBase._Axis,
+	) -> textInfos.TextInfo:
 		# Skip the VirtualBuffer implementation as the base BrowseMode implementation is good enough for us here.
-		return super(VirtualBuffer, self)._getNearestTableCell(
-			tableID,
-			startPos,
-			origRow,
-			origCol,
-			origRowSpan,
-			origColSpan,
-			movement,
-			axis
-		)
+		return super(VirtualBuffer, self)._getNearestTableCell(startPos, cell, movement, axis)
 
 	def _get_documentConstantIdentifier(self):
 		try:

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1853,6 +1853,197 @@ def test_tableNavigationWithMergedColumns():
 	_asserts.strings_match(actualSpeech, "row 1  column 2  b 1")
 
 
+def prepareChromeForTableSayAllTests():
+	_chrome.prepareChrome("""
+		<p>Hello, world!</p>
+		<table border=3>
+			<tr>
+				<td>A1</td>
+				<td>B1</td>
+				<td rowspan=2>C1+C2</td>
+				<td>D1</td>
+				<td>E1</td>
+			</tr>
+			<tr>
+				<td>A2</td>
+				<td>B2</td>
+				<td>D2</td>
+				<td>E2</td>
+			</tr>
+			<tr>
+				<td colspan=2>A3+B3</td>
+				<td>C3</td>
+				<td colspan=2>D3+E3</td>
+			</tr>
+			<tr>
+				<td>A4</td>
+				<td>B4</td>
+				<td colspan=2 rowspan=2>C4+D4+<br>C5+D5</td>
+				<td>E4</td>
+			</tr>
+			<tr>
+				<td>A5</td>
+				<td>B5</td>
+				<td>E5</td>
+			</tr>
+		</table>
+		<p>Bye-bye, world!</p>
+	""")
+
+	# Jump to table
+	actualSpeech = _chrome.getSpeechAfterKey("t")
+	_asserts.strings_match(actualSpeech, "table  with 5 rows and 5 columns  row 1  column 1  A 1")
+
+
+def tableSayAllJumpToB2():
+	_chrome.getSpeechAfterKey("control+alt+pageUp")
+	_chrome.getSpeechAfterKey("control+alt+home")
+	_chrome.getSpeechAfterKey("control+alt+rightArrow")
+	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
+	_asserts.strings_match(actualSpeech, "row 2  B 2")
+
+
+def test_tableSayAllCommands():
+	""" Tests that table sayAll commands work correctly.
+	Key bindings: NVDA+control+alt+downArrow/rightArrow
+	Refer to #13469.
+	"""
+	prepareChromeForTableSayAllTests()
+	tableSayAllJumpToB2()
+	# sayAll column
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"B 2",
+			"row 3  column 1  through 2  A 3 plus B 3",
+			"row 4  column 2  B 4",
+			"row 5  B 5",
+		]),
+	)
+
+	# Check that cursor has moved to B5
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "B 5")
+
+	tableSayAllJumpToB2()
+	# sayAll row
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"B 2",
+			"row 1  through 2  column 3  C 1 plus C 2",
+			"row 2  D 2",
+			"column 4  E 2",
+		]),
+	)
+
+	# Check that cursor has moved to E2
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "E 2")
+
+	# Jump to A3
+	_chrome.getSpeechAfterKey("control+alt+pageUp")
+	_chrome.getSpeechAfterKey("control+alt+home")
+	_chrome.getSpeechAfterKey("control+alt+downArrow")
+	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
+	_asserts.strings_match(actualSpeech, "row 3  column 1  through 2  A 3 plus B 3")
+
+	# sayAll row with cells merged horizontally
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"A 3 plus B 3",
+			"column 3  C 3",
+			"column 4  through 5  D 3 plus E 3",
+		]),
+	)
+
+	# Check that cursor has moved to E3
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "D 3 plus E 3")
+
+
+def test_tableSpeakAllCommands():
+	""" Tests that table speak entire row/column commands work correctly.
+	Key bindings: NVDA+control+alt+upArrow/leftArrow
+	Refer to #13469.
+	"""
+	prepareChromeForTableSayAllTests()
+	tableSayAllJumpToB2()
+	# Speak current column
+	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey("NVDA+control+alt+upArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"row 1  B 1",
+			"row 2  B 2",
+			"row 3  column 1  through 2  A 3 plus B 3",
+			"row 4  column 2  B 4",
+			"row 5  B 5",
+		])
+	)
+	_asserts.braille_matches(
+		actualBraille,
+		"r2 c2 B2",
+		message="Speak entire column",
+	)
+
+	# Check that cursor still stays at B2
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "row 2  B 2")
+
+	# Speak current row
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+leftArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"column 1  A 2",
+			"column 2  B 2",
+			"row 1  through 2  column 3  C 1 plus C 2",
+			"row 2  D 2",
+			"column 4  E 2",
+		])
+	)
+
+	# Check that cursor stays at B2
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "column 2  B 2")
+
+
+def test_tableSayAllAxisCachingForMergedCells():
+	""" Tests that axis caching for merged cells in table sayAll commands works.
+	Refer to #13469.
+	"""
+	prepareChromeForTableSayAllTests()
+
+	# Jump to D5
+	_chrome.getSpeechAfterKey("control+alt+pageUp")
+	_chrome.getSpeechAfterKey("control+alt+end")
+	_chrome.getSpeechAfterKey("control+alt+leftArrow")
+	_chrome.getSpeechAfterKey("control+alt+downArrow")
+	_chrome.getSpeechAfterKey("control+alt+downArrow")
+	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"row 4  column 3  through row 5 column 4  C 4 plus D 4 plus  C 5 plus D 5"
+	)
+
+	# Speak current column - should reuse cached column
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+upArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"row 1  column 4  D 1",
+			"row 2  column 3  D 2",
+			"row 3  column 4  through 5  D 3 plus E 3",
+			"row 4  column 3  through row 5 column 4  C 4 plus D 4 plus  C 5 plus D 5",
+		]),
+	)
+
+
 def test_focus_mode_on_focusable_read_only_lists():
 	"""
 	If a list is read-only, but is focusable, and a list element receives focus, switch to focus mode.

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -123,6 +123,15 @@ Focus reports target first
 Table navigation with merged columns
 	[Documentation]	When navigating through a merged cell, preserve the column/row position from the previous cell.
 	test_tableNavigationWithMergedColumns
+Table sayAll commands
+	[Documentation]	Table sayAll commands
+	test_tableSayAllCommands
+Table Speak All commands
+	[Documentation]	Table speak entire row/column commands
+	test_tableSpeakAllCommands
+Table sayAll axis caching for merged cells
+	[Documentation]	Tests that axis caching for merged cells in table sayAll commands works.
+	test_tableSayAllAxisCachingForMergedCells
 focus mode is turned on on focused read-only list item
 	[Documentation]	Focused list items with a focusable list container should cause focus mode to be turned on automatically.
 	test_focus_mode_on_focusable_read_only_lists

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,6 +6,13 @@ What's New in NVDA
 = 2022.4 =
 
 == New Features ==
+- Added the following table commands. (#13469)
+  - Say all in column: ``NVDA+control+alt+downArrow``
+  - Say all in row: ``NVDA+control+alt+rightArrow``
+  - Read entire column: ``NVDA+control+alt+upArrow``
+  - Read entire row: ``NVDA+control+alt+leftArrow``
+  -
+-
 
 
 == Changes ==
@@ -28,7 +35,7 @@ For add-on authors, please open a GitHub issue if these changes stop the API fro
 
 = 2022.3 =
 A significant amount of this release was contributed by the NVDA development community.
-This includes table say all commands, delayed character descriptions, and improved Windows Console support.
+This includes delayed character descriptions and improved Windows Console support.
 
 This release also includes several bug fixes.
 Notably, up-to-date versions of Adobe Acrobat/Reader will no longer crash when reading a PDF document.
@@ -43,12 +50,6 @@ eSpeak has been updated, which introduces 3 new languages: Belarusian, Luxembour
 It can be re-enabled in NVDA's advanced settings panel. (#11554)
   - Text that has scrolled offscreen can be reviewed without scrolling the console window. (#12669)
   - More detailed text formatting information is available. ([microsoft/terminal PR 10336 https://github.com/microsoft/terminal/pull/10336])
-  -
-- Added the following table commands. (#13469)
-  - Say all in column: ``NVDA+control+alt+downArrow``
-  - Say all in row: ``NVDA+control+alt+rightArrow``
-  - Read entire column: ``NVDA+control+alt+upArrow``
-  - Read entire row: ``NVDA+control+alt+leftArrow``
   -
 - A new Speech option has been added to read character descriptions after a delay. (#13509)
 - A new Braille option has been added to determine if scrolling the display forward/back should interrupt speech. (#2124)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,7 +5,7 @@ What's New in NVDA
 
 = 2022.3 =
 A significant amount of this release was contributed by the NVDA development community.
-This includes delayed character descriptions and improved Windows Console support.
+This includes table say all commands, delayed character descriptions, and improved Windows Console support.
 
 This release also includes several bug fixes.
 Notably, up-to-date versions of Adobe Acrobat/Reader will no longer crash when reading a PDF document.
@@ -20,6 +20,12 @@ eSpeak has been updated, which introduces 3 new languages: Belarusian, Luxembour
 It can be re-enabled in NVDA's advanced settings panel. (#11554)
   - Text that has scrolled offscreen can be reviewed without scrolling the console window. (#12669)
   - More detailed text formatting information is available. ([microsoft/terminal PR 10336 https://github.com/microsoft/terminal/pull/10336])
+  -
+- Added the following table commands. (#13469)
+  - Say all in column: ``NVDA+control+alt+downArrow``
+  - Say all in row: ``NVDA+control+alt+rightArrow``
+  - Read entire column: ``NVDA+control+alt+upArrow``
+  - Read entire row: ``NVDA+control+alt+leftArrow``
   -
 - A new Speech option has been added to read character descriptions after a delay. (#13509)
 - A new Braille option has been added to determine if scrolling the display forward/back should interrupt speech. (#2124)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -346,6 +346,10 @@ When within a table, the following key commands are also available:
 | Move to last column | control+alt+end | Moves the system caret to the last column (staying in the same row) |
 | Move to first row | control+alt+pageUp | Moves the system caret to the first row (staying in the same column) |
 | Move to last row | control+alt+pageDown | Moves the system caret to the last row (staying in the same column) |
+| Say all in column | ``NVDA+control+alt+downArrow`` | Reads the column vertically from the current cell downwards to the last cell in the column. |
+| Say all in row | ``NVDA+control+alt+rightArrow`` | Reads the row horizontally from the current cell rightwards to the last cell in the row. |
+| Read entire column | ``NVDA+control+alt+upArrow`` | Reads the current column vertically from top to bottom without moving the system caret. |
+| Read entire row | ``NVDA+control+alt+leftArrow`` | Reads the current row horizontally from left to right without moving the system caret. |
 %kc:endInclude
 
 ++ Object Navigation ++[ObjectNavigation]


### PR DESCRIPTION
Credit @mltony 
This feature was on track for release with 2022.3, however it was found to cause / uncover issues that could not be resolved quickly. Rather than delay the release of 2022.3, this feature was reverted in PR #13954.

### Link to issue number:
Reverts #13954
Fixes #13469
### Summary of the issue:
Feature request: add table sayAll commands to read rows and columns.
### Description of how this pull request fixes the issue:
Adds 4 commands:
* SayAll from current cell horizontally to the right.
* SayAll from current cell vertically down.
* Speak current column from top to bottom without moving caret.
* speak current row from left to right without moving caret.

Additionally:
* Refactored class _TextReader in sayAll.py:
    * Refactored out a few methods for different types of cursor and made them abstract.
    * Added implementations for review and caret cursor types and also for new table cursor type.
* Refactored class DocumentWithTableNavigation:
    * Refactored cell moving logic as method _tableFindNewCell, which is used in both simple table commands and sayAll commands.
    * Added _TableCell class to replace 5-element tuples that contain information about table cells.
### Testing strategy:
* Tested sayall commands in Chrome, Firefox, MSWord (both browse and focus mode); tested with merged cels to check that they are handled correctly during sayAll.
* Tested normal table navigation commands to avoid regression.
* Tested sayAll commands in Chrome, Firefox, MSWord to avoid regressions.

### Known issues with pull request:
* **Blocked due to causing: #13927**
  * Refer to the details on that issue.
* Doesn't support Excel tables.
* Doesn't support table-like list views.
### Change log entries:
Refer to PR diff

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English