### PR TITLE
Always speak labels of landmarks and regions when jumping inside from outside using quicknav or focus in browse mode

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2032,9 +2032,15 @@ def getControlFieldSpeech(  # noqa: C901
 		nameSequence
 		and reason in [OutputReason.FOCUS, OutputReason.QUICKNAV]
 		and fieldType == "start_addedToControlFieldStack"
-		and role in (controlTypes.Role.GROUPING, controlTypes.Role.PROPERTYPAGE)
+		and role in (
+			controlTypes.Role.GROUPING,
+			controlTypes.Role.PROPERTYPAGE,
+			controlTypes.Role.LANDMARK,
+			controlTypes.Role.REGION,
+		)
 	):
 		# #10095, #3321, #709: Report the name and description of groupings (such as fieldsets) and tab pages
+		# #13307: report the label for landmarks and regions
 		nameAndRole = nameSequence[:]
 		nameAndRole.extend(roleTextSequence)
 		types.logBadSequenceTypes(nameAndRole)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -2226,3 +2226,78 @@ def test_ARIASwitchRole():
 		]),
 		message="Report focus",
 	)
+
+
+def test_i13307():
+	"""
+	Even if (to avoid duplication) NVDA may choose to not speak a landmark or region's label
+	when arrowing into a landmark or region with an aria-labelledby,
+	it should still speak the label when junping inside the landmark or region
+	from outside using quicknav or focus.
+	"""
+	_chrome.prepareChrome(
+		"""
+		<p>navigation landmark with aria-label</p>
+		<nav aria-label="label">
+			<button>inner element</button>
+		</nav>
+		<p>Navigation landmark with aria-labelledby</p>
+		<nav aria-labelledby="innerHeading1">
+			<h1 id="innerHeading1">labelled by</h1>
+			<button>inner element</button>
+		</nav>
+		<p>Region with aria-label</p>
+		<section aria-label="label">
+			<button>inner element</button>
+		</section>
+		<p>Region with aria-labelledby</p>
+		<section aria-labelledby="innerHeading2">
+			<h1 id="innerHeading2">labelled by</h1>
+			<button>inner element</button>
+		</section>
+		"""
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"label",
+			"navigation landmark",
+			"inner element",
+			"button",
+		]),
+		message="jumping into landmark with aria-label should speak label",
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"labelled by",
+			"navigation landmark",
+			"inner element",
+			"button",
+		]),
+		message="jumping into landmark with aria-labelledby should speak label",
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"label",
+			"region",
+			"inner element",
+			"button",
+		]),
+		message="jumping into region with aria-label should speak label",
+	)
+	actualSpeech = _chrome.getSpeechAfterKey("tab")
+	_asserts.strings_match(
+		actualSpeech,
+		SPEECH_SEP.join([
+			"labelled by",
+			"region",
+			"inner element",
+			"button",
+		]),
+		message="jumping into region with aria-labelledby should speak label",
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -141,3 +141,6 @@ ARIA details role
 ARIA switch role
 	[Documentation]	Test aria switch control has appropriate role and states in browse mode and when focused
 	test_ARIASwitchRole
+i13307
+	[Documentation]	ensure aria-labelledby on a landmark or region is automatically spoken when jumping inside from outside using focus in browse mode
+	test_i13307

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -32,6 +32,7 @@ What's New in NVDA
 - The date picker controls in Outlook 2016 / 365 Advanced search dialog now report their label and value. (#12726)
 - ARIA switch controls are now actually reported as switches in Firefox, Chrome and Edge, rather than checkboxes. (#11310)
 - NVDA will automatically announce the sort state on an HTML table column header when changed by pressing an inner button. (#10890)
+- A landmark or region's name is always automatically spoken when jumping inside from outside using quick navigation or focus in browse mode. (#13307)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #13307
Fixes #13996

### Summary of the issue:
Some time after NVDA 2019.2, labels of landmarks and regions were no longer automatically spoken when jumping inside from outside using quick nav or focus in browse mode.
Although a label should not be spoken when moving into a landmark or region with the arrow keys if the label is from an associated node via aria-labelledby, when jumping in with quick nav / focus, it always should, as context is more important than rare duplication.

### Description of user facing changes
A landmark or region's name is always automatically spoken when jumping inside from outside using quick navigation or focus in browse mode.
 
### Description of development approach
landmark and region roles are treated the same as groupings and propertypages in getcontrolFieldSpeech. I.e. the name is always announced if it has one when entering from outside for a reason of quicknav or focus.
 
### Testing strategy:
Performed steps in issue #13307
Created a system test based on testcase in #13307.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
* A landmark or region's name is always automatically spoken when jumping inside from outside using quick navigation or focus in browse mode. (#13307)
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
