### PR TITLE
Fixed an issue where symbol repetition was not correctly reported by the synthesizer

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2010-2022 NV Access Limited, World Light Information Limited,
-# Hong Kong Blind Union, Babbage B.V., Julien Cochuyt
+# Hong Kong Blind Union, Babbage B.V., Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -578,7 +578,7 @@ class SpeechSymbolProcessor(object):
 			text = m.group()
 			symbol = self.computedSymbols[text[0]]
 			if self._level >= symbol.level:
-				return u" {count} {char} ".format(count=len(text), char=symbol.replacement)
+				return "  {count} {char} ".format(count=len(text), char=symbol.replacement)
 			else:
 				return " "
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

Read the following line with OneCore (e.g. Zira) and symbol level all:
What is USD????

I can hear:  
"What is four US dollars question"

Instead I expect  
"What is USD four question"

The issue is due to the fact that the synth interprets "USD 4" as "four dollars". Instead, the repetition of "question" should not handled with the rest of the text by the synth but reported as is.

The impacted synthesizers are:
- OneCore
- SAPI5
- IBMTTS

On the contrary, eSpeak is not impacted. Probably because it does not handle internally expressions such as "USD 4".

### Description of user facing changes

The user should not hear anymore issues when reporting repeated symbols.

### Description of development approach

Two spaces are added instead of only one between the rest of the text.

### Testing strategy:
Manual test with the expression in this PR.

### Known issues with pull request:
None.

### Change log entries:
IMO, a such small bugfix does not deserve an entry. If you disagree, I can writre something for the "Bugfixes" section.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
