### PR TITLE
Lower log level to debug warning for lock screen not found case

### DIFF
--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -227,7 +227,10 @@ def _isObjectBelowLockScreenCheckZOrder(objWindowHandle: int) -> bool:
 	try:
 		return _isWindowBelowWindowMatchesCond(objWindowHandle, _isWindowLockScreen)
 	except _UnexpectedWindowCountError:
-		log.exception("Couldn't find lock screen")
+		log.debugWarning(
+			"Couldn't determine lock screen and NVDA object relative z-order",
+			exc_info=True
+		)
 		return False
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #14475
Follow up for #14416 

### Summary of the issue:
#14416 added a log message at exception level.
This log message is for when the relative z-order for an NVDAObject and the lock screen cannot be determined.
While a noisy exception here is useful for alpha/beta testing of this code, this log message is almost always triggered once when locking windows. This is because the lock screen may not exist while windows is in the process of locking.

### Description of user facing changes
Lower log level

### Description of development approach
n/a
### Testing strategy:
n/a
### Known issues with pull request:
N/a
### Change log entries:
N/a

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
