### PR TITLE
Use CI env var to specify tags for or skip sys tests

### DIFF
--- a/appveyor/README.md
+++ b/appveyor/README.md
@@ -67,7 +67,8 @@ These must be set before the build starts, and should be removed again once the 
 
 - `APPVEYOR_RDP_PASSWORD`: Setting an RDP password will allow connecting over RDP.
    Monitor the early build output to get the connection string.
-- `VERBOSE_SYSTEM_TEST_LOGGING`: Setting "true" will enable more verbose NVDA logs for the tests
+- `VERBOSE_SYSTEM_TEST_LOGGING`: Setting `True` (or any non-empty string) will enable more verbose NVDA logs
+   for the tests.
    See method `enable_verbose_debug_logging_if_requested` in `NvdaLib.py`, enables:
   - `MSAA`
   - `UIA`

--- a/appveyor/README.md
+++ b/appveyor/README.md
@@ -57,3 +57,17 @@ At the end of the build, regardless of failure, we upload the list of successful
 ## Deploying
 
 The server side deploy code (`nvdaAppveyorHook`) is triggered from `deployScript.ps1`. The server-side deployment relies on our artifacts, so they must be uploaded first.
+
+
+## Modifying behavior
+
+Environment variables can be configured to modify behavior on Appveyor.
+These tools can be used (by NV Access) to more quickly investigate issues with the build.
+These must be set before the build starts, and should be removed again once the build has started.
+
+- `APPVEYOR_RDP_PASSWORD` Setting an RDP password will allow connecting over RDP.
+   Monitor the early build output to get the connection string.
+- `INCLUDE_SYSTEM_TEST_TAGS` Set (space separated) tags to be used when running system tests.
+  - E.G. To run the tests with the default tags: `installer NVDA`
+  - See the `*.robot` files for tags.
+  - Use `excluded_from_build` to run no system tests.

--- a/appveyor/README.md
+++ b/appveyor/README.md
@@ -65,14 +65,14 @@ Environment variables can be configured to modify behavior on Appveyor.
 These tools can be used (by NV Access) to more quickly investigate issues with the build.
 These must be set before the build starts, and should be removed again once the build has started.
 
-- `APPVEYOR_RDP_PASSWORD` Setting an RDP password will allow connecting over RDP.
+- `APPVEYOR_RDP_PASSWORD`: Setting an RDP password will allow connecting over RDP.
    Monitor the early build output to get the connection string.
-- `VERBOSE_SYSTEM_TEST_LOGGING` Setting "true" will enable more verbose NVDA logs for the tests
+- `VERBOSE_SYSTEM_TEST_LOGGING`: Setting "true" will enable more verbose NVDA logs for the tests
    See method `enable_verbose_debug_logging_if_requested` in `NvdaLib.py`, enables:
   - `MSAA`
   - `UIA`
   - `TimeSinceInput`
-- `INCLUDE_SYSTEM_TEST_TAGS` Set (space separated) tags to be used when running system tests.
+- `INCLUDE_SYSTEM_TEST_TAGS`: Set (space separated) tags to be used when running system tests.
   - E.G. To run the tests with the default tags: `installer NVDA`
   - See the `*.robot` files for tags.
   - Use `excluded_from_build` to run no system tests.

--- a/appveyor/scripts/tests/systemTests.ps1
+++ b/appveyor/scripts/tests/systemTests.ps1
@@ -1,18 +1,38 @@
 $testOutput = (Resolve-Path .\testOutput\)
 $systemTestOutput = (Resolve-Path "$testOutput\system")
 
+# This tag is used to exclude system tests.
+# If provided to runsystemtests, RF would give an error.
+$SKIP_SYS_TESTS = "excluded_from_build"
+$tagsForTest = "installer NVDA"  # include the tests tagged with installer, or NVDA
+if ($env:INCLUDE_SYSTEM_TEST_TAGS) {
+	if ($env:INCLUDE_SYSTEM_TEST_TAGS -eq $SKIP_SYS_TESTS) {
+		# Indicate the tests were skipped, and exit early.
+		Add-AppveyorMessage "Skipped: System tests."
+		return
+	}
+	$tagsForTest = $env:INCLUDE_SYSTEM_TEST_TAGS
+
+}
+$tagsForTestArray = -split $tagsForTest # turn this string into an array
+$includeTags = $tagsForTestArray | ForEach-Object {
+	# Before every item output '--include'
+	# No spaces required.
+	# Including spaces will result in automatic quote characters around the string. I.E. "--include "
+	"--include", $_
+}
+
 .\runsystemtests.bat `
 --variable whichNVDA:installed `
 --variable installDir:"${env:nvdaLauncherFile}" `
---include installer `
---include NVDA `
+@includeTags `
 # last line inentionally blank, allowing all lines to have line continuations.
 
 if($LastExitCode -ne 0) {
 	Set-AppveyorBuildVariable "testFailExitCode" $LastExitCode
-	Add-AppveyorMessage "FAIL: System tests. See test results for more information."
+	Add-AppveyorMessage "FAIL: System tests (tags: ${tagsForTest}). See test results for more information."
 } else {
-	Add-AppveyorMessage "PASS: System tests."
+	Add-AppveyorMessage "PASS: System tests (tags: ${tagsForTest})."
 }
 Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
 Push-AppveyorArtifact "$testOutput\systemTestResult.zip"


### PR DESCRIPTION
### Link to issue number:
Follow on from https://github.com/nvaccess/nvda/pull/14055

### Summary of the issue:
When a release is required, and system tests are failing due to the CI environment or aspects beyond our control, it would be helpful to be able to decide to disable the test requirements and continue.

### Description of user facing changes
For developers:
- Setting `INCLUDE_SYSTEM_TEST_TAGS` environment variable on CI allows control over the tags included in the system test phase.
- Setting to `excluded_from_build` will disable the running of the tests.
- Messages from CI now include the tags used when the system tests were run.

### Description of development approach
- Observe `INCLUDE_SYSTEM_TEST_TAGS` environment variable
- Check for value `excluded_from_build`. If so, output "Skipped: System Tests" and return.
- Other values are assumed to be space delimited tags to be included in the system tests.

### Testing strategy:
- [x] Testing with power shell locally, mocking (powershell) dependencies as required.
- [x] Test on CI with no `INCLUDE_SYSTEM_TEST_TAGS` environment variable present. [Build](https://ci.appveyor.com/project/NVAccess/nvda/builds/44686867/messages)
- [x] Test on CI with `INCLUDE_SYSTEM_TEST_TAGS` environment variable set to `excluded_from_build`. [Build](https://ci.appveyor.com/project/NVAccess/nvda/builds/44690929/messages) (note, message "skipped system tests", no "robot" tests listed, no systemTestResults.zip artifact
- [x] Test on CI with `INCLUDE_SYSTEM_TEST_TAGS` environment variable set to `symbols` to run only symbols tests. [Build](https://ci.appveyor.com/project/NVAccess/nvda/builds/44699858/messages) (note, message "tags: symbols", only robot tests for "symbols")

### Known issues with pull request:
Care will need to be taken to remove the environment variable after a build starts.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
