### PR TITLE
Revert change of globalMapScripts in scriptHandler, which is now again a list instead of a set

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2599,8 +2599,7 @@ class BrailleDisplayDriver(driverHandler.Driver):
 					yield match
 
 	#: Global input gesture map for this display driver.
-	#: @type: L{inputCore.GlobalGestureMap}
-	gestureMap = None
+	gestureMap: Optional[inputCore.GlobalGestureMap] = None
 
 	@classmethod
 	def _getModifierGestures(cls, model=None):

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -42,8 +42,9 @@ import controlTypes
 import winKernel
 
 
-_InputGestureBindingClassT = TypeVar("_InputGestureBindingClassT")
-InputGestureScriptT = Tuple[_InputGestureBindingClassT, Optional[str]]
+InputGestureBindingClassT = TypeVar("InputGestureBindingClassT")
+ScriptNameT = str
+InputGestureScriptT = Tuple[InputGestureBindingClassT, Optional[ScriptNameT]]
 """
 The Python class and script name for each script;
 the script name may be C{None} indicating that the gesture should be unbound for this class.

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -13,7 +13,16 @@ import sys
 import os
 import weakref
 import time
-from typing import Dict, Any, Tuple, List, Union
+from typing import (
+	Any,
+	Dict,
+	Generator,
+	List,
+	Optional,
+	Tuple,
+	TypeVar,
+	Union,
+)
 from gui import blockAction
 import configobj
 from speech import sayAll
@@ -31,6 +40,15 @@ import globalVars
 import languageHandler
 import controlTypes
 import winKernel
+
+
+_InputGestureBindingClassT = TypeVar("_InputGestureBindingClassT")
+InputGestureScriptT = Tuple[_InputGestureBindingClassT, Optional[str]]
+"""
+The Python class and script name for each script;
+the script name may be C{None} indicating that the gesture should be unbound for this class.
+"""
+
 
 #: Script category for emulated keyboard keys.
 # Translators: The name of a category of NVDA commands.
@@ -321,13 +339,11 @@ class GlobalGestureMap(object):
 						self.lastUpdateContainedError = True
 						continue
 
-	def getScriptsForGesture(self, gesture):
+	def getScriptsForGesture(self, gesture: str) -> Generator[InputGestureScriptT, None, None]:
 		"""Get the scripts associated with a particular gesture.
 		@param gesture: The gesture identifier.
-		@type gesture: str
 		@return: The Python class and script name for each script;
 			the script name may be C{None} indicating that the gesture should be unbound for this class.
-		@rtype: generator of (class, str)
 		"""
 		try:
 			scripts = self._map[gesture]
@@ -845,9 +861,10 @@ def getDisplayTextForGestureIdentifier(identifier):
 		raise
 		raise LookupError("Couldn't get display text for identifier: %s" % identifier)
 
+
 #: The singleton input manager instance.
-#: @type: L{InputManager}
-manager = None
+manager: Optional[InputManager] = None
+
 
 def initialize():
 	"""Initializes input core, creating a global L{InputManager} singleton.

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -48,10 +48,10 @@ def _makeKbEmulateScript(scriptName):
 def _getObjScript(
 		obj: "NVDAObjects.NVDAObject",
 		gesture: "inputCore.InputGesture",
-		globalMapScripts: List[_ScriptFunctionT],
+		globalMapScripts: List[inputCore.InputGestureScriptT],
 ) -> Optional[_ScriptFunctionT]:
 	"""
-	@param globalMapScripts: An ordered list of maps.
+	@param globalMapScripts: An ordered list of scripts.
 	The list is ordered by resolution priority,
 	the first map in the list should be used to resolve the script first.
 	"""
