### PR TITLE
New script to toggle delayed descriptions for characters.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -948,7 +948,7 @@ class GlobalCommands(ScriptableObject):
 		description=_("Toggles on and off delayed descriptions for characters on cursor movement"),
 		category=SCRCAT_SPEECH,
 	)
-	def script_toggleDelayedCharacterDescription(self, gesture: inputCore.InputGesture) -> None:
+	def script_toggleDelayedCharacterDescriptions(self, gesture: inputCore.InputGesture) -> None:
 		enabled: bool = not config.conf["speech"]["delayedCharacterDescriptions"]
 		config.conf["speech"]["delayedCharacterDescriptions"] = enabled
 		if enabled:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -944,6 +944,22 @@ class GlobalCommands(ScriptableObject):
 		ui.message(_("Symbol level %s") % name)
 
 	@script(
+		# Translators: Input help mode message for toggle delayed character description command.
+		description=_("Toggles on and off delayed descriptions for characters on cursor movement"),
+		category=SCRCAT_SPEECH,
+	)
+	def script_toggleDelayedCharacterDescription(self, gesture: inputCore.InputGesture) -> None:
+		enabled: bool = not config.conf["speech"]["delayedCharacterDescriptions"]
+		config.conf["speech"]["delayedCharacterDescriptions"] = enabled
+		if enabled:
+			# Translators: The message announced when toggling the delayed character description setting.
+			state = _("delayed character descriptions on")
+		else:
+			# Translators: The message announced when toggling the delayed character description setting.
+			state = _("delayed character descriptions off")
+		ui.message(state)
+	
+	@script(
 		# Translators: Input help mode message for move mouse to navigator object command.
 		description=_("Moves the mouse pointer to the current navigator object"),
 		category=SCRCAT_MOUSE,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,8 @@ What's New in NVDA
 - Microsoft Excel via UI Automation: Automatic reporting of column and row headers in tables. (#14228)
  - Note this is referring to tables formatted via Insert -> Table on the Ribon, where the table has a header row, and or a special first column.
  - This is not referring to screen reader specific headers via named ranges, which is currently not supported via UI automation.
+ -
+- An unassigned script has been added to toggle delayed character descriptions. (#14267)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
https://nvda.groups.io/g/nvda/message/100197

### Summary of the issue:

A script to toggle delayed character description has been asked.

### Description of user facing changes

Added a script to toggle delayed character description.

Keep this script unassigned because it does not seem to me that this feature deserve a predefined gesture.

### Description of development approach

Added the script in global commands, as other such scripts.

### Additional possible changes
I am always a bit disturbed by the wording "Delayed character descriptions" or "Delayed descriptions for characters" with the plural form, specifically in my language (French). The other options, on the contrary, are worded with singular form, e.g. we do not have "Font sizes".
If you agree, while at it, I may reword this option using singular form.
What do you think? CC @Qchristensen 

If it's not an issue in English, I'll see on French translation side only.


### Testing strategy:
Manual tests:
I have assigned the script and used it. I have checked that:
- the script correctly reports its action
- the option in the GUI is changed adequately
- the feature is enabled/disabled according to the action of the script
- input help is working well

### Known issues with pull request:
None.

### Change log entries:
`An unassigned command has been added to toggle delayed character descriptions.`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
