### PR TITLE
restore API import to core.main on beta

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -503,6 +503,17 @@ def _initializeObjectCaches():
 	api.setMouseObject(foregroundObject)
 
 
+def _doLoseFocus():
+	import api
+	focusObject = api.getFocusObject()
+	if focusObject and hasattr(focusObject, "event_loseFocus"):
+		log.debug("calling lose focus on object with focus")
+		try:
+			focusObject.event_loseFocus()
+		except Exception:
+			log.exception("Lose focus error")
+
+
 def main():
 	"""NVDA's core main loop.
 	This initializes all modules such as audio, IAccessible, keyboard, mouse, and GUI.
@@ -796,14 +807,8 @@ def main():
 	_terminate(gui)
 	config.saveOnExit()
 
-	try:
-		import api
-		focusObject = api.getFocusObject()
-		if focusObject and hasattr(focusObject, "event_loseFocus"):
-			log.debug("calling lose focus on object with focus")
-			focusObject.event_loseFocus()
-	except:
-		log.exception("Lose focus error")
+	_doLoseFocus()
+
 	try:
 		speech.cancelSpeech()
 	except:

--- a/source/core.py
+++ b/source/core.py
@@ -797,6 +797,7 @@ def main():
 	config.saveOnExit()
 
 	try:
+		import api
 		focusObject = api.getFocusObject()
 		if focusObject and hasattr(focusObject, "event_loseFocus"):
 			log.debug("calling lose focus on object with focus")


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
#14301 moved an `api` import from `core.main` as it was otherwise unused
#14050 introduced a usage of `api` to `core.main` to beta
This means that `api` was used without being imported on beta and master.

### Description of user facing changes
None

### Description of development approach
Fix import error

### Testing strategy:
Exit NVDA, check log for error

### Known issues with pull request:
None

### Change log entries:
None, unreleased bug

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
