### PR TITLE
Fix text selection with NVDA+f10 key on Java applications

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -565,7 +565,7 @@ class JABContext(object):
 		bridgeDll.getCurrentAccessibleValueFromContext(self.vmID,self.accContext,buf,SHORT_STRING_SIZE)
 		return buf.value
 
-	def selectTextRange(self,start,end):
+	def selectTextRange(self, start: int, end: int) -> None:
 		bridgeDll.selectTextRange(self.vmID, self.accContext, start, end)
 
 	def setCaretPosition(self,offset):

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -566,7 +566,7 @@ class JABContext(object):
 		return buf.value
 
 	def selectTextRange(self,start,end):
-		bridgeDll.selectTextRange(start,end)
+		bridgeDll.selectTextRange(self.vmID, self.accContext, start ,end)
 
 	def setCaretPosition(self,offset):
 		bridgeDll.setCaretPosition(self.vmID,self.accContext,offset)

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -566,7 +566,7 @@ class JABContext(object):
 		return buf.value
 
 	def selectTextRange(self,start,end):
-		bridgeDll.selectTextRange(self.vmID, self.accContext, start ,end)
+		bridgeDll.selectTextRange(self.vmID, self.accContext, start, end)
 
 	def setCaretPosition(self,offset):
 		bridgeDll.setCaretPosition(self.vmID,self.accContext,offset)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -70,6 +70,7 @@ Note there are still known issues with Chrome and Edge. (#13254)
 - Orientation state (landscape/portrait) changes are now correctly ignored when there is no change (e.g. monitor changes). (#14035)
 - NVDA will announce dragging items on screen in places such as rearranging Windows 10 Start menu tiles and virtual desktops in Windows 11. (#12271, #14081)
 - In advanced settings, "Play a sound for logged errors" option is now correctly restored to its default value when pressing the "Restore defaults" button. (#14149)
+- NVDA can now select text using the ``NVDA+f10`` keyboard shortcut on Java applications. (#14163)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14163

### Summary of the issue:
NVDA cannot select text in Java applications with the `NVDA+f10` gesture.

### Description of user facing changes
NVDA can now select text using the `NVDA+f10` gesture on Java applications.

### Description of development approach
This pull request adds the missing parameters to the `selectTextRange` function.

### Testing strategy:
Tested on IntelliJ idea 2022.1.4 by performing the gesture.

### Known issues with pull request:

### Change log entries:
New features
Changes
Bug fixes
`- NVDA can now select text using the ``NVDA+f10`` keyboard shortcut on Java applications (#14163)`
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
