### PR TITLE
NVDAObjects.UIA: introduce UIA is grabbed property handler

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1589,6 +1589,7 @@ class UIA(Window):
 		UIAHandler.UIA_IsEnabledPropertyId,
 		UIAHandler.UIA_IsOffscreenPropertyId,
 		UIAHandler.UIA_AnnotationTypesPropertyId,
+		UIAHandler.UIA_DragIsGrabbedPropertyId,
 	}
 
 	def _get_states(self):
@@ -1667,6 +1668,13 @@ class UIA(Window):
 		if annotationTypes:
 			if UIAHandler.AnnotationType_Comment in annotationTypes:
 				states.add(controlTypes.State.HASCOMMENT)
+		# Drag "is grabbed" property was added in Windows 8.
+		try:
+			isGrabbed = self._getUIACacheablePropertyValue(UIAHandler.UIA_DragIsGrabbedPropertyId)
+		except COMError:
+			isGrabbed = False
+		if isGrabbed:
+			states.add(controlTypes.State.DRAGGING)
 		return states
 
 	def _getReadOnlyState(self) -> bool:

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -209,6 +209,7 @@ UIAEventIdsToNVDAEventNames: Dict[int, str] = {
 	UIA.UIA_Window_WindowOpenedEventId: "UIA_window_windowOpen",
 	UIA.UIA_SystemAlertEventId: "UIA_systemAlert",
 	UIA.UIA_LayoutInvalidatedEventId: "UIA_layoutInvalidated",
+	UIA.UIA_Drag_DragStartEventId: "stateChange",
 }
 
 localEventHandlerGroupUIAEventIds = set()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,6 +57,7 @@ Note there are still known issues with Chrome and Edge. (#13254)
   -
 - NVDA will announce UIA item status property changes in places such as the Visual Studio 2022 create app packages dialog. (#13973)
 - Orientation state (landscape/portrait) changes are now correctly ignored when there is no change (e.g. monitor changes). (#14035)
+- NVDA will announce dragging state when a UI Automation control is about to be dragged via mouse or keyboard, notably when rearranging tiles in Windows 10 start menu. (#14081)
 -
 
 


### PR DESCRIPTION
Hi,

First part of two-part pull request series to handle keyboard-based accessible drag and drop powered by UI Automation, ultimately deriving from #12271 work:

### Link to issue number:
Closes #14081 

### Summary of the issue:
NVDA does not recognize if a UIA element is about to be dragged when using keyboards.

### Description of user facing changes
When a UIA element such as Windows 10 Start menu tile is about to be dragged and rearranged, NVDA will say "dragging" to indicate the dragging state.

### Description of development approach
Add UIA "IsGrabbed" property to list of states to be handled by UIA objects, and map drag start UIA event to state change event.

### Testing strategy:
Manual and add-on based testing:

Prerequisites: a Windows 10 system.

1. Add UIA is grabbed property to states to be handled by UIA NVDA objects.
2. Create a binary build of NVDA locally, preferably on a Windows 10 system.
3. Run the just created binary copy of NVDA on a Windows 10 computer.
4. Open Start menu, press Shift+Tab to move to tiles.
5. Select any tile, then press Alt+Shift+arrow keys to rearrange them.

Before the PR: NVDA does not announce anything.
After the PR: NVDA says "dragging".

### Known issues with pull request:
This does not address another drag and drop events set, namely drop target enter/leave/dropped events, nor announces drag drop effect (a separate property must be handled). A follow-up pull request, designed to address these known issues in one go, is on its way. A resolution to the issues described is part of latest development builds of Windows App Essentials add-on.

### Change log entries:
Bug fixes (or can go under new features):

NVDA will announce dragging state when a UI Automation control is about to be dragged via mouse or keyboard, notably when rearranging tiles in Windows 10 start menu. (#14081)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
