### PR TITLE
Simplify lock state tracking

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -1,12 +1,18 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2020 NV Access Limited, Christopher Toth, Babbage B.V., Julien Cochuyt
+# Copyright (C) 2007-2022 NV Access Limited, Christopher Toth, Babbage B.V., Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 """Contains the base classes that many of NVDA's classes such as NVDAObjects, virtualBuffers, appModules, synthDrivers inherit from. These base classes provide such things as auto properties, and methods and properties for scripting and key binding.
 """
 
-from typing import Any, Callable, Optional, Set
+from typing import (
+	Any,
+	Callable,
+	Optional,
+	Set,
+	Union,
+)
 import weakref
 import garbageHandler
 from logHandler import log
@@ -23,7 +29,11 @@ class Getter(object):
 		if abstract:
 			self._abstract = self.__isabstractmethod__ = abstract
 
-	def __get__(self, instance, owner) -> GetterReturnT:
+	def __get__(
+			self,
+			instance: Union[Any, None, "AutoPropertyObject"],
+			owner,
+	) -> Union[GetterReturnT, "Getter"]:
 		if isinstance(self.fget, classmethod):
 			return self.fget.__get__(instance, owner)()
 		elif instance is None:
@@ -39,7 +49,11 @@ class Getter(object):
 
 class CachingGetter(Getter):
 
-	def __get__(self, instance, owner) -> GetterReturnT:
+	def __get__(
+			self,
+			instance: Union[Any, None, "AutoPropertyObject"],
+			owner,
+	) -> Union[GetterReturnT, "CachingGetter"]:
 		if isinstance(self.fget, classmethod):
 			log.warning("Class properties do not support caching")
 			return self.fget.__get__(instance, owner)()

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -21,6 +21,4 @@ class WindowMessage(enum.IntEnum):
 	"""
 	WM_WTSSESSION_CHANGE
 	Windows Message for when a Session State Changes.
-	Receiving these messages is registered by sessionTracking.register.
-	handleSessionChange handles these messages.
 	"""

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -12,8 +12,6 @@ and prevents navigating beyond apps open on the lock screen (LockScreen.exe, Mag
 Used to:
 - only allow a whitelist of safe scripts to run
 - ensure object navigation cannot occur outside of the lockscreen
-
-https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
If NVDA freezes, session tracking notifications may be dropped.
If this happens when locking, NVDA will be insecure while on the Windows lock screen.
If this happens when unlocking, NVDA will not behave correctly and be inaccessible while Windows is unlocked.

### Description of user facing changes
Should avoid the described issue, otherwise no changes.

### Description of development approach
The previous approach is querying an initial state, and tracking state changes via session tracking notification.
Instead, query and cache the lock state on each core cycle with `AutoPropertyObject`.

### Testing strategy:
As it is difficult to time and simulate a freeze, general smoke testing on the new session tracking method should be performed instead.

With a try-build, use speech, enable error sounds, and monitor the logs for errors/warnings.
- [x] Smoke test the sign-in flow from lock, switch users, sleep, restart, log in and log out, checking the lock screen, sign-in screen, and general NVDA usage after sign in.
- [x] Smoke test the UAC dialog
- [x] Test the STR for issues fixed in 2022.3.1 and 2022.3.2

### Known issues with pull request:

### Change log entries:

Bug fixes
```
- Fixed bug where if NVDA freezes when locking, NVDA will allow access to the users desktop while on the Windows lock screen.
- Fixed bug where if NVDA freezes when locking, NVDA will not behave correctly, as if the device was still locked.
```

Deprecation warnings: TODO

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
