### PR TITLE
Revert "Add speakSymsMoveByWord as a feature branch"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ branches:
   - rc
   - /try-.*/
   - /release-.*/
-  - speakSymsMoveByWord
 
 # scripts that are called at very beginning, before repo cloning
 init:


### PR DESCRIPTION
Reverts nvaccess/nvda#14287

When there is a resolution to issue #12779 and issues described on PR  #12710, the feature branch `speakSymsMoveByWord` should no longer be built automatically, and the branch protection rules can be removed.