### PR TITLE
Set foreground object rather than desktop object when initializing object cache

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -419,6 +419,20 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	brailleViewer.destroyBrailleViewer()
 
 
+def _initializeObjectCaches():
+	import api
+	import NVDAObjects
+	import winUser
+	foregroundObject = NVDAObjects.window.Window(windowHandle=winUser.getForegroundWindow())
+	api.setForegroundObject(foregroundObject)
+	api.setFocusObject(foregroundObject)
+	api.setNavigatorObject(foregroundObject)
+	api.setMouseObject(foregroundObject)
+
+	desktopObject = NVDAObjects.window.Window(windowHandle=winUser.getDesktopWindow())
+	api.setDesktopObject(desktopObject)
+
+
 def main():
 	"""NVDA's core main loop.
 	This initializes all modules such as audio, IAccessible, keyboard, mouse, and GUI.
@@ -667,14 +681,8 @@ def main():
 	log.debug("Initializing garbageHandler")
 	garbageHandler.initialize()
 
-	import api
-	import winUser
-	import NVDAObjects.window
-	desktopObject=NVDAObjects.window.Window(windowHandle=winUser.getDesktopWindow())
-	api.setDesktopObject(desktopObject)
-	api.setFocusObject(desktopObject)
-	api.setNavigatorObject(desktopObject)
-	api.setMouseObject(desktopObject)
+	_initializeObjectCaches()
+
 	import JABHandler
 	log.debug("initializing Java Access Bridge support")
 	try:

--- a/source/core.py
+++ b/source/core.py
@@ -427,6 +427,7 @@ def _pollForForegroundHWND() -> int:
 	_hasWarned = False
 	WARN_AFTER_SECS = 5
 	MAX_WAIT_TIME_SECS = 20
+	POLL_INTERVAL_SECS = 0.1
 	waitForForegroundHWND_startTime = time.time()
 
 	while not foregroundHWND:
@@ -454,7 +455,7 @@ def _pollForForegroundHWND() -> int:
 			raise NVDANotInitializedError("Could not fetch foreground window")
 
 		log.debugWarning("Foreground window not found, fetching again")
-		time.sleep(0.1)
+		time.sleep(POLL_INTERVAL_SECS)
 		foregroundHWND = winUser.getForegroundWindow()
 
 	return foregroundHWND

--- a/source/core.py
+++ b/source/core.py
@@ -423,7 +423,16 @@ def _initializeObjectCaches():
 	import api
 	import NVDAObjects
 	import winUser
-	foregroundObject = NVDAObjects.window.Window(windowHandle=winUser.getForegroundWindow())
+
+	foregroundWindowHWND = winUser.getForegroundWindow()
+	while not foregroundWindowHWND:
+		# The foreground window can be NULL in certain circumstances,
+		# such as when a window is losing activation.
+		# This should not remain the case for an extended period of time.
+		log.debugWarning("Foreground window not found, fetching again")
+		time.sleep(0.1)
+		foregroundWindowHWND = winUser.getForegroundWindow()
+	foregroundObject = NVDAObjects.window.Window(windowHandle=foregroundWindowHWND)
 	api.setForegroundObject(foregroundObject)
 	api.setFocusObject(foregroundObject)
 	api.setNavigatorObject(foregroundObject)

--- a/source/core.py
+++ b/source/core.py
@@ -422,13 +422,14 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 def _pollForForegroundHWND() -> int:
 	import ui
 	import winUser
+
 	foregroundHWND = winUser.getForegroundWindow()
 	_hasWarned = False
 	WARN_AFTER_SECS = 5
 	MAX_WAIT_TIME_SECS = 20
 	waitForForegroundHWND_startTime = time.time()
-	while True:
-		# while not foregroundHWND:
+
+	while not foregroundHWND:
 		_timeElapsed = time.time() - waitForForegroundHWND_startTime
 		if (
 			not _hasWarned

--- a/source/core.py
+++ b/source/core.py
@@ -479,6 +479,7 @@ def _initializeObjectCaches():
 
 	desktopObject = NVDAObjects.window.Window(windowHandle=winUser.getDesktopWindow())
 	api.setDesktopObject(desktopObject)
+
 	foregroundHWND = _pollForForegroundHWND()
 	foregroundObject = NVDAObjects.window.Window(windowHandle=foregroundHWND)
 	api.setForegroundObject(foregroundObject)

--- a/source/core.py
+++ b/source/core.py
@@ -446,15 +446,17 @@ def _pollForForegroundHWND() -> int:
 	)
 	if success:
 		return foregroundHWND
+
+	exitAfterWarningSecs = MAX_WAIT_TIME_SECS - WARN_AFTER_SECS
 	ui.message(_(
 		# Translators: Message when NVDA is having an issue starting up
 		"NVDA is failing to fetch the foreground window. "
-		"If this continues, NVDA will quit starting in %d seconds." % (MAX_WAIT_TIME_SECS - WARN_AFTER_SECS)
+		"If this continues, NVDA will quit starting in %d seconds." % exitAfterWarningSecs
 	))
 
 	success, foregroundHWND = blockUntilConditionMet(
 		getValue=winUser.getForegroundWindow,
-		giveUpAfterSeconds=MAX_WAIT_TIME_SECS - WARN_AFTER_SECS,
+		giveUpAfterSeconds=exitAfterWarningSecs,
 	)
 	if success:
 		return foregroundHWND

--- a/source/core.py
+++ b/source/core.py
@@ -430,6 +430,10 @@ def _pollForForegroundHWND() -> int:
 	waitForForegroundHWND_startTime = time.time()
 
 	while not foregroundHWND:
+		# The foreground window can be NULL in certain circumstances,
+		# such as when a window is losing activation.
+		# This should not remain the case for an extended period of time.
+
 		_timeElapsed = time.time() - waitForForegroundHWND_startTime
 		if (
 			not _hasWarned
@@ -449,9 +453,6 @@ def _pollForForegroundHWND() -> int:
 			# Raising exception here causes core.main to exit and NVDA to fail to start
 			raise NVDANotInitializedError("Could not fetch foreground window")
 
-		# The foreground window can be NULL in certain circumstances,
-		# such as when a window is losing activation.
-		# This should not remain the case for an extended period of time.
 		log.debugWarning("Foreground window not found, fetching again")
 		time.sleep(0.1)
 		foregroundHWND = winUser.getForegroundWindow()

--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -31,18 +31,20 @@ Optional[Any]  # None or the value when the evaluator was met
 	the default evaluator just returns the value converted to a boolean.
 	@return: A tuple, (True, value) if evaluator condition is met, otherwise (False, None)
 	"""
