### PR TITLE
Re-Introduce Table SayAll commands

### DIFF
--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -10,6 +10,7 @@ from baseObject import AutoPropertyObject, ScriptableObject
 import config
 import textInfos
 import controlTypes
+from speech import sayAll
 
 _TableID = Union[int, Tuple, Any]
 """
@@ -45,6 +46,18 @@ class _TableSelection:
 	trueRow: int
 	rowSpan: int
 	trueCol: int
+	colSpan: int
+
+
+@dataclass
+class _TableCell:
+	"""
+	Contains information about a cell in the table with matching tableID
+	"""
+	tableID: _TableID
+	row: int
+	col: int
+	rowSpan: int
 	colSpan: int
 
 
@@ -100,13 +113,14 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 						layoutIDs.add(tableID)
 		return layoutIDs
 
-	def _getTableCellCoords(self, info):
+	def _getTableCellCoords(
+			self,
+			info: textInfos.TextInfo,
+	) -> _TableCell:
 		"""
 		Fetches information about the deepest table cell at the given position.
 		@param info:  the position where the table cell should be looked for.
-		@type info: L{textInfos.TextInfo}
-		@returns: a tuple of table ID, row number, column number, row span, and column span.
-		@rtype: tuple
+		@returns: Information about requested cell.
 		@raises: LookupError if there is no table cell at this position.
 		"""
 		if info.isCollapsed:
@@ -126,13 +140,52 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 				break
 		else:
 			raise LookupError("Not in a table cell")
-		return (
+		return _TableCell(
 			attrs["table-id"],
 			attrs["table-rownumber"],
 			attrs["table-columnnumber"],
 			attrs.get("table-rowsspanned", 1),
 			attrs.get("table-columnsspanned", 1),
 		)
+
+	def _getTableCellCoordsCached(
+			self,
+			info: textInfos.TextInfo,
+			axis: Optional[_Axis] = None,
+	) -> _TableCell:
+		cell = self._getTableCellCoords(info)
+
+		# The following lines check whether user has been issuing table navigation commands repeatedly.
+		# In this case, instead of using current column/row index, we used cached value
+		# to allow users being able to skip merged cells without affecting the initial column/row index.
+		# For more info see issue #11919 and #7278.
+		if (
+			self._lastTableSelection
+			and cell.row == self._lastTableSelection.lastRow
+			and cell.col == self._lastTableSelection.lastCol
+			and self._lastTableSelection.axis == axis
+		):
+			if axis == _Axis.ROW:
+				newCol = self._lastTableSelection.trueCol
+				newColSpan = self._lastTableSelection.colSpan
+				return _TableCell(
+					cell.tableID,
+					cell.row,
+					newCol,
+					cell.rowSpan,
+					newColSpan,
+				)
+			else:
+				newRow = self._lastTableSelection.trueRow
+				newRowSpan = self._lastTableSelection.rowSpan
+				return _TableCell(
+					cell.tableID,
+					newRow,
+					cell.col,
+					newRowSpan,
+					cell.colSpan,
+				)
+		return cell
 
 	def _getTableDimensions(self, info: textInfos.TextInfo) -> Tuple[int, int]:
 		"""
@@ -188,12 +241,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 
 	def _getNearestTableCell(
 			self,
-			tableID: _TableID,
 			startPos: textInfos.TextInfo,
-			origRow: int,
-			origCol: int,
-			origRowSpan: int,
-			origColSpan: int,
+			cell: _TableCell,
 			movement: _Movement,
 			axis: _Axis,
 	) -> textInfos.TextInfo:
@@ -201,26 +250,22 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		Locates the nearest table cell relative to another table cell in a given direction, given its coordinates.
 		For example, this is used to move to the cell in the next column, previous row, etc.
 		This method will skip over missing table cells (where L{_getTableCellAt} raises LookupError), up to the number of times set by _missingTableCellSearchLimit set on this instance.
-		@param tableID: the ID of the table
 		@param startPos: the position in the document to start searching from.
