### PR TITLE
Use locale for delayed character descriptions

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -309,7 +309,6 @@ def _getSpellingSpeechWithoutCharMode(
 		text=text.rstrip()
 
 	textLength=len(text)
-	count = 0
 	localeHasConjuncts = True if locale.split('_',1)[0] in LANGS_WITH_CONJUNCT_CHARS else False
 	charDescList = getCharDescListFromText(text,locale) if localeHasConjuncts else text
 	for item in charDescList:
@@ -361,23 +360,14 @@ def getSingleCharDescription(
 		capPitchChange = synthConfig["capPitchChange"]
 	else:
 		capPitchChange = 0
-	defaultLanguage = getCurrentLanguage()
-	if not locale or (
-		not config.conf['speech']['autoDialectSwitching']
-		and locale.split('_')[0] == defaultLanguage.split('_')[0]
-	):
-		locale = defaultLanguage
-	# If the description for the locale is unknown, we yield nothing.
-	char, description = getCharDescListFromText(text, locale=locale)[0]
-	uppercase = char.isupper()
-	if description is None:
-		return
 	yield BreakCommand(getSingleCharDescriptionDelayMS())
-	yield from _getSpellingCharAddCapNotification(
-		description[0],
-		sayCapForCapitals=uppercase and synthConfig["sayCapForCapitals"],
-		capPitchChange=(capPitchChange if uppercase else 0),
-		beepForCapitals=uppercase and synthConfig["beepForCapitals"],
+	yield from _getSpellingSpeechWithoutCharMode(
+		text,
+		locale,
+		useCharacterDescriptions=True,
+		sayCapForCapitals=text.isupper() and synthConfig["sayCapForCapitals"],
+		capPitchChange=(capPitchChange if text.isupper() else 0),
+		beepForCapitals=text.isupper() and synthConfig["beepForCapitals"],
 	)
 
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -327,10 +327,10 @@ def _getSpellingSpeechWithoutCharMode(
 			speakCharAs = item
 			if useCharacterDescriptions:
 				charDesc=characterProcessing.getCharacterDescription(locale,speakCharAs.lower())
-		uppercase=speakCharAs.isupper()			
+		uppercase=speakCharAs.isupper()
 		if useCharacterDescriptions and charDesc:
-				IDEOGRAPHIC_COMMA = u"\u3001"
-				speakCharAs=charDesc[0] if textLength>1 else IDEOGRAPHIC_COMMA.join(charDesc)
+			IDEOGRAPHIC_COMMA = u"\u3001"
+			speakCharAs=charDesc[0] if textLength>1 else IDEOGRAPHIC_COMMA.join(charDesc)
 		elif useCharacterDescriptions and not charDesc and not fallbackToCharIfNoDescription:
 			return None
 		else:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -295,7 +295,13 @@ def _getSpellingSpeechWithoutCharMode(
 		sayCapForCapitals: bool,
 		capPitchChange: int,
 		beepForCapitals: bool,
+		fallbackToCharIfNoDescription: bool = True,
 ) -> Generator[SequenceItemT, None, None]:
+	"""
+	@param fallbackToCharIfNoDescription: Only applies if useCharacterDescriptions is True.
+	If fallbackToCharIfNoDescription is True, and no character description is found,
+	the character itself will be announced. Otherwise, nothing will be spoken.
+	"""
 	
 	defaultLanguage=getCurrentLanguage()
 	if not locale or (not config.conf['speech']['autoDialectSwitching'] and locale.split('_')[0]==defaultLanguage.split('_')[0]):
@@ -321,10 +327,12 @@ def _getSpellingSpeechWithoutCharMode(
 			speakCharAs = item
 			if useCharacterDescriptions:
 				charDesc=characterProcessing.getCharacterDescription(locale,speakCharAs.lower())
-		uppercase=speakCharAs.isupper()
+		uppercase=speakCharAs.isupper()			
 		if useCharacterDescriptions and charDesc:
-			IDEOGRAPHIC_COMMA = u"\u3001"
-			speakCharAs=charDesc[0] if textLength>1 else IDEOGRAPHIC_COMMA.join(charDesc)
+				IDEOGRAPHIC_COMMA = u"\u3001"
+				speakCharAs=charDesc[0] if textLength>1 else IDEOGRAPHIC_COMMA.join(charDesc)
+		elif useCharacterDescriptions and not charDesc and not fallbackToCharIfNoDescription:
+			return None
 		else:
 			speakCharAs=characterProcessing.processSpeechSymbol(locale,speakCharAs)
 		if config.conf['speech']['autoLanguageSwitching']:
@@ -368,6 +376,7 @@ def getSingleCharDescription(
 		sayCapForCapitals=text.isupper() and synthConfig["sayCapForCapitals"],
 		capPitchChange=(capPitchChange if text.isupper() else 0),
 		beepForCapitals=text.isupper() and synthConfig["beepForCapitals"],
+		fallbackToCharIfNoDescription=False,
 	)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13969 
Fixes #13966 

Background for the feature in PR https://github.com/nvaccess/nvda/pull/13550

### Summary of the issue:
NVDA does not correctly handle language switching commands when speaking character descriptions.

### Description of user facing changes
Ensure character descriptions are read in the proper locale where known.

### Description of development approach
Use the same code other spelling commands use, `_getSpellingSpeechWithoutCharMode`, which handles language switching.

### Testing strategy:

1. Enable delayed character descriptions
1. Open a browser window using the following data string: `data:text/html,<div lang="de" contenteditable="true">Hello! World</div>`
1. Navigate character by character, ensure characters are described with German phonetic descriptions.
1. Ensure "!" and space aren't described.

### Known issues with pull request:
None

### Change log entries:
None: unreleased feature

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
