### PR TITLE
Update liblouis to 3.23.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit 735ecdb8
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
-* [liblouis](http://www.liblouis.org/), version 3.22.0
+* [liblouis](http://www.liblouis.org/), version 3.23.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 41.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -86,6 +86,7 @@ RENAMED_TABLES = {
 	"no-no-comp8.ctb": "no-no-8dot.utb",
 	"ru-compbrl.ctb": "ru.ctb",
 	"ru-ru-g1.utb": "ru-litbrl-detailed.utb",
+	"Se-Se-g1.utb": "sv-g0.utb",
 	"sk-sk-g1.utb": "sk-g1.ctb",
 	"UEBC-g1.ctb": "en-ueb-g1.ctb",
 	"UEBC-g2.ctb": "en-ueb-g2.ctb",
@@ -341,6 +342,9 @@ addTable("ko-g2.ctb", _("Korean grade 2"), contracted=True)
 addTable("ks-in-g1.utb", _("Kashmiri grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("lg-ug-g1.utb", _("Luganda literary braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("lt.ctb", _("Lithuanian 8 dot"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -440,6 +444,9 @@ addTable("ru-litbrl-detailed.utb", _("Russian literary braille (detailed)"))
 addTable("ru-ru-g1.ctb", _("Russian contracted braille"), contracted=True, input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("rw-rw-g1.utb", _("Kinyarwanda literary braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("sa-in-g1.utb", _("Sanskrit grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -447,9 +454,6 @@ addTable("sah.utb", _("Yakut grade 1"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("Se-Se.ctb", _("Swedish 8 dot computer braille"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
-addTable("Se-Se-g1.utb", _("Swedish grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sk-g1.ctb", _("Slovak grade 1"))
@@ -468,6 +472,17 @@ addTable("sot-za-g2.ctb", _("Sesotho grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sr-g1.ctb", _("Serbian grade 1"))
+
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sv-g0.utb", _("Swedish uncontracted braille"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sv-g1.ctb", _("Swedish partially contracted braille"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sv-g2.ctb", _("Swedish contracted braille"), contracted=True, input=False)
+
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ta-ta-g1.ctb", _("Tamil grade 1"))
@@ -542,6 +557,10 @@ addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zh-tw.ctb", _("Chinese (Taiwan, Mandarin)"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("zhcn-cbs.ctb", _("Chinese common braille (simplified Chinese characters)"), input=False)
+
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zu-za-g1.utb", _("Zulu grade 1"))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -34,6 +34,15 @@ What's New in NVDA
 - eSpeak NG has been updated to 1.52-dev commit ``735ecdb8``. (#14060, #14079, #14117)
   - Fixed reporting of Latin characters when using Mandarin. (#12952, #13572)
   -
+- Updated LibLouis braille translator to [3.23.0 https://github.com/liblouis/liblouis/releases/tag/v3.23.0]. (#14112)
+  - Added braille tables:
+    - Chinese common braille (simplified Chinese characters)
+    - Kinyarwanda literary braille
+    - Luganda literary braille
+    - Swedish uncontracted braille
+    - Swedish partially contracted braille
+    - Swedish contracted braille
+    -
 - NVDA now includes the architecture of the operating system as part of user statistics tracking. (#14019)
 - Reporting power state changes and using the script to report battery status now report the same message consistently. (#14035)
 -


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Liblouis 3.23.0 has been released.

### Description of user facing changes
Updates liblouis to 3.23.0 which adds new braille tables. [Changelog](https://github.com/liblouis/liblouis/releases/tag/v3.23.0).

### Description of development approach
Update liblouis submodule, add new builtin tables and map an old table name to new table.

### Testing strategy:
Ran from sources and loaded new braille tables. LGTM.

### Known issues with pull request:
None

### Change log entries:
Section: Changes

```
- Updated liblouis braille translator to [3.23.0 https://github.com/liblouis/liblouis/releases/tag/v3.23.0]. (#14112)
  - New braille table: Chinese common braille (simplified Chinese characters), Kinyarwanda literary braille, Luganda literary braille, Swedish uncontracted braille, Swedish partially contracted braille, Swedish contracted braille
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
