### PR TITLE
Review 2022.4 changelog and documentation changes

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,7 +39,7 @@ There are new Chinese, Swedish, Luganda and Kinyarwanda braille tables.
 
 
 == Changes ==
-- eSpeak NG has been updated to 1.52-dev commit ``735ecdb8``. (#14060, #14079, #14117, #14203)
+- eSpeak NG has been updated to 1.52-dev commit ``735ecdb8``. (#14060, #14079, #14118, #14203)
   - Fixed reporting of Latin characters when using Mandarin. (#12952, #13572, #14197)
   -
 - Updated LibLouis braille translator to [3.23.0 https://github.com/liblouis/liblouis/releases/tag/v3.23.0]. (#14112)
@@ -51,6 +51,7 @@ There are new Chinese, Swedish, Luganda and Kinyarwanda braille tables.
     - Swedish partially contracted braille
     - Swedish contracted braille
     - Chinese (China, Mandarin) Current Braille System (no tones) (#14138)
+    -
 - NVDA now includes the architecture of the operating system as part of user statistics tracking. (#14019)
 - Reporting power state changes and using the script to report battery status now report the same message consistently. (#14035)
 -
@@ -59,9 +60,9 @@ There are new Chinese, Swedish, Luganda and Kinyarwanda braille tables.
 == Bug Fixes ==
 - When updating NVDA using the Windows Package Manager CLI (aka winget), a released version of NVDA is no longer always treated as newer than whatever alpha version is installed. (#12469)
 - NVDA will now correctly announce Group boxes in Java applications. (#13962)
-- Caret properly follows spoken text in say all in applications such as Bookworm, WordPad, or the NVDA log viewer. (#13420, #9179)
+- Caret properly follows spoken text during "say all" in applications such as Bookworm, WordPad, or the NVDA log viewer. (#13420, #9179)
 - In programs using UI Automation, partially checked checkboxes will be reported correctly. (#13975)
-- Improved performance and stability in in Microsoft Visual Studio, Windows Terminal, and other UI Automation based applications. (#11077, #11209)
+- Improved performance and stability in Microsoft Visual Studio, Windows Terminal, and other UI Automation based applications. (#11077, #11209)
   - These fixes apply to Windows 11 Sun Valley 2 (version 22H2) and later.
   - Selective registration for UI Automation events and property changes now enabled by default.
   -

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,12 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2022.4 =
+This release includes several new key commands, including table say all commands.
+A "Quick Start Guide" section has been added to the User Guide.
+There are also several bug fixes.
+
+eSpeak has been updated and LibLouis has been updated.
+There are new Chinese, Swedish, Luganda and Kinyarwanda braille tables.
 
 == New Features ==
 - Added a "Quick Start Guide" section to the User Guide. (#13934)


### PR DESCRIPTION
**Must be a squash merge**

- [x] Review of documentation changes complete

Comparison command:
`git diff release-2022.3...updateChanges2022.4 -- "**/en/*.t2t" "**/developerGuide.t2t"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Lists not terminated with a final `-` on a new line, matching indentation
- List items not indented by a multiple of 2 spaces
- Single grave marks ` instead of double grave marks ``
- Shortcuts added without code markdown, use two 'grave' characters (` ``NVDA+d`` `)
- Double spaces
- Inconsistent use of single vs double quote.