### PR TITLE
UIA NVDAObject's controllerFor property: catch KeyError seen on Windows 7 due to bad UIA client library marshalling and a limitation in comtypes.

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2048,8 +2048,9 @@ class UIA(Window):
 			# On Newer Windows versions, the client library correctly marshals this to
 			# IUIAutomationElementArray per the UI Automation documentation.
 			# UI Automation documentation seems to suggest controllerFor is supported on Windows 7,
-			# So it is unclear as to ewhat versions have this bug.
+			# So it is unclear as to what versions have this bug.
 			# Best just to catch KeyError.
+			log.debugWarning("Bad controllerFor property", exc_info=True)
 			return []
 		if UIAHandler.handler.clientObject.checkNotSupported(e):
 			return None


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14270

### Summary of the issue:
when searching in the Windows 7 start menu or navigating in Windows 7 Explorer, the NVDA error sound is heard and the following traceback is printed to the log:
```
ERROR - eventHandler.executeEvent (19:40:54.124) - MainThread (4480):
error executing event: UIA_elementSelected on <NVDAObjects.Dynamic_UIItemListItemUIA object at 0x06F9EE50> with extra args of {}
Traceback (most recent call last):
  File "eventHandler.pyc", line 300, in executeEvent
  File "eventHandler.pyc", line 101, in __init__
  File "eventHandler.pyc", line 110, in next
  File "NVDAObjects\UIA\__init__.pyc", line 2058, in event_UIA_elementSelected
  File "NVDAObjects\__init__.pyc", line 1189, in event_selection
  File "baseObject.pyc", line 42, in __get__
  File "baseObject.pyc", line 146, in _getPropertyViaCache
  File "NVDAObjects\UIA\__init__.pyc", line 2041, in _get_controllerFor
  File "NVDAObjects\UIA\__init__.pyc", line 987, in _getUIACacheablePropertyValue
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 32, in __call__
  File "comtypes\automation.pyc", line 516, in __ctypes_from_outparam__
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 146, in newVARIANT_value_fget
  File "comtypes\automation.pyc", line 467, in _get_value
KeyError: 13
```

the KeyError is raised by comtypes as it does not know how to unpack a variant of type VT_Unknown | VT_Array.

However, the reason this variant is returned in the first place is because the UIA client library directly returns the provider's VT_Unknown | VT_Array variant on Windows 7, Which is useless for a client.
On Newer Windows versions, the client library correctly marshals this to IUIAutomationElementArray per the UI Automation documentation.

### Description of user facing changes
No error sound is heard and traceback is only printed to the log at debugWarning.

### Description of development approach
Catch KeyError when fetching the UIA_ControllerFor property.
 
An alternative could have been to limit the fetching of the controllerfor property to versions above Windows 7, but as official windows 7 UI automation documentation states that controllerFor is supported, it is unclear then as to exactly what versions are affected.

### Testing strategy:
* [x] Performed steps in pr #14222, ensuring no regression on Windows 11.
* [x] have try build tested on Windows 7 to ensure error sound goes away.

### Known issues with pull request:
None known.

### Change log entries:
None needed.
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
