### PR TITLE
Add repr for plugins

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2012-2022 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
-# Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka
+# Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -547,6 +547,10 @@ class Addon(AddonBase):
 			if os.path.isfile(docFile):
 				return docFile
 		return None
+
+	def __repr__(self):
+		return f"{self.__class__.__name__} ({self.name!r}, running={self.isRunning!r})"
+
 
 def getCodeAddon(obj=None, frameDist=1):
 	""" Returns the L{Addon} where C{obj} is defined. If obj is None the caller code frame is assumed to allow simple retrieval of "current calling addon".

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
-# Babbage B.V., Mozilla Corporation, Julien Cochuyt
+# Babbage B.V., Mozilla Corporation, Julien Cochuyt, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -563,7 +563,10 @@ class AppModule(baseObject.ScriptableObject):
 		return self.productVersion
 
 	def __repr__(self):
-		return "<%r (appName %r, process ID %s) at address %x>"%(self.appModuleName,self.appName,self.processID,id(self))
+		return (
+			f"{self.__class__.__name__}"
+			f"({self.appModuleName}, appName={self.appName!r}, processID={self.processID!r})"
+		)
 
 	def _get_appModuleName(self):
 		return self.__class__.__module__.split('.')[-1]

--- a/source/braille.py
+++ b/source/braille.py
@@ -1,7 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2022 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau
+# Copyright (C) 2008-2022 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau,
+# Leonard de Ruijter
 
 import itertools
 import os
@@ -2497,6 +2498,9 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		@return: The number of cells.
 		"""
 		return 0
+
+	def __repr__(self):
+		return f"{self.__class__.__name__}({self.name!r}, numCells={self.numCells!r})"
 
 	def display(self, cells):
 		"""Display the given braille cells.

--- a/source/driverHandler.py
+++ b/source/driverHandler.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2019 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2006-2022 NV Access Limited, Leonard de Ruijter
 
 """Handler for driver functionality that is global to synthesizers and braille displays."""
 from autoSettingsUtils.autoSettings import AutoSettings
@@ -47,6 +47,9 @@ class Driver(AutoSettings):
 		"""
 		self.saveSettings()
 		self._unregisterConfigSaveAction()
+
+	def __repr__(self):
+		return f"{self.__class__.__name__}({self.name!r})"
 
 	@classmethod
 	def check(cls):

--- a/source/globalPluginHandler.py
+++ b/source/globalPluginHandler.py
@@ -84,3 +84,7 @@ class GlobalPlugin(baseObject.ScriptableObject):
 		@param clsList: The list of classes, which will be modified by this method if appropriate.
 		@type clsList: list of L{NVDAObjects.NVDAObject}
 		"""
+
+	def __repr__(self):
+		return f"{self.__class__.__name__} ({self.__class__.__module__!r})"
+

--- a/source/globalPluginHandler.py
+++ b/source/globalPluginHandler.py
@@ -87,4 +87,3 @@ class GlobalPlugin(baseObject.ScriptableObject):
 
 	def __repr__(self):
 		return f"{self.__class__.__name__} ({self.__class__.__module__!r})"
-

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -67,6 +67,7 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - Now uses the C++20 standard, was C++17.
   - Now uses the '/permissive-' compiler flag which disables permissive behaviors, and sets the '/Zc' compiler options for strict conformance.
   -
+- Some plugin objects (e.g. drivers and add-ons) now have a more informative description in the NVDA python console. (#14463)
 - NVDA can now be fully compiled with Visual Studio 2022, no longer requiring the Visual Studio 2019 build tools.
 - More detailed logging for NVDA freezes to aid debugging. (#14309)
 - The singleton ``braille._BgThread`` class has been replaced with ``hwIo.ioThread.IoThread``. (#14130)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Several plugin types, such as addon objects and drivers, have a default repr that makes it impossible to identify the addon from the python console without further inspection.

### Description of user facing changes
When inspecting addons, drivers and appModules from the python console, the repr will be different.

### Description of development approach
Added `__repr__` method to several classes

### Testing strategy:
Tested inspection of the objects using the python console.

### Known issues with pull request:
None known
### Change log entries:
For Developers
- Some plugin objects (e.g. drivers and add-ons) now have a more informative description in the python console.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
