### PR TITLE
Rename postSessionLockStateChanged to post_sessionLockStateChanged

### DIFF
--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -17,7 +17,7 @@ from logHandler import log
 import fonts
 import inputCore
 import gui.contextHelp
-from utils.security import _isLockScreenModeActive, postSessionLockStateChanged
+from utils.security import _isLockScreenModeActive, post_sessionLockStateChanged
 
 BRAILLE_UNICODE_PATTERNS_START = 0x2800
 BRAILLE_SPACE_CHARACTER = chr(BRAILLE_UNICODE_PATTERNS_START)
@@ -287,7 +287,7 @@ class BrailleViewerFrame(
 			pos=dialogPos,
 			style=wx.CAPTION | wx.CLOSE_BOX | wx.STAY_ON_TOP
 		)
-		postSessionLockStateChanged.register(self.onSessionLockStateChange)
+		post_sessionLockStateChanged.register(self.onSessionLockStateChange)
 		self.Bind(wx.EVT_CLOSE, self._onClose)
 		self.Bind(wx.EVT_WINDOW_DESTROY, self._onDestroy)
 
@@ -557,7 +557,7 @@ class BrailleViewerFrame(
 
 	def _onDestroy(self, evt: wx.Event):
 		log.debug("braille viewer gui onDestroy")
-		postSessionLockStateChanged.unregister(self.onSessionLockStateChange)
+		post_sessionLockStateChanged.unregister(self.onSessionLockStateChange)
 		self.isDestroyed = True
 		self._notifyOfDestroyed()
 		evt.Skip()

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -13,7 +13,7 @@ import config
 from logHandler import log
 from speech import SpeechSequence
 import gui.contextHelp
-from utils.security import _isLockScreenModeActive, postSessionLockStateChanged
+from utils.security import _isLockScreenModeActive, post_sessionLockStateChanged
 
 
 # Inherit from wx.Frame because these windows show in the alt+tab menu (where miniFrame does not)
@@ -45,7 +45,7 @@ class SpeechViewerFrame(
 			pos=dialogPos,
 			style=wx.CAPTION | wx.CLOSE_BOX | wx.RESIZE_BORDER | wx.STAY_ON_TOP
 		)
-		postSessionLockStateChanged.register(self.onSessionLockStateChange)
+		post_sessionLockStateChanged.register(self.onSessionLockStateChange)
 		self._isDestroyed = False
 		self.onDestroyCallBack = onDestroyCallBack
 		self.Bind(wx.EVT_CLOSE, self.onClose)
@@ -126,7 +126,7 @@ class SpeechViewerFrame(
 
 	def onDestroy(self, evt: wx.Event):
 		self._isDestroyed = True
-		postSessionLockStateChanged.unregister(self.onSessionLockStateChange)
+		post_sessionLockStateChanged.unregister(self.onSessionLockStateChange)
 		log.debug("SpeechViewer destroyed")
 		self.onDestroyCallBack()
 		evt.Skip()

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -22,7 +22,25 @@ if typing.TYPE_CHECKING:
 	import NVDAObjects  # noqa: F401, use for typing
 
 
-postSessionLockStateChanged = extensionPoints.Action()
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility.
+	"""
+	import NVDAState
+	if not NVDAState._allowDeprecatedAPI():
+		log.debug(f"Deprecated {attrName} imported while _allowDeprecatedAPI is False")
+	elif attrName == "isObjectAboveLockScreen":
+		log.warning(
+			"Importing isObjectAboveLockScreen(obj) is deprecated. "
+			"Instead use obj.isBelowLockScreen. "
+		)
+		return _isObjectAboveLockScreen
+	elif attrName == "postSessionLockStateChanged":
+		log.warning("postSessionLockStateChanged is deprecated, use post_sessionLockStateChanged instead.")
+		return post_sessionLockStateChanged
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
+
+post_sessionLockStateChanged = extensionPoints.Action()
 """
 Notifies when a session lock or unlock event occurs.
 
@@ -34,9 +52,9 @@ def onSessionLockStateChange(isNowLocked: bool):
 	'''
 	pass
 
-postSessionLockStateChanged.register(onSessionLockStateChange)
-postSessionLockStateChanged.notify(isNowLocked=False)
-postSessionLockStateChanged.unregister(onSessionLockStateChange)
+post_sessionLockStateChanged.register(onSessionLockStateChange)
+post_sessionLockStateChanged.notify(isNowLocked=False)
+post_sessionLockStateChanged.unregister(onSessionLockStateChange)
 ```
 """
 
@@ -162,18 +180,6 @@ def objectBelowLockScreenAndWindowsIsLocked(
 		return True
 
 	return False
-
-
-def __getattr__(attrName: str) -> Any:
-	import NVDAState
-	"""Module level `__getattr__` used to preserve backward compatibility."""
-	if attrName == "isObjectAboveLockScreen" and NVDAState._allowDeprecatedAPI():
-		log.warning(
-			"Importing isObjectAboveLockScreen(obj) is deprecated. "
-			"Instead use obj.isBelowLockScreen. "
-		)
-		return _isObjectAboveLockScreen
-	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
 def _isObjectAboveLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -124,13 +124,13 @@ def initialize():
 def pumpAll():
 	"""Used to track the session lock state every core cycle, and detect changes."""
 	global _wasLockedPreviousPumpAll
-	from utils.security import postSessionLockStateChanged
+	from utils.security import post_sessionLockStateChanged
 	windowsIsNowLocked = _isWindowsLocked()
 	# search for lock app module once lock state is known,
-	# but before triggering callbacks via postSessionLockStateChanged
+	# but before triggering callbacks via post_sessionLockStateChanged
 	if windowsIsNowLocked != _wasLockedPreviousPumpAll:
 		_wasLockedPreviousPumpAll = windowsIsNowLocked
-		postSessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)
+		post_sessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)
 
 
 def __getattr__(attrName: str) -> Any:
@@ -181,7 +181,7 @@ def _isWindowsLocked() -> bool:
 	if not _TrackNVDAInitialization.isInitializationComplete():
 		# Wait until initialization is complete,
 		# so NVDA and other consumers can register the lock state
-		# via postSessionLockStateChanged.
+		# via post_sessionLockStateChanged.
 		return False
 	if _lockStateTracker is None:
 		log.error(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -100,8 +100,12 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
 
 === Deprecations ===
 - ``NVDAObjects.UIA.winConsoleUIA.WinTerminalUIA`` is deprecated and usage is discouraged. (#14047)
-- ``config.addConfigDirsToPythonPackagePath`` has been moved. Use ``addonHandler.packaging.addDirsToPythonPackagePath`` instead. (#14350)
-- ``braille.BrailleHandler.TETHER_*`` are deprecated. Please use ``configFlags.TetherTo.*.value`` instead. (#14233)
+- ``config.addConfigDirsToPythonPackagePath`` has been moved.
+Use ``addonHandler.packaging.addDirsToPythonPackagePath`` instead. (#14350)
+- ``braille.BrailleHandler.TETHER_*`` are deprecated.
+Please use ``configFlags.TetherTo.*.value`` instead. (#14233)
+- ``utils.security.postSessionLockStateChanged`` is deprecated.
+Please use ``utils.security.post_sessionLockStateChanged`` instead. (#14486)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None
### Summary of the issue:
`postSessionLockStateChanged` was named incorrectly, the convention would be to name it `post_sessionLockStateChanged`.

### Description of user facing changes
None

### Description of development approach
Deprecates `postSessionLockStateChanged` in favour of `post_sessionLockStateChanged`.
- [x] After merging, announce on the addon-api list

### Testing strategy:
Tested importing `utils.security.postSessionLockStateChanged` from python console

### Known issues with pull request:
None

### Change log entries:
Refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
