### PR TITLE
winVersion.WinVersion: define processor architecture property

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -125,6 +125,8 @@ class WinVersion(object):
 			winVersionText.append(f"service pack {self.servicePack}")
 		if self.productType != "":
 			winVersionText.append(self.productType)
+		if self.processorArchitecture != "":
+			winVersionText.append(self.processorArchitecture)
 		return " ".join(winVersionText)
 
 	def __eq__(self, other):

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -15,6 +15,7 @@ import sys
 import os
 import functools
 import winreg
+import platform
 
 
 # Records a mapping between Windows builds and release names.
@@ -191,7 +192,8 @@ def getWinVer():
 		build=winVer.build,
 		releaseName=releaseName,
 		servicePack=winVer.service_pack,
-		productType=("workstation", "domain controller", "server")[winVer.product_type - 1]
+		productType=("workstation", "domain controller", "server")[winVer.product_type - 1],
+		processorArchitecture=platform.machine()
 	)
 
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -68,7 +68,7 @@ def _getRunningVersionNameFromWinReg() -> str:
 class WinVersion(object):
 	"""
 	Represents a Windows release.
-	Includes version major, minor, build, service pack information,
+	Includes version major, minor, build, service pack information, machine architecture,
 	as well as tools such as checking for specific Windows 10 releases.
 	"""
 
@@ -79,7 +79,8 @@ class WinVersion(object):
 			build: int = 0,
 			releaseName: Optional[str] = None,
 			servicePack: str = "",
-			productType: str = ""
+			productType: str = "",
+			processorArchitecture: str = ""
 	):
 		self.major = major
 		self.minor = minor
@@ -90,6 +91,7 @@ class WinVersion(object):
 			self.releaseName = self._getWindowsReleaseName()
 		self.servicePack = servicePack
 		self.productType = productType
+		self.processorArchitecture = processorArchitecture
 
 	def _getWindowsReleaseName(self) -> str:
 		"""Returns the public release name for a given Windows release based on major, minor, and build.

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -1,12 +1,13 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2021 NV Access Limited, Joseph Lee
+# Copyright (C) 2021-2022 NV Access Limited, Joseph Lee
 
 """Unit tests for the Windows version module."""
 
 import unittest
 import sys
+import os
 import winVersion
 
 
@@ -78,3 +79,9 @@ class TestWinVersion(unittest.TestCase):
 			major=unknownMajor, minor=unknownMinor, build=unknownBuild
 		)
 		self.assertEqual(badWin81Info.releaseName, "Windows release unknown")
+
+	def test_winVerProcessorArchitecture(self):
+		# See if processor architecture matches what Windows says.
+		# Use os.environ to guard against platform.machine() giving odd results.
+		actualArchitecture = os.environ.get("PROCESSOR_ARCHITEW6432", os.environ["PROCESSOR_ARCHITECTURE"])
+		self.assertEqual(winVersion.getWinVer().processorArchitecture, actualArchitecture)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,6 +73,7 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - A single instance ``hwIo.bgThread`` (in NVDA core) of this class provides background i/o for thread safe braille display drivers.
   - This new class is not a singleton by design, add-on authors are encouraged to use their own instance when doing hardware i/o.
   -
+- The processor architecture for the computer can be queried from ``winVersion.WinVersion.processorArchitecture attribute.`` (#14439)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION

### Link to issue number:
Closes #14439 
Follow-up to #14397 
Follow-up to #14403 

### Summary of the issue:
winVersion.WinVersion class should define processor architecture property to record machine architecture for the current Windows installation.

### Description of user facing changes
At NVDA startup, processor architecture will be logged as part of Windows information.

### Description of development approach
Add "processorArchitecture" property to winVersion.WinVersion class to record machine architecture (currently x86 (32-bit) AMD64 (x64), ARM64). From getWinVer() function, this value will be fetched via Python's platform.machine() function, which itself looks up processor architecture from environment variables. This means NVDA can read the new property instead of consulting environment variables every time it wishes to check machine architecture. Also, added a unit test to see if the processor architecture recorded is indeed the one Windows says.

### Testing strategy:
Unit test: compare winVersion.getWinVer().processorArchitecture against environment variables.

### Known issues with pull request:
None

### Change log entries:
For developers:

The processor architecture for the computer can be queried from winVersion.WinVersion.processorArchitecture attribute. (#14439)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
