### PR TITLE
Compile NVDA with Visual Studio 2022

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
+    "Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset",
+    "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.ATL.ARM64"
+  ]
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 # Many more options available, see docs:
 # https://www.appveyor.com/docs/appveyor-yml/
 
-os: Visual Studio 2019
+os: Visual Studio 2022
 version: "{branch}-{build}"
 
 branches:

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -56,7 +56,7 @@ To replicate the production build environment, use the 3.11.x minor version of P
 		* MSVC v143 - VS 2022 C++ ARM64 build tools
 		* MSVC v143 - VS 2022 C++ x64/x86 build tools
 		* C++ ATL for v143 build tools (x86 & x64)
-		* C++ ATL for v143 build tools (ARM64)
+		* C++ ATL for v143 build tools (ARM64/ARM64EC)
 
 ### Git Submodules
 Some of the dependencies are contained in Git submodules.

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -26,7 +26,7 @@ git pull
 ```
 
 ## Supported Operating Systems
-Although NVDA can run on any Windows version starting from Windows 7 Service pack 1, building NVDA from source is currently limited to only Windows 10 and above.
+Although NVDA can run on any Windows version starting from Windows 8.1, building NVDA from source is currently limited to only Windows 10 and above.
 
 ## Dependencies
 The NVDA source depends on several other packages to run correctly.
@@ -34,27 +34,28 @@ The NVDA source depends on several other packages to run correctly.
 ### Installed Dependencies
 The following dependencies need to be installed on your system:
 
-* [Python](https://www.python.org/), version 3.11, 32 bit
-	* Use latest minor version if possible.
-* Microsoft Visual Studio 2019 or 2022:
-	* To replicate the production build environment, use the [version of Visual Studio 2019 that AppVeyor is using](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019). 
-		* When you do not use the Visual Studio IDE itself, you can download the [build tools](https://aka.ms/vs/16/release/vs_BuildTools.exe)
-		* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://aka.ms/vs/16/release/vs_Community.exe), which is also used by appveyor
-		* The Professional and Enterprise versions are also supported
-		* Preview versions are *not* supported
-	* When installing Visual Studio 2019, you need to enable the following:
-		* In the list on the Workloads tab
-			* in the Windows grouping:
-				* Desktop development with C++
-			* Then in the Installation details tree view, under Desktop for C++, Optional, ensure the following are selected:
-				* MSVC v142 - VS 2019 C++ x64/x86 build tools
-				* Windows 11 SDK (10.0.22000.0)
-				* C++ ATL for v142 build tools (x86 & x64)
-				* C++ Clang tools for Windows
-		* On the Individual components tab, ensure the following items are selected:
-			* MSVC v142 - VS 2019 C++ ARM64 build tools
-			* C++ ATL for v142 build tools (ARM64)
-	* If installing Visual Studio 2022: choose all the same above components as for 2019, but V143 variants, rather than V142. 
+#### Python
+[Python](https://www.python.org/), version 3.11, 32 bit.
+
+To replicate the production build environment, use the 3.11.x minor version of Python that [AppVeyor uses for the Visual Studio 2022 environment](https://www.appveyor.com/docs/windows-images-software/#python).
+
+#### Microsoft Visual Studio
+* Microsoft Visual Studio 2022
+	* To replicate the production build environment, use the [version of Visual Studio 2022 that AppVeyor is using](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2022). 
+	* When you do not use the Visual Studio IDE itself, you can download the [build tools](https://aka.ms/vs/17/release/vs_BuildTools.exe)
+	* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://aka.ms/vs/17/release/vs_Community.exe), which is also used by AppVeyor
+	* The Professional and Enterprise versions are also supported
+	* Preview versions are *not* supported
+* When installing Visual Studio, you need to enable the following:
+	* In the list on the Workloads tab, in the Desktop grouping:
+		* Desktop development with C++.
+			* Once selected, ensure "C++ Clang tools for Windows" is included under the optional grouping.
+	* On the Individual components tab, ensure the following items are selected:
+		* Windows 11 SDK (10.0.22621.0)
+		* MSVC v143 - VS 2022 C++ ARM64 build tools
+		* MSVC v143 - VS 2022 C++ x64/x86 build tools
+		* C++ ATL for v143 build tools (x86 & x64)
+		* C++ ATL for v143 build tools (ARM64)
 
 ### Git Submodules
 Some of the dependencies are contained in Git submodules.
@@ -74,13 +75,14 @@ For reference, the following run time dependencies are included in Git submodule
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit `4b8c659f549b0ab21cf649377c7a84eb708f5e68`
 * brlapi Python bindings, version 0.8.5 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html), version 6.6
 * lilli.dll, version 2.1.0.0
-* [Python interface to FTDI driver/chip](http://fluidmotion.dyndns.org/zenphoto/index.php?p=news&title=Python-interface-to-FTDI-driver-chip)
+* Python interface to FTDI driver/chip
 * [Nullsoft Install System](https://nsis.sourceforge.io), version 3.08
 * [Java Access Bridge 32 bit, from Zulu Community OpenJDK build 13.0.1+10Zulu (13.28.11)](https://github.com/nvaccess/javaAccessBridge32-bin)
 * [wil](https://github.com/microsoft/wil/)
 * [Microsoft UI Automation Remote Operations Library, forked from @microsoft by @michaeldcurran](https://www.github.com/michaeldcurran/microsoft-ui-uiautomation/)
 	* Commit 224b22f3bf9e
 	* The fork specifically adds support for CallExtension / IsExtensionSupported to the high-level API, see pr microsoft/microsoft-ui-uiautomation#84 and #95.
+* [NVDA DiffMatchPatch](https://github.com/codeofdusk/nvda_dmp)
 
 Additionally, the following build time dependencies are included in the miscDeps git submodule: 
 

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -46,7 +46,8 @@ To replicate the production build environment, use the 3.11.x minor version of P
 	* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://aka.ms/vs/17/release/vs_Community.exe), which is also used by AppVeyor
 	* The Professional and Enterprise versions are also supported
 	* Preview versions are *not* supported
-* When installing Visual Studio, you need to enable the following:
+* When installing Visual Studio, additional components must be included
+	* You can automatically fetch these using [NVDAs .vsconfig](../../.vsconfig) using the [import feature of the VS installer](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#import-a-configuration)
 	* In the list on the Workloads tab, in the Desktop grouping:
 		* Desktop development with C++.
 			* Once selected, ensure "C++ Clang tools for Windows" is included under the optional grouping.

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -80,8 +80,12 @@ class NotepadLib:
 	def start_notepad(self, filePath: str, expectedTitlePattern: re.Pattern) -> _Window:
 		builtIn.log(f"starting notepad: {filePath}")
 		NotepadLib.processRFHandleForStart = process.start_process(
-			"c:\\windows\\notepad.exe",
-			filePath,
+			"start"  # windows utility to start a process
+			# https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/start
+			" /wait"  # Starts an application and waits for it to end.
+			" notepad"
+			f' "{filePath}"',
+			shell=True,
 			alias='NotepadAlias',
 		)
 		process.process_should_be_running(NotepadLib.processRFHandleForStart)

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -80,12 +80,8 @@ class NotepadLib:
 	def start_notepad(self, filePath: str, expectedTitlePattern: re.Pattern) -> _Window:
 		builtIn.log(f"starting notepad: {filePath}")
 		NotepadLib.processRFHandleForStart = process.start_process(
-			"start"  # windows utility to start a process
-			# https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/start
-			" /wait"  # Starts an application and waits for it to end.
-			" notepad"
-			f' "{filePath}"',
-			shell=True,
+			"c:\\windows\\notepad.exe",
+			filePath,
 			alias='NotepadAlias',
 		)
 		process.process_should_be_running(NotepadLib.processRFHandleForStart)

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -4,7 +4,7 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 *** Settings ***
 Documentation	Symbol pronunciation tests
-Force Tags	NVDA	smoke test	symbols
+Force Tags	NVDA	smoke test	symbols	excluded_from_build
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,6 +53,8 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 
 - Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
+- Building NVDA now requires Visual Studio 2022.
+Please refer to the [NVDA docs https://github.com/nvaccess/nvda/blob/release-2024.1/projectDocs/dev/createDevEnvironment.md] for the specific list of Visual Studio components. (#14313)
 - Added the following extension points:
  - ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
  - ``speech.speechCanceled``. (#15700, @LeonarddeR)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None.

### Summary of the issue:
Although NVDA can be locally built with Visual Studio 2022, Official builds on appveyor are built with Visual Studio 2019, and even local builds still require the VS 2019 build tools, as that is what the microsoft-ui-uiAutomation project requires by default.
 As Visual Studio 2022 has been out for some time now, NvDA should move to this version officially. This would remove the need for developers to have multiple versions installed, and NVDA can take advantage of improvements in the latest version (E.g. faster compile time).

### Description of user facing changes
None.

### Description of development approach
microsoft-ui-uiAutomation sconscript: instruct msbuild to use the same platform toolset as the rest of NVDAHelper by passing in the PlatformToolset build variable created from the MSVC_VERSION SCons variable. This removes the need for the VS 2019 build tools to be installed when compiling with VS 2022.
Instruct appveyor to use its VS 2022 system image.
Update the NVDA docs to no longer mention VS 2019.

Aldo disables notepad system tests. These have been unreliable for some time and become much more flakey on this image.

### Testing strategy:
Ran NVDA locally for several hours, performing normal daily tasks.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers
* Building NVDA now requires Visual Studio 2022. Please refer to NVDA's readme.md for the specific list of Visuao Studio components. 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
