### PR TITLE
Streamline importing of addon directories for python packages

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -624,11 +624,10 @@ def initializeModulePackagePaths():
 		addDirsToPythonPackagePath(module)
 
 
-def addDirsToPythonPackagePath(module, subdir: typing.Optional[str] = None):
+def addDirsToPythonPackagePath(module: ModuleType, subdir: typing.Optional[str] = None):
 	"""Add add-on and scratchpath directories for a module to the search path (__path__) of a Python package.
 	C{subdir} is added to each directory. It defaults to the name of the Python package.
 	@param module: The root module of the package.
-	@type module: module
 	@param subdir: The subdirectory to be used, C{None} for the name of C{module}.
 	"""
 	if config.isAppX or globalVars.appArgs.disableAddons:
@@ -646,7 +645,7 @@ def addDirsToPythonPackagePath(module, subdir: typing.Optional[str] = None):
 	if not os.path.isdir(fullPath):
 		os.makedirs(fullPath)
 	# Insert this path at the beginning  of the module's search paths.
-	# The module's search paths may not be a mutable  list, so replace it with a new one
+	# The module's search paths may not be a mutable list, so replace it with a new one
 	pathList = [fullPath]
 	pathList.extend(module.__path__)
 	module.__path__ = pathList

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -168,6 +168,7 @@ def initialize():
 	getAvailableAddons(refresh=True, isFirstLoad=True)
 	state.cleanupRemovedDisabledAddons()
 	state.save()
+	initializeModulePackagePaths()
 
 
 def terminate():
@@ -600,6 +601,55 @@ def _translatedManifestPaths(lang=None, forBundle=False):
 			langs.append('en')
 	sep = "/" if forBundle else os.path.sep
 	return [sep.join(("locale", lang, MANIFEST_FILENAME)) for lang in langs]
+
+
+def initializeModulePackagePaths():
+	"""Initializes the module package paths for drivers and plugins.
+	This ensures that drivers (such as braille display drivers) or plugins (such as app modules)
+	can be discovered by NVDA.
+	"""
+	import appModules
+	import brailleDisplayDrivers
+	import globalPlugins
+	import synthDrivers
+	import visionEnhancementProviders
+	modules = [
+		appModules,
+		brailleDisplayDrivers,
+		globalPlugins,
+		synthDrivers,
+		visionEnhancementProviders,
+	]
+	for module in modules:
+		addDirsToPythonPackagePath(module)
+
+
+def addDirsToPythonPackagePath(module, subdir: typing.Optional[str] = None):
+	"""Add add-on and scratchpath directories for a module to the search path (__path__) of a Python package.
+	C{subdir} is added to each directory. It defaults to the name of the Python package.
+	@param module: The root module of the package.
+	@type module: module
+	@param subdir: The subdirectory to be used, C{None} for the name of C{module}.
+	"""
+	if config.isAppX or globalVars.appArgs.disableAddons:
+		return
+	for addon in getRunningAddons():
+		addon.addToPackagePath(module)
+	if globalVars.appArgs.secure or not config.conf['development']['enableScratchpadDir']:
+		return
+	if not subdir:
+		subdir = module.__name__
+	fullPath = os.path.join(config.getScratchpadDir(), subdir)
+	if fullPath in module.__path__:
+		return
+	# Ensure this directory exists otherwise pkgutil.iter_importers may emit None for missing paths.
+	if not os.path.isdir(fullPath):
+		os.makedirs(fullPath)
+	# Insert this path at the beginning  of the module's search paths.
+	# The module's search paths may not be a mutable  list, so replace it with a new one
+	pathList = [fullPath]
+	pathList.extend(module.__path__)
+	module.__path__ = pathList
 
 
 class AddonBundle(AddonBase):

