### PR TITLE
Selectively register for UIA events by default on SV2

### DIFF
--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -9,6 +9,7 @@ import config
 import ctypes
 import UIAHandler
 import weakref
+import winVersion
 from functools import lru_cache
 from logHandler import log
 from .constants import WinConsoleAPILevel
@@ -355,4 +356,9 @@ def _getConhostAPILevel(hwnd: int) -> WinConsoleAPILevel:
 def _shouldSelectivelyRegister() -> bool:
 	"Determines whether to register for UIA events selectively or globally."
 	setting = config.conf['UIA']['eventRegistration']
-	return setting == "selective"
+	if setting == "selective":
+		return True
+	elif setting == "global":
+		return False
+	else:
+		return winVersion.getWinVer() >= winVersion.WIN11_22H2

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2662,7 +2662,7 @@ class AdvancedPanelControls(
 			# Translators: A choice in a combo box in the advanced settings
 			# panel to have NVDA decide whether to register
 			# selectively or globally for UI Automation events.
-			_("Automatic (globally)"),
+			_("Automatic (prefer selectively)"),
 			# Translators: A choice in a combo box in the advanced settings
 			# panel to have NVDA register selectively for UI Automation events
 			# (i.e. not to request events for objects outside immediate focus).

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,6 +22,10 @@ What's New in NVDA
 - NVDA will now correctly announce Group boxes in Java applications. (#13962)
 - Caret properly follows spoken text in say all in applications such as Bookworm, WordPad, or the NVDA log viewer. (#13420, #9179)
 - In programs using UI Automation, partially checked checkboxes will be reported correctly. (#13975)
+- Improved performance and stability in in Microsoft Visual Studio, Windows Terminal, and other UI Automation based applications. (#11077, #11209)
+  - These fixes apply to Windows 11 Sun Valley 2 (version 22H2) and later.
+  - Selective registration for UI Automation events and property changes now enabled by default.
+  -
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2122,7 +2122,7 @@ This button is only enabled if NVDA is configured to enable loading custom code 
 
 This option changes how NVDA registers for events fired by the Microsoft UI Automation accessibility API.
 The registration for UI Automation events and property changes combo box has three options:
-- Automatic: Currently equivalent to "globally".
+- Automatic: "selectively" on Windows 11 Sun Valley 2 (version 22H2) and later, "globally" otherwise.
 - Selectively: NVDA will limit event registration to the system focus for most events.
 If you suffer from performance issues in one or more applications, We recommend you to try this functionality to see whether performance improves.
 However, on older versions of Windows, NVDA may have trouble tracking focus in some controls (such as the task manager and emoji panel).


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Partial mitigation for #11002.
Follow-up of #11214 and #13297.

### Summary of the issue:
NVDA 2020.3 introduced support for selective registration for UIA events based on the currently-focused provider, but this is disabled by default due to bugs in the Windows 10 task manager and emoji panel.
These bugs have been fixed in Windows 11 SV2.

### Description of how this pull request fixes the issue:
By default, enable selective UIA event registration on Windows 11 Sun Valley 2 (22H2).

### Testing strategy:
Enable by default in master snapshots to allow for wider testing.

### Known issues with pull request:
None known.

### Change log entries:
=== Bug Fixes ===
- Improved performance and stability in in Microsoft Visual Studio, Windows Terminal, and other UI Automation based applications on Windows 11 Sun Valley 2 (version 22H2). (#11077, #11209)
    - Selective registration for UI Automation events and property changes now enabled by default.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
