### PR TITLE
Update eSpeak to a51235aa commit

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -101,8 +101,8 @@ env.Append(
 		# errors when winsock2 is included by espeak\src\include\compat\endian.h
 		'/DWIN32_LEAN_AND_MEAN',
 		# Preprocessor definitions. Espeak Features
-		'/DINCLUDE_SPEECHPLAYER=1',
-		'/DINCLUDE_KLATT=1',
+		'/DUSE_SPEECHPLAYER=1',
+		'/DUSE_KLATT=1',
 		'/DHAVE_SONIC_H=1',
 	])
 
@@ -395,6 +395,7 @@ espeakLib=env.SharedLibrary(
 		"espeak_api.c",
 		"ieee80.c",
 		"intonation.c",
+		"langopts.c",
 		"klatt.c", # we do use KLATT, this is a compile option in espeak
 #		"mbrowrap.c", # we don't use MBROLA, this is a compile option in espeak
 		"mnemonics.c",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `b17ed2d6`
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `a51235aa`
 * [Sonic](https://github.com/waywardgeek/sonic), commit 1d705135
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.23.0

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -334,9 +334,7 @@ class SynthDriver(SynthDriver):
 				textList.append(langChangeXML)
 				langChanged = True
 			elif isinstance(item, BreakCommand):
-				# Break commands are ignored at the start of speech unless strength is specified.
-				# Refer to eSpeak issue: https://github.com/espeak-ng/espeak-ng/issues/1232
-				textList.append(f'<break time="{item.time}ms" strength="1" />')
+				textList.append(f'<break time="{item.time}ms" />')
 			elif type(item) in self.PROSODY_ATTRS:
 				if prosody:
 					# Close previous prosody tag.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,9 @@ This can be used with text editors that do not support paragraph navigation nati
 == Changes ==
 - Updated Sonic rate boost library to commit ``1d70513``. (#14180)
 - CLDR has been updated to version 42.0. (#14273)
+- eSpeak NG has been updated to 1.52-dev commit ``a51235aa``. (#14281)
+  - Fixed reporting of large numbers. (#14241)
+  -
 - Java applications with controls using the selectable state will now announce when an item is not selected rather than when the item is selected. (#14336)
 -
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #14281
Closes #14241
Addresses https://github.com/nvaccess/nvda/pull/13875#issuecomment-1345362397

### Summary of the issue:
Janitorial update of eSpeak.
Removes a workaround added to handle a bug with eSpeaks `BreakCommand` implementation, tracked in https://github.com/espeak-ng/espeak-ng/issues/1232, https://github.com/nvaccess/nvda/pull/13875#issuecomment-1345362397

### Description of user facing changes
eSpeak is updated.
Fixes pronunciation of large numbers (#14241).

### Description of development approach

Dropped `strength` for eSpeak `BreakCommand` attribute per https://github.com/espeak-ng/espeak-ng/issues/1232 being fixed in eSpeak.

#### Janitorial update
Followed instructions in `include/espeak.md`.
Checked the following diffs.

```git
cd include/espeak
git diff a51235aa b17ed2d6 src/windows/config.h
git diff a51235aa b17ed2d6 Makefile.am
```

Addressed the following eSpeak changes:
- Introduction of `langopts.c`: https://github.com/espeak-ng/espeak-ng/commit/4a2890250b95f5d3f72a9fd468809fcf1685abe4
- Fix up of code standards: change `DINCLUDE` to `DUSE`: https://github.com/espeak-ng/espeak-ng/commit/ca1f59010130c7f981e0dd91148e6fdc89fe0390
- Note that eSpeak has changed MBROLA compilation, does not affect our build: https://github.com/espeak-ng/espeak-ng/commit/78ac6c4a882517d611ec0b23bda2e48e661e89f1

### Testing strategy:

**Manual testing:**

- General testing of eSpeak for janitorial update.
- Test STR for #14241, read the number 2748573849604723649583647594365737548.
- Test delayed character descriptions, which uses the `BreakCommand` with eSpeak.

### Known issues with pull request:
None

### Change log entries:
Refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
