### PR TITLE
winVersion: recognize build 19045 as Windows 10 22H2 (Vibranium). Re #13845

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -32,6 +32,7 @@ _BUILDS_TO_RELEASE_NAMES = {
 	19042: "Windows 10 20H2",
 	19043: "Windows 10 21H1",
 	19044: "Windows 10 21H2",
+	19045: "Windows 10 22H2",
 	20348: "Windows Server 2022",
 	22000: "Windows 11 21H2",
 }
@@ -152,6 +153,7 @@ WIN10_2004 = WinVersion(major=10, minor=0, build=19041)
 WIN10_20H2 = WinVersion(major=10, minor=0, build=19042)
 WIN10_21H1 = WinVersion(major=10, minor=0, build=19043)
 WIN10_21H2 = WinVersion(major=10, minor=0, build=19044)
+WIN10_22H2 = WinVersion(major=10, minor=0, build=19045)
 WINSERVER_2022 = WinVersion(major=10, minor=0, build=20348)
 WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
 


### PR DESCRIPTION

### Link to issue number:
Partially closes #13845
Windows 10 part of #13867 

### Summary of the issue:
Recognize Windows 10 build 19045 as Version 22H2.

### Description of user facing changes
None

### Description of development approach
Tested through Windows Insider Program - added Windows 10 build 19045 metadata.

### Testing strategy:
Manual testing: instal Windows 10 build 19045 release preview build to make sure it is recognized as 22H2 by NVDA.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English

### Additional context:
Split from PR #13867 - Windows 10 22H2 build is certain but not Windows 11 22H2 yet. No need to change SDK requirements as using Windows 11 SDK 10.0.22000 will let NVDA run on Windows 10 22H2 (Vibranium 5).
