### PR TITLE
rename _isSecureObjectWhileLockScreenActivated, mark as stable API

### DIFF
--- a/source/NVDAObjects/lockscreen.py
+++ b/source/NVDAObjects/lockscreen.py
@@ -13,7 +13,7 @@ from NVDAObjects import NVDAObject
 class LockScreenObject(NVDAObject):
 	"""
 	Prevent users from object navigating outside of the lock screen.
-	While usages of `_isSecureObjectWhileLockScreenActivated` in the api module prevent
+	While usages of `api.objectOutsideOfLockScreenAndWindowsIsLocked` prevent
 	the user from moving to the object, this overlay class prevents reading neighbouring objects.
 	"""
 

--- a/source/NVDAObjects/lockscreen.py
+++ b/source/NVDAObjects/lockscreen.py
@@ -13,7 +13,7 @@ from NVDAObjects import NVDAObject
 class LockScreenObject(NVDAObject):
 	"""
 	Prevent users from object navigating outside of the lock screen.
-	While usages of `api.objectOutsideOfLockScreenAndWindowsIsLocked` prevent
+	While usages of `api.objectBelowLockScreenAndWindowsIsLocked` prevent
 	the user from moving to the object, this overlay class prevents reading neighbouring objects.
 	"""
 

--- a/source/api.py
+++ b/source/api.py
@@ -28,7 +28,7 @@ import exceptions
 import appModuleHandler
 import cursorManager
 from typing import Any, Optional
-from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
+from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import documentBase
@@ -66,7 +66,7 @@ def setForegroundObject(obj: NVDAObjects.NVDAObject) -> bool:
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False
 	globalVars.foregroundObject=obj
 	return True
@@ -86,7 +86,7 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False
 	if globalVars.focusObject:
 		eventHandler.executeEvent("loseFocus",globalVars.focusObject)
@@ -194,7 +194,7 @@ def setMouseObject(obj: NVDAObjects.NVDAObject) -> bool:
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False
 	globalVars.mouseObject=obj
 	return True
@@ -207,7 +207,7 @@ def getDesktopObject() -> NVDAObjects.NVDAObject:
 
 def setDesktopObject(obj: NVDAObjects.NVDAObject) -> None:
 	"""Tells NVDA to remember the given object as the desktop object.
-	We cannot prevent setting this when objectOutsideOfLockScreenAndWindowsIsLocked is True,
+	We cannot prevent setting this when objectBelowLockScreenAndWindowsIsLocked is True,
 	as NVDA needs to set the desktopObject on start, and NVDA may start from the lockscreen.
 	"""
 	globalVars.desktopObject=obj
@@ -270,7 +270,7 @@ def getNavigatorObject() -> NVDAObjects.NVDAObject:
 		except (NotImplementedError, LookupError):
 			obj = globalVars.reviewPosition.obj
 	nextObj = getattr(obj, 'rootNVDAObject', None) or obj
-	if objectOutsideOfLockScreenAndWindowsIsLocked(nextObj):
+	if objectBelowLockScreenAndWindowsIsLocked(nextObj):
 		return globalVars.navigatorObject
 	globalVars.navigatorObject = nextObj
 	return globalVars.navigatorObject
@@ -289,7 +289,7 @@ def setNavigatorObject(obj: NVDAObjects.NVDAObject, isFocus: bool = False) -> bo
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False
 	globalVars.navigatorObject=obj
 	globalVars.reviewPosition=None

--- a/source/api.py
+++ b/source/api.py
@@ -28,7 +28,7 @@ import exceptions
 import appModuleHandler
 import cursorManager
 from typing import Any, Optional
-from utils.security import _isSecureObjectWhileLockScreenActivated
+from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import documentBase
@@ -66,7 +66,7 @@ def setForegroundObject(obj: NVDAObjects.NVDAObject) -> bool:
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return False
 	globalVars.foregroundObject=obj
 	return True
@@ -86,7 +86,7 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return False
 	if globalVars.focusObject:
 		eventHandler.executeEvent("loseFocus",globalVars.focusObject)
@@ -194,7 +194,7 @@ def setMouseObject(obj: NVDAObjects.NVDAObject) -> bool:
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return False
 	globalVars.mouseObject=obj
 	return True
