### PR TITLE
Fix misspell in the quick start guide

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -170,7 +170,7 @@ Press ``enter`` to start the installed copy.
 The focus is on the "Keyboard Layout" drop-down.
 By default, "Desktop" keyboard layout uses the number pad for some function.
 If desired, press ``downArrow`` to choose "Laptop" keyboard layout to reassign number pad functions to other keys.
-+ Press ``tab`` to move to "Use ``capLock`` as an NVDA modifier key".
++ Press ``tab`` to move to "Use ``capsLock`` as an NVDA modifier key".
 ``Insert`` is set as the NVDA modifier key by default.
 Press ``spaceBar`` to select ``capsLock`` as an alternate modifier key.
 Note that the keyboard layout is set separately from the NVDA modifier key.


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
In the quick start guide capsLock was misspelled  as capLock
### Description of user facing changes
The misspell in the user guide is fixed.
### Description of development approach
None
### Testing strategy:
None needed
### Known issues with pull request:
None known
### Change log entries:
None needed

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
