### PR TITLE
Prototype Nav to annotation and return in browse mode

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1523,7 +1523,7 @@ the NVDAObject for IAccessible
 			self,
 			relationType: "IAccessibleHandler.RelationType",
 			maxRelations: int = 1,
-	) -> typing.List[IUnknown]:
+	) -> typing.Iterable[IUnknown]:
 		"""Gets the target IAccessible (actually IUnknown; use QueryInterface or
 		normalizeIAccessible to resolve) for the relations with given type.
 		Allows escape of exception: COMError(-2147417836, 'Requested object does not exist.'),
@@ -1539,17 +1539,20 @@ the NVDAObject for IAccessible
 			raise ValueError
 		if not isinstance(acc, IA2.IAccessible2_2):
 			acc = acc.QueryInterface(IA2.IAccessible2_2)
+
 		targets, count = acc.relationTargetsOfType(
 			relationType.value,
+			# todo: bug in relationTargetsOfType? Chrome returns count of two when (there are two)
+			#  but maxRelations is 1.
 			maxRelations
 		)
+		log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
 		if count == 0:
-			return list()
-		relationsGen = (
+			return
+		yield from (
 			targets[i]
 			for i in range(min(maxRelations, count))
 		)
-		return list(relationsGen)
 
 	def _getIA2RelationFirstTarget(
 			self,
@@ -1568,9 +1571,10 @@ the NVDAObject for IAccessible
 
 		try:
 			# rather than fetch all the relations and querying the type, do that in process for performance reasons
-			targets = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
-			if targets:
-				ia2Object = IAccessibleHandler.normalizeIAccessible(targets[0])
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				# Just take the first.
 				return IAccessible(
 					IAccessibleObject=ia2Object,
 					IAccessibleChildID=0
@@ -1578,7 +1582,7 @@ the NVDAObject for IAccessible
 		except (NotImplementedError, COMError):
 			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
 
-		# eg IA2_2 is not available, fall back to old approach
+		# IA2_2 is not available, fall back to old approach
 		try:
 			for relation in self._IA2Relations:
 				if relation.relationType == relationType:
@@ -1594,8 +1598,61 @@ the NVDAObject for IAccessible
 			pass
 		return None
 
+	def _getIA2RelationTargetsOfType(
+			self,
+			relationType: typing.Union[str, "IAccessibleHandler.RelationType"]
+	) -> typing.Iterable["IAccessible"]:
+		""" Get the targets for the relation of type.
+		Higher level function than _getIA2TargetsForRelationsOfType
+		@param relationType: The type of relation to fetch.
+		"""
+		if not isinstance(relationType, IAccessibleHandler.RelationType):
+			if isinstance(relationType, str):
+				relationType = IAccessibleHandler.RelationType(relationType)
+			else:
+				raise TypeError(f"Bad type for 'relationType' arg, got: {type(relationType)}")
+
+		relationType = typing.cast(IAccessibleHandler.RelationType, relationType)
+
+		try:
+			# rather than fetch all the relations and querying the type, do that in process for performance reasons
+			# todo: but with nRelations in chrome? Returns 1 when there should be two?
+			# maxRelsToFetch = self.IAccessibleObject.nRelations  # they may or may not all match 'relationType'
+			maxRelsToFetch = 10
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=maxRelsToFetch)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				ia = IAccessible(
+					IAccessibleObject=ia2Object,
+					IAccessibleChildID=0
+				)
+				yield ia
+			# NotImplementedError is expected to occur for all targets or none.
+			return  # Iterated all targets without error.
+		except (NotImplementedError, COMError):
+			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
+
+		# IA2_2 is not available, fall back to old approach
+		log.debugWarning("IA2_2 is not available, fall back to old approach")
+		try:
+			for relation in self._IA2Relations:
+				if relation.relationType == relationType:
+					# Take the first of 'relation.nTargets' see IAccessibleRelation._methods_
+					for i in range(0, relation.nTargets):
+						target = relation.target(i)
+						ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+						yield IAccessible(
+							IAccessibleObject=ia2Object,
+							IAccessibleChildID=0
+						)
+			return
+		except (NotImplementedError, COMError):
+			log.debug("Unable to fetch _IA2Relations", exc_info=True)
+			pass
+		return None
+
 	#: Type definition for auto prop '_get_detailsRelations'
-	detailsRelations: typing.Iterable["IAccessible"]
+	detailsRelations: typing.List["IAccessible"]
 
 	def _get_controllerFor(self) -> List[NVDAObject]:
 		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
@@ -1603,11 +1660,10 @@ the NVDAObject for IAccessible
 			return [control]
 		return []
 
-	def _get_detailsRelations(self) -> typing.Iterable["IAccessible"]:
-		relationTarget = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.DETAILS)
-		if not relationTarget:
-			return ()
-		return (relationTarget, )
+	def _get_detailsRelations(self) -> typing.List["IAccessible"]:
+		detailsRelsGen = self._getIA2RelationTargetsOfType(IAccessibleHandler.RelationType.DETAILS)
+		# due to caching of baseObject.AutoPropertyObject, do not attempt to return a generator.
+		return list(detailsRelsGen)
 
 	#: Type definition for auto prop '_get_flowsTo'
 	flowsTo: typing.Optional["IAccessible"]
@@ -1763,7 +1819,7 @@ the NVDAObject for IAccessible
 				ret = "exception: %s" % e
 			info.append("IAccessible2 attributes: %s" % ret)
 			try:
-				ret = ", ".join(r.RelationType for r in self._IA2Relations)
+				ret = ", ".join(f"{r.RelationType} * {r.nTargets}" for r in self._IA2Relations)
 			except Exception as e:
 				ret = f"exception: {e}"
 			info.append(f"IAccessible2 relations: {ret}")

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -60,9 +60,12 @@ class IA2WebAnnotation(AnnotationOrigin):
 			if config.conf["debugLog"]["annotations"]:
 				log.debug("no annotations available")
 			return
-		detailsRelations = self._originObj.detailsRelations
-		for rel in detailsRelations:
-			yield IA2WebAnnotationTarget(rel)
+
+		ia2WebAnnotationTargetsGen = (
+			IA2WebAnnotationTarget(rel)
+			for rel in self._originObj.detailsRelations
+		)
+		yield from ia2WebAnnotationTargetsGen
 
 	@property
 	def roles(self) -> typing.Iterable["controlTypes.Role"]:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -10,6 +10,10 @@ from ctypes import c_short
 from comtypes import COMError, BSTR
 
 import oleacc
+from annotation import (
+	AnnotationTarget,
+	AnnotationOrigin
+)
 from comInterfaces import IAccessible2Lib as IA2
 import controlTypes
 from logHandler import log
@@ -22,6 +26,73 @@ import api
 import speech
 import config
 import NVDAObjects
+
+
+class IA2WebAnnotationTarget(AnnotationTarget):
+	def __init__(self, target: IAccessible):
+		self._target: IAccessible = target
+
+	@property
+	def summary(self) -> str:
+		return self._target.summarizeInProcess()
+
+	@property
+	def role(self) -> "controlTypes.Role":
+		return self._target.role
+
+	@property
+	def targetObject(self) -> IAccessible:
+		return self._target
+
+
+class IA2WebAnnotation(AnnotationOrigin):
+	_originObj: "Ia2Web"
+
+	def __bool__(self) -> bool:
+		return bool(
+			self._originObj.IA2Attributes.get("details-roles")
+		)
+
+	@property
+	def targets(self) -> typing.Iterable[AnnotationTarget]:
+		if not bool(self):
+			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("no annotations available")
+			return
+		detailsRelations = self._originObj.detailsRelations
+		for rel in detailsRelations:
+			yield IA2WebAnnotationTarget(rel)
+
+	@property
+	def roles(self) -> typing.Iterable["controlTypes.Role"]:
+		"""
+		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
+		to return them.
+		@remarks: The order of "details-roles" IA2Attributes is expected to match the order of detailsRelations
+		objects.
+		"""
+		from .chromium import supportedAriaDetailsRoles
+		# Currently only defined in Chrome as of May 2022
+		# Refer to ComputeDetailsRoles
+		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
+		detailsRoles = self._originObj.IA2Attributes.get("details-roles")
+		if not detailsRoles:
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("details-roles not found")
+			return None
+
+		for roleStr in detailsRoles.split(" "):
+			# Created supported details role
+			detailsRole = supportedAriaDetailsRoles.get(roleStr)
+			if config.conf["debugLog"]["annotations"]:
+				log.debug(f"detailsRole: {repr(detailsRole)}")
+			yield detailsRole
+
+	@property
+	def summaries(self) -> typing.Iterable["str"]:
+		for target in self.targets:
+			yield target.summary
 
 
 class Ia2Web(IAccessible):
@@ -60,42 +131,26 @@ class Ia2Web(IAccessible):
 				log.debugWarning(f"Unknown 'description-from' IA2Attribute value: {ia2attrDescriptionFrom}")
 			return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: "IA2WebAnnotation"
+	"""Typing information for auto property _get_annotations
+	"""
+	def _get_annotations(self) -> "AnnotationOrigin":
+		annotationOrigin = IA2WebAnnotation(self)
+		return annotationOrigin
+
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		if not self.hasDetails:
-			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("no details-roles")
-			return None
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			log.error("should be able to fetch detailsRelations")
-			return None
-		for target in detailsRelations:
+		for summary in self.annotations.summaries:
 			# just take the first for now.
-			return target.summarizeInProcess()
+			return summary
 
 	@property
 	def hasDetails(self) -> bool:
-		return bool(self.IA2Attributes.get("details-roles"))
+		return bool(self.annotations)
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
-		from .chromium import supportedAriaDetailsRoles
-		# Currently only defined in Chrome as of May 2022
-		# Refer to ComputeDetailsRoles
-		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
-		detailsRoles = self.IA2Attributes.get("details-roles")
-		if not detailsRoles:
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("details-roles not found")
-			return None
-		
-		firstDetailsRole = detailsRoles.split(" ")[0]
-		# return a supported details role
-		detailsRole = supportedAriaDetailsRoles.get(firstDetailsRole)
-		if config.conf["debugLog"]["annotations"]:
-			log.debug(f"detailsRole: {repr(detailsRole)}")
-		return detailsRole
-
+		for role in self.annotations.roles:
+			# just take the first for now.
+			return role
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
 		ia2attrCurrent: str = self.IA2Attributes.get("current", "false")

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -12,6 +12,9 @@ import time
 import typing
 import weakref
 import textUtils
+from annotation import (
+	AnnotationOrigin,
+)
 from logHandler import log
 import review
 import eventHandler
@@ -510,6 +513,17 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
 		return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: "AnnotationOrigin"
+	"""Typing information for auto property _get_annotations
+	"""
+
+	def _get_annotations(self) -> typing.Optional["AnnotationOrigin"]:
+		if config.conf["debugLog"]["annotations"]:
+			log.debugWarning(
+				f"Fetching annotations not supported on: {self.__class__.__qualname__}"
+			)
+		return None
+
 	#: Typing information for auto property _get_detailsSummary
 	detailsSummary: typing.Optional[str]
 
@@ -523,7 +537,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""Default implementation is based on the result of _get_detailsSummary
 		In most instances this should be optimised.
 		"""
