### PR TITLE
Teams: No longer inappropriately focus reaction menus when conversation messages are focused.

### DIFF
--- a/source/appModules/teams.py
+++ b/source/appModules/teams.py
@@ -17,11 +17,22 @@ class PopOverMenu(Ia2Web):
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+		# #11821, #14355
+		# Teams will sometimes create an element with an ARIA role of menu
+		# at the same time another element gets focus,
+		# E.g. an emoji menu appears every time a conversation message is focused.
+		# Web frameworks such as Chromium will tend to fire a menu_popupStart event
+		# when a node with a role of menu is added to the DOM.
+		# NVDA's default behaviour for handling menu_popupStart is to set NVDA's focus to the menu
+		# and cancel speech.
+		# We should deliberately suppress this in Teams however,
+		# Otherwise the focused message cannot be read.
+		# Previously this was limited to message menus, however
+		# As Teams keeps changing the layout,
+		# and all menus in Teams do set focus to their first item when truly focused,
+		# It is safer just to ignore all menu popupStart events within Teams content for now.
 		if (
 			Ia2Web in clsList
 			and obj.IA2Attributes.get("xml-roles") == "menu"
-			and obj.parent
-			and obj.parent.parent
-			and "message-actions-popover-container" in obj.parent.parent.IA2Attributes.get("class", "")
 		):
 			clsList.insert(0, PopOverMenu)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -79,6 +79,7 @@ Note there are still known issues with Chrome and Edge. (#13254)
 - NVDA will announce dragging items on screen in places such as rearranging Windows 10 Start menu tiles and virtual desktops in Windows 11. (#12271, #14081)
 - In advanced settings, "Play a sound for logged errors" option is now correctly restored to its default value when pressing the "Restore defaults" button. (#14149)
 - NVDA can now select text using the ``NVDA+f10`` keyboard shortcut on Java applications. (#14163)
+- NVDA will no longer get stuck in a menu when arrowing up and down threaded conversations in Microsoft Teams. (#14355)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14355
Broadens approach from pr #11822 which was to fix #11821.

### Summary of the issue:
When a conversation message is focused in Microsoft Teams (E.g. arrowing up and down a threaded conversation list) Teams displays a reaction menu along side the focused message. As Chromium therefore fires a menu popupStart event, NVDA handles this by faking focus on the menu itself
This behaviour has been historically necessary for win32 context menus that fail to focus the first item in the menu.
However, In Teams this is very disruptive.

### Description of user facing changes
NVDA will no longer get stuck in a menu when arrowing up and down threaded conversations in Microsoft Teams.

### Description of development approach
Broaden the approach taken in pr #11821 by suppressing handling of menu popupStart for any element in teams with 'menu' in its xml-roles attribute. Previously NVDA would also check for very particular message container classes on the parent's parent. But as Teams keeps moving these, this is no longer managable.

### Testing strategy:
Performed steps in #14355. I.e. arrowed up and down a threaded conversation, ensuring each message was read and was not interuppted by a menu.
Ensured that pressing enter on the message still allowed the user to interact with the reaction menu when  its items truely got focus.
Smoke tested other context menus in Teams such as the menu on the tab control and the search field.

### Known issues with pull request:
This more broad approach may mean there could mean that NVDA won't announce "menu" for a menu that appears that does not focus one of its items until the user presses an arrow key. However, having checked all menus that I know, and waying up the slight confusion of NvDA saying nothing on a menu until pressing a key verses the real focus such as for a message being interuppted all the time by an incorrect menu, I feel this approach is by far the best choice for the user.
 
### Change log entries:
New features
Changes
Bug fixes
* NVDA will no longer get stuck in a menu when arrowing up and down threaded conversations in Microsoft Teams.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
