### PR TITLE
vbuf backend: If a node has been marked allowReuseInAncestorUpdate, ensure we propagate alwaysRerenderDescendants if appropriate before returning.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,6 +22,7 @@ What's New in NVDA
 - Suggestions are reported when typing an @mention in in Microsoft Excel comments. (#13764)
 - In the Google Chrome location bar, suggestion controls (switch to tab, remove suggestion etc) are now reported when selected. (#13522)
 - When requesting formatting information, colors are now explicitly reported in Wordpad or log viewer, rather than only "Default color". (#13959)
+- In Firefox, activating the Show options button on GitHub issue pages now works reliably. (#14269)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,7 +22,7 @@ What's New in NVDA
 - Suggestions are reported when typing an @mention in in Microsoft Excel comments. (#13764)
 - In the Google Chrome location bar, suggestion controls (switch to tab, remove suggestion etc) are now reported when selected. (#13522)
 - When requesting formatting information, colors are now explicitly reported in Wordpad or log viewer, rather than only "Default color". (#13959)
-- In Firefox, activating the Show options button on GitHub issue pages now works reliably. (#14269)
+- In Firefox, activating the "Show options" button on GitHub issue pages now works reliably. (#14269)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
With the Firefox accessibility cache enabled, the "Show options" button above GitHub issue comments sometimes doesn't render correctly in browse mode. Pressing enter on it won't open the menu. Sometimes, completely irrelevant text (potentially even from other tabs) gets rendered instead of that button.

### Description of user facing changes
Fixes the above issues.

### Description of development approach
Previously, the vbuf backend check for allowReuseInAncestorUpdate was before alwaysRerenderDescendants. This meant that if the node had allowReuseInAncestorUpdate and its parent had alwaysRerenderDescendants, we wouldn't propagate alwaysRerenderDescendants down the tree. That meant that we might not pick up changes in a subtree which was moved at the same time as descendants were mutated. I fixed this by moving the check and propagation of alwaysRerenderDescendants before the allowReuseInAncestorUpdate check.

This still results in an early null return. It just ensures we propagate alwaysRerenderDescendants before we do.

### Testing strategy:
1. Used Firefox Nightly with the accessibility cache enabled; [instructions](https://blog.mozilla.org/accessibility/cache-the-world-opt-in-preview/).
2. Opened https://github.com/jcsteh/osara/issues/801
3. Control+home, 3, up arrow to get to the Show options button for the first comment.
4. Pressed enter.
    - Before PR: Sometimes, the window title is announced and the options menu does not appear.
    - After PR: The menu always appears.
5. Even without the PR, this sometimes works. When it did work, I refreshed the page with control+r and repeated from step 2. This usually failed within 10 refreshes.

Notes:
- Although I could only reproduce this with the Firefox accessibility cache enabled, I don't believe this is a bug therein. We fire the same events regardless of the cache. I think the variable here is that the cache makes Firefox respond much faster, so the timing of events and buffer renders is very different.
- I tried really hard to come up with a distilled test case, but I failed. Creating the sequence of events needed to make this happen is pretty mind-boggling. I hope the logic makes sense, though: if we're not supposed to re-render descendants and we fail to propagate that to descendants, we're not going to honour that flag correctly.
- That unfortunately means I also wasn't able to come up with an automated test.

### Known issues with pull request:
None known.

### Change log entries:
Bug fixes
In Firefox, activating the Show options button on GitHub issue pages now works reliably.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