-		@param origRow: the row number of the starting cell
-		@param origCol: the column number  of the starting cell
-		@param origRowSpan: the row span of the row of the starting cell
-		@param origColSpan: the column span of the column of the starting cell
+		@param cell: the cell information of start position.
 		@param movement: the direction ("next" or "previous")
 		@param axis: the axis of movement ("row" or "column")
 		@returns: the position of the nearest table cell
 		"""
+		tableID = cell.tableID
 		if not axis:
 			raise ValueError("Axis must be row or column")
 
 		# Determine destination row and column.
-		destRow = origRow
-		destCol = origCol
+		destRow, destCol = cell.row, cell.col
 		if axis == _Axis.ROW:
-			destRow += origRowSpan if movement == _Movement.NEXT else -1
+			destRow += cell.rowSpan if movement == _Movement.NEXT else -1
 		elif axis == _Axis.COLUMN:
-			destCol += origColSpan if movement == _Movement.NEXT else -1
+			destCol += cell.colSpan if movement == _Movement.NEXT else -1
 
 		# Try and fetch the cell at these coordinates, though  if a  cell is missing, try  several more times moving the coordinates on by one cell each time
 		limit=self._missingTableCellSearchLimit
@@ -241,12 +286,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 
 	def _getFirstOrLastTableCell(
 			self,
-			tableID: _TableID,
 			startPos: textInfos.TextInfo,
-			origRow: int,
-			origCol: int,
-			origRowSpan: int,
-			origColSpan: int,
+			cell: _TableCell,
 			movement: _Movement,
 			axis: _Axis
 	) -> textInfos.TextInfo:
@@ -258,17 +299,13 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		After figuring out exact coordinates of the cell it will try to jump directly to that cell,
 		or if that fails (due to missing table cell), it will walk in the opposite direction skipping missing cells
 		up to the number of times set by _missingTableCellSearchLimit set on this instance.
-		@param tableID: the ID of the table
 		@param startPos: the position in the document to start searching from.
-		@param origRow: the row number of the starting cell
-		@param origCol: the column number  of the starting cell
-		@param origRowSpan: the row span of the row of the starting cell
-		@param origColSpan: the column span of the column of the starting cell
+		@param cell: the cell information of start position.
 		@param movement: the direction ("first" or "last")
 		@param axis: the axis of movement ("row" or "column")
 		@returns: the position of the destination table cell
 		"""
-		destRow, destCol = origRow, origCol
+		destRow, destCol = cell.row, cell.col
 		if movement == _Movement.FIRST:
 			if axis == _Axis.COLUMN:
 				destCol = 1
@@ -281,19 +318,83 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			else:
 				destRow = nRows
 		try:
-			return self._getTableCellAt(tableID, startPos, destRow, destCol)
+			return self._getTableCellAt(cell.tableID, startPos, destRow, destCol)
 		except LookupError:
 			oppositeMovement = _Movement.PREVIOUS if movement == _Movement.LAST else _Movement.NEXT
 			return self._getNearestTableCell(
-				tableID,
 				startPos,
-				destRow,
-				destCol,
-				origRowSpan=1,
-				origColSpan=1,
+				_TableCell(
+					cell.TableID,
+					destRow,
+					destCol,
+					rowSpan=1,
+					colSpan=1,
+				),
 				movement=oppositeMovement,
-				axis=axis
+				axis=axis,
 			)