@@ -207,7 +207,7 @@ def getDesktopObject() -> NVDAObjects.NVDAObject:
 
 def setDesktopObject(obj: NVDAObjects.NVDAObject) -> None:
 	"""Tells NVDA to remember the given object as the desktop object.
-	We cannot prevent setting this when _isSecureObjectWhileLockScreenActivated is True,
+	We cannot prevent setting this when objectOutsideOfLockScreenAndWindowsIsLocked is True,
 	as NVDA needs to set the desktopObject on start, and NVDA may start from the lockscreen.
 	"""
 	globalVars.desktopObject=obj
@@ -270,7 +270,7 @@ def getNavigatorObject() -> NVDAObjects.NVDAObject:
 		except (NotImplementedError, LookupError):
 			obj = globalVars.reviewPosition.obj
 	nextObj = getattr(obj, 'rootNVDAObject', None) or obj
-	if _isSecureObjectWhileLockScreenActivated(nextObj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(nextObj):
 		return globalVars.navigatorObject
 	globalVars.navigatorObject = nextObj
 	return globalVars.navigatorObject
@@ -289,7 +289,7 @@ def setNavigatorObject(obj: NVDAObjects.NVDAObject, isFocus: bool = False) -> bo
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		log.error("Object is not a valid NVDAObject")
 		return False
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return False
 	globalVars.navigatorObject=obj
 	globalVars.reviewPosition=None

--- a/source/braille.py
+++ b/source/braille.py
@@ -48,7 +48,7 @@ import bdDetect
 import queueHandler
 import brailleViewer
 from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
-from utils.security import _isSecureObjectWhileLockScreenActivated
+from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
 
 if TYPE_CHECKING:
 	from NVDAObjects import NVDAObject
@@ -343,7 +343,7 @@ BLUETOOTH_PORT =  ("bluetooth", _("Bluetooth"))
 
 
 def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return False
 	import displayModel
 	if issubclass(obj.TextInfo,displayModel.DisplayModelTextInfo):
@@ -643,7 +643,7 @@ class NVDAObjectRegion(Region):
 		@param obj: The associated NVDAObject.
 		@param appendText: Text which should always be appended to the NVDAObject text, useful if this region will always precede other regions.
 		"""
-		if _isSecureObjectWhileLockScreenActivated(obj):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 			raise RuntimeError("NVDA object is secure and should not be initialized as a braille region")
 		super().__init__()
 		self.obj = obj
@@ -915,7 +915,7 @@ class TextInfoRegion(Region):
 	allowPageTurns=True #: True if a page turn should be tried when a TextInfo cannot move anymore and the object supports page turns.
 
 	def __init__(self, obj: "NVDAObject"):
-		if _isSecureObjectWhileLockScreenActivated(obj):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 			raise RuntimeError("NVDA object is secure and should not be initialized as a braille region")
 		super().__init__()
 		self.obj = obj
@@ -1629,7 +1629,7 @@ def getFocusContextRegions(
 		obj: "NVDAObject",
 		oldFocusRegions: Optional[List[Region]] = None,
 ) -> Generator[Region, None, None]:
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return
 	global _cachedFocusAncestorsEnd
 	# Late import to avoid circular import.
@@ -1702,7 +1702,7 @@ def getFocusRegions(
 		obj: "NVDAObject",
 		review: bool = False,
 ) -> Generator[Region, None, None]:
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return
 	# Allow objects to override normal behaviour.
 	try:
@@ -2069,7 +2069,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def handleGainFocus(self, obj: "NVDAObject", shouldAutoTether: bool = True) -> None:
 		if not self.enabled:
 			return
-		if _isSecureObjectWhileLockScreenActivated(obj):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 			return
 		if shouldAutoTether:
 			self.setTether(self.TETHER_FOCUS, auto=True)
@@ -2111,7 +2111,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	) -> None:
 		if not self.enabled:
 			return
-		if _isSecureObjectWhileLockScreenActivated(obj):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 			return
 		prevTether = self._tether
 		if shouldAutoTether:
@@ -2162,7 +2162,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self,
 			obj: "NVDAObject",
 	) -> None:
-		if _isSecureObjectWhileLockScreenActivated(obj):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 			return
 		oldTime = getattr(self, "_lastProgressBarUpdateTime", None)
 		newTime = time.time()
@@ -2178,7 +2178,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def handleUpdate(self, obj: "NVDAObject") -> None:
 		if not self.enabled:
 			return
-		if _isSecureObjectWhileLockScreenActivated(obj):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 			return
 		# Optimisation: It is very likely that it is the focus object that is being updated.
 		# If the focus object is in the braille buffer, it will be the last region, so scan the regions backwards.

--- a/source/braille.py
+++ b/source/braille.py
@@ -48,7 +48,7 @@ import bdDetect
 import queueHandler
 import brailleViewer
 from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
-from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
+from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 if TYPE_CHECKING:
 	from NVDAObjects import NVDAObject
@@ -343,7 +343,7 @@ BLUETOOTH_PORT =  ("bluetooth", _("Bluetooth"))
 
 
 def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False
 	import displayModel
 	if issubclass(obj.TextInfo,displayModel.DisplayModelTextInfo):
@@ -643,7 +643,7 @@ class NVDAObjectRegion(Region):
 		@param obj: The associated NVDAObject.
 		@param appendText: Text which should always be appended to the NVDAObject text, useful if this region will always precede other regions.
 		"""
-		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+		if objectBelowLockScreenAndWindowsIsLocked(obj):
 			raise RuntimeError("NVDA object is secure and should not be initialized as a braille region")
 		super().__init__()
 		self.obj = obj
@@ -915,7 +915,7 @@ class TextInfoRegion(Region):
 	allowPageTurns=True #: True if a page turn should be tried when a TextInfo cannot move anymore and the object supports page turns.
 
 	def __init__(self, obj: "NVDAObject"):
-		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+		if objectBelowLockScreenAndWindowsIsLocked(obj):
 			raise RuntimeError("NVDA object is secure and should not be initialized as a braille region")
 		super().__init__()
 		self.obj = obj
@@ -1629,7 +1629,7 @@ def getFocusContextRegions(
 		obj: "NVDAObject",
 		oldFocusRegions: Optional[List[Region]] = None,
 ) -> Generator[Region, None, None]:
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return
 	global _cachedFocusAncestorsEnd
 	# Late import to avoid circular import.
@@ -1702,7 +1702,7 @@ def getFocusRegions(
 		obj: "NVDAObject",
 		review: bool = False,
 ) -> Generator[Region, None, None]:
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return
 	# Allow objects to override normal behaviour.
 	try:
@@ -2069,7 +2069,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def handleGainFocus(self, obj: "NVDAObject", shouldAutoTether: bool = True) -> None:
 		if not self.enabled:
 			return
-		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+		if objectBelowLockScreenAndWindowsIsLocked(obj):
 			return
 		if shouldAutoTether:
 			self.setTether(self.TETHER_FOCUS, auto=True)
@@ -2111,7 +2111,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	) -> None:
 		if not self.enabled:
 			return
