### PR TITLE
Reporting table headers can now be configured separately for rows and columns

### DIFF
--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Peter Vágner, Leonard de Ruijter
+# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -18,6 +18,7 @@ from . import IAccessible, List
 from ..window import Window
 from NVDAObjects.behaviors import RowWithoutCellObjects, RowWithFakeNavigation
 import config
+from config.configFlags import ReportTableHeaders
 from locationHelper import RectLTRB
 from logHandler import log
 from typing import Optional
@@ -626,7 +627,10 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			content = self._getColumnContent(col)
 			if not content:
 				continue
-			if config.conf["documentFormatting"]["reportTableHeaders"] and col != 1:
+			if config.conf["documentFormatting"]["reportTableHeaders"] in (
+				ReportTableHeaders.ROWS_AND_COLUMNS,
+				ReportTableHeaders.COLUMNS,
+			) and col != 1:
 				header = self._getColumnHeader(col)
 			else:
 				header = None

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -13,7 +13,6 @@ import speech
 import braille
 import controlTypes
 import config
-from config.configFlags import ReportTableHeaders
 import tableUtils
 import textInfos
 import eventHandler

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -13,6 +13,7 @@ import speech
 import braille
 import controlTypes
 import config
+from config.configFlags import ReportTableHeaders
 import tableUtils
 import textInfos
 import eventHandler
@@ -205,7 +206,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if not config.conf['documentFormatting']['reportTableHeaders']:
+		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
 			# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
 			return
@@ -233,7 +234,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if not config.conf['documentFormatting']['reportTableHeaders']:
+		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
 			# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
 			return

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -206,10 +206,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
-			# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
-			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
-			return
 		try:
 			cell=self.WinwordSelectionObject.cells[1]
 		except COMError:
@@ -234,10 +230,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
-			# Translators: a message reported in the SetRowHeader script for Microsoft Word.
-			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
-			return
 		try:
 			cell=self.WinwordSelectionObject.cells[1]
 		except COMError:

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1,5 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta, Accessolutions, Julien Cochuyt
+# Copyright (C) 2006-2022 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta, Accessolutions, Julien Cochuyt,
+# Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -24,6 +25,7 @@ import ui
 import speech
 from tableUtils import HeaderCellInfo, HeaderCellTracker
 import config
+from config.configFlags import ReportTableHeaders
 import textInfos
 import colors
 import eventHandler
@@ -1272,7 +1274,7 @@ class ExcelCell(ExcelBase):
 		gesture="kb:NVDA+shift+c")
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if not config.conf['documentFormatting']['reportTableHeaders']:
+		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
 			# Translators: a message reported in the SetColumnHeader script for Excel.
 			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
 			return
@@ -1298,7 +1300,7 @@ class ExcelCell(ExcelBase):
 		gesture="kb:NVDA+shift+r")
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if not config.conf['documentFormatting']['reportTableHeaders']:
+		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
 			# Translators: a message reported in the SetRowHeader script for Excel.
 			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
 			return

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1274,10 +1274,6 @@ class ExcelCell(ExcelBase):
 		gesture="kb:NVDA+shift+c")
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
-			# Translators: a message reported in the SetColumnHeader script for Excel.
-			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
-			return
 		if scriptCount==0:
 			if self.parent.setAsHeaderCell(self,isColumnHeader=True,isRowHeader=False):
 				# Translators: a message reported in the SetColumnHeader script for Excel.
@@ -1300,10 +1296,6 @@ class ExcelCell(ExcelBase):
 		gesture="kb:NVDA+shift+r")
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
-		if config.conf['documentFormatting']['reportTableHeaders'] == ReportTableHeaders.OFF:
-			# Translators: a message reported in the SetRowHeader script for Excel.
-			ui.message(_("Cannot set headers. Please enable reporting of table headers in Document Formatting Settings"))
-			return
 		if scriptCount==0:
 			if self.parent.setAsHeaderCell(self,isColumnHeader=False,isRowHeader=True):
 				# Translators: a message reported in the SetRowHeader script for Excel.

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -25,7 +25,6 @@ import ui
 import speech
 from tableUtils import HeaderCellInfo, HeaderCellTracker
 import config
-from config.configFlags import ReportTableHeaders
 import textInfos
 import colors
 import eventHandler

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -26,6 +26,7 @@ from UIAHandler.utils import createUIAMultiPropertyCondition
 import api
 import controlTypes
 import config