+
+	def _tableFindNewCell(
+			self,
+			movement: Optional[_Movement] = None,
+			axis: Optional[_Axis] = None,
+			selection: Optional[textInfos.TextInfo] = None,
+			raiseOnEdge: bool = False,
+	) -> Tuple[_TableCell, textInfos.TextInfo, Optional[_TableSelection]]:
+		# documentBase is a core module and should not depend on these UI modules and so they are imported
+		import ui
+		if not selection:
+			selection = self.selection
+		try:
+			cell = self._getTableCellCoordsCached(selection, axis)
+		except LookupError as e:
+			# Translators: The message reported when a user attempts to use a table movement command
+			# when the cursor is not within a table.
+			ui.message(_("Not in a table cell"))
+			raise e
+
+		try:
+			if movement in {_Movement.PREVIOUS, _Movement.NEXT}:
+				info = self._getNearestTableCell(
+					self.selection,
+					cell,
+					movement,
+					axis,
+				)
+			elif movement in {_Movement.FIRST, _Movement.LAST}:
+				info = self._getFirstOrLastTableCell(
+					self.selection,
+					cell,
+					movement,
+					axis
+				)
+			elif movement is None:
+				info = self._getTableCellAt(cell.tableID, self.selection, cell.row, cell.col)
+			else:
+				raise ValueError(f"Unknown movement {movement}")
+			newCell = self._getTableCellCoords(info)
+		except LookupError as e:
+			if raiseOnEdge:
+				raise e
+			# Translators: The message reported when a user attempts to use a table movement command
+			# but the cursor can't be moved in that direction because it is at the edge of the table.
+			ui.message(_("Edge of table"))
+			# Retrieve the cell on which we started.
+			try:
+				info = self._getTableCellAt(cell.tableID, self.selection, cell.row, cell.col)
+			except LookupError as e:
+				raise RuntimeError("Unable to find current cell.", e)
+			newCell = self._getTableCellCoords(info)
+		tableSelection = _TableSelection(
+			lastRow=newCell.row,
+			lastCol=newCell.col,
+			axis=axis,
+			trueRow=cell.row if axis == _Axis.COLUMN else newCell.row,
+			rowSpan=cell.rowSpan if axis == _Axis.COLUMN else newCell.rowSpan,
+			trueCol=cell.col if axis == _Axis.ROW else newCell.col,
+			colSpan=cell.colSpan if axis == _Axis.ROW else newCell.colSpan,
+		) if movement is not None else None
+		return newCell, info, tableSelection
 
 	def _tableMovementScriptHelper(
 			self,
@@ -304,83 +405,66 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		# at run-time. (#12404)
 		from scriptHandler import isScriptWaiting
 		from speech import speakTextInfo
-		import ui
 
 		if isScriptWaiting():
 			return
+
 		formatConfig = config.conf["documentFormatting"].copy()
 		formatConfig["reportTables"] = True
 		try:
-			tableID, origRow, origCol, origRowSpan, origColSpan = self._getTableCellCoords(self.selection)
+			_cell, info, tableSelection = self._tableFindNewCell(
+				movement,
+				axis,
+			)
 		except LookupError:
-			# Translators: The message reported when a user attempts to use a table movement command
-			# when the cursor is not within a table.
-			ui.message(_("Not in a table cell"))
+			# _tableFindNewCell already spoke proper error message
 			return
-
-		# The following lines check whether user has been issuing table navigation commands repeatedly.
-		# In this case, instead of using current column/row index, we used cached value
-		# to allow users being able to skip merged cells without affecting the initial column/row index.
-		# For more info see issue #11919 and #7278.
-		if (
-			self._lastTableSelection
-			and origRow == self._lastTableSelection.lastRow
-			and origCol == self._lastTableSelection.lastCol
-			and self._lastTableSelection.axis == axis
-		):
-			if axis == _Axis.ROW:
-				origCol = self._lastTableSelection.trueCol
-				origColSpan = self._lastTableSelection.colSpan
-			else:
-				origRow = self._lastTableSelection.trueRow
-				origRowSpan = self._lastTableSelection.rowSpan
-
-		try:
-			if movement in {_Movement.PREVIOUS, _Movement.NEXT}:
-				info = self._getNearestTableCell(
-					tableID,
-					self.selection,
-					origRow,
-					origCol,
-					origRowSpan,
-					origColSpan,
-					movement,
-					axis
-				)
-			elif movement in {_Movement.FIRST, _Movement.LAST}:
-				info = self._getFirstOrLastTableCell(
-					tableID,
-					self.selection,
-					origRow,
-					origCol,
-					origRowSpan,
-					origColSpan,
-					movement,
-					axis
-				)
-			else:
-				raise ValueError(f"Unknown movement {movement}")
-			newTableID, newRow, newCol, newRowSpan, newColSpan = self._getTableCellCoords(info)
-		except LookupError:
-			# Translators: The message reported when a user attempts to use a table movement command
-			# but the cursor can't be moved in that direction because it is at the edge of the table.
-			ui.message(_("Edge of table"))
-			# Retrieve the cell on which we started.
-			info = self._getTableCellAt(tableID, self.selection, origRow, origCol)
-			newTableID, newRow, newCol, newRowSpan, newColSpan = self._getTableCellCoords(info)
 
 		speakTextInfo(info, formatConfig=formatConfig, reason=controlTypes.OutputReason.CARET)
 		info.collapse()
 		self.selection = info
+		self._lastTableSelection = tableSelection
+
+	def _tableSayAll(
+			self,
+			movement: _Movement,
+			axis: _Axis,
+			updateCaret: bool = True,
+	) -> None:
+		try:
+			cell, info, _tableSelection = self._tableFindNewCell(
+				movement if movement == _Movement.FIRST else None,
+				axis,
+			)
+		except LookupError:
+			# _tableFindNewCell already spoke proper error message
+			return
+
+		def nextLineFunc(info: textInfos.TextInfo) -> textInfos.TextInfo:
+			try:
+				_cell, newInfo, tableSelection = self._tableFindNewCell(
+					_Movement.NEXT,
+					axis,
+					selection=info,
+					raiseOnEdge=True,
+				)
+				self._lastTableSelection = tableSelection
+				return newInfo
+			except LookupError as e:
+				raise StopIteration(e)
+		oldSelection = self._lastTableSelection
+		bothAxesColumn = oldSelection is not None and axis == _Axis.COLUMN and axis == oldSelection.axis
+		bothAxesRow = oldSelection is not None and axis == _Axis.ROW and axis == oldSelection.axis
 		self._lastTableSelection = _TableSelection(
-			lastRow=newRow,
-			lastCol=newCol,
+			lastRow=cell.row,
+			lastCol=cell.col,
 			axis=axis,
-			trueRow=origRow,
-			rowSpan=origRow,
-			trueCol=origCol,
-			colSpan=origColSpan,
+			trueRow=oldSelection .trueRow if bothAxesColumn else cell.row,
+			rowSpan=oldSelection .rowSpan if bothAxesColumn else cell.rowSpan,
+			trueCol=oldSelection.trueCol if bothAxesRow else cell.col,
+			colSpan=oldSelection .colSpan if bothAxesRow else cell.colSpan,
 		)
+		sayAll.SayAllHandler.readText(sayAll.CURSOR.TABLE, info, nextLineFunc, updateCaret)
 
 	def script_nextRow(self, gesture):
 		self._tableMovementScriptHelper(axis=_Axis.ROW, movement=_Movement.NEXT)
@@ -422,6 +506,36 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 	# Translators: the description for the last table column script on browseMode documents.
 	script_lastColumn.__doc__ = _("moves to the last table column")
 
+	def script_sayAllRow(self, gesture):
+		self._tableSayAll(_Movement.NEXT, _Axis.COLUMN)
+	script_sayAllRow.__doc__ = _(
+		# Translators: the description for the sayAll row command
+		"Reads the row horizontally from the current cell rightwards to the last cell in the row."
+	)
+
+	def script_sayAllColumn(self, gesture):
+		self._tableSayAll(_Movement.NEXT, _Axis.ROW)
+	script_sayAllColumn.__doc__ = _(
+		# Translators: the description for the sayAll row command
+		"Reads the column vertically from the current cell downwards to the last cell in the column."
+	)
+
+	def script_speakRow(self, gesture):
+		self._tableSayAll(_Movement.FIRST, _Axis.COLUMN, updateCaret=False)
+	script_speakRow.__doc__ = _(
+		# Translators: the description for the speak row command
+		"Reads the current row horizontally from left to right "
+		"without moving the system caret."
+	)
+
+	def script_speakColumn(self, gesture):
+		self._tableSayAll(_Movement.FIRST, _Axis.ROW, updateCaret=False)
+	script_speakColumn.__doc__ = _(
+		# Translators: the description for the speak column command
+		"Reads the current column vertically from top to bottom "
+		"without moving the system caret."
+	)
+
 	def script_toggleIncludeLayoutTables(self,gesture):
 		# documentBase is a core module and should not depend on UI, so it is imported at run-time. (#12404)
 		import ui
@@ -444,6 +558,10 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		"kb:control+alt+leftArrow": "previousColumn",
 		"kb:control+alt+pageUp": "firstRow",
 		"kb:control+alt+pageDown": "lastRow",
-		"kb:control+alt+Home": "firstColumn",
-		"kb:control+alt+End": "lastColumn",
+		"kb:control+alt+home": "firstColumn",
+		"kb:control+alt+end": "lastColumn",
+		"kb:NVDA+control+alt+rightArrow": "sayAllRow",
+		"kb:NVDA+control+alt+downArrow": "sayAllColumn",
+		"kb:NVDA+control+alt+leftArrow": "speakRow",
+		"kb:NVDA+control+alt+upArrow": "speakColumn",
 	}

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -38,6 +38,8 @@ import aria
 import treeInterceptorHandler
 import watchdog
 from abc import abstractmethod
