### PR TITLE
Remove reference to non-existent directory containing static files to fix warning when building developer documentation

### DIFF
--- a/devDocs/conf.py
+++ b/devDocs/conf.py
@@ -93,11 +93,6 @@ exclude_patterns = [
 
 html_theme = "sphinx_rtd_theme"
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
 # -- Extension configuration -------------------------------------------------
 
 # sphinx.ext.autodoc configuration


### PR DESCRIPTION
### Link to issue number:
None - related to #12971

### Summary of the issue:
When building developer documentation the following warning is shown:

```
WARNING: html_static_path entry '_static' does not exist
```

### Description of user facing changes
One less warning when building developer documentation is shown.
### Description of development approach
Since we don't have any custom static files I've just removed the path - that was a left over from the default Sphinx template.
### Testing strategy:
Created developer documentation made sure that this specific warning is gone.
### Known issues with pull request:
None known
### Change log entries:
None needed.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
