### PR TITLE
Cycle through reporting annotation target summaries with `nvda+d`

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -5,7 +5,9 @@
 
 import typing
 from typing import (
+	Generator,
 	Optional,
+	Tuple,
 	Union,
 	List,
 )
@@ -1523,7 +1525,7 @@ the NVDAObject for IAccessible
 			self,
 			relationType: "IAccessibleHandler.RelationType",
 			maxRelations: int = 1,
-	) -> typing.List[IUnknown]:
+	) -> Generator[IUnknown, None, None]:
 		"""Gets the target IAccessible (actually IUnknown; use QueryInterface or
 		normalizeIAccessible to resolve) for the relations with given type.
 		Allows escape of exception: COMError(-2147417836, 'Requested object does not exist.'),
@@ -1539,17 +1541,20 @@ the NVDAObject for IAccessible
 			raise ValueError
 		if not isinstance(acc, IA2.IAccessible2_2):
 			acc = acc.QueryInterface(IA2.IAccessible2_2)
+
 		targets, count = acc.relationTargetsOfType(
 			relationType.value,
+			# Bug in relationTargetsOfType, Chrome does not respect maxRelations param.
+			# https://crbug.com/1399184
 			maxRelations
 		)
+		log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
 		if count == 0:
-			return list()
-		relationsGen = (
+			return
+		yield from (
 			targets[i]
 			for i in range(min(maxRelations, count))
 		)
-		return list(relationsGen)
 
 	def _getIA2RelationFirstTarget(
 			self,
@@ -1568,9 +1573,10 @@ the NVDAObject for IAccessible
 
 		try:
 			# rather than fetch all the relations and querying the type, do that in process for performance reasons
-			targets = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
-			if targets:
-				ia2Object = IAccessibleHandler.normalizeIAccessible(targets[0])
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				# Just take the first.
 				return IAccessible(
 					IAccessibleObject=ia2Object,
 					IAccessibleChildID=0
@@ -1578,7 +1584,7 @@ the NVDAObject for IAccessible
 		except (NotImplementedError, COMError):
 			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
 
-		# eg IA2_2 is not available, fall back to old approach
+		# IA2_2 is not available, fall back to old approach
 		try:
 			for relation in self._IA2Relations:
 				if relation.relationType == relationType:
@@ -1594,20 +1600,73 @@ the NVDAObject for IAccessible
 			pass
 		return None
 
+	def _getIA2RelationTargetsOfType(
+			self,
+			relationType: Union[str, IAccessibleHandler.RelationType]
+	) -> typing.Iterable["IAccessible"]:
+		""" Get the targets for the relation of type.
+		Higher level function than _getIA2TargetsForRelationsOfType
+		@param relationType: The type of relation to fetch.
+		"""
+		if not isinstance(relationType, IAccessibleHandler.RelationType):
+			if isinstance(relationType, str):
+				relationType = IAccessibleHandler.RelationType(relationType)
+			else:
+				raise TypeError(f"Bad type for 'relationType' arg, got: {type(relationType)}")
+
+		relationType = typing.cast(IAccessibleHandler.RelationType, relationType)
+
+		try:
+			# rather than fetch all the relations and querying the type, do that in process for performance reasons
+			# Bug in Chrome, Chrome does not respect maxRelations param.
+			# https://crbug.com/1399184. In future, uncomment the next line.
+			# maxRelsToFetch = self.IAccessibleObject.nRelations  # they may or may not all match 'relationType'
+			maxRelsToFetch = 10
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=maxRelsToFetch)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				ia = IAccessible(
+					IAccessibleObject=ia2Object,
+					IAccessibleChildID=0
+				)
+				yield ia
+			# NotImplementedError is expected to occur for all targets or none.
+			return  # Iterated all targets without error.
+		except (NotImplementedError, COMError):
+			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
+
+		# IA2_2 is not available, fall back to old approach
+		log.debugWarning("IA2_2 is not available, fall back to old approach")
+		try:
+			for relation in self._IA2Relations:
+				if relation.relationType == relationType:
+					# Take the first of 'relation.nTargets' see IAccessibleRelation._methods_
+					for i in range(0, relation.nTargets):
+						target = relation.target(i)
+						ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+						yield IAccessible(
+							IAccessibleObject=ia2Object,
+							IAccessibleChildID=0
+						)
+			return
+		except (NotImplementedError, COMError):
+			log.debug("Unable to fetch _IA2Relations", exc_info=True)
+			pass
+		return None
+
 	#: Type definition for auto prop '_get_detailsRelations'
-	detailsRelations: typing.Iterable["IAccessible"]
+	detailsRelations: Tuple["IAccessible"]
+
+	def _get_detailsRelations(self) -> Tuple["IAccessible"]:
+		detailsRelsGen = self._getIA2RelationTargetsOfType(IAccessibleHandler.RelationType.DETAILS)
+		# due to caching of baseObject.AutoPropertyObject, do not attempt to return a generator.
+		return tuple(detailsRelsGen)
 
 	def _get_controllerFor(self) -> List[NVDAObject]:
 		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
 		if control:
 			return [control]
 		return []
-
-	def _get_detailsRelations(self) -> typing.Iterable["IAccessible"]:
-		relationTarget = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.DETAILS)
-		if not relationTarget:
-			return ()
-		return (relationTarget, )
 
 	#: Type definition for auto prop '_get_flowsTo'
 	flowsTo: typing.Optional["IAccessible"]
@@ -1763,7 +1822,7 @@ the NVDAObject for IAccessible
 				ret = "exception: %s" % e
 			info.append("IAccessible2 attributes: %s" % ret)
 			try:
-				ret = ", ".join(r.RelationType for r in self._IA2Relations)
+				ret = ", ".join(f"{r.RelationType} * {r.nTargets}" for r in self._IA2Relations)
 			except Exception as e:
 				ret = f"exception: {e}"
 			info.append(f"IAccessible2 relations: {ret}")

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -6,10 +6,17 @@
 """Base classes with common support for browsers exposing IAccessible2.
 """
 import typing
+from typing import (
+	Iterable,
+)
 from ctypes import c_short
 from comtypes import COMError, BSTR
 
 import oleacc
+from annotation import (
+	AnnotationTarget,
+	AnnotationOrigin,
+)
 from comInterfaces import IAccessible2Lib as IA2
 import controlTypes
 from logHandler import log
@@ -22,6 +29,76 @@ import api
 import speech
 import config
 import NVDAObjects
+
+
+class IA2WebAnnotationTarget(AnnotationTarget):
+	def __init__(self, target: IAccessible):
+		self._target: IAccessible = target
+
+	@property
+	def summary(self) -> str:
+		return self._target.summarizeInProcess()
+
+	@property
+	def role(self) -> controlTypes.Role:
+		return self._target.role
+
+	@property
+	def targetObject(self) -> IAccessible:
+		return self._target
+
+
+class IA2WebAnnotation(AnnotationOrigin):
+	_originObj: "Ia2Web"
+
+	def __bool__(self) -> bool:
+		return bool(
+			self._originObj.IA2Attributes.get("details-roles")
+		)
+
+	@property
+	def targets(self) -> Iterable[AnnotationTarget]:
+		if not bool(self):
+			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("no annotations available")
+			return
+
+		ia2WebAnnotationTargetsGen = (
+			IA2WebAnnotationTarget(rel)
+			for rel in self._originObj.detailsRelations
+		)
+		yield from ia2WebAnnotationTargetsGen
+
+	@property
+	def roles(self) -> Iterable[controlTypes.Role]:
+		"""
+		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
+		to return them.
+		@remarks: The order of "details-roles" IA2Attributes is expected to match the order of detailsRelations
+		objects.
+		"""
+		from .chromium import supportedAriaDetailsRoles
+		# Currently only defined in Chrome as of May 2022
+		# Refer to ComputeDetailsRoles
+		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
+		detailsRoles = self._originObj.IA2Attributes.get("details-roles")
+		if not detailsRoles:
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("details-roles not found")
+			return None
+
+		for roleStr in detailsRoles.split(" "):
+			# Created supported details role
+			detailsRole = supportedAriaDetailsRoles.get(roleStr)
+			if config.conf["debugLog"]["annotations"]:
+				log.debug(f"detailsRole: {repr(detailsRole)}")
+			yield detailsRole
+
+	@property
+	def summaries(self) -> Iterable[str]:
+		for target in self.targets:
+			yield target.summary
 
 
 class Ia2Web(IAccessible):
@@ -60,42 +137,26 @@ class Ia2Web(IAccessible):
 				log.debugWarning(f"Unknown 'description-from' IA2Attribute value: {ia2attrDescriptionFrom}")
 			return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: "IA2WebAnnotation"
+	"""Typing information for auto property _get_annotations
+	"""
+	def _get_annotations(self) -> "AnnotationOrigin":
+		annotationOrigin = IA2WebAnnotation(self)
+		return annotationOrigin
+
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		if not self.hasDetails:
-			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("no details-roles")
-			return None
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			log.error("should be able to fetch detailsRelations")
-			return None
-		for target in detailsRelations:
+		for summary in self.annotations.summaries:
 			# just take the first for now.
-			return target.summarizeInProcess()
+			return summary
 
 	@property
 	def hasDetails(self) -> bool:
-		return bool(self.IA2Attributes.get("details-roles"))
+		return bool(self.annotations)
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
-		from .chromium import supportedAriaDetailsRoles
-		# Currently only defined in Chrome as of May 2022
-		# Refer to ComputeDetailsRoles
-		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
-		detailsRoles = self.IA2Attributes.get("details-roles")
-		if not detailsRoles:
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("details-roles not found")
-			return None
-		
-		firstDetailsRole = detailsRoles.split(" ")[0]
-		# return a supported details role
-		detailsRole = supportedAriaDetailsRoles.get(firstDetailsRole)
-		if config.conf["debugLog"]["annotations"]:
-			log.debug(f"detailsRole: {repr(detailsRole)}")
-		return detailsRole
-
+		for role in self.annotations.roles:
+			# just take the first for now.
+			return role
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
 		ia2attrCurrent: str = self.IA2Attributes.get("current", "false")

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -4,6 +4,15 @@
 # See the file COPYING for more details.
 # Copyright (C) 2006-2022 NV Access Limited, Peter Vágner
 
+from typing import (
+	Iterable,
+	Optional,
+)
+
+from annotation import (
+	AnnotationTarget,
+	AnnotationOrigin,
+)
 import IAccessibleHandler
 from comInterfaces import IAccessible2Lib as IA2
 import config
@@ -14,9 +23,72 @@ from . import IAccessible, WindowRoot
 from logHandler import log
 from NVDAObjects.behaviors import RowWithFakeNavigation
 from . import ia2Web
-from typing import (
-	Optional,
-)
+
+
+class MozAnnotationTarget(AnnotationTarget):
+	def __init__(self, target: IAccessible):
+		self._target: IAccessible = target
+
+	@property
+	def summary(self) -> str:
+		return self._target.summarizeInProcess()
+
+	@property
+	def role(self) -> controlTypes.Role:
+		# details-roles is currently only defined in Chromium
+		# this may diverge in Firefox in the future.
+		from .chromium import supportedAriaDetailsRoles
+		detailsRole = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(
+			self._target.IAccessibleRole
+		)
+		# return a supported details role
+		if config.conf["debugLog"]["annotations"]:
+			log.debug(f"detailsRole: {repr(detailsRole)}")
+		if detailsRole in supportedAriaDetailsRoles.values():
+			return detailsRole
+		raise ValueError(f"Unsupported aria details role: {detailsRole}")
+
+	@property
+	def targetObject(self) -> IAccessible:
+		return self._target
+
+
+class MozAnnotation(AnnotationOrigin):
+	"""
+	Unlike base Ia2Web implementation, the details-roles IA2 attribute is not exposed in Firefox.
+	"""
+	_originObj: "Mozilla"
+
+	def __bool__(self) -> bool:
+		# Unlike base Ia2Web implementation, the details-roles
+		# IA2 attribute is not exposed in Firefox.
+		# Although slower, we have to fetch the details relations instead.
+		return bool(
+			self._originObj.detailsRelations
+		)
+
+	@property
+	def targets(self) -> Iterable[MozAnnotationTarget]:
+		detailsRelations = self._originObj.detailsRelations
+		for rel in detailsRelations:
+			yield MozAnnotationTarget(rel)
+
+	@property
+	def roles(self) -> Iterable[controlTypes.Role]:
+		# Unlike base Ia2Web implementation, the details-roles
+		# IA2 attribute is not exposed in Firefox.
+		# Although slower, we have to fetch the details relations instead.
+		for target in self.targets:
+			# just take the first target for now.
+			try:
+				yield target.role
+			except ValueError:
+				log.error("Error getting role.", exc_info=True)
+
+	@property
+	def summaries(self) -> Iterable[str]:
+		for target in self.targets:
+			yield target.summary
 
 
 class Mozilla(ia2Web.Ia2Web):
@@ -63,43 +135,27 @@ class Mozilla(ia2Web.Ia2Web):
 				presType=self.presType_layout
 		return presType
 
+	annotations: MozAnnotation
+	"""Typing information for auto property _get_annotations
+	"""
+
+	def _get_annotations(self) -> MozAnnotation:
+		annotationOrigin = MozAnnotation(self)
+		return annotationOrigin
+
 	def _get_detailsSummary(self) -> Optional[str]:
-		# Unlike base Ia2Web implementation, the details-roles
-		# IA2 attribute is not exposed in Firefox.
-		# Although slower, we have to fetch the details relations instead.
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			return None
-		for target in detailsRelations:
+		for summary in self.annotations.summaries:
 			# just take the first for now.
-			return target.summarizeInProcess()
+			return summary
 
 	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
-		# Unlike base Ia2Web implementation, the details-roles
-		# IA2 attribute is not exposed in Firefox.
-		# Although slower, we have to fetch the details relations instead.
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			return None
-		for target in detailsRelations:
+		for role in self.annotations.roles:
 			# just take the first target for now.
-			# details-roles is currently only defined in Chromium
-			# this may diverge in Firefox in future.
-			from .chromium import supportedAriaDetailsRoles
-			detailsRole = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(target.IAccessibleRole)
-			# return a supported details role
-			if config.conf["debugLog"]["annotations"]:
-				log.debug(f"detailsRole: {repr(detailsRole)}")
-			if detailsRole in supportedAriaDetailsRoles.values():
-				return detailsRole
-			return None
+			return role
 
 	@property
 	def hasDetails(self) -> bool:
-		# Unlike base Ia2Web implementation, the details-roles
-		# IA2 attribute is not exposed in Firefox.
-		# Although slower, we have to fetch the details relations instead.
-		return bool(self.detailsRelations)
+		return bool(self.annotations)
 
 
 class Document(ia2Web.Document):

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -12,6 +12,9 @@ import time
 import typing
 import weakref
 import textUtils
+from annotation import (
+	AnnotationOrigin,
+)
 from logHandler import log
 import review
 import eventHandler
@@ -511,6 +514,17 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
 		return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: AnnotationOrigin
+	"""Typing information for auto property _get_annotations
+	"""
+
+	def _get_annotations(self) -> typing.Optional[AnnotationOrigin]:
+		if config.conf["debugLog"]["annotations"]:
+			log.debugWarning(
+				f"Fetching annotations not supported on: {self.__class__.__qualname__}"
+			)
+		return None
+
 	#: Typing information for auto property _get_detailsSummary
 	detailsSummary: typing.Optional[str]
 
@@ -524,7 +538,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""Default implementation is based on the result of _get_detailsSummary
 		In most instances this should be optimised.
 		"""
