### PR TITLE
Fix up 2022.2.4 changes

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,15 +3,20 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
-= 2022.2.3 =
+= 2022.2.4 =
 This is a patch release to fix a security issue.
-This release also fixes an accidental API breakage introduced in 2022.2.1.
+
+== Bug Fixes ==
+- Fixed an exploit where it was possible to open the NVDA python console via the log viewer on the lock screen.
+([GHSA-585m-rpvv-93qg https://github.com/nvaccess/nvda/security/advisories/GHSA-585m-rpvv-93qg])
+-
+
+= 2022.2.3 =
+This is a patch release to fix an accidental API breakage introduced in 2022.2.1.
 
 == Bug Fixes ==
 - Fixed a bug where NVDA did not announce "Secure Desktop" when entering a secure desktop.
 This caused NVDA remote to not recognize secure desktops. (#14094)
-- Fixed an exploit where it was possible to open the NVDA python console via the log viewer on the lock screen.
-([GHSA-585m-rpvv-93qg https://github.com/nvaccess/nvda/security/advisories/GHSA-585m-rpvv-93qg])
 -
 
 = 2022.2.2 =


### PR DESCRIPTION
**Squash merge not merge commit**

**Context:**

> Commit [c53bc97](https://github.com/nvaccess/nvda/commit/c53bc97dc66296c04b00a2e038f4a0cef71dee51) is tagged release-2022.2.3.
> 
> But the head of rc branch (commit [428622f](https://github.com/nvaccess/nvda/commit/428622f954cce8018a08992d3dec5688ea316015)) which is 1 commit ahead from the 2022.2.3 release, still adds items in the change log for 2022.2.3 release.
> 
> It's obviously a mistake.
> 
> Probably a 2022.2.4 should be released with GHSA-585m-rpvv-93qg and the change log should show it.

https://github.com/nvaccess/nvda/commit/428622f954cce8018a08992d3dec5688ea316015#r84574470