### PR TITLE
UIA handler: add and map drag cancel and complete events to state change event

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -210,6 +210,8 @@ UIAEventIdsToNVDAEventNames: Dict[int, str] = {
 	UIA.UIA_SystemAlertEventId: "UIA_systemAlert",
 	UIA.UIA_LayoutInvalidatedEventId: "UIA_layoutInvalidated",
 	UIA.UIA_Drag_DragStartEventId: "stateChange",
+	UIA.UIA_Drag_DragCancelEventId: "stateChange",
+	UIA.UIA_Drag_DragCompleteEventId: "stateChange",
 }
 
 localEventHandlerGroupUIAEventIds = set()


### PR DESCRIPTION
### Link to issue number:
Additional fix for #14081 
Follow-up to #14097 

### Summary of the issue:
NVDA is not announcing "dragging' when the item being dragged is let go and dragged again.

### Description of user facing changes
When the item is grabbed a second tie, NVDA will announce 'dragging'.

### Description of development approach
Add and map UIA drag cancel and complete events to state changes. This allows UIA object states cache to reflect the fact that "is grabbed" property is False, allowing NVDA to announce "dragging" when the item is grabbed again. At the moment NVDA will not say "done dragging" when drag complete event fires - that might be something to investigate in the future (remapping drag cancel/commplete events or doing soething with state change event/speech output).

### Testing strategy:
Manual and add-on based testing:

1. While the build for the pull request is running, rearranging Windows 10 Start menu tiles or Windows 11 taskbar icons.
2. Select an item and reposition it (drag and drop part 1).
3. Let go of the item.
4. Reposition the same item again (drag and drop step 2).
Before the PR: NVDA does not say "dragging" when the same item is dragged a second time.
After the PR: NVDA says "dragging" when drag and drop happens a second time.
In the future (perhaps by someone else): NVDA says "done dragging" when UIA drag complete event fires, hopefully with improved object states announcement logic unless event remapping is desirable.

### Known issues with pull request:
None

### Change log entries:
None needed as this is a follow-up fix for #14081.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
