### PR TITLE
Accept already processed FeatureFlag when validating FeatureFlag

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -35,6 +35,7 @@ import extensionPoints
 from . import profileUpgrader
 from .configSpec import confspec
 from .featureFlag import (
+	FeatureFlag,
 	_transformSpec_AddFeatureFlagDefault,
 	_validateConfig_featureFlag,
 )
@@ -1157,6 +1158,8 @@ class AggregatedSection(object):
 	def _cacheLeaf(self, key, spec, val):
 		if spec:
 			# Validate and convert the value.
+			if isinstance(val, FeatureFlag):
+				val = str(val)
 			val = self.manager.validator.check(spec, val)
 		self._cache[key] = val
 		return val

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -35,7 +35,6 @@ import extensionPoints
 from . import profileUpgrader
 from .configSpec import confspec
 from .featureFlag import (
-	FeatureFlag,
 	_transformSpec_AddFeatureFlagDefault,
 	_validateConfig_featureFlag,
 )
@@ -1158,8 +1157,6 @@ class AggregatedSection(object):
 	def _cacheLeaf(self, key, spec, val):
 		if spec:
 			# Validate and convert the value.
-			if isinstance(val, FeatureFlag):
-				val = str(val)
 			val = self.manager.validator.check(spec, val)
 		self._cache[key] = val
 		return val

--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -15,7 +15,7 @@ from .featureFlagEnums import (
 	FlagValueEnum,
 )
 from typing import (
-	Optional,
+	Union,
 )
 from configobj.validate import (
 	ValidateError,
@@ -79,7 +79,7 @@ class FeatureFlag:
 
 
 def _validateConfig_featureFlag(
-		value: Optional[str],
+		value: Union[str, FeatureFlag],
 		optionsEnum: str,
 		behaviorOfDefault: str
 ) -> FeatureFlag:
@@ -121,6 +121,9 @@ def _validateConfig_featureFlag(
 		)
 	if behaviorOfDefault == OptionsEnumClass.DEFAULT:
 		raise ValidateError("Spec Error: behaviorOfDefault must not be 'default'/'DEFAULT'")
+
+	if isinstance(value, FeatureFlag):
+		return value
 
 	if not isinstance(value, str):
 		raise ValidateError(

--- a/source/config/featureFlag.py
+++ b/source/config/featureFlag.py
@@ -79,7 +79,7 @@ class FeatureFlag:
 
 
 def _validateConfig_featureFlag(
-		value: Union[str, FeatureFlag],
+		value: Union[str, FeatureFlag, None],
 		optionsEnum: str,
 		behaviorOfDefault: str
 ) -> FeatureFlag:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

reported in https://github.com/nvaccess/nvda/pull/13798#discussion_r963699236

### Summary of the issue:

NVDA fails to cache feature flag settings for new settings panels, if they have not been written to disk.
NVDA expects a string when reading and writing config values to disk, but the caching system keeps objects.
The flag fails to cache because validation fails, as the FeatureFlag validator expects a string, likely due to the expectation of disk R/W operations.

1. Apply [testFeatureFlag.diff.txt](https://github.com/nvaccess/nvda/files/9544647/testFeatureFlag.diff.txt) to create a new settings panel with a new feature flag setting
1. Create a configuration profile for Notepad
1. Go to "Test Panel" and set a new value for the feature flag, save the settings
1. Switch to Notepad
1. Switch away from Notepad
1. At that point, the above error is given on every keypress, and NVDA never focuses on the active application.

### Description of user facing changes

NVDA correctly caches the feature flag value when switching config profiles.

### Description of development approach
When validating feature flag values, accept an already processed FeatureFlag value instead of just a string.

### Testing strategy:
Test STR

### Known issues with pull request:
None

### Change log entries:
Not worth a changelog entry

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