+import documentBase
+
 
 VBufStorage_findDirection_forward=0
 VBufStorage_findDirection_back=1
@@ -640,15 +642,14 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	def _getNearestTableCell(
 			self,
-			tableID,
-			startPos,
-			origRow,
-			origCol,
-			origRowSpan,
-			origColSpan,
-			movement,
-			axis
-	):
+			startPos: textInfos.TextInfo,
+			cell: documentBase._TableCell,
+			movement: documentBase._Movement,
+			axis: documentBase._Axis,
+	) -> textInfos.TextInfo:
+		tableID, origRow, origCol, origRowSpan, origColSpan = (
+			cell.tableID, cell.row, cell.col, cell.rowSpan, cell.colSpan
+		)
 		# Determine destination row and column.
 		destRow = origRow
 		destCol = origCol

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -23,6 +23,7 @@ from comtypes import COMError
 import aria
 import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
+import documentBase
 
 
 def _getNormalizedCurrentAttrs(attrs: textInfos.ControlField) -> typing.Dict[str, typing.Any]:
@@ -548,26 +549,13 @@ class Gecko_ia2(VirtualBuffer):
 
 	def _getNearestTableCell(
 			self,
-			tableID,
-			startPos,
-			origRow,
-			origCol,
-			origRowSpan,
-			origColSpan,
-			movement,
-			axis,
-	):
+			startPos: textInfos.TextInfo,
+			cell: documentBase._TableCell,
+			movement: documentBase._Movement,
+			axis: documentBase._Axis,
+	) -> textInfos.TextInfo:
 		# Skip the VirtualBuffer implementation as the base BrowseMode implementation is good enough for us here.
