### PR TITLE
Use std min/max, prevent min/max macro

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -87,8 +87,11 @@ env.Append(
 	CPPDEFINES=[
 		'UNICODE',
 		'_CRT_SECURE_NO_DEPRECATE',
-		('LOGLEVEL','${nvdaHelperLogLevel}'),
-		('_WIN32_WINNT','_WIN32_WINNT_WIN7')
+		('LOGLEVEL', '${nvdaHelperLogLevel}'),
+		('_WIN32_WINNT', '_WIN32_WINNT_WIN7'),
+		# NOMINMAX: prevent minwindef.h min/max macro definition, which unexpectedly override developer
+		# expectations
+		'NOMINMAX',
 	]
 )
 

--- a/nvdaHelper/local/beeps.cpp
+++ b/nvdaHelper/local/beeps.cpp
@@ -11,10 +11,13 @@ Copyright 2006-2015 NVDA contributers.
 This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include "beeps.h"
+
+
+using std::min;
+using std::max;
 
 const int sampleRate=44100;
 const int amplitude=14000;

--- a/nvdaHelper/local/nvdaHelperLocal.cpp
+++ b/nvdaHelper/local/nvdaHelperLocal.cpp
@@ -106,7 +106,7 @@ DWORD WINAPI bgSendMessageThreadProc(LPVOID param) {
 				bgSendMessageData.error = ERROR_CANCELLED;
 				break;
 			}
