### PR TITLE
Make runningAsSource a global variable

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -1,11 +1,10 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2020 NV Access Limited, Peter Vagner, Davy Kager, Mozilla Corporation, Google LLC,
+# Copyright (C) 2008-2022 NV Access Limited, Peter Vagner, Davy Kager, Mozilla Corporation, Google LLC,
 # Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 import os
-import sys
 import winreg
 import msvcrt
 import versionInfo
@@ -34,7 +33,9 @@ if os.environ.get('PROCESSOR_ARCHITEW6432') == 'ARM64':
 	versionedLib64Path = os.path.join(globalVars.appDir, 'libArm64')
 else:
 	versionedLib64Path = os.path.join(globalVars.appDir, 'lib64')
-if getattr(sys,'frozen',None):
+
+
+if not globalVars.runningAsSource:
 	# Not running from source. Libraries are in a version-specific directory
 	versionedLibPath=os.path.join(versionedLibPath,versionInfo.version)
 	versionedLib64Path=os.path.join(versionedLib64Path,versionInfo.version)

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -36,7 +36,7 @@ else:
 
 
 if not globalVars.runningAsSource:
-	# Not running from source. Libraries are in a version-specific directory
+	# When running as a py2exe build, libraries are in a version-specific directory
 	versionedLibPath=os.path.join(versionedLibPath,versionInfo.version)
 	versionedLib64Path=os.path.join(versionedLib64Path,versionInfo.version)
 

--- a/source/core.py
+++ b/source/core.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, Aleksey Sadovoy, Christopher Toth, Joseph Lee, Peter Vágner,
+# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Christopher Toth, Joseph Lee, Peter Vágner,
 # Derek Riemer, Babbage B.V., Zahari Yurukov, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -156,7 +156,7 @@ def restartUnsafely():
 		except ValueError:
 			pass
 	options = []
