### PR TITLE
Lower poll interval for blockUntilConditionMet

### DIFF
--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -19,10 +19,10 @@ from typing import (
 EvaluatorWasMetT = bool
 GetValueResultT = Any
 
-DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS = 0.3
+DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS = 0.1
 """The default interval (in seconds) between calls to the evaluator."""
 
-_MIN_INTERVAL_BETWEEN_EVAL_SECONDS = 0.1
+_MIN_INTERVAL_BETWEEN_EVAL_SECONDS = 0.01
 """The minimum interval (in seconds) between calls to the evaluator.
 Small values for the interval can starve NVDA core, preventing it
 from being able to process queued events.

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -22,14 +22,15 @@ from typing import (
 EvaluatorWasMetT = bool
 GetValueResultT = Any
 
-DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS = 0.3
+DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS = 0.1
 """The default interval (in seconds) between calls to the evaluator."""
 
-_MIN_INTERVAL_BETWEEN_EVAL_SECONDS = 0.1
+_MIN_INTERVAL_BETWEEN_EVAL_SECONDS = 0.01
 """The minimum interval (in seconds) between calls to the evaluator.
 Small values for the interval can starve NVDA core, preventing it
 from being able to process queued events.
 """
+
 
 def _blockUntilConditionMet(
 		getValue: Callable[[], GetValueResultT],

--- a/tests/unit/test_util/test_blockUntilConditionMet.py
+++ b/tests/unit/test_util/test_blockUntilConditionMet.py
@@ -23,7 +23,7 @@ class _FakeTimer():
 	Patches sleeping and getting the current time,
 	so that the module under test is not dependent on real world time.
 	"""
-	POLL_INTERVAL = 0.2
+	POLL_INTERVAL = 0.1
 
 	def __init__(self) -> None:
 		self._fakeTime: float = 0.0


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
Due to intermittent system test failures, #14284 increased the polling interval used in `blockUntilConditionMet`.
When writing unit tests for  `blockUntilConditionMet` in #14301, a bug was picked up. This bug caused `blockUntilConditionMet` to spin for longer than expected and potentially caused system tests to fail.

This bug was fixed with a new implementation of  `blockUntilConditionMet`.

### Description of user facing changes

For devs, system tests should be faster (**todo:** estimate from build?)

### Description of development approach
Lower default polling interval

### Testing strategy:
 Monitor system tests for a while, check if `blockUntilConditionMet` causes a system test failure.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
