### PR TITLE
Fix-up #14070: No more error at edge of table with MSHtml

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -672,7 +672,10 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		# Cells are grouped by row, so in most cases, we simply need to search in the right direction.
 		for info in self._iterTableCells(tableID, direction=movement, startPos=startPos):
 			cell = self._getTableCellCoords(info)
-			if cell.row <= destRow < cell.row + cell.rowSpan and cell.col <= destCol < cell.col + cell.colSpan:
+			if (
+				cell.row <= destRow < (cell.row + cell.rowSpan)
+				and cell.col <= destCol < (cell.col + cell.colSpan)
+			):
 				return info
 			elif cell.row > destRow and movement == "next":
 				# Optimisation: We've gone forward past destRow, so we know we won't find the cell.
@@ -689,7 +692,10 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 			# Therefore, try searching backwards.
 			for info in self._iterTableCells(tableID, direction="previous", startPos=startPos):
 				cell = self._getTableCellCoords(info)
-				if cell.row <= destRow < cell.row + cell.rowSpan and cell.col <= destCol < cell.col + cell.colSpan:
+			if (
+				cell.row <= destRow < (cell.row + cell.rowSpan)
+				and cell.col <= destCol < (cell.col + cell.colSpan)
+			):
 					return info
 			else:
 				raise LookupError

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2007-2022 NV Access Limited, Peter Vágner
+# Copyright (C) 2007-2022 NV Access Limited, Peter Vágner, Cyrille Bougot
 
 import time
 import threading
@@ -671,10 +671,10 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 		# Cells are grouped by row, so in most cases, we simply need to search in the right direction.
 		for info in self._iterTableCells(tableID, direction=movement, startPos=startPos):
-			_ignore, row, col, rowSpan, colSpan = self._getTableCellCoords(info)
-			if row <= destRow < row + rowSpan and col <= destCol < col + colSpan:
+			cell = self._getTableCellCoords(info)
+			if cell.row <= destRow < cell.row + cell.rowSpan and cell.col <= destCol < cell.col + cell.colSpan:
 				return info
-			elif row > destRow and movement == "next":
+			elif cell.row > destRow and movement == "next":
 				# Optimisation: We've gone forward past destRow, so we know we won't find the cell.
 				# We can't reverse this logic when moving backwards because there might be a prior cell on an earlier row which spans multiple rows.
 				break
@@ -688,8 +688,8 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 			# In this case, there might be a cell on an earlier row which spans multiple rows.
 			# Therefore, try searching backwards.
 			for info in self._iterTableCells(tableID, direction="previous", startPos=startPos):
-				_ignore, row, col, rowSpan, colSpan = self._getTableCellCoords(info)
-				if row <= destRow < row + rowSpan and col <= destCol < col + colSpan:
+				cell = self._getTableCellCoords(info)
+				if cell.row <= destRow < cell.row + cell.rowSpan and cell.col <= destCol < cell.col + cell.colSpan:
 					return info
 			else:
 				raise LookupError


### PR DESCRIPTION
Opened against beta branch since it fixes a non-released code.

### Link to issue number:
None

### Summary of the issue:
In MSHtml container, e.g. NVDA's browseable message, the table edge is not reported. The following error is found instead:
```
ERROR - scriptHandler.executeScript (23:32:09.385) - MainThread (6444):
error executing script: <bound method DocumentWithTableNavigation.script_nextColumn of <virtualBuffers.MSHTML.MSHTML object at 0x0953F690>> with gesture 'alt+contrôle+flèche droite'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 289, in executeScript
  File "documentBase.pyc", line 480, in script_nextColumn
  File "documentBase.pyc", line 417, in _tableMovementScriptHelper
  File "documentBase.pyc", line 362, in _tableFindNewCell
  File "virtualBuffers\__init__.pyc", line 674, in _getNearestTableCell
TypeError: cannot unpack non-iterable _TableCell object
```

### Description of user facing changes
No more error reported at edge and the edge is reported.
### Description of development approach
The dataclass `documentBase._TableCell` was added in #14070. More specifically, `DocumentWithTableNavigation._getTableCellCoords` now returns `_TableCell`. But some usages of the return of this function have been forgotten.
This PR fixes this.

### Testing strategy:
Manual testing:
In the console, paste the following script:
```
import ui
s = "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>C</td><td>D</td></tr></tbody></table>"
ui.browseableMessage(s, isHtml=True)

```

Then navigate in the table with all possible gestures:
* control+alt+arrows
* control+alt+pgUp/pgDown/Home/End
* NVDA+control+alt+arrows

### Known issues with pull request:
None

### Change log entries:
Not needed, unreleased bug.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
