### PR TITLE
Fix error in UIA focus event handler when NVDAObject can't be created

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -860,6 +860,7 @@ class UIAHandler(COMObject):
 				log.debug(
 					"handleFocusChangedEvent: Could not create an NVDAObject "
 				)
+			return
 		if _isDebug():
 			log.debug(f"Created object {obj} for element {self.getUIAElementDebugString(sender)}")
 		if not obj.shouldAllowUIAFocusEvent:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fix regression introduced in pr #14256


### Summary of the issue:
Sometimes a UIA focus event handler can't create an NVDAObject for the element being focused. Normally, in this situation, the event would be silently dropped.
However, with the introduction of extra debugging for UIA events in pr #14256, a return was accidently removed, which meant that the shouldAllowUIAFocusEvent attribute tried to be looed up on the None (failed NVDAObject). This caused a noisy traceback in the log at level error.

### Description of user facing changes
A noisy error traceback is no longer produced when NVDA cannot handle certain broken UIA focus events.

### Description of development approach
Make sure to return if instantiating the NVDAObject produces None.

### Testing strategy:
Run NVDA for an hour or so performing normal daily tasks. Previously the error would have been seen multiple times.

### Known issues with pull request:
None known.

### Change log entries:
None needed - regression only in master.
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