-		return bool(self.detailsSummary)
+		return bool(self.annotations)
 
 	#: Typing information for auto property _get_detailsRole
 	detailsRole: typing.Optional[controlTypes.Role]

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -1,0 +1,86 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""
+Annotations are part of the ARIA spec, used to create relationships between nodes.
+For example: comment reply chains, terms with definitions, footnotes.
+
+https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Annotations
+"""
+
+from dataclasses import dataclass
+from typing import (
+	TYPE_CHECKING,
+	Iterable,
+	List,
+	Optional,
+)
+
+if TYPE_CHECKING:
+	import controlTypes
+	from NVDAObjects import NVDAObject
+
+
+class AnnotationTarget:
+	"""
+	Structured information of an annotation target.
+	For example, the definition of a term.
+	"""
+
+	@property
+	def role(self) -> "controlTypes.Role":
+		raise NotImplementedError
+
+	@property
+	def targetObject(self) -> "NVDAObject":
+		raise NotImplementedError
+
+	@property
+	def summary(self) -> str:
+		raise NotImplementedError
+
+
+class AnnotationOrigin:
+	"""
+	Structured information of an annotation origin.
+	For example, a phrase with a footnote and comments associated with it.
+	"""
+
+	def __init__(self, originObj: "NVDAObject"):
+		self._originObj: "NVDAObject" = originObj
+
+	def __bool__(self):
+		"""Performant implementation required to test for annotations
+		"""
+		raise NotImplementedError
+
+	@property
+	def targets(self) -> Iterable[AnnotationTarget]:
+		raise NotImplementedError
+
+	@property
+	def roles(self) -> Iterable["controlTypes.Role"]:
+		raise NotImplementedError
+
+	@property
+	def summaries(self) -> Iterable[str]:
+		raise NotImplementedError
+
+
+@dataclass
+class _AnnotationNavigationNode:
+	"""Node used in _AnnotationNavigation, for navigating between annotations."""
+	_TargetIndex = int  # Type for target index
+	origin: "NVDAObject"  # this is the last known location
+	indexOfLastReportedSummary: Optional[_TargetIndex] = None  # this would be the next destination
+
+
+class _AnnotationNavigation:
+	"""
+	Used to manage navigation of annotations.
+	For example, reporting a summary of each comment for an object with multiple comment annotation targets.
+	"""
+	lastReported: Optional[_AnnotationNavigationNode] = None
+	priorOrigins: List["NVDAObject"] = []


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Supersedes  #14389 and #14426.
Fixes #14360

### Summary of the issue:
Before this PR, NVDA was only aware of the first annotation target.
NVDA announces the presence of an annotation target.
`nvda+d` is used to announce the summary of the first annotation target.

This PR introduces base code to support multiple annotation targets, and enables cycling though reporting each summary.
Similarly, #14507 introduces reporting the presence of multiple annotation targets.

### Description of user facing changes

`nvda+d` now cycles through reporting each annotation target for an annotated item. For example reading the summary of each child comment.

### Description of development approach

Creates abstractions for the relationships between annotation origins and targets.
The global command to report a summary of an annotation target has been updated.

### Testing strategy:

 - [x] **Manual testing**
Tested using `nvda+d` on the annotations test document with Chrome and Firefox: https://mdn.github.io/html-examples/aria-annotations/
Confirmed that each comment was reported for the first example of comments.
Tested with Chrome and Firefox

### Known issues with pull request:
Max 10 targets are fetched, this should be dynamic, however there is a Chrome bug preventing this, requiring investigation.
https://crbug.com/1399184

### Change log entries:
New features
```
- `nvda+d` now cycles through reporting the summary of each annotation target for origins with multiple annotation targets. For example reading the summary of each child comment.
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
