### PR TITLE
Add notes on limitations to retaining backwards compatibility

### DIFF
--- a/devDocs/codingStandards.md
+++ b/devDocs/codingStandards.md
@@ -102,3 +102,8 @@ self.copySettingsButton = wx.Button(
 * Unused imports will give a lint warning. These can be handled the following ways: 
   - If these imports are inteded to be imported from other modules, they can be done included in a definition for `__all__`. This will override and define the symbols imported when performing a star import, eg `from module import *`.
   - Otherwise, with a comment like `# noqa: <explanation>`.
+
+### Considering future backwards compatibility
+
+When writing new code, consider how the code can be moved in future while retaining backwards compatibility.
+Refer to the [limitations to retaining backwards compatibility](./deprecations.md#limitations-to-retaining-backwards-compatibility).

--- a/devDocs/codingStandards.md
+++ b/devDocs/codingStandards.md
@@ -107,3 +107,9 @@ self.copySettingsButton = wx.Button(
 
 When writing new code, consider how the code can be moved in future while retaining backwards compatibility.
 Refer to the [limitations to retaining backwards compatibility](./deprecations.md#limitations-to-retaining-backwards-compatibility).
+
+In summary:
+- Avoid module level global variables.
+Any module level variables should be prefixed with and underscore and be encapsulated, e.g. via getters and setters.
+- Avoid code which executes at import time.
+Instead use initializer functions.

--- a/devDocs/deprecations.md
+++ b/devDocs/deprecations.md
@@ -10,10 +10,10 @@ Where possible, ensure the NVDA API maintains backwards compatibility.
 If no removal is required or proposed, backwards compatibility can be maintained via the following snippet:
 
 ```py
-import globalVars
+import NVDAState
 def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""
-	if attrName == "deprecatedSymbolName" and globalVars._allowDeprecatedAPI:
+	if attrName == "deprecatedSymbolName" and NVDAState._allowDeprecatedAPI():
 		# Note: this should only log in situations where it will not be excessively noisy.
 		log.warning(
 			"Importing deprecatedSymbolName from here is deprecated. "
@@ -24,17 +24,34 @@ def __getattr__(attrName: str) -> Any:
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 ```
 
-
 ## Required API breaking changes
 In order to improve the NVDA API, changes that will break future compatibility may be implemented, as long they retain backwards compatibility until the `20XX.1` release.
 
-This can be done by using a version check to automate deprecation. For example, if you wish to replace usages of `foo` with `bar`. When we begin work on `NEXT_YEAR`, `foo` will no longer be part of the NVDA API and all internal usages must be removed prior. 
+This can be done by using a version check to automate deprecation.
+For example, if you wish to replace usages of `deprecatedSymbolName` with `newSymbolName`.
+When we begin work on `NEXT_YEAR`, `deprecatedSymbolName` will no longer be part of the NVDA API and all internal usages must be removed prior. 
+
 ```python
 from buildVersion import version_year
-import globalVars
-if version_year < NEXT_YEAR and globalVars._allowDeprecatedAPI:
-	foo = bar
+import NVDAState
+if version_year < NEXT_YEAR and NVDAState._allowDeprecatedAPI():
+	deprecatedSymbolName = newSymbolName
 ```
+
+## Limitations to retaining backwards compatibility
+
+These snippets do not support re-assignment to `deprecatedSymbolName`.
+As a result, it not possible to retain backwards compatibility for module level variables which are expected to support assignment.
+
+For example, if there is a global variable named `currentState` in `exampleModule.py`, `currentState` cannot be deprecated.
+
+This is because:
+* Setting an attribute that is fetched via `__getattr__` will override the `__getattr__`, and any future gets will fetch the newly assigned value.
+* Python does not have an equivalent module level `__setattr__` like the `__getattr__` example.
+* Encapsulating a module level variable into another data structure changes the import behaviour.
+	- e.g. if `exampleModule` became a class, so `exampleModule.currentState` was a class level variable with the same namespace as the deprecated symbol, `exampleModule` may not be importable in the same manner.
+
+As a result, module level variables should be avoided.
 
 ## Testing backwards compatibility
 

--- a/devDocs/deprecations.md
+++ b/devDocs/deprecations.md
@@ -46,7 +46,9 @@ As a result, it not possible to retain backwards compatibility for module level 
 For example, if there is a global variable named `currentState` in `exampleModule.py`, `currentState` cannot be deprecated.
 
 This is because:
-* Setting an attribute that is fetched via `__getattr__` will override the `__getattr__`, and any future gets will fetch the newly assigned value.
+* `__getattr__` only fetches variables which are not defined on the module level.
+As such, setting an attribute that is fetched via `__getattr__` will prevent `__getattr__` from fetching the attribute.
+Any future gets will fetch the newly assigned value.
 * Python does not have an equivalent module level `__setattr__` like the `__getattr__` example.
 * Encapsulating a module level variable into another data structure changes the import behaviour.
 	- e.g. if `exampleModule` became a class, so `exampleModule.currentState` was a class level variable with the same namespace as the deprecated symbol, `exampleModule` may not be importable in the same manner.

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -13,7 +13,7 @@ NVDA NVDA_VERSION Developer Guide
 This guide provides information concerning NVDA development, including translation and the development of components for NVDA.
 
 ++ Add-on API stability ++[API]
- The NVDA Add-on API includes all NVDA internals, except symbols that are prefixed with an underscore.
+The NVDA Add-on API includes all NVDA internals, except symbols that are prefixed with an underscore.
 
 The NVDA Add-on API changes over time, such as removals, deprecations and new features.
 Important changes to the API are announced on the [NVDA API mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about].

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -9,7 +9,7 @@ import time
 import globalVars
 
 
-def isNVDARunningAsSource() -> bool:
+def isRunningAsSource() -> bool:
 	"""
 	True if NVDA is running as a source copy.
 	When running as an installed copy, py2exe sets sys.frozen to 'windows_exe'.

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -1,0 +1,46 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import sys
+import time
+
+import globalVars
+
+
+def isNVDARunningAsSource() -> bool:
+	"""
+	True if NVDA is running as a source copy.
+	When running as an installed copy, py2exe sets sys.frozen to 'windows_exe'.
+	"""
+	return getattr(sys, 'frozen', None) is None
+
+
+def _allowDeprecatedAPI() -> bool:
+	"""
+	Used for marking code as deprecated.
+	This should never be False in released code.
+
+	Making this False may be useful for testing if code is compliant without using deprecated APIs.
+	Note that deprecated code may be imported at runtime,
+	and as such, this value cannot be changed at runtime to test compliance.
+	"""
+	return True
+
+
+def getStartTime() -> float:
+	return globalVars.startTime
+
+
+def _initializeStartTime() -> None:
+	assert globalVars.startTime == 0
+	globalVars.startTime = time.time()
+
+
+def _getExitCode() -> int:
+	return globalVars.exitCode
+
+
+def _setExitCode(exitCode: int) -> None:
+	globalVars.exitCode = exitCode


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
See also #14050

### Summary of the issue:
#14037 was closed because there was no way to preserve backwards compatibility.
This is the case for any module level variable which the NVDA API expects to support assignment.

### Description of user facing changes
None

### Description of development approach
Documentation has been added:
- to warn developers about writing code which allows for future changes without breaking backwards compatibility.
- keep track of cases which we cannot safely retain backwards compatibility, so that we can clearly define when API breaking changes are necessary

### Testing strategy:
N/A

### Known issues with pull request:
N/A

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
