### PR TITLE
Track SUT app lifetime in system tests

### DIFF
--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -183,4 +183,3 @@ class NotepadLib:
 		windowsLib.logForegroundWindowTitle()
 		# Move to the start of file
 		_NvdaLib.getSpeechAfterKey('home')
-

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -19,8 +19,9 @@ from SystemTestSpy import (
 from SystemTestSpy.windows import (
 	GetForegroundWindowTitle,
 	GetVisibleWindowTitles,
-	GetForegroundHwnd,
+	GetForegroundHwnd as _getForegroundHwnd,
 	GetWindowWithTitle,
+	Window as _Window,
 )
 import re
 from robot.libraries.BuiltIn import BuiltIn
@@ -30,11 +31,13 @@ from robot.libraries.OperatingSystem import OperatingSystem as _OpSysLib
 from robot.libraries.Process import Process as _ProcessLib
 from AssertsLib import AssertsLib as _AssertsLib
 import NvdaLib as _NvdaLib
+import WindowsLib as _WindowsLib
 
 builtIn: BuiltIn = BuiltIn()
 opSys: _OpSysLib = _getLib('OperatingSystem')
 process: _ProcessLib = _getLib('Process')
 assertsLib: _AssertsLib = _getLib('AssertsLib')
+windowsLib: _WindowsLib = _getLib('WindowsLib')
 
 
 # In Robot libraries, class name must match the name of the module. Use caps for both.
@@ -42,28 +45,62 @@ class NotepadLib:
 	_testFileStagingPath = _tempfile.mkdtemp()
 	_testCaseTitle = "test"
 
-	def __init__(self):
-		self.notepadHandle: _Optional[int] = None
+	# Use class variables for state that should be tied to the RF library instance.
+	# These variables will be available in the teardown
+	notepadWindow: _Optional[_Window] = None
+	processRFHandleForStart: _Optional[int] = None
 
 	@staticmethod
 	def _getTestCasePath(filename):
 		return _pJoin(NotepadLib._testFileStagingPath, filename)
 
 	def exit_notepad(self):
+		builtIn.log(
+			# True is expected due to /wait argument.
+			"Is Start process still running (True expected): "
+			f"{process.is_process_running(NotepadLib.processRFHandleForStart)}"
+		)
 		spy = _NvdaLib.getSpyLib()
-		spy.emulateKeyPress('alt+f4')
-		process.wait_for_process(self.notepadHandle, timeout="1 minute", on_timeout="continue")
+		if _getForegroundHwnd() == NotepadLib.notepadWindow.hwndVal:
+			builtIn.log("Test case in foreground, trying to close")
+			spy.emulateKeyPress('alt+f4')
+			process.wait_for_process(
+				NotepadLib.processRFHandleForStart,
+				timeout="10 seconds",
+				on_timeout="continue"
+			)
+		else:
+			builtIn.log("Test case not in foreground, can't close it.")
+		builtIn.log(
+			# False is expected, notepad should have allowed "Start" to exit.
+			"Is Start process still running (False expected): "
+			f"{process.is_process_running(NotepadLib.processRFHandleForStart)}"
+		)
 
-	def start_notepad(self, filePath):
+	def start_notepad(self, filePath: str, expectedTitlePattern: re.Pattern) -> _Window:
 		builtIn.log(f"starting notepad: {filePath}")
-		self.notepadHandle = process.start_process(
-			"start notepad"
+		NotepadLib.processRFHandleForStart = process.start_process(
+			"start"  # windows utility to start a process
+			# https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/start
+			" /wait"  # Starts an application and waits for it to end.
+			" notepad"
 			f' "{filePath}"',
 			shell=True,
 			alias='NotepadAlias',
 		)
-		process.process_should_be_running(self.notepadHandle)
-		return self.notepadHandle
+		process.process_should_be_running(NotepadLib.processRFHandleForStart)
+
+		success, NotepadLib.notepadWindow = _blockUntilConditionMet(
+			getValue=lambda: GetWindowWithTitle(expectedTitlePattern, lambda message: builtIn.log(message, "DEBUG")),
+			giveUpAfterSeconds=3,
+			shouldStopEvaluator=lambda _window: _window is not None,
+			intervalBetweenSeconds=0.5,
+			errorMessage="Unable to get notepad window"
+		)
+
+		if not success or NotepadLib.notepadWindow is None:
+			builtIn.fatal_error("Unable to get notepad window")
+		return NotepadLib.notepadWindow
 
 	@staticmethod
 	def getUniqueTestCaseTitle(testCaseHash: int) -> str:
@@ -92,7 +129,7 @@ class NotepadLib:
 			notepadWindow = GetWindowWithTitle(startsWithTestCaseTitle, builtIn.log)
 			if notepadWindow is None:
 				return False
-			return notepadWindow.hwndVal == GetForegroundHwnd()
+			return notepadWindow.hwndVal == _getForegroundHwnd()
 
 		success, _success = _blockUntilConditionMet(
 			getValue=_isNotepadInForeground,
@@ -112,6 +149,12 @@ class NotepadLib:
 			f"{windowInformation}"
 		)
 
+	def canNotepadTitleBeReported(self, notepadTitleSpeechPattern: re.Pattern) -> bool:
+		titleSpeech = _NvdaLib.getSpeechAfterKey('NVDA+t')
+		return bool(
+			notepadTitleSpeechPattern.search(titleSpeech)
+		)
+
 	def prepareNotepad(self, testCase: str) -> None:
 		"""
 		Starts Notepad opening a file containing the plaintext sample.
@@ -126,8 +169,18 @@ class NotepadLib:
 		path = self._writeTestFile(testCase, self.getUniqueTestCaseTitle(_testCaseHash))
 
 		spy.wait_for_speech_to_finish()
-		self.start_notepad(path)
+		self.start_notepad(path, expectedTitlePattern=uniqueTitleRegex)
+
+		windowsLib.logForegroundWindowTitle()
+		testCaseNotepadTitleSpeech = re.compile(
+			# Unlike getUniqueTestCaseTitleRegex, this speech does not have to be at the start of the string.
+			f"{NotepadLib._testCaseTitle} \\({abs(_testCaseHash)}\\)"
+		)
+		if not self.canNotepadTitleBeReported(notepadTitleSpeechPattern=testCaseNotepadTitleSpeech):
+			builtIn.log(f"Unable to report notepad title: {testCaseNotepadTitleSpeech!r}")
+
 		self._waitForNotepadFocus(uniqueTitleRegex)
+		windowsLib.logForegroundWindowTitle()
 		# Move to the start of file
-		spy.emulateKeyPress('home')
-		spy.wait_for_speech_to_finish()
+		_NvdaLib.getSpeechAfterKey('home')
+

--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -1,0 +1,36 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+""" This module provides the WindowsLib Robot Framework Library which allows interacting with Windows GUI
+features.
+"""
+# imported methods start with underscore (_) so they don't get imported into robot files as keywords
+
+from robot.libraries.BuiltIn import BuiltIn as _BuiltInLib
+
+from SystemTestSpy.windows import (
+	GetForegroundWindowTitle as _getForegroundWindowTitle,
+	GetForegroundHwnd as _getForegroundHwnd,
+	Window as _Window,
+)
+
+builtIn: _BuiltInLib = _BuiltInLib()
+
+# This library doesn't rely on state, so it is not a class.
+# However, if converting to a class note that in Robot libraries, the class name must match the name
+# of the module.
+# Use caps for both.
+
+
+def isWindowInForeground(window: _Window) -> bool:
+	return window.hwndVal == _getForegroundHwnd()
+
+
+def logForegroundWindowTitle():
+	"""Debugging helper, log the current foreground window title to the robot framework log.
+	See log.html.
+	"""
+	windowTitle = _getForegroundWindowTitle()
+	builtIn.log(f"Foreground window title: {windowTitle}")

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -17,14 +17,19 @@ Test Teardown	default teardown
 
 *** Keywords ***
 default teardown
+	logForegroundWindowTitle
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
 	dump_speech_to_log
 	dump_braille_to_log
+	# leaving the chrome tabs open may slow down / cause chrome to crash on appveyor
+	close_chrome_tab
 	quit NVDA
 
 default setup
+	logForegroundWindowTitle
 	start NVDA	standard-dontShowWelcomeDialog.ini
+	logForegroundWindowTitle
 	enable_verbose_debug_logging_if_requested
 
 *** Test Cases ***

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -17,6 +17,7 @@ Test Teardown	default teardown
 
 *** Keywords ***
 default teardown
+	logForegroundWindowTitle
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
 	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
 	dump_speech_to_log
@@ -24,7 +25,9 @@ default teardown
 	quit NVDA
 
 default setup
+	logForegroundWindowTitle
 	start NVDA	standard-dontShowWelcomeDialog.ini
+	logForegroundWindowTitle
 	enable_verbose_debug_logging_if_requested
 
 *** Test Cases ***


### PR DESCRIPTION
### Link to issue number:
Splitting up PR #14054

### Summary of the issue:
- Tracking of the System Under Test (SUT) application (I.E. Notepad, Chrome) was not accurate, instead, the "start.exe" app was being tracked.
- Instance variables in robot libraries are reset for teardown, the SUT app cannot be tracked if the window handle is lost.
- Many chrome tabs in appveyor may cause slowdowns, and chrome crashes.
- Attempting to close notepad (with `alt+F4`) can result in closing developer tools when notepad is not the foreground application.

### Description of user facing changes
None

### Description of development approach
- Use class variables on Robot library classes so that the variables survive through different phases of the test.
- Close chrome tab after tests complete, chrome sometimes crashes on appveyor, possibly due to memory limitations.
- Only close notepad if it is the foreground window, prevent closing developers' tools when focus shifts.

### Testing strategy:
Test on appveyor.

### Known issues with pull request:
None.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
