### PR TITLE
Fix up API naming for winAPI changes in nvda-ghsa-rmq3-vvhq-gp32

### DIFF
--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -13,10 +13,14 @@ import enum
 
 
 class WindowMessage(enum.IntEnum):
-	POWERBROADCAST = 0x0218
-	WTSSESSION_CHANGE = 0x02B1
+	POWER_BROADCAST = 0x0218
 	"""
+	WM_POWERBROADCAST
+	"""
+	WTS_SESSION_CHANGE = 0x02B1
+	"""
+	WM_WTSSESSION_CHANGE
 	Windows Message for when a Session State Changes.
-	Receiving these messages is registered by registerSessionNotification.
+	Receiving these messages is registered by sessionTracking.register.
 	handleSessionChange handles these messages.
 	"""

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -104,7 +104,7 @@ def isWindowsLocked() -> bool:
 	return WindowsTrackedSession.SESSION_LOCK in _currentSessionStates
 
 
-def registerSessionNotification(handle: HWND) -> bool:
+def register(handle: HWND) -> bool:
 	"""
 	@param handle: handle for NVDA message window.
 	When registered, Windows Messages related to session event changes will be
@@ -113,7 +113,7 @@ def registerSessionNotification(handle: HWND) -> bool:
 
 	Blocks until Windows accepts session tracking registration.
 
-	Every call to this function must be paired with a call to unregisterSessionNotification.
+	Every call to this function must be paired with a call to unregister.
 
 	If registration fails, NVDA may not work properly until the session can be registered in a new instance.
 	NVDA will not know when the lock screen is activated, which means it becomes a security risk.
@@ -157,9 +157,9 @@ def registerSessionNotification(handle: HWND) -> bool:
 	return registrationSuccess
 
 
-def unregisterSessionNotification(handle: HWND) -> None:
+def unregister(handle: HWND) -> None:
 	"""
-	This function must be called once for every call to registerSessionNotification.
+	This function must be called once for every call to register.
 	If unregistration fails, NVDA may not work properly until the session can be unregistered in a new instance.
 
 	https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsunregistersessionnotification


### PR DESCRIPTION
Fix up API naming to be more readable, from changes in https://github.com/nvaccess/nvda/commit/d4de23820c793b8d612fa74fa42167922a75a00c (ghsa-rmq3-vvhq-gp32)