### PR TITLE
Check if on secure desktop when checking if Windows is locked

### DIFF
--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -38,6 +38,11 @@ class DefaultAppArgs(argparse.Namespace):
 	This is also set to True when NVDA is running on a secure screen
 	(systemUtils._isSecureDesktop() returns True)
 	and the serviceDebug parameter has not been set.
+
+	For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
+	and the following userGuide sections:
+	 - SystemWideParameters (information on the serviceDebug parameter)
+	 - SecureMode and SecureScreens
 	"""
 	disableAddons: bool = False
 	debugLogging: bool = False

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -32,6 +32,13 @@ class DefaultAppArgs(argparse.Namespace):
 	language: str = "en"
 	minimal: bool = False
 	secure: bool = False
+	"""
+	When this is True, NVDA is running in secure mode.
+	This is set to True when NVDA starts with the --secure parameter.
+	This is also set to True when NVDA is running on a secure screen
+	(systemUtils._isSecureDesktop() returns True)
+	and the serviceDebug parameter has not been set.
+	"""
 	disableAddons: bool = False
 	debugLogging: bool = False
 	noLogging: bool = False

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -37,7 +37,7 @@ class DefaultAppArgs(argparse.Namespace):
 	This is set to True when NVDA starts with the --secure parameter.
 	This is also set to True when NVDA is running on a secure screen
 	(systemUtils._isSecureDesktop() returns True)
-	and the serviceDebug parameter has not been set.
+	and the serviceDebug parameter is not set.
 
 	For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
 	and the following userGuide sections:

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -260,16 +260,11 @@ elif globalVars.appArgs.check_running:
 	_log.debug("Exiting")
 	sys.exit(1)
 
-UOI_NAME = 2
-def getDesktopName():
-	desktop = ctypes.windll.user32.GetThreadDesktop(ctypes.windll.kernel32.GetCurrentThreadId())
-	name = ctypes.create_unicode_buffer(256)
-	ctypes.windll.user32.GetUserObjectInformationW(desktop, UOI_NAME, ctypes.byref(name), ctypes.sizeof(name), None)
-	return name.value
 
-
+# Suppress E402 (module level import not at top of file)
+from systemUtils import _getDesktopName, _isSecureDesktop  # noqa: E402
 # Ensure multiple instances are not fully started by using a mutex
-desktopName = getDesktopName()
+desktopName = _getDesktopName()
 _log.info(f"DesktopName: {desktopName}")
 
 
@@ -345,8 +340,8 @@ if mutex is None:
 	_log.error(f"Unknown mutex acquisition error. Exiting")
 	sys.exit(1)
 
-isSecureDesktop = desktopName == "Winlogon"
-if isSecureDesktop:
+
+if _isSecureDesktop():
 	import winreg
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NVDA")
@@ -382,7 +377,7 @@ if not ctypes.windll.user32.ChangeWindowMessageFilter(winUser.WM_QUIT, winUser.M
 	raise winUser.WinError()
 # Make this the last application to be shut down and don't display a retry dialog box.
 winKernel.SetProcessShutdownParameters(0x100, winKernel.SHUTDOWN_NORETRY)
-if not isSecureDesktop and not config.isAppX:
+if not _isSecureDesktop() and not config.isAppX:
 	import easeOfAccess
 	easeOfAccess.notify(3)
 try:
@@ -392,7 +387,7 @@ except:
 	log.critical("core failure",exc_info=True)
 	sys.exit(1)
 finally:
-	if not isSecureDesktop and not config.isAppX:
+	if not _isSecureDesktop() and not config.isAppX:
 		easeOfAccess.notify(2)
 	if globalVars.appArgs.changeScreenReaderFlag:
 		winUser.setSystemScreenReaderFlag(False)

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -158,7 +158,16 @@ parser.add_argument(
 	)
 )
 parser.add_argument('-m','--minimal',action="store_true",dest='minimal',default=False,help="No sounds, no interface, no start message etc")
-parser.add_argument('-s','--secure',action="store_true",dest='secure',default=False,help="Secure mode (disable Python console)")
+# --secure is used to force secure mode.
+# Documented in the userGuide in #SecureMode.
+parser.add_argument(
+	'-s',
+	'--secure',
+	action="store_true",
+	dest='secure',
+	default=False,
+	help="Starts NVDA in secure mode",  
+)
 parser.add_argument('--disable-addons',action="store_true",dest='disableAddons',default=False,help="Disable all add-ons")
 parser.add_argument('--debug-logging',action="store_true",dest='debugLogging',default=False,help="Enable debug level logging just for this run. This setting will override any other log level (--loglevel, -l) argument given, as well as no logging option.")
 parser.add_argument('--no-logging',action="store_true",dest='noLogging',default=False,help="Disable logging completely for this run. This setting can be overwritten with other log level (--loglevel, -l) switch or if debug logging is specified.")

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -166,7 +166,7 @@ parser.add_argument(
 	action="store_true",
 	dest='secure',
 	default=False,
-	help="Starts NVDA in secure mode",  
+	help="Starts NVDA in secure mode",
 )
 parser.add_argument('--disable-addons',action="store_true",dest='disableAddons',default=False,help="Disable all add-ons")
 parser.add_argument('--debug-logging',action="store_true",dest='debugLogging',default=False,help="Enable debug level logging just for this run. This setting will override any other log level (--loglevel, -l) argument given, as well as no logging option.")

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -172,5 +172,10 @@ def _isSecureDesktop() -> bool:
 	When the serviceDebug parameter is not set,
 	NVDA should run in secure mode when on the secure desktop.
 	globalVars.appArgs.secure being set to True means NVDA is running in secure mode.
+
+	For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
+	and the following userGuide sections:
+	 - SystemWideParameters (information on the serviceDebug parameter)
+	 - SecureMode and SecureScreens
 	"""
 	return _getDesktopName() == "Winlogon"

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -1,11 +1,17 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2021 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2020-2022 NV Access Limited, Łukasz Golonka
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """ System related functions."""
 import ctypes
