### PR TITLE
Support multiple details roles

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -407,6 +407,10 @@ void GeckoVBufBackend_t::fillVBufAriaDetails(
 		auto detailsChildNode = buffer.getControlFieldNodeWithIdentifier(docHandle, detailsId.value());
 		if (detailsChildNode != nullptr) {
 			detailsRole = detailsChildNode->getAttribute(L"role");
+			if (!detailsRole.has_value()) {
+				// This is not an error, the target may not have a role listed in its attributes.
+				LOG_DEBUG(L"Couldn't find attribute: '" << roleName << '\'');
+			}
 		}
 	}
 	if (detailsForId.has_value()) {

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -472,14 +472,18 @@ void GeckoVBufBackend_t::fillVBufAriaDetails(
 					_extendDetailsRolesAttribute(nodeBeingFilled, *targetDetailsRole);
 				}
 				else {
-					// This is not an error, the target may not have a role listed in its attributes.
-					/* todo: Add "details" to the ariaDetailsRoles. Explanation:
-						hasDetail=True is not enough to describe the scenario when there multiple details
-						relations but one has a generic role, EG. a comment and an 'unknown' role.
-						This would then produce 'hasDetail=True detailsRoles="comment"'
-						Instead of the preferred 'hasDetail=True detailsRoles="comment, details"'
+					/*
+					This is not an error, the target may not have a role listed in its attributes.
+					Add "unknown" to the ariaDetailsRoles.
+					Explanation:
+					hasDetail=True is not enough to describe the scenario when there multiple details
+					relations but one has a generic role, EG. a comment and an 'unknown' role.
+					This would then produce attributes 'hasDetail=True detailsRoles="comment"',
+					reported as "has comment" since only one role is listed.
+					Instead prefer 'hasDetail=True detailsRoles="comment, unknown"',
+					reported as "has comment has details" since both roles are listed.
 					*/
-					LOG_DEBUG(L"Couldn't find attribute: '" << roleName << '\'');
+					_extendDetailsRolesAttribute(nodeBeingFilled, L"unknown");
 				}
 			}
 		}

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -55,7 +55,15 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	std::wstring toolkitName;
 
-	std::optional<int> getRelationId(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2);
+	/* Get the IAccessible IDs for all relation targets of the specified relation type.
+	* @param ia2TargetRelation: The type of relation to fetch. Use IA2_RELATION_* constants
+			from 'include/ia2/api/AccessibleRelation.idl' becomes 'build/<arch>/ia2.h'
+	* @param pacc2: The element to fetch relations for.
+	*/
+	std::vector<int> getAllRelationIdsForRelationType(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2);
+
+	/*
+	*/
 	std::optional< LabelInfo > getLabelInfo(IAccessible2* pacc2);
 
 	/* Get relation elements of the type.
@@ -89,5 +97,6 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 	GeckoVBufBackend_t(int docHandle, int ID);
 
 };
+
 
 #endif

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -57,7 +57,18 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	std::optional<int> getRelationId(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2);
 	std::optional< LabelInfo > getLabelInfo(IAccessible2* pacc2);
-	CComPtr<IAccessible2> getRelationElement(LPCOLESTR ia2TargetRelation, IAccessible2_2* element);
+
+	/* Get relation elements of the type.
+	 * @param ia2TargetRelation: The type of relation to fetch. Use IA2_RELATION_* constants
+			from 'include/ia2/api/AccessibleRelation.idl' becomes 'build/<arch>/ia2.h'
+	 * @param element: The element to fetch relations for.
+	 * @param numRelations: If supplied, only return up to numRelations. Note: Fetches all by default.
+	 */
+	std::vector<CComQIPtr<IAccessible2>> getRelationElementsOfType(
+		LPCOLESTR ia2TargetRelation,
+		IAccessible2_2* element,
+		const std::optional<std::size_t> numRelations = {}
+	);
 	CComPtr<IAccessible2> getSelectedItem(IAccessible2* container,
 		const std::map<std::wstring, std::wstring>& attribs);
 

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -33,12 +33,20 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 		bool ignoreInteractiveUnlabelledGraphics=false
 	);
 
+	/* Fill the virtual buffer with information required for aria details (annotations) information.
+	 * @note: Expected to be called by fillVBuf
+	 * @param docHandle: The handle of the current document, required to identify target/origin of an annotation relationship.
+	 * @param pacc: The IAccessible for the nodeBeingFilled
+	 * @param buffer: The virtual buffer that is being filled, used to get the other side of the relationship (target/origin)
+	 * @param nodeBeingFilled: The current node being filled. This maybe a target, origin, or neither.
+	 * @param nodeBeingFilledRole: The role of the parentNode, used to set the detailsRole in the origin of the annotation relationship.
+	 */
 	void fillVBufAriaDetails(
 		int docHandle,
 		CComPtr<IAccessible2> pacc,
 		VBufStorage_buffer_t& buffer,
-		VBufStorage_controlFieldNode_t& parentNode,
-		const std::wstring& roleAttr
+		VBufStorage_controlFieldNode_t& nodeBeingFilled,
+		const std::wstring& nodeBeingFilledRole
 	);
 
 	void versionSpecificInit(IAccessible2* pacc);

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -328,7 +328,6 @@ std::optional<std::wstring> VBufStorage_fieldNode_t::getAttribute(const std::wst
 	if (foundAttrib != attributes.end()) {
 		return foundAttrib->second;
 	}
-	LOG_ERROR(L"Couldn't find attribute " << name);
 	return std::nullopt;
 }
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1523,7 +1523,7 @@ the NVDAObject for IAccessible
 			self,
 			relationType: "IAccessibleHandler.RelationType",
 			maxRelations: int = 1,