-		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+		if objectBelowLockScreenAndWindowsIsLocked(obj):
 			return
 		prevTether = self._tether
 		if shouldAutoTether:
@@ -2162,7 +2162,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self,
 			obj: "NVDAObject",
 	) -> None:
-		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+		if objectBelowLockScreenAndWindowsIsLocked(obj):
 			return
 		oldTime = getattr(self, "_lastProgressBarUpdateTime", None)
 		newTime = time.time()
@@ -2178,7 +2178,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def handleUpdate(self, obj: "NVDAObject") -> None:
 		if not self.enabled:
 			return
-		if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+		if objectBelowLockScreenAndWindowsIsLocked(obj):
 			return
 		# Optimisation: It is very likely that it is the focus object that is being updated.
 		# If the focus object is in the braille buffer, it will be the last region, so scan the regions backwards.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -22,7 +22,7 @@ import config
 import winUser
 import extensionPoints
 import oleacc
-from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
+from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
@@ -158,7 +158,7 @@ def _trackFocusObject(eventName: str, obj: "NVDAObjects.NVDAObject") -> None:
 
 	if (
 		eventName == "gainFocus"
-		and not objectOutsideOfLockScreenAndWindowsIsLocked(
+		and not objectBelowLockScreenAndWindowsIsLocked(
 			obj,
 			shouldLog=config.conf["debugLog"]["events"],
 		)
@@ -282,7 +282,7 @@ def executeEvent(
 	@param obj: the object the event is for
 	@param kwargs: Additional event parameters as keyword arguments.
 	"""
-	if objectOutsideOfLockScreenAndWindowsIsLocked(
+	if objectBelowLockScreenAndWindowsIsLocked(
 		obj,
 		shouldLog=config.conf["debugLog"]["events"],
 	):
@@ -304,7 +304,7 @@ def executeEvent(
 
 
 def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bool:
-	if objectOutsideOfLockScreenAndWindowsIsLocked(
+	if objectBelowLockScreenAndWindowsIsLocked(
 		obj,
 		shouldLog=config.conf["debugLog"]["events"],
 	):

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -22,7 +22,7 @@ import config
 import winUser
 import extensionPoints
 import oleacc
-from utils.security import _isSecureObjectWhileLockScreenActivated
+from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
@@ -158,7 +158,7 @@ def _trackFocusObject(eventName: str, obj: "NVDAObjects.NVDAObject") -> None:
 
 	if (
 		eventName == "gainFocus"
-		and not _isSecureObjectWhileLockScreenActivated(
+		and not objectOutsideOfLockScreenAndWindowsIsLocked(
 			obj,
 			shouldLog=config.conf["debugLog"]["events"],
 		)
@@ -282,7 +282,7 @@ def executeEvent(
 	@param obj: the object the event is for
 	@param kwargs: Additional event parameters as keyword arguments.
 	"""
-	if _isSecureObjectWhileLockScreenActivated(
+	if objectOutsideOfLockScreenAndWindowsIsLocked(
 		obj,
 		shouldLog=config.conf["debugLog"]["events"],
 	):
@@ -304,7 +304,7 @@ def executeEvent(
 
 
 def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bool:
-	if _isSecureObjectWhileLockScreenActivated(
+	if objectOutsideOfLockScreenAndWindowsIsLocked(
 		obj,
 		shouldLog=config.conf["debugLog"]["events"],
 	):

--- a/source/mathPres/mathPlayer.py
+++ b/source/mathPres/mathPlayer.py
@@ -30,7 +30,7 @@ from speech.commands import (
 	CharacterModeCommand,
 	PhonemeCommand,
 )
-from utils.security import _isSecureObjectWhileLockScreenActivated
+from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
 
 
 RE_MP_SPEECH = re.compile(
@@ -103,7 +103,7 @@ class MathPlayerInteraction(mathPres.MathInteractionNVDAObject):
 			self,
 			review: bool = False,
 	) -> Generator[braille.Region, None, None]:
-		if _isSecureObjectWhileLockScreenActivated(self):
+		if objectOutsideOfLockScreenAndWindowsIsLocked(self):
 			return
 		yield braille.NVDAObjectRegion(self, appendText=" ")
 		region = braille.Region()

--- a/source/mathPres/mathPlayer.py
+++ b/source/mathPres/mathPlayer.py
@@ -30,7 +30,7 @@ from speech.commands import (
 	CharacterModeCommand,
 	PhonemeCommand,
 )
-from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
+from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 
 RE_MP_SPEECH = re.compile(
@@ -103,7 +103,7 @@ class MathPlayerInteraction(mathPres.MathInteractionNVDAObject):
 			self,
 			review: bool = False,
 	) -> Generator[braille.Region, None, None]:
-		if objectOutsideOfLockScreenAndWindowsIsLocked(self):
+		if objectBelowLockScreenAndWindowsIsLocked(self):
 			return
 		yield braille.NVDAObjectRegion(self, appendText=" ")
 		region = braille.Region()

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -60,7 +60,7 @@ from .priorities import Spri
 from enum import IntEnum
 from dataclasses import dataclass
 from copy import copy
-from utils.security import _isSecureObjectWhileLockScreenActivated
+from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
@@ -457,7 +457,7 @@ def getObjectPropertiesSpeech(  # noqa: C901
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
 		**allowedProperties
 ) -> SpeechSequence:
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return []
 	#Fetch the values for all wanted properties
 	newPropertyValues={}
@@ -621,7 +621,7 @@ def getObjectSpeech(  # noqa: C901
 		reason: OutputReason = OutputReason.QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
 ) -> SpeechSequence:
-	if _isSecureObjectWhileLockScreenActivated(obj):
+	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
 		return []
 	role=obj.role
 	# Choose when we should report the content of this object's textInfo, rather than just the object's value

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -60,7 +60,7 @@ from .priorities import Spri
 from enum import IntEnum
 from dataclasses import dataclass
 from copy import copy
-from utils.security import objectOutsideOfLockScreenAndWindowsIsLocked
+from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
@@ -457,7 +457,7 @@ def getObjectPropertiesSpeech(  # noqa: C901
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
 		**allowedProperties
 ) -> SpeechSequence:
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return []
 	#Fetch the values for all wanted properties
 	newPropertyValues={}
@@ -621,7 +621,7 @@ def getObjectSpeech(  # noqa: C901
 		reason: OutputReason = OutputReason.QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
 ) -> SpeechSequence:
-	if objectOutsideOfLockScreenAndWindowsIsLocked(obj):
+	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return []
 	role=obj.role
 	# Choose when we should report the content of this object's textInfo, rather than just the object's value

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -78,7 +78,7 @@ def _isLockAppAndAlive(appModule: "appModuleHandler.AppModule") -> bool:
 	return appModule.appName == "lockapp" and appModule.isAlive
 
 
-def objectOutsideOfLockScreenAndWindowsIsLocked(
+def objectBelowLockScreenAndWindowsIsLocked(
 		obj: "NVDAObjects.NVDAObject",
 		shouldLog: bool = True,
 ) -> bool:

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -83,11 +83,20 @@ def objectBelowLockScreenAndWindowsIsLocked(
 		shouldLog: bool = True,
 ) -> bool:
 	"""
-	While Windows is locked, Windows 10 and 11 doesn't prevent object navigation outside of the lockscreen.
-	As such, NVDA must prevent accessing and reading objects outside of the lockscreen when Windows is locked.
-	@return: C{True} if the Windows 10/11 lockscreen is active and C{obj} is outside of the lock screen.
+	While Windows is locked, the current user session is still running, and below the lockscreen
+	exists the current user's desktop.
+
+	Windows 10 and 11 doesn't prevent object navigation below the lockscreen.
+
+	If an object is above the lockscreen, it is accessible and visible to the user
+	through the Windows UX while Windows is locked.
+	An object below the lockscreen should only be accessible when Windows is unlocked,
+	as it may contain sensitive information.
+
+	As such, NVDA must prevent accessing and reading objects below the lockscreen when Windows is locked.
+	@return: C{True} if the Windows 10/11 lockscreen is active and C{obj} is below the lock screen.
 	"""
-	if isWindowsLocked() and not isObjectInsideLockScreen(obj):
+	if isWindowsLocked() and not isObjectAboveLockScreen(obj):
 		if shouldLog and log.isEnabledFor(log.DEBUG):
 			devInfo = '\n'.join(obj.devInfo)
 			log.debug(f"Attempt at navigating to a secure object: {devInfo}")
@@ -96,10 +105,18 @@ def objectBelowLockScreenAndWindowsIsLocked(
 	return False
 
 
-def isObjectInsideLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
+def isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 	"""
+	While Windows is locked, the current user session is still running, and below the lockscreen
+	exists the current user's desktop.
+
 	When Windows is locked, the foreground Window is usually LockApp,
 	but other Windows can be focused (e.g. Windows Magnifier).
+
+	If an object is above the lockscreen, it is accessible and visible to the user
+	through the Windows UX while Windows is locked.
+	An object below the lockscreen should only be accessible when Windows is unlocked,
+	as it may contain sensitive information.
 	"""
 	import appModuleHandler
 	from NVDAObjects.IAccessible import TaskListIcon

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -78,10 +78,7 @@ def _isLockAppAndAlive(appModule: "appModuleHandler.AppModule") -> bool:
 	return appModule.appName == "lockapp" and appModule.isAlive
 
 
-# TODO: mark this API as public when it becomes stable (i.e. remove the underscore).
-# Add-on authors may require this function to make their code secure.
-# Consider renaming (e.g. objectOutsideOfLockScreenAndWindowsIsLocked).
-def _isSecureObjectWhileLockScreenActivated(
+def objectOutsideOfLockScreenAndWindowsIsLocked(
 		obj: "NVDAObjects.NVDAObject",
 		shouldLog: bool = True,
 ) -> bool:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Follow up of GHSA-rmq3-vvhq-gp32

### Summary of the issue:
The function `_isSecureObjectWhileLockScreenActivated` may be useful to add-on authors.
Therefore the API should become stable, i.e. not prefixed with an underscore.

The function is also not named in a way that makes it clear what a "secure object" is.

### Description of user facing changes
None

### Description of development approach
Rename `_isSecureObjectWhileLockScreenActivated` to `objectBelowLockScreenAndWindowsIsLocked`

### Testing strategy:
Tested that the lock screen object navigation limitations still work

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
