### PR TITLE
Complete setup before modifying NVDA config

### DIFF
--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -112,7 +112,15 @@ class NVDASpyLib:
 		self._brailleSpy = BrailleViewerSpy()
 		self._brailleSpy.postBrailleUpdate.register(self._onNvdaBraille)
 
-	def set_configValue(self, keyPath: typing.List[str], val: typing.Union[str, bool, int]):
+	ConfKeyPath = typing.List[str]
+	ConfKeyVal = typing.Union[str, bool, int]
+	NVDAConfMods = typing.List[typing.Tuple[ConfKeyPath, ConfKeyVal]]
+
+	def modifyNVDAConfig(self, confMods: NVDAConfMods):
+		for keyPath, keyVal in confMods:
+			self.set_configValue(keyPath, keyVal)
+
+	def set_configValue(self, keyPath: ConfKeyPath, val: ConfKeyVal):
 		import config
 		if not keyPath or len(keyPath) < 1:
 			raise ValueError("Key path not provided")


### PR DESCRIPTION
### Link to issue number:
Splitting up PR #14054

### Summary of the issue:
Some config can affect the way the test samples are prepared, E.G. moving focus / review to the start location.

### Description of user facing changes
None

### Description of development approach
For all tests that modify NVDA config, ensure this happens after the initial set up is completed.
Introduce a new helper to allow modifying multiple settings at once.

### Testing strategy:
System tests:
- locally
- Appveyor

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
