### PR TITLE
Handle SUT Application title report failure

### DIFF
--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -177,7 +177,9 @@ class NotepadLib:
 			f"{NotepadLib._testCaseTitle} \\({abs(_testCaseHash)}\\)"
 		)
 		if not self.canNotepadTitleBeReported(notepadTitleSpeechPattern=testCaseNotepadTitleSpeech):
-			builtIn.log(f"Unable to report notepad title: {testCaseNotepadTitleSpeech!r}")
+			builtIn.log("Trying to switch to notepad Window")
+			windowsLib.taskSwitchToItemMatching(targetWindowNamePattern=testCaseNotepadTitleSpeech)
+			windowsLib.logForegroundWindowTitle()
 
 		self._waitForNotepadFocus(uniqueTitleRegex)
 		windowsLib.logForegroundWindowTitle()

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -34,6 +34,7 @@ import ctypes
 import sys
 import os
 
+SpeechIndexT = int
 
 def _importRobotRemoteServer() -> typing.Type:
 	log.debug(f"before path mod: {sys.path}")
@@ -352,7 +353,7 @@ class NVDASpyLib:
 		self._allSpeechStartIndex = self.get_last_speech_index()
 		return self._allSpeechStartIndex
 
-	def get_next_speech_index(self) -> int:
+	def get_next_speech_index(self) -> SpeechIndexT:
 		""" @return: the next index that will be used.
 		"""
 		return self.get_last_speech_index() + 1
@@ -378,6 +379,30 @@ class NVDASpyLib:
 			intervalBetweenSeconds=intervalBetweenSeconds,
 			errorMessage=None
 		)
+
+	def wait_for_specific_speech_no_raise(
+			self,
+			speech: str,
+			afterIndex: Optional[int] = None,
+			maxWaitSeconds: float = 5.0,
+			intervalBetweenSeconds: float = DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS,
+	) -> Optional[int]:
+		"""
+		@param speech: The speech to expect.
+		@param afterIndex: The speech should come after this index. The index is exclusive.
+		@param maxWaitSeconds: The amount of time to wait in seconds.
+		@param intervalBetweenSeconds: The amount of time to wait between checking speech, in seconds.
+		@return: the index of the speech.
+		"""
+		success, speechIndex = self._has_speech_occurred_before_timeout(
+			speech,
+			afterIndex,
+			maxWaitSeconds,
+			intervalBetweenSeconds
+		)
+		if not success:
+			return None
+		return speechIndex
 
 	def wait_for_specific_speech(
 			self,
@@ -438,13 +463,18 @@ class NVDASpyLib:
 	def wait_for_speech_to_finish(
 			self,
 			maxWaitSeconds=5.0,
-			speechStartedIndex: Optional[int] = None
-	):
-		_blockUntilConditionMet(
+			speechStartedIndex: Optional[int] = None,
+			errorMessage: Optional[str] = "Speech did not finish before timeout"
+	) -> bool:
+		"""speechStartedIndex should generally be fetched with get_next_speech_index
+		@param errorMessage: Supply None to bypass assert.
+		"""
+		success, _value = _blockUntilConditionMet(
 			getValue=lambda: self._hasSpeechFinished(speechStartedIndex=speechStartedIndex),
 			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),
-			errorMessage="Speech did not finish before timeout"
+			errorMessage=errorMessage,
 		)
