### PR TITLE
appModules/searchui: add support for Search Highlights announcement in Windows 11

### DIFF
--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -20,6 +20,12 @@ class StartMenuSearchField(SearchField):
 	# #7370: do not announce text when start menu (searchui) closes.
 	announceNewLineText = False
 
+	def _get_description(self):
+		# #13841: detect search highlights and anounce it.
+		if self.lastChild.UIAAutomationId == "PlaceholderTextContentPresenter":
+			return self.lastChild.name
+		return super().description
+
 
 class AppModule(appModuleHandler.AppModule):
 

--- a/source/appModules/searchui.py
+++ b/source/appModules/searchui.py
@@ -20,7 +20,7 @@ class StartMenuSearchField(SearchField):
 	# #7370: do not announce text when start menu (searchui) closes.
 	announceNewLineText = False
 
-	def _get_description(self):
+	def _get_description(self) -> str:
 		# #13841: detect search highlights and anounce it.
 		if self.lastChild.UIAAutomationId == "PlaceholderTextContentPresenter":
 			return self.lastChild.name

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,10 +10,12 @@ What's New in NVDA
 
 == Changes ==
 - Updated Sonic rate boost library to commit ``1d70513``. (#14180)
-
+-
 
 
 == Bug Fixes ==
+- In Windows 11, NVDA will announce search highlights when opening Start menu. (#13841)
+-
 
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13841 

### Summary of the issue:
In Windows 11, NVDA does not announce search highlights when entering Start menu.

### Description of user facing changes
In Windows 11 21H2 and 22H2, NVDA will announce search highlights as part of the search box description (example: search box edit type here to search, search highlight text).

### Description of development approach
_get_description method is introduced in appModules.searchui.StartMenuSearchField class that will obtain search highlights text (last child of the search box element with a unique UIA Automation Id) and treat it as the description text for the search field. To account for Windows 10 and to handle search results display (when search highlights text is unavailable), return the description provided by base UIA object if search highlights element is gone. With this change, if no search term is entered, NVDA will announce search highlights as part of search field description in speech and braille.

### Testing strategy:
Manual testing (cannot be tested with Appveyor as it uses Windows Server 2019 so no search highlights there):

Requirements: Windows 11 Version 21H2 build 22000.800 or above, Version 22H2 build 22621.521 and later:

1. Open Start menu.
2. Prior to the pull request, NVDA will say, "search box edit". With the PR, NVDA will say, "search box edit" followed by the name of the last element (search highlights text) if present.
3. Without entering search terms, press NVDA+Tab to read focused element properties. NVDA will announce search highlights if present.
4. Type something (say, NVDA) to the search field. NVDA will announce the top search result.
5. Press NVDA+Tab, and NVDA will announce "search box" followed by the terms entered (no search highlights text).
6. Clear search terms.
7. Press NVDA+Tab and NVDA will announce search highlights text again.

### Known issues with pull request:
Braille is not updated when search terms are entered into Start menu search field, more towards a limitation of not refreshing element properties when it changes. This may require a fix from braille output side unless the PR approach is the cause.

### Change log entries:
Can be both a new feature and a bug fix, will leave it up to NV Access to decide what's better (sensitive to Windows 10 Version 22H2 feature set as Search Highlights may or may not be backported to Vibranium):

In Windows 11, NVDA will announce search highlights when opening Start menu. (#13841)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

### Additional context:
https://blogs.windows.com/windows-insider/2022/06/16/releasing-windows-11-build-22000-766-to-the-release-preview-channel/
