### PR TITLE
No longer fail to start NVDA from sources on Windows 7 when setting DPI awareness

### DIFF
--- a/source/winAPI/constants.py
+++ b/source/winAPI/constants.py
@@ -17,3 +17,4 @@ class SystemErrorCodes(enum.IntEnum):
 	# https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
 	ACCESS_DENIED = 0x5
 	INVALID_PARAMETER = 0x57
+	MOD_NOT_FOUND = 0x7E

--- a/source/winAPI/dpiAwareness.py
+++ b/source/winAPI/dpiAwareness.py
@@ -63,10 +63,25 @@ def setDPIAwareness() -> None:
 		# This window checks for the DPI when it is created and adjusts the scale factor whenever the DPI changes.
 		# These processes are not automatically scaled by the system.
 		PROCESS_PER_MONITOR_DPI_AWARE = 2
-		# Method introduced in Windows 8
+		# Method introduced in Windows 8.1
 		hResult = ctypes.windll.shcore.SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)
 	except AttributeError:
-		log.debug("Cannot set PROCESS_PER_MONITOR_DPI_AWARE")
+		# Windows 8 / Server 2012 - `shcore` library exists,
+		# but `SetProcessDpiAwareness` is not present yet.
+		log.debug("Cannot set PROCESS_PER_MONITOR_DPI_AWARE - SetProcessDpiAwareness missing")
+	except WindowsError as e:
+		# `ctypes` raises `WindowsError` for missing DLL's.
+		# On Windows 7 `shcore` library is not present.
+		# Inspect error code and either ignore the exception falling back to the legacy method
+		# if it is caused by missing dll, log an error otherwise.
+		# In Python 3.8 and later `ctypes` raises `FileNotFoundError`
+		# rather than `WindowsError` for missing libraries.
+		# When updating NVDA the exception has to be changed
+		# or, if support for Windows 7 is dropped, this section should be removed.
+		if e.winerror == SystemErrorCodes.MOD_NOT_FOUND:
+			log.debug("Cannot set PROCESS_PER_MONITOR_DPI_AWARE - shcore not found")
+		else:
+			log.error("Failed to set PROCESS_PER_MONITOR_DPI_AWARE", exc_info=True)
 	else:
 		if hResult == HResult.S_OK:
 			return


### PR DESCRIPTION
### Link to issue number:
None - fix-up of #13254

### Summary of the issue:
After #13254 got merged NVDA failed to start from sources on Windows 7 with the following exception:

```
CRITICAL - __main__ (16:59:34.992) - MainThread (6908):
core failure
Traceback (most recent call last):
  File "nvda.pyw", line 393, in <module>
    core.main()
  File "core.py", line 436, in main
    setDPIAwareness()
  File "winAPI\dpiAwareness.py", line 67, in setDPIAwareness
    hResult = ctypes.windll.shcore.SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)
  File "C:\Python37\lib\ctypes\__init__.py", line 434, in __getattr__
    dll = self._dlltype(name)
  File "C:\Python37\lib\ctypes\__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: [WinError 126] The specified module cannot be found
```

While we handle different versions of Windows by catching `AttributeError` if the given function for setting DPI awareness is not present on Windows 7 `shcore` is missing and ctypes raises a different error for missing libraries.
### Description of user facing changes
NVDA can once again start from sources when running on Windows 7.
### Description of development approach
In addition to catching `AttributeError` we also catch `WindowsError` and inspect its error code. If it is caused by the missing library appropriate info is logged and the function continues to use legacy method of setting DPI awareness. Note that `AttributeError` has to be handled as well to allow NVDA to start on Windows 8/Server 2012.
### Testing strategy:
Made sure that NVDA can start from sources on Windows 7, Server 2012 and Windows 10.
### Known issues with pull request:
The raised exception is different in Python 3.7 and more recent versions of Python. This information is included as a code comment, so that this is not forgotten when updating the version of Python we're using.
### Change log entries:
None needed -unreleased regression which affects only source copies.
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