--- a/source/addonHandler/packaging.py
+++ b/source/addonHandler/packaging.py
@@ -1,0 +1,62 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2009-2022 NV Access Limited, Rui Batista, Zahari Yurukov, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Functions to add python modules within addon directories to python module paths.
+"""
+
+import os.path
+from typing import Optional
+from types import ModuleType
+import globalVars
+import config
+
+
+def initializeModulePackagePaths():
+	"""Initializes the module package paths for drivers and plugins.
+	This ensures that drivers (such as braille display drivers) or plugins (such as app modules)
+	can be discovered by NVDA.
+	"""
+	import appModules
+	import brailleDisplayDrivers
+	import globalPlugins
+	import synthDrivers
+	import visionEnhancementProviders
+	modules = [
+		appModules,
+		brailleDisplayDrivers,
+		globalPlugins,
+		synthDrivers,
+		visionEnhancementProviders,
+	]
+	for module in modules:
+		addDirsToPythonPackagePath(module)
+
+
+def addDirsToPythonPackagePath(module: ModuleType, subdir: Optional[str] = None):
+	"""Add add-on and scratchpath directories for a module to the search path (__path__) of a Python package.
+	C{subdir} is added to each directory. It defaults to the name of the Python package.
+	@param module: The root module of the package.
+	@param subdir: The subdirectory to be used, C{None} for the name of C{module}.
+	"""
+	if config.isAppX or globalVars.appArgs.disableAddons:
+		return
+	from . import getRunningAddons
+	for addon in getRunningAddons():
+		addon.addToPackagePath(module)
+	if globalVars.appArgs.secure or not config.conf['development']['enableScratchpadDir']:
+		return
+	if not subdir:
+		subdir = module.__name__
+	fullPath = os.path.join(config.getScratchpadDir(), subdir)
+	if fullPath in module.__path__:
+		return
+	# Ensure this directory exists otherwise pkgutil.iter_importers may emit None for missing paths.
+	if not os.path.isdir(fullPath):
+		os.makedirs(fullPath)
+	# Insert this path at the beginning  of the module's search paths.
+	# The module's search paths may not be a mutable list, so replace it with a new one
+	pathList = [fullPath]
+	pathList.extend(module.__path__)
+	module.__path__ = pathList

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -361,7 +361,6 @@ def reloadAppModules():
 def initialize():
 	"""Initializes the appModule subsystem. 
 	"""
-	config.addConfigDirsToPythonPackagePath(appModules)
 	if not initialize._alreadyInitialized:
 		initialize._alreadyInitialized = True
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -2393,7 +2393,6 @@ handler: BrailleHandler
 
 def initialize():
 	global handler
-	config.addConfigDirsToPythonPackagePath(brailleDisplayDrivers)
 	log.info("Using liblouis version %s" % louis.version())
 	import serial
 	log.info("Using pySerial version %s"%serial.VERSION)

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -74,6 +74,13 @@ def __getattr__(attrName: str) -> Any:
 	if attrName == "RUN_REGKEY" and NVDAState._allowDeprecatedAPI():
 		log.warning("RUN_REGKEY is deprecated, use RegistryKey.RUN instead.")
 		return RegistryKey.RUN.value
+	if attrName == "addConfigDirsToPythonPackagePath" and NVDAState._allowDeprecatedAPI():
+		log.warning(
+			"addConfigDirsToPythonPackagePath is deprecated, "
+			"use addonHandler.packaging.addDirsToPythonPackagePath instead."
+		)
+		from addonHandler.packaging import addDirsToPythonPackagePath
+		return addDirsToPythonPackagePath
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -474,35 +474,6 @@ def setStartOnLogonScreen(enable: bool) -> None:
 			raise RuntimeError("Slave failed to set startOnLogonScreen")
 
 
-def addConfigDirsToPythonPackagePath(module, subdir=None):
-	"""Add the configuration directories to the module search path (__path__) of a Python package.
-	C{subdir} is added to each configuration directory. It defaults to the name of the Python package.
-	@param module: The root module of the package.
-	@type module: module
-	@param subdir: The subdirectory to be used, C{None} for the name of C{module}.
-	@type subdir: str
-	"""
-	if isAppX or globalVars.appArgs.disableAddons:
-		return
-	# FIXME: this should not be coupled to the config module....
-	import addonHandler
-	for addon in addonHandler.getRunningAddons():
-		addon.addToPackagePath(module)
-	if globalVars.appArgs.secure or not conf['development']['enableScratchpadDir']:
-		return
-	if not subdir:
-		subdir = module.__name__
-	fullPath=os.path.join(getScratchpadDir(),subdir)
-	# Ensure this directory exists otherwise pkgutil.iter_importers may emit None for missing paths.
-	if not os.path.isdir(fullPath):
-		os.makedirs(fullPath)
-	# Insert this path at the beginning  of the module's search paths.
-	# The module's search paths may not be a mutable  list, so replace it with a new one 
-	pathList=[fullPath]
-	pathList.extend(module.__path__)
-	module.__path__=pathList
-
-
 def _transformSpec(spec: ConfigObj):
 	"""To make the spec less verbose, transform the spec:
 	- Add default="default" to all featureFlag items. This is required so that the key can be read,

--- a/source/globalPluginHandler.py
+++ b/source/globalPluginHandler.py
@@ -27,7 +27,6 @@ def listPlugins():
 		yield plugin
 
 def initialize():
-	config.addConfigDirsToPythonPackagePath(globalPlugins)
 	for plugin in listPlugins():
 		try:
 			runningPlugins.add(plugin())

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -375,7 +375,6 @@ _audioOutputDevice = None
 
 
 def initialize():
-	config.addConfigDirsToPythonPackagePath(synthDrivers)
 	config.post_configProfileSwitch.register(handlePostConfigProfileSwitch)
 
 

--- a/source/vision/__init__.py
+++ b/source/vision/__init__.py
@@ -20,7 +20,6 @@ handler: Optional[VisionHandler] = None
 
 def initialize() -> None:
 	global handler
-	config.addConfigDirsToPythonPackagePath(visionEnhancementProviders)
 	handler = VisionHandler()
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -60,7 +60,8 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
 
 
 === Deprecations ===
-- ``NVDAObjects.UIA.winConsoleUIA.WinTerminalUIA`` is deprecated and usage is dscouraged. (#14047)
+- ``NVDAObjects.UIA.winConsoleUIA.WinTerminalUIA`` is deprecated and usage is discouraged. (#14047)
+- ``config.addConfigDirsToPythonPackagePath`` has been moved. Use ``addonHandler.packaging.addDirsToPythonPackagePath`` instead. (#14350)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Closes #14340

### Summary of the issue:
For addons, the several directories are added to the python package path using a function in the config module. This needs refactoring:
https://github.com/nvaccess/nvda/blob/f674505671e6f170bd33b2902ad7a7eb423df097/source/config/__init__.py#L487

### Description of user facing changes
None

### Description of development approach
This pr changes logic to add the several addon directories to the package path in the addonHandler.

### Testing strategy:
Tested a source copy of NVDA. Ensured that at least appModules and globalPlugins are loaded correctly. synthDrivers, visionEnhancementProviders and brailleDisplayDrivers need to be tested.

### Known issues with pull request:
None known

### Change log entries:
deprecations:
```
- config.addConfigDirsToPythonPackagePath has been moved and renamed. Use addonHandler.packaging.addDirsToPythonPackagePath instead. (#14350)
```
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