-	if not hasattr(sys, "frozen"):
+	if globalVars.runningAsSource:
 		options.append(os.path.basename(sys.argv[0]))
 	_startNewInstance(NewNVDAInstance(
 		sys.executable,
@@ -181,7 +181,7 @@ def restart(disableAddons=False, debugLogging=False):
 		except ValueError:
 			pass
 	options = []
-	if not hasattr(sys, "frozen"):
+	if globalVars.runningAsSource:
 		options.append(os.path.basename(sys.argv[0]))
 	if disableAddons:
 		options.append('--disable-addons')
@@ -628,7 +628,7 @@ def main():
 	# initialize wxpython localization support
 	wxLocaleObj = wx.Locale()
 	wxLang = getWxLangOrNone()
-	if hasattr(sys,'frozen'):
+	if not globalVars.runningAsSource:
 		wxLocaleObj.AddCatalogLookupPathPrefix(os.path.join(globalVars.appDir, "locale"))
 	if wxLang:
 		try:

--- a/source/diffHandler.py
+++ b/source/diffHandler.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020-2022 NV Access Limited, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2020 Bill Dengler
 
 import config
 import globalVars
@@ -44,12 +44,12 @@ class DiffMatchPatch(DiffAlgo):
 		@note: This should be run from within the context of an acquired lock."""
 		if not DiffMatchPatch._proc:
 			log.debug("Starting diff-match-patch proxy")
-			if hasattr(sys, "frozen"):
-				dmp_path = (os.path.join(globalVars.appDir, "nvda_dmp.exe"),)
-			else:
+			if globalVars.runningAsSource:
 				dmp_path = (sys.executable, os.path.join(
 					globalVars.appDir, "..", "include", "nvda_dmp", "nvda_dmp.py"
 				))
+			else:
+				dmp_path = (os.path.join(globalVars.appDir, "nvda_dmp.exe"),)
 			DiffMatchPatch._proc = subprocess.Popen(
 				dmp_path,
 				creationflags=subprocess.CREATE_NO_WINDOW,

--- a/source/documentationUtils.py
+++ b/source/documentationUtils.py
@@ -1,11 +1,10 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2006-2022 NV Access Limited, Łukasz Golonka
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import os
-import sys
 
 import globalVars
 import languageHandler
@@ -13,10 +12,10 @@ import languageHandler
 
 def getDocFilePath(fileName, localized=True):
 	if not getDocFilePath.rootPath:
-		if hasattr(sys, "frozen"):
-			getDocFilePath.rootPath = os.path.join(globalVars.appDir, "documentation")
-		else:
+		if globalVars.runningAsSource:
 			getDocFilePath.rootPath = os.path.join(globalVars.appDir, "..", "user_docs")
+		else:
+			getDocFilePath.rootPath = os.path.join(globalVars.appDir, "documentation")
 
 	if localized:
 		lang = languageHandler.getLanguage()
@@ -42,7 +41,7 @@ def getDocFilePath(fileName, localized=True):
 		return None
 	else:
 		# Not localized.
-		if not hasattr(sys, "frozen") and fileName in ("copying.txt", "contributors.txt"):
+		if globalVars.runningAsSource and fileName in ("copying.txt", "contributors.txt"):
 			# If running from source, these two files are in the root dir.
 			return os.path.join(globalVars.appDir, "..", fileName)
 		else:

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -84,4 +84,5 @@ and as such, this value cannot be changed at runtime to test compliance.
 runningAsSource = getattr(sys, 'frozen', None) is None
 """
 True if NVDA is running as a source copy.
+When running as an installed copy, py2exe sets sys.frozen to 'windows_exe'.
 """

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -17,6 +17,7 @@
 
 import argparse
 import os
+import sys
 import typing
 
 if typing.TYPE_CHECKING:
@@ -78,4 +79,9 @@ This should never be False in released code.
 Making this False may be useful for testing if code is compliant without using deprecated APIs.
 Note that deprecated code may be imported at runtime,
 and as such, this value cannot be changed at runtime to test compliance.
+"""
+
+runningAsSource = getattr(sys, 'frozen', None) is None
+"""
+True if NVDA is running as a source copy.
 """

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -81,7 +81,7 @@ Note that deprecated code may be imported at runtime,
 and as such, this value cannot be changed at runtime to test compliance.
 """
 
-runningAsSource = getattr(sys, 'frozen', None) is None
+runningAsSource: bool = getattr(sys, 'frozen', None) is None
 """
 True if NVDA is running as a source copy.
 When running as an installed copy, py2exe sets sys.frozen to 'windows_exe'.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -7,7 +7,6 @@
 
 import time
 import os
-import sys
 import threading
 import ctypes
 import wx
@@ -453,7 +452,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			# Translators: The label of a menu item to open the Add-ons Manager.
 			item = menu_tools.Append(wx.ID_ANY, _("Manage &add-ons..."))
 			self.Bind(wx.EVT_MENU, frame.onAddonsManagerCommand, item)
-		if not globalVars.appArgs.secure and not config.isAppX and getattr(sys,'frozen',None):
+		if not globalVars.appArgs.secure and not config.isAppX and not globalVars.runningAsSource:
 			# Translators: The label for the menu item to create a portable copy of NVDA from an installed or another portable version.
 			item = menu_tools.Append(wx.ID_ANY, _("Create portable copy..."))
 			self.Bind(wx.EVT_MENU, frame.onCreatePortableCopyCommand, item)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -132,7 +132,6 @@ if globalVars.runningAsSource:
 	def stripBasePathFromTracebackText(text):
 		return text.replace(TB_BASE_PATH_MATCH, TB_BASE_PATH_PREFIX)
 else:
-	# We're running a py2exe build.
 	def stripBasePathFromTracebackText(text: str) -> str:
 		return text
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2020 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
+# Copyright (C) 2007-2022 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
 # Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -125,15 +125,17 @@ def shouldPlayErrorSound() -> bool:
 
 
 # Function to strip the base path of our code from traceback text to improve readability.
-if getattr(sys, "frozen", None):
-	# We're running a py2exe build.
-	stripBasePathFromTracebackText = lambda text: text
-else:
+if globalVars.runningAsSource:
 	BASE_PATH = os.path.split(__file__)[0] + os.sep
 	TB_BASE_PATH_PREFIX = '  File "'
 	TB_BASE_PATH_MATCH = TB_BASE_PATH_PREFIX + BASE_PATH
 	def stripBasePathFromTracebackText(text):
 		return text.replace(TB_BASE_PATH_MATCH, TB_BASE_PATH_PREFIX)
+else:
+	# We're running a py2exe build.
+	def stripBasePathFromTracebackText(text: str) -> str:
+		return text
+
 
 class Logger(logging.Logger):
 	# Import standard levels for convenience.
@@ -379,12 +381,14 @@ log: Logger = logging.getLogger("nvda")
 #: The singleton log handler instance.
 logHandler: Optional[logging.Handler] = None
 
+
 def _getDefaultLogFilePath():
-	if getattr(sys, "frozen", None):
+	if globalVars.runningAsSource:
+		return os.path.join(globalVars.appDir, "nvda.log")
+	else:
 		import tempfile
 		return os.path.join(tempfile.gettempdir(), "nvda.log")
-	else:
-		return os.path.join(globalVars.appDir, "nvda.log")
+
 
 def _excepthook(*exc_info):
 	log.exception(exc_info=exc_info, codepath="unhandled exception")

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka
+# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -28,13 +28,7 @@ _log = logging.Logger(name="preStartup", level=logging.INFO)
 _log.addHandler(logging.NullHandler(level=logging.INFO))
 
 customVenvDetected = False
-if getattr(sys, "frozen", None):
-	# We are running as an executable.
-	# Append the path of the executable to sys so we can import modules from the dist dir.
-	sys.path.append(sys.prefix)
-	appDir = sys.prefix
-else:
-	# we are running from source
+if globalVars.runningAsSource:
 	# Ensure we are inside the NVDA build system's Python virtual environment.
 	nvdaVenv = os.getenv("NVDA_VENV")
 	virtualEnv = os.getenv("VIRTUAL_ENV")
@@ -51,6 +45,11 @@ else:
 	import sourceEnv
 	#We should always change directory to the location of this module (nvda.pyw), don't rely on sys.path[0]
 	appDir = os.path.normpath(os.path.dirname(__file__))
+else:
+	# Append the path of the executable to sys so we can import modules from the dist dir.
+	sys.path.append(sys.prefix)
+	appDir = sys.prefix
+
 appDir = os.path.abspath(appDir)
 os.chdir(appDir)
 globalVars.appDir = appDir

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -1,8 +1,7 @@
-#nvda_slave.pyw
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2009-2017 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2009-2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 """NVDA slave process
 Performs miscellaneous tasks which need to be performed in a separate process.
@@ -17,12 +16,13 @@ import monkeyPatches.comtypesMonkeyPatches
 monkeyPatches.comtypesMonkeyPatches.appendComInterfacesToGenSearchPath()
 
 
-if hasattr(sys, "frozen"):
+if globalVars.runningAsSource:
+	globalVars.appDir = os.path.abspath(os.path.dirname(__file__))
+else:
 	# Error messages (which are only for debugging) should not cause the py2exe log message box to appear.
 	sys.stderr = sys.stdout
 	globalVars.appDir = sys.prefix
-else:
-	globalVars.appDir = os.path.abspath(os.path.dirname(__file__))
+
 
 # #2391: some functions may still require the current directory to be set to NVDA's app dir
 os.chdir(globalVars.appDir)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Blocking #13254, as this PR needs to check if NVDA is running as source

### Summary of the issue:
NVDA checks in various places if it is running as source.
This check should be abstracted out, as the check is dependent on py2exe behaviour.
When viewing code, it is also not immediately clear what `getattr(sys, 'frozen')` means, whereas a named variable will be clearer.

### Description of user facing changes
A named variable with documentation for code contributors.

### Description of development approach
Checked what `import sys; getattr(sys, 'frozen', None)` returns in the python console of an installed copy of NVDA and a source copy of NVDA.

### Testing strategy:
Smoke test running NVDA from installed and source.

### Known issues with pull request:
None
### Change log entries:

N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