-	assert intervalBetweenSeconds > 0.001
-	SLEEP_TIME = intervalBetweenSeconds * 0.5
+	minIntervalBetweenSeconds = 0.001
+	assert intervalBetweenSeconds > minIntervalBetweenSeconds
 	startTime = timer()
-	lastRunTime = startTime
-	firstRun = True  # ensure we start immediately
 	while (timer() - startTime) < giveUpAfterSeconds:
-		if firstRun or (timer() - lastRunTime) > intervalBetweenSeconds:
-			firstRun = False
-			lastRunTime = timer()
-			val = getValue()
-			if shouldStopEvaluator(val):
-				return True, val
-			sleep(SLEEP_TIME)
+		val = getValue()
+		conditionTimeStart = timer()
+		if shouldStopEvaluator(val):
+			return True, val
+		conditionTimeElapsed = timer() - conditionTimeStart
+		sleepTime = max(
+			# attempt to keep a regular period between polling
+			intervalBetweenSeconds - conditionTimeElapsed,
+			minIntervalBetweenSeconds,
+		)
+		sleep(sleepTime)
 
 	return False, None

--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -21,9 +21,9 @@ def blockUntilConditionMet(
 		giveUpAfterSeconds: float,
 		shouldStopEvaluator: Callable[[Any], bool] = lambda value: bool(value),
 		intervalBetweenSeconds: float = 0.1,
-) -> Tuple[
-	bool,  # Was evaluator met?
-	Optional[Any]  # None or the value when the evaluator was met
+		) -> Tuple[
+bool,  # Was evaluator met?
+Optional[Any]  # None or the value when the evaluator was met
 ]:
 	"""Repeatedly tries to get a value up until a time limit expires.
 	Tries are separated by a time interval.

--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -1,0 +1,48 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2020-2022 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+
+from time import (
+	perf_counter as timer,
+	sleep,
+)
+from typing import (
+	Any,
+	Callable,
+	Optional,
+	Tuple,
+)
+
+
+def blockUntilConditionMet(
+		getValue: Callable[[], Any],
+		giveUpAfterSeconds: float,
+		shouldStopEvaluator: Callable[[Any], bool] = lambda value: bool(value),
+		intervalBetweenSeconds: float = 0.1,
+) -> Tuple[
+	bool,  # Was evaluator met?
+	Optional[Any]  # None or the value when the evaluator was met
+]:
+	"""Repeatedly tries to get a value up until a time limit expires.
+	Tries are separated by a time interval.
+	The call will block until shouldStopEvaluator returns True when given the value,
+	the default evaluator just returns the value converted to a boolean.
+	@return: A tuple, (True, value) if evaluator condition is met, otherwise (False, None)
+	"""
+	assert intervalBetweenSeconds > 0.001
+	SLEEP_TIME = intervalBetweenSeconds * 0.5
+	startTime = timer()
+	lastRunTime = startTime
+	firstRun = True  # ensure we start immediately
+	while (timer() - startTime) < giveUpAfterSeconds:
+		if firstRun or (timer() - lastRunTime) > intervalBetweenSeconds:
+			firstRun = False
+			lastRunTime = timer()
+			val = getValue()
+			if shouldStopEvaluator(val):
+				return True, val
+			sleep(SLEEP_TIME)
+
+	return False, None

--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -33,18 +33,18 @@ Optional[Any]  # None or the value when the evaluator was met
 	"""
 	minIntervalBetweenSeconds = 0.001
 	assert intervalBetweenSeconds > minIntervalBetweenSeconds
