### PR TITLE
Braille: report 'details' for non-landmarks

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -785,6 +785,8 @@ def getControlFieldBraille(  # noqa: C901
 			text.append(getPropertiesBraille(description=description))
 		if current:
 			text.append(getPropertiesBraille(current=current))
+		if hasDetails:
+			text.append(getPropertiesBraille(hasDetails=hasDetails, detailsRole=detailsRole))
 		if role == controlTypes.Role.GRAPHIC and content:
 			text.append(content)
 		return TEXT_SEPARATOR.join(text) if len(text) != 0 else None

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -225,30 +225,6 @@ def test_mark_aria_details_role():
 		"form",
 	])
 
-	# TODO: fix known bug with braille not announcing details #13815
-	expectedBraille = " ".join([  # noqa: F841
-		"mln",
-		"edit",
-		# the role doc-endnote is unsupported as an IA2 role
-		# The role "ROLE_LIST_ITEM" is used instead
-		"details",
-		"doc endnote,",
-		"has fnote",
-		"doc footnote,",
-		"has cmnt",
-		"comment,",
-		# the role definition is unsupported as an IA2 role
-		# The role "ROLE_PARAGRAPH" is used instead
-		"details",
-		"definition,",
-		"details",
-		"definition,",
-		# The role "form" is deliberately unsupported
-		"details",
-		"form",
-		"edt end",
-	])
-
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey('downArrow')
 
 	_asserts.speech_matches(
@@ -257,11 +233,34 @@ def test_mark_aria_details_role():
 		message="Browse mode speech: Read line with different aria details roles."
 	)
 	_asserts.braille_matches(
-		actualBraille,
-		# TODO: fix known bug with braille not announcing details #13815
-		# expectedBraille,
-		"mln edt doc-endnote, doc-footnote, comment, definition, definition, form edt end",
 		message="Browse mode braille: Read line with different aria details roles.",
+		actual=actualBraille,
+		expected=" ".join([
+			"mln",
+			"edt ",
+			# the role doc-endnote is unsupported as an IA2 role
+			# The role "ROLE_LIST_ITEM" is used instead
+			"details",
+			"doc-endnote,",
+			" ",  # space between spans
+			"has fnote",
+			"doc-footnote,",
+			" ",  # space between spans
+			"has cmnt",
+			"comment,",
+			" ",  # space between spans
+			# the role definition is unsupported as an IA2 role
+			# The role "ROLE_PARAGRAPH" is used instead
+			"details",
+			"definition,",
+			" ",  # space between spans
+			"details",
+			"definition,",
+			# The role "form" is deliberately unsupported
+			# "details",
+			# "form",
+			# "edt end",
+		])
 	)
 	
 	# Reset caret
@@ -291,11 +290,35 @@ def test_mark_aria_details_role():
 		message="Focus mode speech: Read line with different aria details roles"
 	)
 	_asserts.braille_matches(
-		actualBraille,
-		# TODO: fix known bug with braille not announcing details #13815
-		# expectedBraille,
-		"doc-endnote, doc-footnote, comment, definition, definition, form",
 		message="Focus mode braille: Read line with different aria details roles",
+		actual=actualBraille,
+		expected=" ".join([
+			# no "mln edt"
+			# the role doc-endnote is unsupported as an IA2 role
+			# The role "ROLE_LIST_ITEM" is used instead
+			"details",
+			"doc-endnote,",
+			" ",  # space between spans
+			"has fnote",
+			"doc-footnote,",
+			" ",  # space between spans
+			"has cmnt",
+			"comment,",
+			" ",  # space between spans
+			# the role definition is unsupported as an IA2 role
+			# The role "ROLE_PARAGRAPH" is used instead
+			"details",
+			"definition,",
+			" ",  # space between spans
+			"details",
+			"definition,",
+			" ",  # space between spans
+			"d"  # Is this the start of the word 'details' with the rest cut-off?
+			# The role "form" is deliberately unsupported
+			# "details",
+			# "form",
+			# "edt end",
+		])
 	)
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ What's New in NVDA
   - In some rare cases, these settings used in profiles may be unexpectedly modified when installing this version of NVDA.
   - Please check these options in your profiles after upgrading NVDA to this version.
   -
+- The presence of an annotation is no longer missing in braille for some elements. (#13815)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13815

### Summary of the issue:
"details" not reported with braille for some elements.
Test case: https://codepen.io/reefturner/pen/VwdgxPv

### Description of user facing changes
Braille will now report "details" for non-landmark elements.

### Description of development approach
Found missing case, get braille for text properties and add to output.

### Testing strategy:
Manually tested case: https://codepen.io/reefturner/pen/VwdgxPv

### Known issues with pull request:
None

### Change log entries:
Bug fixes
```
- The presence of an annotation is no longer missing in braille for some elements.
```

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
