### PR TITLE
Make capitalisation consistent when reading data point changes

### DIFF
--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2014-2021 NV Access Limited, NVDA India, dineshkaushal
+# Copyright (C) 2014-2022 NV Access Limited, NVDA India, dineshkaushal
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -710,16 +710,23 @@ class OfficeChartElementPoint(OfficeChartElementBase):
 				output=""
 				if self.officeChartObject.ChartType in (xlLine, xlLineMarkers , xlLineMarkersStacked, xlLineMarkersStacked100, xlLineStacked, xlLineStacked100):
 					if arg2 > 1:
-
-						if self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 1] == self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 2]: 
+						rightDataPoint = self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 1]
+						leftDataPoint = self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 2]
+						if rightDataPoint == leftDataPoint:
 							# Translators: For line charts, indicates no change from the previous data point on the left
-							output += _( "no change from point {previousIndex}, ").format( previousIndex = arg2 - 1 )
-						elif self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 1] > self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 2]: 
+							output += _("no change from point {previousIndex}, ").format(previousIndex=arg2 - 1)
+						elif rightDataPoint > leftDataPoint:
 							# Translators: For line charts, indicates an increase from the previous data point on the left
-							output += _( "Increased by {incrementValue} from point {previousIndex}, ").format( incrementValue = self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 1] - self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 2] , previousIndex = arg2 - 1 ) 
+							output += _("increased by {incrementValue} from point {previousIndex}, ").format(
+								incrementValue=rightDataPoint - leftDataPoint,
+								previousIndex=arg2 - 1,
+							)
 						else:
 							# Translators: For line charts, indicates a decrease from the previous data point on the left
-							output += _( "decreased by {decrementValue} from point {previousIndex}, ").format( decrementValue = self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 2] - self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 1] , previousIndex = arg2 - 1 ) 
+							output += _("decreased by {decrementValue} from point {previousIndex}, ").format(
+								decrementValue=leftDataPoint - rightDataPoint,
+								previousIndex=arg2 - 1,
+							)
 
 				if self.officeChartObject.HasAxis(xlCategory) and self.officeChartObject.Axes(xlCategory).HasTitle:
 					# Translators: Specifies the category of a data point.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:

A translator on the mailing list raised an issue, pointing out that the capitalization is inconsistent for these strings.

`Increased by {incrementValue} from point {previousIndex},` - on beginning of sentence (I) is capitalised.
`decreased by {decrementValue} from point {previousIndex},` - on beginning of sentence (d) is not capitalised

These should both begin with lowercase, as they are comma separated phrases as part of a longer message.

### Description of user facing changes
Make the translation strings consistently begin with a lowercase letter

### Description of development approach
Fixed up translation string, linted afterwards

### Testing strategy:
Manual testing: Test navigating between datapoints in a PowerPoint chart

### Known issues with pull request:
N/A

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
