### PR TITLE
Make AppModule alias names case insensitive

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -112,7 +112,7 @@ def _warnDeprecatedAliasAppModule() -> None:
 	# Since the current frame belongs to the calling function inside `appModuleHandler`
 	# we need to retrieve the file name from the preceding frame which belongs to the module in which this
 	# function is executed.
-	currModName = os.path.splitext(os.path.basename(inspect.stack()[1].filename))[0]
+	currModName = os.path.splitext(os.path.basename(inspect.stack()[1].filename))[0].lower()
 	try:
 		replacementModName = appModules.EXECUTABLE_NAMES_TO_APP_MODS[currModName]
 	except KeyError:
@@ -149,6 +149,7 @@ def _getPossibleAppModuleNamesForExecutable(executableName: str) -> Tuple[str, .
 	- Just the name of the executable to cover a standard appModule named the same as the executable
 	- The alias from `appModules.EXECUTABLE_NAMES_TO_APP_MODS` if it exists.
 	"""
+	executableName = executableName.lower()
 	return tuple(
 		aliasName for aliasName in (
 			_executableNamesToAppModsAddons.get(executableName),
@@ -168,6 +169,7 @@ def doesAppModuleExist(name: str, ignoreDeprecatedAliases: bool = False) -> bool
 	:param ignoreDeprecatedAliases: used for backward compatibility, so that by default alias modules
 	are not excluded.
 	"""
+	name = name.lower()
 	try:
 		modSpec = importlib.util.find_spec(f"appModules.{name}", package=appModules)
 	except ImportError:

--- a/source/appModules/__init__.py
+++ b/source/appModules/__init__.py
@@ -65,4 +65,6 @@ This mapping is needed since:
 - Names of some programs are incompatible with the Python's import system (they contain a dot or a plus)
 - Sometimes it is necessary to map one module to multiple executables - this map saves us from adding multiple
  appModules in such cases.
+
+Names should be handled in a case-insensitive manner and lowercase.
 """


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14446 

### Summary of the issue:
The VS Code App Module contains code which prevents performance issues when using the document.
Microsoft uses a capital "C" for "Code.exe" now, which broke how NVDA handled VS Code.
#13366 changed how AppModule aliases worked, which may have broke case sensitivity.

### Description of user facing changes
Performance issues with VS Code have been fixed.

### Description of development approach
Checked usages of `EXECUTABLE_NAMES_TO_APP_MODS`, ensured names were handled in a case insensitive manner.

### Testing strategy:
- [ ] Confirm #14446 is fixed.
- [x] Tested checking the active app module with `nvda+f1` while VS code was focused.

### Known issues with pull request:
None

### Change log entries:
Bug fixes
- Fixed issues with NVDA registering the presence of some applications.
For example, performance fixes have been restored on VS Code.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
