### PR TITLE
Start 2023.1 release cycle

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -65,8 +65,8 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2022
-version_major = 4
+version_year = 2023
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,31 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2023.1 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+Note: this is an Add-on API compatibility breaking release.
+Add-ons will need to be re-tested and have their manifest updated.
+Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
+
+
+=== API Breaking Changes ===
+These are breaking API changes.
+Please open a GitHub issue if your Add-on has an issue with updating to the new API.
+
+
+=== Deprecations ===
+
+
 = 2022.4 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for the 2023.1 release.
This will be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [ ] Bump the add-on API compatibility (separate PR): #14172

On merge:
- [x] Update auto milestone ID