-	startTime = timer()
+	lastSleepTime = startTime = timer()
 	while (timer() - startTime) < giveUpAfterSeconds:
 		val = getValue()
-		conditionTimeStart = timer()
 		if shouldStopEvaluator(val):
 			return True, val
-		conditionTimeElapsed = timer() - conditionTimeStart
+		timeElapsedSinceLastSleep = timer() - lastSleepTime
 		sleepTime = max(
 			# attempt to keep a regular period between polling
-			intervalBetweenSeconds - conditionTimeElapsed,
+			intervalBetweenSeconds - timeElapsedSinceLastSleep,
 			minIntervalBetweenSeconds,
 		)
 		sleep(sleepTime)
+		lastSleepTime = timer()
 
 	return False, None

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -467,8 +467,10 @@ def setForegroundWindow(hwnd):
 def setFocus(hwnd):
 	user32.SetFocus(hwnd)
 
-def getDesktopWindow():
+
+def getDesktopWindow() -> HWND:
 	return user32.GetDesktopWindow()
+
 
 def getControlID(hwnd):
 	return user32.GetWindowLongW(hwnd,GWL_ID)

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -18,6 +18,10 @@ import enum
 #dll handles
 user32=windll.user32
 
+# rather than using the ctypes.c_void_p type, which may encourage attempting to dereference
+# what may be an invalid or illegal pointer, we'll treat it as an opaque value.
+HWNDVal = int
+
 LRESULT=c_long
 HCURSOR=c_long
 
@@ -458,7 +462,7 @@ def isDescendantWindow(parentHwnd,childHwnd):
 		return False
 
 
-def getForegroundWindow() -> HWND:
+def getForegroundWindow() -> HWNDVal:
 	return user32.GetForegroundWindow()
 
 def setForegroundWindow(hwnd):
@@ -468,7 +472,7 @@ def setFocus(hwnd):
 	user32.SetFocus(hwnd)
 
 
-def getDesktopWindow() -> HWND:
+def getDesktopWindow() -> HWNDVal:
 	return user32.GetDesktopWindow()
 
 

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited
+# Copyright (C) 2020-2022 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -8,27 +8,34 @@ libraries. It is also copied into the (system test specific) NVDA profile direct
 package. This enables sharing utility methods between the global plugin and other Robot Framework libraries.
 """
 
-from time import sleep as _sleep
-from time import perf_counter as _timer
-from typing import Any, Callable, Optional, Tuple
+from time import (
+	perf_counter as _timer,
+	sleep as _sleep,
+)
+from typing import (
+	Any,
+	Callable,
+	Optional,
+	Tuple,
+)
 
 
 def _blockUntilConditionMet(
 		getValue: Callable[[], Any],
 		giveUpAfterSeconds: float,
-		shouldStopEvaluator=lambda value: bool(value),
+		shouldStopEvaluator: Callable[[Any], bool] = lambda value: bool(value),
 		intervalBetweenSeconds: float = 0.1,
 		errorMessage: Optional[str] = None
-		) -> Tuple[
-bool,  # Was evaluator met?
-Optional[Any]  # None or the value when the evaluator was met
+) -> Tuple[
+	bool,  # Was evaluator met?
+	Optional[Any]  # None or the value when the evaluator was met
 ]:
 	"""Repeatedly tries to get a value up until a time limit expires. Tries are separated by
 	a time interval. The call will block until shouldStopEvaluator returns True when given the value,
 	the default evaluator just returns the value converted to a boolean.
