### PR TITLE
allow importing add-on code from an addons namespace

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -849,7 +849,7 @@ As this happens on NVDA startup before other components are initialized, this fu
 ++ Optional plugin independent code ++
 In NVDA 2023.1 and above, it is possible to bundle plugin independent code with an add-on.
 This can be used to bundle base classes, constants, etc. that have to be available to multiple plugins in the add-on.
-This is especially useful if your add-on bundles an appModule and a globalPlugin and both plugins need to access the same class bundled with the add-on, for example.
+This is especially useful if your add-on bundles an appModule and a globalPlugin and both plugins need to access the same class bundled with the add-on.
 
 Plugin independent code can be accessed from the addons namespace, for example under addons.myTestAddon.
 If your add-on has a folder called ``lib`` in its root directory that contains a python module called ``constants.py``, the constants module can be imported and used as follows:

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -827,6 +827,7 @@ The following plugins and drivers can be included in an add-on:
 - Braille display drivers: Place them in a brailleDisplayDrivers directory in the archive.
 - Global plugins: Place them in a globalPlugins directory in the archive.
 - Synthesizer drivers: Place them in a synthDrivers directory in the archive.
+- Vision enhancement providers: Place them in a visionEnhancementProviders directory in the archive.
 -
 
 ++ Optional install / Uninstall code ++
@@ -844,6 +845,20 @@ If this function raises an exception, the installation of the add-on will fail a
 NVDA will look for and execute an onUninstall function in installTasks.py when NVDA is restarted after the user has chosen to remove the add-on.
 After this function completes, the add-on's directory will automatically be removed.
 As this happens on NVDA startup before other components are initialized, this function cannot request input from the user.
+
+++ Optional plugin independent code ++
+In NVDA 2023.1 and above, it is possible to bundle plugin independent code with an add-on.
+This can be used to bundle base classes, constants, etc. that have to be available to multiple plugins in the add-on.
+This is especially useful if your add-on bundles an appModule and a globalPlugin and both plugins need to access the same class bundled with the add-on, for example.
+
+Plugin independent code can be accessed from the addons namespace, for example under addons.myTestAddon.
+If your add-on has a folder called ``lib`` in its root directory that contains a python module called ``constants.py``, the constants module can be imported and used as follows:
+```
+from addons.myTestAddon.lib import constants
+
+if constants.SOME_BOOLEAN_CONSTANT is True:
+	# perform action
+```
 
 ++ Localizing Add-ons ++
 It is possible to provide locale-specific information and messages for your add-on.

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2012-2022 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
-# Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka
+# Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -21,7 +21,7 @@ import globalVars
 import zipfile
 from configobj import ConfigObj
 from configobj.validate import Validator
-from .packaging import initializeModulePackagePaths
+from .packaging import initializeAddonsNamespacePackage, initializeModulePackagePaths
 import config
 import languageHandler
 from logHandler import log
@@ -30,6 +30,7 @@ import addonAPIVersion
 from . import addonVersionCheck
 from .addonVersionCheck import isAddonCompatible
 import extensionPoints
+from types import ModuleType
 
 
 MANIFEST_FILENAME = "manifest.ini"
@@ -168,6 +169,7 @@ def initialize():
 	getAvailableAddons(refresh=True, isFirstLoad=True)
 	state.cleanupRemovedDisabledAddons()
 	state.save()
+	initializeAddonsNamespacePackage()
 	initializeModulePackagePaths()
 
 
@@ -395,7 +397,7 @@ class Addon(AddonBase):
 		_blockedAddons.discard(self.name)
 		state.save()
 
-	def addToPackagePath(self, package):
+	def addToPackagePath(self, package: ModuleType):
 		""" Adds this L{Addon} extensions to the specific package path if those exist.
 		This allows the addon to "run" / be available because the package is able to search its path,
 		looking for particular modules. This is used by the following:
@@ -403,8 +405,8 @@ class Addon(AddonBase):
 		- `appModules`
 		- `synthDrivers`
 		- `brailleDisplayDrivers`
+		- `visionEnhancementProviders`
 		@param package: the python module representing the package.
-		@type package: python module.
 		"""
 		# #3090: Ensure that we don't add disabled / blocked add-ons to package path.
 		# By returning here the addon does not "run"/ become active / registered.