-	) -> typing.List[IUnknown]:
+	) -> typing.Iterable[IUnknown]:
 		"""Gets the target IAccessible (actually IUnknown; use QueryInterface or
 		normalizeIAccessible to resolve) for the relations with given type.
 		Allows escape of exception: COMError(-2147417836, 'Requested object does not exist.'),
@@ -1539,17 +1539,20 @@ the NVDAObject for IAccessible
 			raise ValueError
 		if not isinstance(acc, IA2.IAccessible2_2):
 			acc = acc.QueryInterface(IA2.IAccessible2_2)
+
 		targets, count = acc.relationTargetsOfType(
 			relationType.value,
+			# todo: bug in relationTargetsOfType? Chrome returns count of two when (there are two)
+			#  but maxRelations is 1.
 			maxRelations
 		)
+		log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
 		if count == 0:
-			return list()
-		relationsGen = (
+			return
+		yield from (
 			targets[i]
 			for i in range(min(maxRelations, count))
 		)
-		return list(relationsGen)
 
 	def _getIA2RelationFirstTarget(
 			self,
@@ -1568,9 +1571,10 @@ the NVDAObject for IAccessible
 
 		try:
 			# rather than fetch all the relations and querying the type, do that in process for performance reasons
-			targets = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
-			if targets:
-				ia2Object = IAccessibleHandler.normalizeIAccessible(targets[0])
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				# Just take the first.
 				return IAccessible(
 					IAccessibleObject=ia2Object,
 					IAccessibleChildID=0
@@ -1578,7 +1582,7 @@ the NVDAObject for IAccessible
 		except (NotImplementedError, COMError):
 			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
 
-		# eg IA2_2 is not available, fall back to old approach
+		# IA2_2 is not available, fall back to old approach
 		try:
 			for relation in self._IA2Relations:
 				if relation.relationType == relationType:
@@ -1594,8 +1598,61 @@ the NVDAObject for IAccessible
 			pass
 		return None
 
+	def _getIA2RelationTargetsOfType(
+			self,
+			relationType: typing.Union[str, "IAccessibleHandler.RelationType"]
+	) -> typing.Iterable["IAccessible"]:
+		""" Get the targets for the relation of type.
+		Higher level function than _getIA2TargetsForRelationsOfType
+		@param relationType: The type of relation to fetch.
+		"""
+		if not isinstance(relationType, IAccessibleHandler.RelationType):
+			if isinstance(relationType, str):
+				relationType = IAccessibleHandler.RelationType(relationType)
+			else:
+				raise TypeError(f"Bad type for 'relationType' arg, got: {type(relationType)}")
+
+		relationType = typing.cast(IAccessibleHandler.RelationType, relationType)
+
+		try:
+			# rather than fetch all the relations and querying the type, do that in process for performance reasons
+			# todo: but with nRelations in chrome? Returns 1 when there should be two?
+			# maxRelsToFetch = self.IAccessibleObject.nRelations  # they may or may not all match 'relationType'
+			maxRelsToFetch = 10
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=maxRelsToFetch)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				ia = IAccessible(
+					IAccessibleObject=ia2Object,
+					IAccessibleChildID=0
+				)
+				yield ia
+			# NotImplementedError is expected to occur for all targets or none.
+			return  # Iterated all targets without error.
+		except (NotImplementedError, COMError):
+			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
+
+		# IA2_2 is not available, fall back to old approach
+		log.debugWarning("IA2_2 is not available, fall back to old approach")
+		try:
+			for relation in self._IA2Relations:
+				if relation.relationType == relationType:
+					# Take the first of 'relation.nTargets' see IAccessibleRelation._methods_
+					for i in range(0, relation.nTargets):
+						target = relation.target(i)
+						ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+						yield IAccessible(
+							IAccessibleObject=ia2Object,
+							IAccessibleChildID=0
+						)
+			return
+		except (NotImplementedError, COMError):
+			log.debug("Unable to fetch _IA2Relations", exc_info=True)
+			pass
+		return None
+
 	#: Type definition for auto prop '_get_detailsRelations'
-	detailsRelations: typing.Iterable["IAccessible"]
+	detailsRelations: typing.List["IAccessible"]
 
 	def _get_controllerFor(self) -> List[NVDAObject]:
 		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
@@ -1603,11 +1660,10 @@ the NVDAObject for IAccessible
 			return [control]
 		return []
 
-	def _get_detailsRelations(self) -> typing.Iterable["IAccessible"]:
-		relationTarget = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.DETAILS)
-		if not relationTarget:
-			return ()
-		return (relationTarget, )
+	def _get_detailsRelations(self) -> typing.List["IAccessible"]:
+		detailsRelsGen = self._getIA2RelationTargetsOfType(IAccessibleHandler.RelationType.DETAILS)
+		# due to caching of baseObject.AutoPropertyObject, do not attempt to return a generator.
+		return list(detailsRelsGen)
 
 	#: Type definition for auto prop '_get_flowsTo'
 	flowsTo: typing.Optional["IAccessible"]
@@ -1763,7 +1819,7 @@ the NVDAObject for IAccessible
 				ret = "exception: %s" % e
 			info.append("IAccessible2 attributes: %s" % ret)
 			try:
-				ret = ", ".join(r.RelationType for r in self._IA2Relations)
+				ret = ", ".join(f"{r.RelationType} * {r.nTargets}" for r in self._IA2Relations)
 			except Exception as e:
 				ret = f"exception: {e}"
 			info.append(f"IAccessible2 relations: {ret}")

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 	from treeInterceptorHandler import TreeInterceptor  # noqa: F401
 
 supportedAriaDetailsRoles: Dict[str, Optional[controlTypes.Role]] = {
-	"details": None,  # no explicit role
+	"unknown": None,  # no explicit role, should be reported as "details"
 	"comment": controlTypes.Role.COMMENT,
 	"doc-footnote": controlTypes.Role.FOOTNOTE,
 	# These roles are current unsupported by IAccessible2,

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
 	from treeInterceptorHandler import TreeInterceptor  # noqa: F401
 
 supportedAriaDetailsRoles: Dict[str, Optional[controlTypes.Role]] = {
+	"details": None,  # no explicit role
 	"comment": controlTypes.Role.COMMENT,
 	"doc-footnote": controlTypes.Role.FOOTNOTE,
 	# These roles are current unsupported by IAccessible2,

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -17,6 +17,7 @@ from annotation import (
 from comInterfaces import IAccessible2Lib as IA2
 import controlTypes
 from logHandler import log
+import warnings
 from documentBase import DocumentWithTableNavigation
 from NVDAObjects.behaviors import Dialog, WebDialog 
 from . import IAccessible, Groupbox
@@ -142,15 +143,39 @@ class Ia2Web(IAccessible):
 		return annotationOrigin
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
+		warnings.warn(
+			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		for summary in self.annotations.summaries:
 			# just take the first for now.
 			return summary
 
 	@property
 	def hasDetails(self) -> bool:
+		warnings.warn(
+			"NVDAObject.hasDetails is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		return bool(self.annotations)
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
+		warnings.warn(
+			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		for role in self.annotations.roles:
 			# just take the first for now.
 			return role

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -60,9 +60,12 @@ class IA2WebAnnotation(AnnotationOrigin):
 			if config.conf["debugLog"]["annotations"]:
 				log.debug("no annotations available")
 			return
-		detailsRelations = self._originObj.detailsRelations
-		for rel in detailsRelations:
-			yield IA2WebAnnotationTarget(rel)
+
+		ia2WebAnnotationTargetsGen = (
+			IA2WebAnnotationTarget(rel)
+			for rel in self._originObj.detailsRelations
+		)
+		yield from ia2WebAnnotationTargetsGen
 
 	@property
 	def roles(self) -> typing.Iterable["controlTypes.Role"]:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -10,6 +10,10 @@ from ctypes import c_short
 from comtypes import COMError, BSTR
 
 import oleacc
+from annotation import (
+	AnnotationTarget,
+	AnnotationOrigin
+)
 from comInterfaces import IAccessible2Lib as IA2
 import controlTypes
 from logHandler import log
@@ -22,6 +26,73 @@ import api
 import speech
 import config
 import NVDAObjects
+
+
+class IA2WebAnnotationTarget(AnnotationTarget):
+	def __init__(self, target: IAccessible):
+		self._target: IAccessible = target
+
+	@property
+	def summary(self) -> str:
+		return self._target.summarizeInProcess()
+
+	@property
+	def role(self) -> "controlTypes.Role":
+		return self._target.role
+
+	@property
+	def targetObject(self) -> IAccessible:
+		return self._target
+
+
+class IA2WebAnnotation(AnnotationOrigin):
+	_originObj: "Ia2Web"
+
+	def __bool__(self) -> bool:
+		return bool(
+			self._originObj.IA2Attributes.get("details-roles")
+		)
+
+	@property
+	def targets(self) -> typing.Iterable[AnnotationTarget]:
+		if not bool(self):
+			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("no annotations available")
+			return
+		detailsRelations = self._originObj.detailsRelations
+		for rel in detailsRelations:
+			yield IA2WebAnnotationTarget(rel)
+
+	@property
+	def roles(self) -> typing.Iterable["controlTypes.Role"]:
+		"""
+		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
+		to return them.
+		@remarks: The order of "details-roles" IA2Attributes is expected to match the order of detailsRelations
+		objects.
+		"""
+		from .chromium import supportedAriaDetailsRoles
+		# Currently only defined in Chrome as of May 2022
+		# Refer to ComputeDetailsRoles
+		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
+		detailsRoles = self._originObj.IA2Attributes.get("details-roles")
+		if not detailsRoles:
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("details-roles not found")
+			return None
+
+		for roleStr in detailsRoles.split(" "):
+			# Created supported details role
+			detailsRole = supportedAriaDetailsRoles.get(roleStr)
+			if config.conf["debugLog"]["annotations"]:
+				log.debug(f"detailsRole: {repr(detailsRole)}")
+			yield detailsRole
+
+	@property
+	def summaries(self) -> typing.Iterable["str"]:
+		for target in self.targets:
+			yield target.summary
 
 
 class Ia2Web(IAccessible):
@@ -60,42 +131,26 @@ class Ia2Web(IAccessible):
 				log.debugWarning(f"Unknown 'description-from' IA2Attribute value: {ia2attrDescriptionFrom}")
 			return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: "IA2WebAnnotation"
+	"""Typing information for auto property _get_annotations
+	"""
+	def _get_annotations(self) -> "AnnotationOrigin":
+		annotationOrigin = IA2WebAnnotation(self)
+		return annotationOrigin
+
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		if not self.hasDetails:
-			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("no details-roles")
-			return None
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			log.error("should be able to fetch detailsRelations")
-			return None
-		for target in detailsRelations:
+		for summary in self.annotations.summaries:
 			# just take the first for now.
-			return target.summarizeInProcess()
+			return summary
 
 	@property
 	def hasDetails(self) -> bool:
-		return bool(self.IA2Attributes.get("details-roles"))
+		return bool(self.annotations)
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
-		from .chromium import supportedAriaDetailsRoles
-		# Currently only defined in Chrome as of May 2022
-		# Refer to ComputeDetailsRoles
-		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
-		detailsRoles = self.IA2Attributes.get("details-roles")
-		if not detailsRoles:
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("details-roles not found")
-			return None
-		
-		firstDetailsRole = detailsRoles.split(" ")[0]
-		# return a supported details role
-		detailsRole = supportedAriaDetailsRoles.get(firstDetailsRole)
-		if config.conf["debugLog"]["annotations"]:
-			log.debug(f"detailsRole: {repr(detailsRole)}")
-		return detailsRole
-
+		for role in self.annotations.roles:
+			# just take the first for now.
+			return role
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
 		ia2attrCurrent: str = self.IA2Attributes.get("current", "false")

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -14,6 +14,7 @@ import winUser
 import controlTypes
 from . import IAccessible, WindowRoot
 from logHandler import log
+import warnings
 from NVDAObjects.behaviors import RowWithFakeNavigation
 from . import ia2Web
 from typing import (
@@ -140,17 +141,41 @@ class Mozilla(ia2Web.Ia2Web):
 		return annotationOrigin
 
 	def _get_detailsSummary(self) -> Optional[str]:
+		warnings.warn(
+			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		for summary in self.annotations.summaries:
 			# just take the first for now.
 			return summary
 
 	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
+		warnings.warn(
+			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		for role in self.annotations.roles:
 			# just take the first target for now.
 			return role
 
 	@property
 	def hasDetails(self) -> bool:
+		warnings.warn(
+			"NVDAObject.hasDetails is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		return bool(self.annotations)
 
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -16,6 +16,7 @@ from annotation import (
 	AnnotationOrigin,
 )
 from logHandler import log
+import warnings
 import review
 import eventHandler
 from displayModel import DisplayModelTextInfo
@@ -524,12 +525,20 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 			)
 		return None
 
-	#: Typing information for auto property _get_detailsSummary
 	detailsSummary: typing.Optional[str]
+	""" Typing information for auto property _get_detailsSummary
+	Deprecated, use self.annotations.roles instead.
+	"""
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		if config.conf["debugLog"]["annotations"]:
-			log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
+		warnings.warn(
+			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		return None
 
 	@property
@@ -537,6 +546,14 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""Default implementation is based on the result of _get_detailsSummary
 		In most instances this should be optimised.
 		"""
