### PR TITLE
Allow compiling microsoft-ui-uiAutomation with VS 2022

### DIFF
--- a/nvdaHelper/microsoft-ui-uiautomation/sconscript
+++ b/nvdaHelper/microsoft-ui-uiautomation/sconscript
@@ -41,6 +41,12 @@ env = env.Clone()
 # otherwise the build fails with Visual Studio 2022
 env['ENV']['windir'] = os.environ['windir']
 
+
+# We must ensure that msbuild uses the same platform toolset as the rest of NVDA.
+# Thus we must fetch this info from the MSVC_VERSION SCons variable,
+# Formatting it as vMajorMinor (e.g. v143 for 14.3). 
+platformToolset = "v" + "".join(env.get('MSVC_VERSION').split('.')[:2])
+
 MSUIA_sourceDir = Dir('#include/microsoft-ui-uiautomation/src/uiAutomation')
 MSUIA_lib_outDir = Dir('lib')
 MSUIA_include_outDir = Dir('include')
@@ -66,11 +72,14 @@ MSUIA_wrapper_libs = env.Command(
 	],
 	action = [
 		# Fetch any required NuGet packages
-		f"msbuild {MSUIA_solutionFile} /t:Restore /p:RestorePackagesConfig=true,Configuration=Release,Platform=x86",
+		f"msbuild {MSUIA_solutionFile} /t:Restore /p:RestorePackagesConfig=true,Configuration=Release,Platform=x86,PlatformToolset={platformToolset}",
 		# Remove any old generated files
 		Delete(MSUIA_sourceDir.Dir('microsoft.ui.uiautomation/Generated Files')),
 		# Do the actual build
-		"msbuild /t:Build /p:Configuration=Release,Platform=x86,OutDir={outDir}/ $SOURCE".format(outDir=MSUIA_lib_outDir.abspath)
+		"msbuild /t:Build /p:Configuration=Release,Platform=x86,PlatformToolset={platformToolset},OutDir={outDir}/ $SOURCE".format(
+			outDir=MSUIA_lib_outDir.abspath,
+			platformToolset=platformToolset
+		)
 	],
 )
 env.Ignore(MSUIA_wrapper_libs,MSUIA_sourceDir.File('microsoft.ui.uiautomation/Microsoft.UI.UIAutomation_h.h'))
@@ -88,7 +97,10 @@ MSUIA_abstraction_libs = env.Command(
 		glob.glob(os.path.join(MSUIA_sourceDir.abspath, 'UiaOperationAbstraction', '*.h')),
 	],
 	action = [
-		"msbuild /t:Build /p:Configuration=Release,Platform=x86,OutDir={outDir}/ $SOURCE".format(outDir=MSUIA_lib_outDir.abspath),
+		"msbuild /t:Build /p:Configuration=Release,Platform=x86,PlatformToolset={platformToolset},OutDir={outDir}/ $SOURCE".format(
+			outDir=MSUIA_lib_outDir.abspath,
+			platformToolset=platformToolset
+		),
 	]
 )
 

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,7 @@ The following dependencies need to be installed on your system:
 		* When you are intending to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://aka.ms/vs/16/release/vs_Community.exe), which is also used by appveyor
 		* The Professional and Enterprise versions are also supported
 		* Preview versions are *not* supported
-		* Building with Visual Studio 2022 explicitly requires the MSVC v142 - VS 2019 C++ build tools to be installed (see below)
-	* When installing Visual Studio, you need to enable the following:
+	* When installing Visual Studio 2019, you need to enable the following:
 		* In the list  on the Workloads tab
 			* in the Windows grouping:
 				* Desktop development with C++
@@ -79,7 +78,7 @@ The following dependencies need to be installed on your system:
 		* On the Individual components tab, ensure the following items are selected:
 			* MSVC v142 - VS 2019 C++ ARM64 build tools
 			* C++ ATL for v142 build tools (ARM64)
-
+	* If installing Visual Studio 2022: choose all the same above components as for 2019, but V143 variants, rather than V142. 
 
 ### Git Submodules
 Some of the dependencies are contained in Git submodules.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,7 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - Now uses the C++20 standard, was C++17.
   - Now uses the '/permissive-' compiler flag which disables permissive behaviors, and sets the '/Zc' compiler options for strict conformance.
   -
+- NVDA can now be fully compiled with Visual Studio 2022, no longer  requiring the Visual Studio 2019 build tools. 
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,7 +50,7 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - Now uses the C++20 standard, was C++17.
   - Now uses the '/permissive-' compiler flag which disables permissive behaviors, and sets the '/Zc' compiler options for strict conformance.
   -
-- NVDA can now be fully compiled with Visual Studio 2022, no longer  requiring the Visual Studio 2019 build tools. 
+- NVDA can now be fully compiled with Visual Studio 2022, no longer requiring the Visual Studio 2019 build tools. 
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Taken from pr #14313 which cannot yet be merged in its entireity.

### Summary of the issue:
NVDA can be compiled locally with VS 2022, but the VS 2019 build tools are required, due to the Microsoft-UI-UIAutomation project specifying the VS 2019 platform toolset by default.

### Description of user facing changes
None

### Description of developer facing changes
NVDA can now be fully compiled locally with Visual Studio 2022, without also requiring the 2019 build tools.

### Description of development approach
* When compiling the microsoft-ui-uiAutomation project, instruct msbuild to use the same platform toolset as the rest of NVDAHelper.

### Testing strategy:
Built with VS 2022 with no VS 2019 components installed.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers
* NVDA can be now fully compiled with Visual Studio 2022, with out requiring the Visual Studio 2019 build tools.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
