### PR TITLE
Fixing exception during sayAll on desktop

### DIFF
--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -187,6 +187,7 @@ class _TextReader(garbageHandler.TrackedObject, metaclass=ABCMeta):
 	MAX_BUFFERED_LINES = 10
 
 	def __init__(self, handler: _SayAllHandler):
+		self.reader = None
 		self.handler = handler
 		self.trigger = SayAllProfileTrigger()
 		self.reader = self.getInitialTextInfo()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14090.
### Summary of the issue:
Getting rid of exception when trying to sayall on desktop.
### Description of user facing changes
n/a
### Description of development approach
Exception happens when trying to dispose of _TextReader object, that failed to initialize its textInfo.
Initializing textInfo (reader field) to None to avoid this.
### Testing strategy:
Tested manually as described in #14090.
Also tested manually that sayall still works in text documents and in HTML tables.
### Known issues with pull request:
n/a
### Change log entries:
n/a
