### PR TITLE
Increase Chrome focus time during system tests

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -67,7 +67,7 @@ class ChromeLib:
 			f"{process.is_process_running(ChromeLib._processRFHandleForStart)}"
 		)
 
-		if not windowsLib.isWindowInForeground(ChromeLib._chromeWindow):
+		if ChromeLib._chromeWindow and not windowsLib.isWindowInForeground(ChromeLib._chromeWindow):
 			builtIn.log(
 				"Unable to close tab, window not in foreground: "
 				f"({ChromeLib._chromeWindow.title} - {ChromeLib._chromeWindow.hwndVal})"
@@ -96,7 +96,7 @@ class ChromeLib:
 		if _window is not None:
 			res = CloseWindow(_window)
 			if not res:
-				builtIn.log(f"Unable to task kill chrome hwnd: {ChromeLib._chromeWindow.hwndVal}", level="ERROR")
+				builtIn.log(f"Unable to task kill chrome hwnd: {_window.hwndVal}", level="ERROR")
 			else:
 				ChromeLib._chromeWindow = _window = None
 		else:
@@ -250,7 +250,8 @@ class ChromeLib:
 			if not _chromeLib.canChromeTitleBeReported(chromeTitleSpeechPattern):
 				raise AssertionError("NVDA unable to report chrome title")
 
-		spy.wait_for_speech_to_finish()
+		# May take some time for chrome to focus
+		spy.wait_for_speech_to_finish(maxWaitSeconds=10.0)
 
 		if not self._waitForStartMarker():
 			builtIn.fail(

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -182,7 +182,12 @@ class ChromeLib:
 				)
 				return False
 
-		afterControlF6Speech = _NvdaLib.getSpeechAfterKey('control+F6')  # focus web content, chrome shortcut.
+		afterControlF6Speech = _NvdaLib.getSpeechAfterKey(
+			# focus web content, chrome shortcut.
+			'control+F6',
+			# Chrome may take longer to handle this key
+			maxWaitSeconds=10.0,
+		)
 		documentDescriptor = f"document\n{ChromeLib._beforeMarker}"
 		if documentDescriptor not in afterControlF6Speech:
 			builtIn.log(

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -67,7 +67,10 @@ class ChromeLib:
 			f"{process.is_process_running(ChromeLib._processRFHandleForStart)}"
 		)
 
-		if ChromeLib._chromeWindow and not windowsLib.isWindowInForeground(ChromeLib._chromeWindow):
+		if (
+			not ChromeLib._chromeWindow
+			or not windowsLib.isWindowInForeground(ChromeLib._chromeWindow)
+		):
 			builtIn.log(
 				"Unable to close tab, window not in foreground: "
 				f"({ChromeLib._chromeWindow.title} - {ChromeLib._chromeWindow.hwndVal})"

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -184,4 +184,8 @@ class NotepadLib:
 		self._waitForNotepadFocus(uniqueTitleRegex)
 		windowsLib.logForegroundWindowTitle()
 		# Move to the start of file
-		_NvdaLib.getSpeechAfterKey('home')
+		_NvdaLib.getSpeechAfterKey(
+			"home",
+			# may take some time to focus content
+			maxWaitSeconds=10.0,
+		)

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -428,7 +428,8 @@ def getSpeechAfterKey(key, maxWaitSeconds: _Optional[float] = None) -> str:
 	nextSpeechIndex = spy.get_next_speech_index()
 	spy.emulateKeyPress(key)
 	if maxWaitSeconds is None:
-		maxWaitSeconds = spy._SPEECH_HAS_FINISHED_SECONDS_MAX
+		from SystemTestSpy.speechSpyGlobalPlugin import NVDASpyLib
+		maxWaitSeconds = NVDASpyLib._SPEECH_HAS_FINISHED_SECONDS_MAX
 	spy.wait_for_speech_to_finish(
 		speechStartedIndex=nextSpeechIndex,
 		maxWaitSeconds=maxWaitSeconds

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -419,7 +419,7 @@ def getSpyLib() -> "NVDASpyLib":
 	return spy
 
 
-def getSpeechAfterKey(key, maxWaitSeconds: _Optional[float] = None) -> str:
+def getSpeechAfterKey(key: str, maxWaitSeconds: _Optional[float] = None) -> str:
 	"""Ensure speech has stopped, press key, and get speech until it stops.
 	@return: The speech after key press.
 	"""
@@ -427,12 +427,9 @@ def getSpeechAfterKey(key, maxWaitSeconds: _Optional[float] = None) -> str:
 	spy.wait_for_speech_to_finish()
 	nextSpeechIndex = spy.get_next_speech_index()
 	spy.emulateKeyPress(key)
-	if maxWaitSeconds is None:
-		from SystemTestSpy.speechSpyGlobalPlugin import NVDASpyLib
-		maxWaitSeconds = NVDASpyLib._SPEECH_HAS_FINISHED_SECONDS_MAX
 	spy.wait_for_speech_to_finish(
+		maxWaitSeconds=maxWaitSeconds,
 		speechStartedIndex=nextSpeechIndex,
-		maxWaitSeconds=maxWaitSeconds
 	)
 	speech = spy.get_speech_at_index_until_now(nextSpeechIndex)
 	return speech

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -419,7 +419,7 @@ def getSpyLib() -> "NVDASpyLib":
 	return spy
 
 
-def getSpeechAfterKey(key) -> str:
+def getSpeechAfterKey(key, maxWaitSeconds: _Optional[float] = None) -> str:
 	"""Ensure speech has stopped, press key, and get speech until it stops.
 	@return: The speech after key press.
 	"""
@@ -427,7 +427,12 @@ def getSpeechAfterKey(key) -> str:
 	spy.wait_for_speech_to_finish()
 	nextSpeechIndex = spy.get_next_speech_index()
 	spy.emulateKeyPress(key)
-	spy.wait_for_speech_to_finish(speechStartedIndex=nextSpeechIndex)
+	if maxWaitSeconds is None:
+		maxWaitSeconds = spy._SPEECH_HAS_FINISHED_SECONDS_MAX
+	spy.wait_for_speech_to_finish(
+		speechStartedIndex=nextSpeechIndex,
+		maxWaitSeconds=maxWaitSeconds
+	)
 	speech = spy.get_speech_at_index_until_now(nextSpeechIndex)
 	return speech
 

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -79,7 +79,7 @@ class NVDASpyLib:
 	All public methods are part of the Robot Library
 	"""
 	SPEECH_HAS_FINISHED_SECONDS: float = 1.0
-	_SPEECH_HAS_FINISHED_SECONDS_MAX: float = 5.0  # TODO: should this just be SPEECH_HAS_FINISHED_SECONDS?
+	_SPEECH_HAS_FINISHED_SECONDS_MAX: float = SPEECH_HAS_FINISHED_SECONDS
 
 	def __init__(self):
 		# speech cache is ordered temporally, oldest at low indexes, most recent at highest index.

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -79,6 +79,7 @@ class NVDASpyLib:
 	All public methods are part of the Robot Library
 	"""
 	SPEECH_HAS_FINISHED_SECONDS: float = 1.0
+	_SPEECH_HAS_FINISHED_SECONDS_MAX: float = 5.0  # TODO: should this just be SPEECH_HAS_FINISHED_SECONDS?
 
 	def __init__(self):
 		# speech cache is ordered temporally, oldest at low indexes, most recent at highest index.
@@ -462,7 +463,7 @@ class NVDASpyLib:
 
 	def wait_for_speech_to_finish(
 			self,
-			maxWaitSeconds=5.0,
+			maxWaitSeconds: float = _SPEECH_HAS_FINISHED_SECONDS_MAX,
 			speechStartedIndex: Optional[int] = None,
 			errorMessage: Optional[str] = "Speech did not finish before timeout"
 	) -> bool:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -79,7 +79,6 @@ class NVDASpyLib:
 	All public methods are part of the Robot Library
 	"""
 	SPEECH_HAS_FINISHED_SECONDS: float = 1.0
-	_SPEECH_HAS_FINISHED_SECONDS_MAX: float = 1.0
 
 	def __init__(self):
 		# speech cache is ordered temporally, oldest at low indexes, most recent at highest index.
@@ -470,8 +469,9 @@ class NVDASpyLib:
 		"""speechStartedIndex should generally be fetched with get_next_speech_index
 		@param errorMessage: Supply None to bypass assert.
 		"""
+		DEFAULT_MAX_WAIT_SECONDS = 5.0
 		if not maxWaitSeconds:
-			maxWaitSeconds = NVDASpyLib._SPEECH_HAS_FINISHED_SECONDS_MAX
+			maxWaitSeconds = DEFAULT_MAX_WAIT_SECONDS
 		success, _value = _blockUntilConditionMet(
 			getValue=lambda: self._hasSpeechFinished(speechStartedIndex=speechStartedIndex),
 			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -79,7 +79,7 @@ class NVDASpyLib:
 	All public methods are part of the Robot Library
 	"""
 	SPEECH_HAS_FINISHED_SECONDS: float = 1.0
-	_SPEECH_HAS_FINISHED_SECONDS_MAX: float = SPEECH_HAS_FINISHED_SECONDS
+	_SPEECH_HAS_FINISHED_SECONDS_MAX: float = 1.0
 
 	def __init__(self):
 		# speech cache is ordered temporally, oldest at low indexes, most recent at highest index.
@@ -463,13 +463,15 @@ class NVDASpyLib:
 
 	def wait_for_speech_to_finish(
 			self,
-			maxWaitSeconds: float = _SPEECH_HAS_FINISHED_SECONDS_MAX,
+			maxWaitSeconds: Optional[float] = None,
 			speechStartedIndex: Optional[int] = None,
 			errorMessage: Optional[str] = "Speech did not finish before timeout"
 	) -> bool:
 		"""speechStartedIndex should generally be fetched with get_next_speech_index
 		@param errorMessage: Supply None to bypass assert.
 		"""
+		if not maxWaitSeconds:
+			maxWaitSeconds = NVDASpyLib._SPEECH_HAS_FINISHED_SECONDS_MAX
 		success, _value = _blockUntilConditionMet(
 			getValue=lambda: self._hasSpeechFinished(speechStartedIndex=speechStartedIndex),
 			giveUpAfterSeconds=self._minTimeout(maxWaitSeconds),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Described in https://github.com/nvaccess/nvda/issues/14353#issuecomment-1356921578

### Summary of the issue:
`getSpeechAfterKey` uses the default `maxWaitSeconds=5.0` when calling `wait_for_speech_to_finish`.
This means that any speech as a result from the key press must be handled within 5 seconds.
As a key press may take longer to be handled (e.g. chrome handling `control+F6`) this is not ideal, and should be parameterised.
Chrome sometimes takes more than 5 seconds to handle `control+F6`, as noticed in https://github.com/nvaccess/nvda/issues/14353#issuecomment-1356921578.

### Description of user facing changes
System tests should fail less for devs

### Description of development approach
Investigated the `log.html` file for the failed builds.
Noticed that it was when focusing chrome each time.
Increased the wait for speech time out for handling `control+F6`.

### Testing strategy:
Run several tests

### Known issues with pull request:
N/A
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
