### PR TITLE
    Do not ignore locale CLDR file when locale symbol file is missing

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -373,11 +373,16 @@ class SpeechSymbols(object):
 		return u"\t".join(fields)
 
 _noSymbolLocalesCache = set()
+_noCLDRLocalesCache = set()
 
 
 def _getSpeechSymbolsForLocale(locale: str) -> Tuple[SpeechSymbols, SpeechSymbols]:
-	if locale in _noSymbolLocalesCache:
+	if (
+		locale in _noSymbolLocalesCache
+		and (locale in _noCLDRLocalesCache or not config.conf['speech']['includeCLDR'])
+	):
 		raise LookupError
+	builtinDataImported = False
 	builtin = SpeechSymbols()
 	if config.conf['speech']['includeCLDR']:
 		# Try to load CLDR data when processing is on.
@@ -388,12 +393,17 @@ def _getSpeechSymbolsForLocale(locale: str) -> Tuple[SpeechSymbols, SpeechSymbol
 				os.path.join(globalVars.appDir, "locale", locale, "cldr.dic"),
 				allowComplexSymbols=False
 			)
+			builtinDataImported = True
 		except IOError:
+			_noCLDRLocalesCache.add(locale)
 			log.debugWarning("No CLDR data for locale %s" % locale)
 	try:
 		builtin.load(os.path.join(globalVars.appDir, "locale", locale, "symbols.dic"))
+		builtinDataImported = True
 	except IOError:
 		_noSymbolLocalesCache.add(locale)
+		log.debugWarning("No symbol data for locale %s" % locale)
+	if not builtinDataImported:
 		raise LookupError("No symbol information for locale %s" % locale)
 	user = SpeechSymbols()
 	try:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,6 +45,7 @@ What's New in NVDA
   - In some rare cases, these settings used in profiles may be unexpectedly modified when installing this version of NVDA.
   - Please check these options in your profiles after upgrading NVDA to this version.
   -
+- Emojis should now be reported in more languages. (#14433)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Found while investigating #14417; it does not fix it but it is related.

### Summary of the issue:
In NVDA some languages do not have a `symbol.dic` file but have a `cldr.dic` file. Today, these are the following languages: 'af_ZA', 'am', 'as', 'gu', 'id', 'kok', 'ml', 'mni', 'ne', 'te', 'th', 'ur'.

For these languages the symbols belonging to CLDR file (e.g. "☺") are reported in English rather than in the locale language.

This is because we detect if a language has no symbol file and in this case, we store it in `_noSymbolLocalesCache` and raise a `LookupError` in the future, even if the language has a CLDR file.

### Description of user facing changes

Languages with no symbol file will be able to report CLDR in the locale language if available.

### Description of development approach

Use two caches, one for languages with no symbol file and one for languages with no CLDR file.

### Testing strategy:
* Wrote two unit tests
  * Confirm the current issue with commit e38fe30823312b5a830efa75e2daae6e2d20e818 (before the fix), i.e. `test_processSpeechSymbol_withoutSymbolFile` fails.
  * Upon commit e38fe30823312b5a830efa75e2daae6e2d20e818 (before the fix), checked that the languages in `test_processSpeechSymbol_withoutSymbolFile` report the CLDR in English by modifying locally line 157 to 
`self.assertEqual(`
and running successfully the unit tests
  * Checked after the fix (commit ba01bc8157eb9c03e0107ad7f911bdc58f14f2d4) that unit tests pass.
* Manual tests:
  * Checked with eSpeak Amharic that "☺" is reported in the locale language and no more in English. Note: I do not know this language, so I have just checked that the symbol and its description in `cldr.dic` sound the same with eSpeak.

### Known issues with pull request:
CLDR symbols are still reported in English with eSpeak for Afrikaans and Portuguese (Portugal). This is because:
* eSpeak use 'af' and 'pt' (no country) for these languages
* but in NVDA we cannot fallback to these languages, we only have 'af_ZA' on one side and 'pt_PT' or 'pt_BR'.

Since the solution to this issue is not trivial, I prefer discuss it in a separate issue and have the issue already fixed for the other languages. I guess that the issue would also be fixed for OneCore since I think that these voices are country-aware.

I have opened #14434 to track this specific issue with eSpeak Portuguese (Portugal) and Afrikaans.

### Change log entries:

Bug fixes
`Emojis should now be reported in more languages. (#14433)`

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
