### PR TITLE
remove log message used during development

### DIFF
--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -151,7 +151,6 @@ def _transformSpec_AddFeatureFlagDefault(specString: str, **kwargs) -> str:
 		- 'behaviorOfDefault'
 		- 'optionsEnum'
 	"""
-	log.info(f"specString: {specString}, kwargs: {kwargs}")
 	usage = 'Usage: featureFlag(behaviorOfDefault="enabled"|"disabled", optionsEnum="BoolFlag")'
 	if "default=" in specString:
 		raise VdtParamError(


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/pull/13851#pullrequestreview-1058883808

### Summary of the issue:
A log message used during development was left in PR #13851

### Description of user facing changes
Reduces noise in the NVDA.log

### Description of development approach
Removed the logging of this message.

### Testing strategy:
Beta / alpha testsing
This is a very low risk change.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
