### PR TITLE
Make system tests pass when run locally on non-English systems

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2021 NV Access Limited
+# Copyright (C) 2020-2022 NV Access Limited, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -97,6 +97,7 @@ class ChromeLib:
 			" --disable-notifications"
 			" --no-experiments"
 			" --no-default-browser-check"
+			" --lang=en-US"
 			f' "{filePath}"',
 			shell=True,
 			alias='chromeStartAlias',
@@ -141,7 +142,7 @@ class ChromeLib:
 			<head>
 				<title>{ChromeLib.getUniqueTestCaseTitle(testCase)}</title>
 			</head>
-			<body onload="document.getElementById('loadStatus').innerHTML='{ChromeLib._loadCompleteString}'">
+			<body lang="en" onload="document.getElementById('loadStatus').innerHTML='{ChromeLib._loadCompleteString}'">
 				<p>{ChromeLib._beforeMarker}</p>
 				<p id="loadStatus">Loading...</p>
 				{testCase}

--- a/tests/system/nvdaSettingsFiles/chrome-gestures.ini
+++ b/tests/system/nvdaSettingsFiles/chrome-gestures.ini
@@ -1,2 +1,0 @@
-[globalCommands.GlobalCommands]
-reportDetailsSummary = kb:nvda+\

--- a/tests/system/nvdaSettingsFiles/standard-doShowWelcomeDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-doShowWelcomeDialog.ini
@@ -1,5 +1,6 @@
 schemaVersion = 2
 [general]
+	language = en
 	showWelcomeDialogAtStartup = True
 [update]
 	askedAllowUsageStats = True

--- a/tests/system/nvdaSettingsFiles/standard-dontShowExitDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-dontShowExitDialog.ini
@@ -1,5 +1,6 @@
 schemaVersion = 2
 [general]
+	language = en
 	showWelcomeDialogAtStartup = True
 	askToExit = False
 [update]

--- a/tests/system/nvdaSettingsFiles/standard-dontShowWelcomeDialog.ini
+++ b/tests/system/nvdaSettingsFiles/standard-dontShowWelcomeDialog.ini
@@ -1,5 +1,6 @@
 schemaVersion = 2
 [general]
+	language = en
 	showWelcomeDialogAtStartup = False
 [update]
 	askedAllowUsageStats = True

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -25,7 +25,9 @@ E.G. to run all tests with the chrome tag use:
 runsystemtests -i "chrome" ...
 ```
 
-Other options exit for specifying tests to run (e.g. by suite, tag, etc).
+Note: For tests based on Chrome, be sure that no previous instance of Chrome is open when you launch the test, specifically on non-English systems.
+
+Other options exist for specifying tests to run (e.g. by suite, tag, etc).
 Consult `runsystemtests --help`
 
 ### Tags are required

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2021 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2020-2022 NV Access Limited, Leonard de Ruijter, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,7 +57,7 @@ def checkbox_labelled_by_inner_element():
 
 REVIEW_CURSOR_FOLLOW_CARET_KEY = ["reviewCursor", "followCaret"]
 REVIEW_CURSOR_FOLLOW_FOCUS_KEY = ["reviewCursor", "followFocus"]
-READ_DETAILS_GESTURE = "NVDA+\\"  # see chrome-gestures.ini
+READ_DETAILS_GESTURE = "NVDA+d"
 
 
 def _getNoVBuf_AriaDetails_sample() -> str:

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2019 NV Access Limited
+# Copyright (C) 2019-2022 NV Access Limited, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 *** Settings ***
@@ -24,7 +24,7 @@ default teardown
 	quit NVDA
 
 default setup
-	start NVDA	standard-dontShowWelcomeDialog.ini	chrome-gestures.ini
+	start NVDA	standard-dontShowWelcomeDialog.ini
 	enable_verbose_debug_logging_if_requested
 
 *** Test Cases ***

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,8 @@ Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
+- System test should now pass when run locally on non-English systems. (#13362)
+-
 
 === API Breaking Changes ===
 These are breaking API changes.


### PR DESCRIPTION
### Link to issue number:
Closes #13362

### Summary of the issue:
The majority of system tests fail when run on non-English systems. On my system (French), failures are due to the following reasons:
- Default NVDA's UI language is user's default Windows language, thus the messages of NVDA are reported in this language.
- If not specified, the language of an HTML page is set by the browser itself which may not be English (system language?)
- According to the locale keyboard layout, someemulated  keypress may fail. E.g. "NVDA+\" cannot be emulated with French keyboard layout since \ (backslash) can only be accessed with modifiers (AltGr).

In #13362, it was also stated that Chrome's language may make some tests fail. That's not the case on my French system. But we may imagine that the keyboard shortcuts could vary from one language to another, e.g. "Alt+d" to focus the address field.

### Description of user facing changes
System tests now pass on French system. It should pass on any system regardless of its language.

### Description of development approach

1. NVDA interface language is forced to English in the various config files.
2. HTML sample content forced to English (via lang HTML attribute)
3. Removed the unneeded NVDA+\ custom gesture which cannot be executed without modifier on some keyboard layout (e.g. French). Actually, there is no need for custom gesture since `NVDA+d` is now a native gesture of NVDA for the same script.
   Even if not used anymore for now, I have not removed the possibility to use a custom gesture file in case an unassigned script has to be tested in the future. Should it be the case, care should be taken to assign a gesture that can be executed on any keyboard layout, i.e. use a letter rather than punctuation as the main key name.
E. Chrome UI language is forced to English via command line parameter (see [List of Chromium Command Line Switches « Peter Beverloo](https://peter.sh/experiments/chromium-command-line-switches/))

Note: For the Chrome command line --lang parameter to be taken into account, it should be ensured that no previous Chrome window is open when the tests are run.

### Testing strategy:

- [x] System tests pass on my French local system
  Windows 10 20H2 (x64) build 19042.1889, Chrome 105
  Only "NVDA" tag tested, not "installer".:
  `runsystemtests.bat -i nvda`
- [x] System test pass locally on an English system (tested by @lukaszgo1 on Windows 10)
- [x] System tests pass on appVeyor

### Known issues with pull request:

I have not the opportunity to test it myself.
But according to @lukaszgo1's tests, Notepad system test fail on Windows 11.
Since it is unrelated to the changes of this PR, I suggest to handle in a different issue/PR if needed.

### Change log entries:
Bug fixes (or For Developers ?)
`System test should now pass when run locally on non-English systems. (#13362)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

Cc @lukaszgo1, @MarcoZehe 