+		return success
 
 	def wait_for_braille_update(
 			self,

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -81,9 +81,9 @@ def CloseWindow(window: Window) -> bool:
 	@return: True if the window exists and the message was sent.
 	"""
 	if windowWithHandleExists(window.hwndVal):
-		return windll.user32.CloseWindow(
+		return bool(windll.user32.CloseWindow(
 			window.hwndVal,
-		)
+		))
 	return False
 
 

--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -7,8 +7,21 @@
 features.
 """
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
-
+import typing as _typing
+from typing import (
+	Optional as _Optional,
+)
+from SystemTestSpy import (
+	_getLib,
+)
+import re as _re
 from robot.libraries.BuiltIn import BuiltIn as _BuiltInLib
+
+# Imported for type information
+from robot.libraries.OperatingSystem import OperatingSystem as _OpSysLib
+from robot.libraries.Process import Process as _ProcessLib
+from AssertsLib import AssertsLib as _AssertsLib
+import NvdaLib as _NvdaLib
 
 from SystemTestSpy.windows import (
 	GetForegroundWindowTitle as _getForegroundWindowTitle,
@@ -16,7 +29,15 @@ from SystemTestSpy.windows import (
 	Window as _Window,
 )
 
+if _typing.TYPE_CHECKING:
+	#  F401 used for type checking only
+	from SystemTestSpy.speechSpyGlobalPlugin import SpeechIndexT as _SpeechIndexT  # noqa: F401
+
+
 builtIn: _BuiltInLib = _BuiltInLib()
+opSys: _OpSysLib = _getLib('OperatingSystem')
+process: _ProcessLib = _getLib('Process')
+assertsLib: _AssertsLib = _getLib('AssertsLib')
 
 # This library doesn't rely on state, so it is not a class.
 # However, if converting to a class note that in Robot libraries, the class name must match the name
@@ -34,3 +55,112 @@ def logForegroundWindowTitle():
 	"""
 	windowTitle = _getForegroundWindowTitle()
 	builtIn.log(f"Foreground window title: {windowTitle}")
+
+
+def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToTest: int = 10) -> None:
+	"""Opens the task switcher, rightArrows through the items trying to search the for the pattern in the
+	speech for each item.
+	Raises AssertionError if not found.
+	If found "enter" is pressed to select and exit the task switcher, waits for speech to finish after this.
+	If not found "escape" is pressed to exit the task switcher, waits for speech to finish after this.
+	"""
+	spy = _NvdaLib.getSpyLib()
+	spy.wait_for_speech_to_finish()
+
+	builtIn.log(f"Looking for window: {targetWindowNamePattern}", level="DEBUG")
+	startOfTaskSwitcherSpeech = _tryOpenTaskSwitcher()
+	if startOfTaskSwitcherSpeech is None:
+		# Try opening the task switcher again
+		spy.emulateKeyPress('escape')
+		# Hack: using 'sleep' is error-prone.
+		# Given that opening the task switcher failed, or was too slow, the intention is to dismiss it
+		# and give the system time to recover before trying again.
+		builtIn.sleep(3)
+
+		startOfTaskSwitcherSpeech = _tryOpenTaskSwitcher()
+		if startOfTaskSwitcherSpeech is None:
+			raise AssertionError("Tried twice to open task switcher and failed.")
+
+	spy.wait_for_speech_to_finish(speechStartedIndex=startOfTaskSwitcherSpeech)
+	speech = spy.get_speech_at_index_until_now(startOfTaskSwitcherSpeech)
+	# if there is only one application open, it will already be selected:
+	firstItemPattern = _re.compile(r"row 1\s+column 1")
+	atFirstItemAlready = bool(firstItemPattern.search(speech))
+
+	if not atFirstItemAlready:
+		# The second item (in the task switcher) is normally selected initially (when there are multiple windows),
+		# the nominal case is that the first item is the required target.
+		nextIndex = spy.get_next_speech_index()
+		spy.emulateKeyPress('leftArrow')  # So move back to the first.
+		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
+		speech = spy.get_speech_at_index_until_now(nextIndex)
+		builtIn.log(f"First window: {speech}", level="DEBUG")
+
+		# ensure this is now the first item
+		if not firstItemPattern.search(speech):
+			raise AssertionError("Didn't return to the first item with left arrow")
+
+	found = False
+	if targetWindowNamePattern.search(speech):
+		found = True
+
+	speech = ""
+	windowsTested = 1
+	while (
+		not found
+		and not firstItemPattern.search(speech)
+		# In most cases it is expected that the target Window is close to the top of the z-order.
+		# On CI there should not be many windows open.
+		# A sanity check on the max windows to test ensures the test does not get stuck cycling through the
+		# available windows if the other tests fail for some reason.
+		and windowsTested < maxWindowsToTest
+	):
+		nextIndex = spy.get_next_speech_index()
+		spy.emulateKeyPress('rightArrow')  # move to the next task switcher item
+		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
+		speech = spy.get_speech_at_index_until_now(nextIndex)
+		builtIn.log(f"next window: {speech}", level="DEBUG")
+		if targetWindowNamePattern.search(speech):
+			found = True
+		windowsTested += 1
+
+	if not found:
+		nextIndex = spy.get_next_speech_index()
+		spy.emulateKeyPress("escape")
+		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
+		raise AssertionError(
+			f"Unable to find Window in task switcher matching: {targetWindowNamePattern}\n"
+			"See NVDA log for dump of all speech."
+		)
+	else:
+		nextIndex = spy.get_next_speech_index()
+		spy.emulateKeyPress("enter")
+		if not spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex, errorMessage=None):
+			AssertionError(
+				f"Expected some speech after enter press."
+				f" Speech at index: {nextIndex}"
+				f", nextIndex: {spy.get_next_speech_index()}"
+				f", speech in range: {spy.get_speech_at_index_until_now(nextIndex)}"
+			)
+
+
+def _tryOpenTaskSwitcher() -> _Optional["_SpeechIndexT"]:
+	"""
+	@return: If the task switcher 'row 1' was spoken, the speech index for the start of the task switcher
+	speech.
+	"""
+	spy = _NvdaLib.getSpyLib()
+	expectedStartOfKeypressSpeechIndex = spy.get_next_speech_index()
+	spy.emulateKeyPress('control+alt+tab')  # opens the task switcher until enter or escape is pressed.
+	# each item has "row 1 column 1" appended, ensure that the task switcher has opened.
+	firstRow = "row 1"
+	indexOfSpeech: _Optional[int] = spy.wait_for_specific_speech_no_raise(
+		firstRow,
+		afterIndex=expectedStartOfKeypressSpeechIndex - 1,
+		maxWaitSeconds=5,
+		intervalBetweenSeconds=0.3
+	)
+	builtIn.log(f"indexOfSpeech '{firstRow}': {indexOfSpeech}", level="DEBUG")
+	if indexOfSpeech:
+		return expectedStartOfKeypressSpeechIndex
+	return None


### PR DESCRIPTION
Depends on:
- https://github.com/nvaccess/nvda/pull/14289

### Link to issue number:
Splitting up PR https://github.com/nvaccess/nvda/pull/14054

### Summary of the issue:
It is possible for another application / Window to open in the foreground while appveyor scripts are running.
This prevents appveyor build sub-processes (I.E robot framework system tests) from taking the foreground.

In particular, occasionally docker desktop pops up a net promoter score survey window before/early in the build.
This interferes with system tests.

### Description of user facing changes
None

### Description of development approach
When the title of the application cannot be reported use the task switcher to bring the application to the foreground.
- Use the `control+alt+tab` task switcher, it does not require holding a key down while interacting.
- Move through all the items in the switcher, starting with 'row 1, column 1' looking for the title of the application.
- When found press enter.

Note:
- Limit the number of windows to check. This is a failsafe to ensure the test does not try to run forever.
- Handle only one window open.
- Handle failure to open the task switcher on first try.

### Testing strategy:
Run on appveyor.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