-			if (SendMessageTimeoutW(bgSendMessageData.hwnd, bgSendMessageData.Msg, bgSendMessageData.wParam, bgSendMessageData.lParam, bgSendMessageData.fuFlags, min(remainingTimeout, CANCELSENDMESSAGE_CHECK_INTERVAL), &bgSendMessageData.dwResult) != 0) {
+			if (SendMessageTimeoutW(bgSendMessageData.hwnd, bgSendMessageData.Msg, bgSendMessageData.wParam, bgSendMessageData.lParam, bgSendMessageData.fuFlags, std::min(remainingTimeout, CANCELSENDMESSAGE_CHECK_INTERVAL), &bgSendMessageData.dwResult) != 0) {
 				// Success.
 				bgSendMessageData.error = 0;
 				break;
@@ -167,7 +167,7 @@ LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM
 				SetLastError(ERROR_CANCELLED);
 				return 0;
 			}
-			if ((ret = SendMessageTimeoutW(hwnd, Msg, wParam, lParam, fuFlags, min(remainingTimeout, CANCELSENDMESSAGE_CHECK_INTERVAL), lpdwResult)) != 0 || GetLastError() != ERROR_TIMEOUT) {
+			if ((ret = SendMessageTimeoutW(hwnd, Msg, wParam, lParam, fuFlags, std::min(remainingTimeout, CANCELSENDMESSAGE_CHECK_INTERVAL), lpdwResult)) != 0 || GetLastError() != ERROR_TIMEOUT) {
 				// Success or error other than timeout.
 				return ret;
 			}

--- a/nvdaHelper/readme.md
+++ b/nvdaHelper/readme.md
@@ -53,22 +53,35 @@ The following steps won't prepare a buildable solution, but it will enable intel
 You should still build on the command line to verify errors.
 
 - Ensure you have built NVDA on the command line first.
-- Create a new project from existing code
-- Type: Visual C++, press next.
-- Set the `<repo root>/nvdaHelper/` directory as the project file location.
-- Project name: "nvdaHelper"
-- Add files to the project from these folders: checked.
-  - This should have a single 'checked' item, the path to nvdaHelper
-- Other defaults are fine, press next
-- Select "use external build system" for "How do you want to build the project?", press next
-- Build command line: `scons source`
-- Include search paths: `../include;../miscDeps/include;./;../build\x86_64;../include/minhook/include`
-- Preprocessor definitions: `WIN32;_WINDOWS;_USRDLL;NVDAHELPER_EXPORTS;UNICODE;_CRT_SECURE_NO_DEPRECATE;LOGLEVEL=15;_WIN32_WINNT=_WIN32_WINNT_WIN7;`
-- Forced Included files: `winuser.h`
-- Press next
-- Ensure "same as Debug configuration" is checked and press finish
-- Open the project settings and change the following:
-  - NMake -> Additional Options -> `/std:c++17`
+- From the files menu select: `Create a new project from existing code`
+- "Welcome to the Create Project from Existing Code Files Wizard"
+  - "What type of project would you like to create?": `Visual C++`
+  - Press next.
+- "Specify Project Location and Source Files"
+  - "Project file location": `<repo root>/nvdaHelper/`
+  - Project name: `nvdaHelper`
+  - Add files to the project from these folders: `checked`
+  - One **checked** item: `<path to nvdaHelper>`
+  - Files types to add to the project: **use default**
+  - Show all files in Solution Explorer: *use default (checked)**
+  - Press next
+- "Specify Project Settings"
+  - "How do you want to build the project?": Select `use external build system`
+  - Press next
+-  Specify Debug Configuration Settings
+  - Build command line: `scons source`
+  - Preprocessor definitions (/D): `WIN32;_WINDOWS;_USRDLL;NVDAHELPER_EXPORTS;UNICODE;_CRT_SECURE_NO_DEPRECATE;LOGLEVEL=15;_WIN32_WINNT=_WIN32_WINNT_WIN7;NOMINMAX`
+  - Include search paths (/I): `../include;../miscDeps/include;./;../build\x86_64;../include/minhook/include`
+  - Forced Included files (/FI): `winuser.h`
+  - Press next
+-  Specify Debug Configuration Settings
+  - "Same as Debug configuration": **Checked**
+- Press Finish
+- Set the C++ standard:
+  - In the project menu, select Properties
+  - Select "Configuration:" `All Configurations`
+  - Under "Configuration Properties" select NMake
+  - Set additional Options -> `/std:c++20`
 
 #### To confirm these settings
 - Build NVDA normally
@@ -76,15 +89,15 @@ You should still build on the command line to verify errors.
   - EG
   ```
   cl /Fobuild\x86\vbufBackends\gecko_ia2\gecko_ia2.obj /c build\x86\vbufBackends\gecko_ia2\gecko_ia2.cpp
-  /TP /EHsc /nologo /std:c++17 /Od /MT /W3 /WX
-  /DUNICODE /D_CRT_SECURE_NO_DEPRECATE /DLOGLEVEL=15 /D_WIN32_WINNT=_WIN32_WINNT_WIN7 /DNDEBUG
+  /TP /EHsc /nologo /std:c++20 /permissive- /Od /MT /W3 /WX
+  /DUNICODE /D_CRT_SECURE_NO_DEPRECATE /DLOGLEVEL=15 /D_WIN32_WINNT=_WIN32_WINNT_WIN7 /DNOMINMAX /DNDEBUG
   /Iinclude /Imiscdeps\include /Ibuild\x86
   /Z7
   ```
 - This shows the:
   - defines beginning with `/D`
   - includes directories beginning with `/I`
-  - Additional options like `/std:c++17`
+  - Additional options like `/std:c++20`
 
 ### Virtual Buffer Backends
 

--- a/nvdaHelper/remote/tsf.cpp
+++ b/nvdaHelper/remote/tsf.cpp
@@ -13,6 +13,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
 #include <map>
+#include <algorithm>
 #include <windows.h>
 #include <wchar.h>
 #include <msctf.h>
@@ -500,10 +501,12 @@ STDMETHODIMP TsfSink::OnEndEdit(
 		return S_OK;
 	}
 	inComposition=true;
-	wchar_t buf[256];
+	constexpr unsigned long BUF_SIZE = 256;
+	wchar_t buf[BUF_SIZE];
 	ULONG len = ARRAYSIZE(buf) - 1;
 	pRange->GetText(cookie, 0, buf, len, &len);
-	buf[min(len,255)]=L'\0';
+	const ULONG strNullCharIndex = std::min(len, BUF_SIZE - 1);
+	buf[strNullCharIndex] = L'\0';
 	long compStart=0;
 	fetchRangeExtent(pRange,&compStart,&len);
 	long selStart=compStart;
@@ -515,8 +518,8 @@ STDMETHODIMP TsfSink::OnEndEdit(
 		}
 		tfSelection.range->Release();
 	}
-	selStart=max(0,selStart-compStart);
-	selEnd=max(0,selEnd-compStart);
+	selStart = std::max(0l, selStart-compStart);
+	selEnd = std::max(0l, selEnd-compStart);
 	nvdaControllerInternal_inputCompositionUpdate(buf,selStart,selEnd,0);
 	return S_OK;
 }


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Windows include files (`minwindef.h`) provide `min` and `max` macros.
These interfere with the type safe and standard `std::min` and `std::max`

### Description of user facing changes
None

### Description of development approach
- Prevent the definition of `min`/`max` by supplying `/DNOMINMAX` during the build.
- Updated `nvdaHelper` readme to include this and other changes (updated `c++` standard)
- Fixed code that relied on the `min`/`max` macros.

### Testing strategy:
- Local build, smoke testing.
- System tests on PR build.

### Known issues with pull request:
None.

### Change log entries:
None.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
