### PR TITLE
Fix API breakage of SecureDesktopNVDAObject

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, Łukasz Golonka, Leonard de Ruijter
+# Copyright (C) 2006-2022 NV Access Limited, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -797,6 +797,7 @@ def processDesktopSwitchWinEvent(window, objectID, childID):
 		)
 	hDesk = windll.user32.OpenInputDesktop(0, False, 0)
 	if hDesk != 0:
+		api.setDesktopObject(NVDAObjects.window.Desktop(windowHandle=hDesk))
 		windll.user32.CloseDesktop(hDesk)
 		core.callLater(200, _correctFocus)
 	else:
@@ -805,6 +806,7 @@ def processDesktopSwitchWinEvent(window, objectID, childID):
 		# so clear our recorded modifiers.
 		keyboardHandler.currentModifiers.clear()
 		obj = SecureDesktopNVDAObject(windowHandle=window)
+		api.setDesktopObject(obj)
 		eventHandler.executeEvent("gainFocus", obj)
 
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -330,11 +330,10 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		return obj
 
 	@staticmethod
-	def objectInForeground():
+	def objectInForeground() -> typing.Optional["NVDAObject"]:
 		"""Retrieves the object representing the current foreground control according to the
 		Operating System. This may differ from NVDA's cached foreground object.
 		@return: the foreground object
-		@rtype: L{NVDAObject}
 		"""
 		kwargs={}
 		APIClass=NVDAObject.findBestAPIClass(kwargs,relation="foreground")

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -329,7 +329,7 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 
 	if globalVars.focusDifferenceLevel<=1:
 		newForeground=api.getDesktopObject().objectInForeground()
-		if not newForeground:
+		if not newForeground or _isSecureObjectWhileLockScreenActivated(newForeground):
 			log.debugWarning("Can not get real foreground, resorting to focus ancestors")
 			ancestors=api.getFocusAncestors()
 			if len(ancestors)>1:

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -105,6 +105,7 @@ def isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 	but other Windows can be focused (e.g. Windows Magnifier).
 	"""
 	import appModuleHandler
+	from IAccessibleHandler import SecureDesktopNVDAObject
 	from NVDAObjects.IAccessible import TaskListIcon
 
 	foregroundWindow = winUser.getForegroundWindow()
@@ -118,6 +119,10 @@ def isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 		# The task switcher window does not become the foreground process on the lock screen,
 		# so we must whitelist it explicitly.
 		isinstance(obj, TaskListIcon)
+		# Secure Desktop Object.
+		# Used to indicate to the user and to API consumers (including NVDA remote),
+		# that the user has switched to a secure desktop.
+		or isinstance(obj, SecureDesktopNVDAObject)
 	):
 		return True
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,14 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.2.3 =
+This is a patch release to fix an accidental API breakage introduced in 2022.2.1.
+
+== Bug Fixes ==
+- Fixed a bug where NVDA did not announce "Secure Desktop" when entering a secure desktop.
+This caused NVDA remote to not recognize secure desktops. (#14094)
+-
+
 = 2022.2.2 =
 This is a patch release to fix a bug introduced in 2022.2.1 with input gestures.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14094

### Summary of the issue:
`SecureDesktopNVDAObject` needs to be whitelisted on the lock screen.
This is an NVDA Object used to notify the user and API consumers that NVDA has entered a secure desktop.
In a separate issue, we should investigate if other approaches should be recommended for API consumers (eg session tracking, secure mode check).

### Description of user facing changes
Fixes NVDA remote bug described in #14094.
"Secure Desktop" is now consistently announced again when entering a secure desktop.

### Description of development approach
Add `SecureDesktopNVDAObject` to the whitelist of available objects on the lock screen.
Changes the desktop to  `SecureDesktopNVDAObject` when the desktop switches.
Ensures that when setting the foreground object via `doPreGainFocus` that the focused object is above the lockscreen.

An alternative (and possibly safer) development approach.
To avoid setting the desktop object, an alternative is to check the returned handle of `windll.user32.OpenInputDesktop(0, False, 0)` and whitelist `Desktop` objects as if they were `SecureDesktopNVDAObject` if the returned handle is a secure desktop.

### Testing strategy:
**Manual testing**
- [x] Test that "Secure Desktop" is announced again when going to the lock screen
- [x] Test NVDA Remote steps to reproduce found in #14094

### Known issues with pull request:
None

### Change log entries:
Refer to PR diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
