### PR TITLE
Ignore foreground event for SecureDesktopNVDAObject

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -772,6 +772,14 @@ def processFocusNVDAEvent(obj, force=False):
 
 
 class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
+	"""
+	Used to indicate to the user and to API consumers (including NVDA remote),
+	that the user has switched to a secure desktop.
+	This is triggered when Windows notification EVENT_SYSTEM_DESKTOPSWITCH
+	notifies that the desktop has changed, and is handled via a gainFocus event.
+	The gainFocus event causes NVDA to enter sleep mode as the secure mode
+	NVDA instance starts on the secure screen.
+	"""
 
 	def findOverlayClasses(self, clsList):
 		clsList.append(SecureDesktopNVDAObject)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -48,6 +48,7 @@ import eventHandler
 import keyboardHandler
 from logHandler import log
 import mouseHandler
+from NVDAObjects import NVDAObject
 import NVDAObjects.IAccessible
 import NVDAObjects.window
 import winUser
@@ -771,7 +772,7 @@ def processFocusNVDAEvent(obj, force=False):
 	return True
 
 
-class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
+class SecureDesktopNVDAObject(NVDAObject):
 	"""
 	Used to indicate to the user and to API consumers (including NVDA remote),
 	that the user has switched to a secure desktop.
@@ -779,7 +780,23 @@ class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
 	notifies that the desktop has changed, and is handled via a gainFocus event.
 	The gainFocus event causes NVDA to enter sleep mode as the secure mode
 	NVDA instance starts on the secure screen.
+
+	This object is not backed by a valid MSAA object as the Secure Desktop
+	object should not be accessed via NVDA.
+	The minimal functionality has been added to support backwards compatibility.
 	"""
+
+	def __init__(self, windowHandle: int):
+		"""
+		@param windowHandle: to retain backwards compatibility,
+		unused as this object is not backed by a valid MSAA object.
+		This object just serves as a minimal API endpoint.
+		"""
+		self._windowHandle = windowHandle
+		super().__init__()
+
+	def _get_processID(self) -> int:
+		return 0
 
 	def findOverlayClasses(self, clsList):
 		clsList.append(SecureDesktopNVDAObject)

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -304,6 +304,8 @@ def executeEvent(
 
 
 def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bool:
+	from IAccessibleHandler import SecureDesktopNVDAObject
+
 	if _isSecureObjectWhileLockScreenActivated(
 		obj,
 		shouldLog=config.conf["debugLog"]["events"],
@@ -327,7 +329,16 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 		# - api.getFocusAncestors() via api.setFocusObject() called in doPreGainFocus
 		speech._manager.removeCancelledSpeechCommands()
 
-	if globalVars.focusDifferenceLevel<=1:
+	if (
+		globalVars.focusDifferenceLevel <= 1
+		# This object should not set off a foreground event.
+		# SecureDesktopNVDAObject uses a gainFocus event to trigger NVDA
+		# to sleep as the secure instance of NVDA starts for the
+		# secure desktop.
+		# The newForeground object fetches from the User Desktop,
+		# not the secure desktop.
+		and not isinstance(obj, SecureDesktopNVDAObject)
+	):
 		newForeground=api.getDesktopObject().objectInForeground()
 		if not newForeground:
 			log.debugWarning("Can not get real foreground, resorting to focus ancestors")

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -105,6 +105,7 @@ def isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 	but other Windows can be focused (e.g. Windows Magnifier).
 	"""
 	import appModuleHandler
+	from IAccessibleHandler import SecureDesktopNVDAObject
 	from NVDAObjects.IAccessible import TaskListIcon
 
 	foregroundWindow = winUser.getForegroundWindow()
@@ -118,6 +119,10 @@ def isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 		# The task switcher window does not become the foreground process on the lock screen,
 		# so we must whitelist it explicitly.
 		isinstance(obj, TaskListIcon)
+		# Secure Desktop Object.
+		# Used to indicate to the user and to API consumers (including NVDA remote) via gainFocus,
+		# that the user has switched to a secure desktop.
+		or isinstance(obj, SecureDesktopNVDAObject)
 	):
 		return True
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,14 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.2.3 =
+This is a patch release to fix an accidental API breakage introduced in 2022.2.1.
+
+== Bug Fixes ==
+- Fixed a bug where NVDA did not announce "Secure Desktop" when entering a secure desktop.
+This caused NVDA remote to not recognize secure desktops. (#14094)
+-
+
 = 2022.2.2 =
 This is a patch release to fix a bug introduced in 2022.2.1 with input gestures.
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,14 @@ This is a patch release to fix an accidental API breakage introduced in 2022.2.1
 This caused NVDA remote to not recognize secure desktops. (#14094)
 -
 
+== Changes for Developers ==
+This release contains a technical breakage in API backwards compatibility.
+It is expected that this change does not affect any add-ons.
+Please open a GitHub issue if your add-on becomes incompatible as a result of this release.
+
+- ``SecureDesktopNVDAObject`` is no longer a subclass of ``Desktop`` or ``Window``. (#14105)
+-
+
 = 2022.2.2 =
 This is a patch release to fix a bug introduced in 2022.2.1 with input gestures.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Supersedes #14098 
Fixes #14094

### Summary of the issue:
`SecureDesktopNVDAObject` needs to be whitelisted on the lock screen.
This is an `NVDAObject` used to notify the user and API consumers that NVDA has entered a secure desktop.

### Description of user facing changes
Fixes NVDA remote bug described in #14094.
"Secure Desktop" is now consistently announced again when entering a secure desktop.

### Description of development approach
Add `SecureDesktopNVDAObject` to the whitelist of available objects on the lock screen.
Ensures that when setting the foreground event does not occur via `doPreGainFocus`  for `SecureDesktopNVDAObject`.
This is because the foreground event cannot be handled in a secure manner, and is not required for the `SecureDesktopNVDAObject` API.

### Testing strategy:
**Manual testing**
- [x] Test that "Secure Desktop" is announced again when going to the lock screen
- [x] Test NVDA Remote steps to reproduce found in #14094

### Known issues with pull request:
**Important note: This change technically results in an add-on API change**
`SecureDesktopNVDAObject` is no longer a subclass of `Desktop` or `Window`

It is unexpected that `SecureDesktopNVDAObject` is used as a general `NVDAObject`:
- NVDA is in sleep mode after the internal gain focus event for the `SecureDesktopNVDAObject`.
- The only known use-case was as a notification of a desktop change (to a secure desktop). If this assumptions holds, other information on the object is not required.

Allowing this object to use `Desktop` or `Window` as a base class creates another vector for information leaks or privilege escalation. 

Future plans:
Cater to the notification use-case via an extension point rather than the internal gain gocus event.

### Change log entries:
Refer to PR diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
