### PR TITLE
Move some global vars to private variables

### DIFF
--- a/source/api.py
+++ b/source/api.py
@@ -14,10 +14,10 @@ from typing import (
 	Any,
 	List,
 	Optional,
+	Tuple,
 )
 
 import config
-from NVDAObjects import NVDAObject
 import textInfos
 import review
 from logHandler import log
@@ -42,7 +42,7 @@ if typing.TYPE_CHECKING:
 @dataclass
 class _APIState:
 	desktopObject: Optional[NVDAObjects.NVDAObject] = None
-	focusAncestors: List[NVDAObjects.NVDAObject] = []
+	focusAncestors: Tuple[NVDAObjects.NVDAObject] = ()
 	focusObject: Optional[NVDAObjects.NVDAObject] = None
 	focusDifferenceLevel: Optional[int] = None
 	foregroundObject: Optional[NVDAObjects.NVDAObject] = None
@@ -110,7 +110,7 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 		return False
 	if _apiState.focusObject:
 		eventHandler.executeEvent("loseFocus", _apiState.focusObject)
-	oldFocusLine = _apiState.focusAncestors
+	oldFocusLine = getFocusAncestors()
 	#add the old focus to the old focus ancestors, but only if its not None (is none at NVDA initialization)
 	if _apiState.focusObject:
 		oldFocusLine.append(_apiState.focusObject)
@@ -191,7 +191,7 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 	# Set global focus variables.
 	_apiState.focusDifferenceLevel = focusDifferenceLevel
 	_apiState.focusObject = obj
-	_apiState.focusAncestors = ancestors
+	_apiState.focusAncestors = tuple(ancestors)
 	braille.invalidateCachedFocusAncestors(focusDifferenceLevel)
 	if config.conf["reviewCursor"]["followFocus"]:
 		setNavigatorObject(obj,isFocus=True)
@@ -204,10 +204,10 @@ def getFocusDifferenceLevel() -> Optional[int]:
 
 def getFocusAncestors() -> List[NVDAObjects.NVDAObject]:
 	"""An array of NVDAObjects that are all parents of the object which currently has focus"""
-	return _apiState.focusAncestors
+	return list(_apiState.focusAncestors)
 
 
-def getMouseObject() -> Optional[NVDAObject]:
+def getMouseObject() -> Optional[NVDAObjects.NVDAObject]:
 	"""Returns the object that is directly under the mouse"""
 	return _apiState.mouseObject
 

--- a/source/core.py
+++ b/source/core.py
@@ -840,9 +840,10 @@ def main():
 	config.saveOnExit()
 
 	try:
-		if globalVars.focusObject and hasattr(globalVars.focusObject,"event_loseFocus"):
+		focusObject = api.getFocusObject()
+		if focusObject and hasattr(focusObject, "event_loseFocus"):
 			log.debug("calling lose focus on object with focus")
-			globalVars.focusObject.event_loseFocus()
+			focusObject.event_loseFocus()
 	except:
 		log.exception("Lose focus error")
 	try:

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -14,7 +14,6 @@ import api
 import speech
 from speech.commands import _CancellableSpeechCommand
 import treeInterceptorHandler
-import globalVars
 import controlTypes
 from logHandler import log
 import globalPluginHandler
@@ -182,7 +181,7 @@ class FocusLossCancellableSpeechCommand(_CancellableSpeechCommand):
 
 			# Assumption: we only process one focus event at a time, so even if several focus events are queued,
 			# all focused objects will still gain this tracking attribute. Otherwise, this may need to be set via
-			# api.setFocusObject when globalVars.focusObject is set.
+			# api.setFocusObject when api.getFocusObject is set.
 			setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, True)
 		elif not hasattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME):
 			setattr(obj, WAS_GAIN_FOCUS_OBJ_ATTR_NAME, False)
@@ -327,7 +326,7 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 		# - api.getFocusAncestors() via api.setFocusObject() called in doPreGainFocus
 		speech._manager.removeCancelledSpeechCommands()
 
-	if globalVars.focusDifferenceLevel<=1:
+	if api.getFocusDifferenceLevel() <= 1:
 		newForeground=api.getDesktopObject().objectInForeground()
 		if not newForeground:
 			log.debugWarning("Can not get real foreground, resorting to focus ancestors")
@@ -341,7 +340,7 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 		executeEvent('foreground', newForeground)
 	if sleepMode: return True
 	#Fire focus entered events for all new ancestors of the focus if this is a gainFocus event
-	for parent in globalVars.focusAncestors[globalVars.focusDifferenceLevel:]:
+	for parent in api.getFocusAncestors()[api.getFocusDifferenceLevel()]:
 		executeEvent("focusEntered",parent)
 	if obj.treeInterceptor is not oldTreeInterceptor:
 		if hasattr(oldTreeInterceptor,"event_treeInterceptor_loseFocus"):

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -4,25 +4,10 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-"""global variables module
-@var foregroundObject: holds the current foreground object. The object for the last foreground event received.
-@var focusObject: holds the current focus object
-@var mouseObject: holds the object that is at the position of the mouse pointer
-@var mouseOldX: the last x coordinate of the mouse pointer before its current position
-@type oldMouseX: int
-@var mouseOldY: the last y coordinate of the mouse pointer before its current position
-@type oldMouseY: int
-@var navigatorObject: holds the current navigator object
-"""
-
 import argparse
 import os
 import sys
 import typing