+from ctypes import (
+	byref,
+	create_unicode_buffer,
+	sizeof,
+	windll,
+)
 import winKernel
 import shellapi
 import winUser
@@ -142,3 +148,22 @@ def execElevated(path, params=None, wait=False, handleAlreadyElevated=False):
 			return winKernel.GetExitCodeProcess(sei.hProcess)
 		finally:
 			winKernel.closeHandle(sei.hProcess)
+
+
+@functools.lru_cache(maxsize=1)
+def _getDesktopName() -> str:
+	UOI_NAME = 2  # The name of the object, as a string
+	desktop = windll.user32.GetThreadDesktop(windll.kernel32.GetCurrentThreadId())
+	name = create_unicode_buffer(256)
+	windll.user32.GetUserObjectInformationW(
+		desktop,
+		UOI_NAME,
+		byref(name),
+		sizeof(name),
+		None
+	)
+	return name.value
+
+
+def _isSecureDesktop() -> bool:
+	return _getDesktopName() == "Winlogon"

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -166,4 +166,11 @@ def _getDesktopName() -> str:
 
 
 def _isSecureDesktop() -> bool:
+	"""
+	When NVDA is running on a secure screen,
+	it is running on the secure desktop.
+	When the serviceDebug parameter is not set,
+	NVDA should run in secure mode when on the secure desktop.
+	globalVars.appArgs.secure being set to True means NVDA is running in secure mode.
+	"""
 	return _getDesktopName() == "Winlogon"

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -30,6 +30,8 @@ from typing import (
 	Set,
 	Optional,
 )
+
+from systemUtils import _isSecureDesktop
 from winAPI.wtsApi32 import (
 	WTSINFOEXW,
 	WTSQuerySessionInformation,
@@ -148,6 +150,12 @@ def isWindowsLocked() -> bool:
 	Checks if the Window lockscreen is active.
 	Not to be confused with the Windows sign-in screen, a secure screen.
 	"""
+	if _isSecureDesktop():
+		# If this is the Secure Desktop,
+		# we are in secure mode and on a secure screen,
+		# e.g. on the sign-in screen.
+		# _isSecureDesktop may also return True on the lock screen before a user has signed in.
+		return False
 	lockStateTracked = _hasLockStateBeenTracked()
 	if lockStateTracked:
 		return WindowsTrackedSession.SESSION_LOCK in _currentSessionStates

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -155,6 +155,11 @@ def isWindowsLocked() -> bool:
 		# we are in secure mode and on a secure screen,
 		# e.g. on the sign-in screen.
 		# _isSecureDesktop may also return True on the lock screen before a user has signed in.
+
+		# For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
+		# and the following userGuide sections:
+		# - SystemWideParameters (information on the serviceDebug parameter)
+		# - SecureMode and SecureScreens
 		return False
 	lockStateTracked = _hasLockStateBeenTracked()
 	if lockStateTracked:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,17 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.3.2 =
+This is a minor release to fix regressions with 2022.3.1 and address a security issue.
+
+== Security Fixes ==
+
+
+== Bug Fixes ==
+- Fixes a regression from 2022.3.1 where certain functionality was disabled on secure screens. (#14286)
+-
+
+
 = 2022.3.1 =
 This is a minor release to fix several security issues.
 Please responsibly disclose security issues to info@nvaccess.org.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14286 

### Summary of the issue:
`isWindowsLocked` is meant to return `False` when on secure screens.
`isWindowsLocked` should return True, only when Windows is on the lock screen, to prevent users from escaping the lock screen.
This is because NVDA secure mode prevents a different set of exploits for secure screens.
2022.3.1 introduced a regression where when using a secure screen, `isWindowsLocked` returned True.

### Description of user facing changes
NVDA menu and other functionality is re-enabled on secure screens.

### Description of development approach
A new function has been added to check if NVDA is running on the secure desktop.
If that is the case, `isWindowsLocked` returns `False` ,

Returning `False` if NVDA is in a secure mode was not a viable path.
This is because if NVDA is running on secure mode via the `--secure` parameter, and a user navigates to the Windows lock screen, then there would be no security parameters.

### Testing strategy:
Test using NVDA on the sign-in screen, lock screen and UAC screen.

### Known issues with pull request:
None

### Change log entries:
Bug fixes
```
- Fixes a regression from 2022.3.1 where certain functionality was disabled on secure screens. (#14286)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
