### PR TITLE
Use only supported log levels for command line option (second attempt)

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -154,11 +154,10 @@ parser.add_argument(
 	'--log-level',
 	dest='logLevel',
 	type=int,
-	default=20,
+	default=0,  # 0 means unspecified in command line.
 	choices=[10, 12, 15, 20, 100],
 	help=(
 		"The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100),"
-		" default is 20 (info)"
 	),
 )
 parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str,help="The path where all settings for NVDA are stored")

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -149,12 +149,23 @@ quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument('-q','--quit',action="store_true",dest='quit',default=False,help="Quit already running copy of NVDA")
 parser.add_argument('-k','--check-running',action="store_true",dest='check_running',default=False,help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running")
 parser.add_argument('-f','--log-file',dest='logFileName',type=str,help="The file where log messages should be written to")
-parser.add_argument('-l','--log-level',dest='logLevel',type=int,default=0,choices=[10, 12, 15, 20, 30, 40, 50, 100],help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, warning 30, error 40, critical 50, off 100), default is info")
+parser.add_argument(
+	'-l',
+	'--log-level',
+	dest='logLevel',
+	type=int,
+	default=20,
+	choices=[10, 12, 15, 20, 100],
+	help=(
+		"The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100),"
+		" default is 20 (info)"
+	),
+)
 parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str,help="The path where all settings for NVDA are stored")
 parser.add_argument(
 	'--lang',
 	dest='language',
-	default="en",
+	default="Windows",
 	type=stringToLang,
 	help=(
 		"Override the configured NVDA language."

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -164,7 +164,7 @@ parser.add_argument('-c','--config-path',dest='configPath',default=None,type=str
 parser.add_argument(
 	'--lang',
 	dest='language',
-	default="Windows",
+	default="en",
 	type=stringToLang,
 	help=(
 		"Override the configured NVDA language."

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3675,7 +3675,7 @@ Following are the command line options for NVDA:
 | -q | --quit | Quit already running copy of NVDA |
 | -k | --check-running | Report whether NVDA is running via the exit code; 0 if running, 1 if not running |
 | -f LOGFILENAME | --log-file=LOGFILENAME | The file where log messages should be written to |
-| -l LOGLEVEL | --log-level=LOGLEVEL | The lowest level of message logged (debug 10, input/output 12, debug warning 15, info 20, warning 30, error 40, critical 50, disabled 100), default is warning |
+| -l LOGLEVEL | --log-level=LOGLEVEL | The lowest level of message logged (debug 10, input/output 12, debug warning 15, info 20, disabled 100) |
 | -c CONFIGPATH | --config-path=CONFIGPATH | The path where all settings for NVDA are stored |
 | None | --lang=LANGUAGE | Override the configured NVDA language. Set to "Windows" for current user default, "en" for English, etc. |
 | -m | --minimal | No sounds, no interface, no start message, etc. |


### PR DESCRIPTION
Context: issue found while reading the code for #14398.

### Link to issue number:
PR #14406 reverted in #14442 due to log level combo-box that has become unavailable.
And PR #14432 that was a fix-up of #14406 but that was closed since not applicable after reversion of #14406.

### Summary of the issue:

When starting NVDA with an unsupported command line parameter, you get the following suggestion for log level in the error message:
> [-l {10,12,15,20,30,40,50,100}]

Launching NVDA with log level set to 30, 40 or 50 leads to undesirable behaviours:
- an empty value in the log level combo-box in NVDA's general settings.
- NVDA+F1 does not open the log
- NVAccess does not want log level WARNING, ERROR or CRITICAL as written by @michaelDCurran  in https://github.com/nvaccess/nvda/pull/14406#issuecomment-1348375145:
  > We don't ever want users providing logs to us at level warning, error or critical as they are simply not useful as they drop too much information and therefore just waste time for the user and us.

Also, the description of the `-l` option is erroneous in the user guide and in the help text for command line since it indicates that the default value for this option is WARNING. Instead, the default behaviour (i.e. when the option is not specified) is to follow what comes from NVDA config; and if there is nothing in the user's config, the default config spec specifies that the log level is INFO.

### Description of user facing changes

* Only supported log levels are indicated in the error message when a wrong parameter is passed to NVDA.
* Only supported log level can now be used from command line, i.e. 10=debug, 12=I/O, 15=debugWarning, 20=info and 100=off
* The description of the `-l`  option is updated in the user guide and in the help text for command line

### Description of development approach
* Changed the information passed to the command line parser.
* Updated the available log levels in the user guide and the command line help; also removed the indication related to "default" since it was just adding confusion. For more clarity I may have rewritten the option description in command line help and in the user guide to something like "Forces the log level". I have not done this since it is not done for other options such as -c, --log-file, etc.

### Testing strategy:
Manual tests:
* NVDA starts normally when `-l` parameter is not passed to NVDA and the log level can be changed in general settings
* NVDA starts normally with `-l` command line param set to 10, 12, 15, 20 and 100 and the appropriate log level is used; the log level is indicated in general settings but the combo-box is unavailable (greyed out).
* NVDA does not start and displays the usage message when launched with `-l` set to 30, 40, 50 and 99.
* Checked the `-l` parameter description in the user guide and in the help message (`nvda --help`)

### Known issues with pull request:
None
### Change log entries:
Probably not needed.
Or maybe something in the bugfixes category? What do you think?


### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