@@ -76,13 +76,13 @@ def _getObjScript(
 		log.exception()
 
 
-def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List[_ScriptFunctionT]:
+def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List[inputCore.InputGestureScriptT]:
 	"""
-	@returns: An ordered list of maps.
+	@returns: An ordered list of scripts.
 	The list is ordered by resolution priority,
 	the first map in the list should be used to resolve scripts first.
 	"""
-	globalMapScripts: List[_ScriptFunctionT] = []
+	globalMapScripts: List[inputCore.InputGestureScriptT] = []
 	globalMaps = [inputCore.manager.userGestureMap, inputCore.manager.localeGestureMap]
 	globalMap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None
 	if globalMap:

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -48,7 +48,7 @@ def _makeKbEmulateScript(scriptName):
 def _getObjScript(
 		obj: "NVDAObjects.NVDAObject",
 		gesture: "inputCore.InputGesture",
-		globalMapScripts: List[inputCore.InputGestureScriptT],
+		globalMapScripts: List["inputCore.InputGestureScriptT"],
 ) -> Optional[_ScriptFunctionT]:
 	"""
 	@param globalMapScripts: An ordered list of scripts.
@@ -76,13 +76,13 @@ def _getObjScript(
 		log.exception()
 
 
-def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List[inputCore.InputGestureScriptT]:
+def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List["inputCore.InputGestureScriptT"]:
 	"""
 	@returns: An ordered list of scripts.
 	The list is ordered by resolution priority,
 	the first map in the list should be used to resolve scripts first.
 	"""
-	globalMapScripts: List[inputCore.InputGestureScriptT] = []
+	globalMapScripts: List["inputCore.InputGestureScriptT"] = []
 	globalMaps = [inputCore.manager.userGestureMap, inputCore.manager.localeGestureMap]
 	globalMap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None
 	if globalMap:

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2022 NV Access Limited, Babbage B.V., Julien Cochuyt
+# Copyright (C) 2007-2022 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -8,7 +8,6 @@ from typing import (
 	Optional,
 	Iterator,
 	List,
-	Set,
 )
 import time
 import weakref
@@ -49,7 +48,7 @@ def _makeKbEmulateScript(scriptName):
 def _getObjScript(
 		obj: "NVDAObjects.NVDAObject",
 		gesture: "inputCore.InputGesture",
-		globalMapScripts: Set[_ScriptFunctionT],
+		globalMapScripts: List[_ScriptFunctionT],
 ) -> Optional[_ScriptFunctionT]:
 	# Search the scripts from the global gesture maps.
 	for cls, scriptName in globalMapScripts:
@@ -72,15 +71,15 @@ def _getObjScript(
 		log.exception()
 
 
-def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> Set[_ScriptFunctionT]:
-	globalMapScripts: Set[_ScriptFunctionT] = set()
+def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List[_ScriptFunctionT]:
+	globalMapScripts: List[_ScriptFunctionT] = []
 	globalMaps = [inputCore.manager.userGestureMap, inputCore.manager.localeGestureMap]
 	globalMap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None
 	if globalMap:
 		globalMaps.append(globalMap)
 	for globalMap in globalMaps:
 		for identifier in gesture.normalizedIdentifiers:
-			globalMapScripts.update(globalMap.getScriptsForGesture(identifier))
+			globalMapScripts.extend(globalMap.getScriptsForGesture(identifier))
 	return globalMapScripts
 
 

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -50,6 +50,11 @@ def _getObjScript(
 		gesture: "inputCore.InputGesture",
 		globalMapScripts: List[_ScriptFunctionT],
 ) -> Optional[_ScriptFunctionT]:
+	"""
+	@param globalMapScripts: An ordered list of maps.
+	The list is ordered by resolution priority,
+	the first map in the list should be used to resolve the script first.
+	"""
 	# Search the scripts from the global gesture maps.
 	for cls, scriptName in globalMapScripts:
 		if isinstance(obj, cls):
@@ -72,6 +77,11 @@ def _getObjScript(
 
 
 def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List[_ScriptFunctionT]:
+	"""
+	@returns: An ordered list of maps.
+	The list is ordered by resolution priority,
+	the first map in the list should be used to resolve scripts first.
+	"""
 	globalMapScripts: List[_ScriptFunctionT] = []
 	globalMaps = [inputCore.manager.userGestureMap, inputCore.manager.localeGestureMap]
 	globalMap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,13 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.2.2 =
+This is a patch release to fix a bug introduced in 2022.2.1 with input gestures.
+
+== Bug Fixes ==
+- Fixed a bug where input gestures didn't always work. (#14065)
+-
+
 = 2022.2.1 =
 This is a minor release to fix a security issue.
 Please responsibly disclose security issues to info@nvaccess.org.


### PR DESCRIPTION
### Link to issue number:
Fixes #14065

### Summary of the issue:
Overriding/remapping existing braille display gestures was broken in NVDA 2022.2.1.

### Description of user facing changes
Gesture overrides work again in the mentioned case in #14065 

### Description of development approach
Revert an uncessary and seemlinly undocumented change in scriptHandler. It would help if we could clear up how this change ended up in this release.

### Testing strategy:
Followed the str in #14065 for at least three times, in all cases my remappings worked as expected.

### Known issues with pull request:
None known

### Change log entries:
Bug fixes
- Fixed a bug where custom input gestures didn't always work for braille displays, notably when using the HumanWare Brailliant braille display driver. (#14065 )

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