+from config.configFlags import ReportTableHeaders
 import speech
 import ui
 from NVDAObjects.IAccessible import IAccessible
@@ -509,7 +510,10 @@ class UIAGridRow(RowWithFakeNavigation,UIA):
 				continue
 			name=e.cachedName
 			columnHeaderTextList=[]
-			if name and config.conf['documentFormatting']['reportTableHeaders']:
+			if name and config.conf['documentFormatting']['reportTableHeaders'] in (
+				ReportTableHeaders.ROWS_AND_COLUMNS,
+				ReportTableHeaders.COLUMNS,
+			):
 				columnHeaderItems=e.getCachedPropertyValueEx(UIAHandler.UIA_TableItemColumnHeaderItemsPropertyId,True)
 			else:
 				columnHeaderItems=None

--- a/source/braille.py
+++ b/source/braille.py
@@ -32,6 +32,7 @@ import winKernel
 import keyboardHandler
 import baseObject
 import config
+from config.configFlags import ReportTableHeaders
 from logHandler import log
 import controlTypes
 import api
@@ -794,7 +795,7 @@ def getControlFieldBraille(  # noqa: C901
 			"hasDetails": hasDetails,
 			"detailsRole": detailsRole,
 		}
-		if reportTableHeaders:
+		if reportTableHeaders in (ReportTableHeaders.ROWS_AND_COLUMNS, ReportTableHeaders.COLUMNS):
 			props["columnHeaderText"] = field.get("table-columnheadertext")
 		return getPropertiesBraille(**props)
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -1,0 +1,37 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited, Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Flags used for the configuration.
+"""
+from enum import unique
+from utils.displayString import DisplayStringIntEnum
+
+
+@unique
+class ReportTableHeaders(DisplayStringIntEnum):
+	"""The possible config values to report table headers.
+	"""
+	
+	OFF = 0
+	ROWS_AND_COLUMNS = 1
+	ROWS = 2
+	COLUMNS = 3
+	
+	@property
+	def _displayStringLabels(self):
+		return {
+			# Translators: This is the label for a combobox in the
+			# document formatting settings panel.
+			ReportTableHeaders.OFF: _("Off"),
+			# Translators: This is the label for a combobox in the
+			# document formatting settings panel.
+			ReportTableHeaders.ROWS_AND_COLUMNS: _("Rows and columns"),
+			# Translators: This is the label for a combobox in the
+			# document formatting settings panel.
+			ReportTableHeaders.ROWS: _("Rows"),
+			# Translators: This is the label for a combobox in the
+			# document formatting settings panel.
+			ReportTableHeaders.COLUMNS: _("Columns"),
+		}

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -3,15 +3,18 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-"""Flags used for the configuration.
-"""
+"""Flags used for the configuration."""
+
 from enum import unique
 from utils.displayString import DisplayStringIntEnum
 
 
 @unique
 class ReportTableHeaders(DisplayStringIntEnum):
-	"""The possible config values to report table headers.
+	"""Enumeration containing the possible config values to report table headers.
+	
+	Use ReportTableHeaders.MEMBER.value to compare with the config;
+	use ReportTableHeaders.MEMBER.displayString in the UI for a translatable description of this member.
 	"""
 	
 	OFF = 0

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -208,7 +208,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	reportTables = boolean(default=true)
 	includeLayoutTables = boolean(default=False)
 	# 0: Off, 1: Rows and columns, 2: Rows, 3: Columns
-	reportTableHeaders = integer(0, 3, default=0)
+	reportTableHeaders = integer(0, 3, default=1)
 	reportTableCellCoords = boolean(default=True)
 	reportBorderStyle = boolean(default=False)
 	reportBorderColor = boolean(default=False)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2022 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
-# Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau
+# Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -12,7 +12,7 @@ from configobj import ConfigObj
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config 
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 7
+latestSchemaVersion = 8
 
 #: The configuration specification string
 #: @type: String
@@ -207,7 +207,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	reportParagraphIndentation = boolean(default=False)
 	reportTables = boolean(default=true)
 	includeLayoutTables = boolean(default=False)
