### PR TITLE
System test robustness

### DIFF
--- a/appveyor/scripts/tests/systemTests.ps1
+++ b/appveyor/scripts/tests/systemTests.ps1
@@ -1,6 +1,13 @@
 $testOutput = (Resolve-Path .\testOutput\)
 $systemTestOutput = (Resolve-Path "$testOutput\system")
-.\runsystemtests.bat --variable whichNVDA:installed --variable installDir:"${env:nvdaLauncherFile}" --include installer
+
+.\runsystemtests.bat `
+--variable whichNVDA:installed `
+--variable installDir:"${env:nvdaLauncherFile}" `
+--include installer `
+--include NVDA `
+# last line inentionally blank, allowing all lines to have line continuations.
+
 if($LastExitCode -ne 0) {
 	Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
 	Add-AppveyorMessage "FAIL: System tests. See test results for more information."

--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,8 @@ Any arguments given to rununittests.bat are forwarded onto Nose.
 Please refer to Nose's own documentation on how to filter tests etc.
 
 ### System Tests
-System tests can be run with the `runsystemtests.bat` script.
+System tests can be run with the `runsystemtests.bat --include <TAG>` script.
+To run all tests standard tests for developers use `runsystemtests.bat --include NVDA`.
 Internally this script uses the Robot  test framework to execute the tests.
 Any arguments given to runsystemtests.bat are forwarded onto Robot.
 For more details (including filtering and exclusion of tests) see `tests/system/readme.md`.

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -183,7 +183,6 @@ class ChromeLib:
 	def toggleFocusChrome(self):
 		"""Remove focus, then refocus chrome
 		Attempt to work around NVDA missing focus / foreground events when chrome first opens
-		@returns: last speech index before refocusing chrome
 		"""
 		spy = _NvdaLib.getSpyLib()
 		spy.emulateKeyPress('windows+d')
@@ -202,7 +201,7 @@ class ChromeLib:
 		)
 		spy.wait_for_speech_to_finish()
 
-	def ensureChromeTitleCanBeReported(self, applicationTitle) -> int:
+	def ensureChromeTitleCanBeReported(self, applicationTitle: str) -> int:
 		spy = _NvdaLib.getSpyLib()
 		afterFocusToggleIndex = spy.get_last_speech_index()
 		spy.emulateKeyPress('NVDA+t')

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -16,10 +16,7 @@ from SystemTestSpy import (
 	_getLib,
 )
 from SystemTestSpy.windows import (
-	GetForegroundWindowTitle,
 	GetWindowWithTitle,
-	GetVisibleWindowTitles,
-	SetForegroundWindow,
 	Window,
 )
 import re
@@ -165,33 +162,6 @@ class ChromeLib:
 				" See NVDA log for full speech."
 			)
 
-	def _focusChrome(self, startsWithTestCaseTitle: re.Pattern):
-		""" Ensure chrome started and is focused.
-		Different versions of chrome have variations in how the title is presented.
-		This may mean that there is a separator between document name and application name.
-		E.G. "htmlTest   Google Chrome", "html – Google Chrome" or perhaps no application name at all.
-		Rather than try to get this right, just use the doc title.
-		If this continues to be unreliable we could use Selenium or similar to start chrome and inform us
-		when it is ready.
-		"""
-		success, _success = _blockUntilConditionMet(
-			getValue=lambda: SetForegroundWindow(startsWithTestCaseTitle, builtIn.log),
-			giveUpAfterSeconds=5,
-			intervalBetweenSeconds=0.2
-		)
-		if success:
-			return
-		windowInformation = ""
-		try:
-			windowInformation = f"Foreground Window: {GetForegroundWindowTitle()}.\n"
-			windowInformation += f"Open Windows: {GetVisibleWindowTitles()}"
-		except OSError as e:
-			builtIn.log(f"Couldn't retrieve active window information.\nException: {e}")
-		raise AssertionError(
-			"Unable to focus Chrome.\n"
-			f"{windowInformation}"
-		)
-
 	def prepareChrome(self, testCase: str) -> None:
 		"""
 		Starts Chrome opening a file containing the HTML sample
@@ -204,7 +174,6 @@ class ChromeLib:
 		spy.wait_for_speech_to_finish()
 		lastSpeechIndex = spy.get_last_speech_index()
 		_chromeLib.start_chrome(path, testCase)
-		self._focusChrome(ChromeLib.getUniqueTestCaseTitleRegex(testCase))
 		applicationTitle = ChromeLib.getUniqueTestCaseTitle(testCase)
 		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=lastSpeechIndex)
 		self._waitForStartMarker(spy, appTitleIndex)

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -82,7 +82,6 @@ class ChromeLib:
 			" --disable-notifications"
 			" --no-experiments"
 			" --no-default-browser-check"
-			" -kiosk"
 			f' "{filePath}"',
 			shell=True,
 			alias='chromeStartAlias',

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -180,7 +180,7 @@ class ChromeLib:
 			return False
 		return True
 
-	def toggleFocusChrome(self):
+	def toggleFocusChrome(self) -> None:
 		"""Remove focus, then refocus chrome
 		Attempt to work around NVDA missing focus / foreground events when chrome first opens.
 		Forcing chrome to send another foreground event by focusing the desktop, then using alt+tab to return
@@ -213,10 +213,11 @@ class ChromeLib:
 		appTitleIndex = spy.wait_for_specific_speech(applicationTitle, afterIndex=afterFocusToggleIndex)
 		return appTitleIndex
 
-	def prepareChrome(self, testCase: str, _doToggleFocus=False) -> None:
+	def prepareChrome(self, testCase: str, _doToggleFocus: bool = False) -> None:
 		"""
 		Starts Chrome opening a file containing the HTML sample
 		@param testCase - The HTML sample to test.
+		@param _doToggleFocus - When True, Chrome will be intentionally de-focused and re-focused
 		"""
 		spy = _NvdaLib.getSpyLib()
 		_chromeLib: "ChromeLib" = _getLib('ChromeLib')  # using the lib gives automatic 'keyword' logging.

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -182,7 +182,12 @@ class ChromeLib:
 
 	def toggleFocusChrome(self):
 		"""Remove focus, then refocus chrome
-		Attempt to work around NVDA missing focus / foreground events when chrome first opens
+		Attempt to work around NVDA missing focus / foreground events when chrome first opens.
+		Forcing chrome to send another foreground event by focusing the desktop, then using alt+tab to return
+		chrome to the foreground.
+		@remarks If another application raises to the foreground after chrome, this approach won't resolve that
+		situation.
+		We don't have evidence that another application taking focus is a cause of failure yet.
 		"""
 		spy = _NvdaLib.getSpyLib()
 		spy.emulateKeyPress('windows+d')

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -279,10 +279,14 @@ class NvdaLib:
 		self.lastNVDAStart = _datetime.utcnow()
 		builtIn.log(f"Starting NVDA with config: {settingsFileName}")
 		self.setup_nvda_profile(settingsFileName, gesturesFileName)
+		builtIn.log("Config copied", level="DEBUG")  # observe timing of the startup
 		nvdaProcessHandle = self._startNVDAProcess()
+		builtIn.log("Started NVDA process", level="DEBUG")   # observe timing of the startup
 		process.process_should_be_running(nvdaProcessHandle)
 		self._connectToRemoteServer()
+		builtIn.log("Connected to RF remote server", level="DEBUG")  # observe timing of the startup
 		self.nvdaSpy.wait_for_NVDA_startup_to_complete()
+		builtIn.log("Startup complete", level="DEBUG")  # observe timing of the startup
 		return nvdaProcessHandle
 
 	def save_NVDA_log(self):

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -200,7 +200,7 @@ class NvdaLib:
 		)
 		return handle
 
-	def _connectToRemoteServer(self, connectionTimeoutSecs=10):
+	def _connectToRemoteServer(self, connectionTimeoutSecs=15):
 		"""Connects to the nvdaSpyServer
 		Because we do not know how far through the startup NVDA is, we have to poll
 		to check that the server is available. Importing the library immediately seems
@@ -217,6 +217,7 @@ class NvdaLib:
 		_blockUntilConditionMet(
 			getValue=lambda: _testRemoteServer(self._spyServerURI, log=False),
 			giveUpAfterSeconds=connectionTimeoutSecs,
+			intervalBetweenSeconds=0.3,
 			errorMessage=f"Unable to connect to {self._spyAlias}",
 		)
 		builtIn.log(f"Connecting to {self._spyAlias}", level='DEBUG')

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -200,7 +200,7 @@ class NvdaLib:
 		)
 		return handle
 
-	def _connectToRemoteServer(self, connectionTimeoutSecs:int = 15) -> None:
+	def _connectToRemoteServer(self, connectionTimeoutSecs: int = 15) -> None:
 		"""Connects to the nvdaSpyServer
 		Because we do not know how far through the startup NVDA is, we have to poll
 		to check that the server is available. Importing the library immediately seems

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -200,7 +200,7 @@ class NvdaLib:
 		)
 		return handle
 
-	def _connectToRemoteServer(self, connectionTimeoutSecs=15):
+	def _connectToRemoteServer(self, connectionTimeoutSecs:int = 15) -> None:
 		"""Connects to the nvdaSpyServer
 		Because we do not know how far through the startup NVDA is, we have to poll
 		to check that the server is available. Importing the library immediately seems

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -511,6 +511,11 @@ class SystemTestSpyServer(globalPluginHandler.GlobalPlugin):
 
 
 def _crashNVDA():
+	# Causes a breakpoint exception to occur in the current process.
+	# This allows the calling thread to signal the debugger to handle the exception.
+	#
+	# This may be caught by a "postmortem debugger", which would prevent the application from exiting.
+	# https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/enabling-postmortem-debugging
 	ctypes.windll.Kernel32.DebugBreak()
 
 

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -15,6 +15,7 @@ from typing import (
 	Tuple,
 )
 
+import core
 import extensionPoints
 import globalPluginHandler
 import threading
@@ -256,6 +257,9 @@ class NVDASpyLib:
 			return len(self._nvdaBraille_requiresLock) - 1
 
 	def _devInfoToLog(self):
+		"""Should only be called on main thread"""
+		if threading.get_ident() != core.mainThreadId:
+			log.warning("RF lib error, must be called on main thread.")
 		import api
 		obj = api.getNavigatorObject()
 		if hasattr(obj, "devInfo"):
@@ -263,7 +267,10 @@ class NVDASpyLib:
 		else:
 			log.info("No developer info for navigator object")
 
-	def dump_speech_to_log(self):
+	def _dump_speech_to_log(self):
+		"""Should only be called on main thread"""
+		if threading.get_ident() != core.mainThreadId:
+			log.warning("RF lib error, must be called on main thread.")
 		log.debug("dump_speech_to_log.")
 		with self._speechLock:
 			try:
@@ -275,13 +282,24 @@ class NVDASpyLib:
 			except Exception:
 				log.error("Unable to log speech")
 
-	def dump_braille_to_log(self):
+	def _dump_braille_to_log(self):
+		"""Should only be called on main thread"""
+		if threading.get_ident() != core.mainThreadId:
+			log.warning("RF lib error, must be called on main thread.")
 		log.debug("dump_braille_to_log.")
 		with self._brailleLock:
 			try:
 				log.debug(f"All braille:\n{repr(self._nvdaBraille_requiresLock)}")
 			except Exception:
 				log.error("Unable to log braille")
+
+	def dump_speech_to_log(self):
+		# must be called on mainThread queue that to happen
+		core.callLater(0, self._dump_speech_to_log)
+
+	def dump_braille_to_log(self):
+		# must be called on mainThread queue that to happen
+		core.callLater(0, self._dump_speech_to_log)
 
 	def _minTimeout(self, timeout: float) -> float:
 		"""Helper to get the minimum value, the timeout passed in, or self._maxKeywordDuration"""

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -95,8 +95,8 @@ def SetForegroundWindow(window: Window, logger: Logger) -> bool:
 	https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow#remarks
 	Additionally, note that this code is run by the Robot Framework test runner, not NVDA.
 	"""
-	if window is None or Window.hwndVal is None:
-		return False
+	assert window is not None
+	assert bool(window.hwndVal)
 
 	if window.hwndVal == GetForegroundHwnd():
 		title = _GetWindowTitle(window.hwndVal)

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -16,9 +16,14 @@ from ctypes import (
 	windll,
 	WinError,
 )
+from typing import (
+	Callable,
+	List,
+	NamedTuple,
+	Optional,
+)
 import re
 from SystemTestSpy.blockUntilConditionMet import _blockUntilConditionMet
-from typing import Callable, List, NamedTuple
 from robot.libraries.BuiltIn import BuiltIn
 
 builtIn: BuiltIn = BuiltIn()
@@ -71,6 +76,9 @@ def _GetVisibleWindows() -> List[Window]:
 	)
 
 
+Logger = Callable[[str], None]
+
+
 def SetForegroundWindow(targetTitle: re.Pattern, logger: Callable[[str], None] = lambda _: None) -> bool:
 	currentTitle = GetForegroundWindowTitle()
 	if re.match(targetTitle, currentTitle):
@@ -87,6 +95,21 @@ def SetForegroundWindow(targetTitle: re.Pattern, logger: Callable[[str], None] =
 	else:
 		logger(f"Too many windows to focus {windows}")
 	return False
+
+
+def GetWindowWithTitle(targetTitle: re.Pattern, logger: Logger) -> Optional[Window]:
+	windows = _GetWindows(
+		filterUsingWindow=lambda _window: bool(re.match(targetTitle, _window.title))
+	)
+	if len(windows) == 1:
+		logger(f"Found window (HWND: {windows[0].hwndVal}) (title: {windows[0].title})")
+		return windows[0]
+	elif len(windows) == 0:
+		logger(f"No windows found matching the pattern: {targetTitle}")
+		return None
+	else:
+		logger(f"Too many windows to focus {windows}")
+		return None
 
 
 def GetVisibleWindowTitles() -> List[str]:

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -76,6 +76,17 @@ def _GetVisibleWindows() -> List[Window]:
 	)
 
 
+def CloseWindow(window: Window) -> bool:
+	"""
+	@return: True if the window exists and the message was sent.
+	"""
+	if windowWithHandleExists(window.hwndVal):
+		return windll.user32.CloseWindow(
+			window.hwndVal,
+		)
+	return False
+
+
 Logger = Callable[[str], None]
 
 

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -7,23 +7,41 @@ Dependencies such as Robot are automatically installed for you when NVDA's build
  
 ### Running the tests
 
-You can run the tests with `runsystemtests.bat`.
-Running this script with no arguments will run all system tests found in tests\system\robot, against the current source copy of NVDA.
+You can run the tests with `runsystemtests.bat --include <TAG>`.
+This will run against the source copy of NVDA.
 Any extra arguments provided to this script are forwarded on to Robot.
+**Note:** For tests to run the [tags to include **must** be specified](#tags-are-required).
+Include can be specified multiple times, acting as a logical OR.
 
 To run a single test, add the `--test` argument (wildcards accepted).
 
 ```