-	@param errorMessage Use 'None' to suppress the exception.
-	@return A tuple, (True, value) if evaluator condition is met, otherwise (False, None)
-	@raises RuntimeError if the time limit expires and an errorMessage is given.
+	@param errorMessage: Use 'None' to suppress the exception.
+	@return: A tuple, (True, value) if evaluator condition is met, otherwise (False, None)
+	@raises: AssertionError if the time limit expires and an errorMessage is given.
 	"""
 	assert callable(getValue)
 	assert callable(shouldStopEvaluator)

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -26,9 +26,9 @@ def _blockUntilConditionMet(
 		shouldStopEvaluator: Callable[[Any], bool] = lambda value: bool(value),
 		intervalBetweenSeconds: float = 0.1,
 		errorMessage: Optional[str] = None
-) -> Tuple[
-	bool,  # Was evaluator met?
-	Optional[Any]  # None or the value when the evaluator was met
+		) -> Tuple[
+bool,  # Was evaluator met?
+Optional[Any]  # None or the value when the evaluator was met
 ]:
 	"""Repeatedly tries to get a value up until a time limit expires. Tries are separated by
 	a time interval. The call will block until shouldStopEvaluator returns True when given the value,

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -42,19 +42,19 @@ Optional[Any]  # None or the value when the evaluator was met
 	assert callable(shouldStopEvaluator)
 	minIntervalBetweenSeconds = 0.001
 	assert intervalBetweenSeconds > minIntervalBetweenSeconds
-	startTime = _timer()
+	lastSleepTime = startTime = _timer()
 	while (_timer() - startTime) < giveUpAfterSeconds:
 		val = getValue()
-		conditionTimeStart = _timer()
 		if shouldStopEvaluator(val):
 			return True, val
-		conditionTimeElapsed = _timer() - conditionTimeStart
+		timeElapsedSinceLastSleep = _timer() - lastSleepTime
 		sleepTime = max(
 			# attempt to keep a regular period between polling
-			intervalBetweenSeconds - conditionTimeElapsed,
+			intervalBetweenSeconds - timeElapsedSinceLastSleep,
 			minIntervalBetweenSeconds,
 		)
 		_sleep(sleepTime)
+		lastSleepTime = _timer()
 
 	if errorMessage:
 		raise AssertionError(errorMessage)

--- a/tests/unit/test_util/test_blockUntilConditionMet.py
+++ b/tests/unit/test_util/test_blockUntilConditionMet.py
@@ -1,0 +1,49 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2022 NV Access Limited.
+
+"""Unit tests for the blockUntilConditionMet submodule.
+"""
+
+from time import perf_counter as timer
+import unittest
+
+from utils.blockUntilConditionMet import blockUntilConditionMet
+
+class Test_blockUntilConditionMet(unittest.TestCase):
+	def test_condition_succeeds_before_timeout(self):
+		giveUpAfterSecs = 0.5
+		pollInterval = 0.1
+		startTime = timer()
+		succeedJustBeforeTimeOut = lambda value: (value - startTime) > (giveUpAfterSecs - pollInterval)
+		success, endTimeOrNone = blockUntilConditionMet(
+			getValue=timer,
+			giveUpAfterSeconds=giveUpAfterSecs,
+			shouldStopEvaluator=succeedJustBeforeTimeOut,
+			intervalBetweenSeconds=pollInterval,
+		)
+		timeElapsed = timer() - startTime
+		self.assertTrue(
+			success,
+			msg=f"Test condition failed unexpectedly due to timeout. Elapsed time: {timeElapsed:.2f}s"
+		)
+		self.assertGreater(giveUpAfterSecs, timeElapsed)
+
+	def test_condition_fails_on_timeout(self):
+		giveUpAfterSecs = 0.5
+		pollInterval = 0.1
+		startTime = timer()
+		succeedJustAfterTimeOut = lambda value: (value - startTime) > (giveUpAfterSecs + pollInterval)
+		success, endTimeOrNone = blockUntilConditionMet(
+			getValue=timer,
+			giveUpAfterSeconds=giveUpAfterSecs,
+			shouldStopEvaluator=succeedJustAfterTimeOut,
+			intervalBetweenSeconds=pollInterval,
+		)
+		timeElapsed = timer() - startTime
+		self.assertFalse(
+			success,
+			msg=f"Test condition succeeded unexpectedly before timeout. Elapsed time: {timeElapsed:.2f}s"
+		)
+		self.assertGreater(timeElapsed, giveUpAfterSecs)

