### PR TITLE
Map the selectable state for Java Access Bridge

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -97,6 +97,7 @@ JABStatesToNVDAStates={
 	"modal":controlTypes.State.MODAL,
 	"multi_line":controlTypes.State.MULTILINE,
 	"focusable":controlTypes.State.FOCUSABLE,
+	"selectable": controlTypes.State.SELECTABLE,
 	"editable":controlTypes.State.EDITABLE,
 }
 

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -86,7 +86,7 @@ JABRolesToNVDARoles: Dict[str, controlTypes.Role] = {
 }
 
 JABStatesToNVDAStates={
-	"busy": controlTypes.State.BUSY,
+	"busy":controlTypes.State.BUSY,
 	"checked":controlTypes.State.CHECKED,
 	"focused":controlTypes.State.FOCUSED,
 	"selected":controlTypes.State.SELECTED,

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -86,18 +86,19 @@ JABRolesToNVDARoles: Dict[str, controlTypes.Role] = {
 }
 
 JABStatesToNVDAStates={
-	"busy":controlTypes.State.BUSY,
-	"checked":controlTypes.State.CHECKED,
-	"focused":controlTypes.State.FOCUSED,
-	"selected":controlTypes.State.SELECTED,
-	"pressed":controlTypes.State.PRESSED,
-	"expanded":controlTypes.State.EXPANDED,
-	"collapsed":controlTypes.State.COLLAPSED,
-	"iconified":controlTypes.State.ICONIFIED,
-	"modal":controlTypes.State.MODAL,
-	"multi_line":controlTypes.State.MULTILINE,
-	"focusable":controlTypes.State.FOCUSABLE,
-	"editable":controlTypes.State.EDITABLE,
+	"busy": controlTypes.State.BUSY,
+	"checked": controlTypes.State.CHECKED,
+	"focused": controlTypes.State.FOCUSED,
+	"selected": controlTypes.State.SELECTED,
+	"pressed": controlTypes.State.PRESSED,
+	"expanded": controlTypes.State.EXPANDED,
+	"collapsed": controlTypes.State.COLLAPSED,
+	"iconified": controlTypes.State.ICONIFIED,
+	"modal": controlTypes.State.MODAL,
+	"multi_line": controlTypes.State.MULTILINE,
+	"focusable": controlTypes.State.FOCUSABLE,
+	"selectable": controlTypes.State.SELECTABLE,
+	"editable": controlTypes.State.EDITABLE,
 }
 
 

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -86,19 +86,18 @@ JABRolesToNVDARoles: Dict[str, controlTypes.Role] = {
 }
 
 JABStatesToNVDAStates={
-	"busy": controlTypes.State.BUSY,
-	"checked": controlTypes.State.CHECKED,
-	"focused": controlTypes.State.FOCUSED,
-	"selected": controlTypes.State.SELECTED,
-	"pressed": controlTypes.State.PRESSED,
-	"expanded": controlTypes.State.EXPANDED,
-	"collapsed": controlTypes.State.COLLAPSED,
-	"iconified": controlTypes.State.ICONIFIED,
-	"modal": controlTypes.State.MODAL,
-	"multi_line": controlTypes.State.MULTILINE,
-	"focusable": controlTypes.State.FOCUSABLE,
-	"selectable": controlTypes.State.SELECTABLE,
-	"editable": controlTypes.State.EDITABLE,
+	"busy":controlTypes.State.BUSY,
+	"checked":controlTypes.State.CHECKED,
+	"focused":controlTypes.State.FOCUSED,
+	"selected":controlTypes.State.SELECTED,
+	"pressed":controlTypes.State.PRESSED,
+	"expanded":controlTypes.State.EXPANDED,
+	"collapsed":controlTypes.State.COLLAPSED,
+	"iconified":controlTypes.State.ICONIFIED,
+	"modal":controlTypes.State.MODAL,
+	"multi_line":controlTypes.State.MULTILINE,
+	"focusable":controlTypes.State.FOCUSABLE,
+	"editable":controlTypes.State.EDITABLE,
 }
 
 

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -86,19 +86,19 @@ JABRolesToNVDARoles: Dict[str, controlTypes.Role] = {
 }
 
 JABStatesToNVDAStates={
-	"busy":controlTypes.State.BUSY,
-	"checked":controlTypes.State.CHECKED,
-	"focused":controlTypes.State.FOCUSED,
-	"selected":controlTypes.State.SELECTED,
-	"pressed":controlTypes.State.PRESSED,
-	"expanded":controlTypes.State.EXPANDED,
-	"collapsed":controlTypes.State.COLLAPSED,
-	"iconified":controlTypes.State.ICONIFIED,
-	"modal":controlTypes.State.MODAL,
-	"multi_line":controlTypes.State.MULTILINE,
-	"focusable":controlTypes.State.FOCUSABLE,
+	"busy": controlTypes.State.BUSY,
+	"checked": controlTypes.State.CHECKED,
+	"focused": controlTypes.State.FOCUSED,
+	"selected": controlTypes.State.SELECTED,
+	"pressed": controlTypes.State.PRESSED,
+	"expanded": controlTypes.State.EXPANDED,
+	"collapsed": controlTypes.State.COLLAPSED,
+	"iconified": controlTypes.State.ICONIFIED,
+	"modal": controlTypes.State.MODAL,
+	"multi_line": controlTypes.State.MULTILINE,
+	"focusable": controlTypes.State.FOCUSABLE,
 	"selectable": controlTypes.State.SELECTABLE,
-	"editable":controlTypes.State.EDITABLE,
+	"editable": controlTypes.State.EDITABLE,
 }
 
 

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -87,18 +87,18 @@ JABRolesToNVDARoles: Dict[str, controlTypes.Role] = {
 
 JABStatesToNVDAStates={
 	"busy": controlTypes.State.BUSY,
-	"checked": controlTypes.State.CHECKED,
-	"focused": controlTypes.State.FOCUSED,
-	"selected": controlTypes.State.SELECTED,
-	"pressed": controlTypes.State.PRESSED,
-	"expanded": controlTypes.State.EXPANDED,
-	"collapsed": controlTypes.State.COLLAPSED,
-	"iconified": controlTypes.State.ICONIFIED,
-	"modal": controlTypes.State.MODAL,
-	"multi_line": controlTypes.State.MULTILINE,
-	"focusable": controlTypes.State.FOCUSABLE,
+	"checked":controlTypes.State.CHECKED,
+	"focused":controlTypes.State.FOCUSED,
+	"selected":controlTypes.State.SELECTED,
+	"pressed":controlTypes.State.PRESSED,
+	"expanded":controlTypes.State.EXPANDED,
+	"collapsed":controlTypes.State.COLLAPSED,
+	"iconified":controlTypes.State.ICONIFIED,
+	"modal":controlTypes.State.MODAL,
+	"multi_line":controlTypes.State.MULTILINE,
+	"focusable":controlTypes.State.FOCUSABLE,
+	"editable":controlTypes.State.EDITABLE,
 	"selectable": controlTypes.State.SELECTABLE,
-	"editable": controlTypes.State.EDITABLE,
 }
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,7 @@ What's New in NVDA
 == Changes ==
 - Updated Sonic rate boost library to commit ``1d70513``. (#14180)
 - CLDR has been updated to version 42.0. (#14273)
+- Java applications with controls using the selectable state will now announce when an item is not selected rather than when the item is selected. (#14336)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14336 
### Summary of the issue:
In Java applications NVDA always announces selected for items which are selected. This can be quite annoying in certain controls such as menus. In these cases it is preferred to announce when something is not selected. The issue is that NVDA was not mapping the selectable state for Java Access Bridge. With this fix Java controls which have the selectable state will now only announce when something is not selected.
### Description of user facing changes
For selectable controls in Java applications using the Java Access Bridge the user will now notice NVDA does not announce if something is selected, rather it will only announce when something is not selected.
### Description of development approach
After discussing how to reduce the selected announcement verbosity in the associated issue, I decided to check what states were being exposed in other applications where it would announce items as "not selected". When reviewing the logs it appeared that the common factor is these controls had the selectable state. I am aware that Java Access Bridge exposes a selectable state. Upon inspecting the NVDA code for mapping Java Access Bridge objects to NVDA objects, I could not find any mapping for the selectable state. So I added the mapping and tested whether this fixed the issue.
### Testing strategy:
Manual testing using the Java demo application swingset2. Checked both controls which have the selectable state and those which can be selected but do not expose the selectable state through the Java Access Bridge.
### Known issues with pull request:
None.
### Change log entries:
New features
Changes
Bug fixes
Java applications with controls using the selectable state will now announce when an item is not selected rather than when the item is selected.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests N/A
  - System (end to end) tests N/A
  - Manual testing Done
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
