### PR TITLE
Update CLDR to version 42

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [Sonic](https://github.com/waywardgeek/sonic), commit 1d705135
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.23.0
-* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 42
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 42.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit 45a76a3

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [Sonic](https://github.com/waywardgeek/sonic), commit 1d705135
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.23.0
-* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 41.0
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 42
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit 45a76a3

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,6 +14,7 @@ What's New in NVDA
 
 == Changes ==
 - Updated Sonic rate boost library to commit ``1d70513``. (#14180)
+- CLDR has been updated to version 42.0. (#14273)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Related `nvda-cldr` update: https://github.com/nvaccess/nvda-cldr/pull/3
### Summary of the issue:
Periodically CLDR update: CLDR team released version 42 of the CLDR package.
### Description of user facing changes
New emojis and characters
### Description of development approach
None
### Testing strategy:
Use your favorite emoji provider like emojipedia.org
### Known issues with pull request:
None
### Change log entries:
Changes
- Update CLDR to version 42. (#14273)
### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.