### PR TITLE
Disable UIA text change events outside of Word, Windows Console, and Windows Terminal

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -416,6 +416,7 @@ class UIAHandler(COMObject):
 			not utils._shouldSelectivelyRegister()
 			and winVersion.getWinVer() >= winVersion.WIN10
 		):
+			# #14067: Due to poor performance, textChange requires special handling
 			self.globalEventHandlerGroup.AddAutomationEventHandler(
 				UIA.UIA_Text_TextChangedEventId,
 				UIA.TreeScope_Subtree,

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -412,6 +412,16 @@ class UIAHandler(COMObject):
 				self.baseCacheRequest,
 				self
 			)
+		if (
+			not utils._shouldSelectivelyRegister()
+			and winVersion.getWinVer() >= winVersion.WIN10
+		):
+			self.globalEventHandlerGroup.AddAutomationEventHandler(
+				UIA.UIA_Text_TextChangedEventId,
+				UIA.TreeScope_Subtree,
+				self.baseCacheRequest,
+				self
+			)
 		# #7984: add support for notification event (IUIAutomation5, part of Windows 10 build 16299 and later).
 		if isinstance(self.clientObject, UIA.IUIAutomation5):
 			self.globalEventHandlerGroup.AddNotificationEventHandler(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -276,6 +276,7 @@ class UIAHandler(COMObject):
 		super(UIAHandler,self).__init__()
 		self.globalEventHandlerGroup = None
 		self.localEventHandlerGroup = None
+		self.localEventHandlerGroupWithTextChanges = None
 		self._localEventHandlerGroupElements = set()
 		self.MTAThreadInitEvent=threading.Event()
 		self.MTAThreadQueue = Queue()
@@ -500,6 +501,17 @@ class UIAHandler(COMObject):
 					or element.CachedAutomationID in textChangeUIAAutomationIDs
 					else self.localEventHandlerGroup
 				)
+				if _isDebug():
+					prefix = (
+						"Explicitly"
+						if group == self.localEventHandlerGroupWithTextChanges
+						else "Not"
+					)
+					log.debugWarning(
+						f"{prefix} registering for textChange events from UIA element "
+						f"with class name {repr(element.currentClassName)} "
+						f"and automation ID {repr(element.CachedAutomationID)}"
+					)
 				self.addEventHandlerGroup(element, group)
 			except COMError:
 				log.error("Could not register for UIA events for element", exc_info=True)
@@ -543,8 +555,9 @@ class UIAHandler(COMObject):
 			else:
 				if _isDebug():
 					log.debugWarning(
-						"HandleAutomationEvent: Dropping unused textChange event"
-						+ f" from {sender.currentClassName}" if sender.currentClassName else ""
+						"HandleAutomationEvent: Dropping textChange event from element "
+						f"with class name {repr(sender.currentClassName)} "
+						f"and automation ID {repr(sender.CachedAutomationID)}"
 					)
 				return
 		else:

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -507,14 +507,14 @@ class UIAHandler(COMObject):
 					return
 			try:
 				if (
-						element.currentClassName in textChangeUIAClassNames
-						or element.CachedAutomationID in textChangeUIAAutomationIDs
+					element.currentClassName in textChangeUIAClassNames
+					or element.CachedAutomationID in textChangeUIAAutomationIDs
 				):
