### PR TITLE
When entering a secure desktop, cancel speech

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -803,8 +803,10 @@ class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
 		# Before announcing the secure desktop and entering sleep mode,
 		# cancel speech so that speech does not overlap with the new instance of NVDA
 		# started on the secure desktop.
-		# Cancelling speech was previously handled by a foreground event on SecureDesktopNVDAObject.
-		# This foreground event is now explicitly prevented for security purposes.
+		# Cancelling speech was previously handled by a foreground event fired when focusing SecureDesktopNVDAObject.
+		# The foreground event would incorrectly fire on the foreground window of the user desktop.
+		# This foreground event is now explicitly prevented due to the security concerns of
+		# setting the foreground object to an object 'below the lock screen'.
 		cancelSpeech()
 		super().event_gainFocus()
 		# After handling the focus, NVDA should sleep while the secure desktop is active.

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -815,6 +815,8 @@ class SecureDesktopNVDAObject(NVDAObject):
 		# Before announcing the secure desktop and entering sleep mode,
 		# cancel speech so that speech does not overlap with the new instance of NVDA
 		# started on the secure desktop.
+		# Cancelling speech was previously handled by a foreground event on SecureDesktopNVDAObject.
+		# This foreground event is now explicitly prevented for security purposes.
 		cancelSpeech()
 		super().event_gainFocus()
 		# After handling the focus, NVDA should sleep while the secure desktop is active.

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -810,7 +810,9 @@ class SecureDesktopNVDAObject(NVDAObject):
 		return controlTypes.Role.PANE
 
 	def event_gainFocus(self):
-		super(SecureDesktopNVDAObject, self).event_gainFocus()
+		from speech.speech import cancelSpeech
+		super().event_gainFocus()
+		cancelSpeech()
 		# After handling the focus, NVDA should sleep while the secure desktop is active.
 		self.sleepMode = self.SLEEP_FULL
 

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -811,8 +811,8 @@ class SecureDesktopNVDAObject(NVDAObject):
 
 	def event_gainFocus(self):
 		from speech.speech import cancelSpeech
-		super().event_gainFocus()
 		cancelSpeech()
+		super().event_gainFocus()
 		# After handling the focus, NVDA should sleep while the secure desktop is active.
 		self.sleepMode = self.SLEEP_FULL
 

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -811,6 +811,10 @@ class SecureDesktopNVDAObject(NVDAObject):
 
 	def event_gainFocus(self):
 		from speech.speech import cancelSpeech
+		# NVDA announces the secure desktop when handling the gainFocus event.
+		# Before announcing the secure desktop and entering sleep mode,
+		# cancel speech so that speech does not overlap with the new instance of NVDA
+		# started on the secure desktop.
 		cancelSpeech()
 		super().event_gainFocus()
 		# After handling the focus, NVDA should sleep while the secure desktop is active.

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -803,7 +803,8 @@ class SecureDesktopNVDAObject(NVDAObjects.window.Desktop):
 		# Before announcing the secure desktop and entering sleep mode,
 		# cancel speech so that speech does not overlap with the new instance of NVDA
 		# started on the secure desktop.
-		# Cancelling speech was previously handled by a foreground event fired when focusing SecureDesktopNVDAObject.
+		# Cancelling speech was previously handled by a foreground event,
+		# fired when focusing SecureDesktopNVDAObject.
 		# The foreground event would incorrectly fire on the foreground window of the user desktop.
 		# This foreground event is now explicitly prevented due to the security concerns of
 		# setting the foreground object to an object 'below the lock screen'.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
NVDA 2022.2 would cancel speech when handling the foreground event for entering a secure desktop.

The security patch for 2022.2.1 broke how the foreground event was handled, and subsequently #14105 opted to avoid the foreground event entirely.

This results in NVDA not correctly cancelling speech when entering a secure desktop.

### Description of user facing changes
Speech is cancelled when entering a secure desktop

### Description of development approach
Cancel speech just before enter sleep mode, when `SecureDesktopNVDAObject` handles it's gain focus event.

### Testing strategy:
Manual testing

### Known issues with pull request:

### Change log entries:
N/A unreleased bug in 2022.2.3

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
