### PR TITLE
Revert "Use only supported log levels for command line option"

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -149,23 +149,12 @@ quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument('-q','--quit',action="store_true",dest='quit',default=False,help="Quit already running copy of NVDA")
 parser.add_argument('-k','--check-running',action="store_true",dest='check_running',default=False,help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running")
 parser.add_argument('-f','--log-file',dest='logFileName',type=str,help="The file where log messages should be written to")
-parser.add_argument(
-	'-l',
-	'--log-level',
-	dest='logLevel',
-	type=int,
-	default=20,
-	choices=[10, 12, 15, 20, 100],
-	help=(
-		"The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100),"
-		" default is 20 (info)"
-	),
-)
+parser.add_argument('-l','--log-level',dest='logLevel',type=int,default=0,choices=[10, 12, 15, 20, 30, 40, 50, 100],help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, warning 30, error 40, critical 50, off 100), default is info")
 parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str,help="The path where all settings for NVDA are stored")
 parser.add_argument(
 	'--lang',
 	dest='language',
-	default="Windows",
+	default="en",
 	type=stringToLang,
 	help=(
 		"Override the configured NVDA language."


### PR DESCRIPTION
Reverts nvaccess/nvda#14406
PR #14406  accidentally hid the log level combo box. Also it looks like further work was identified to provide a complete soltuion. All of this should be handled in a new PR.