--- a/tests/unit/test_util/test_blockUntilConditionMet.py
+++ b/tests/unit/test_util/test_blockUntilConditionMet.py
@@ -11,12 +11,16 @@ import unittest
 
 from utils.blockUntilConditionMet import blockUntilConditionMet
 
+
 class Test_blockUntilConditionMet(unittest.TestCase):
 	def test_condition_succeeds_before_timeout(self):
 		giveUpAfterSecs = 0.5
 		pollInterval = 0.1
 		startTime = timer()
-		succeedJustBeforeTimeOut = lambda value: (value - startTime) > (giveUpAfterSecs - pollInterval)
+
+		def succeedJustBeforeTimeOut(currentTime: float):
+			return (currentTime - startTime) > (giveUpAfterSecs - pollInterval)
+
 		success, endTimeOrNone = blockUntilConditionMet(
 			getValue=timer,
 			giveUpAfterSeconds=giveUpAfterSecs,
@@ -34,7 +38,10 @@ class Test_blockUntilConditionMet(unittest.TestCase):
 		giveUpAfterSecs = 0.5
 		pollInterval = 0.1
 		startTime = timer()
-		succeedJustAfterTimeOut = lambda value: (value - startTime) > (giveUpAfterSecs + pollInterval)
+
+		def succeedJustAfterTimeOut(currentTime: float):
+			return (currentTime - startTime) > (giveUpAfterSecs + pollInterval)
+
 		success, endTimeOrNone = blockUntilConditionMet(
 			getValue=timer,
 			giveUpAfterSeconds=giveUpAfterSecs,

--- a/tests/unit/test_util/test_blockUntilConditionMet.py
+++ b/tests/unit/test_util/test_blockUntilConditionMet.py
@@ -37,10 +37,10 @@ class Test_blockUntilConditionMet(unittest.TestCase):
 		startTime = self._timer.time()
 
 		def succeedJustBeforeTimeOut(currentTime: float):
-			return (currentTime - startTime) > (giveUpAfterSecs - pollInterval)
+			return (currentTime - startTime) >= (giveUpAfterSecs - pollInterval)
 
-		with patch("time.sleep", new_callable=lambda: self._timer.sleep):
-			with patch("time.perf_counter", new_callable=lambda: self._timer.time):
+		with patch("utils.blockUntilConditionMet.sleep", new_callable=lambda: self._timer.sleep):
+			with patch("utils.blockUntilConditionMet.timer", new_callable=lambda: self._timer.time):
 				success, endTimeOrNone = _moduleUnderTest.blockUntilConditionMet(
 					getValue=self._timer.time,
 					giveUpAfterSeconds=giveUpAfterSecs,
@@ -60,10 +60,10 @@ class Test_blockUntilConditionMet(unittest.TestCase):
 		startTime = self._timer.time()
 
 		def succeedJustAfterTimeOut(currentTime: float):
-			return (currentTime - startTime) > (giveUpAfterSecs + pollInterval)
+			return (currentTime - startTime) >= (giveUpAfterSecs + pollInterval)
 
-		with patch("time.sleep", new_callable=lambda: self._timer.sleep):
-			with patch("time.perf_counter", new_callable=lambda: self._timer.time):
+		with patch("utils.blockUntilConditionMet.sleep", new_callable=lambda: self._timer.sleep):
+			with patch("utils.blockUntilConditionMet.timer", new_callable=lambda: self._timer.time):
 				success, endTimeOrNone = _moduleUnderTest.blockUntilConditionMet(
 					getValue=self._timer.time,
 					giveUpAfterSeconds=giveUpAfterSecs,
@@ -75,4 +75,4 @@ class Test_blockUntilConditionMet(unittest.TestCase):
 			success,
 			msg=f"Test condition succeeded unexpectedly before timeout. Elapsed time: {timeElapsed:.2f}s"
 		)
-		self.assertGreater(timeElapsed, giveUpAfterSecs)
+		self.assertGreaterEqual(timeElapsed, giveUpAfterSecs)

--- a/tests/unit/test_util/test_blockUntilConditionMet.py
+++ b/tests/unit/test_util/test_blockUntilConditionMet.py
@@ -8,6 +8,7 @@
 
 from typing import (
 	Any,
+	Callable,
 	Type,
 )
 import unittest
@@ -31,17 +32,17 @@ class _FakeTimer():
 		"""Patch for utils.blockUntilConditionMet.sleep"""
 		self._fakeTime += secs
 
-	def time(self):
+	def time(self) -> float:
 		"""Patch for utils.blockUntilConditionMet.timer"""
 		return self._fakeTime
 
-	def getValue(self):
+	def getValue(self) -> float:
 		"""Used to test the getValue parameter of utils.blockUntilConditionMet.blockUntilConditionMet"""
 		return self.time()
 
-	def createShouldStopEvaluator(self, succeedAfterSeconds: float):
+	def createShouldStopEvaluator(self, succeedAfterSeconds: float) -> Callable[[Any], bool]:
 		"""Used to test the shouldStopEvaluator parameter of utils.blockUntilConditionMet.blockUntilConditionMet"""
-		def _shouldStopEvaluator(_value: Any):
+		def _shouldStopEvaluator(_value: Any) -> bool:
 			return self._fakeTime >= succeedAfterSeconds
 		return _shouldStopEvaluator
 
@@ -52,15 +53,15 @@ class _Timer_SlowSleep(_FakeTimer):
 	the device taking longer than expected.
 	"""
 	def sleep(self, secs: float) -> None:
-		self._fakeTime += secs + 2 * self.POLL_INTERVAL
+		return super().sleep(secs + 2 * self.POLL_INTERVAL)
 
 
 class _Timer_SlowGetValue(_FakeTimer):
 	"""
 	Adds an extra amount of sleep when getValue is called to simulate
-	the device taking longer than expected.
+	the function taking a significant amount of time.
 	"""
-	def getValue(self):
+	def getValue(self) -> float:
 		self._fakeTime += 2 * self.POLL_INTERVAL
 		return super().getValue()
 
@@ -68,9 +69,9 @@ class _Timer_SlowGetValue(_FakeTimer):
 class _Timer_SlowShouldStop(_FakeTimer):
 	"""
 	Adds an extra amount of sleep when shouldStopEvaluator is called to simulate
-	the device taking longer than expected.
+	the function taking a significant amount of time.
 	"""
-	def createShouldStopEvaluator(self, succeedAfterSeconds: float):
+	def createShouldStopEvaluator(self, succeedAfterSeconds: float) -> Callable[[Any], bool]:
 		"""Used to test the shouldStopEvaluator parameter of utils.blockUntilConditionMet.blockUntilConditionMet"""
 		def _shouldStopEvaluator(_value: Any):
 			self._fakeTime += 2 * self.POLL_INTERVAL

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,7 @@ This is a minor release to fix regressions with 2022.3.1 and address a security 
 
 == Bug Fixes ==
 - Fixes a regression from 2022.3.1 where certain functionality was disabled on secure screens. (#14286)
+- Fixes a regression from 2022.3.1 where certain functionality was disabled after sign-in, if NVDA started on the lock screen. (#14301)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
This regression was introduced in 2022.3.1

If NVDA starts on the lock screen (such as when starting your device), NVDA fails to cache the desktop object as the focus object, mouse object, etc. as it is from below the lock screen.
This causes NVDA to not function correctly after sign-in, such as the inability to use `nvda+q`.

### Description of user facing changes
Fixes severe regression with using NVDA after sign-in, if NVDA starts on the lock screen.

### Description of development approach
Cache the foreground window when NVDA starts up, rather than the desktop object.
This window should be accessible from the lock screen when NVDA starts on the lock screen.
The `setDesktopObject` should continue to cached the desktop object as usual, as security code has not been implemented to prevent this from being set to insecure objects.

Creates a generic function `blockUntilConditionMet`, to wait for the foreground window to be fetched successfully.
Unit testing discovered a bug with the system test implementation of `blockUntilConditionMet`. This has now been fixed.

### Testing strategy:
Using a try build tested the following steps:
1. Restart device
1. Wait for NVDA to start automatically on the lock screen
1. Sign-in to Windows
1. Continue to use NVDA normally after sign-in (e.g `nvda+q` opens the quit dialog)

Unit tests have been added for `blockUntilConditionMet`.

### Known issues with pull request:
None

### Change log entries:
```
- Fixes a regression from 2022.3.1 where certain functionality was disabled after sign-in, if NVDA started on the lock screen. (#14301)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