+		warnings.warn(
+			"NVDAObject.hasDetails is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		return bool(self.annotations)
 
 	detailsRole: typing.Optional[controlTypes.Role]
@@ -545,6 +562,14 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	"""
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
+		warnings.warn(
+			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
+			category=DeprecationWarning,
+			# Stack level is used to point to the callers code.
+			# Rather than this method, point to the code that called the deprecated method.
+			# 4 levels required due to autoProperty wrappers
+			stacklevel=4
+		)
 		if config.conf["debugLog"]["annotations"]:
 			log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
 		return None

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -12,6 +12,9 @@ import time
 import typing
 import weakref
 import textUtils
+from annotation import (
+	AnnotationOrigin,
+)
 from logHandler import log
 import review
 import eventHandler
@@ -510,6 +513,17 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
 		return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: "AnnotationOrigin"
+	"""Typing information for auto property _get_annotations
+	"""
+
+	def _get_annotations(self) -> typing.Optional["AnnotationOrigin"]:
+		if config.conf["debugLog"]["annotations"]:
+			log.debugWarning(
+				f"Fetching annotations not supported on: {self.__class__.__qualname__}"
+			)
+		return None
+
 	#: Typing information for auto property _get_detailsSummary
 	detailsSummary: typing.Optional[str]
 
@@ -523,7 +537,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""Default implementation is based on the result of _get_detailsSummary
 		In most instances this should be optimised.
 		"""
-		return bool(self.detailsSummary)
+		return bool(self.annotations)
 
 	#: Typing information for auto property _get_detailsRole
 	detailsRole: typing.Optional[controlTypes.Role]

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -539,8 +539,10 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""
 		return bool(self.annotations)
 
-	#: Typing information for auto property _get_detailsRole
 	detailsRole: typing.Optional[controlTypes.Role]
+	"""Typing information for auto property _get_detailsRole
+	Deprecated, use self.annotations.roles instead.
+	"""
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
 		if config.conf["debugLog"]["annotations"]:

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -1,0 +1,45 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+import typing
+
+if typing.TYPE_CHECKING:
+	import controlTypes
+	from NVDAObjects import NVDAObject
+
+
+class AnnotationTarget:
+	@property
+	def role(self) -> "controlTypes.Role":
+		raise NotImplementedError
+
+	@property
+	def targetObject(self) -> "NVDAObject":
+		raise NotImplementedError
+
+	@property
+	def summary(self) -> str:
+		raise NotImplementedError
+
+
+class AnnotationOrigin:
+	def __init__(self, originObj: "NVDAObject"):
+		self._originObj: "NVDAObject" = originObj
+
+	def __bool__(self):
+		"""Performant implementation required to test for annotations
+		"""
+		raise NotImplementedError
+
+	@property
+	def targets(self) -> typing.Iterable[AnnotationTarget]:
+		raise NotImplementedError
+
+	@property
+	def roles(self) -> typing.Iterable["controlTypes.Role"]:
+		raise NotImplementedError
+
+	@property
+	def summaries(self) -> typing.Iterable["str"]:
+		raise NotImplementedError

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -24,6 +24,11 @@ class AnnotationTarget:
 
 
 class AnnotationOrigin:
+	""" Annotation relation information.
+	Each origin may have many annotation targets.
+	Targets can have different roles.
+	This class encapsulates the relation.
+	"""
 	def __init__(self, originObj: "NVDAObject"):
 		self._originObj: "NVDAObject" = originObj
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -584,7 +584,8 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 		detailsRoles: typing.Set[controlTypes.Role] = set(propertyValues.get("detailsRoles", []))
 		if detailsRoles:
 			detailsRoleLabels = (
-				roleLabels.get(role, role.displayString) if role else _("details")
+				roleLabels.get(role, role.displayString)
+				if role else _("details")  # handle the generic case.
 				for role in detailsRoles
 			)
 			# Translators: Braille when there are further details/annotations that can be fetched manually.
@@ -593,7 +594,7 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 		else:
 			textList.append(
 				# Translators: Braille when there are further details/annotations that can be fetched manually.
-				_("details")
+				_("has details")  # be consistent with reporting the generic case.
 			)
 	keyboardShortcut = propertyValues.get("keyboardShortcut")
 	if keyboardShortcut:

--- a/source/braille.py
+++ b/source/braille.py
@@ -688,15 +688,15 @@ class NVDAObjectRegion(Region):
 			)
 		)
 		description = obj.description if _shouldUseDescription else None
