### PR TITLE
No longer try to return to first task switch item

### DIFF
--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -70,7 +70,7 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 	builtIn.log(f"Looking for window: {targetWindowNamePattern}", level="DEBUG")
 	startOfTaskSwitcherSpeech = _tryOpenTaskSwitcher()
 	if startOfTaskSwitcherSpeech is None:
-		builtIn.log(f"No speech for opening the task switcher, trying again", level="DEBUG")
+		builtIn.log("No speech for opening the task switcher, trying again", level="DEBUG")
 		# Try opening the task switcher again
 		spy.emulateKeyPress('escape')
 		# Hack: using 'sleep' is error-prone.
@@ -80,7 +80,7 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 
 		startOfTaskSwitcherSpeech = _tryOpenTaskSwitcher()
 		if startOfTaskSwitcherSpeech is None:
-			builtIn.log(f"No speech for opening the task switcher again", level="DEBUG")
+			builtIn.log("No speech for opening the task switcher again", level="DEBUG")
 			spy.emulateKeyPress('escape')
 			raise AssertionError("Tried twice to open task switcher and failed.")
 
@@ -126,13 +126,13 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 			builtIn.log(f"Found target window at item {windowsTested}", level="DEBUG")
 			found = True
 		elif rowChangedPattern.search(speech):
-			builtIn.log(f"Multiple task switch rows detected.", level="DEBUG")
+			builtIn.log("Multiple task switch rows detected.", level="DEBUG")
 			# Once in a row > 1, row and column will be reported when returning to the first row.
 			returnToFirstItemPattern = firstRowColPattern
 		windowsTested += 1
 
 	if not found:
-		builtIn.log(f"Not found, attempting to close task switcher.", level="DEBUG")
+		builtIn.log("Not found, attempting to close task switcher.", level="DEBUG")
 		nextIndex = spy.get_next_speech_index()
 		spy.emulateKeyPress("escape")
 		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
