### PR TITLE
Report battery information first when fetching current status

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -46,7 +46,7 @@ import inputCore
 import characterProcessing
 from baseObject import ScriptableObject
 import core
-from winAPI._powerTracking import reportCurrentBatteryStatus, ReportContext
+from winAPI._powerTracking import reportCurrentBatteryStatus
 import winVersion
 from base64 import b16encode
 import vision
@@ -2515,7 +2515,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+shift+b"
 	)
 	def script_say_battery_status(self, gesture: inputCore.InputGesture) -> None:
-		reportCurrentBatteryStatus(ReportContext.FETCH_STATUS)
+		reportCurrentBatteryStatus()
 
 	@script(
 		description=_(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -46,7 +46,7 @@ import inputCore
 import characterProcessing
 from baseObject import ScriptableObject
 import core
-from winAPI._powerTracking import reportCurrentBatteryStatus
+from winAPI._powerTracking import reportCurrentBatteryStatus, ReportContext
 import winVersion
 from base64 import b16encode
 import vision
@@ -2515,7 +2515,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+shift+b"
 	)
 	def script_say_battery_status(self, gesture: inputCore.InputGesture) -> None:
-		reportCurrentBatteryStatus()
+		reportCurrentBatteryStatus(ReportContext.FETCH_STATUS)
 
 	@script(
 		description=_(

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -128,7 +128,7 @@ def initialize():
 
 
 @unique
-class ReportContext(Enum):
+class _ReportContext(Enum):
 	"""
 	Used to determine the order of information, based on relevance to the user,
 	when announcing power status information
@@ -140,7 +140,15 @@ class ReportContext(Enum):
 	"""e.g. when a user presses nvda+shift+b to fetch the current battery status"""
 
 
-def reportCurrentBatteryStatus(context: ReportContext) -> None:
+def reportACStateChange() -> None:
+	_reportPowerStatus(_ReportContext.AC_STATUS_CHANGE)
+
+
+def reportCurrentBatteryStatus() -> None:
+	_reportPowerStatus(_ReportContext.FETCH_STATUS)
+
+
+def _reportPowerStatus(context: _ReportContext) -> None:
 	"""
 	@param context: the context is used to order the announcement.
 	When the context is AC_STATUS_CHANGE, this reports the current AC status first.
@@ -166,7 +174,7 @@ def _getPowerStatus() -> Optional[SystemPowerStatus]:
 
 def _getSpeechForBatteryStatus(
 		systemPowerStatus: Optional[SystemPowerStatus],
-		context: ReportContext,
+		context: _ReportContext,
 		oldPowerState: PowerState,
 ) -> List[str]:
 	if not systemPowerStatus or systemPowerStatus.BatteryFlag == BatteryFlag.UNKNOWN:
@@ -179,7 +187,7 @@ def _getSpeechForBatteryStatus(
 		return [_("No system battery")]
 
 	if (
-		context == ReportContext.AC_STATUS_CHANGE
+		context == _ReportContext.AC_STATUS_CHANGE
 		and systemPowerStatus.ACLineStatus == oldPowerState
 	):
 		# Sometimes, the power change event double fires.
@@ -188,18 +196,18 @@ def _getSpeechForBatteryStatus(
 
 	text: List[str] = []
 
-	if context == ReportContext.AC_STATUS_CHANGE:
+	if context == _ReportContext.AC_STATUS_CHANGE:
 		# When the AC status changes, users want to be alerted to the new AC status first.
 		text.append(_getACStatusText(systemPowerStatus))
 		text.extend(_getBatteryInformation(systemPowerStatus))
-	elif context == ReportContext.FETCH_STATUS:
+	elif context == _ReportContext.FETCH_STATUS:
 		# When fetching the current battery status,
 		# users want to know the current battery status first,
 		# rather than the AC status which should be unchanged.
 		text.extend(_getBatteryInformation(systemPowerStatus))
 		text.append(_getACStatusText(systemPowerStatus))
 	else:
-		raise NotImplementedError(f"Unexpected ReportContext: {context}")
+		raise NotImplementedError(f"Unexpected _ReportContext: {context}")
 
 	return text
 

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -148,7 +148,7 @@ class _MessageWindow(windowUtils.CustomWindow):
 		"""
 		if msg == WindowMessage.POWER_BROADCAST:
 			if wParam == _powerTracking.PowerBroadcast.APM_POWER_STATUS_CHANGE:
-				_powerTracking.reportCurrentBatteryStatus(_powerTracking.ReportContext.AC_STATUS_CHANGE)
+				_powerTracking.reportACStateChange()
 		elif msg == WindowMessage.DISPLAY_CHANGE:
 			_displayTracking.reportScreenOrientationChange(lParam)
 		elif msg == WindowMessage.WTS_SESSION_CHANGE:

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -148,7 +148,7 @@ class _MessageWindow(windowUtils.CustomWindow):
 		"""
 		if msg == WindowMessage.POWER_BROADCAST:
 			if wParam == _powerTracking.PowerBroadcast.APM_POWER_STATUS_CHANGE:
-				_powerTracking.reportCurrentBatteryStatus(onlyReportIfStatusChanged=True)
+				_powerTracking.reportCurrentBatteryStatus(_powerTracking.ReportContext.AC_STATUS_CHANGE)
 		elif msg == WindowMessage.DISPLAY_CHANGE:
 			_displayTracking.reportScreenOrientationChange(lParam)
 		elif msg == WindowMessage.WTS_SESSION_CHANGE:

--- a/tests/unit/test_winAPI/test_powerTracking.py
+++ b/tests/unit/test_winAPI/test_powerTracking.py
@@ -11,7 +11,7 @@ from winAPI._powerTracking import (
 	BATTERY_LIFE_TIME_UNKNOWN,
 	BatteryFlag,
 	PowerState,
-	ReportContext,
+	_ReportContext,
 	SystemPowerStatus,
 	_getSpeechForBatteryStatus,
 )
@@ -27,7 +27,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 	def test_fetch_status_fetchFailed(self):
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=None,
-			context=ReportContext.FETCH_STATUS,
+			context=_ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.UNKNOWN,
 		)
 		self.assertEqual(
@@ -39,7 +39,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryFlag = BatteryFlag.UNKNOWN
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.FETCH_STATUS,
+			context=_ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.UNKNOWN,
 		)
 		self.assertEqual(
@@ -51,7 +51,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryFlag = 0 ^ BatteryFlag.NO_SYSTEM_BATTERY
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.FETCH_STATUS,
+			context=_ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.UNKNOWN,
 		)
 		self.assertEqual(
@@ -65,7 +65,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryLifeTime = 3660
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.FETCH_STATUS,
+			context=_ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
@@ -78,7 +78,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.AC_STATUS_CHANGE,
+			context=_ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
@@ -92,7 +92,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryLifeTime = 3660
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.AC_STATUS_CHANGE,
+			context=_ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
@@ -106,7 +106,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryLifeTime = 3660
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.AC_STATUS_CHANGE,
+			context=_ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(
@@ -120,7 +120,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryLifeTime = BATTERY_LIFE_TIME_UNKNOWN
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.AC_STATUS_CHANGE,
+			context=_ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(
@@ -135,7 +135,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 		self.testPowerStatus.BatteryLifeTime = BATTERY_LIFE_TIME_UNKNOWN
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			context=ReportContext.AC_STATUS_CHANGE,
+			context=_ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(

--- a/tests/unit/test_winAPI/test_powerTracking.py
+++ b/tests/unit/test_winAPI/test_powerTracking.py
@@ -11,6 +11,7 @@ from winAPI._powerTracking import (
 	BATTERY_LIFE_TIME_UNKNOWN,
 	BatteryFlag,
 	PowerState,
+	ReportContext,
 	SystemPowerStatus,
 	_getSpeechForBatteryStatus,
 )
@@ -23,10 +24,10 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			MagicMock(SystemPowerStatus())
 		)
 
-	def test_unknownPowerStatus_failedFetch(self):
+	def test_fetch_status_fetchFailed(self):
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=None,
-			onlyReportIfStatusChanged=False,
+			context=ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.UNKNOWN,
 		)
 		self.assertEqual(
@@ -34,11 +35,11 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_unknownPowerStatus_fetchSuccessful(self):
+	def test_fetch_status_fetchSuccessful_unknownPowerStatus(self):
 		self.testPowerStatus.BatteryFlag = BatteryFlag.UNKNOWN
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=False,
+			context=ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.UNKNOWN,
 		)
 		self.assertEqual(
@@ -46,11 +47,11 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_noSystemBattery(self):
+	def test_fetch_status_fetchSuccessful_noSystemBattery(self):
 		self.testPowerStatus.BatteryFlag = 0 ^ BatteryFlag.NO_SYSTEM_BATTERY
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=False,
+			context=ReportContext.FETCH_STATUS,
 			oldPowerState=PowerState.UNKNOWN,
 		)
 		self.assertEqual(
@@ -58,12 +59,26 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_statusUnchanged_ignore(self):
+	def test_fetch_status_full_report(self):
+		self.testPowerStatus.ACLineStatus = PowerState.AC_OFFLINE
+		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
+		self.testPowerStatus.BatteryLifeTime = 3660
+		actualSpeech = _getSpeechForBatteryStatus(
+			systemPowerStatus=self.testPowerStatus,
+			context=ReportContext.FETCH_STATUS,
+			oldPowerState=PowerState.AC_OFFLINE,
+		)
+		self.assertEqual(
+			['1 percent', '1 hours and 1 minutes remaining', "AC disconnected"],
+			actualSpeech,
+		)
+
+	def test_ac_status_change_statusUnchanged_ignore(self):
 		self.testPowerStatus.ACLineStatus = PowerState.AC_OFFLINE
 		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=True,
+			context=ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
@@ -71,27 +86,13 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_statusUnchanged_report(self):
-		self.testPowerStatus.ACLineStatus = PowerState.AC_OFFLINE
-		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
-		self.testPowerStatus.BatteryLifeTime = 3660
-		actualSpeech = _getSpeechForBatteryStatus(
-			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=False,
-			oldPowerState=PowerState.AC_OFFLINE,
-		)
-		self.assertEqual(
-			["AC disconnected", '1 percent', '1 hours and 1 minutes remaining'],
-			actualSpeech,
-		)
-
-	def test_statusChanged_connected(self):
+	def test_ac_status_change_statusChanged_connected(self):
 		self.testPowerStatus.ACLineStatus = PowerState.AC_ONLINE
 		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
 		self.testPowerStatus.BatteryLifeTime = 3660
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=True,
+			context=ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
@@ -99,13 +100,13 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_statusChanged_disconnected(self):
+	def test_ac_status_change_statusChanged_disconnected(self):
 		self.testPowerStatus.ACLineStatus = PowerState.AC_OFFLINE
 		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
 		self.testPowerStatus.BatteryLifeTime = 3660
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=True,
+			context=ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(
@@ -113,13 +114,13 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_batteryLifetimeUnknown(self):
+	def test_ac_status_change_batteryLifetimeUnknown(self):
 		self.testPowerStatus.ACLineStatus = PowerState.AC_OFFLINE
 		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
 		self.testPowerStatus.BatteryLifeTime = BATTERY_LIFE_TIME_UNKNOWN
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=True,
+			context=ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(
@@ -127,14 +128,14 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			actualSpeech,
 		)
 
-	def test_batteryLifePercent(self):
+	def test_ac_status_change_batteryLifePercent(self):
 		self.testPowerStatus.ACLineStatus = PowerState.AC_OFFLINE
 		self.testPowerStatus.BatteryFlag = BatteryFlag.HIGH
 		self.testPowerStatus.BatteryLifePercent = 7
 		self.testPowerStatus.BatteryLifeTime = BATTERY_LIFE_TIME_UNKNOWN
 		actualSpeech = _getSpeechForBatteryStatus(
 			systemPowerStatus=self.testPowerStatus,
-			onlyReportIfStatusChanged=True,
+			context=ReportContext.AC_STATUS_CHANGE,
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,7 +53,6 @@ There are new Chinese, Swedish, Luganda and Kinyarwanda braille tables.
     - Chinese (China, Mandarin) Current Braille System (no tones) (#14138)
     -
 - NVDA now includes the architecture of the operating system as part of user statistics tracking. (#14019)
-- Reporting power state changes and using the script to report battery status now report the same message consistently. (#14035)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14214 
See also #14213

### Summary of the issue:
The current battery status message when pressing `NVDA+shift+b` is too verbose, because it reports the AC status before the battery level.

This is useful for an AC state change (e.g. when plugging in a charger)
But is not ideal for when pressing `NVDA+shift+b` to fetch the battery status.

### Description of user facing changes
Reverts to previous ordering in 2022.3.

When the AC status changes, the AC status is still reported first: "charging" or "AC disconnected".
When `NVDA+shift+b` is pressed to fetch the battery status, the battery status is reported first: "X percentage, Z hours and Y minutes remaining"

### Description of development approach
Change internal parameter `onlyReportIfStatusChanged` to `ReportContext`.
A `ReportContext` is used to determine order of speech.

When the context is an AC status change, this reports the current AC status first.
When the context is a user fetching the current battery status, this reports the remaining battery life first.

### Testing strategy:
Manually test disconnecting and connecting AC and using `NVDA+shift+b`

Existing unit tests have been updated

### Known issues with pull request:
None

### Change log entries:
None, fixes unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