-	reportTableHeaders = boolean(default=True)
+	# 0: Off, 1: Rows and columns, 2: Rows, 3: Columns
+	reportTableHeaders = integer(0, 3, default=0)
 	reportTableCellCoords = boolean(default=True)
 	reportBorderStyle = boolean(default=False)
 	reportBorderColor = boolean(default=False)

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -15,6 +15,7 @@ that no information is lost, while updating the ConfigObj to meet the requiremen
 """
 
 from logHandler import log
+from config.configFlags import ReportTableHeaders
 from typing import (
 	Dict,
 )
@@ -131,6 +132,6 @@ def upgradeConfigFrom_7_to_8(profile: Dict[str, str]) -> None:
 		log.debug("reportTableHeaders not present, no action taken.")
 	else:
 		if reportTableHeaders:
-			profile['documentFormatting']['reportTableHeaders'] = 1  # Rows and columns
+			profile['documentFormatting']['reportTableHeaders'] = ReportTableHeaders.ROWS_AND_COLUMNS.value
 		else:
-			profile['documentFormatting']['reportTableHeaders'] = 0  # Off
+			profile['documentFormatting']['reportTableHeaders'] = ReportTableHeaders.OFF.value

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016–2022 NV Access Limited, Bill Dengler
+# Copyright (C) 2016–2022 NV Access Limited, Bill Dengler, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -118,3 +118,19 @@ def upgradeConfigFrom_6_to_7(profile: Dict[str, str]) -> None:
 		selectiveEventRegistration = False
 	if selectiveEventRegistration:
 		profile['UIA']['eventRegistration'] = "selective"
+
+
+def upgradeConfigFrom_7_to_8(profile: Dict[str, str]) -> None:
+	"""
+	In Document formatting settings, "Row/column headers" check box has been replaced with "Headers" combobox.
+	"""
+	try:
+		reportTableHeaders = profile['documentFormatting']['reportTableHeaders']
+	except KeyError:
+		# Setting does not exist, no need for upgrade of this setting
+		log.debug("reportTableHeaders not present, no action taken.")
+	else:
+		if reportTableHeaders:
+			profile['documentFormatting']['reportTableHeaders'] = 1  # Rows and columns
+		else:
+			profile['documentFormatting']['reportTableHeaders'] = 0  # Off

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
-# Julien Cochuyt, Jakub Lukowicz, Bill Dengler
+# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot
 
 import itertools
 
@@ -667,19 +667,17 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Input help mode message for toggle report table row/column headers command.
-		description=_("Toggles on and off the reporting of table row and column headers"),
+		description=_("Cycle through the possible modes to report table row and column headers"),
 		category=SCRCAT_DOCUMENTFORMATTING
 	)
 	def script_toggleReportTableHeaders(self,gesture):
-		if config.conf["documentFormatting"]["reportTableHeaders"]:
-			# Translators: The message announced when toggling the report table row/column headers document formatting setting.
-			state = _("report table row and column headers off")
-			config.conf["documentFormatting"]["reportTableHeaders"]=False
-		else:
-			# Translators: The message announced when toggling the report table row/column headers document formatting setting.
-			state = _("report table row and column headers on")
-			config.conf["documentFormatting"]["reportTableHeaders"]=True
-		ui.message(state)
+		from config.configFlags import ReportTableHeaders
+		numVals = len(ReportTableHeaders)
+		state = ReportTableHeaders((config.conf["documentFormatting"]["reportTableHeaders"] + 1) % numVals)
+		config.conf["documentFormatting"]["reportTableHeaders"] = state.value
+		# Translators: Reported when the user cycles through report table header modes.
+		# {mode} will be replaced with the mode; e.g. None, Rows and columns, Rows or Columns.
+		ui.message(_("Report table headers {mode}").format(mode=state.displayString))
 
 	@script(
 		# Translators: Input help mode message for toggle report table cell coordinates command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -671,7 +671,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_DOCUMENTFORMATTING
 	)
 	def script_toggleReportTableHeaders(self,gesture):
-		from config.configFlags import ReportTableHeaders
+		ReportTableHeaders = config.configFlags.ReportTableHeaders
 		numVals = len(ReportTableHeaders)
 		state = ReportTableHeaders((config.conf["documentFormatting"]["reportTableHeaders"] + 1) % numVals)
 		config.conf["documentFormatting"]["reportTableHeaders"] = state.value

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -25,6 +25,7 @@ import logHandler
 import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
+from config.configFlags import ReportTableHeaders
 import languageHandler
 import speech
 import gui
@@ -2395,11 +2396,18 @@ class DocumentFormattingPanel(SettingsPanel):
 		self.tablesCheckBox = tablesGroup.addItem(wx.CheckBox(tablesGroupBox, label=_("&Tables")))
 		self.tablesCheckBox.SetValue(config.conf["documentFormatting"]["reportTables"])
 
-		# Translators: This is the label for a checkbox in the
-		# document formatting settings panel.
-		_tableHeadersCheckBox = wx.CheckBox(tablesGroupBox, label=_("Row/column h&eaders"))
-		self.tableHeadersCheckBox = tablesGroup.addItem(_tableHeadersCheckBox)
-		self.tableHeadersCheckBox.SetValue(config.conf["documentFormatting"]["reportTableHeaders"])
+		tableHeaderChoices = [i.displayString for i in ReportTableHeaders]
+		# The possible config values to report table headers, in the order they appear
+		# in the combo box.
+		self.tableHeaderVals = [i.value for i in ReportTableHeaders]
+		self.tableHeadersComboBox = tablesGroup.addLabeledControl(
+			# Translators: This is the label for a combobox in the
+			# document formatting settings panel.
+			_("H&eaders"),
+			wx.Choice,
+			choices=tableHeaderChoices,
+		)
+		self.tableHeadersComboBox.SetSelection(config.conf['documentFormatting']['reportTableHeaders'])
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
@@ -2530,7 +2538,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		config.conf["documentFormatting"]["reportParagraphIndentation"]=self.paragraphIndentationCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportLineSpacing"]=self.lineSpacingCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportTables"]=self.tablesCheckBox.IsChecked()
-		config.conf["documentFormatting"]["reportTableHeaders"]=self.tableHeadersCheckBox.IsChecked()
+		config.conf["documentFormatting"]["reportTableHeaders"] = self.tableHeadersComboBox.GetSelection()
 		config.conf["documentFormatting"]["reportTableCellCoords"]=self.tableCellCoordsCheckBox.IsChecked()
 		choice = self.borderComboBox.GetSelection()
 		config.conf["documentFormatting"]["reportBorderStyle"] = choice in (1,2)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2,7 +2,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
-# Julien Cochuyt, Derek Riemer
+# Julien Cochuyt, Derek Riemer, Cyrille Bougot
 
 """High-level functions to speak information.
 """ 
@@ -55,6 +55,7 @@ from typing import (
 )
 from logHandler import log
 import config
+from config.configFlags import ReportTableHeaders
 import aria
 from .priorities import Spri
 from enum import IntEnum
@@ -611,12 +612,7 @@ def speakObject(
 		speak(sequence, priority=priority)
 
 
-
-
-# C901 'getObjectSpeech' is too complex
-# Note: when working on getObjectSpeech, look for opportunities to simplify
-# and move logic out into smaller helper functions.
-def getObjectSpeech(  # noqa: C901
+def getObjectSpeech(
 		obj: "NVDAObjects.NVDAObject",
 		reason: OutputReason = OutputReason.QUERY,
 		_prefixSpeechCommand: Optional[SpeechCommand] = None,
@@ -733,20 +729,29 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		allowProperties["cellCoordsText"] = False
 		# rowNumber and columnNumber might be needed even if we're not reporting coordinates.
 		allowProperties["includeTableCellCoords"] = False
-	if not formatConf["reportTableHeaders"]:
+	if formatConf["reportTableHeaders"] not in (ReportTableHeaders.ROWS_AND_COLUMNS, ReportTableHeaders.ROWS):
 		allowProperties["rowHeaderText"] = False
+	if formatConf["reportTableHeaders"] not in (ReportTableHeaders.ROWS_AND_COLUMNS, ReportTableHeaders.COLUMNS):
 		allowProperties["columnHeaderText"] = False
 	if (
 		not formatConf["reportTables"]
 		or (
 			not formatConf["reportTableCellCoords"]
-			and not formatConf["reportTableHeaders"]
+			and formatConf["reportTableHeaders"] in (ReportTableHeaders.OFF, ReportTableHeaders.COLUMNS)
 		)
 	):
-		# We definitely aren't reporting any table info at all.
+		# We definitely aren't reporting any table row info at all.
 		allowProperties["rowNumber"] = False
-		allowProperties["columnNumber"] = False
 		allowProperties["rowSpan"] = False
+	if (
+		not formatConf["reportTables"]
+		or (
+			not formatConf["reportTableCellCoords"]
+			and formatConf["reportTableHeaders"] in (ReportTableHeaders.OFF, ReportTableHeaders.ROWS)
+		)
+	):
+		# We definitely aren't reporting any table column info at all.
+		allowProperties["columnNumber"] = False
 		allowProperties["columnSpan"] = False
 	if shouldReportTextContent:
 		allowProperties['value'] = False
@@ -2053,8 +2058,9 @@ def getControlFieldSpeech(  # noqa: C901
 			'columnSpan': attrs.get("table-columnsspanned"),
 			'includeTableCellCoords': reportTableCellCoords
 		}
-		if reportTableHeaders:
+		if reportTableHeaders in (ReportTableHeaders.ROWS_AND_COLUMNS, ReportTableHeaders.ROWS):
 			getProps['rowHeaderText'] = attrs.get("table-rowheadertext")
+		if reportTableHeaders in (ReportTableHeaders.ROWS_AND_COLUMNS, ReportTableHeaders.COLUMNS):
 			getProps['columnHeaderText'] = attrs.get("table-columnheadertext")
 		tableCellSequence = getPropertiesSpeech(_tableID=tableID, **getProps)
 		tableCellSequence.extend(stateTextSequence)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ What's New in NVDA
   - Read entire column: ``NVDA+control+alt+upArrow``
   - Read entire row: ``NVDA+control+alt+leftArrow``
   -
+- Reporting table headers can now be configured separately for rows and columns. (#14075)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2024,7 +2024,7 @@ The focus will yet be updated to the particular element when interacting with it
 Enabling this option may improve support for some websites at the cost of performance and stability.
 
 +++ Document Formatting (NVDA+control+d) +++[DocumentFormattingSettings]
-Most of the checkboxes in this category are for configuring what type of formatting you wish to have reported as you move the cursor around documents.
+Most of the options in this category are for configuring what type of formatting you wish to have reported as you move the cursor around documents.
 For example, if you check the report font name checkbox, each time you arrow onto text with a different font, the name of the font will be announced.
 
 The document formatting options are organized into groups.
@@ -2052,7 +2052,7 @@ You can configure reporting of:
  - Alignment
 - Table information
  - Tables
- - Row/column headers
+ - Row/column headers (Off, Rows, Columns, Rows and columns)
  - Cell coordinates
  - Cell borders (Off, Styles, Both Colours and Styles)
 - Elements


### PR DESCRIPTION
### Link to issue number:
Closes #14075
### Summary of the issue:
It was asked in #14075 to be able to have table row/column headers reporting configured separately.

### Description of user facing changes
* A combo-box in Documentation formatting settings allows to select among 4 options to have table headers reported: Off, Columns and rows, Rows and Columns; it replaces the previous checkbox for table headers reporting.
* Setting row/column headers in Word or Excel (no UIA) is now possible even if the option to report table headers is disabled. Indeed, it is clearer from a UX point of view to allow it than to disallow it only when reporting table headers in the same direction (row/column) is disabled.
* The toggle script for table headers reporting has also been adapted to cycle through the 4 options.

### Description of development approach
* Implemented as per https://github.com/nvaccess/nvda/issues/14075#issuecomment-1240263166.
* Created an enumeration to store the possible options for this parameter, containing the numeric values for the config file and the display strings for the UI.
* Not directly linked but a a `noqa` exception for code complexity of `getObjectSpeech` has been removed because it was not relevant anymore. Excepted the removal of this #`noqa` directive, `getObjectSpeech` is not modified in this PR.

### Testing strategy
Manual testing of table navigation commands combining all the following possibilities:
* Tested in the following applications/controls:
  * Browsers (Chrome, Firefox, Edge, `ui.browseableMessage`)
  * Word with and without UIA
  * Excel without UIA (not possible to set table headers when using UIA, as described in #12882 )
  * Outlook message list
  * list view In task manager's tab "Details" (of processes)
* Tested with the 4 options: "Off", "Rows and columns", "Rows" and "Columns".
* Tested that headers were reported with speech with the appropriate options
* Tested that columns headers were reported with braille when "Rows and columns" or "Columns" option is enabled.

It has also been checked in `nvda.ini` that saving the config works as expected.

### Known issues with pull request:
None

### Change log entries:
New features (or Changes ?)
`Reporting table headers can now be configured separately for rows and columns. (#14075)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
