### PR TITLE
Initialize object caches in a safer manner

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -454,6 +454,7 @@ class _TrackNVDAInitialization:
 
 	TODO: move to NVDAState module
 	"""
+
 	_isNVDAInitialized = False
 	"""When False, isWindowsLocked is forced to return False.
 	"""

--- a/source/core.py
+++ b/source/core.py
@@ -9,6 +9,8 @@
 
 from dataclasses import dataclass
 from typing import (
+	Any,
+	Callable,
 	List,
 	Optional,
 )
@@ -419,6 +421,30 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	brailleViewer.destroyBrailleViewer()
 
 
+def _pollForForegroundHWND() -> Optional[int]:
+	"""
+	@note: The foreground window should usually be fetched on the first try,
+	however it may take longer if Windows is taking a long time changing window focus.
+	Gives up after 10 seconds (MAX_WAIT_TIME_SECS).
+	"""
+	from utils.blockUntilConditionMet import blockUntilConditionMet
+	import winUser
+
+	# winUser.getForegroundWindow may return NULL in certain circumstances,
+	# such as when a window is losing activation.
+	# This should not remain the case for an extended period of time.
+	MAX_WAIT_TIME_SECS = 10
+
+	success, foregroundHWND = blockUntilConditionMet(
+		getValue=winUser.getForegroundWindow,
+		giveUpAfterSeconds=MAX_WAIT_TIME_SECS,
+	)
+	if success:
+		return foregroundHWND
+	log.error("NVDA could not fetch the foreground window.")
+	return None
+
+
 def _initializeObjectCaches():
 	"""
 	Caches the desktop object.
@@ -443,6 +469,35 @@ def _initializeObjectCaches():
 		api.setFocusObject(desktopObject)
 		api.setNavigatorObject(desktopObject)
 		api.setMouseObject(desktopObject)
+
+
+def _updateObjectCachesToForeground():
+	"""
+	Initializes object caches (other than desktop object) to the foreground window.
+	Before this, the object that is cached is the desktopObject,
+	however this may leak secure information to the lock screen.
+	The foreground window is set as the object cache,
+	as the foreground window would already be accessible on the lock screen (e.g. Magnifier).
+	It also is more intuitive that NVDA focuses the foreground window,
+	as opposed to the desktop object.
+
+	@note: The foreground window should usually be fetched on the first try,
+	however it may take longer if Windows is taking a long time changing window focus.
+	Gives up after 10 seconds (MAX_WAIT_TIME_SECS in _pollForForegroundHWND).
+	"""
+	import api
+	import NVDAObjects
+	
+	foregroundHWND = _pollForForegroundHWND()
+	if not foregroundHWND:
+		log.error("Could not update object caches to foreground window.")
+		return
+
+	foregroundObject = NVDAObjects.window.Window(windowHandle=foregroundHWND)
+	api.setForegroundObject(foregroundObject)
+	api.setFocusObject(foregroundObject)
+	api.setNavigatorObject(foregroundObject)
+	api.setMouseObject(foregroundObject)
 
 
 def main():
@@ -771,10 +826,18 @@ def main():
 	log.debug("Initializing core pump")
 	class CorePump(gui.NonReEntrantTimer):
 		"Checks the queues and executes functions."
+
+		def __init__(self, run: Optional[Callable[[None], Any]] = None):
+			self._firstRun = True
+			super().__init__(run)
+
 		def run(self):
 			global _isPumpPending
 			_isPumpPending = False
 			watchdog.alive()
+			if self._firstRun:
+				_updateObjectCachesToForeground()
+				self.firstRun = False
 			try:
 				if touchHandler.handler:
 					touchHandler.handler.pump()

--- a/source/core.py
+++ b/source/core.py
@@ -428,8 +428,9 @@ def _initializeObjectCaches():
 
 	The desktop object must be used, as setting the object caches has side effects,
 	such as focus events.
