### PR TITLE
Visual Studio 2022: Support building liblouis on Clang 15 and above

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -59,8 +59,10 @@ env['CC'] = 'clang-cl'
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
-# Ignore some warnings as the code is not ours
-env.Replace(CCFLAGS='/W2')
+# Starting from Clang 15, the -Wint-conversion warning diagnostic for implicit int <-> pointer conversions
+# now defaults to an error in all C language modes.
+# Downgrade this to a warning so we can still build.
+env.Append(CCFLAGS='-Wno-error=int-conversion')
 
 env.Append(CPPDEFINES=[
 	# The Visual C++ C Runtime deprecates standard POSIX APIs that conflict with


### PR DESCRIPTION
### Link to issue number:
https://github.com/liblouis/liblouis/issues/1259

### Summary of the issue:
Starting with Clang 15, liblouis no longer compiles because Clang 15 treats int to pointer conversion as erroneous.

### Description of user facing changes
NVDA builds properly again on VS 2022 preview.

### Description of development approach
Added a flag that degrades the error to a warning again.

### Testing strategy:
Ensure that NVDA builds correctly.

### Known issues with pull request:
This is not strictly necessary at this moment because Clang 15 hasn't yet landed in stable. Please note however that we have no control over the appveyor release process and that building will instantly break without this patch as soon as Appveyor updates VS to a version that has Clang 15.

### Change log entries:
none needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
