### PR TITLE
Fix plugin reload

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -341,6 +341,8 @@ def reloadAppModules():
 	for mod in mods:
 		del sys.modules[mod]
 	import appModules
+	from addonHandler.packaging import addDirsToPythonPackagePath
+	addDirsToPythonPackagePath(appModules)
 	initialize()
 	for entry in state:
 		pid = entry.pop("processID")

--- a/source/globalPluginHandler.py
+++ b/source/globalPluginHandler.py
@@ -51,6 +51,8 @@ def reloadGlobalPlugins():
 	for mod in mods:
 		del sys.modules[mod]
 	import globalPlugins
+	from addonHandler.packaging import addDirsToPythonPackagePath
+	addDirsToPythonPackagePath(globalPlugins)
 	initialize()
 
 class GlobalPlugin(baseObject.ScriptableObject):


### PR DESCRIPTION
### Link to issue number:
Fixes #14408

### Summary of the issue:
PR #14350 streamlined import code for globalPlugins and appModules. However, the reloading of these modules was overlooked.

### Description of user facing changes
Reloading of appModules/globalPlugins works again

### Description of development approach
The reloading functions for both appModules and globalPlugins call addonhandler.packaging.addDirsToPythonPackagePath

### Testing strategy:
Tested that at least globalPlugin reloading works again. @nvdaes could you please have a test as well?

### Known issues with pull request:
### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
