### PR TITLE
Honour symbol preserve property in the case of repeated symbols

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -579,6 +579,8 @@ class SpeechSymbolProcessor(object):
 			symbol = self.computedSymbols[text[0]]
 			if self._level >= symbol.level:
 				return "  {count} {char} ".format(count=len(text), char=symbol.replacement)
+			elif symbol.preserve in [SYMPRES_ALWAYS, SYMPRES_NOREP]:
+				return text
 			else:
 				return " "
 


### PR DESCRIPTION
### Link to issue number:
Fixes #14391
### Summary of the issue:
Symbol 'preserve' property was not honoured when the symbol is repeated more than 3 times. E.g. on the following line containing 4 dollar sign and at symbol level None:
`$$$$`

The synth does not read anything whereas it usually reads something when passed the dollar sign.

### Description of user facing changes
When repeated, a symbol for which reporting level is below the current level is now passed to the synth is 'preserve' property is set to `norep` or `always`.

### Description of development approach
Handle this case in the code.
### Testing strategy:
Manual tests:

* Tested that STR in #14391 produces expected result
* Checked in French that the following line reports Y's:
  `DD/MM/YYYY`
* Checked that there is no other unexpected reporting
  * for the following characters$ ! § = , _ 😃 ( – € ; :
  * at symbol level None or All
  * when repeated twice (i.e. no specific repetition reporting from NVDA) or 4 times (i.e. when NVDA should report repetition at symbol All level)

### Known issues with pull request:
None
### Change log entries:
I do not know if this very little fix deserve an entry.

If you wish though, I can write something in the Bug fixes section.


### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