-runsystemtests --test "starts" ...
+runsystemtests --include chrome --test "starts" ...
 ```
 
-To run all tests with a particular tag use `-i`:
+A shorter alternative for `--include` is `-i`.
+E.G. to run all tests with the chrome tag use:
 ```
 runsystemtests -i "chrome" ...
 ```
 
 Other options exit for specifying tests to run (e.g. by suite, tag, etc).
 Consult `runsystemtests --help`
+
+### Tags are required
+
+Running this script with no arguments won't run any tests, instead an error will be given:
+```
+[ ERROR ] Suite 'Robot' contains no tests matching tag 'fakeTagToEnforceUsageOfInclude' and not matching tag 'excluded from build'.
+```
+This is to prevent accidental running of the installer tests.
+Instead, the tags should be explicitly included, to run all (except installer) tests.
+Examples:
+- All tests tagged with NVDA: `runsystemtests.bat --include NVDA`
+- All Chrome tests: `runsystemtests.bat --include chrome`
+
+This is implemented by supplying an unused tag `fakeTagToEnforceUsageOfInclude` to RobotFramework via the
+`tests\system\robotArgs.robot` file.
 
 ### Getting the results
 

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -21,7 +21,6 @@ default teardown
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
 	dump_speech_to_log
 	dump_braille_to_log
-	exit chrome
 	quit NVDA
 
 default setup

--- a/tests/system/robotArgs.robot
+++ b/tests/system/robotArgs.robot
@@ -2,7 +2,7 @@
 --outputdir testOutput\system
 --xunit systemTests.xml
 --pythonpath .\tests\system\libraries
---include NVDA
 --exclude excluded_from_build
+--include fakeTagToEnforceUsageOfInclude
 --variable whichNVDA:source
 --variable installDir:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
- System tests (particularly the first to run chrome test) are failing intermittently.
- This has become an obstruction for making an NVDA release, taking many builds to show that the tests can pass.

### Description of user facing changes
For developers:
- Screenshots on failure are more likely to show something useful. Kiosk mode has been removed.

### Description of development approach
Investigated the approach being taken to look for flawed assumptions.
- Using `SetForegroundWindow` [may be unreliable for the system tests](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow#remarks)
- The way that HWND values were retrieved in one case made it easy for mistakes to made when comparing them.
- Fixed an error when trying to use IAccessible from the incorrect thread. 
- Added further chrome flags disabling behavior we know we don't want during our tests:
  - The best list of command line args I could find: https://peter.sh/experiments/chromium-command-line-switches/
  - Added " --no-experiments"
  - Added " --no-default-browser-check"
- Clarified "start.exe" process vs chrome process tracking.
- Tell "start.exe" process to `/wait` for chrome process to finish before exiting, aiding with tracking of the processes.
- Added a way to toggle focus in chrome, currently not used.
  - My suspicion is that when NVDA is unable to communicate with Chrome, the issue can be worked around by ensuring chrome looses focus (no longer foreground app), then gains focus again (becomes the foreground app).  Having run into this a few times on my own machine.
- Intentionally toggles focus in chrome to the address bar (`alt+d`) then to the document with `control+F6` [chrome shortcut ](https://support.google.com/chrome/answer/157179?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Caddress-bar-shortcuts) to ensure focus is in the document.
- Uses ['Report current line in review' (`numpad 8`)](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#ReviewingText) to check if already on the start marker, rather than trying to move away and back.


### Testing strategy:
- Run the tests locally
- Run many builds on appveyor, looking for similar intermittent failures.

The runs on appveyor:
- Passed [Build nvda try-sysTests-26073,ac73ad75 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44357913). Commit ac73ad75ed
- Passed  [Build nvda try-sysTests-26074,ac73ad75 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44358290). Commit ac73ad75ed
- Passed [Build nvda try-sysTests-26075,ac73ad75 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44358841). Commit ac73ad75ed
- Passed [Build nvda try-sysTests-26076,ac73ad75 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44359323). Commit ac73ad75ed
- Failed [Build nvda try-sysTests-26077,ac73ad75 failed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44362247). Commit [ac73ad75ed](https://github.com/nvaccess/nvda/commit/ac73ad75ed)
  - Build execution time has reached the maximum allowed time for your plan (60 minutes).
  - Not much we can do about this.
  - The log only gets to 37 minutes before the build is cancelled.
  - A breakdown of the [timing of a single build has been collected](https://github.com/nvaccess/nvda/issues/13823#issuecomment-1204726009)
- Failed [Build nvda try-sysTests-26079,7a9958cb failed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44363247). Commit 7a9958cb57
  - Failure `Robot.symbolPronunciationTests.symbolInSpeechUIRobot`
   Setup failed: `Unable to connect to nvdaSpyLib` 
   To mitigate, the [time to wait for NVDA to startup has been extended](https://github.com/nvaccess/nvda/commit/5dd3bcdb6d48a9258b2d00b549cff5d7ad8c2905)
- Passed [Build nvda try-sysTests-26080,7a9958cb completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44368140). Commit 7a9958cb57
- Passed [Build nvda try-sysTests-26087,e4b95e83 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44368721). Commit e4b95e835f
- Passed [Build nvda pr13983-26089,92ba79e6 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44368979). Commit 92ba79e684
- Passed [Build nvda pr13983-26093,c28a3023 failed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44369575). Commit c28a30236f
  - FAIL: Lint check. See test results for more information.
  - PASS: System tests.
- Passed [Build nvda pr13983-26094,5af03bb3 completed](https://ci.appveyor.com/project/NVAccess/nvda/builds/44370251). Commit 5af03bb3f8

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