@@ -146,7 +146,7 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 		spy.emulateKeyPress("enter")
 		if not spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex, errorMessage=None):
 			AssertionError(
-				f"Expected some speech after enter press."
+				"Expected some speech after enter press."
 				f" Speech at index: {nextIndex}"
 				f", nextIndex: {spy.get_next_speech_index()}"
 				f", speech in range: {spy.get_speech_at_index_until_now(nextIndex)}"

--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -70,6 +70,7 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 	builtIn.log(f"Looking for window: {targetWindowNamePattern}", level="DEBUG")
 	startOfTaskSwitcherSpeech = _tryOpenTaskSwitcher()
 	if startOfTaskSwitcherSpeech is None:
+		builtIn.log(f"No speech for opening the task switcher, trying again", level="DEBUG")
 		# Try opening the task switcher again
 		spy.emulateKeyPress('escape')
 		# Hack: using 'sleep' is error-prone.
@@ -79,36 +80,37 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 
 		startOfTaskSwitcherSpeech = _tryOpenTaskSwitcher()
 		if startOfTaskSwitcherSpeech is None:
+			builtIn.log(f"No speech for opening the task switcher again", level="DEBUG")
+			spy.emulateKeyPress('escape')
 			raise AssertionError("Tried twice to open task switcher and failed.")
 
 	spy.wait_for_speech_to_finish(speechStartedIndex=startOfTaskSwitcherSpeech)
 	speech = spy.get_speech_at_index_until_now(startOfTaskSwitcherSpeech)
-	# if there is only one application open, it will already be selected:
-	firstItemPattern = _re.compile(r"row 1\s+column 1")
-	atFirstItemAlready = bool(firstItemPattern.search(speech))
+	builtIn.log(f"Open task switch speech: '{speech}'", level="DEBUG")
+	# If there is only one application open, it will already be selected:
+	# Match "row 1  column 1" not "row 2  column 1" and not "column 1"
+	firstRowColPattern = _re.compile(r"row 1\s\scolumn 1")
+	atFirstItemAlready = bool(firstRowColPattern.search(speech))
 
-	if not atFirstItemAlready:
-		# The second item (in the task switcher) is normally selected initially (when there are multiple windows),
-		# the nominal case is that the first item is the required target.
-		nextIndex = spy.get_next_speech_index()
-		spy.emulateKeyPress('leftArrow')  # So move back to the first.
-		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
-		speech = spy.get_speech_at_index_until_now(nextIndex)
-		builtIn.log(f"First window: {speech}", level="DEBUG")
-
-		# ensure this is now the first item
-		if not firstItemPattern.search(speech):
-			raise AssertionError("Didn't return to the first item with left arrow")
+	# Match only "column 1" not "row 1  column 1" and not "row 2  column 1"
+	firstColPattern = _re.compile(r"(?<!row \d\s\s)column 1")
+	# For a single row of items, returning to the first item will not report the row again.
+	returnToFirstItemPattern = firstColPattern
+	# When there are many items, cycling through items will result in row changes.
+	# Match "row 2  column 1" but not "row 1  column 1" and not "column 1"
+	rowChangedPattern = _re.compile(r"row [2-9]\s\scolumn 1")
 
 	found = False
 	if targetWindowNamePattern.search(speech):
+		builtIn.log("Found target window in first item.", level="DEBUG")
 		found = True
 
 	speech = ""
 	windowsTested = 1
 	while (
 		not found
-		and not firstItemPattern.search(speech)
+		and not atFirstItemAlready  # no point navigating through items if there is only one.
+		and not returnToFirstItemPattern.search(speech)
 		# In most cases it is expected that the target Window is close to the top of the z-order.
 		# On CI there should not be many windows open.
 		# A sanity check on the max windows to test ensures the test does not get stuck cycling through the
@@ -119,12 +121,18 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 		spy.emulateKeyPress('rightArrow')  # move to the next task switcher item
 		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
 		speech = spy.get_speech_at_index_until_now(nextIndex)
-		builtIn.log(f"next window: {speech}", level="DEBUG")
+		builtIn.log(f"next window: '{speech}'", level="DEBUG")
 		if targetWindowNamePattern.search(speech):
+			builtIn.log(f"Found target window at item {windowsTested}", level="DEBUG")
 			found = True
+		elif rowChangedPattern.search(speech):
+			builtIn.log(f"Multiple task switch rows detected.", level="DEBUG")
+			# Once in a row > 1, row and column will be reported when returning to the first row.
+			returnToFirstItemPattern = firstRowColPattern
 		windowsTested += 1
 
 	if not found:
+		builtIn.log(f"Not found, attempting to close task switcher.", level="DEBUG")
 		nextIndex = spy.get_next_speech_index()
 		spy.emulateKeyPress("escape")
 		spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex)
@@ -133,6 +141,7 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 			"See NVDA log for dump of all speech."
 		)
 	else:
+		builtIn.log(f"Found, attempting to select.", level="DEBUG")
 		nextIndex = spy.get_next_speech_index()
 		spy.emulateKeyPress("enter")
 		if not spy.wait_for_speech_to_finish(speechStartedIndex=nextIndex, errorMessage=None):


### PR DESCRIPTION
Also track row column announcement accurately.
### Link to issue number:
Fixes: https://github.com/nvaccess/nvda/issues/14342

### Summary of the issue:
When using the task switcher to navigate to the SUT application window, it is unnecessary to return to the first item in the task switcher. It is unlikely that there will be more than the current limit of 10 windows open on appveyor. If the test needs to return to the first window it will cycle through and return to the first row and column.

### Description of user facing changes
None

### Description of development approach
- Adds more debug logging to the robot framework log.
- Always cycle forwards through the task switcher.
- All failure paths send escape to dismiss the task switcher.
- Consider variations in task switcher content:
  - A single item. Unlikely during the tests, there should be the SUT application and the appveyor build agent.
  - A single row of items, most likely. Row is only reported when the row number changes. "column 1" indicates cycling back to the first item.
  - Multiple rows of items, unlikely on build systems, more likely on dev systems. 

### Testing strategy:
- Ran a symbols test locally, closing the notepad window as the test starts so that the window cannot be found. Observed the behavior with different numbers of windows open.
- Appveyor builds.

### Known issues with pull request:
None.

### Change log entries:
None

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
