### PR TITLE
NVDAObjects.UIA: announce drag and drop target effects

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2082,6 +2082,7 @@ class UIA(Window):
 				if dropTargetEffect:
 					break
 		if dropTargetEffect:
+			speech.cancelSpeech()
 			ui.message(dropTargetEffect)
 
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2073,6 +2073,8 @@ class UIA(Window):
 		# Sometimes drop target effect text is empty as it comes from a different object.
 		if not dropTargetEffect:
 			for element in reversed(api.getFocusAncestors()):
+				if not isinstance(element, NVDAObjects.UIA.UIA):
+					continue
 				try:
 					dropTargetEffect = element._getUIACacheablePropertyValue(
 						UIAHandler.UIA_DropTargetDropTargetEffectPropertyId

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2079,7 +2079,7 @@ class UIA(Window):
 					dropTargetEffect = element._getUIACacheablePropertyValue(
 						UIAHandler.UIA_DropTargetDropTargetEffectPropertyId
 					)
-				except (COMError, AttributeError):
+				except COMError:
 					dropTargetEffect = ""
 				if dropTargetEffect:
 					break

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2082,7 +2082,6 @@ class UIA(Window):
 				if dropTargetEffect:
 					break
 		if dropTargetEffect:
-			speech.cancelSpeech()
 			ui.message(dropTargetEffect)
 
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2054,6 +2054,28 @@ class UIA(Window):
 		except COMError:
 			pass
 
+	def event_UIA_dropTargetEffect(self):
+		# UIA drop target effect property was introduced in Windows 8.
+		try:
+			dropTargetEffect = self._getUIACacheablePropertyValue(
+				UIAHandler.UIA_DropTargetDropTargetEffectPropertyId
+			)
+		except COMError:
+			dropTargetEffect = ""
+		# Sometimes drop target effect text is empty as it comes from a different object.
+		if not dropTargetEffect:
+			for element in reversed(api.getFocusAncestors()):
+				try:
+					dropTargetEffect = element._getUIACacheablePropertyValue(
+						UIAHandler.UIA_DropTargetDropTargetEffectPropertyId
+					)
+				except (COMError, AttributeError):
+					dropTargetEffect = ""
+				if dropTargetEffect:
+					break
+		if dropTargetEffect:
+			ui.message(dropTargetEffect)
+
 
 class TreeviewItem(UIA):
 

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2073,7 +2073,7 @@ class UIA(Window):
 		# Sometimes drop target effect text is empty as it comes from a different object.
 		if not dropTargetEffect:
 			for element in reversed(api.getFocusAncestors()):
-				if not isinstance(element, NVDAObjects.UIA.UIA):
+				if not isinstance(element, UIA):
 					continue
 				try:
 					dropTargetEffect = element._getUIACacheablePropertyValue(

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2047,6 +2047,13 @@ class UIA(Window):
 			ui.message(f"{self.name} {itemStatus}")
 		self._itemStatusCache = itemStatus
 
+	def event_UIA_dragDropEffect(self):
+		# UIA drag drop effect was introduced in Windows 8.
+		try:
+			ui.message(self._getUIACacheablePropertyValue(UIAHandler.UIA_DragDropEffectPropertyId))
+		except COMError:
+			pass
+
 
 class TreeviewItem(UIA):
 

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -184,7 +184,7 @@ UIAPropertyIdsToNVDAEventNames={
 
 globalEventHandlerGroupUIAPropertyIds = {
 	UIA.UIA_RangeValueValuePropertyId,
-	UIA.UIA_DropTargetDropTargetEffectPropertyId
+	UIA.UIA_DropTargetDropTargetEffectPropertyId,
 }
 
 localEventHandlerGroupUIAPropertyIds = (

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -179,6 +179,7 @@ UIAPropertyIdsToNVDAEventNames={
 	UIA_ControllerForPropertyId:"UIA_controllerFor",
 	UIA_ItemStatusPropertyId:"UIA_itemStatus",
 	UIA_DragDropEffectPropertyId: "UIA_dragDropEffect",
+	UIA_DropTargetDropTargetEffectPropertyId: "UIA_dropTargetEffect",
 }
 
 globalEventHandlerGroupUIAPropertyIds = {

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -178,6 +178,7 @@ UIAPropertyIdsToNVDAEventNames={
 	UIA_RangeValueValuePropertyId:"valueChange",
 	UIA_ControllerForPropertyId:"UIA_controllerFor",
 	UIA_ItemStatusPropertyId:"UIA_itemStatus",
+	UIA_DragDropEffectPropertyId: "UIA_dragDropEffect",
 }
 
 globalEventHandlerGroupUIAPropertyIds = {

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -169,22 +169,22 @@ UIALiveSettingtoNVDAAriaLivePoliteness: Dict[str, aria.AriaLivePoliteness] = {
 }
 
 UIAPropertyIdsToNVDAEventNames={
-	UIA_NamePropertyId:"nameChange",
-	UIA_HelpTextPropertyId:"descriptionChange",
-	UIA_ExpandCollapseExpandCollapseStatePropertyId:"stateChange",
-	UIA_ToggleToggleStatePropertyId:"stateChange",
-	UIA_IsEnabledPropertyId:"stateChange",
-	UIA_ValueValuePropertyId:"valueChange",
-	UIA_RangeValueValuePropertyId:"valueChange",
-	UIA_ControllerForPropertyId:"UIA_controllerFor",
-	UIA_ItemStatusPropertyId:"UIA_itemStatus",
-	UIA_DragDropEffectPropertyId: "UIA_dragDropEffect",
-	UIA_DropTargetDropTargetEffectPropertyId: "UIA_dropTargetEffect",
+	UIA.UIA_NamePropertyId: "nameChange",
+	UIA.UIA_HelpTextPropertyId: "descriptionChange",
+	UIA.UIA_ExpandCollapseExpandCollapseStatePropertyId: "stateChange",
+	UIA.UIA_ToggleToggleStatePropertyId: "stateChange",
+	UIA.UIA_IsEnabledPropertyId: "stateChange",
+	UIA.UIA_ValueValuePropertyId: "valueChange",
+	UIA.UIA_RangeValueValuePropertyId: "valueChange",
+	UIA.UIA_ControllerForPropertyId: "UIA_controllerFor",
+	UIA.UIA_ItemStatusPropertyId: "UIA_itemStatus",
+	UIA.UIA_DragDropEffectPropertyId: "UIA_dragDropEffect",
+	UIA.UIA_DropTargetDropTargetEffectPropertyId: "UIA_dropTargetEffect",
 }
 
 globalEventHandlerGroupUIAPropertyIds = {
 	UIA.UIA_RangeValueValuePropertyId,
-	UIA_DropTargetDropTargetEffectPropertyId
+	UIA.UIA_DropTargetDropTargetEffectPropertyId
 }
 
 localEventHandlerGroupUIAPropertyIds = (

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -183,7 +183,8 @@ UIAPropertyIdsToNVDAEventNames={
 }
 
 globalEventHandlerGroupUIAPropertyIds = {
-	UIA.UIA_RangeValueValuePropertyId
+	UIA.UIA_RangeValueValuePropertyId,
+	UIA_DropTargetDropTargetEffectPropertyId
 }
 
 localEventHandlerGroupUIAPropertyIds = (

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,7 +57,7 @@ Note there are still known issues with Chrome and Edge. (#13254)
   -
 - NVDA will announce UIA item status property changes in places such as the Visual Studio 2022 create app packages dialog. (#13973)
 - Orientation state (landscape/portrait) changes are now correctly ignored when there is no change (e.g. monitor changes). (#14035)
-- NVDA will announce dragging state when a UI Automation control is about to be dragged via mouse or keyboard, notably when rearranging tiles in Windows 10 start menu. (#14081)
+- NVDA will announce dragging items on screen in places such as rearranging Windows 10 Start menu tiles and virtual desktops in Windows 11. (#12271, #14081)
 -
 
 


### PR DESCRIPTION
Hi,

This is more of a second attempt at #12271 

### Link to issue number:
Fixes #12271 
Follow-up and a different approach to #12428 

### Summary of the issue:
When drag and drop target events happen, NVDA does not announce their effects such as screen content changes such as effect of rearranging Start menu tiles.

### Description of user facing changes
NVDA will announce effects of drag and drop events in places such as:

* Windows 10 Start menu: after moving tiles
* Windows 10 Action center/Windows 11 quick setings: afterreordering settings items
* Windows 11 task view: rearranging virtual desktops
* Windows 11 Start menu: rearranging pinned items, and from Version 22H2 onwards, creating app folders

### Description of development approach
While this PR may look similar to #12428, the internals are different:

* In UIA handler, added property events for drag drop and drop target effects.
* In UIA objects, add property events for drag drop and drop target effects and announce effect text.
* For drop target effect, because drop target event may come from somewhere other than the object that "raises" it, traverse focus ancestors looking for UIA elements with drop target effect text set.
* Back in UIA handler, because drop target effect event can come from somewhere other than the focused element or its parent, treat it as a global event.

### Testing strategy:
Manual and add-on based testing:

Testing drag drop effect (prerequisite: Windows 10):

1. After building this PR from source, open Windows 10 Start menu.
2. Press Shift+Tab to go to tiles.
3. Press Alt+Shift+arrow keys to arrange tiles.
Before the PR: NVDA says nothing about drag drop effect.
After the PR: NVDA will announce the new position of the dragged tile.

Testing drop target effect (for best results, use Windows 11):

1. After building the PR from source, open multiple virtual desktops (Control+Windows+D).
2. Move to a virtual desktop (say, Desktop 1).
3. Open task view (Windows+Ta), then move to desktops list.
4. Press Alt+Shift+left/right arrows to reoder virtual desktops.

Before the PR: NVDA does not say anything about virtual desktop position.
After the PR: NVDA announces effect of reordering virtual desktop such as new item position.

### Known issues with pull request:
This PR takes care of drag and drop target effect texts announcement, but does not include additional work for handling drag start/cancel/complete and drop target enter/leave/dropped events themselves (at least drag start event and the resulting dragging state change is handled by #14097). Should the need arise to handle actual drag and drop target events set, foundation is there to support them.

### Change log entries:
Similar to #14097 but could be expanded to say (new features or bug fixes):

NVDA will announce effects of dragging items on screen in places such as rearranging Windows 10 Start menu tiles and virtual desktops in Windows 11. (#12271)


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