-	Side effects from objects may require NVDA to be finished initializing.
-	The desktop object is an NVDA object without custom code associated with it.
+	Side effects from events generated while setting these objects may require NVDA to be finished initializing.
+	E.G. An app module for a lockScreen window.
+	The desktop object is an NVDA object without event handlers associated with it.
 	"""
 	import api
 	import NVDAObjects

--- a/source/core.py
+++ b/source/core.py
@@ -419,52 +419,6 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	brailleViewer.destroyBrailleViewer()
 
 
-def _pollForForegroundHWND() -> int:
-	"""
-	@note: The foreground window should usually be fetched on the first try,
-	however it may take longer if Windows is taking a long time changing window focus.
-	Times out after 20 seconds (MAX_WAIT_TIME_SECS).
-	After timing out, NVDA will give up trying to start and exit.
-	"""
-	import ui
-	from utils.blockUntilConditionMet import blockUntilConditionMet
-	import winUser
-
-	# winUser.getForegroundWindow may return NULL in certain circumstances,
-	# such as when a window is losing activation.
-	# This should not remain the case for an extended period of time.
-	# If NVDA is taking longer than expected to fetch the foreground window, perform a warning.
-	# We must wait a long time after this warning to
-	# allow for braille / speech to be understood before exiting.
-	# Unfortunately we cannot block with a dialog as NVDA cannot read dialogs yet.
-	WARN_AFTER_SECS = 5
-	MAX_WAIT_TIME_SECS = 20
-
-	success, foregroundHWND = blockUntilConditionMet(
-		getValue=winUser.getForegroundWindow,
-		giveUpAfterSeconds=WARN_AFTER_SECS,
-	)
-	if success:
-		return foregroundHWND
-
-	exitAfterWarningSecs = MAX_WAIT_TIME_SECS - WARN_AFTER_SECS
-	ui.message(_(
-		# Translators: Message when NVDA is having an issue starting up
-		"NVDA is failing to fetch the foreground window. "
-		"If this continues, NVDA will quit starting in %d seconds." % exitAfterWarningSecs
-	))
-
-	success, foregroundHWND = blockUntilConditionMet(
-		getValue=winUser.getForegroundWindow,
-		giveUpAfterSeconds=exitAfterWarningSecs,
-	)
-	if success:
-		return foregroundHWND
-	log.critical("NVDA could not fetch the foreground window. Exiting NVDA.")
-	# Raising exception here causes core.main to exit and NVDA to fail to start
-	raise NVDANotInitializedError("Could not fetch foreground window")
-
-
 def _initializeObjectCaches():
 	"""
 	Caches the desktop object.
@@ -472,32 +426,23 @@ def _initializeObjectCaches():
 	however no known exploit is known for this.
 	2023.1 plans to ensure the desktopObject is available only when signed-in.
 
-	Also initializes other object caches to the foreground window.
-	Previously the object that was cached was the desktopObject,
-	however this may leak secure information to the lock screen.
-	The foreground window is set as the object cache,
-	as the foreground window would already be accessible on the lock screen (e.g. Magnifier).
-	It also is more intuitive that NVDA focuses the foreground window,
-	as opposed to the desktop object.
-
-	@note: The foreground window should usually be fetched on the first try,
-	however it may take longer if Windows is taking a long time changing window focus.
-	Times out after 20 seconds (MAX_WAIT_TIME_SECS in _pollForForegroundHWND).
-	After timing out, NVDA will give up trying to start and exit.
+	The desktop object must be used, as setting the object caches has side effects,
+	such as focus events.
+	Side effects from objects may require NVDA to be finished initializing.
+	The desktop object is an NVDA object without custom code associated with it.
 	"""
 	import api
 	import NVDAObjects
+	from winAPI.sessionTracking import _IgnoreWindowsLockState
 	import winUser
 
 	desktopObject = NVDAObjects.window.Window(windowHandle=winUser.getDesktopWindow())
-	api.setDesktopObject(desktopObject)
-
-	foregroundHWND = _pollForForegroundHWND()
-	foregroundObject = NVDAObjects.window.Window(windowHandle=foregroundHWND)
-	api.setForegroundObject(foregroundObject)
-	api.setFocusObject(foregroundObject)
-	api.setNavigatorObject(foregroundObject)
-	api.setMouseObject(foregroundObject)
+	with _IgnoreWindowsLockState():
+		api.setDesktopObject(desktopObject)
+		api.setForegroundObject(desktopObject)
+		api.setFocusObject(desktopObject)
+		api.setNavigatorObject(desktopObject)
+		api.setMouseObject(desktopObject)
 
 
 def main():

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -121,7 +121,7 @@ class _IgnoreWindowsLockState:
 		_IgnoreWindowsLockState._shouldIgnoreLockStateLock.release()
 		return _IgnoreWindowsLockState.shouldIgnoreLockState
 
-	@classmethod
+	@staticmethod
 	def shouldIgnoreLockState() -> bool:
 		"""May block if another thread is using _IgnoreWindowsLockState"""
 		with _IgnoreWindowsLockState._shouldIgnoreLockStateLock:

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -25,7 +25,7 @@ from ctypes.wintypes import (
 	HWND,
 )
 import enum
-from threading import Lock, RLock
+from threading import Lock
 from typing import (
 	Dict,
 	Set,
@@ -82,50 +82,6 @@ SYNCHRONIZE = 0x00100000
 Parameter for OpenEventW, blocks thread until event is registered.
 https://docs.microsoft.com/en-us/windows/win32/sync/synchronization-object-security-and-access-rights
 """
