### PR TITLE
Prevent race condition between initializing session tracking state and handling session change notification

### DIFF
--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -25,6 +25,7 @@ from ctypes.wintypes import (
 	HWND,
 )
 import enum
+from threading import Lock
 from typing import (
 	Dict,
 	Set,
@@ -42,11 +43,14 @@ from winAPI.wtsApi32 import (
 )
 from logHandler import log
 
+_updateSessionStateLock = Lock()
+"""Used to protect updates to _currentSessionStates"""
 _currentSessionStates: Set["WindowsTrackedSession"] = set()
 """
 Current state of the Windows session associated with this instance of NVDA.
 Maintained via receiving session notifications via the NVDA MessageWindow.
 Initial state will be set by querying the current status.
+Actions which involve updating this state this should be protected by _updateSessionStateLock.
 """
 
 _sessionQueryLockStateHasBeenUnknown = False
@@ -162,22 +166,29 @@ def isWindowsLocked() -> bool:
 
 
 def _setInitialWindowLockState() -> None:
-	"""Ensure that session tracking state is initialized.
-	If NVDA has started on a lockScreen, it needs to be aware of this.
 	"""
-	lockStateTracked = _hasLockStateBeenTracked()
-	if lockStateTracked:
-		raise RuntimeError("Can't set initial state if it is already tracked.")
-	# Fall back to explicit query
-	try:
-		isLocked = _isWindowsLocked_checkViaSessionQuery()
-		_currentSessionStates.add(
-			WindowsTrackedSession.SESSION_LOCK
-			if isLocked
-			else WindowsTrackedSession.SESSION_UNLOCK
-		)
-	except RuntimeError as error:
-		_recordLockStateTrackingFailure(error)
+	Ensure that session tracking state is initialized.
+	If NVDA has started on a lockScreen, it needs to be aware of this.
+	As NVDA has already registered for session tracking notifications,
+	a lock is used to prevent conflicts.
+	"""
+	with _updateSessionStateLock:
+		lockStateTracked = _hasLockStateBeenTracked()
+		if lockStateTracked:
+			log.debugWarning(
+				"Initial state already set."
+				" NVDA may have received a session change notification before initialising"
+			)
+		# Fall back to explicit query
+		try:
+			isLocked = _isWindowsLocked_checkViaSessionQuery()
+			_currentSessionStates.add(
+				WindowsTrackedSession.SESSION_LOCK
+				if isLocked
+				else WindowsTrackedSession.SESSION_UNLOCK
+			)
+		except RuntimeError as error:
+			_recordLockStateTrackingFailure(error)
 
 
 def _isWindowsLocked_checkViaSessionQuery() -> bool:
@@ -222,10 +233,6 @@ def register(handle: HWND) -> bool:
 
 	https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification
 	"""
-	##
-	# Ensure that an initial state is set,
-	# do this first to prevent a race condition with session tracking / message processing.
-	_setInitialWindowLockState()
 
 	# OpenEvent handle must be closed with CloseHandle.
 	eventObjectHandle: HANDLE = ctypes.windll.kernel32.OpenEventW(
@@ -249,6 +256,15 @@ def register(handle: HWND) -> bool:
 
 	if registrationSuccess:
 		log.debug("Registered session tracking")
+		# Ensure that an initial state is set.
+		# Do this only when session tracking has been registered,
+		# so that any changes to the state are not missed via a race condition with session tracking registration.
+		# As this occurs after NVDA hs registered for session tracking,
+		# it is possible NVDA is expected to handle a session change notification
+		# at the same time as initialisation.
+		# _updateSessionStateLock is used to prevent received session notifications from being handled at the
+		# same time as initialisation.
+		_setInitialWindowLockState()
 	else:
 		error = ctypes.WinError()
 		if error.errno == RPC_S_INVALID_BINDING:
@@ -295,43 +311,44 @@ def handleSessionChange(newState: WindowsTrackedSession, sessionId: int) -> None
 
 	https://docs.microsoft.com/en-us/windows/win32/termserv/wm-wtssession-change
 	"""
-	stateChanged = False
+	with _updateSessionStateLock:
+		stateChanged = False
 
-	log.debug(f"Windows Session state notification received: {newState.name}")
+		log.debug(f"Windows Session state notification received: {newState.name}")
 
-	if not _isSessionTrackingRegistered:
-		log.debugWarning("Session tracking not registered, unexpected session change message")
+		if not _isSessionTrackingRegistered:
+			log.debugWarning("Session tracking not registered, unexpected session change message")
 
-	if newState not in _toggleWindowsSessionStatePair:
-		log.debug(f"Ignoring {newState} event as tracking is not required.")
-		return
+		if newState not in _toggleWindowsSessionStatePair:
+			log.debug(f"Ignoring {newState} event as tracking is not required.")
+			return
 
-	oppositeState = _toggleWindowsSessionStatePair[newState]
-	if newState in _currentSessionStates:
-		log.error(
-			f"NVDA expects Windows to be in {newState} already. "
-			f"NVDA may have dropped a {oppositeState} event. "
-			f"Dropping this {newState} event. "
-		)
-	else:
-		_currentSessionStates.add(newState)
-		stateChanged = True
+		oppositeState = _toggleWindowsSessionStatePair[newState]
+		if newState in _currentSessionStates:
+			log.error(
+				f"NVDA expects Windows to be in {newState} already. "
+				f"NVDA may have dropped a {oppositeState} event. "
+				f"Dropping this {newState} event. "
+			)
+		else:
+			_currentSessionStates.add(newState)
+			stateChanged = True
 
-	if oppositeState in _currentSessionStates:
-		_currentSessionStates.remove(oppositeState)
-	else:
-		log.debugWarning(
-			f"NVDA expects Windows to be in {newState} already. "
-			f"NVDA may have dropped a {oppositeState} event. "
-		)
+		if oppositeState in _currentSessionStates:
+			_currentSessionStates.remove(oppositeState)
+		else:
+			log.debugWarning(
+				f"NVDA expects Windows to be in {newState} already. "
+				f"NVDA may have dropped a {oppositeState} event. "
+			)
 
-	log.debug(f"New Windows Session state: {_currentSessionStates}")
-	if (
-		stateChanged
-		and newState in {WindowsTrackedSession.SESSION_LOCK, WindowsTrackedSession.SESSION_UNLOCK}
-	):
-		from utils.security import postSessionLockStateChanged
-		postSessionLockStateChanged.notify(isNowLocked=newState == WindowsTrackedSession.SESSION_LOCK)
+		log.debug(f"New Windows Session state: {_currentSessionStates}")
+		if (
+			stateChanged
+			and newState in {WindowsTrackedSession.SESSION_LOCK, WindowsTrackedSession.SESSION_UNLOCK}
+		):
+			from utils.security import postSessionLockStateChanged
+			postSessionLockStateChanged.notify(isNowLocked=newState == WindowsTrackedSession.SESSION_LOCK)
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
A race condition exists between initializing session tracking state and handling a session change notification.
The lock state is initialized before registering for session tracking.
That means if the session state changes between initializing and registration, a session change notification may be dropped.

### Description of user facing changes
None

### Description of development approach
NVDA is set to initialize the state after registration.

If NVDA initializes the state after registration, a session change notification may be received while NVDA is initializing the state. A lock is used to prevent these events from being handled simultaneously.
Initialization happening before receiving a notification is expected.
If a notification is received without lock state initialization, the new state from the notification will be set, then initialization will override the lock state.

### Testing strategy:
Smoke test the sign-in process with a signed build.
Requires wider alpha testing for confidence.

### Known issues with pull request:
None

### Change log entries:
Not needed, fixes very rare and unreported theoretical bug.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
