### PR TITLE
Report name of configuration profile when deleting

### DIFF
--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -187,6 +187,7 @@ class ProfilesDialog(
 		name = self.profileNames[index]
 		if gui.messageBox(
 			# Translators: The confirmation prompt displayed when the user requests to delete a configuration profile.
+			# The placeholder {} is replaced with the name of the configuration profile that will be deleted.
 			_("The profile {} will be permanently deleted. This action cannot be undone.").format(name),
 			# Translators: The title of the confirmation dialog for deletion of a configuration profile.
 			_("Confirm Deletion"),

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -184,15 +184,15 @@ class ProfilesDialog(
 
 	def onDelete(self, evt):
 		index = self.profileList.Selection
+		name = self.profileNames[index]
 		if gui.messageBox(
 			# Translators: The confirmation prompt displayed when the user requests to delete a configuration profile.
-			_("This profile will be permanently deleted. This action cannot be undone."),
+			_("The profile {} will be permanently deleted. This action cannot be undone.").format(name),
 			# Translators: The title of the confirmation dialog for deletion of a configuration profile.
 			_("Confirm Deletion"),
-			wx.OK | wx.CANCEL | wx.ICON_QUESTION, self
+			wx.OK | wx.CANCEL | wx.CANCEL_DEFAULT | wx.ICON_QUESTION, self
 		) != wx.OK:
 			return
-		name = self.profileNames[index]
 		try:
 			config.conf.deleteProfile(name)
 		except:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #13677 

### Summary of the issue:
When deleting a profile, the confirmation dialog does not name the profile that should be deleted

### Description of user facing changes
The name of the profile is added to the message box text, also, like the addons deletion dialog, cancel is the default to prevent accidental deletion.

### Description of development approach
Change message box text to
> The profile {} will be permanently deleted. This action cannot be undone.

### Testing strategy:
Deleted a profile, insured that the profile name is spoken

### Known issues with pull request:
None

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
