### PR TITLE
Log the source of the error when the profile activation fails

### DIFF
--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2013-2018 NV Access Limited, Joseph Lee, Julien Cochuyt, Thomas Stivers
+# Copyright (C) 2013-2022 NV Access Limited, Joseph Lee, Julien Cochuyt, Thomas Stivers, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -171,6 +171,7 @@ class ProfilesDialog(
 		try:
 			config.conf.manualActivateProfile(profile)
 		except:
+			log.debugWarning("", exc_info=True)
 			# Translators: An error displayed when activating a configuration profile fails.
 			gui.messageBox(_("Error activating profile."),
 				_("Error"), wx.OK | wx.ICON_ERROR, self)


### PR DESCRIPTION
Issue found while working on #14233 (testing).

### Link to issue number:
None
### Summary of the issue:
When an error occurs while switching profile manually, a message box indicates that there has been an error, but nothing in the  message box nor in the log indicates the source of error (no traceback...).

### Description of user facing changes
When profile switching fails, the traceback of the error is logged.

### Description of development approach
Added the log

### Testing strategy:
Manual testing:
* Created a new profile
* Manually edited the file to make it invalid, e.g. remove "]" in a section name.
* Manually activate the profile
* Check the log
### Known issues with pull request:
None
### Change log entries:
Do not deserve change log.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
