### PR TITLE
Fixup minor issue with system test chrome logging

### DIFF
--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -67,7 +67,10 @@ class ChromeLib:
 			f"{process.is_process_running(ChromeLib._processRFHandleForStart)}"
 		)
 
-		if not windowsLib.isWindowInForeground(ChromeLib._chromeWindow):
+		if (
+			not ChromeLib._chromeWindow
+			or not windowsLib.isWindowInForeground(ChromeLib._chromeWindow)
+		):
 			builtIn.log(
 				"Unable to close tab, window not in foreground: "
 				f"({ChromeLib._chromeWindow.title} - {ChromeLib._chromeWindow.hwndVal})"
@@ -96,7 +99,7 @@ class ChromeLib:
 		if _window is not None:
 			res = CloseWindow(_window)
 			if not res:
-				builtIn.log(f"Unable to task kill chrome hwnd: {ChromeLib._chromeWindow.hwndVal}", level="ERROR")
+				builtIn.log(f"Unable to task kill chrome hwnd: {_window.hwndVal}", level="ERROR")
 			else:
 				ChromeLib._chromeWindow = _window = None
 		else:

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -67,10 +67,14 @@ class ChromeLib:
 			f"{process.is_process_running(ChromeLib._processRFHandleForStart)}"
 		)
 
-		if (
-			not ChromeLib._chromeWindow
-			or not windowsLib.isWindowInForeground(ChromeLib._chromeWindow)
-		):
+		if not ChromeLib._chromeWindow:
+			builtIn.log(
+				"Unable to close tab, Chrome window not initialised correctly.",
+				level="WARN"
+			)
+			return
+
+		if not windowsLib.isWindowInForeground(ChromeLib._chromeWindow):
 			builtIn.log(
 				"Unable to close tab, window not in foreground: "
 				f"({ChromeLib._chromeWindow.title} - {ChromeLib._chromeWindow.hwndVal})"


### PR DESCRIPTION
`ChromeLib._chromeWindow` can be `None` if not initialized correctly. 
This causes an unhandled failure in the system test tear down when Chrome fails to initialise.
This PR fixes up the system test teardown to handle this case better.