### PR TITLE
Announce when moving outside a table in an Excel spreadsheet with UIA

### DIFF
--- a/source/NVDAObjects/UIA/excel.py
+++ b/source/NVDAObjects/UIA/excel.py
@@ -11,6 +11,8 @@ import UIAHandler.constants
 from UIAHandler.constants import (
 	UIAutomationType,
 )
+import speech
+import api
 import colors
 import locationHelper
 import controlTypes
@@ -592,3 +594,18 @@ class BadExcelFormulaEdit(ExcelObject):
 	"""
 
 	shouldAllowUIAFocusEvent = False
+
+
+class ExcelTable(UIA):
+	""" Represents a table within an Excel spreadsheet."""
+
+	def event_focusExited(self):
+		# Generally, NVDA would not announce when focus exits an ancestor control.
+		# However, it is very common for focus to enter and exit tables within a spreadsheet,
+		# Thus we specifically announce exiting tables here,
+		# But only when focus is on an Excel cell,
+		# As we don't want to announce exiting the table when focus moves out of the spreadsheet entirely.
+		newFocus = api.getFocusObject()
+		if isinstance(newFocus, ExcelCell):
+			# Translators: announced when moving outside of a table in an Excel spreadsheet.
+			speech.speakMessage(_("Out of table"))

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1203,6 +1203,10 @@ This code is executed if a gain focus event is received by this object.
 		# Forget the word currently being typed as focus is moving to a new control. 
 		speech.clearTypedWordBuffer()
 
+	def event_focusExited(self):
+		# In the general case, NVDA should not announce anything when focus exits an ancestor control.
+		pass
+
 	def event_foreground(self):
 		"""Called when the foreground window changes.
 		This method should only perform tasks specific to the foreground window changing.

--- a/source/api.py
+++ b/source/api.py
@@ -175,6 +175,9 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 	braille.invalidateCachedFocusAncestors(focusDifferenceLevel)
 	if config.conf["reviewCursor"]["followFocus"]:
 		setNavigatorObject(obj,isFocus=True)
+	# Fire focusExited event for all old focus ancestors not common with the new focus
+	for oldFocusAncestor in reversed(oldFocusLine[focusDifferenceLevel:-1]):
+		eventHandler.executeEvent("focusExited", oldFocusAncestor)
 	return True
 
 def getFocusDifferenceLevel():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ What's New in NVDA
   - Read entire column: ``NVDA+control+alt+upArrow``
   - Read entire row: ``NVDA+control+alt+leftArrow``
   -
+- Microsoft Excel via UI Automation: NVDA now announces when moving out of a table within a spreadsheet. (#14165)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
A particular range of an Excel spreadsheet can be formatted as a self-contained table.
When NVDA uses UIA to access Excel, it announces when focus enteres the table, but does not announce when exiting.
The impact is that the user does not know when focus moves onto a cell outside of the table. E.g. when perhaps trying to enter a new row of data at the bottom.

Technically, tables in Excel are exposed in Excel as UIA elements, themselves containing child cells.
NVDA already announces entering tables as NVDA has had a 'focusEntered' event which fires on all new focus ancestors, but does not have the opposite for firing on old ancestors.
  
### Description of user facing changes
NVDA will now announce "out of table" when focus moves from a cell inside a table, to a cell outside of a table or in a different table.
This is not directly reported in Braille however, as the user has always been able to scroll backward from the cell to see if they are in the table or just the worksheet.

This feature has not been added to NVDA's support for Excel when using the object model (not UIA), and there are no plans to further enhance the older object model code in the future.
 
### Description of development approach
`api.setFocusObject` now fires a new 'focusExited' event on any ancestor of the old focus, that is not common with the new focus. It does this at the very end, after firing loseFocus and actually setting the focus.
This means, focus-related event ordering is as follows:
* event_loseFocus fired on the old focus
* event_focusExited is fired on the old focus's parent (assuming it is not common with the new focus ancestors)
* event_focusExited is fired on the old focus's parent's parent (assuming it is not common with the new focus)...
* event_focusEntered is fired on the highest new ancestor for the new focus
* event_focusEntered is fired on the next highest new ancestor for the new focus...
* event_gainFocus is fired on the new focus.

Base NVDAObject's event_focusExited does nothing, as generaly, NVDA should not announce when focus exits an ancestor control.
However, a new ExcelTable UIA NVDAObject has an event_focusExited which announces "out of table" if the new focus is still an ExcelCell. I.e. focus exited the table but is still in the spreadsheet. Not doing this check would mean that "out of table" would have been announced when moving away from Excel or into the ribbon etc which is not preferable.

### Testing strategy:
* Ensure NVDA is configured to use UIA for Excel in NVDA's advanced settings.
* Open [example_color_table.xlsx](https://github.com/nvaccess/nvda/files/9595911/example_color_table.xlsx) in Excel.
* Press down arrow multiple times, noticing that NVDA announces when entering the table at a3, and then announces "out of table" at a8.
* Similarly, moving to d4 and then pressing right arrow, NVDA announces "out of table". 

### Known issues with pull request:
None known.

### Change log entries:
New features
* Excel with UI automation: NVDA now announces when moving outside a table within a spreadsheet.
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