-
+		detailsRoles = obj.annotations.roles if obj.annotations else None
 		text = getPropertiesBraille(
 			name=name,
 			role=role,
 			roleText=obj.roleTextBraille,
 			current=obj.isCurrent,
 			placeholder=placeholderValue,
-			hasDetails=obj.hasDetails,
-			detailsRole=obj.detailsRole,
+			hasDetails=bool(obj.annotations),
+			detailsRoles=detailsRoles,
 			value=obj.value if not NVDAObjectHasUsefulText(obj) else None ,
 			states=obj.states,
 			description=description,

--- a/source/braille.py
+++ b/source/braille.py
@@ -788,6 +788,8 @@ def getControlFieldBraille(  # noqa: C901
 			text.append(getPropertiesBraille(description=description))
 		if current:
 			text.append(getPropertiesBraille(current=current))
+		if hasDetails:
+			text.append(getPropertiesBraille(hasDetails=hasDetails, detailsRoles=detailsRoles))
 		if role == controlTypes.Role.GRAPHIC and content:
 			text.append(content)
 		return TEXT_SEPARATOR.join(text) if len(text) != 0 else None

--- a/source/braille.py
+++ b/source/braille.py
@@ -581,12 +581,15 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 		textList.append(description)
 	hasDetails = propertyValues.get("hasDetails")
 	if hasDetails:
-		detailsRole: Optional[controlTypes.Role] = propertyValues.get("detailsRole")
-		if detailsRole is not None:
-			detailsRoleLabel = roleLabels.get(detailsRole, detailsRole.displayString)
+		detailsRoles: typing.Set[controlTypes.Role] = set(propertyValues.get("detailsRoles", []))
+		if detailsRoles:
+			detailsRoleLabels = (
+				roleLabels.get(role, role.displayString) if role else _("details")
+				for role in detailsRoles
+			)
 			# Translators: Braille when there are further details/annotations that can be fetched manually.
-			# %s specifies the type of details (e.g. comment, suggestion)
-			textList.append(_("has %s") % detailsRoleLabel)
+			# %s specifies the type of details (e.g. "has comment suggestion")
+			textList.append(_("has %s") % " ".join(detailsRoleLabels))  # no comma to save cells on braille display
 		else:
 			textList.append(
 				# Translators: Braille when there are further details/annotations that can be fetched manually.
@@ -768,9 +771,9 @@ def getControlFieldBraille(  # noqa: C901
 	placeholder=field.get('placeholder', None)
 	hasDetails = field.get('hasDetails', False) and config.conf["annotations"]["reportDetails"]
 	if config.conf["annotations"]["reportDetails"]:
-		detailsRole: Optional[controlTypes.Role] = field.get('detailsRole')
+		detailsRoles: typing.Set[None, controlTypes.Role] = field.get('detailsRoles')
 	else:
-		detailsRole = None
+		detailsRoles = set()
 
 	roleText = field.get('roleTextBraille', field.get('roleText'))
 	landmark = field.get("landmark")
@@ -803,7 +806,7 @@ def getControlFieldBraille(  # noqa: C901
 			"current": current,
 			"description": description,
 			"hasDetails": hasDetails,
-			"detailsRole": detailsRole,
+			"detailsRoles": detailsRoles,
 		}
 		if reportTableHeaders in (ReportTableHeaders.ROWS_AND_COLUMNS, ReportTableHeaders.COLUMNS):
 			props["columnHeaderText"] = field.get("table-columnheadertext")
@@ -821,7 +824,7 @@ def getControlFieldBraille(  # noqa: C901
 			"roleText": roleText,
 			"description": description,
 			"hasDetails": hasDetails,
-			"detailsRole": detailsRole,
+			"detailsRoles": detailsRoles,
 		}
 		if field.get('alwaysReportName', False):
 			# Ensure that the name of the field gets presented even if normally it wouldn't.

--- a/source/braille.py
+++ b/source/braille.py
@@ -581,21 +581,29 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 		textList.append(description)
 	hasDetails = propertyValues.get("hasDetails")
 	if hasDetails:
-		detailsRoles: typing.Set[controlTypes.Role] = set(propertyValues.get("detailsRoles", []))
-		if detailsRoles:
-			detailsRoleLabels = (
-				roleLabels.get(role, role.displayString)
-				if role else _("details")  # handle the generic case.
-				for role in detailsRoles
+		# Translators: Braille when there are further details/annotations that can be fetched manually.
+		genericDetailsRole = _("details")
+		detailsRoles: typing.Set[None, controlTypes.Role] = set(propertyValues.get("detailsRoles", []))
+		if not detailsRoles:
+			log.debugWarning(
+				"There should always be detailsRoles (at least a single None value) when hasDetails is true."
 			)
+			textList.append(
+				genericDetailsRole
+			)
+		else:
 			# Translators: Braille when there are further details/annotations that can be fetched manually.
 			# %s specifies the type of details (e.g. "has comment suggestion")
-			textList.append(_("has %s") % " ".join(detailsRoleLabels))  # no comma to save cells on braille display
-		else:
-			textList.append(
-				# Translators: Braille when there are further details/annotations that can be fetched manually.
-				_("has details")  # be consistent with reporting the generic case.
-			)
+			hasDetailsRoleTemplate = _("has %s")
+			rolesLabels = list((
+				hasDetailsRoleTemplate % roleLabels.get(role, role.displayString)
+				for role in detailsRoles
+				if role  # handle none case without the "has X" grammar.
+			))
+			if None in detailsRoles:
+				rolesLabels.insert(0, genericDetailsRole)
+			textList.append(" ".join(rolesLabels))  # no comma to save cells on braille display
+
 	keyboardShortcut = propertyValues.get("keyboardShortcut")
 	if keyboardShortcut:
 		textList.append(keyboardShortcut)

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -155,7 +155,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 		field['roleText'] = obj.roleText
 		field['description'] = obj.description
 		field['_description-from'] = obj.descriptionFrom
-		field['hasDetails'] = obj.hasDetails
+		field['hasDetails'] = bool(obj.annotations)
 		field["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.State.EDITABLE)

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -156,7 +156,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 		field['description'] = obj.description
 		field['_description-from'] = obj.descriptionFrom
 		field['hasDetails'] = obj.hasDetails
-		field["detailsRole"] = obj.detailsRole
+		field["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.State.EDITABLE)
 		states.discard(controlTypes.State.MULTILINE)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2430,6 +2430,41 @@ class GlobalCommands(ScriptableObject):
 		treeInterceptor._set_selection(info, reason=OutputReason.QUICKNAV)
 		speech.speakObject(treeInterceptor.currentNVDAObject, reason=OutputReason.QUICKNAV)
 		api.setNavigatorObject(target.targetObject)
+		self._annotationNav.priorOrigins.append(objWithAnnotation)
+		return
+
+	@script(
+		gesture="kb:NVDA+alt+shift+d",
+		description=_(
+			# Translators: the description for the script_popAnnotationStack script.
+			"Return to annotation subject"
+		),
+		category=SCRCAT_SYSTEMCARET,
+	)
+	def script_popAnnotationStack(self, gesture):
+		"""Go to the annotation details for the single character under the caret or the object with
+		system focus.
+		@note: See related script_reportDetailsSummary
+		"""
+		log.debug("Return to annotation parent.")
+		if not self._annotationNav.priorOrigins:
+			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
+			ui.message(_("No annotation subject present"))
+			return
+		annotationParent = self._annotationNav.priorOrigins.pop()
+		ui.message("Navigating to origin")
+		focus = api.getFocusObject()
+		treeInterceptor = focus.treeInterceptor
+		from browseMode import BrowseModeDocumentTreeInterceptor
+		if not isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) or treeInterceptor.passThrough:
+			ui.message("Not supported yet")
+			return
+		info = treeInterceptor.makeTextInfo(annotationParent)
+		info.collapse()
+		from controlTypes import OutputReason
+		treeInterceptor._set_selection(info, reason=OutputReason.QUICKNAV)
+		speech.speakObject(treeInterceptor.currentNVDAObject, reason=OutputReason.QUICKNAV)
+		api.setNavigatorObject(annotationParent)
 		return
 
 	@script(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2304,8 +2304,8 @@ class GlobalCommands(ScriptableObject):
 		if _isDebugLogCatEnabled:
 			log.debug(f"Trying with nvdaObject : {objAtStart}")
 
-		if objAtStart.detailsSummary:
-			log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
+		if objAtStart.annotations:
+			log.debug(f"NVDAObjectAtStart of caret has details: {list(objAtStart.annotations.summaries)}")
 			return objAtStart
 		elif api.getFocusObject():
 			# If fetching from the caret position fails, try via the focus object
@@ -2317,7 +2317,7 @@ class GlobalCommands(ScriptableObject):
 			if _isDebugLogCatEnabled:
 				log.debug(f"Trying focus object: {focus}")
 
-			if focus.detailsSummary:
+			if focus.annotations:
 				if _isDebugLogCatEnabled:
 					log.debug("focus object has details, able to proceed")
 				return focus

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2305,7 +2305,7 @@ class GlobalCommands(ScriptableObject):
 			log.debug(f"Trying with nvdaObject : {objAtStart}")
 
 		if objAtStart.detailsSummary:
-			log.debug("NVDAObjectAtStart of caret has details.")
+			log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
 			return objAtStart
 		elif api.getFocusObject():
 			# If fetching from the caret position fails, try via the focus object
@@ -2366,17 +2366,28 @@ class GlobalCommands(ScriptableObject):
 			return
 
 		targets = list(objWithAnnotation.annotations.targets)
+		log.debug(f"Number of targets: {len(targets)}")
+		if 1 > len(targets):
+			log.debugWarning("Expected some annotation targets, none retrieved.")
+			return
 		if (
 			self._annotationNav.lastReported
 			and objWithAnnotation == self._annotationNav.lastReported.origin
 			and None is not self._annotationNav.lastReported.indexOfLastReportedSummary
 		):
 			last = self._annotationNav.lastReported.indexOfLastReportedSummary
-			indexOfNextTarget = next(itertools.cycle(itertools.chain(
-				range(last + 1, len(targets)),
-				range(0, last + 1))
-			))
+			indexOfNextTarget = (last + 1) % len(targets)
 		else:
+			log.debug(
+				f"No prior target summary reported:"
+				f" lastReported: {self._annotationNav.lastReported}")
+			if self._annotationNav.lastReported:
+				log.debug(
+					f" objWithAnnotation == self._annotationNav.lastReported.origin: "
+					f"{objWithAnnotation == self._annotationNav.lastReported.origin}"
+					f" self._annotationNav.lastReported.indexOfLastReportedSummary: "
+					f"{self._annotationNav.lastReported.indexOfLastReportedSummary}"
+				)
 			indexOfNextTarget = 0
 		targetToReport = targets[indexOfNextTarget]
 		ui.message(targetToReport.summary)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -495,8 +495,8 @@ def getObjectPropertiesSpeech(  # noqa: C901
 
 		elif value and name == "hasDetails":
 			newPropertyValues['hasDetails'] = obj.hasDetails
-		elif value and name == "detailsRole":
-			newPropertyValues["detailsRole"] = obj.detailsRole
+		elif value and name == "detailsRoles":
+			newPropertyValues["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
 		elif value and name == "descriptionFrom" and (
 			obj.descriptionFrom == controlTypes.DescriptionFrom.ARIA_DESCRIPTION
 		):
@@ -709,7 +709,7 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		'value': True,
 		'description': True,
 		'hasDetails': config.conf["annotations"]["reportDetails"],
-		"detailsRole": config.conf["annotations"]["reportDetails"],
+		"detailsRoles": config.conf["annotations"]["reportDetails"],
 		'descriptionFrom': config.conf["annotations"]["reportAriaDescription"],
 		'keyboardShortcut': True,
 		'positionInfo_level': True,
@@ -1813,13 +1813,15 @@ def getPropertiesSpeech(  # noqa: C901
 	# are there further details
 	hasDetails = propertyValues.get('hasDetails', False)
 	if hasDetails:
-		detailsRole: Optional[controlTypes.Role] = propertyValues.get("detailsRole")
-		if detailsRole is not None:
-			textList.append(
-				# Translators: Speaks when there are further details/annotations that can be fetched manually.
-				# %s specifies the type of details (e.g. comment, suggestion)
-				_("has %s" % detailsRole.displayString)
-			)
+		detailsRoles: typing.Set[controlTypes.Role] = propertyValues.get("detailsRoles", set())
+		if detailsRoles:
+			roleStrings = (role.displayString if role else _("details") for role in detailsRoles)
+			for roleString in roleStrings:
+				textList.append(
+					# Translators: Speaks when there are further details/annotations that can be fetched manually.
+					# %s specifies the type of details (e.g. "comment, suggestion, details")
+					_("has %s" % roleString)
+				)
 		else:
 			textList.append(
 				# Translators: Speaks when there are further details/annotations that can be fetched manually.
@@ -1926,7 +1928,7 @@ def getControlFieldSpeech(  # noqa: C901
 	keyboardShortcut=attrs.get('keyboardShortcut', "")
 	isCurrent = attrs.get('current', controlTypes.IsCurrent.NO)
 	hasDetails = attrs.get('hasDetails', False)
-	detailsRole: Optional[controlTypes.Role] = attrs.get("detailsRole")
+	detailsRoles: typing.Set[controlTypes.Role] = set(attrs.get("detailsRoles", []))
 	placeholderValue=attrs.get('placeholder', None)
 	value=attrs.get('value',"")
 
@@ -1986,7 +1988,7 @@ def getControlFieldSpeech(  # noqa: C901
 			reason=reason, keyboardShortcut=keyboardShortcut
 		)
 	isCurrentSequence = getPropertiesSpeech(reason=reason, current=isCurrent)
-	hasDetailsSequence = getPropertiesSpeech(reason=reason, hasDetails=hasDetails, detailsRole=detailsRole)
+	hasDetailsSequence = getPropertiesSpeech(reason=reason, hasDetails=hasDetails, detailsRoles=detailsRoles)
 	placeholderSequence = getPropertiesSpeech(reason=reason, placeholder=placeholderValue)
 	nameSequence = getPropertiesSpeech(reason=reason, name=name)
 	valueSequence = getPropertiesSpeech(reason=reason, value=value, _role=role)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -494,7 +494,7 @@ def getObjectPropertiesSpeech(  # noqa: C901
 			newPropertyValues['current'] = obj.isCurrent
 
 		elif value and name == "hasDetails":
-			newPropertyValues['hasDetails'] = obj.hasDetails
+			newPropertyValues['hasDetails'] = bool(obj.annotations)
 		elif value and name == "detailsRoles":
 			newPropertyValues["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
 		elif value and name == "descriptionFrom" and (

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -176,7 +176,7 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 			log.debug(f"detailsRoles: {attrs['detailsRoles']}")
 		return super()._normalizeControlField(attrs)
 
-	def _normalizeDetailsRole(self, detailsRoles: str) -> typing.Iterable[controlTypes.Role]:
+	def _normalizeDetailsRole(self, detailsRoles: str) -> typing.Iterable[typing.Optional[controlTypes.Role]]:
 		"""
 		The attribute has been added directly to the buffer as a string, containing a comma separated list
 		of values, each value is either:
@@ -203,6 +203,9 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 					yield None
 			else:
 				# return a supported details role
+				# Note, "unknown" is used when the target has no role.
+				if detailsRole == "unknown":
+					log.debug("Found unknown aria details role")
 				detailsRole = supportedAriaDetailsRoles.get(detailsRole)
 				yield detailsRole
 

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -225,30 +225,6 @@ def test_mark_aria_details_role():
 		"form",
 	])
 
-	# TODO: fix known bug with braille not announcing details #13815
-	expectedBraille = " ".join([  # noqa: F841
-		"mln",
-		"edit",
-		# the role doc-endnote is unsupported as an IA2 role
-		# The role "ROLE_LIST_ITEM" is used instead
-		"details",
-		"doc endnote,",
-		"has fnote",
-		"doc footnote,",
-		"has cmnt",
-		"comment,",
-		# the role definition is unsupported as an IA2 role
-		# The role "ROLE_PARAGRAPH" is used instead
-		"details",
-		"definition,",
-		"details",
-		"definition,",
-		# The role "form" is deliberately unsupported
-		"details",
-		"form",
-		"edt end",
-	])
-
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey('downArrow')
 
 	_asserts.speech_matches(
@@ -257,11 +233,34 @@ def test_mark_aria_details_role():
 		message="Browse mode speech: Read line with different aria details roles."
 	)
 	_asserts.braille_matches(
-		actualBraille,
-		# TODO: fix known bug with braille not announcing details #13815
-		# expectedBraille,
-		"mln edt doc-endnote, doc-footnote, comment, definition, definition, form edt end",
 		message="Browse mode braille: Read line with different aria details roles.",
+		actual=actualBraille,
+		expected=" ".join([
+			"mln",
+			"edt ",
+			# the role doc-endnote is unsupported as an IA2 role
+			# The role "ROLE_LIST_ITEM" is used instead
+			"details",
+			"doc-endnote,",
+			" ",  # space between spans
+			"has fnote",
+			"doc-footnote,",
+			" ",  # space between spans
+			"has cmnt",
+			"comment,",
+			" ",  # space between spans
+			# the role definition is unsupported as an IA2 role
+			# The role "ROLE_PARAGRAPH" is used instead
+			"details",
+			"definition,",
+			" ",  # space between spans
+			"details",
+			"definition,",
+			# The role "form" is deliberately unsupported
+			# "details",
+			# "form",
+			# "edt end",
+		])
 	)
 	
 	# Reset caret
@@ -291,11 +290,35 @@ def test_mark_aria_details_role():
 		message="Focus mode speech: Read line with different aria details roles"
 	)
 	_asserts.braille_matches(
-		actualBraille,
-		# TODO: fix known bug with braille not announcing details #13815
-		# expectedBraille,
-		"doc-endnote, doc-footnote, comment, definition, definition, form",
 		message="Focus mode braille: Read line with different aria details roles",
+		actual=actualBraille,
+		expected=" ".join([
+			# no "mln edt"
+			# the role doc-endnote is unsupported as an IA2 role
+			# The role "ROLE_LIST_ITEM" is used instead
+			"details",
+			"doc-endnote,",
+			" ",  # space between spans
+			"has fnote",
+			"doc-footnote,",
+			" ",  # space between spans
+			"has cmnt",
+			"comment,",
+			" ",  # space between spans
+			# the role definition is unsupported as an IA2 role
+			# The role "ROLE_PARAGRAPH" is used instead
+			"details",
+			"definition,",
+			" ",  # space between spans
+			"details",
+			"definition,",
+			" ",  # space between spans
+			"d"  # Is this the start of the word 'details' with the rest cut-off?
+			# The role "form" is deliberately unsupported
+			# "details",
+			# "form",
+			# "edt end",
+		])
 	)
 
 

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -224,6 +224,8 @@ def test_mark_aria_details_role():
 		"has details",
 		"form",
 	])
+	_spy: NVDASpyLib = _NvdaLib.getSpyLib()
+	_spy.setBrailleCellCount(400)
 
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey('downArrow')
 
@@ -240,7 +242,7 @@ def test_mark_aria_details_role():
 			"edt ",
 			# the role doc-endnote is unsupported as an IA2 role
 			# The role "ROLE_LIST_ITEM" is used instead
-			"has details",
+			"details",
 			"doc-endnote,",
 			" ",  # space between spans
 			"has fnote",
@@ -251,15 +253,15 @@ def test_mark_aria_details_role():
 			" ",  # space between spans
 			# the role definition is unsupported as an IA2 role
 			# The role "ROLE_PARAGRAPH" is used instead
-			"has details",
+			"details",
 			"definition,",
 			" ",  # space between spans
-			"has details",
-			"d",  # definition
-			# The role "form" is deliberately unsupported
-			# "details",
-			# "form",
-			# "edt end",
+			"details",
+			"definition,",
+			" ",
+			"details",
+			"form",
+			"edt end",
 		])
 	)
 	
@@ -296,7 +298,7 @@ def test_mark_aria_details_role():
 			# no "mln edt"
 			# the role doc-endnote is unsupported as an IA2 role
 			# The role "ROLE_LIST_ITEM" is used instead
-			"has details",
+			"details",
 			"doc-endnote,",
 			" ",  # space between spans
 			"has fnote",
@@ -307,14 +309,14 @@ def test_mark_aria_details_role():
 			" ",  # space between spans
 			# the role definition is unsupported as an IA2 role
 			# The role "ROLE_PARAGRAPH" is used instead
-			"has details",
+			"details",
 			"definition,",
 			" ",  # space between spans
-			"has details",
-			"d",  # definition doesn't finish
-			# The role "form" is deliberately unsupported
-			# "details",
-			# "form",
+			"details",
+			"definition,",
+			" ",
+			"details",
+			"form",
 			# "edt end",
 		])
 	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -240,7 +240,7 @@ def test_mark_aria_details_role():
 			"edt ",
 			# the role doc-endnote is unsupported as an IA2 role
 			# The role "ROLE_LIST_ITEM" is used instead
-			"details",
+			"has details",
 			"doc-endnote,",
 			" ",  # space between spans
 			"has fnote",
@@ -251,11 +251,11 @@ def test_mark_aria_details_role():
 			" ",  # space between spans
 			# the role definition is unsupported as an IA2 role
 			# The role "ROLE_PARAGRAPH" is used instead
-			"details",
+			"has details",
 			"definition,",
 			" ",  # space between spans
-			"details",
-			"definition,",
+			"has details",
+			"d",  # definition
 			# The role "form" is deliberately unsupported
 			# "details",
 			# "form",
@@ -296,7 +296,7 @@ def test_mark_aria_details_role():
 			# no "mln edt"
 			# the role doc-endnote is unsupported as an IA2 role
 			# The role "ROLE_LIST_ITEM" is used instead
-			"details",
+			"has details",
 			"doc-endnote,",
 			" ",  # space between spans
 			"has fnote",
@@ -307,13 +307,11 @@ def test_mark_aria_details_role():
 			" ",  # space between spans
 			# the role definition is unsupported as an IA2 role
 			# The role "ROLE_PARAGRAPH" is used instead
-			"details",
+			"has details",
 			"definition,",
 			" ",  # space between spans
-			"details",
-			"definition,",
-			" ",  # space between spans
-			"d"  # Is this the start of the word 'details' with the rest cut-off?
+			"has details",
+			"d",  # definition doesn't finish
 			# The role "form" is deliberately unsupported
 			# "details",
 			# "form",


### PR DESCRIPTION
- [ ] When https://github.com/nvaccess/nvda/pull/14425 is merged, commit ([braille hasDetails for non-landmark](https://github.com/nvaccess/nvda/commit/95ef705d0c677f59eab4109703058bbec9e73133) can be squashed into the prior commit when rebasing on master. Note the plurality change of the variable names.
- [ ] This PR should be stacked on https://github.com/nvaccess/nvda/pull/14389

### Link to issue number:
None

### Summary of the issue:
When multiple annotation targets are present with different roles, NVDA should announce them.
Example:
- A footnote, a comment, and a no-role annotation are present
- NVDA should announce "has footnote, has comment, has details" to make it easier for the user to find the annotation they want to interact with.
- Instead, NVDA was only reporting the role of the first annotation target.

### Description of user facing changes
When the annotation feature is enabled, NVDA will now report all the unique annotation target roles.

### Description of development approach
- From the virtual buffer, exposed comma separated values for the roles of annotation targets via the "detailsRoles" property.
- Converted all aria-details functions to plural form (handling a collection rather than a single optional value).
- Removed usages of, and deprecated `nvdaObject.hasDetails`, `nvdaObject.detailsSummary`, `nvdaObject.detailsRole`
   - These are replaced with new Annotations types.

### Testing strategy:
Manual testing with: https://codepen.io/reefturner/pen/poKLQyj

### Known issues with pull request:
None

### Change log entries:
New features
```
- The presence of multiple annotation types are now reported.
```
For Developers
```
- Deprecated `nvdaObject.hasDetails`, `nvdaObject.detailsSummary`, `nvdaObject.detailsRole`
   - These are replaced with new Annotations types.
```

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
