### PR TITLE
Fix punctuation in report accelerator key script description for consistency

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2181,7 +2181,7 @@ class GlobalCommands(ScriptableObject):
 		description=_(
 			# Translators: Description for a keyboard command which reports the
 			# accelerator key of the currently focused object.
-			"Reports the shortcut key of the currently focused object.",
+			"Reports the shortcut key of the currently focused object",
 		),
 		category=SCRCAT_FOCUS,
 		gestures=("kb:shift+numpad2", "kb(laptop):NVDA+control+shift+."),

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -527,7 +527,7 @@ There are some key commands that are useful when moving with the System focus:
 | Report title | NVDA+t | NVDA+t | Reports the title of the currently active window. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
 | Read active window | NVDA+b | NVDA+b | reads all the controls in the currently active window (useful for dialogs) |
 | Report Status Bar | NVDA+end | NVDA+shift+end | Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
-| Report Shortcut Key | ``shift+numpad2`` | ``NVDA+control+shift+.`` | Reports the shortcut (accelerator) key of the currently focused object. |
+| Report Shortcut Key | ``shift+numpad2`` | ``NVDA+control+shift+.`` | Reports the shortcut (accelerator) key of the currently focused object |
 %kc:endInclude
 
 ++ Navigating with the System Caret ++[SystemCaret]


### PR DESCRIPTION
Removes dot from end of description to make consistent with other scripts.