### PR TITLE
Disable 'Starts from desktop shortcut' system test

### DIFF
--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -27,6 +27,8 @@ Starts
 	NVDA_Starts	# run test
 
 Starts from desktop shortcut
+	# Excluded until test can be fixed. Tracked in issue: (#14293)
+	[Tags]	excluded_from_build
 	[Documentation]	Ensure that NVDA can start from desktop shortcut
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
 	Pass Execution If	"${whichNVDA}"!="installed"	Desktop shortcut only exists on installed copies


### PR DESCRIPTION
### Link to issue number:
None, related to work in #14054 

### Summary of the issue:
Test 'Starts from desktop shortcut' relies on NVDA to be running to send the hotkey.
NVDA running interferes with the logic of the test.
The test intermittently fails, see: https://github.com/nvaccess/nvda/pull/14054/#issuecomment-1231560477

### Description of user facing changes
None

### Description of development approach
Disable the test until this can be addressed, issue #14293 has been opened to resolve this and re-enable the test.

### Testing strategy:
Run on appveyor.

### Known issues with pull request:
NVDA starting from hotkey will not be automatically tested.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
