### PR TITLE
Update liblouis to 3.24.0

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -59,11 +59,6 @@ env['CC'] = 'clang-cl'
 if 'analyze' in env['nvdaHelperDebugFlags']:
 	env.Append(CCFLAGS='/analyze-')
 
-# Starting from Clang 15, the -Wint-conversion warning diagnostic for implicit int <-> pointer conversions
-# now defaults to an error in all C language modes.
-# Downgrade this to a warning so we can still build.
-env.Append(CCFLAGS='-Wno-error=int-conversion')
-
 env.Append(CPPDEFINES=[
 	# The Visual C++ C Runtime deprecates standard POSIX APIs that conflict with
 	# reserved ISO C names (like strdup) in favour of non-portable conforming

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `a51235aa`
 * [Sonic](https://github.com/waywardgeek/sonic), commit 1d705135
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
-* [liblouis](http://www.liblouis.org/), version 3.23.0
+* [liblouis](http://www.liblouis.org/), version 3.24.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 42.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -154,31 +154,31 @@ addTable("cs-g1.ctb", _("Czech grade 1"))
 
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g08.ctb", _("Danish 8 dot computer braille (2022)"))
+addTable("da-dk-g08.ctb", _("Danish 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("da-dk-g08_1993.ctb", _("Danish 8 dot computer braille (1993)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g16.ctb", _("Danish 6 dot grade 1 (2022)"))
+addTable("da-dk-g16.ctb", _("Danish 6 dot grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("da-dk-g16_1993.ctb", _("Danish 6 dot grade 1 (1993)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g18.ctb", _("Danish 8 dot grade 1 (2022)"))
+addTable("da-dk-g18.ctb", _("Danish 8 dot grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("da-dk-g18_1993.ctb", _("Danish 8 dot grade 1 (1993)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g26.ctb", _("Danish 6 dot grade 2 (2022)"), contracted=True)
+addTable("da-dk-g26.ctb", _("Danish 6 dot grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("da-dk-g26_1993.ctb", _("Danish 6 dot grade 2 (1993)"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2 (2022)"), contracted=True)
+addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("da-dk-g28_1993.ctb", _("Danish 8 dot grade 2 (1993)"), contracted=True)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -151,21 +151,38 @@ addTable("cs-comp8.utb", _("Czech 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("cs-g1.ctb", _("Czech grade 1"))
+
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g08.ctb", _("Danish 8 dot computer braille"))
+addTable("da-dk-g08.ctb", _("Danish 8 dot computer braille (2022)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g16.ctb", _("Danish 6 dot grade 1"))
+addTable("da-dk-g08_1993.ctb", _("Danish 8 dot computer braille (1993)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g18.ctb", _("Danish 8 dot grade 1"))
+addTable("da-dk-g16.ctb", _("Danish 6 dot grade 1 (2022)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g26.ctb", _("Danish 6 dot grade 2"), contracted=True)
+addTable("da-dk-g16_1993.ctb", _("Danish 6 dot grade 1 (1993)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2"), contracted=True)
+addTable("da-dk-g18.ctb", _("Danish 8 dot grade 1 (2022)"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("da-dk-g18_1993.ctb", _("Danish 8 dot grade 1 (1993)"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("da-dk-g26.ctb", _("Danish 6 dot grade 2 (2022)"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("da-dk-g26_1993.ctb", _("Danish 6 dot grade 2 (1993)"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("da-dk-g28.ctb", _("Danish 8 dot grade 2 (2022)"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("da-dk-g28_1993.ctb", _("Danish 8 dot grade 2 (1993)"), contracted=True)
+
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("de-comp6.utb", _("German 6 dot computer braille"))
@@ -318,6 +335,9 @@ addTable("ja-kantenji.utb", _("Japanese (Kantenji) literary braille"), input=Fal
 addTable("ka-in-g1.utb", _("Kannada grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("ka.utb", _("Georgian literary braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("kk.utb", _("Kazakh grade 1"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -408,6 +428,9 @@ addTable("nso-za-g1.utb", _("Sepedi grade 1"))
 addTable("nso-za-g2.ctb", _("Sepedi grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("ny-mw.utb", _("Chichewa (Malawi) literary braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("or-in-g1.utb", _("Oriya grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -482,6 +505,25 @@ addTable("sv-g1.ctb", _("Swedish partially contracted braille"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sv-g2.ctb", _("Swedish contracted braille"), contracted=True, input=False)
+
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sw-ke-g1.utb", _("Swahili (Kenya) grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sw-ke-g1-2.ctb", _("Swahili (Kenya) grade 1.2"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sw-ke-g1-3.ctb", _("Swahili (Kenya) grade 1.3"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sw-ke-g1-4.ctb", _("Swahili (Kenya) grade 1.4"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sw-ke-g1-5.ctb", _("Swahili (Kenya) grade 1.5"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("sw-ke-g2.ctb", _("Swahili (Kenya) Grade 2"), contracted=True)
 
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,11 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 
 
 == Changes ==
+- Updated LibLouis braille translator to [3.24.0 https://github.com/liblouis/liblouis/releases/tag/v3.24.0]. (#14436)
+  - Major updates to Hungarian, UEB, and Chinese bopomofo braille.
+  - Support for the Danish braille standard 2022.
+  - New braille tables for Georgian literary braille, Swahili (Kenya) and Chichewa (Malawi).
+  -
 - Updated Sonic rate boost library to commit ``1d70513``. (#14180)
 - CLDR has been updated to version 42.0. (#14273)
 - eSpeak NG has been updated to 1.52-dev commit ``a51235aa``. (#14281)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Liblouis 3.24.0 has been released.

### Description of user facing changes
Updates liblouis to 3.24.0 which adds new braille tables. [Changelog](https://github.com/liblouis/liblouis/releases/tag/v3.24.0).

### Description of development approach
Update liblouis submodule and make new braille tables available from the NVDA settings.

### Testing strategy:
Ran from sources and loaded new braille tables. LGTM.

### Known issues with pull request:
None

### Change log entries:
Section: Changes

```
- Updated liblouis braille translator to [3.24.0 https://github.com/liblouis/liblouis/releases/tag/v3.24.0]. (#14436)
  - Major updates to Hungarian, UEB, and Chinese bopomofo braille.
  - Support for the Danish braille standard 2022.
  - New braille tables for Georgian literary braille, Swahili (Kenya) and Chichewa (Malawi).
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
