### PR TITLE
Check Z-Order for making content accessible on the lock screen.

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -28,7 +28,7 @@ import queueHandler
 import api
 import globalVars
 from logHandler import log
-from utils.security import isWindowsLocked
+from utils.security import _isLockScreenModeActive
 
 versionedLibPath = os.path.join(globalVars.appDir, 'lib')
 if os.environ.get('PROCESSOR_ARCHITEW6432') == 'ARM64':
@@ -455,7 +455,7 @@ def nvdaControllerInternal_installAddonPackageFromPath(addonPath):
 	if globalVars.appArgs.secure:
 		log.debugWarning("Unable to install add-on into secure copy of NVDA.")
 		return
-	if isWindowsLocked():
+	if _isLockScreenModeActive():
 		log.debugWarning("Unable to install add-on while Windows is locked.")
 		return
 	import wx
@@ -470,7 +470,7 @@ def nvdaControllerInternal_openConfigDirectory():
 	if globalVars.appArgs.secure:
 		log.debugWarning("Unable to open user config directory for secure copy of NVDA.")
 		return
-	if isWindowsLocked():
+	if _isLockScreenModeActive():
 		log.debugWarning("Unable to open user config directory while Windows is locked.")
 		return
 	import systemUtils

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -30,6 +30,7 @@ from treeInterceptorHandler import (
 	TreeInterceptor,
 )
 import braille
+from utils.security import _isObjectAboveLockScreen
 import vision
 import globalPluginHandler
 import brailleInput
@@ -1433,3 +1434,11 @@ This code is executed if a gain focus event is received by this object.
 		For performance, this method will only count up to the given maxCount number, and if there is one more above that, then sys.maxint is returned stating that many items are selected.
 		"""
 		return 0
+
+	#: Type definition for auto prop '_get_isAboveLockScreen'
+	isAboveLockScreen: bool
+
+	def _get_isAboveLockScreen(self) -> bool:
+		if not isWindowsLocked():
+			return True
+		return _isObjectAboveLockScreen(self)

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -30,7 +30,7 @@ from treeInterceptorHandler import (
 	TreeInterceptor,
 )
 import braille
-from utils.security import _isObjectAboveLockScreen
+from utils.security import _isObjectBelowLockScreen
 import vision
 import globalPluginHandler
 import brailleInput
@@ -1435,10 +1435,10 @@ This code is executed if a gain focus event is received by this object.
 		"""
 		return 0
 
-	#: Type definition for auto prop '_get_isAboveLockScreen'
-	isAboveLockScreen: bool
+	#: Type definition for auto prop '_get_isBelowLockScreen'
+	isBelowLockScreen: bool
 
-	def _get_isAboveLockScreen(self) -> bool:
+	def _get_isBelowLockScreen(self) -> bool:
 		if not _isLockScreenModeActive():
-			return True
-		return _isObjectAboveLockScreen(self)
+			return False
+		return _isObjectBelowLockScreen(self)

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1441,4 +1441,5 @@ This code is executed if a gain focus event is received by this object.
 	def _get_isAboveLockScreen(self) -> bool:
 		if not isWindowsLocked():
 			return True
+		# TODO time _isObjectAbovelockScreen
 		return _isObjectAboveLockScreen(self)

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -36,7 +36,7 @@ import globalPluginHandler
 import brailleInput
 import locationHelper
 import aria
-from winAPI.sessionTracking import isWindowsLocked
+from winAPI.sessionTracking import _isLockScreenModeActive
 
 
 class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
@@ -182,7 +182,7 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 		Inserts LockScreenObject to the start of the clsList if Windows is locked.
 		"""
 		from .lockscreen import LockScreenObject
-		if isWindowsLocked():
+		if _isLockScreenModeActive():
 			# This must be resolved first to prevent object navigation outside of the lockscreen.
 			clsList.insert(0, LockScreenObject)
 
@@ -1439,7 +1439,6 @@ This code is executed if a gain focus event is received by this object.
 	isAboveLockScreen: bool
 
 	def _get_isAboveLockScreen(self) -> bool:
-		if not isWindowsLocked():
+		if not _isLockScreenModeActive():
 			return True
-		# TODO time _isObjectAbovelockScreen
 		return _isObjectAboveLockScreen(self)

--- a/source/api.py
+++ b/source/api.py
@@ -237,7 +237,10 @@ def setReviewPosition(
 	@param isCaret: Whether the review position is changed due to caret following.
 	@param isMouse: Whether the review position is changed due to mouse following.
 	"""
-	if _isSecureObjectWhileLockScreenActivated(reviewPosition.obj):
+	reviewObj = reviewPosition.obj
+	if isinstance(reviewObj, treeInterceptorHandler.TreeInterceptor):
+		reviewObj = reviewObj.rootNVDAObject
+	if _isSecureObjectWhileLockScreenActivated(reviewObj):
 		return False
 	globalVars.reviewPosition=reviewPosition.copy()
 	globalVars.reviewPositionObj=reviewPosition.obj