-		return super(VirtualBuffer, self)._getNearestTableCell(
-			tableID,
-			startPos,
-			origRow,
-			origCol,
-			origRowSpan,
-			origColSpan,
-			movement,
-			axis
-		)
+		return super(VirtualBuffer, self)._getNearestTableCell(startPos, cell, movement, axis)
 
 	def _get_documentConstantIdentifier(self):
 		try:

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1853,6 +1853,197 @@ def test_tableNavigationWithMergedColumns():
 	_asserts.strings_match(actualSpeech, "row 1  column 2  b 1")
 
 
+def prepareChromeForTableSayAllTests():
+	_chrome.prepareChrome("""
+		<p>Hello, world!</p>
+		<table border=3>
+			<tr>
+				<td>A1</td>
+				<td>B1</td>
+				<td rowspan=2>C1+C2</td>
+				<td>D1</td>
+				<td>E1</td>
+			</tr>
+			<tr>
+				<td>A2</td>
+				<td>B2</td>
+				<td>D2</td>
+				<td>E2</td>
+			</tr>
+			<tr>
+				<td colspan=2>A3+B3</td>
+				<td>C3</td>
+				<td colspan=2>D3+E3</td>
+			</tr>
+			<tr>
+				<td>A4</td>
+				<td>B4</td>
+				<td colspan=2 rowspan=2>C4+D4+<br>C5+D5</td>
+				<td>E4</td>
+			</tr>
+			<tr>
+				<td>A5</td>
+				<td>B5</td>
+				<td>E5</td>
+			</tr>
+		</table>
+		<p>Bye-bye, world!</p>
+	""")
+
+	# Jump to table
+	actualSpeech = _chrome.getSpeechAfterKey("t")
+	_asserts.strings_match(actualSpeech, "table  with 5 rows and 5 columns  row 1  column 1  A 1")
+
+
+def tableSayAllJumpToB2():
+	_chrome.getSpeechAfterKey("control+alt+pageUp")
+	_chrome.getSpeechAfterKey("control+alt+home")
+	_chrome.getSpeechAfterKey("control+alt+rightArrow")
+	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
+	_asserts.strings_match(actualSpeech, "row 2  B 2")
+
+
+def test_tableSayAllCommands():
+	""" Tests that table sayAll commands work correctly.
+	Key bindings: NVDA+control+alt+downArrow/rightArrow
+	Refer to #13469.
+	"""
+	prepareChromeForTableSayAllTests()
+	tableSayAllJumpToB2()
+	# sayAll column
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"B 2",
+			"row 3  column 1  through 2  A 3 plus B 3",
+			"row 4  column 2  B 4",
+			"row 5  B 5",
+		]),
+	)
+
+	# Check that cursor has moved to B5
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "B 5")
+
+	tableSayAllJumpToB2()
+	# sayAll row
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"B 2",
+			"row 1  through 2  column 3  C 1 plus C 2",
+			"row 2  D 2",
+			"column 4  E 2",
+		]),
+	)
+
+	# Check that cursor has moved to E2
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "E 2")
+
+	# Jump to A3
+	_chrome.getSpeechAfterKey("control+alt+pageUp")
+	_chrome.getSpeechAfterKey("control+alt+home")
+	_chrome.getSpeechAfterKey("control+alt+downArrow")
+	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
+	_asserts.strings_match(actualSpeech, "row 3  column 1  through 2  A 3 plus B 3")
+
+	# sayAll row with cells merged horizontally
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+rightArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"A 3 plus B 3",
+			"column 3  C 3",
+			"column 4  through 5  D 3 plus E 3",
+		]),
+	)
+
+	# Check that cursor has moved to E3
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "D 3 plus E 3")
+
+
+def test_tableSpeakAllCommands():
+	""" Tests that table speak entire row/column commands work correctly.
+	Key bindings: NVDA+control+alt+upArrow/leftArrow
+	Refer to #13469.
+	"""
+	prepareChromeForTableSayAllTests()
+	tableSayAllJumpToB2()
+	# Speak current column
+	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey("NVDA+control+alt+upArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"row 1  B 1",
+			"row 2  B 2",
+			"row 3  column 1  through 2  A 3 plus B 3",
+			"row 4  column 2  B 4",
+			"row 5  B 5",
+		])
+	)
+	_asserts.braille_matches(
+		actualBraille,
+		"r2 c2 B2",
+		message="Speak entire column",
+	)
+
+	# Check that cursor still stays at B2
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "row 2  B 2")
+
+	# Speak current row
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+leftArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"column 1  A 2",
+			"column 2  B 2",
+			"row 1  through 2  column 3  C 1 plus C 2",
+			"row 2  D 2",
+			"column 4  E 2",
+		])
+	)
+
+	# Check that cursor stays at B2
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+upArrow")
+	_asserts.strings_match(actualSpeech, "column 2  B 2")
+
+
+def test_tableSayAllAxisCachingForMergedCells():
+	""" Tests that axis caching for merged cells in table sayAll commands works.
+	Refer to #13469.
+	"""
+	prepareChromeForTableSayAllTests()
+
+	# Jump to D5
+	_chrome.getSpeechAfterKey("control+alt+pageUp")
+	_chrome.getSpeechAfterKey("control+alt+end")
+	_chrome.getSpeechAfterKey("control+alt+leftArrow")
+	_chrome.getSpeechAfterKey("control+alt+downArrow")
+	_chrome.getSpeechAfterKey("control+alt+downArrow")
+	actualSpeech = _chrome.getSpeechAfterKey("control+alt+downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"row 4  column 3  through row 5 column 4  C 4 plus D 4 plus  C 5 plus D 5"
+	)
+
+	# Speak current column - should reuse cached column
+	actualSpeech = _chrome.getSpeechAfterKey("NVDA+control+alt+upArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"\n".join([
+			"row 1  column 4  D 1",
+			"row 2  column 3  D 2",
+			"row 3  column 4  through 5  D 3 plus E 3",
+			"row 4  column 3  through row 5 column 4  C 4 plus D 4 plus  C 5 plus D 5",
+		]),
+	)
+
+
 def test_focus_mode_on_focusable_read_only_lists():
 	"""
 	If a list is read-only, but is focusable, and a list element receives focus, switch to focus mode.

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -122,6 +122,15 @@ Focus reports target first
 Table navigation with merged columns
 	[Documentation]	When navigating through a merged cell, preserve the column/row position from the previous cell.
 	test_tableNavigationWithMergedColumns
+Table sayAll commands
+	[Documentation]	Table sayAll commands
+	test_tableSayAllCommands
+Table Speak All commands
+	[Documentation]	Table speak entire row/column commands
+	test_tableSpeakAllCommands
+Table sayAll axis caching for merged cells
+	[Documentation]	Tests that axis caching for merged cells in table sayAll commands works.
+	test_tableSayAllAxisCachingForMergedCells
 focus mode is turned on on focused read-only list item
 	[Documentation]	Focused list items with a focusable list container should cause focus mode to be turned on automatically.
 	test_focus_mode_on_focusable_read_only_lists

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,12 @@ What's New in NVDA
     - Laptop: ``NVDA+shift+pageDown``.
     -
   -
+- Added the following table commands. (#14070)
+  - Say all in column: ``NVDA+control+alt+downArrow``
+  - Say all in row: ``NVDA+control+alt+rightArrow``
+  - Read entire column: ``NVDA+control+alt+upArrow``
+  - Read entire row: ``NVDA+control+alt+leftArrow``
+  -
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -558,6 +558,10 @@ When within a table, the following key commands are also available:
 | Move to last column | control+alt+end | Moves the system caret to the last column (staying in the same row) |
 | Move to first row | control+alt+pageUp | Moves the system caret to the first row (staying in the same column) |
 | Move to last row | control+alt+pageDown | Moves the system caret to the last row (staying in the same column) |
+| Say all in column | ``NVDA+control+alt+downArrow`` | Reads the column vertically from the current cell downwards to the last cell in the column. |
+| Say all in row | ``NVDA+control+alt+rightArrow`` | Reads the row horizontally from the current cell rightwards to the last cell in the row. |
+| Read entire column | ``NVDA+control+alt+upArrow`` | Reads the current column vertically from top to bottom without moving the system caret. |
+| Read entire row | ``NVDA+control+alt+leftArrow`` | Reads the current row horizontally from left to right without moving the system caret. |
 %kc:endInclude
 
 ++ Object Navigation ++[ObjectNavigation]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13469.
Fixes #13927.

### Summary of the issue:
Previous PR #13956 broke sayAll functionality in BookWorm (#13927) and therefore was reverted.
This PR undoes reverting, in other words it reintroduces table sayAll commands. It also contains a minor change that fixes sayAll in BookWorm.

### Description of user facing changes
Reintroduces table sayAll commands.

### Description of development approach
In my original PR #13956 I did a minor refactoring of SayAll classes, in order to avoid code reduplication and have a nice class inheritance. In order to achieve this I slightly rearranged calls to textInfo. This didn't affect functionality anywhere except for page turn detector in BookWorm.
Reverting to the original order of TextInfo calls at the cost of slightly less elegant code.

### Testing strategy:
Tested manually with BookWorm and confirmed that pages turn successfully.
Tested on tables in browsers.
### Known issues with pull request:
No system testing was performed as `runsystemtests.bat` script appears to be broken. When trying to run command mentioned as example from https://github.com/nvaccess/nvda/tree/master/tests/system on clean master:
```
HH) runsystemtests --include chrome --test "starts" ...
Ensuring NVDA Python virtual environment
call py -m robot --argumentfile "H:\mltony\nvda\tests\system\robotArgs.robot" --include chrome --test "starts" ... "H:\m
ltony\nvda\tests\system\robot"
[ ERROR ] Suite 'Nvda & Robot' contains no tests matching tags 'fakeTagToEnforceUsageOfInclude' or 'chrome', not matchin
g tag 'excluded from build' and matching name 'starts'.

Try --help for usage information.
Deactivating NVDA Python virtual environment
```
### Change log entries:
New features
- Added the following table commands:
  - Say all in column: ``NVDA+control+alt+downArrow``
  - Say all in row: ``NVDA+control+alt+rightArrow``
  - Read entire column: ``NVDA+control+alt+upArrow``
  - Read entire row: ``NVDA+control+alt+leftArrow``
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.