### PR TITLE
Restore backwards compatibility of SecureDesktopNVDAObject

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -48,7 +48,6 @@ import eventHandler
 import keyboardHandler
 from logHandler import log
 import mouseHandler
-from NVDAObjects import NVDAObject
 import NVDAObjects.IAccessible
 import NVDAObjects.window
 import winUser
@@ -772,7 +771,7 @@ def processFocusNVDAEvent(obj, force=False):
 	return True
 
 
-class SecureDesktopNVDAObject(NVDAObject):
+class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
 	"""
 	Used to indicate to the user and to API consumers (including NVDA remote),
 	that the user has switched to a secure desktop.
@@ -781,22 +780,11 @@ class SecureDesktopNVDAObject(NVDAObject):
 	The gainFocus event causes NVDA to enter sleep mode as the secure mode
 	NVDA instance starts on the secure screen.
 
-	This object is not backed by a valid MSAA object as the Secure Desktop
-	object should not be accessed via NVDA.
-	The minimal functionality has been added to support backwards compatibility.
+	This object is backed by a valid MSAA object.
+	However, as information from the Secure Desktop object should not be accessed via this instance of NVDA,
+	getting related objects returns None.
+	This object must remain a Desktop subclass to retain backwards compatibility.
 	"""
-
-	def __init__(self, windowHandle: int):
-		"""
-		@param windowHandle: to retain backwards compatibility,
-		unused as this object is not backed by a valid MSAA object.
-		This object just serves as a minimal API endpoint.
-		"""
-		self._windowHandle = windowHandle
-		super().__init__()
-
-	def _get_processID(self) -> int:
-		return 0
 
 	def findOverlayClasses(self, clsList):
 		clsList.append(SecureDesktopNVDAObject)
@@ -813,6 +801,21 @@ class SecureDesktopNVDAObject(NVDAObject):
 		super(SecureDesktopNVDAObject, self).event_gainFocus()
 		# After handling the focus, NVDA should sleep while the secure desktop is active.
 		self.sleepMode = self.SLEEP_FULL
+
+	def _get_next(self) -> None:
+		return None
+
+	def _get_previous(self) -> None:
+		return None
+
+	def _get_firstChild(self) -> None:
+		return None
+
+	def _get_lastChild(self) -> None:
+		return None
+
+	def _get_parent(self) -> None:
+		return None
 
 
 def processDesktopSwitchWinEvent(window, objectID, childID):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,14 +11,6 @@ This is a patch release to fix an accidental API breakage introduced in 2022.2.1
 This caused NVDA remote to not recognize secure desktops. (#14094)
 -
 
-== Changes for Developers ==
-This release contains a technical breakage in API backwards compatibility.
-It is expected that this change does not affect any add-ons.
-Please open a GitHub issue if your add-on becomes incompatible as a result of this release.
-
-- ``SecureDesktopNVDAObject`` is no longer a subclass of ``Desktop`` or ``Window``. (#14105)
--
-
 = 2022.2.2 =
 This is a patch release to fix a bug introduced in 2022.2.1 with input gestures.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

After merging to beta, translations should be pushed and translators should be notified of the lines removed.

### Link to issue number:
Follow up to #14105
Fixes issue described in https://github.com/nvaccess/nvda/pull/14111#issuecomment-1239040406

### Summary of the issue:
`SecureDesktopNVDAObject` is an API end point used to indicate to the user and to API consumers (including NVDA remote), that the user has switched to a secure desktop.
This is triggered when Windows notification `EVENT_SYSTEM_DESKTOPSWITCH` notifies that the desktop has changed.
The switch is handled via a `gainFocus` event.
The `gainFocus` event causes the user instance of NVDA to enter sleep mode as the secure mode NVDA instance starts on the secure screen.

Information from `SecureDesktopNVDAObject` should not be accessible to the user, as it is backed by a valid MSAA desktop running on a secure profile, that NVDA can report information from.
This should generally be handled by NVDA entering sleep mode.
In #14105, `SecureDesktopNVDAObject` became based on `NVDAObject` to improve security for the object, by breaking it's connection to a valid window.
This was to decrease the theoretical risk of information leakage.

However, it was discovered that NVDA core event tracking and API consumers rely on `SecureDesktopNVDAObject` inheriting from `Window` (a parent class of `Desktop`).

As such, `SecureDesktopNVDAObject` must remain a `Desktop` subclass to retain backwards compatibility.

However we can prevent neighbouring objects from being accessed.

### Description of user facing changes
Fixes bug in NVDA alpha with handling `SecureDesktopNVDAObject`.
Fixes API breakage.

### Description of development approach
Reverts the change in #14105, making `SecureDesktopNVDAObject` inherit from `Desktop`.

Prevents neighbouring objects to `SecureDesktopNVDAObject` from being accessed by overriding relevant methods.

### Testing strategy:
Checked diff between `release-2022.2.2` and this branch.
Ensured "Secure Desktop" was still announced when switching to a secure desktop, i.e. #14094 was still fixed.

### Known issues with pull request:
`SecureDesktopNVDAObject` is being used an API end point for handling a `EVENT_SYSTEM_DESKTOPSWITCH` to a secure desktop.
Using a `gainFocus` event on an `NVDAObject` to handle a Windows notification seems to be an obscure method of handling events.
NVDA has `extensionPoint`s for that purpose.
In 2023.1 `SecureDesktopNVDAObject` should be removed, replaced by an extension point to notify add-ons that NVDA has entered a secure desktop.

### Change log entries:
See PR diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
