### PR TITLE
Count \t as a character in speech.isBlank.

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -119,7 +119,7 @@ CHUNK_SEPARATOR = "  "
 
 
 #: If a chunk of text contains only these characters, it will be considered blank.
-BLANK_CHUNK_CHARS = frozenset((" ", "\n", "\r", "\0", u"\xa0"))
+BLANK_CHUNK_CHARS = frozenset((" ", "\n", "\r", "\0", u"\xa0", "\t"))
 def isBlank(text):
 	"""Determine whether text should be reported as blank.
 	@param text: The text in question.


### PR DESCRIPTION
### Link to issue number:

Alternative to #13483 
Fixes #13431
related to mltony/nvda-indent-nav#6

### Summary of the issue:

speech.isBlank() wasn't counting tab as a blank character. This lead to two issues:

1. A tab not being reported as a blank line unless indentation reporting was on.
2. The issue outlined in mltony/nvda-indent-nav#6 (i.e. indent nav would see lines containing tabs only as not being blank).

### Description of user facing changes

If a line contains only tabs, it will now be reported as blank.

### Description of development approach

added "\t" to speech.BLANK_CHUNK_CHARS

### Testing strategy:

Turned off indentation reporting, and attempted to read a line containing only a tab.

### Known issues with pull request:

None

### Change log entries:
Changes

* NVDA will now see lines containing only tabs as being blank.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
