### PR TITLE
Bump Add-on backwards compatibility

### DIFF
--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -13,12 +13,13 @@ how the API has changed as well as the range of API versions supported by this b
 """
 
 CURRENT = (buildVersion.version_year, buildVersion.version_major, buildVersion.version_minor)
-BACK_COMPAT_TO = (2022, 1, 0)
+BACK_COMPAT_TO = (2023, 1, 0)
 """
 As BACK_COMPAT_TO is incremented, the changed / removed parts / or reasoning should be added below.
 These only serve to act as a reminder, the changelog should be consulted for a comprehensive listing.
 EG: (x, y, z): Large changes to speech.py
 ---
+(2023, 1, 0): speech as str was dropped in favor of only SpeechCommand, and security changes.
 (2022, 1, 0): various constants moved to enums, notably a controlTypes refactor.
 (2021, 1, 0): wxPython 4.1.1, SayAll / Speech re-arranged, removal of previously deprecated code.
 (2019, 3, 0): speech refactor, Python 3

--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -1,7 +1,7 @@
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2018 NV Access Limited
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2018-2023 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import buildVersion
 import re


### PR DESCRIPTION
Once merged, NVDA versions with this commit will require add-ons to support 2023.1.
This PR does not need be merged until branching for the beta of the 2023.1 release.
The existence of the PR is intended to act as an early warning for add-on developers of the coming change.

**Note: Squash merge not merge commit**