### PR TITLE
Do not present usage information anymore when NVDA cannot restart

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka
+# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -261,7 +261,12 @@ if oldAppWindowHandle and not globalVars.appArgs.easeOfAccess:
 		_log.debug(f"Terminating oldAppWindowHandle: {oldAppWindowHandle}")
 		terminateRunningNVDA(oldAppWindowHandle)
 	except Exception as e:
-		parser.error(f"Couldn't terminate existing NVDA process, abandoning start:\nException: {e}")
+		winUser.MessageBox(
+			0,
+			f"Couldn't terminate existing NVDA process, abandoning start:\nException: {e}",
+			"Error",
+			winUser.MB_OK
+		)
 
 if globalVars.appArgs.quit or (oldAppWindowHandle and globalVars.appArgs.easeOfAccess):
 	_log.debug("Quitting")

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka, Cyrille Bougot
+# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka,
+# Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -622,6 +622,7 @@ def FindWindow(className, windowName):
 		raise WinError()
 	return res
 
+MB_OK = 0
 MB_RETRYCANCEL=5
 MB_ICONERROR=0x10
 MB_SYSTEMMODAL=0x1000

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -622,6 +622,7 @@ def FindWindow(className, windowName):
 		raise WinError()
 	return res
 
+
 MB_OK = 0
 MB_RETRYCANCEL=5
 MB_ICONERROR=0x10


### PR DESCRIPTION
### Link to issue number:
Linked to #14251

### Summary of the issue:
In #14251, the following error message is seen when restarting:

> usage: nvda.exe [-h] [-q] [-k] [-f LOGFILENAME]
>                 [-l {10,12,15,20,30,40,50,100}] [-c CONFIGPATH]
>                 [--lang LANGUAGE] [-m] [-s] [--disable-addons]
>                 [--debug-logging] [--no-logging] [--no-sr-flag]
>                 [--install | --install-silent | --create-portable | --create-portable-silent]
>                 [--portable-path PORTABLEPATH] [--launcher]
>                 [--enable-start-on-logon True|False] [--copy-portable-config]
>                 [--ease-of-access]
> 
> error: Couldn't terminate existing NVDA process, abandoning start:
> Exception: [WinError 5] Access is denied.

This message is quite confusing and only the end of the message is relevant; all the usage part is not relevant when restarting NVDA with normal options (e.g. no option at all)

### Description of user facing changes
In case NVDA cannot restart, the error message will not show the command line usage anymore.

### Description of development approach
Use `winUser.MessageBox` instead of `parser.error`.
### Testing strategy:
Manually raise an Exception just before the following line:
`terminateRunningNVDA(oldAppWindowHandle)`
e.g.:
`raise Exception("This is a test exception.")`

### Known issues with pull request:
* This PR does not address the root cause of #14251. The error message will just be clearer when NVDA cannot restart.
* The error message is not translated as for any other message in `nvda.pyw`.

### Change log entries:
Not needed

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