-		return bool(self.detailsSummary)
+		return bool(self.annotations)
 
 	#: Typing information for auto property _get_detailsRole
 	detailsRole: typing.Optional[controlTypes.Role]

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -1,0 +1,45 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+import typing
+
+if typing.TYPE_CHECKING:
+	import controlTypes
+	from NVDAObjects import NVDAObject
+
+
+class AnnotationTarget:
+	@property
+	def role(self) -> "controlTypes.Role":
+		raise NotImplementedError
+
+	@property
+	def targetObject(self) -> "NVDAObject":
+		raise NotImplementedError
+
+	@property
+	def summary(self) -> str:
+		raise NotImplementedError
+
+
+class AnnotationOrigin:
+	def __init__(self, originObj: "NVDAObject"):
+		self._originObj: "NVDAObject" = originObj
+
+	def __bool__(self):
+		"""Performant implementation required to test for annotations
+		"""
+		raise NotImplementedError
+
+	@property
+	def targets(self) -> typing.Iterable[AnnotationTarget]:
+		raise NotImplementedError
+
+	@property
+	def roles(self) -> typing.Iterable["controlTypes.Role"]:
+		raise NotImplementedError
+
+	@property
+	def summaries(self) -> typing.Iterable["str"]:
+		raise NotImplementedError

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2430,6 +2430,41 @@ class GlobalCommands(ScriptableObject):
 		treeInterceptor._set_selection(info, reason=OutputReason.QUICKNAV)
 		speech.speakObject(treeInterceptor.currentNVDAObject, reason=OutputReason.QUICKNAV)
 		api.setNavigatorObject(target.targetObject)