-						group = self.localEventHandlerGroupWithTextChanges
-						logPrefix = "Explicitly"
-				else :
-						group = self.localEventHandlerGroup
-						logPrefix = "Not"
+					group = self.localEventHandlerGroupWithTextChanges
+					logPrefix = "Explicitly"
+				else:
+					group = self.localEventHandlerGroup
+					logPrefix = "Not"
 
 				if _isDebug():
 					log.debugWarning(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -506,20 +506,19 @@ class UIAHandler(COMObject):
 				if not isStillFocus:
 					return
 			try:
-				group = (
-					self.localEventHandlerGroupWithTextChanges
-					if element.currentClassName in textChangeUIAClassNames
-					or element.CachedAutomationID in textChangeUIAAutomationIDs
-					else self.localEventHandlerGroup
-				)
+				if (
+						element.currentClassName in textChangeUIAClassNames
+						or element.CachedAutomationID in textChangeUIAAutomationIDs
+				):
+						group = self.localEventHandlerGroupWithTextChanges
+						logPrefix = "Explicitly"
+				else :
+						group = self.localEventHandlerGroup
+						logPrefix = "Not"
+
 				if _isDebug():
-					prefix = (
-						"Explicitly"
-						if group == self.localEventHandlerGroupWithTextChanges
-						else "Not"
-					)
 					log.debugWarning(
-						f"{prefix} registering for textChange events from UIA element "
+						f"{logPrefix} registering for textChange events from UIA element "
 						f"with class name {repr(element.currentClassName)} "
 						f"and automation ID {repr(element.CachedAutomationID)}"
 					)

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -99,9 +99,12 @@ UIADialogClassNames=[
 	"Shell_SystemDialog", # Various dialogs in Windows 10 Settings app
 ]
 
+textChangeUIAAutomationIDs = (
+	"Text Area",  # Windows Console Host
+)
+
 textChangeUIAClassNames = (
-	"_WwG",
-	"ConsoleWindowClass",
+	"_WwG",  # Microsoft Word
 	"TermControl",
 	"TermControl2"
 )
@@ -494,6 +497,7 @@ class UIAHandler(COMObject):
 				group = (
 					self.localEventHandlerGroupWithTextChanges
 					if element.currentClassName in textChangeUIAClassNames
+					or element.CachedAutomationID in textChangeUIAAutomationIDs
 					else self.localEventHandlerGroup
 				)
 				self.addEventHandlerGroup(element, group)
@@ -531,7 +535,10 @@ class UIAHandler(COMObject):
 				log.debug("HandleAutomationEvent: Ignored MenuOpenedEvent while focus event pending")
 			return
 		if eventID == UIA.UIA_Text_TextChangedEventId:
-			if sender.currentClassName in textChangeUIAClassNames:
+			if (
+				sender.currentClassName in textChangeUIAClassNames
+				or sender.CachedAutomationID in textChangeUIAAutomationIDs
+			):
 				NVDAEventName = "textChange"
 			else:
 				if _isDebug():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -46,6 +46,7 @@ What's New in NVDA
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
 - The [NVDA API Announcement mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about] was created. (#13999)
+- NVDA no longer processes ``textChange`` events for most UI Automation applications due to their extreme negative performance impact. (#11002, #14067)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Mitigation for #11002.
Blocking #14047.

### Summary of the issue:
UIA `textChange` NVDA events are seldom (if ever) used outside of a few specific situations, but have an extreme performance impact (see #11002).

### Description of user facing changes
Improved performance/less chance of NVDA hanging in UIA applications.

### Description of development approach
Explicitly do not process UIA `textChange` events outside of Windows Console, Terminal, and Word. The eventual end goal is to remove `TermControl`/`TermControl2` from `UIAHandler.textChangeUIAClassNames` in #14047, which will **very greatly** improve performance in Windows Terminal. (`conhost` will remain, as there don't seem to be any plans to add notifications, especially as `wt` is becoming the default).

I'm very reluctant to add a mechanism by which add-ons/app modules can request `textChange` events unless someone requests it, especially given #11002.

### Testing strategy:
* Tested in a self-signed build of NVDA over a few days.
* Tested that `conhost` and `wt` remain functional.
* Removed `TermControl` from `textChangeUIAClassNames` and verified that `textChange` events are not received.

### Known issues with pull request:
None known.

### Change log entries:
== Changes for Developers ==
- NVDA no longer processes `textChange` events for most UI Automation applications due to their extreme negative performance impact. (#11002, #14067)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