-
-
-class _IgnoreWindowsLockState:
-	"""
-	Used to bypass security checks by forcing isWindowsLocked to return False.
-	Should only be used where the following conditions all apply:
-	- security checks are not possible, such as during NVDA initialization/termination.
-	- usage has no security implications, there are no exploits if the lock state is ignored.
-	- code does not take a long time to execute.
-
-	Using _IgnoreWindowsLockState blocks other threads from:
-	- checking isWindowsLocked
-	- using _IgnoreWindowsLockState
-
-	Usage
-	```
-	with _IgnoreWindowsLockState():
-		doCodeWhichIsSafe
-	"""
-	_shouldIgnoreLockState = False
-	"""When True, isWindowsLocked is forced to return False"""
-	_shouldIgnoreLockStateLock = RLock()
-	"""
-	This lock is used to protect _shouldIgnoreLockState.
-	If 2 threads are reading from shouldIgnoreLockState simultaneously,
-	and 1 thread is using `_IgnoreWindowsLockState`,
-	then both threads would act as if windows is unlocked.
-	"""
-
-	def __enter__(self) -> bool:
-		_IgnoreWindowsLockState._shouldIgnoreLockStateLock.acquire()
-		_IgnoreWindowsLockState._shouldIgnoreLockState = True
-		return _IgnoreWindowsLockState._shouldIgnoreLockState
-
-	def __exit__(self, excType, excVal, traceback):
-		_IgnoreWindowsLockState._shouldIgnoreLockState = False
-		_IgnoreWindowsLockState._shouldIgnoreLockStateLock.release()
-		return _IgnoreWindowsLockState._shouldIgnoreLockState
-
-	@staticmethod
-	def shouldIgnoreLockState() -> bool:
-		"""May block if another thread is using _IgnoreWindowsLockState"""
-		with _IgnoreWindowsLockState._shouldIgnoreLockStateLock:
-			return _IgnoreWindowsLockState._shouldIgnoreLockState
 
 
 class WindowsTrackedSession(enum.IntEnum):
@@ -198,7 +154,8 @@ def isWindowsLocked() -> bool:
 	Checks if the Window lockscreen is active.
 	Not to be confused with the Windows sign-in screen, a secure screen.
 	"""
-	if _IgnoreWindowsLockState.shouldIgnoreLockState():
+	from core import _TrackNVDAInitialization
+	if not _TrackNVDAInitialization.isInitializationComplete():
 		return False
 	if _isSecureDesktop():
 		# If this is the Secure Desktop,

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -113,13 +113,13 @@ class _IgnoreWindowsLockState:
 
 	def __enter__(self) -> bool:
 		_IgnoreWindowsLockState._shouldIgnoreLockStateLock.acquire()
-		_IgnoreWindowsLockState.shouldIgnoreLockState = True
-		return _IgnoreWindowsLockState.shouldIgnoreLockState
+		_IgnoreWindowsLockState._shouldIgnoreLockState = True
+		return _IgnoreWindowsLockState._shouldIgnoreLockState
 
 	def __exit__(self, excType, excVal, traceback):
-		_IgnoreWindowsLockState.shouldIgnoreLockState = False
+		_IgnoreWindowsLockState._shouldIgnoreLockState = False
 		_IgnoreWindowsLockState._shouldIgnoreLockStateLock.release()
-		return _IgnoreWindowsLockState.shouldIgnoreLockState
+		return _IgnoreWindowsLockState._shouldIgnoreLockState
 
 	@staticmethod
 	def shouldIgnoreLockState() -> bool:

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -156,6 +156,11 @@ def isWindowsLocked() -> bool:
 	"""
 	from core import _TrackNVDAInitialization
 	if not _TrackNVDAInitialization.isInitializationComplete():
+		# During NVDA initialization,
+		# core._initializeObjectCaches needs to cache the desktop object,
+		# regardless of lock state.
+		# Security checks may cause the desktop object to not be set if NVDA starts on the lock screen.
+		# As such, during initialization, NVDA should behave as if Windows is unlocked.
 		return False
 	if _isSecureDesktop():
 		# If this is the Secure Desktop,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
none

### Summary of the issue:
During NVDA initialization, the api module is used to set initial object caches.
These api functions check if an object is behind the lock screen when Windows is locked before setting the cache.
Until #14301, the api module initialised the object caches to the desktop object.
When NVDA started on the lock screen, it failed to set the desktop object due to the added security checks.
Now the object caches are initialised to the foreground window, to avoid leaking insecure information.
Unfortunately, setting those object caches causes side-effects, which may rely on uninitialized dependencies. 

### Description of user facing changes
None

### Description of development approach
Revert to setting initial object caches to the desktop object.
Ensure security failures are not raised when initialising caches by ignoring the windows lock state.

### Testing strategy:
**Manual testing**
Use speech, enable error sounds, and monitor the logs for errors/warnings.
- [x] Smoke test the sign-in flow from lock, switch users, sleep, restart, log in and log out, checking the lock screen, sign-in screen, and general NVDA usage after sign in.
- [x] Smoke test the UAC dialog
- [x] Test the STR for security issues fixed in 2022.3.1

### Known issues with pull request:
None

### Change log entries:
None, fixes unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
