### PR TITLE
Fix formatting in change log for 2022.4 (beta)

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -95,6 +95,8 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 - ``core.post_windowMessageReceipt`` is deprecated, use ``winAPI.messageWindow.pre_handleWindowMessage`` instead.
 - ``winKernel.SYSTEM_POWER_STATUS`` is deprecated and usage is discouraged, this has been moved to ``winAPI._powerTracking.SystemPowerStatus``.
 - ``winUser.SM_*`` constants are deprecated, use ``winAPI.winUser.constants.SystemMetrics`` instead.
+- 
+
 = 2022.3.2 =
 This is a minor release to fix regressions with 2022.3.1 and address a security issue.
 


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
The two following headings are not correctly formatted in the change log:
* `= 2022.3.2 = `
* `== Security Fixes ==`

They appear with the t2t formatting character `=` instead.

This is due to a list which is not terminated with an empty item as required in t2t syntax.

### Description of user facing changes
Headings are correctly formatted.

### Description of development approach
Add empty list item to close the list and thus fix t2t formatting.

### Testing strategy:
Check the change log generated by appVeyor.
### Known issues with pull request:
Probably requires another translation freeze; but I think it was already foreseen.
### Change log entries:
Not needed.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
