### PR TITLE
Fix generation of developer documentation for modules which rely on our generated comInterfaces

### DIFF
--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -16,9 +16,10 @@ import sourceEnv  # noqa: F401, E402
 # Apply several monkey patches to comtypes.
 # Add our `comInterfaces` to the `comtypes.gen` search path to replicate the behavior at runtime
 # without this patch many modules aren't importable, since they depend on `comInterfaces` being present.
-# Also disable module being never than typelib error, seen when
-# virtual environment has been created under different version of Windows than the one
-# used for developer documentation build. This also matches the behavior at runtime.
+# When a virtual environment has been created under a different version of Windows than the one
+# used for developer documentation build, "ImportError: Typelib different than module" is raised
+# by comTypes.
+# This patch causes the error to be ignored, which matches the behavior at runtime.
 import monkeyPatches.comtypesMonkeyPatches  # noqa: E402
 monkeyPatches.comtypesMonkeyPatches.replace_check_version()
 monkeyPatches.comtypesMonkeyPatches.appendComInterfacesToGenSearchPath()

--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -14,7 +14,7 @@ import sourceEnv  # noqa: F401, E402
 
 
 # Apply several monkey patches to comtypes.
-# Add our `comInterfaces` to the `comtypes.gen` seach path to replicate the behavior at runtime
+# Add our `comInterfaces` to the `comtypes.gen` search path to replicate the behavior at runtime
 # without this patch many modules aren't importable, since they depend on `comInterfaces` being present.
 # Also disable module being never than typelib error, seen when
 # virtual environment has been created under different version of Windows than the one

--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -12,6 +12,17 @@ import sys
 sys.path.insert(0, os.path.abspath('../source'))
 import sourceEnv  # noqa: F401, E402
 
+
+# Apply several monkey patches to comtypes.
+# Add our `comInterfaces` to the `comtypes.gen` seach path to replicate the behavior at runtime
+# without this patch many modules aren't importable, since they depend on `comInterfaces` being present.
+# Also disable module being never than typelib error, seen when
+# virtual environment has been created under different version of Windows than the one
+# used for developer documentation build. This also matches the behavior at runtime.
+import monkeyPatches.comtypesMonkeyPatches  # noqa: E402
+monkeyPatches.comtypesMonkeyPatches.replace_check_version()
+monkeyPatches.comtypesMonkeyPatches.appendComInterfacesToGenSearchPath()
+
 # Initialize languageHandler so that sphinx is able to deal with translatable strings.
 import languageHandler  # noqa: E402
 languageHandler.setLanguage("en")


### PR DESCRIPTION
### Link to issue number:
None - one of the prerequisites for eventual further work on #12971

### Summary of the issue:
When trying to generate developer documentation various modules cannot be imported, and as a result it is impossible to generate any documentation  from their docstrings.
In most cases this is caused by the fact that they try to import various com interfaces from our `comInterfaces` package, which cannot work since we set its path in a particular way at runtime.
The example error for one of the modules is as follows:
```
WARNING: autodoc: failed to import module 'IAccessibleHandler'; the following exception was raised:
cannot import name '_CE3F726E_D1D3_44FE_B995_FF1DB3B48B2B_0_1_3' from 'comtypes.gen' (D:\my_repos\nvda\.venv\lib\site-packages\comtypes\gen\__init__.py)
```

### Description of user facing changes
None
### Description of development approach
During developer documentation build our com interfaces directory is appended to the `comtypes.gen` search path, to match the behavior at runtime.

### Testing strategy:
Generated developer documentation - made sure that there are no errors similar to the one shown in the problem description. Checked count of warnings before and after this change - their amount decreased from 532 to 484.

### Known issues with pull request:
Since we now generate documentation for some modules which previously weren't importable this PR almost certainly introduces some new warnings. In my opinion any attempt at fixing warnings automatically or making note of which warnings are present and which are new should wait until all our modules can be imported successfully during build of the developer documentation, which is not yet the case.
### Change log entries:
None needed
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