--- a/source/api.py
+++ b/source/api.py
@@ -238,10 +238,20 @@ def setReviewPosition(
 	@param isMouse: Whether the review position is changed due to mouse following.
 	"""
 	reviewObj = reviewPosition.obj
-	if isinstance(reviewObj, treeInterceptorHandler.TreeInterceptor):
+
+	if isinstance(reviewObj, treeInterceptorHandler.DocumentTreeInterceptor):
+		# reviewPosition.obj can be a number of classes, e.g.
+		# CursorManager, DocumentWithTableNavigation, EditableText.
+		# We can only handle the NVDAObject case.
 		reviewObj = reviewObj.rootNVDAObject
-	if _isSecureObjectWhileLockScreenActivated(reviewObj):
-		return False
+
+	if isinstance(reviewObj, NVDAObjects.NVDAObject):
+		# reviewPosition.obj can be a number of classes, e.g.
+		# CursorManager, DocumentWithTableNavigation, EditableText.
+		# We can only handle the NVDAObject case.
+		if _isSecureObjectWhileLockScreenActivated(reviewObj):
+			return False
+
 	globalVars.reviewPosition=reviewPosition.copy()
 	globalVars.reviewPositionObj=reviewPosition.obj
 	if clearNavigatorObject: globalVars.navigatorObject=None

--- a/source/api.py
+++ b/source/api.py
@@ -251,6 +251,8 @@ def setReviewPosition(
 		# We can only handle the NVDAObject case.
 		if _isSecureObjectWhileLockScreenActivated(reviewObj):
 			return False
+	else:
+		log.debug(f"Unhandled reviewObj type {type(reviewObj)} when checking security of reviewObj")
 
 	globalVars.reviewPosition=reviewPosition.copy()
 	globalVars.reviewPositionObj=reviewPosition.obj

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -832,28 +832,3 @@ def getWmiProcessInfo(processId):
 	except:
 		raise LookupError("Couldn't get process information using WMI")
 	raise LookupError("No such process")
-
-
-def _checkWindowsForAppModules():
-	"""
-	Updates the appModuleHandler with the process from all top level windows.
-	Adds any missing processes.
-	"""
-	import winUser
-
-	# BOOL CALLBACK EnumWindowsProc _In_ HWND,_In_ LPARAM
-	# HWND as a pointer creates confusion, treat as an int
-	# http://makble.com/the-story-of-lpclong
-
-	@ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_int, ctypes.POINTER(ctypes.c_int))
-	def _appModuleHandlerUpdate(
-			hwnd: winUser.HWNDVal,
-			_lParam: ctypes.wintypes.LPARAM
-	) -> bool:
-		processID, _threadID = winUser.getWindowThreadProcessID(hwnd)
-		if processID not in runningTable:
-			update(processID)
-		return True
-
-	if not ctypes.windll.user32.EnumWindows(_appModuleHandlerUpdate, 0):
-		log.error("Failed to refresh app modules")

--- a/source/appModules/lockapp.py
+++ b/source/appModules/lockapp.py
@@ -21,13 +21,13 @@ from NVDAObjects import NVDAObject
 from NVDAObjects.lockscreen import LockScreenObject
 from NVDAObjects.UIA import UIA
 from utils.security import getSafeScripts
-from winAPI.sessionTracking import isWindowsLocked
+from winAPI.sessionTracking import _isLockScreenModeActive
 
 """App module for the Windows 10 and 11 lock screen.
 
 The lock screen allows other windows to be opened, so security related functions
 are done at a higher level than the lockapp app module.
-Refer to usages of `winAPI.sessionTracking.isWindowsLocked`.
+Refer to usages of `winAPI.sessionTracking._isLockScreenModeActive`.
 """
 
 
@@ -60,11 +60,11 @@ class AppModule(appModuleHandler.AppModule):
 		if isinstance(obj,UIA) and obj.role==controlTypes.Role.PANE and obj.UIAElement.cachedClassName=="LockAppContainer":
 			clsList.insert(0,LockAppContainer)
 
-		if not isWindowsLocked():
+		if not _isLockScreenModeActive():
 			log.debugWarning(
 				"LockApp is being initialized but NVDA does not expect Windows to be locked. "
 				"DynamicNVDAObjectType may have failed to apply LockScreenObject. "
-				"This means Windows session tracking has failed or NVDA is yet to receive lock event. "
+				"This means session lock state tracking has failed. "
 			)
 			clsList.insert(0, LockScreenObject)
 
@@ -83,7 +83,7 @@ class AppModule(appModuleHandler.AppModule):
 		if not scriptShouldRun:
 			log.error(
 				"scriptHandler failed to block script when Windows is locked. "
-				"This means Windows session tracking has failed. "
+				"This means session lock state tracking has failed. "
 			)
 		return scriptShouldRun
 

--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -17,7 +17,7 @@ from logHandler import log
 import fonts
 import inputCore
 import gui.contextHelp
-from utils.security import isWindowsLocked, postSessionLockStateChanged
+from utils.security import _isLockScreenModeActive, postSessionLockStateChanged
 
 BRAILLE_UNICODE_PATTERNS_START = 0x2800
 BRAILLE_SPACE_CHARACTER = chr(BRAILLE_UNICODE_PATTERNS_START)
@@ -398,7 +398,7 @@ class BrailleViewerFrame(
 		self._shouldShowOnStartupCheckBox.SetValue(config.conf["brailleViewer"]["showBrailleViewerAtStartup"])
 		self._shouldShowOnStartupCheckBox.Bind(wx.EVT_CHECKBOX, self._onShouldShowOnStartupChanged)
 		optionsSizer.Add(self._shouldShowOnStartupCheckBox)
-		if isWindowsLocked():
+		if _isLockScreenModeActive():
 			self._shouldShowOnStartupCheckBox.Disable()
 
 		# Translators: The label for a setting in the braille viewer that controls
@@ -415,11 +415,11 @@ class BrailleViewerFrame(
 		sizer.Add(optionsSizer, flag=wx.EXPAND | wx.TOP, border=5)
 
 	def _onShouldShowOnStartupChanged(self, evt: wx.CommandEvent):
-		if not isWindowsLocked():
+		if not _isLockScreenModeActive():
 			config.conf["brailleViewer"]["showBrailleViewerAtStartup"] = self._shouldShowOnStartupCheckBox.IsChecked()
 
 	def _onShouldHoverRouteToCellCheckBoxChanged(self, evt: wx.CommandEvent):
-		if not isWindowsLocked():
+		if not _isLockScreenModeActive():
 			config.conf["brailleViewer"]["shouldHoverRouteToCell"] = self._shouldHoverRouteToCellCheckBox.IsChecked()
 		self._updateMouseOverBinding(self._shouldHoverRouteToCellCheckBox.IsChecked())
 

--- a/source/core.py
+++ b/source/core.py
@@ -451,13 +451,13 @@ class _TrackNVDAInitialization:
 	regardless of lock state.
 	Security checks may cause the desktop object to not be set if NVDA starts on the lock screen.
 	As such, during initialization, NVDA should behave as if Windows is unlocked,
-	i.e. winAPI.sessionTracking.isWindowsLocked should return False.
+	i.e. winAPI.sessionTracking._isLockScreenModeActive should return False.
 
 	TODO: move to NVDAState module
 	"""
 
 	_isNVDAInitialized = False
-	"""When False, isWindowsLocked is forced to return False.
+	"""When False, _isLockScreenModeActive is forced to return False.
 	"""
 
 	@staticmethod

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -21,6 +21,7 @@ import typing
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects  # noqa: F401 used for type checking only
+	import textInfos  # noqa: F401 used for type checking only
 
 
 class DefaultAppArgs(argparse.Namespace):
@@ -70,7 +71,7 @@ mouseOldX=None
 mouseOldY=None
 navigatorObject: typing.Optional['NVDAObjects.NVDAObject'] = None
 reviewPosition=None
-reviewPositionObj=None
+reviewPositionObj: typing.Optional["textInfos.TextInfoObjT"] = None
 lastProgressValue=0
 appArgs = DefaultAppArgs()
 unknownAppArgs: typing.List[str] = []

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -20,8 +20,8 @@ import os
 import typing
 
 if typing.TYPE_CHECKING:
+	import documentBase  # noqa: F401 used for type checking only
 	import NVDAObjects  # noqa: F401 used for type checking only
-	import textInfos  # noqa: F401 used for type checking only
 
 
 class DefaultAppArgs(argparse.Namespace):
@@ -71,7 +71,7 @@ mouseOldX=None
 mouseOldY=None
 navigatorObject: typing.Optional['NVDAObjects.NVDAObject'] = None
 reviewPosition=None
-reviewPositionObj: typing.Optional["textInfos.TextInfoObjT"] = None
+reviewPositionObj: typing.Optional["documentBase.TextContainerObject"] = None
 lastProgressValue=0
 appArgs = DefaultAppArgs()
 unknownAppArgs: typing.List[str] = []

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -357,6 +357,7 @@ def _serviceDebugEnabled() -> bool:
 		if winreg.QueryValueEx(k, "serviceDebug")[0]:
 			return True
 	except WindowsError:
+		# Expected state by default, serviceDebug parameter not set
 		pass
 	return False
 

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -350,13 +350,19 @@ if mutex is None:
 	sys.exit(1)
 
 
-if _isSecureDesktop():
+def _serviceDebugEnabled() -> bool:
 	import winreg
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NVDA")
-		if not winreg.QueryValueEx(k, u"serviceDebug")[0]:
-			globalVars.appArgs.secure = True
+		if winreg.QueryValueEx(k, "serviceDebug")[0]:
+			return True
 	except WindowsError:
+		pass
+	return False
+
+
+if _isSecureDesktop():
+	if not _serviceDebugEnabled():
 		globalVars.appArgs.secure = True
 	globalVars.appArgs.changeScreenReaderFlag = False
 	globalVars.appArgs.minimal = True

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -95,11 +95,11 @@ def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List["inputCore.In
 
 def findScript(gesture: "inputCore.InputGesture") -> Optional[_ScriptFunctionT]:
 	from utils.security import getSafeScripts
-	from winAPI.sessionTracking import isWindowsLocked
+	from winAPI.sessionTracking import _isLockScreenModeActive
 	foundScript = _findScript(gesture)
 	if (
 		foundScript is not None
-		and isWindowsLocked()
+		and _isLockScreenModeActive()
 		and foundScript not in getSafeScripts()
 	):
 		return None

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -13,7 +13,7 @@ import config
 from logHandler import log
 from speech import SpeechSequence
 import gui.contextHelp
-from utils.security import isWindowsLocked, postSessionLockStateChanged
+from utils.security import _isLockScreenModeActive, postSessionLockStateChanged
 
 
 # Inherit from wx.Frame because these windows show in the alt+tab menu (where miniFrame does not)
@@ -102,7 +102,7 @@ class SpeechViewerFrame(
 			wx.EVT_CHECKBOX,
 			self.onShouldShowOnStartupChanged
 		)
-		if isWindowsLocked():
+		if _isLockScreenModeActive():
 			self.shouldShowOnStartupCheckBox.Disable()
 
 	def _onDialogActivated(self, evt):
@@ -119,7 +119,7 @@ class SpeechViewerFrame(
 		deactivate()
 
 	def onShouldShowOnStartupChanged(self, evt: wx.CommandEvent):
-		if not isWindowsLocked():
+		if not _isLockScreenModeActive():
 			config.conf["speechViewer"]["showSpeechViewerAtStartup"] = self.shouldShowOnStartupCheckBox.IsChecked()
 
 	_isDestroyed: bool

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -31,8 +31,9 @@ import locationHelper
 from logHandler import log
 
 if typing.TYPE_CHECKING:
+	import documentBase  # noqa: F401 used for type checking only
 	import NVDAObjects
-	import treeInterceptorHandler  # noqa: F401 used for type checking only
+
 
 SpeechSequence = List[Union[Any, str]]
 
@@ -288,9 +289,6 @@ def _logBadSequenceTypes(sequence: SpeechSequence, shouldRaise: bool = True):
 	return speech.types.logBadSequenceTypes(sequence, raiseExceptionOnError=shouldRaise)
 
 
-TextInfoObjT = Union["NVDAObjects.NVDAObject", "treeInterceptorHandler.TreeInterceptor"]
-
-
 class TextInfo(baseObject.AutoPropertyObject):
 	"""Provides information about a range of text in an object and facilitates access to all text in the widget.
 	A TextInfo represents a specific range of text, providing access to the text itself, as well as information about the text such as its formatting and any associated controls.
@@ -313,7 +311,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 
 	def __init__(
 			self,
-			obj: TextInfoObjT,
+			obj: "documentBase.TextContainerObject",
 			position
 	):
 		"""Constructor.
@@ -346,9 +344,9 @@ class TextInfo(baseObject.AutoPropertyObject):
 		self.end.moveTo(otherEndpoint)
 
 	#: Typing information for auto-property: _get_obj
-	obj: TextInfoObjT
+	obj: "documentBase.TextContainerObject"
 
-	def _get_obj(self) -> TextInfoObjT:
+	def _get_obj(self) -> "documentBase.TextContainerObject":
 		"""The object containing the range of text being represented."""
 		return self._obj()
 

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -312,12 +312,11 @@ class TextInfo(baseObject.AutoPropertyObject):
 	def __init__(
 			self,
 			obj: "documentBase.TextContainerObject",
-			position
+			position: Union[int, Tuple, str],
 	):
 		"""Constructor.
 		Subclasses must extend this, calling the superclass method first.
 		@param position: The initial position of this range; one of the POSITION_* constants or a position object supported by the implementation.
-		@type position: int, tuple or string
 		@param obj: The object containing the range of text being represented.
 		"""
 		super(TextInfo,self).__init__()

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2021 NV Access Limited, Babbage B.V., Accessolutions, Julien Cochuyt
+# Copyright (C) 2006-2022 NV Access Limited, Babbage B.V., Accessolutions, Julien Cochuyt
 
 """Framework for accessing text content in widgets.
 The core component of this framework is the L{TextInfo} class.
@@ -32,6 +32,7 @@ from logHandler import log
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
+	import treeInterceptorHandler  # noqa: F401 used for type checking only
 
 SpeechSequence = List[Union[Any, str]]
 
@@ -287,6 +288,9 @@ def _logBadSequenceTypes(sequence: SpeechSequence, shouldRaise: bool = True):
 	return speech.types.logBadSequenceTypes(sequence, raiseExceptionOnError=shouldRaise)
 
 
+TextInfoObjT = Union["NVDAObjects.NVDAObject", "treeInterceptorHandler.TreeInterceptor"]
+
+
 class TextInfo(baseObject.AutoPropertyObject):
 	"""Provides information about a range of text in an object and facilitates access to all text in the widget.
 	A TextInfo represents a specific range of text, providing access to the text itself, as well as information about the text such as its formatting and any associated controls.
@@ -307,7 +311,11 @@ class TextInfo(baseObject.AutoPropertyObject):
 	@type bookmark: L{Bookmark}
 	"""
 
-	def __init__(self,obj,position):
+	def __init__(
+			self,
+			obj: TextInfoObjT,
+			position
+	):
 		"""Constructor.
 		Subclasses must extend this, calling the superclass method first.
 		@param position: The initial position of this range; one of the POSITION_* constants or a position object supported by the implementation.
@@ -338,9 +346,9 @@ class TextInfo(baseObject.AutoPropertyObject):
 		self.end.moveTo(otherEndpoint)
 
 	#: Typing information for auto-property: _get_obj
-	obj: "NVDAObjects.NVDAObject"
+	obj: TextInfoObjT
 
-	def _get_obj(self) -> "NVDAObjects.NVDAObject":
+	def _get_obj(self) -> TextInfoObjT:
 		"""The object containing the range of text being represented."""
 		return self._obj()
 

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -1,10 +1,13 @@
-# treeInterceptorHandler.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2020 NV Access Limited, Davy Kager, Accessolutions, Julien Cochuyt
+# Copyright (C) 2006-2022 NV Access Limited, Davy Kager, Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from typing import Optional, Dict
+from typing import (
+	TYPE_CHECKING,
+	Dict,
+	Optional,
+)
 
 from logHandler import log
 import baseObject
@@ -17,6 +20,10 @@ import braille
 import vision
 from speech.types import SpeechSequence
 from controlTypes import OutputReason
+
+if TYPE_CHECKING:
+	import NVDAObjects
+
 
 runningTable=set()
 
@@ -84,12 +91,11 @@ class TreeInterceptor(baseObject.ScriptableObject):
 
 	shouldTrapNonCommandGestures=False #: If true then gestures that do not have a script and are not a command gesture should be trapped from going through to Windows.
 
-	def __init__(self, rootNVDAObject):
+	def __init__(self, rootNVDAObject: "NVDAObjects.NVDAObject"):
 		super(TreeInterceptor, self).__init__()
 		self._passThrough = False
 		#: The root object of the tree wherein events and scripts are intercepted.
-		#: @type: L{NVDAObjects.NVDAObject}
-		self.rootNVDAObject = rootNVDAObject
+		self.rootNVDAObject: "NVDAObjects.NVDAObject" = rootNVDAObject
 
 	def terminate(self):
 		"""Terminate this interceptor.

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -271,7 +271,10 @@ def _isWindowBelowWindowMatchesCond(
 
 	In the context of _isObjectBelowLockScreenCheckZOrder, NVDA starts at the lowest window,
 	and searches up towards the closest/lowest lock screen window.
-	If the lock screen window is found before the NVDAobject, the object should be made accessible.
+	If the lock screen window is found before the NVDAObject,
+	then the NVDAObject is above the lock screen,
+	or not present at all,
+	and therefore the NVDAObject should be made accessible.
 	This is because if the NVDAObject is not present, we want to make it accessible by default.
 	If the lock screen window is not present at all, we also want to make the NVDAObject accessible,
 	so the lock screen window must be comprehensively searched for.

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -273,7 +273,7 @@ def _isWindowBelowWindowMatchesCond(
 	and searches up towards the closest/lowest lock screen window.
 	If the lock screen window is found before the NVDAobject, the object should be made accessible.
 	This is because if the NVDAObject is not present, we want to make it accessible by default.
-	If the lock screen window is not present, we also want to make the NVDAObject accessible,
+	If the lock screen window is not present at all, we also want to make the NVDAObject accessible,
 	so the lock screen window must be comprehensively searched for.
 	If the NVDAObject is found, and then a lock screen window,
 	the object is not made accessible as it is below the lock screen.

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -227,16 +227,16 @@ def _isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 			# lockAppModule not running/registered by NVDA yet
 			log.debug(
 				"lockAppModule not detected when Windows is locked. "
-				"Cannot detect if object is in lock app, considering object as safe. "
+				"Cannot detect if object is above lock app, considering object as safe. "
 			)
 			return True
 
 	from NVDAObjects.window import Window
 	if not isinstance(obj, Window):
 		log.debug(
-			"Cannot detect if object is in lock app, considering object as safe. "
+			"Cannot detect if object is above lock app, considering object as safe. "
 		)
-		# must be a window to get its HWNDVal
+		# Must be a window instance to get the HWNDVal, other NVDAObjects do not support this.
 		return True
 
 	topLevelWindowHandle = winUser.getAncestor(obj.windowHandle, winUser.GA_ROOT)

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -249,7 +249,7 @@ def _isObjectAboveLockScreenCheckZOrder(objWindowHandle: int, lockAppModuleProce
 	elif objectZIndex is None or objectZIndexCheck is None:
 		# this is an unexpected state
 		# err on accessibility
-		log.error("Couldn't find NVDA object's window")
+		log.debugWarning("Couldn't find NVDA object's window")
 		return True
 	elif lockAppZIndex > objectZIndex and lockAppZIndexCheck > objectZIndexCheck:
 		# object is behind the lock screen, hide it from the user

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -174,6 +174,14 @@ def _findLockAppModule() -> Optional["appModuleHandler.AppModule"]:
 	return next(filter(_isLockAppAndAlive, runningAppModules), None)
 
 
+def _searchForLockAppModule():
+	from appModuleHandler import _checkWindowsForAppModules
+	if _isLockScreenModeActive():
+		lockAppModule = _findLockAppModule()
+		if lockAppModule is None:
+			_checkWindowsForAppModules()
+
+
 def _isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 	"""
 	When Windows is locked, the foreground Window is usually LockApp,
@@ -200,18 +208,15 @@ def _isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 	):
 		return True
 
-	from appModuleHandler import _checkWindowsForAppModules
 	lockAppModule = _findLockAppModule()
 	if lockAppModule is None:
-		_checkWindowsForAppModules()
-		lockAppModule = _findLockAppModule()
-		if lockAppModule is None:
-			# lockAppModule not running/registered by NVDA yet
-			log.debug(
-				"lockAppModule not detected when Windows is locked. "
-				"Cannot detect if object is above lock app, considering object as safe. "
-			)
-			return True
+		# lockAppModule not running/registered by NVDA yet.
+		# This is not an expected state.
+		log.error(
+			"lockAppModule not detected when Windows is locked. "
+			"Cannot detect if object is above lock app, considering object as safe. "
+		)
+		return True
 
 	from NVDAObjects.window import Window
 	if not isinstance(obj, Window):

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -227,7 +227,7 @@ def _isObjectBelowLockScreenCheckZOrder(objWindowHandle: int) -> bool:
 	try:
 		return _isWindowBelowWindowMatchesCond(objWindowHandle, _isWindowLockScreen)
 	except _UnexpectedWindowCountError:
-		log.error("Couldn't find lock screen")
+		log.exception("Couldn't find lock screen")
 		return False
 
 

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -267,7 +267,7 @@ def _isWindowBelowWindowMatchesCond(
 
 	@returns: True if window is below a window that matches matchCond.
 	If the first window is not found, but the second window is,
-	it is assumed that the first window is below the second window.
+	it is assumed that the first window is above the second window.
 
 	In the context of _isObjectBelowLockScreenCheckZOrder, NVDA starts at the lowest window,
 	and searches up towards the closest/lowest lock screen window.

--- a/source/winAPI/_wtsApi32.py
+++ b/source/winAPI/_wtsApi32.py
@@ -11,7 +11,7 @@ This file refers to this header with the convention `WtsApi32.h#L36` meaning lin
 """
 
 from enum import (
-	IntEnum
+	IntEnum,
 )
 from typing import (
 	Callable,
@@ -133,6 +133,8 @@ class WTSINFOEX_LEVEL1_W(ctypes.Structure):
 		("OutgoingCompressedBytes", DWORD),
 	)
 
+	SessionFlags: LONG
+
 
 class WTSINFOEX_LEVEL_W(ctypes.Union):
 	""" WtsApi32.h#L483
@@ -141,6 +143,8 @@ class WTSINFOEX_LEVEL_W(ctypes.Union):
 	_fields_ = (
 		("WTSInfoExLevel1", WTSINFOEX_LEVEL1_W),
 	)
+
+	WTSInfoExLevel1: WTSINFOEX_LEVEL1_W
 
 
 class WTSINFOEXW(ctypes.Structure):
@@ -151,6 +155,9 @@ class WTSINFOEXW(ctypes.Structure):
 		('Level', DWORD),
 		('Data', WTSINFOEX_LEVEL_W),
 	)
+
+	Level: DWORD
+	Data: WTSINFOEX_LEVEL_W
 
 
 # WTSQuerySessionInformationW Definition
@@ -179,13 +186,6 @@ WTSQuerySessionInformation.restype = BOOL  # On Failure, the return value is zer
 
 class _WTS_LockState(IntEnum):
 	"""
-	In some cases, -0x1 is also a known state returned when queried (#14379).
-	WTSINFOEX_LEVEL1_W.SessionFlags returns a flag state.
-	This means that the following is a valid state according to the winAPI:
-	WTS_SESSIONSTATE_UNKNOWN | WTS_SESSIONSTATE_LOCK | WTS_SESSIONSTATE_UNLOCK.
-	As mixed states imply an unknown state,
-	WTS_LockState is an IntEnum rather than an IntFlag and mixed state flags are unexpected enum values.
-
 	WtsApi32.h#L437
 	"""
 	WTS_SESSIONSTATE_UNKNOWN = 0xFFFFFFFF  # dec(4294967295)
@@ -221,6 +221,15 @@ def _setWTS_LockState() -> Type[Union[_WTS_LockState, _WTS_LockState_Win7]]:
 	return _WTS_LockState_Win7 if (winVersion.getWinVer() < winVersion.WIN8) else _WTS_LockState
 
 
-WTS_LockState: Type[_WTS_LockState] = _setWTS_LockState()
-"""Contains WTS_SESSIONSTATE_LOCK, WTS_SESSIONSTATE_UNLOCK, WTS_SESSIONSTATE_UNKNOWN
+WTS_LockState: Type[Union[_WTS_LockState, _WTS_LockState_Win7]] = _setWTS_LockState()
+"""
+Set of known session states that NVDA can handle.
+These values are different on different versions of Windows.
+
+In some cases, other states such as -0x1 are returned when queried (#14379).
+Generally, WTSINFOEX_LEVEL1_W.SessionFlags returns a flag state.
+This means that the following is a valid state according to the winAPI:
+WTS_SESSIONSTATE_UNKNOWN | WTS_SESSIONSTATE_LOCK | WTS_SESSIONSTATE_UNLOCK.
+As mixed states imply an unknown state,
+_WTS_LockStateT is an IntEnum rather than an IntFlag and mixed state flags are unexpected enum values.
 """

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -21,6 +21,4 @@ class WindowMessage(enum.IntEnum):
 	"""
 	WM_WTSSESSION_CHANGE
 	Windows Message for when a Session State Changes.
-	Receiving these messages is registered by sessionTracking.register.
-	handleSessionChange handles these messages.
 	"""

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -63,7 +63,6 @@ https://docs.microsoft.com/en-us/windows/win32/sync/synchronization-object-secur
 Unused in NVDA core, duplicate of winKernel.SYNCHRONIZE.
 """
 
-_initializationLockState: Optional[bool] = None
 _lockStateTracker: Optional["_WindowsLockedState"] = None
 _windowsWasPreviouslyLocked = False
 
@@ -122,20 +121,15 @@ def isWindowsLocked() -> bool:
 	Not to be confused with the Windows sign-in screen, a secure screen.
 	"""
 	from core import _TrackNVDAInitialization
-	from winAPI.sessionTracking import _isWindowsLocked_checkViaSessionQuery
 	from systemUtils import _isSecureDesktop
 	if not _TrackNVDAInitialization.isInitializationComplete():
 		return False
 	if _isSecureDesktop():
 		return False
-	global _initializationLockState
-	if _lockStateTracker is not None:
-		_isWindowsLocked = _lockStateTracker.isWindowsLocked
-	else:
-		if _initializationLockState is None:
-			_initializationLockState = _isWindowsLocked_checkViaSessionQuery()
-		_isWindowsLocked = _initializationLockState
-	return _isWindowsLocked
+	if _lockStateTracker is None:
+		log.error("_TrackNVDAInitialization.markInitializationComplete was called before sessionTracking.initialize")
+		return False
+	return _lockStateTracker.isWindowsLocked
 
 
 def _isWindowsLocked_checkViaSessionQuery() -> bool:

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -127,7 +127,10 @@ def isWindowsLocked() -> bool:
 	if _isSecureDesktop():
 		return False
 	if _lockStateTracker is None:
-		log.error("_TrackNVDAInitialization.markInitializationComplete was called before sessionTracking.initialize")
+		log.error(
+			"_TrackNVDAInitialization.markInitializationComplete was called "
+			"before sessionTracking.initialize"
+		)
 		return False
 	return _lockStateTracker.isWindowsLocked
 

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -12,8 +12,6 @@ and prevents navigating beyond apps open on the lock screen (LockScreen.exe, Mag
 Used to:
 - only allow a whitelist of safe scripts to run
 - ensure object navigation cannot occur outside of the lockscreen
-
-https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification
 """
 
 from __future__ import annotations
@@ -21,18 +19,14 @@ import contextlib
 import ctypes
 from contextlib import contextmanager
 from ctypes.wintypes import (
-	HANDLE,
 	HWND,
 )
 import enum
-from threading import Lock
 from typing import (
-	Dict,
-	Set,
 	Optional,
 )
 
-from systemUtils import _isSecureDesktop
+from baseObject import AutoPropertyObject
 from winAPI.wtsApi32 import (
 	WTSINFOEXW,
 	WTSQuerySessionInformation,
@@ -45,43 +39,33 @@ from winAPI.wtsApi32 import (
 )
 from logHandler import log
 
-_updateSessionStateLock = Lock()
-"""Used to protect updates to _currentSessionStates"""
-_currentSessionStates: Set["WindowsTrackedSession"] = set()
-"""
-Current state of the Windows session associated with this instance of NVDA.
-Maintained via receiving session notifications via the NVDA MessageWindow.
-Initial state will be set by querying the current status.
-Actions which involve updating this state this should be protected by _updateSessionStateLock.
-"""
-
-_sessionQueryLockStateHasBeenUnknown = False
-"""
-Track if any 'Unknown' Value when querying the Session Lock status has been encountered.
-"""
-
-_isSessionTrackingRegistered = False
-"""
-Session tracking is required for NVDA to be notified of lock state changes for security purposes.
-"""
-
 RPC_S_INVALID_BINDING = 0x6A6
 """
 Error which occurs when Windows is not ready to register session notification tracking.
 This error can be prevented by waiting for the event: 'Global\\TermSrvReadyEvent.'
+
+Unused in NVDA core.
 """
 
 NOTIFY_FOR_THIS_SESSION = 0
 """
 The alternative to NOTIFY_FOR_THIS_SESSION is to be notified for all user sessions.
 NOTIFY_FOR_ALL_SESSIONS is not required as NVDA runs on separate user profiles, including the system profile.
+
+Unused in NVDA core.
 """
 
 SYNCHRONIZE = 0x00100000
 """
 Parameter for OpenEventW, blocks thread until event is registered.
 https://docs.microsoft.com/en-us/windows/win32/sync/synchronization-object-security-and-access-rights
+
+Unused in NVDA core, duplicate of winKernel.SYNCHRONIZE.
 """
+
+_initializationLockState: Optional[bool] = None
+_lockStateTracker: Optional["_WindowsLockedState"] = None
+_windowsWasPreviouslyLocked = False
 
 
 class WindowsTrackedSession(enum.IntEnum):
@@ -106,47 +90,30 @@ class WindowsTrackedSession(enum.IntEnum):
 	SESSION_TERMINATE = 11
 
 
-_toggleWindowsSessionStatePair: Dict[WindowsTrackedSession, WindowsTrackedSession] = {
-	WindowsTrackedSession.CONSOLE_CONNECT: WindowsTrackedSession.CONSOLE_DISCONNECT,
-	WindowsTrackedSession.CONSOLE_DISCONNECT: WindowsTrackedSession.CONSOLE_CONNECT,
-	WindowsTrackedSession.REMOTE_CONNECT: WindowsTrackedSession.REMOTE_DISCONNECT,
-	WindowsTrackedSession.REMOTE_DISCONNECT: WindowsTrackedSession.REMOTE_CONNECT,
-	WindowsTrackedSession.SESSION_LOGON: WindowsTrackedSession.SESSION_LOGOFF,
-	WindowsTrackedSession.SESSION_LOGOFF: WindowsTrackedSession.SESSION_LOGON,
-	WindowsTrackedSession.SESSION_LOCK: WindowsTrackedSession.SESSION_UNLOCK,
-	WindowsTrackedSession.SESSION_UNLOCK: WindowsTrackedSession.SESSION_LOCK,
-	WindowsTrackedSession.SESSION_CREATE: WindowsTrackedSession.SESSION_TERMINATE,
-	WindowsTrackedSession.SESSION_TERMINATE: WindowsTrackedSession.SESSION_CREATE,
-}
-"""
-Pair of WindowsTrackedSession, where each key has a value of the opposite state.
-e.g. SESSION_LOCK/SESSION_UNLOCK.
-"""
+class _WindowsLockedState(AutoPropertyObject):
+	# Refer to AutoPropertyObject for notes on caching
+	_cache_isWindowsLocked = True
+	
+	# Typing information for auto-property _get_isWindowsLocked
+	isWindowsLocked: bool
+
+	def _get_isWindowsLocked(self) -> bool:
+		from winAPI.sessionTracking import _isWindowsLocked_checkViaSessionQuery
+		return _isWindowsLocked_checkViaSessionQuery()
 
 
-def _hasLockStateBeenTracked() -> bool:
-	"""
-	Checks if NVDA is aware of a session lock state change since NVDA started.
-	"""
-	return bool(_currentSessionStates.intersection({
-		WindowsTrackedSession.SESSION_LOCK,
-		WindowsTrackedSession.SESSION_UNLOCK
-	}))
+def initialize():
+	global _lockStateTracker
+	_lockStateTracker = _WindowsLockedState()
 
 
-def _recordLockStateTrackingFailure(error: Optional[Exception] = None):
-	log.error(
-		"Unknown lock state, unexpected, potential security issue, please report.",
-		exc_info=error
-	)  # Report error repeatedly, attention is required.
-	##
-	# For security it would be best to treat unknown as locked.
-	# However, this would make NVDA unusable.
-	# Instead, the user should be warned, and allowed to mitigate the impact themselves.
-	# Reporting is achieved via _sessionQueryLockStateHasBeenUnknown exposed with
-	# L{hasLockStateBeenUnknown}.
-	global _sessionQueryLockStateHasBeenUnknown
-	_sessionQueryLockStateHasBeenUnknown = True
+def pumpAll():
+	global _windowsWasPreviouslyLocked
+	from utils.security import postSessionLockStateChanged
+	windowsIsNowLocked = isWindowsLocked()
+	if windowsIsNowLocked != _windowsWasPreviouslyLocked:
+		_windowsWasPreviouslyLocked = windowsIsNowLocked
+		postSessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)
 
 
 def isWindowsLocked() -> bool:
@@ -155,74 +122,37 @@ def isWindowsLocked() -> bool:
 	Not to be confused with the Windows sign-in screen, a secure screen.
 	"""
 	from core import _TrackNVDAInitialization
+	from winAPI.sessionTracking import _isWindowsLocked_checkViaSessionQuery
+	from systemUtils import _isSecureDesktop
 	if not _TrackNVDAInitialization.isInitializationComplete():
-		# During NVDA initialization,
-		# core._initializeObjectCaches needs to cache the desktop object,
-		# regardless of lock state.
-		# Security checks may cause the desktop object to not be set if NVDA starts on the lock screen.
-		# As such, during initialization, NVDA should behave as if Windows is unlocked.
 		return False
 	if _isSecureDesktop():
-		# If this is the Secure Desktop,
-		# we are in secure mode and on a secure screen,
-		# e.g. on the sign-in screen.
-		# _isSecureDesktop may also return True on the lock screen before a user has signed in.
-
-		# For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
-		# and the following userGuide sections:
-		# - SystemWideParameters (information on the serviceDebug parameter)
-		# - SecureMode and SecureScreens
 		return False
-	lockStateTracked = _hasLockStateBeenTracked()
-	if lockStateTracked:
-		return WindowsTrackedSession.SESSION_LOCK in _currentSessionStates
+	global _initializationLockState
+	if _lockStateTracker is not None:
+		_isWindowsLocked = _lockStateTracker.isWindowsLocked
 	else:
-		_recordLockStateTrackingFailure()  # Report error repeatedly, attention is required.
-		##
-		# For security it would be best to treat unknown as locked.
-		# However, this would make NVDA unusable.
-		# Instead, the user should be warned via UI, and allowed to mitigate the impact themselves.
-		# See usage of L{hasLockStateBeenUnknown}.
-		return False  # return False, indicating unlocked, to allow NVDA to be used
-
-
-def _setInitialWindowLockState() -> None:
-	"""
-	Ensure that session tracking state is initialized.
-	If NVDA has started on a lockScreen, it needs to be aware of this.
-	As NVDA has already registered for session tracking notifications,
-	a lock is used to prevent conflicts.
-	"""
-	with _updateSessionStateLock:
-		lockStateTracked = _hasLockStateBeenTracked()
-		if lockStateTracked:
-			log.debugWarning(
-				"Initial state already set."
-				" NVDA may have received a session change notification before initialising"
-			)
-		# Fall back to explicit query
-		try:
-			isLocked = _isWindowsLocked_checkViaSessionQuery()
-			_currentSessionStates.add(
-				WindowsTrackedSession.SESSION_LOCK
-				if isLocked
-				else WindowsTrackedSession.SESSION_UNLOCK
-			)
-		except RuntimeError as error:
-			_recordLockStateTrackingFailure(error)
+		if _initializationLockState is None:
+			_initializationLockState = _isWindowsLocked_checkViaSessionQuery()
+		_isWindowsLocked = _initializationLockState
+	return _isWindowsLocked
 
 
 def _isWindowsLocked_checkViaSessionQuery() -> bool:
 	""" Use a session query to check if the session is locked
 	@return: True is the session is locked.
-	@raise: Runtime error if the lock state can not be determined via a Session Query.
+	Also returns False if the lock state can not be determined via a Session Query.
 	"""
-	sessionQueryLockState = _getSessionLockedValue()
+	try:
+		sessionQueryLockState = _getSessionLockedValue()
+	except RuntimeError:
+		return False
 	if sessionQueryLockState == WTS_LockState.WTS_SESSIONSTATE_UNKNOWN:
-		raise RuntimeError(
+		log.error(
 			"Unable to determine lock state via Session Query."
 			f" Lock state value: {sessionQueryLockState!r}"
 		)
+		return False
 	return sessionQueryLockState == WTS_LockState.WTS_SESSIONSTATE_LOCK
 
 
@@ -231,145 +161,41 @@ def isLockStateSuccessfullyTracked() -> bool:
 	I.E. Registered for session tracking AND initial value set correctly.
 	@return: True when successfully tracked.
 	"""
-	return (
-		not _sessionQueryLockStateHasBeenUnknown
-		or not _isSessionTrackingRegistered
+	# TODO: improve deprecation practice on beta/master merges
+	log.error(
+		"NVDA no longer registers session tracking notifications. "
+		"This function is deprecated, for removal in 2023.1. "
+		"It was never expected that add-on authors would use this function"
 	)
+	return True
 
 
-def register(handle: HWND) -> bool:
-	"""
-	@param handle: handle for NVDA message window.
-	When registered, Windows Messages related to session event changes will be
-	sent to the message window.
-	@returns: True is session tracking is successfully registered.
-
-	Blocks until Windows accepts session tracking registration.
-
-	Every call to this function must be paired with a call to unregister.
-
-	If registration fails, NVDA may not work properly until the session can be registered in a new instance.
-	NVDA will not know when the lock screen is activated, which means it becomes a security risk.
-	NVDA should warn the user if registering the session notification fails.
-
-	https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification
-	"""
-
-	# OpenEvent handle must be closed with CloseHandle.
-	eventObjectHandle: HANDLE = ctypes.windll.kernel32.OpenEventW(
-		# Blocks until WTS session tracking can be registered.
-		# Windows needs time for the WTS session tracking service to initialize.
-		# NVDA must ensure that the WTS session tracking service is ready before trying to register
-		SYNCHRONIZE,  # DWORD dwDesiredAccess
-		False,  # BOOL bInheritHandle - NVDA sub-processes do not need to inherit this handle
-		# According to the docs, when the Global\TermSrvReadyEvent global event is set,
-		# all dependent services have started and WTSRegisterSessionNotification can be successfully called.
-		# https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification#remarks
-		"Global\\TermSrvReadyEvent"  # LPCWSTR lpName - The name of the event object.
+def register(handle: int) -> bool:
+	# TODO: improve deprecation practice on beta/master merges
+	log.error(
+		"NVDA no longer registers session tracking notifications. "
+		"This function is deprecated, for removal in 2023.1. "
+		"It was never expected that add-on authors would use this function"
 	)
-	if not eventObjectHandle:
-		error = ctypes.WinError()
-		log.error("Unexpected error waiting to register session tracking.", exc_info=error)
-		return False
-
-	registrationSuccess = ctypes.windll.wtsapi32.WTSRegisterSessionNotification(handle, NOTIFY_FOR_THIS_SESSION)
-	ctypes.windll.kernel32.CloseHandle(eventObjectHandle)
-
-	if registrationSuccess:
-		log.debug("Registered session tracking")
-		# Ensure that an initial state is set.
-		# Do this only when session tracking has been registered,
-		# so that any changes to the state are not missed via a race condition with session tracking registration.
-		# As this occurs after NVDA hs registered for session tracking,
-		# it is possible NVDA is expected to handle a session change notification
-		# at the same time as initialisation.
-		# _updateSessionStateLock is used to prevent received session notifications from being handled at the
-		# same time as initialisation.
-		_setInitialWindowLockState()
-	else:
-		error = ctypes.WinError()
-		if error.errno == RPC_S_INVALID_BINDING:
-			log.error(
-				"WTS registration failed. "
-				"NVDA waited successfully on TermSrvReadyEvent to ensure that WTS is ready to allow registration. "
-				"Cause of failure unknown. "
-			)
-		else:
-			log.error("Unexpected error registering session tracking.", exc_info=error)
-
-	global _isSessionTrackingRegistered
-	_isSessionTrackingRegistered = registrationSuccess
-	return isLockStateSuccessfullyTracked()
+	return True
 
 
 def unregister(handle: HWND) -> None:
-	"""
-	This function must be called once for every call to register.
-	If unregistration fails, NVDA may not work properly until the session can be unregistered in a new instance.
-
-	https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsunregistersessionnotification
-	"""
-	if not _isSessionTrackingRegistered:
-		log.info("Not unregistered session tracking, it was not registered.")
-		return
-	if ctypes.windll.wtsapi32.WTSUnRegisterSessionNotification(handle):
-		log.debug("Unregistered session tracking")
-	else:
-		error = ctypes.WinError()
-		log.error("Unexpected error unregistering session tracking.", exc_info=error)
+	# TODO: improve deprecation practice on beta/master merges
+	log.error(
+		"NVDA no longer registers session tracking notifications. "
+		"This function is deprecated, for removal in 2023.1. "
+		"It was never expected that add-on authors would use this function"
+	)
 
 
 def handleSessionChange(newState: WindowsTrackedSession, sessionId: int) -> None:
-	"""
-	Keeps track of the Windows session state.
-	When a session change event occurs, the new state is added and the opposite state
-	is removed.
-
-	For example a "SESSION_LOCK" event removes the "SESSION_UNLOCK" state.
-
-	This does not track SESSION_REMOTE_CONTROL, which isn't part of a logical pair of states.
-	Managing the state of this is more complex, and NVDA does not need to track this status.
-
-	https://docs.microsoft.com/en-us/windows/win32/termserv/wm-wtssession-change
-	"""
-	with _updateSessionStateLock:
-		stateChanged = False
-
-		log.debug(f"Windows Session state notification received: {newState.name}")
-
-		if not _isSessionTrackingRegistered:
-			log.debugWarning("Session tracking not registered, unexpected session change message")
-
-		if newState not in _toggleWindowsSessionStatePair:
-			log.debug(f"Ignoring {newState} event as tracking is not required.")
-			return
-
-		oppositeState = _toggleWindowsSessionStatePair[newState]
-		if newState in _currentSessionStates:
-			log.error(
-				f"NVDA expects Windows to be in {newState} already. "
-				f"NVDA may have dropped a {oppositeState} event. "
-				f"Dropping this {newState} event. "
-			)
-		else:
-			_currentSessionStates.add(newState)
-			stateChanged = True
-
-		if oppositeState in _currentSessionStates:
-			_currentSessionStates.remove(oppositeState)
-		else:
-			log.debugWarning(
-				f"NVDA expects Windows to be in {newState} already. "
-				f"NVDA may have dropped a {oppositeState} event. "
-			)
-
-		log.debug(f"New Windows Session state: {_currentSessionStates}")
-		if (
-			stateChanged
-			and newState in {WindowsTrackedSession.SESSION_LOCK, WindowsTrackedSession.SESSION_UNLOCK}
-		):
-			from utils.security import postSessionLockStateChanged
-			postSessionLockStateChanged.notify(isNowLocked=newState == WindowsTrackedSession.SESSION_LOCK)
+	# TODO: improve deprecation practice on beta/master merges
+	log.error(
+		"NVDA no longer registers session tracking notifications. "
+		"This function is deprecated, for removal in 2023.1. "
+		"It was never expected that add-on authors would use this function"
+	)
 
 
 @contextmanager
@@ -445,6 +271,8 @@ def _getSessionLockedValue() -> WTS_LockState:
 	with WTSCurrentSessionInfoEx() as info:
 		infoEx: WTSINFOEX_LEVEL1_W = info.contents.Data.WTSInfoExLevel1
 		sessionFlags: ctypes.wintypes.LONG = infoEx.SessionFlags
-		lockState = WTS_LockState(sessionFlags)
-		log.debug(f"Query Lock state result: {lockState!r}")
+		try:
+			lockState = WTS_LockState(sessionFlags)
+		except ValueError:
+			return WTS_LockState.WTS_SESSIONSTATE_UNKNOWN
 		return lockState

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -122,11 +122,10 @@ def initialize():
 def pumpAll():
 	"""Used to track the session lock state every core cycle, and detect changes."""
 	global _wasLockedPreviousPumpAll
-	from utils.security import postSessionLockStateChanged, _searchForLockAppModule
+	from utils.security import postSessionLockStateChanged
 	windowsIsNowLocked = _isWindowsLocked()
 	# search for lock app module once lock state is known,
 	# but before triggering callbacks via postSessionLockStateChanged
-	_searchForLockAppModule()
 	if windowsIsNowLocked != _wasLockedPreviousPumpAll:
 		_wasLockedPreviousPumpAll = windowsIsNowLocked
 		postSessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -124,10 +124,12 @@ def pumpAll():
 	global _wasLockedPreviousPumpAll
 	from utils.security import postSessionLockStateChanged, _searchForLockAppModule
 	windowsIsNowLocked = _isWindowsLocked()
+	# search for lock app module once lock state is known,
+	# but before triggering callbacks via postSessionLockStateChanged
+	_searchForLockAppModule()
 	if windowsIsNowLocked != _wasLockedPreviousPumpAll:
 		_wasLockedPreviousPumpAll = windowsIsNowLocked
 		postSessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)
-	_searchForLockAppModule()
 
 
 def isWindowsLocked() -> bool:

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -122,11 +122,12 @@ def initialize():
 def pumpAll():
 	"""Used to track the session lock state every core cycle, and detect changes."""
 	global _wasLockedPreviousPumpAll
-	from utils.security import postSessionLockStateChanged
+	from utils.security import postSessionLockStateChanged, _searchForLockAppModule
 	windowsIsNowLocked = _isWindowsLocked()
 	if windowsIsNowLocked != _wasLockedPreviousPumpAll:
 		_wasLockedPreviousPumpAll = windowsIsNowLocked
 		postSessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)
+	_searchForLockAppModule()
 
 
 def isWindowsLocked() -> bool:
@@ -165,6 +166,14 @@ def _isLockScreenModeActive() -> bool:
 	if _isSecureDesktop():
 		# Use secure mode instead if on the secure desktop
 		return False
+
+	import winVersion
+	if winVersion.getWinVer() < winVersion.WIN10:
+		# On Windows 8 and Earlier, the lock screen runs on
+		# the secure desktop.
+		# Lock screen mode is not supported on these Windows versions.
+		return False
+
 	return _isWindowsLocked()
 
 

--- a/source/winAPI/wtsApi32.py
+++ b/source/winAPI/wtsApi32.py
@@ -178,7 +178,16 @@ WTSQuerySessionInformation.restype = BOOL  # On Failure, the return value is zer
 
 
 class _WTS_LockState(IntEnum):
-	"""WtsApi32.h#L437"""
+	"""
+	In some cases, -0x1 is also a known state returned when queried (#14379).
+	WTSINFOEX_LEVEL1_W.SessionFlags returns a flag state.
+	This means that the following is a valid state according to the winAPI:
+	WTS_SESSIONSTATE_UNKNOWN | WTS_SESSIONSTATE_LOCK | WTS_SESSIONSTATE_UNLOCK.
+	As mixed states imply an unknown state,
+	WTS_LockState is an IntEnum rather than an IntFlag and mixed state flags are unexpected enum values.
+
+	WtsApi32.h#L437
+	"""
 	WTS_SESSIONSTATE_UNKNOWN = 0xFFFFFFFF  # dec(4294967295)
 	"""The session state is not known."""
 

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -500,7 +500,7 @@ def sendMessage(hwnd,msg,param1,param2):
 	return user32.SendMessageW(hwnd,msg,param1,param2)
 
 
-def getWindowThreadProcessID(hwnd: HWND) -> Tuple[int, int]:
+def getWindowThreadProcessID(hwnd: HWNDVal) -> Tuple[int, int]:
 	"""Returns a tuple of (processID, threadID)"""
 	processID=c_int()
 	threadID=user32.GetWindowThreadProcessId(hwnd,byref(processID))

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -517,10 +517,12 @@ def getWindowThreadProcessID(hwnd: HWNDVal) -> Tuple[int, int]:
 	threadID=user32.GetWindowThreadProcessId(hwnd,byref(processID))
 	return (processID.value, threadID)
 
-def getClassName(window):
+
+def getClassName(window: HWNDVal) -> str:
 	buf=create_unicode_buffer(256)
 	user32.GetClassNameW(window,buf,255)
 	return buf.value
+
 
 def keybd_event(*args):
 	return user32.keybd_event(*args)

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -132,10 +132,17 @@ GA_ROOTOWNER=3
 GWL_ID=-12
 GWL_STYLE=-16
 GWL_EXSTYLE=-20
-#getWindow
+
+# getWindow: TODO turn to enum
 GW_HWNDNEXT=2
 GW_HWNDPREV=3
 GW_OWNER=4
+GW_RESULT_NOT_FOUND = 0
+"""
+When GetWindow returns 0, it means the window has not been found.
+For example the last window has been reached, or an error has occurred.
+"""
+
 # SetLayeredWindowAttributes
 LWA_ALPHA = 2
 LWA_COLORKEY = 1

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -133,10 +133,14 @@ GWL_ID=-12
 GWL_STYLE=-16
 GWL_EXSTYLE=-20
 
-# getWindow: TODO turn to enum
+# getWindow relationship parameters: TODO turn to enum
+GW_HWNDFIRST = 0
+GW_HWNDLAST = 1
 GW_HWNDNEXT=2
 GW_HWNDPREV=3
 GW_OWNER=4
+
+# getWindow results
 GW_RESULT_NOT_FOUND = 0
 """
 When GetWindow returns 0, it means the window has not been found.

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 
 from utils.security import (
 	_UnexpectedWindowCountError,
-	_isWindowAboveWindowMatchesCond,
+	_isWindowBelowWindowMatchesCond,
 )
 import winUser
 
@@ -33,7 +33,7 @@ class _MoveWindow:
 
 class _Test_isWindowAboveWindowMatchesCond(unittest.TestCase):
 	"""
-	Base class to patch winUser functions used in _isWindowAboveWindowMatchesCond.
+	Base class to patch winUser functions used in _isWindowBelowWindowMatchesCond.
 
 	Navigating windows is replaced by a list of fake HWNDs.
 	HWNDs are represented by integers (1-10).
@@ -94,20 +94,20 @@ class Test_isWindowAboveWindowMatchesCond_static(_Test_isWindowAboveWindowMatche
 	def test_secondWindowNotFound(self):
 		with self.assertRaises(_UnexpectedWindowCountError):
 			# Errors are handled as if window is above
-			_isWindowAboveWindowMatchesCond(5, lambda x: False)
+			_isWindowBelowWindowMatchesCond(5, lambda x: False)
 
 	def test_firstWindowNotFound(self):
-		self.assertTrue(_isWindowAboveWindowMatchesCond(-1, lambda x: x == 5))
+		self.assertFalse(_isWindowBelowWindowMatchesCond(-1, lambda x: x == 5))
 
 	def test_isAbove(self):
 		aboveIndex = 2
 		belowIndex = 1
-		self.assertTrue(_isWindowAboveWindowMatchesCond(aboveIndex, self._windowMatches(belowIndex)))
+		self.assertFalse(_isWindowBelowWindowMatchesCond(aboveIndex, self._windowMatches(belowIndex)))
 
 	def test_isBelow(self):
 		aboveIndex = 2
 		belowIndex = 1
-		self.assertFalse(_isWindowAboveWindowMatchesCond(belowIndex, self._windowMatches(aboveIndex)))
+		self.assertTrue(_isWindowBelowWindowMatchesCond(belowIndex, self._windowMatches(aboveIndex)))
 
 
 class Test_isWindowAboveWindowMatchesCond_dynamic(_Test_isWindowAboveWindowMatchesCond):
@@ -168,14 +168,14 @@ class Test_isWindowAboveWindowMatchesCond_dynamic(_Test_isWindowAboveWindowMatch
 		self._queuedMove = move
 
 		# Check aboveWindow is above belowWindow
-		isAbove = True
+		isBelow = False
 		if aboveExpectFailure:
-			isAbove = not isAbove
+			isBelow = not isBelow
 		if aboveRaises is None:
-			self.assertEqual(isAbove, _isWindowAboveWindowMatchesCond(aboveWindow, self._windowMatches(belowWindow)))
+			self.assertEqual(isBelow, _isWindowBelowWindowMatchesCond(aboveWindow, self._windowMatches(belowWindow)))
 		else:
 			with self.assertRaises(aboveRaises):
-				_isWindowAboveWindowMatchesCond(aboveWindow, self._windowMatches(belowWindow))
+				_isWindowBelowWindowMatchesCond(aboveWindow, self._windowMatches(belowWindow))
 		
 		# Reset the window list
 		self._generateWindows()
@@ -183,14 +183,14 @@ class Test_isWindowAboveWindowMatchesCond_dynamic(_Test_isWindowAboveWindowMatch
 		self._queuedMove.triggered = False
 
 		# Check belowWindow is below aboveWindow
-		isAbove = False
+		isBelow = True
 		if belowExpectFailure:
-			isAbove = not isAbove
+			isBelow = not isBelow
 		if belowRaises is None:
-			self.assertEqual(isAbove, _isWindowAboveWindowMatchesCond(belowWindow, self._windowMatches(aboveWindow)))
+			self.assertEqual(isBelow, _isWindowBelowWindowMatchesCond(belowWindow, self._windowMatches(aboveWindow)))
 		else:
 			with self.assertRaises(belowRaises):
-				_isWindowAboveWindowMatchesCond(belowWindow, self._windowMatches(aboveWindow))
+				_isWindowBelowWindowMatchesCond(belowWindow, self._windowMatches(aboveWindow))
 
 	def test_visited_windowMoves_aboveTargets(self):
 		"""

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -259,3 +259,46 @@ class Test_isWindowAboveWindowMatchesCond_dynamic(_Test_isWindowAboveWindowMatch
 			triggerIndex=3
 		)
 		self.assertTrue(_isWindowAboveWindowMatchesCond(startWindow, self._windowMatches(targetWindow)))
+
+	def test_startWindow_windowMoves_pastTarget(self):
+		"""
+		Start window moves towards, and past the target window.
+		This means the relative z-order has changed, but the change is not detected.
+		The relative z-order of the start of the search is returned.
+		"""
+		startWindow = 2
+		targetWindow = 6
+		self._queuedMove = _MoveWindow(
+			startIndex=startWindow - 1,
+			endIndex=8,
+			triggerIndex=3
+		)
+		self.assertTrue(_isWindowAboveWindowMatchesCond(startWindow, self._windowMatches(targetWindow)))
+
+	def test_startWindow_windowMoves_beforeTarget(self):
+		"""
+		Start window moves towards, but before the target window.
+		This does not affect the relative z-order.
+		"""
+		startWindow = 2
+		targetWindow = 8
+		self._queuedMove = _MoveWindow(
+			startIndex=startWindow - 1,
+			endIndex=6,
+			triggerIndex=3
+		)
+		self.assertTrue(_isWindowAboveWindowMatchesCond(startWindow, self._windowMatches(targetWindow)))
+
+	def test_StartWindow_windowMoves_awayFromTarget(self):
+		"""
+		Start window moves in the opposite direction the target window.
+		This does not affect the relative z-order.
+		"""
+		startWindow = 2
+		targetWindow = 8
+		self._queuedMove = _MoveWindow(
+			startIndex=startWindow - 1,
+			endIndex=1,
+			triggerIndex=3
+		)
+		self.assertTrue(_isWindowAboveWindowMatchesCond(startWindow, self._windowMatches(targetWindow)))

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -6,6 +6,10 @@
 """Unit tests for the blockUntilConditionMet submodule.
 """
 
+from dataclasses import dataclass
+from typing import (
+	Optional,
+)
 import unittest
 from unittest.mock import patch
 
@@ -15,8 +19,17 @@ from utils.security import (
 import winUser
 
 
+@dataclass
+class _MoveWindow:
+	startIndex: int  # A window at this index
+	endIndex: int  # is moved to this index
+	triggerIndex: int  # when this index is reached
+	triggered = False
+
+
 class _Test_getWindowZIndex(unittest.TestCase):
 	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:
+		"""Fetch current window, find adjacent window by relation."""
 		currentWindowIndex = self._windows.index(hwnd)
 		if relation == winUser.GW_HWNDNEXT:
 			try:
@@ -37,7 +50,8 @@ class _Test_getWindowZIndex(unittest.TestCase):
 		return _helper
 
 	def setUp(self) -> None:
-		self._getDesktopWindowPatch = patch("winUser.getDesktopWindow", lambda: 0)  # value is discarded by _getTopWindowPatch
+		# value from _getDesktopWindowPatch is discarded by _getTopWindowPatch
+		self._getDesktopWindowPatch = patch("winUser.getDesktopWindow", lambda: 0)
 		self._getTopWindowPatch = patch("winUser.getTopWindow", lambda _hwnd: self._windows[0])
 		self._getWindowPatch = patch("winUser.getWindow", self._getWindow_patched)
 		self._getDesktopWindowPatch.start()
@@ -69,7 +83,7 @@ class Test_getWindowZIndex_static(_Test_getWindowZIndex):
 
 
 class Test_getWindowZIndex_dynamic(_Test_getWindowZIndex):
-	_triggered = False
+	_queuedMove: Optional[_MoveWindow] = None
 
 	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:
 		self._moveIndexToNewIndexAtIndexOnce(self._windows.index(hwnd))
@@ -80,42 +94,83 @@ class Test_getWindowZIndex_dynamic(_Test_getWindowZIndex):
 		from logging import getLogger
 		
 		getLogger().error(f"{currentIndex}")
-		if currentIndex == self._triggerIndex and not self._triggered:
-			self._triggered = True
-			window = self._windows.pop(self._startIndex)
-			self._windows.insert(self._endIndex, window)
+		if (
+			self._queuedMove
+			and currentIndex == self._queuedMove.triggerIndex
+			and not self._queuedMove.triggered
+		):
+			self._queuedMove.triggered = True
+			window = self._windows.pop(self._queuedMove.startIndex)
+			self._windows.insert(self._queuedMove.endIndex, window)
 
 	def test_prev_windowMoves_pastTarget(self):
 		"""A previous window is moved past the target window. This does not affect the z-order."""
-		self._startIndex = 2  # A window at this index
-		self._endIndex = 9  # is moved to this index
-		self._triggerIndex = 5  # when this index is reached
+		self._queuedMove = _MoveWindow(
+			startIndex=2,
+			endIndex=9,
+			triggerIndex=5
+		)
 		targetWindow = 7
 		expectedIndex = targetWindow - 1
 		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
 
 	def test_prev_windowMoves_beforeTarget(self):
 		"""A previous window is moved before the target window. It is counted twice."""
-		self._startIndex = 2
-		self._endIndex = 5
-		self._triggerIndex = 3
+		self._queuedMove = _MoveWindow(
+			startIndex=2,
+			endIndex=5,
+			triggerIndex=3
+		)
 		targetWindow = 7
 		expectedIndex = targetWindow  # difference is normally 1, however a window is counted twice
 		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
 
 	def test_active_windowMoves_pastTarget(self):
 		"""A window we are looking at moves past the match, skipping our target window."""
-		self._startIndex = 3
-		self._endIndex = 8
-		self._triggerIndex = 3
+		self._queuedMove = _MoveWindow(
+			startIndex=3,
+			endIndex=8,
+			triggerIndex=3
+		)
 		targetWindow = 6
 		self.assertEqual(None, _getWindowZIndex(self._windowMatches(targetWindow)))
 
 	def test_active_windowMoves_beforeTarget(self):
-		pass
+		"""A future window we are looking at moves forward, but before the match, decreasing our z-index."""
+		self._queuedMove = _MoveWindow(
+			startIndex=3,
+			endIndex=4,
+			triggerIndex=3
+		)
+		targetWindow = 7
+		# difference is normally 1, however a window is skipped due to the move
+		expectedIndex = targetWindow - 2
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
 
 	def test_future_windowMoves_pastTarget(self):
-		pass
+		"""A future window moves forward, and past the match.
+		This does not change anything in practice, the windows affected are yet to be indexed.
+		However, during the move, the z-index to target is decreased,
+		as a window is moved past the match."""
+		self._queuedMove = _MoveWindow(
+			startIndex=5,
+			endIndex=9,
+			triggerIndex=3
+		)
+		targetWindow = 7
+		# difference is normally 1, however a window is skipped due to the move
+		expectedIndex = targetWindow - 2
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
 
 	def test_future_windowMoves_beforeTarget(self):
-		pass
+		"""A future window moves forward, and past the match.
+		This does not change anything in practice, the windows affected are yet to be indexed."""
+		self._queuedMove = _MoveWindow(
+			startIndex=5,
+			endIndex=7,
+			triggerIndex=3
+		)
+		targetWindow = 9
+		# difference is normally 1
+		expectedIndex = targetWindow - 1
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -1,0 +1,121 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2022 NV Access Limited.
+
+"""Unit tests for the blockUntilConditionMet submodule.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from utils.security import (
+	_getWindowZIndex,
+)
+import winUser
+
+
+class _Test_getWindowZIndex(unittest.TestCase):
+	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:
+		currentWindowIndex = self._windows.index(hwnd)
+		if relation == winUser.GW_HWNDNEXT:
+			try:
+				return self._windows[currentWindowIndex + 1]
+			except IndexError:
+				return 0
+		elif relation == winUser.GW_HWNDPREV:
+			try:
+				return self._windows[currentWindowIndex - 1]
+			except IndexError:
+				return 0
+		else:
+			return 0
+
+	def _windowMatches(self, expectedWindow: int):
+		def _helper(hwnd: int) -> bool:
+			return hwnd == expectedWindow
+		return _helper
+
+	def setUp(self) -> None:
+		self._getDesktopWindowPatch = patch("winUser.getDesktopWindow", lambda: 0)  # value is discarded by _getTopWindowPatch
+		self._getTopWindowPatch = patch("winUser.getTopWindow", lambda _hwnd: self._windows[0])
+		self._getWindowPatch = patch("winUser.getWindow", self._getWindow_patched)
+		self._getDesktopWindowPatch.start()
+		self._getTopWindowPatch.start()
+		self._getWindowPatch.start()
+		self._windows = list(range(1, 11))  # must be 1 indexed
+		return super().setUp()
+
+	def tearDown(self) -> None:
+		self._getDesktopWindowPatch.stop()
+		self._getTopWindowPatch.stop()
+		self._getWindowPatch.stop()
+		return super().tearDown()
+
+
+class Test_getWindowZIndex_static(_Test_getWindowZIndex):
+	def test_noMatch(self):
+		self.assertIsNone(_getWindowZIndex(lambda x: False))
+
+	def test_firstWindowMatch_noChanges(self):
+		targetWindow = 1
+		expectedIndex = targetWindow - 1
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
+
+	def test_lastWindowMatch_noChanges(self):
+		targetWindow = len(self._windows)
+		expectedIndex = targetWindow - 1
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
+
+
+class Test_getWindowZIndex_dynamic(_Test_getWindowZIndex):
+	_triggered = False
+
+	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:
+		self._moveIndexToNewIndexAtIndexOnce(self._windows.index(hwnd))
+		result = super()._getWindow_patched(hwnd, relation)
+		return result
+
+	def _moveIndexToNewIndexAtIndexOnce(self, currentIndex: int):
+		from logging import getLogger
+		
+		getLogger().error(f"{currentIndex}")
+		if currentIndex == self._triggerIndex and not self._triggered:
+			self._triggered = True
+			window = self._windows.pop(self._startIndex)
+			self._windows.insert(self._endIndex, window)
+
+	def test_prev_windowMoves_pastTarget(self):
+		"""A previous window is moved past the target window. This does not affect the z-order."""
+		self._startIndex = 2
+		self._endIndex = 9
+		self._triggerIndex = 5
+		targetWindow = 7
+		expectedIndex = targetWindow - 1
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
+
+	def test_prev_windowMoves_beforeTarget(self):
+		"""A previous window is moved before the target window. It is counted twice."""
+		self._startIndex = 2
+		self._endIndex = 5
+		self._triggerIndex = 3
+		targetWindow = 7
+		expectedIndex = targetWindow  # difference is normally 1, however a window is counted twice
+		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
+
+	def test_active_windowMoves_pastTarget(self):
+		"""The window we are looking at moves past the match, skipping our target window"""
+		self._startIndex = 3
+		self._endIndex = 8
+		self._triggerIndex = 3
+		targetWindow = 6
+		self.assertEqual(None, _getWindowZIndex(self._windowMatches(targetWindow)))
+
+	def test_active_windowMoves_beforeTarget(self):
+		pass
+
+	def test_future_windowMoves_pastTarget(self):
+		pass
+
+	def test_future_windowMoves_beforeTarget(self):
+		pass

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -87,9 +87,9 @@ class Test_getWindowZIndex_dynamic(_Test_getWindowZIndex):
 
 	def test_prev_windowMoves_pastTarget(self):
 		"""A previous window is moved past the target window. This does not affect the z-order."""
-		self._startIndex = 2
-		self._endIndex = 9
-		self._triggerIndex = 5
+		self._startIndex = 2  # A window at this index
+		self._endIndex = 9  # is moved to this index
+		self._triggerIndex = 5  # when this index is reached
 		targetWindow = 7
 		expectedIndex = targetWindow - 1
 		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
@@ -104,7 +104,7 @@ class Test_getWindowZIndex_dynamic(_Test_getWindowZIndex):
 		self.assertEqual(expectedIndex, _getWindowZIndex(self._windowMatches(targetWindow)))
 
 	def test_active_windowMoves_pastTarget(self):
-		"""The window we are looking at moves past the match, skipping our target window"""
+		"""A window we are looking at moves past the match, skipping our target window."""
 		self._startIndex = 3
 		self._endIndex = 8
 		self._triggerIndex = 3

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -43,19 +43,13 @@ class _Test_isWindowAboveWindowMatchesCond(unittest.TestCase):
 		"""Fetch current window, find adjacent window by relation."""
 		currentWindowIndex = self._windows.index(hwnd)
 		if relation == winUser.GW_HWNDNEXT:
-			try:
 				nextIndex = currentWindowIndex + 1
-			except IndexError:
-				return 0
 		elif relation == winUser.GW_HWNDPREV:
-			try:
 				nextIndex = currentWindowIndex - 1
-			except IndexError:
-				return 0
 		else:
-			return 0
+			return winUser.GW_RESULT_NOT_FOUND
 		if nextIndex >= len(self._windows) or nextIndex < 0:
-			return 0
+			return winUser.GW_RESULT_NOT_FOUND
 		return self._windows[nextIndex]
 
 	def _windowMatches(self, expectedWindow: int):

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -24,7 +24,7 @@ import winUser
 
 @dataclass
 class _MoveWindow:
-	"""Used to move a window from one index to another when a specific index is reached."""
+	"""Used to move a window from one spot to another when a specific window is reached."""
 	HWNDToMove: winUser.HWNDVal  # This window
 	insertBelowHWND: winUser.HWNDVal  # is moved to below this window
 	triggerHWND: winUser.HWNDVal  # when this window is reached

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -21,13 +21,18 @@ import winUser
 
 @dataclass
 class _MoveWindow:
+	"""Used to move a window from one index to another when a specific index is reached."""
 	startIndex: int  # A window at this index
 	endIndex: int  # is moved to this index
 	triggerIndex: int  # when this index is reached
-	triggered = False
+	triggered = False  # If the move has been triggered
 
 
 class _Test_getWindowZIndex(unittest.TestCase):
+	"""
+	Base class to patch winUser functions used in _getWindowZIndex.
+	Navigating windows is replaced by a list of fake HWNDs.
+	"""
 	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:
 		"""Fetch current window, find adjacent window by relation."""
 		currentWindowIndex = self._windows.index(hwnd)
@@ -68,6 +73,7 @@ class _Test_getWindowZIndex(unittest.TestCase):
 
 
 class Test_getWindowZIndex_static(_Test_getWindowZIndex):
+	"""Test fetching a z-index when the order of window does not change"""
 	def test_noMatch(self):
 		self.assertIsNone(_getWindowZIndex(lambda x: False))
 
@@ -83,6 +89,7 @@ class Test_getWindowZIndex_static(_Test_getWindowZIndex):
 
 
 class Test_getWindowZIndex_dynamic(_Test_getWindowZIndex):
+	"""Test fetching a z-index when a window moves during the operation"""
 	_queuedMove: Optional[_MoveWindow] = None
 
 	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,30 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2022.3.3 =
+This is a minor release to fix issues with 2022.3.2, 2022.3.1 and 2022.3.
+
+== Bug Fixes ==
+- Fixed bug where if NVDA freezes when locking, NVDA will allow access to the users desktop while on the Windows lock screen. (#14416)
+- Fixed bug where if NVDA freezes when locking, NVDA will not behave correctly, as if the device was still locked. (#14416)
+- Fixed accessibility issues with the Windows "forgot my PIN" process and Windows update/install experience. (#14368)
+- Fixed bug when trying to install NVDA in some Windows environments, e.g. Windows Server. (#14379)
+-
+
+== Changes for Developers ==
+- ``utils.security.isObjectAboveLockScreen(obj)`` is deprecated, instead use ``obj.isBelowLockScreen``. (#14416)
+- The following functions in ``winAPI.sessionTracking`` are deprecated for removal in 2023.1. (#14416)
+  - ``isWindowsLocked``
+  - ``handleSessionChange``
+  - ``unregister``
+  - ``register``
+  - ``isLockStateSuccessfullyTracked``
+  - 
+- 
+
+=== Deprecations ===
+
+
 = 2022.3.2 =
 This is a minor release to fix regressions with 2022.3.1 and address a security issue.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Supercedes #14358 
Fixes: #14379
Fixes: #14368 

### Summary of the issue:

#### Issue 1: Session tracking notification failures (#14358)
If NVDA freezes, session tracking notifications may be dropped.
If this happens when locking, NVDA will be insecure while on the Windows lock screen.
If this happens when unlocking, NVDA will not behave correctly and be inaccessible while Windows is unlocked.

This is fixed by querying the session directly, and caching this every core cycle.
If a query fails, NVDA should fall back accessible behaviour, rather than secure.

#### Issue 2: Forgot my PIN workflow is inaccessible (#14368)
NVDA cannot read content on the forgot my PIN workflow screen.
This is a similar situation to the lock screen, except an Edge Spartan window is used for the workflow.
This runs on a temporary user profile.

This is fixed by detecting the z-order of windows, and making an window above the lock screen window accessible.

##### Issue 2a: Object navigation does not work on the PIN workflow screen (#14416)
This is because `TextInfo.obj` can be a `TreeInterceptor`, where it was previously documented as just `NVDAObject`.
This assumption caused the `_isSecureObjectWhileLockScreenActivated` function to fail, making object navigation fail.
In those cases, the `TreeInterceptor.rootNVDAObject` should be checked instead.

#### Issue 3: NVDA fails to install in some environments (#14379)
Sometimes an NVDA session query returns an unexpected value.
In this case, default to the "session unknown" behaviour.
If a session query fails, NVDA should roll back to accessible behaviour rather than failing to run.

### Description of user facing changes
PIN workflow screen should become accessible.
NVDA has better session tracking management (i.e. is aware of the lock state more accuractely).
NVDA should handle session query failures without preventing installation, blocking usage, etc.

### Description of development approach

There are 4 security modes of NVDA:
- normal, authenticated user
- secure mode: secure desktop mode (when serviceDebug param not set), or --secure param provided.
Refer to existing docs on this.
- secure desktop mode: enabled secure mode (when serviceDebug param not set).
Also prevents access to some controls, that should not be accessible from the sign-in/UAC dialog.
- lock screen mode: prevents access to user data. Used on the lock screen, which runs on a user desktop.
Also include the reset PIN workflow and out of box experience. (Only Win 10+)

Lock state session tracking is handled by NVDA now, by querying the session state every core pump cycle.

When on lock screen mode, we need to check the z-order of windows to confirm if an NVDA object should be accessible.
The window associated with the NVDAObject should be above the lowest lock screen window.
Lock screen windows can be identified by known class names.
This is risky as class names may change, but the lockapp appModule isn't detectable on the forgot PIN workflow.

We can confirm the windows order by starting at the lowest lock screen, then navigating our way up.
If we can confirm that the NVDA Object is not below the lock screen window, we can make the object accessible.
This method is risky, as z-ordering is dynamic.
There are unit tests to cover this, code aims to make NVDAObjects accessible where the order is unknown.

### Testing strategy:

#### Issue 1
As it is difficult to time and simulate a freeze, general smoke testing on the new session tracking method should be performed instead.

With a try-build, use speech, enable error sounds, and monitor the logs for errors/warnings.
- [x] Smoke test the sign-in flow from lock, switch users, sleep, restart, log in and log out, checking the lock screen, sign-in screen, and general NVDA usage after sign in.
- [x] Smoke test the UAC dialog
- [x] Smoke test the forgot PIN workflow
- [x] Test the STR for known security advisories on the lockscreen, secure screens and PIN workflow:
  - [x] Object navigation getting behind the lock screen
  - [x] Various methods of opening system dialogs to gain system access
  - [x] Various methods of opening improper NVDA dialogs to gain system / user profile access 
 
#### Issue 2
- [x] Smoke test the forgot PIN workflow and object navigation on the screen

**Unit testing**
When on lock screen mode, we need to check the z-order of windows to confirm if an NVDA object should be accessible.
The window associated with the NVDAObject should be above the lowest lock screen window.
We can confirm this by starting at the lowest lock screen, then navigating our way up.
If we can confirm that the NVDA Object is not below the lock screen window, we can make the object accessible.
This method is risky, as z-ordering is dynamic.
There are unit tests to cover this.

#### Issue 3
- [ ] Get users who reported #14379 to test try/alpha build

### Known issues with pull request:

none

### Change log entries:
Refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