+		self._annotationNav.priorOrigins.append(objWithAnnotation)
+		return
+
+	@script(
+		gesture="kb:NVDA+alt+shift+d",
+		description=_(
+			# Translators: the description for the script_popAnnotationStack script.
+			"Return to annotation subject"
+		),
+		category=SCRCAT_SYSTEMCARET,
+	)
+	def script_popAnnotationStack(self, gesture):
+		"""Go to the annotation details for the single character under the caret or the object with
+		system focus.
+		@note: See related script_reportDetailsSummary
+		"""
+		log.debug("Return to annotation parent.")
+		if not self._annotationNav.priorOrigins:
+			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
+			ui.message(_("No annotation subject present"))
+			return
+		annotationParent = self._annotationNav.priorOrigins.pop()
+		ui.message("Navigating to origin")
+		focus = api.getFocusObject()
+		treeInterceptor = focus.treeInterceptor
+		from browseMode import BrowseModeDocumentTreeInterceptor
+		if not isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) or treeInterceptor.passThrough:
+			ui.message("Not supported yet")
+			return
+		info = treeInterceptor.makeTextInfo(annotationParent)
+		info.collapse()
+		from controlTypes import OutputReason
+		treeInterceptor._set_selection(info, reason=OutputReason.QUICKNAV)
+		speech.speakObject(treeInterceptor.currentNVDAObject, reason=OutputReason.QUICKNAV)
+		api.setNavigatorObject(annotationParent)
 		return
 
 	@script(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2305,7 +2305,7 @@ class GlobalCommands(ScriptableObject):
 			log.debug(f"Trying with nvdaObject : {objAtStart}")
 
 		if objAtStart.detailsSummary:
-			log.debug("NVDAObjectAtStart of caret has details.")
+			log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
 			return objAtStart
 		elif api.getFocusObject():
 			# If fetching from the caret position fails, try via the focus object
@@ -2366,17 +2366,28 @@ class GlobalCommands(ScriptableObject):
 			return
 
 		targets = list(objWithAnnotation.annotations.targets)
+		log.debug(f"Number of targets: {len(targets)}")
+		if 1 > len(targets):
+			log.debugWarning("Expected some annotation targets, none retrieved.")
+			return
 		if (
 			self._annotationNav.lastReported
 			and objWithAnnotation == self._annotationNav.lastReported.origin
 			and None is not self._annotationNav.lastReported.indexOfLastReportedSummary
 		):
 			last = self._annotationNav.lastReported.indexOfLastReportedSummary
-			indexOfNextTarget = next(itertools.cycle(itertools.chain(
-				range(last + 1, len(targets)),
-				range(0, last + 1))
-			))
+			indexOfNextTarget = (last + 1) % len(targets)
 		else:
+			log.debug(
+				f"No prior target summary reported:"
+				f" lastReported: {self._annotationNav.lastReported}")
+			if self._annotationNav.lastReported:
+				log.debug(
+					f" objWithAnnotation == self._annotationNav.lastReported.origin: "
+					f"{objWithAnnotation == self._annotationNav.lastReported.origin}"
+					f" self._annotationNav.lastReported.indexOfLastReportedSummary: "
+					f"{self._annotationNav.lastReported.indexOfLastReportedSummary}"
+				)
 			indexOfNextTarget = 0
 		targetToReport = targets[indexOfNextTarget]
 		ui.message(targetToReport.summary)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->
Currently this is just a prototype. There are several more aspect of the UX that need to be developed and combined to test the full experience. Once the prototypes are accepted, then the work can be polished and made ready for alpha.

### Link to issue number:
Partial fix for #13940

### Summary of the issue:
When encountering an annotation, "has details" is reported.
The summary of the annotation can be reported with `NVDA+d`
However, if the annotation contains complex structure, or can be interacted with (E.G. a comment thread), there is no easy way for the user to navigate to the annotation.
Additionally, some locations may have multiple annotation targets.

### Description of user facing changes
Please note, the shortcuts used are not final, and not intended to be the focus of this prototype.
- This provides a UX for interacting with multiple annotation targets.
- Provide navigate (down) to a annotation target.
- Provide navigation (up) to the last annotation origin.
- Cycles are not automatically detected, users need to observe this themselves.

Overview:
- Repeatedly press `NVDA+d` to select the annotation they are interested in (based on the reported summary).
- The summaries loop back to the start. It's expected to be uncommon to have many annotations starting for a single origin.
- Pressing `NVDA+alt+d` will navigate to the annotation target last summarized. After navigation, NVDA will 'read line' for the location.
  - If no summary has been announced, navigate to the first.
- The user can then navigate around the annotation target.
- Pressing `NVDA+alt+shift+d` will navigate back to the annotation origin.

### Description of development approach
- To navigate to the target, the implementation for quick nav was used as an example.
- Extracted Annotation origin and Annotation Target concepts.
- Keep track of the last reported annotation origin / annotation target index using new classes in `globalCommands.py`

### Testing strategy:
- Used https://mdn.github.io/html-examples/aria-annotations/
- https://codepen.io/reefturner/pen/poKLQyj?editors=1100
- With Firefox and Edge
- Exploratory testing.

### Known issues with pull request:
Max 10 targets are fetched, this should be dynamic, however there is a bug preventing this, requiring investigation.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
