### PR TITLE
Tests reusing samples must have unique titles.

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -8,6 +8,7 @@ Google Chrome with a HTML sample and assert NVDA interacts with it in the expect
 """
 
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
+import datetime as _datetime
 from os.path import join as _pJoin
 import tempfile as _tempfile
 from typing import Optional as _Optional
@@ -219,6 +220,13 @@ class ChromeLib:
 		@param testCase - The HTML sample to test.
 		@param _doToggleFocus - When True, Chrome will be intentionally de-focused and re-focused
 		"""
+		testCase = testCase + (
+			"\n<!-- "  # new line, start a HTML comment
+			"Sample generation time, to ensure that the test case title is reproducibly unique purely from"
+			" this test case string: \n"
+			f"{ _datetime.datetime.now().isoformat()} "
+			f" -->"  # end HTML comment
+		)
 		spy = _NvdaLib.getSpyLib()
 		_chromeLib: "ChromeLib" = _getLib('ChromeLib')  # using the lib gives automatic 'keyword' logging.
 		path = self._writeTestFile(testCase)

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -9,6 +9,7 @@ Windows Notepad with a text sample and assert NVDA interacts with it in the expe
 
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
 from os.path import join as _pJoin
+import datetime as _datetime
 import tempfile as _tempfile
 from typing import Optional as _Optional
 from SystemTestSpy import (
@@ -65,21 +66,21 @@ class NotepadLib:
 		return self.notepadHandle
 
 	@staticmethod
-	def getUniqueTestCaseTitle(testCase: str) -> str:
-		return f"{NotepadLib._testCaseTitle} ({abs(hash(testCase))}).txt"
+	def getUniqueTestCaseTitle(testCaseHash: int) -> str:
+		return f"{NotepadLib._testCaseTitle} ({abs(testCaseHash)}).txt"
 
 	@staticmethod
-	def getUniqueTestCaseTitleRegex(testCase: str) -> re.Pattern:
-		return re.compile(f"^{NotepadLib._testCaseTitle} \\({abs(hash(testCase))}\\)")
+	def getUniqueTestCaseTitleRegex(testCaseHash: int) -> re.Pattern:
+		return re.compile(f"^{NotepadLib._testCaseTitle} \\({abs(testCaseHash)}\\)")
 
 	@staticmethod
-	def _writeTestFile(testCase) -> str:
+	def _writeTestFile(testCase: str, filename: str) -> str:
 		"""
 		Creates a file for a plaintext test case.
 		@param testCase:  The plaintext sample that is to be tested.
 		@return: path to the plaintext file.
 		"""
-		filePath = NotepadLib._getTestCasePath(NotepadLib.getUniqueTestCaseTitle(testCase))
+		filePath = NotepadLib._getTestCasePath(filename)
 		with open(file=filePath, mode='w', encoding='UTF-8') as f:
 			f.write(testCase)
 		return filePath
@@ -120,11 +121,13 @@ class NotepadLib:
 		@param testCase - The plaintext sample to test.
 		"""
 		spy = _NvdaLib.getSpyLib()
-		path = self._writeTestFile(testCase)
+		_testCaseHash = hash(testCase + _datetime.datetime.now().isoformat())
+		uniqueTitleRegex = NotepadLib.getUniqueTestCaseTitleRegex(_testCaseHash)
+		path = self._writeTestFile(testCase, self.getUniqueTestCaseTitle(_testCaseHash))
 
 		spy.wait_for_speech_to_finish()
 		self.start_notepad(path)
-		self._waitForNotepadFocus(NotepadLib.getUniqueTestCaseTitleRegex(testCase))
+		self._waitForNotepadFocus(uniqueTitleRegex)
 		# Move to the start of file
 		spy.emulateKeyPress('home')
 		spy.wait_for_speech_to_finish()


### PR DESCRIPTION
### Link to issue number:
Splitting up PR https://github.com/nvaccess/nvda/pull/14054

### Summary of the issue:
When the same sample is used in multiple tests, the title for the app (chrome / notepad) may be identical.
The tests use the app title to determine when the test sample has opened.
When the titles are not unique, the test may start with the app already in an unexpected state, it may also get interrupted by the new app instance opening.

### Description of user facing changes
None

### Description of development approach
Use a timestamp as well as the sample contents to create a unique title.

### Testing strategy:
Run on appveyor.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
