### PR TITLE
Update eSpeak to 735ecdb8

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -385,6 +385,7 @@ espeakLib=env.SharedLibrary(
 		"../ucd-tools/src/proplist.c",
 		"../ucd-tools/src/scripts.c",
 		"../ucd-tools/src/tostring.c",
+		"common.c",
 		"compiledata.c",
 		"compiledict.c",
 #		"compilembrola.c", # we dont use MBROLA, this is a compile option in espeak
@@ -410,6 +411,7 @@ espeakLib=env.SharedLibrary(
 		"synthesize.c",
 		"synth_mbrola.c", # provides symbols used by synthesize.obj, voices.obj, and wavegen.obj
 		"translate.c",
+		"translateword.c",
 		"tr_languages.c",
 		"voices.c",
 		"wavegen.c",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit f9193330
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit 735ecdb8
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.22.0

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit 0dbe7182
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit f9193330
 * [Sonic](https://github.com/waywardgeek/sonic), commit 4f8c1d11
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.22.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -31,7 +31,7 @@ What's New in NVDA
 
 
 == Changes ==
-- eSpeak NG has been updated to 1.52-dev commit ``f9193330``. (#14060, #14079, #14117)
+- eSpeak NG has been updated to 1.52-dev commit ``735ecdb8``. (#14060, #14079, #14117)
   - Fixed reporting of Latin characters when using Mandarin. (#12952, #13572)
   -
 - NVDA now includes the architecture of the operating system as part of user statistics tracking. (#14019)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -31,7 +31,9 @@ What's New in NVDA
 
 
 == Changes ==
-- eSpeak NG has been updated to 1.52-dev commit ``0dbe7182``. (#14060, #14079)
+- eSpeak NG has been updated to 1.52-dev commit ``f9193330``. (#14060, #14079, #14117)
+  - Fixed reporting of Latin characters when using Mandarin. (#12952, #13572)
+  -
 - NVDA now includes the architecture of the operating system as part of user statistics tracking. (#14019)
 - Reporting power state changes and using the script to report battery status now report the same message consistently. (#14035)
 -


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #13572
Closes #12952

### Summary of the issue:
Janitorial update of eSpeak.
Fixes a long standing issue with Mandarin pronunciation of Latin characters. 

### Description of user facing changes
eSpeak is updated

### Description of development approach
Followed instructions in `include/espeak.md`.
Checked the following diffs.

```git
cd include/espeak
git diff 0dbe7182 f9193330 src/windows/config.h
git diff 0dbe7182 f9193330 Makefile.am
```

### Testing strategy:
Tested eSpeak after building.

### Known issues with pull request:
None

### Change log entries:
```t2t
- eSpeak NG has been updated to 1.52-dev commit ``f9193330``. (#14060, #14079, #14117)
  - Fixed reporting of Latin characters when using Mandarin. (#12952, #13572)
  -
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
