### PR TITLE
Drasticly reduce amount of log messages produced for comtypes event handler exceptions

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -328,6 +328,17 @@ class Formatter(logging.Formatter):
 	def formatException(self, ex):
 		return stripBasePathFromTracebackText(super(Formatter, self).formatException(ex))
 
+	def format(self, record: logging.LogRecord) -> str:
+		# NVDA's log calls provide / generate a special 'codepath' record attribute.
+		# Which is a clean and friendly module.class.function string.
+		# However, as NVDA's logger is also installed as the root logger to catch logging from other libraries,
+		# log calls outside of NVDA will not provide codepath.
+		if not hasattr(record, 'codepath'):
+			# #14315: codepath was not provided,
+			# So make up a simple one from standard record attributes we know will exist.
+			record.codepath = "{name}.{funcName}".format(**record.__dict__)
+		return super().format(record)
+
 	def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
 		"""Custom implementation of `formatTime` which avoids `time.localtime`
 		since it causes a crash under some versions of Universal CRT when Python locale


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Partial fix for #14315

### Summary of the issue:
If an exception is raised inside a comtypes event handler and is not caught, Many many log messages are logged by NVDA at level error, with each line of the multiple nested tracebacks being individually logged via standard error.
This is extremely noisy for the user, and the log output is very hard to read.
As an example, if a RuntimeError is raised from our IUIAutomationEventHandler_handleAutomationEvent method, the following 22 log messages are produced all in quick succession:
```
ERROR - stderr (17:24:42.688) - Dummy-2 (13416):
--- Logging error ---
ERROR - stderr (17:24:42.717) - Dummy-2 (13416):
Traceback (most recent call last):
ERROR - stderr (17:24:42.727) - Dummy-2 (13416):
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\comtypes\_comobject.py", line 154, in call_without_this
    result = mth(*inargs)
ERROR - stderr (17:24:42.747) - Dummy-2 (13416):
  File "C:\Users\mick\programming\git\nvda\source\UIAHandler\__init__.py", line 704, in IUIAutomationEventHandler_HandleAutomationEvent
    raise RuntimeError("hello")
ERROR - stderr (17:24:42.757) - Dummy-2 (13416):
RuntimeError: hello
ERROR - stderr (17:24:42.777) - Dummy-2 (13416):

During handling of the above exception, another exception occurred:
ERROR - stderr (17:24:42.792) - Dummy-2 (13416):
Traceback (most recent call last):
ERROR - stderr (17:24:42.807) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 1025, in emit
    msg = self.format(record)
ERROR - stderr (17:24:42.827) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 869, in format
    return fmt.format(record)
ERROR - stderr (17:24:42.842) - Dummy-2 (13416):
  File "C:\Users\mick\programming\git\nvda\source\logHandler.py", line 340, in format
    return super().format(record)
ERROR - stderr (17:24:42.857) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 611, in format
    s = self.formatMessage(record)
ERROR - stderr (17:24:42.872) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 580, in formatMessage
    return self._style.format(record)
ERROR - stderr (17:24:42.892) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 430, in format
    return self._fmt.format(**record.__dict__)
ERROR - stderr (17:24:42.907) - Dummy-2 (13416):
KeyError: 'codepath'
ERROR - stderr (17:24:42.917) - Dummy-2 (13416):
Call stack:
ERROR - stderr (17:24:42.937) - Dummy-2 (13416):
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\comtypes\_comobject.py", line 191, in call_without_this
    mthname, exc_info=True)
ERROR - stderr (17:24:42.952) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 1407, in error
    self._log(ERROR, msg, args, **kwargs)
ERROR - stderr (17:24:42.967) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 1514, in _log
    self.handle(record)
ERROR - stderr (17:24:42.987) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 1524, in handle
    self.callHandlers(record)
ERROR - stderr (17:24:43.002) - Dummy-2 (13416):
  File "C:\Program Files (x86)\Python37-32\lib\logging\__init__.py", line 1586, in callHandlers
    hdlr.handle(record)
ERROR - stderr (17:24:43.017) - Dummy-2 (13416):
  File "C:\Users\mick\programming\git\nvda\source\logHandler.py", line 322, in handle
    return super().handle(record)
ERROR - stderr (17:24:43.032) - Dummy-2 (13416):
Message: 'Exception in %s.%s implementation:'
Arguments: ('IUIAutomationEventHandler', 'HandleAutomationEvent')
```

Some background:
To produce friendly module.class.function paths for NVDA's log messages, NVDA's logging code provides / generates a special 'codepath' attribute on its log erecords. However, as NVDA sets itself as the root logger, it also receives log messages from other libraries (E.g. comtypes). But these log messages don't come with the special 'codepath' record attribute, which is required by NVDA's log formatter.
Thus, if one of these log messages is produced, an internal logging error occurs (KeyError: codepath), and this is pushed out via standard error as the log message could not be written to the log. However, NVDA's redirects standard error back to the logger, logging each line of output as its own log message. 
In this case then, What is logged is each separate line of the multiple nested tracebacks, including the actual exception in the comtypes UI Autpomation event handler, plus the logging error traceback itself, plus also a call stack for debugging.
In totally on average about 22 or so separate log messages for one error.
 
### Description of user facing changes
If an error occurs in a comtypes event handler method, only one error will be written to the log rather than more than 20.

### Description of development approach
Add code to NVDA's log formatter.format method which checks if the record does not contain a codepath attribute, and if so, produces a simple one from standard log record attributes. e.g. name and funcName.

After this change, raising Runtime error in the UI Automation handleAutomationEvent method produces just 1 much shorter and easier to read message:
```
ERROR - comtypes._comobject.call_without_this (17:03:15.784) - Dummy-2 (8492):
Exception in IUIAutomationEventHandler.HandleAutomationEvent implementation:
Traceback (most recent call last):
  File "C:\Users\mick\programming\git\nvda\.venv\lib\site-packages\comtypes\_comobject.py", line 154, in call_without_this
    result = mth(*inargs)
  File "UIAHandler\__init__.py", line 704, in IUIAutomationEventHandler_HandleAutomationEvent
    raise RuntimeError("hello")
RuntimeError: hello
```
 
### Testing strategy:
* Tested by raising RuntimeError from IUIAutomationEventHandler_handleAutomationEvent and viewing the log output.
* Users on win 10 who can reproduce #14315 should test this pr and verify that the amount of errors has greatly reduced.

### Known issues with pull request:
Note that this pr only addresses the logging problem, but does not actually address the underlying exception in the event handler. We should look at this separately, possibly not until 2023.1 dev cycle.

### Change log entries:
New features
Changes
Bug fixes
* NVDA's log is no longer flooded with 20 or more errors when an exception occurs in an external library such as comtypes.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
