### PR TITLE
Added Simplified Chinese Braille table 'Chinese (China, Mandarin) Current Braille System (no tones)'

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -545,6 +545,14 @@ addTable("xh-za-g1.utb", _("Xhosa grade 1"))
 addTable("xh-za-g2.ctb", _("Xhosa grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+# This should be translated to '中文中国汉语通用盲文' in Mandarin.
+addTable("zhcn-cbs.ctb", _("Chinese common braille (simplified Chinese characters)"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+# This should be translated to '中文中国汉语现行盲文（无声调）' in Mandarin.
+addTable("zh-chn.ctb", _("Chinese (China, Mandarin) Current Braille System (no tones)"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 # This should be translated to '中文中国汉语现行盲文' in Mandarin.
 addTable("zhcn-g1.ctb", _("Chinese (China, Mandarin) Current Braille System"))
 # Translators: The name of a braille table displayed in the
@@ -557,13 +565,6 @@ addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zh-tw.ctb", _("Chinese (Taiwan, Mandarin)"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
-addTable("zhcn-cbs.ctb", _("Chinese common braille (simplified Chinese characters)"), input=False)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
-# This should be translated to '中文中国汉语现行盲文（无声调）' in Mandarin.
-addTable("zh-chn.ctb", _("Chinese (China, Mandarin) Current Braille System (no tones)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zu-za-g1.utb", _("Zulu grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -543,6 +543,7 @@ addTable("xh-za-g1.utb", _("Xhosa grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("xh-za-g2.ctb", _("Xhosa grade 2"), contracted=True)
+
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 # This should be translated to '中文中国汉语通用盲文' in Mandarin.
@@ -565,6 +566,7 @@ addTable("zh-hk.ctb", _("Chinese (Hong Kong, Cantonese)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zh-tw.ctb", _("Chinese (Taiwan, Mandarin)"))
+
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zu-za-g1.utb", _("Zulu grade 1"))

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -560,7 +560,10 @@ addTable("zh-tw.ctb", _("Chinese (Taiwan, Mandarin)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zhcn-cbs.ctb", _("Chinese common braille (simplified Chinese characters)"), input=False)
-
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+# This should be translated to '中文中国汉语现行盲文（无声调）' in Mandarin.
+addTable("zh-chn.ctb", _("Chinese (China, Mandarin) Current Braille System (no tones)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("zu-za-g1.utb", _("Zulu grade 1"))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -42,7 +42,7 @@ What's New in NVDA
     - Swedish uncontracted braille
     - Swedish partially contracted braille
     - Swedish contracted braille
-    -
+    - Chinese (China, Mandarin) Current Braille System (no tones) (#14138)
 - NVDA now includes the architecture of the operating system as part of user statistics tracking. (#14019)
 - Reporting power state changes and using the script to report battery status now report the same message consistently. (#14035)
 -


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
zh-chn.ctb is a variant of the Chinese Current Braille System(zhcn-g1.ctb), which omits tones and allows for more braille content to be displayed for small braille displays.
In the nvda Chinese community, some people hope that this braille table can also be a candidate.
But there is no way to do this without manually renaming the table to replace the existing table.
So, I added it to braille settings dialog.
### Description of user facing changes
Added Simplified Chinese Braille table 'Chinese(Current Braille System (no tones)'
### Description of development approach
Add the definition of the table in brailleTables.py.
### Testing strategy:
Manual testing.
### Known issues with pull request:
None
### Change log entries:

Changes 

```t2t
- Added new braille table: Chinese (China, Mandarin) Current Braille System (no tones) (#14138)
````


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
