### PR TITLE
control high verbosity nvda logging during system tests with appveyor environment var

### DIFF
--- a/appveyor/README.md
+++ b/appveyor/README.md
@@ -57,3 +57,18 @@ At the end of the build, regardless of failure, we upload the list of successful
 ## Deploying
 
 The server side deploy code (`nvdaAppveyorHook`) is triggered from `deployScript.ps1`. The server-side deployment relies on our artifacts, so they must be uploaded first.
+
+
+## Modifying behavior
+
+Environment variables can be configured to modify behavior on Appveyor.
+These tools can be used (by NV Access) to more quickly investigate issues with the build.
+These must be set before the build starts, and should be removed again once the build has started.
+
+- `APPVEYOR_RDP_PASSWORD` Setting an RDP password will allow connecting over RDP.
+   Monitor the early build output to get the connection string.
+- `VERBOSE_SYSTEM_TEST_LOGGING` Setting "true" will enable more verbose NVDA logs for the tests
+   See method `enable_verbose_debug_logging_if_requested` in `NvdaLib.py`, enables:
+  - `MSAA`
+  - `UIA`
+  - `TimeSinceInput`

--- a/appveyor/scripts/tests/systemTests.ps1
+++ b/appveyor/scripts/tests/systemTests.ps1
@@ -1,9 +1,16 @@
 $testOutput = (Resolve-Path .\testOutput\)
 $systemTestOutput = (Resolve-Path "$testOutput\system")
 
+if ($env:VERBOSE_SYSTEM_TEST_LOGGING) {
+	$verboseDebugLogging="True"
+} else {
+	$verboseDebugLogging=""
+}
+
 .\runsystemtests.bat `
 --variable whichNVDA:installed `
 --variable installDir:"${env:nvdaLauncherFile}" `
+--variable verboseDebugLogging:"${verboseDebugLogging}" `
 --include installer `
 --include NVDA `
 # last line inentionally blank, allowing all lines to have line continuations.

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -126,7 +126,7 @@ class NvdaLib:
 	- NvdaLib.nvdaSpy is a library instance for getting speech and other information out of NVDA
 	"""
 	def __init__(self):
-		self.nvdaSpy = None  #: _Optional[SystemTestSpy.speechSpyGlobalPlugin.NVDASpyLib]
+		self.nvdaSpy: _Optional["NVDASpyLib"] = None
 		self.nvdaHandle: _Optional[int] = None
 		self.lastNVDAStart: _Optional[_datetime] = None
 
@@ -274,6 +274,19 @@ class NvdaLib:
 		self._connectToRemoteServer(connectionTimeoutSecs=30)
 		self.nvdaSpy.wait_for_NVDA_startup_to_complete()
 		return nvdaProcessHandle
+
+	def enable_verbose_debug_logging_if_requested(self):
+		builtIn.should_be_true(self.nvdaSpy is not None)
+		shouldEnableVerboseDebugLogging = bool(
+			builtIn.get_variable_value("${verboseDebugLogging}", "")
+		)
+		if shouldEnableVerboseDebugLogging:
+			self.nvdaSpy.modifyNVDAConfig(
+				[
+					(["debugLog", "MSAA"], True),
+					(["debugLog", "UIA"], True),
+					(["debugLog", "timeSinceInput"], True),
+			])
 
 	def start_NVDA(self, settingsFileName: str, gesturesFileName: _Optional[str] = None):
 		self.lastNVDAStart = _datetime.utcnow()

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -25,6 +25,7 @@ default teardown
 
 default setup
 	start NVDA	standard-dontShowWelcomeDialog.ini	chrome-gestures.ini
+	enable_verbose_debug_logging_if_requested
 
 *** Test Cases ***
 

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -25,6 +25,7 @@ default teardown
 
 default setup
 	start NVDA	standard-dontShowWelcomeDialog.ini
+	enable_verbose_debug_logging_if_requested
 
 *** Test Cases ***
 


### PR DESCRIPTION
### Link to issue number:
Follow on from https://github.com/nvaccess/nvda/pull/14054

### Summary of the issue:
When tests are failing in an unusual way, it may be helpful to be able to review verbose debug logging for interaction with MSAA or UIA.

### Description of user facing changes
For developers:
`VERBOSE_SYSTEM_TEST_LOGGING` can be set (to "true") via Appveyor settings to enable high verbosity NVDA logging.

### Description of development approach
When the environment variable `VERBOSE_SYSTEM_TEST_LOGGING` is set on appveyor, the system tests are started with an extra parameter (`verboseDebugLogging='True'`) which enables the advanced logging categories in NVDA. 

### Testing strategy:
- Run system tests locally with and without the argument
- Run system tests on Appveyor with and without the argument.

### Known issues with pull request:

### Change log entries:
None

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