--- a/source/addonHandler/packaging.py
+++ b/source/addonHandler/packaging.py
@@ -7,11 +7,15 @@
 """
 
 import os.path
-from typing import Optional
+from typing import Optional, List
 from types import ModuleType
 import globalVars
 import config
+import sys
+import importlib
 
+ADDONS_MODULE_NAME = "addons"
+"""The name of an importable module that nessts add-on code for every active add-on."""
 
 def initializeModulePackagePaths():
 	"""Initializes the module package paths for drivers and plugins.
@@ -60,3 +64,35 @@ def addDirsToPythonPackagePath(module: ModuleType, subdir: Optional[str] = None)
 	pathList = [fullPath]
 	pathList.extend(module.__path__)
 	module.__path__ = pathList
+
+
+def _createModule(moduleName: str, submoduleSearchLocations: Optional[List[str]] = None):
+	"""Creates a module with the given moduleName and adds it to sys.modules.
+	This ensures that the module can be imported.
+	@param moduleName: The name of the module, e.g. addons or addons.example.
+	@param submoduleSearchLocations: Can be provided if the module has to be a python namespace package.
+	"""
+	if moduleName in sys.modules:
+		# module already initialized
+		return
+	spec = importlib._bootstrap.ModuleSpec(moduleName, None)
+	if submoduleSearchLocations:
+		spec.submodule_search_locations = submoduleSearchLocations
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[module.__name__] = module
+
+
+def initializeAddonsNamespacePackage():
+	"""Initializes the addons namespace package.
+	This ensures that all python code in an add-on can be imported, even if code lives
+	outside one of the standard package paths, such as appModules or globalPlugins.
+	For example, if an add-on named example has a python module called lib,
+	that module can be imported with `from addons.example import lib`
+	"""
+	# First, ensure that there is a placeholder addons module that does nothing,
+	# i.e. it has no associated path but is solely there to nest add-ons under it.
+	_createModule(ADDONS_MODULE_NAME)
+
+	from . import getRunningAddons
+	for addon in getRunningAddons():
+		_createModule(f"{ADDONS_MODULE_NAME}.{addon.name}", [addon.path])

--- a/source/addonHandler/packaging.py
+++ b/source/addonHandler/packaging.py
@@ -7,7 +7,10 @@
 """
 
 import os.path
-from typing import Optional, List
+from typing import (
+	List,
+	Optional,
+)
 from types import ModuleType
 import globalVars
 import config


### PR DESCRIPTION
Cc @josephsl 

### Link to issue number:
Closes #14359

### Summary of the issue:
It is currently only possible to import add-on code from the standard NVDA plugin paths, like appModules or globalPlugins. Therefore, there is no elegant way add-ons can store code that has to be shared between appModules and globalPlugins, for example.

### Description of user facing changes
@feerrenrut suggested the following approach in https://github.com/nvaccess/nvda/issues/14359#issuecomment-1314699202:

> I'd prefer that addon code isn't mixed in with the standard namespaces. Instead, a solution that maintained the separation of the add-on.
> 
> When importing shared code from within the addon this should be achieved in a way that avoids namespace collisions: Given an addon called `myAddon` you might import code from a `lib` directory within the add-on with `from myAddon.lib import comInterfaces`
> 
> * This would help to prevent add-ons from inadvertently depending on each other.
> * We don't want to end up in a situation where the addition of a new file in NVDA could break add-ons because of namespace pollution.

The final solution is slightly different in that it adds an `addons` part in the naming scheme: Given an addon called `myAddon` you can import code from a `lib` directory within the add-on with `from addons.myAddon.lib import comInterfaces.

### Description of development approach
This solution depends heavily on importlib. It generates a blank module spec based on a module name and optional path, and constructs a module from that spec. The module is inserted in sys.modules. The addons themselves are simulated [Native Namespace Packages](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages). Long story short, these are python packages that don't require an `__init__.py` file.

### Testing strategy:
Created an addon called `example`. In the addon folder, added a folder called `lib` and in there a module called `test.py`. Successfully imported the module with `from addons.example.lib import test`

### Known issues with pull request:
None known

### Change log entries:
For Developers
- Add-ons can now contain python code anywhere in their directory structure. The contents of an add-on folder are exposed under the addons namespace. For example, a test module in an add-on called example can be imported with "from addons.example import test". (#14359)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
