### PR TITLE
Support Outlook Date picker control in Outlook advanced Search dialog

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -9,6 +9,7 @@ from comtypes.hresult import S_OK
 import comtypes.client
 import comtypes.automation
 import ctypes
+import winVersion
 from hwPortUtils import SYSTEMTIME
 import scriptHandler
 from scriptHandler import script
@@ -98,6 +99,21 @@ def getSentMessageString(obj):
 	return ", ".join(nameList)
 
 class AppModule(appModuleHandler.AppModule):
+
+	def isGoodUIAWindow(self, hwnd: int) -> bool:
+		windowClass = winUser.getClassName(hwnd)
+		versionMajor=int(self.productVersion.split('.')[0])
+		if (
+			versionMajor >= 16
+			and windowClass == "RICHEDIT60W"
+			and winVersion.getWinVer() >= winVersion.WIN10
+		):
+			# #12726: RICHEDIT60W In Outlook 2016+ on Windows 10+ 
+			# has a very good UI Automation implementation,
+			# Though oddly IsServerSideProvider returns false for these windows.
+			# Examples: date picker in the Outlook Advanced search dialog
+			return True
+		return False
 
 	def __init__(self,*args,**kwargs):
 		super(AppModule,self).__init__(*args,**kwargs)

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -102,13 +102,13 @@ class AppModule(appModuleHandler.AppModule):
 
 	def isGoodUIAWindow(self, hwnd: int) -> bool:
 		windowClass = winUser.getClassName(hwnd)
-		versionMajor=int(self.productVersion.split('.')[0])
+		versionMajor = int(self.productVersion.split('.')[0])
 		if (
 			versionMajor >= 16
 			and windowClass == "RICHEDIT60W"
 			and winVersion.getWinVer() >= winVersion.WIN10
 		):
-			# #12726: RICHEDIT60W In Outlook 2016+ on Windows 10+ 
+			# #12726: RICHEDIT60W In Outlook 2016+ on Windows 10+
 			# has a very good UI Automation implementation,
 			# Though oddly IsServerSideProvider returns false for these windows.
 			# Examples: date picker in the Outlook Advanced search dialog

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ What's New in NVDA
 - In the Google Chrome location bar, suggestion controls (switch to tab, remove suggestion etc) are now reported when selected. (#13522)
 - When requesting formatting information, colors are now explicitly reported in Wordpad or log viewer, rather than only "Default color". (#13959)
 - In Firefox, activating the "Show options" button on GitHub issue pages now works reliably. (#14269)
+- The date picker controls in Outlook 2016 / 365 Advanced search dialog now report their label and value. (#12726)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #12726

### Summary of the issue:
When focusing date picker controls in Microsoft Outlook's Advanced Search dialog, NVDA announces no label or value for the control, instead just announcing "edit blank".
NVDA currently accesses these RICHEDIT60W controls with MSAA / the RichEdit API. However, it seems that the UI Automation implementation is much richer, though for some reason these windows do not themselves report as having a UIA implementation (I.e. HasServersideProvider returns false).

### Description of user facing changes
When focusing date picker controls in Microsoft Outlook's advanced search dialog, e.g. the date Received field, NVDA now reports the appropriate label and value of the control.

### Description of development approach
In Outlook appModule's isGoodUIAWindow method, mark RICHEDIT60W windows as having a good UI Automation implementation in Outlook 2016+ / Windows 10+.

### Testing strategy:
In Outlook 365 on Windows 11, open the Outlook Advanced search dialog by pressing control+e and tabbing to the Advanced search button and pressing enter, then tabbing 5 or so times to the Received date field, and ensuring that the label, and value if filled, is announced for the control. Note to fill the field, press downArrow to make the date picker appear and choose a date.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
* The date picker controls in Outlook 2016 / 365 Advanced search dialog now report their label and value.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
