### PR TITLE
Use only supported log levels for command line option

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka
+# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka,
+# Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -148,12 +149,23 @@ quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument('-q','--quit',action="store_true",dest='quit',default=False,help="Quit already running copy of NVDA")
 parser.add_argument('-k','--check-running',action="store_true",dest='check_running',default=False,help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running")
 parser.add_argument('-f','--log-file',dest='logFileName',type=str,help="The file where log messages should be written to")
-parser.add_argument('-l','--log-level',dest='logLevel',type=int,default=0,choices=[10, 12, 15, 20, 30, 40, 50, 100],help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, warning 30, error 40, critical 50, off 100), default is info")
+parser.add_argument(
+	'-l',
+	'--log-level',
+	dest='logLevel',
+	type=int,
+	default=20,
+	choices=[10, 12, 15, 20, 100],
+	help=(
+		"The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100),"
+		" default is 20 (info)"
+	),
+)
 parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str,help="The path where all settings for NVDA are stored")
 parser.add_argument(
 	'--lang',
 	dest='language',
-	default="en",
+	default="Windows",
 	type=stringToLang,
 	help=(
 		"Override the configured NVDA language."


### PR DESCRIPTION
Context: issue found while reading the code for #14398.

### Link to issue number:
None
### Summary of the issue:

When starting NVDA with an unsupported command line parameter, you get the following suggestion for log level in the error message:
> [-l {10,12,15,20,30,40,50,100}]

Launching NVDA with log level set to 30, 40 or 50 actually indicates NVDA using info level.


### Description of user facing changes

* Only supported log levels are indicated in the error message when a wrong parameter is passed to NVDA.
* Only supported log level can now be used from command line, i.e. 10=debug, 12=I/O, 15=debugWarning, 20=info and 100=off

### Description of development approach
* Changed the information passed to the command line parser.
* While at it, changed default from "en" to "Windows" in the parser's `--lang` parameter; this seem to have no impact however since "Windows" was already used when this parameter is missing.
### Testing strategy:
Manual tests:
* NVDA starts normally when `-l` parameter is not passed to NVDA
* NVDA starts normally with `-l` command line param set to 10, 12, 15, 20 and 100 and the appropriate log level is used
* NVDA does not start and displays the usage message when launched with `-l` set to 30, 40, 50 and 99.

Note: also tested `--lang=windows`; this fails but it was already failing before this PR, e.g. in NVDA 2022.4beta3. I will open an issue for that.

### Known issues with pull request:
None
### Change log entries:
Probably not needed.
Or maybe something in the bugfixes category? What do you think?


### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
