### PR TITLE
FeatureFlag: fix changing from default value and value of default

### DIFF
--- a/source/config/aggregatedSection.py
+++ b/source/config/aggregatedSection.py
@@ -1,0 +1,24 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2023 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from typing import (
+	Dict,
+	Union,
+)
+from typing_extensions import Protocol
+
+
+class _SupportsStrT(Protocol):
+	"""
+	Valid config values must support str(),
+	as this is how they are written to disk
+	"""
+	def __str__(self) -> str:
+		...
+
+
+_cacheKeyT = str
+_cacheValueT = Union["_cacheT", _SupportsStrT, KeyError]
+_cacheT = Dict[str, _cacheValueT]

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -68,6 +68,7 @@ For example, when text has a comment and a footnote associated with it. (#14507,
   -
 - Emojis should now be reported in more languages. (#14433)
 - The presence of an annotation is no longer missing in braille for some elements. (#13815)
+- Fixed an issue where config changes not save correctly when changing between a "Default" option and the value of the "Default" option. (#14133)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Feature flags use a default option that results in a default value.
For example, for a boolean feature flag could have three options: `Default (Enabled), Enabled, Disabled`.
When comparing feature flags `__eq__` is overridden such that `Default (Enabled) == Enabled`.

NVDA checks if a value has changed before marking a profile as dirty so that it is written to disk when saving the configuration.
Due to `__eq__` being overridden, NVDA does not write changes to disk if you change from the default value to the value of default.

STR:
1. With NVDA running, open braille preferences
2. Update "Interrupt Speech While scrolling" from `Default (Enabled)` to `Enabled`
3. Save the settings and exit the settings dialog
5. Re-open braille preferences, note the setting is still set to `Default (Enabled)`

### Description of user facing changes
NVDA correctly updates feature flags when changing from the default value to the value of default.

### Description of development approach
When checking if a config setting has changed, compare non-sections as strings, as this is how they are written to the config profile.

### Testing strategy:
Manually test STR

Unit testing has been added for `AggregatedSection`

### Known issues with pull request:
`AggregatedSection` should be moved in a separate PR to the new module.

### Change log entries:
Bug fixes:
- Fixed an issue where the config did not save correctly when changing between a "Default" option and the value of the "Default" option.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
