### PR TITLE
UIA handler: add UIA drag drop effect property as a global property event

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -185,6 +185,7 @@ UIAPropertyIdsToNVDAEventNames={
 
 globalEventHandlerGroupUIAPropertyIds = {
 	UIA.UIA_RangeValueValuePropertyId,
+	UIA.UIA_DragDropEffectPropertyId,
 	UIA.UIA_DropTargetDropTargetEffectPropertyId,
 }
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Follow-up to #12271
Follow-up to #14081 

### Summary of the issue:
Follow-up/quick fix engineering for drag and drop effect announcement: suppose a user moves the mouse to an object that: is a UIA element, supports drag and drop, and is not a system focus. When drag and drop operation starts, drag drop effect is not announced, caused by the drag drop effect not being a global property event.

### Description of user facing changes
Drag drop effect will be announced when performing drag and drop operation via mouse regardless of system focus, similar to drop target effect announcement.

### Description of development approach
Add UIA_DragDropEffectPropertyId to global properties list to align with drop target effect property.

### Testing strategy:
Manual testing (same as #12271 and #14081):

Ideal system: Windows 11 Version 21H2 or 22H2, NVDA 2022.4 beta 2:

1. Press Windows+T to move system focus to the first taskbar icon.
2. Move the mouse to the taskbar icon next to the focused item (idelaly the second pinned item).
3. Hold the mouse down and drag the item to the first position (to the left).

NVDA 2022.4 beta 2: no drag drop effect announcement
After this PR: drag drop effect will be announced

### Known issues with pull request:
None

### Change log entries:
None needed as the bug fix entry for #12271 and #14081 will suffice, but for the release announcement for a potential 2022.4 beta release, one can say:
NVDA will announce drag and drop progress when using the mouse to drag items on screen (or something similar).

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

### Beta branch justification:
This is a bug fix/new feature introduced in NVDA 2022.4. Subsequent testing indicate that drag drop UIA property should have been a global property so the property can be announced based on mouse actions, similar to reporting mouse when mouse tracking is turned on via mouse settings panel. This change also aligns with drop target effect announcement as drag and drop announcement issue covers both.
