### PR TITLE
Reference API mailing list and improve docs for deprecations

### DIFF
--- a/devDocs/deprecations.md
+++ b/devDocs/deprecations.md
@@ -1,14 +1,42 @@
+
+# Deprecations
+
+## Background
 The NVDA API must maintain compatibility with add-ons throughout yearly development cycles.
 The first release of a year, i.e. `20XX.1`, is when the NVDA API can introduce breaking changes.
 
-In order to improve the NVDA API, changes that will break future compatibility can be implemented, as long they retain backwards compatibility until the `20XX.1` release.
+## Deprecations
+Where possible, ensure the NVDA API maintains backwards compatibility.
+If no removal is required or proposed, backwards compatibility can be maintained via the following snippet:
+
+```py
+import globalVars
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "deprecatedSymbolName" and globalVars._allowDeprecatedAPI:
+		# Note: this should only log in situations where it will not be excessively noisy.
+		log.warning(
+			"Importing deprecatedSymbolName from here is deprecated. "
+			"Import X instead and do Y. "
+		)
+		# Ensure the API of deprecatedSymbolNameReplacement is the same as the deprecated symbol.
+		return deprecatedSymbolNameReplacement
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+```
+
+
+## Required API breaking changes
+In order to improve the NVDA API, changes that will break future compatibility may be implemented, as long they retain backwards compatibility until the `20XX.1` release.
 
 This can be done by using a version check to automate deprecation. For example, if you wish to replace usages of `foo` with `bar`. When we begin work on `NEXT_YEAR`, `foo` will no longer be part of the NVDA API and all internal usages must be removed prior. 
 ```python
 from buildVersion import version_year
-if version_year < NEXT_YEAR:
+import globalVars
+if version_year < NEXT_YEAR and globalVars._allowDeprecatedAPI:
 	foo = bar
 ```
+
+## Testing backwards compatibility
 
 To ensure a module retains the same symbol names being importable, check across versions what is imported using the NVDA python console.
 ```python
@@ -19,3 +47,7 @@ dir(controlTypes)
 Changes different to moving or renaming symbols need to be considered carefully with a different approach. 
 
 Any API breaking changes such as deprecations marked for removal should be commented with the year of intended removal, and notes on how to implement the API change as an add-on developer and NVDA developer.
+
+## Announcements
+Deprecations should be announced via the [NVDA API mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-api/about).
+

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -12,8 +12,8 @@ NVDA NVDA_VERSION Developer Guide
 + Introduction +
 This guide provides information concerning NVDA development, including translation and the development of components for NVDA.
 
-++ API stability ++[API]
-The NVDA API only includes symbols which are not marked with prefixing underscores.
+++ Add-on API stability ++[API]
+ The NVDA Add-on API includes all NVDA internals, except symbols that are prefixed with an underscore.
 
 The NVDA Add-on API changes over time, such as removals, deprecations and new features.
 Important changes to the API are announced on the [NVDA API mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about].

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -12,6 +12,20 @@ NVDA NVDA_VERSION Developer Guide
 + Introduction +
 This guide provides information concerning NVDA development, including translation and the development of components for NVDA.
 
+The API only includes symbols which are not marked with prefixing underscores.
+
+++ Changes to the API ++
+The NVDA Add-on API changes over time, such as removals, deprecations and new features.
+Important changes to the API are announced on the [NVDA API mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about].
+
+API breaking releases happen at most once per year, these are ``.1`` releases, e.g. ``2022.1``.
+The API remains backwards compatible between breaking releases.
+API breaking changes should be considered relatively stable in the first beta: e.g. ``2022.1.beta1``.
+
+API features may become deprecated over time.
+Deprecated API features may have a scheduled removal date, a future breaking release (e.g. ``2022.1``).
+Deprecations may also have no scheduled removal date, and will remain supported until it is no longer reasonable.
+
 ++ A Note About Python ++
 NVDA and its components are primarily written in the Python programming language.
 It is not the goal of this guide to teach you Python, though examples are provided through out this guide which will help to familiarise you with the Python syntax.

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -12,9 +12,9 @@ NVDA NVDA_VERSION Developer Guide
 + Introduction +
 This guide provides information concerning NVDA development, including translation and the development of components for NVDA.
 
-The API only includes symbols which are not marked with prefixing underscores.
+++ API stability ++
+The NVDA API only includes symbols which are not marked with prefixing underscores.
 
-++ Changes to the API ++
 The NVDA Add-on API changes over time, such as removals, deprecations and new features.
 Important changes to the API are announced on the [NVDA API mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about].
 

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -25,6 +25,8 @@ API breaking changes should be considered relatively stable in the first beta: e
 API features may become deprecated over time.
 Deprecated API features may have a scheduled removal date, a future breaking release (e.g. ``2022.1``).
 Deprecations may also have no scheduled removal date, and will remain supported until it is no longer reasonable.
+Note, the roadmap for removals is 'best effort' and may be subject to change.
+Please open a GitHub issue if these changes stop the API from meeting your needs.
 
 ++ A Note About Python ++
 NVDA and its components are primarily written in the Python programming language.

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -12,11 +12,13 @@ NVDA NVDA_VERSION Developer Guide
 + Introduction +
 This guide provides information concerning NVDA development, including translation and the development of components for NVDA.
 
-++ API stability ++
+++ API stability ++[API]
 The NVDA API only includes symbols which are not marked with prefixing underscores.
 
 The NVDA Add-on API changes over time, such as removals, deprecations and new features.
 Important changes to the API are announced on the [NVDA API mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about].
+Changes relevant to developers are also announced via the [NVDA changes file](https://www.nvaccess.org/files/nvda/documentation/changes.html).
+Any changes to the API policy outlined in this section will be conveyed via these two channels.
 
 API breaking releases happen at most once per year, these are ``.1`` releases, e.g. ``2022.1``.
 The API remains backwards compatible between breaking releases.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,8 @@ What's New in NVDA
 
 
 == Changes for Developers ==
+- The [NVDA API Announcement mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about] was created. (#13999)
+-
 
 
 === Deprecations ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,8 @@ What's New in NVDA
 
 
 == Changes for Developers ==
+Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
+
 - The [NVDA API Announcement mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about] was created. (#13999)
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,12 +29,6 @@ What's New in NVDA
 
 
 === Deprecations ===
-These are proposed API breaking changes.
-The deprecated part of the API will continue to be available until the specified release.
-If no release is specified, the plan for removal has not been determined.
-Note, the roadmap for removals is 'best effort' and may be subject to change.
-Please test the new API and provide feedback.
-For add-on authors, please open a GitHub issue if these changes stop the API from meeting your needs.
 
 
 = 2022.3 =


### PR DESCRIPTION
Reference the new [NVDA API announcements mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-api/about) in the developer guide and the change log.

Adds notes to the developer guide on the NVDA deprecation, removal and addition process.

Updated the deprecations.md doc to include new deprecation processes.

After merging:
- update https://github.com/nvaccess/nvda/wiki/deprecations to refer to built developer guide (eg html file hosted on NV Access website).
