### PR TITLE
Fix-up 14406: restore combo-box to set log level in GUI parameters.

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -154,11 +154,10 @@ parser.add_argument(
 	'--log-level',
 	dest='logLevel',
 	type=int,
-	default=20,
+	default=0,  # 0 means unspecified in command line.
 	choices=[10, 12, 15, 20, 100],
 	help=(
 		"The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100),"
-		" default is 20 (info)"
 	),
 )
 parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str,help="The path where all settings for NVDA are stored")

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3675,7 +3675,7 @@ Following are the command line options for NVDA:
 | -q | --quit | Quit already running copy of NVDA |
 | -k | --check-running | Report whether NVDA is running via the exit code; 0 if running, 1 if not running |
 | -f LOGFILENAME | --log-file=LOGFILENAME | The file where log messages should be written to |
-| -l LOGLEVEL | --log-level=LOGLEVEL | The lowest level of message logged (debug 10, input/output 12, debug warning 15, info 20, warning 30, error 40, critical 50, disabled 100), default is warning |
+| -l LOGLEVEL | --log-level=LOGLEVEL | The lowest level of message logged (debug 10, input/output 12, debug warning 15, info 20, disabled 100) |
 | -c CONFIGPATH | --config-path=CONFIGPATH | The path where all settings for NVDA are stored |
 | None | --lang=LANGUAGE | Override the configured NVDA language. Set to "Windows" for current user default, "en" for English, etc. |
 | -m | --minimal | No sounds, no interface, no start message, etc. |


### PR DESCRIPTION

### Link to issue number:
Fix-up of #14406
### Summary of the issue:
As described in https://github.com/nvaccess/nvda/pull/14406#issuecomment-1335669275 and https://github.com/nvaccess/nvda/pull/14406#issuecomment-1337079703 by @leonardder (thanks!), the combobox to choose log level is not available anymore.

### Description of user facing changes
* Log level can again be selected in the GUI's combobox
* Also updated the User Guide since this update were missing in #14406.
### Description of development approach
* Reset log level to 0 in default command line argument. Indeed, I had not realized this while developing #14406 but the following two concepts are different and do not match:
  * default log level in the command line is "unspecified" and in this case we set a value of 0. This means that when no `-l` parameter is passed through the command line, the value of NVDA's config is used.
  * default log level in NVDA's config (i.e. in config spec) is INFO, i.e. 20. That means that when no user config is set, the value in the default config spec applies.
  * Also removed the indication of default in command line help text since the default for config was indicated instead of the default for the command line.
* Updated user guide with currently supported log levels; also removed the mention of default level since 'warning' was clearly wrong in any case and because as explained before, the default for command line would be missing = "use the value in config", not 20 = INFO.

Note: For more clarity I may have rewritten the option description in command line help and in the user guide to something like "Forces the log level". I have not done this since it is not done for other options such as `-c`, `--log-file`, etc.

### Testing strategy:
Manual tests:
* launched NVDA with and without `-l` parameter and checked the availability of log level combobox in the GUI.
* checked `nvda --help`

### Known issues with pull request:
I have opened this issue to avoid remaining with half of the work in alpha. However as explained in https://github.com/nvaccess/nvda/pull/14406#issuecomment-1338280470, NVAccess may want instead to fully revert #14406 and ask to do the extra devs to fully support log levels 30 (WARNING), 40 (ERROR) and 50 (CRITICAL) through command line (solution 2 in https://github.com/nvaccess/nvda/pull/14406#issuecomment-1338280470)

### Change log entries:
Not needed: fixing unreleased regression.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ x API is compatible with existing add-ons.
- [ x Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

### Cc
Cc @josephsl for this comment: https://github.com/nvaccess/nvda/pull/8596#issuecomment-411061826 ans since maybe a decision will be made in this PR if log levels 30, 40 and 50 are kept or removed.
