### PR TITLE
Enable rdp via appveyor settings

### DIFF
--- a/appveyor/scripts/setBuildVersionVars.ps1
+++ b/appveyor/scripts/setBuildVersionVars.ps1
@@ -1,5 +1,9 @@
 $ErrorActionPreference = "Stop";
-# iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+# Accessing Windows build worker via Remote Desktop
+# https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 $pythonVersion = (py --version)
 echo $pythonVersion
 if ($env:APPVEYOR_REPO_TAG_NAME -and $env:APPVEYOR_REPO_TAG_NAME.StartsWith("release-")) {

--- a/appveyor/scripts/setBuildVersionVars.ps1
+++ b/appveyor/scripts/setBuildVersionVars.ps1
@@ -1,8 +1,12 @@
 $ErrorActionPreference = "Stop";
 
-# Accessing Windows build worker via Remote Desktop
-# https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
-iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# Accessing Windows build worker via Remote Desktop (RDP)
+# Set a password via Appveyor settings to enable, ensure passsword requirements are met
+# see docs: https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+if ($env:APPVEYOR_RDP_PASSWORD) {
+	$rdpScriptURL = 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'
+	iex ((new-object net.webclient).DownloadString($rdpScriptURL))
+}
 
 $pythonVersion = (py --version)
 echo $pythonVersion

--- a/appveyor/scripts/setBuildVersionVars.ps1
+++ b/appveyor/scripts/setBuildVersionVars.ps1
@@ -1,8 +1,11 @@
 $ErrorActionPreference = "Stop";
 
 # Accessing Windows build worker via Remote Desktop (RDP)
-# Set a password via Appveyor settings to enable, ensure passsword requirements are met
-# see docs: https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+# To enable:
+# Set an RDP password (before triggering the build), ensure password requirements are met.
+# Remove the password after the RDP connection params are shown in the build output.
+# For passwords requirements and instructions for setting, see the appveyor docs:
+# https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
 if ($env:APPVEYOR_RDP_PASSWORD) {
 	$rdpScriptURL = 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'
 	iex ((new-object net.webclient).DownloadString($rdpScriptURL))


### PR DESCRIPTION
### Link to issue number:
Related to #13983 

### Summary of the issue:
Sometimes the Appveyor environment is unpredictable, recently Docker Desktop opens a window asking for feedback. This window takes the foreground which subsequently results in applications started from the system test being unable to take focus back.

### Description of user facing changes
For developers:
The intention is to fix this foreground issue separately, which may take some time. Until then, and for other issues in the future, make it easier to enable RDP as required.

The details of the connection show in the build log at the start of the build (after cloning NVDA)

### Description of development approach
When the environment variable for an RDP password is set (via the Appveyor settings), the appveyor RDP script will be run.
NV Access developers will need to set (and unset) this environment variable as required.

### Testing strategy:
Started two builds:
- With the environment variable set, the RDP server starts, and I was able to connect to it.
- Without the environment variable set, the RDP server wasn't started.

### Known issues with pull request:
This requires developers to remember to remove the environment variable when they are done.

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
