### PR TITLE
Use line as a  unit for which say all is moved in rich edit controls

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -3,38 +3,30 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import locale
 from typing import (
 	Dict,
 	Optional,
 )
 
 import comtypes.client
-import struct
 import ctypes
 from comtypes import COMError
 import oleTypes
 import colors
-import globalVars
 import NVDAHelper
 import eventHandler
 import comInterfaces.tom
 from logHandler import log
 import languageHandler
 import config
-import speech
 import winKernel
 import api
 import winUser
 import textInfos.offsets
-from keyboardHandler import KeyboardInputGesture
-from scriptHandler import isScriptWaiting
 import controlTypes
 from controlTypes import TextPosition
 from . import Window
-from .. import NVDAObjectTextInfo
 from ..behaviors import EditableTextWithAutoSelectDetection
-import braille
 import watchdog
 import locationHelper
 import textUtils
@@ -465,15 +457,16 @@ ITextDocumentUnitsToNVDAUnits={
 	comInterfaces.tom.tomStory:textInfos.UNIT_STORY,
 }
 
-NVDAUnitsToITextDocumentUnits={
-	textInfos.UNIT_CHARACTER:comInterfaces.tom.tomCharacter,
-	textInfos.UNIT_WORD:comInterfaces.tom.tomWord,
-	textInfos.UNIT_LINE:comInterfaces.tom.tomLine,
-	textInfos.UNIT_SENTENCE:comInterfaces.tom.tomSentence,
-	textInfos.UNIT_PARAGRAPH:comInterfaces.tom.tomParagraph,
-	textInfos.UNIT_STORY:comInterfaces.tom.tomStory,
-	textInfos.UNIT_READINGCHUNK:comInterfaces.tom.tomSentence,
+NVDAUnitsToITextDocumentUnits: Dict[str, int] = {
+	textInfos.UNIT_CHARACTER: comInterfaces.tom.tomCharacter,
+	textInfos.UNIT_WORD: comInterfaces.tom.tomWord,
+	textInfos.UNIT_LINE: comInterfaces.tom.tomLine,
+	textInfos.UNIT_SENTENCE: comInterfaces.tom.tomSentence,
+	textInfos.UNIT_PARAGRAPH: comInterfaces.tom.tomParagraph,
+	textInfos.UNIT_STORY: comInterfaces.tom.tomStory,
+	textInfos.UNIT_READINGCHUNK: comInterfaces.tom.tomLine,
 }
+
 
 class ITextDocumentTextInfo(textInfos.TextInfo):
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,6 +14,7 @@ What's New in NVDA
 == Bug Fixes ==
 - When updating NVDA using the Windows Package Manager CLI (aka winget), a released version of NVDA is no longer always treated as newer than whatever alpha version is installed. (#12469)
 - NVDA will now correctly announce Group boxes in Java applications. (#13962)
+- Caret properly follows spoken text in say all in applications such as Bookworm, WordPad, or the NVDA log viewer. (#13420, #9179)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13420
Fixes #9179

### Summary of the issue:
When in say all NVDA moves caret by the unit specified as a `RREADINGCHUNK` for a given text info implementation. In most text info implementations it defaults to line, however in `ITextDocumentTextInfo` it was set to sentence. While it probably results in smoother reading for literary text written in language where TOM can split into sentences properly, in text's such as log or for languages without clear concept of sentence such as Chinese it results in caret not following spoken text since it is moved to the current position only when the sentence ending is reached.

### Description of user facing changes
Say all both for review and system cursor moves by line in Rich Edit controls such as WordPad or NVDA's log viewer.
### Description of development approach
for `ITextDocumentTextInfo` `textInfos.UNIT_READINGCHUNK` has been set to line.
### Testing strategy:
Made sure that say all both with system caret and review cursor follows spoken text in QRead and log viewer.
### Known issues with pull request:
- I'm not sure why the `textInfos.UNIT_READINGCHUNK` was set to the sentence in the first place, perhaps @michaelDCurran  or @jcsteh  would be able to recall the reason
- Ideally we would be able to move caret in say all with a higher precision e.g. by word/character - that is tracked in #11658

### Change log entries:
Bug fixes
- Caret properly follows spoken text in say all in places such as bookworm, WordPad, or NVDA's log viewer (#13420 #9179)

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