-
-if typing.TYPE_CHECKING:
-	import NVDAObjects  # noqa: F401 used for type checking only
-
 
 class DefaultAppArgs(argparse.Namespace):
 	quit: bool = False
@@ -49,18 +34,6 @@ class DefaultAppArgs(argparse.Namespace):
 
 
 startTime=0
-desktopObject: typing.Optional['NVDAObjects.NVDAObject'] = None
-foregroundObject: typing.Optional['NVDAObjects.NVDAObject'] = None
-focusObject: typing.Optional['NVDAObjects.NVDAObject'] = None
-focusAncestors: typing.List['NVDAObjects.NVDAObject'] = []
-focusDifferenceLevel=None
-mouseObject: typing.Optional['NVDAObjects.NVDAObject'] = None
-mouseOldX=None
-mouseOldY=None
-navigatorObject: typing.Optional['NVDAObjects.NVDAObject'] = None
-reviewPosition=None
-reviewPositionObj=None
-lastProgressValue=0
 appArgs = DefaultAppArgs()
 unknownAppArgs: typing.List[str] = []
 settingsRing = None

--- a/source/review.py
+++ b/source/review.py
@@ -1,10 +1,14 @@
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2013 Michael Curran <mick@nvaccess.org>
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2013-2022 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-from collections import OrderedDict
+from typing import (
+	Union,
+)
+
 import api
+from baseObject import ScriptableObject
 import winUser
 from logHandler import log
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
@@ -83,13 +87,12 @@ modes=[
 
 _currentMode=0
 
-def getPositionForCurrentMode(obj):
+
+def getPositionForCurrentMode(obj: NVDAObject) -> Union[textInfos.TextInfo, ScriptableObject]:
 	"""
 	Fetches a TextInfo instance suitable for reviewing the text in or around the given object, according to the current review mode. 
 	@param obj: the NVDAObject to review
-	@type obj: L{NVDAObject}
 	@return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error. 
-	@rtype: (L{TextInfo},L{ScriptableObject})
 	"""
 	mode=_currentMode
 	while mode>=0:
@@ -97,6 +100,7 @@ def getPositionForCurrentMode(obj):
 		if pos:
 			return pos
 		mode-=1
+
 
 def getCurrentMode():
 	"""Fetches the ID of the current mode"""

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -1,19 +1,18 @@
-#tests/unit/test_braille.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2017-2019 NV Access Limited, Babbage B.V.
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2017-2022 NV Access Limited, Babbage B.V.
 
 """Unit tests for the braille module.
 """
 
 import unittest
 import braille
-from .objectProvider import PlaceholderNVDAObject, NVDAObjectWithRole
+from .objectProvider import NVDAObjectWithRole
 import controlTypes
 from config import conf
 import api
-import globalVars
+
 
 class TestFocusContextPresentation(unittest.TestCase):
 	"""A test for the different focus context presentation options."""
@@ -28,7 +27,11 @@ class TestFocusContextPresentation(unittest.TestCase):
 		# Forcefully create a fake focus ancestry
 		# Note that the braille code excludes the desktop object when getting regions for focus ancestry
 		# The resulting focus object including ancestry will look like: "dialog dlg list lst list item"
-		globalVars.focusAncestors=[api.getDesktopObject(),NVDAObjectWithRole(role=controlTypes.Role.DIALOG),NVDAObjectWithRole(role=controlTypes.Role.LIST)]
+		api._apiState.focusAncestors = [
+			api.getDesktopObject(),
+			NVDAObjectWithRole(role=controlTypes.Role.DIALOG),
+			NVDAObjectWithRole(role=controlTypes.Role.LIST),
+		]
 		braille.handler.handleGainFocus(self.obj)
 		# Make sure that we are testing with three regions
 		self.assertEqual(len(self.regionsWithPositions),3)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

### Summary of the issue:
Add-on API authors may mistakenly use objects cached in `globalVars` directly, instead of through `api.get/set` methods.
This means that insecure objects could be set or returned to the user.

### Description of user facing changes
None

### Description of development approach
Removed variables from `globalVars`.

The following have been made removed and made private.
Instead, set and get these variables via the equivalent `api.get/set` method:
  - `desktopObject`
  - `focusAncestors`
  - `focusObject`
  - `focusDifferenceLevel`
  - `foregroundObject`
  - `mouseObject`
  - `navigatorObject`
  - `reviewPosition`

The following have been removed. These variables were previously unset and used:
  - `mouseOldY`
  - `mouseOldX`
  - `lastProgressValue`

`reviewPositionObj` has been removed as it was unused. It can be accessed with the equivalent `getReviewPosition().obj`.

### Testing strategy:

### Known issues with pull request:
API breaking change

### Change log entries:
For Developers

```t2t
- Removed variables from ``globalVars``:
  - The following have been made removed and made private.
  Instead, set and get these variables via the equivalent ``api.get/set`` method:
    - ``desktopObject``
    - ``focusAncestors``
    - ``focusObject``
    - ``focusDifferenceLevel``
    - ``foregroundObject``
    - ``mouseObject``
    - ``navigatorObject``
    - ``reviewPosition``
    -
  - The following have been removed. These variables were previously unset and used:
    - ``mouseOldY``
    - ``mouseOldX``
    - ``lastProgressValue``
    -
  - ``reviewPositionObj`` has been removed as it was unused. It can be accessed with the equivalent ``getReviewPosition().obj``.
  -
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
