### PR TITLE
Only check the lock screen order if NVDA is installed

### DIFF
--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -199,6 +199,11 @@ def _isObjectBelowLockScreen(obj: "NVDAObjects.NVDAObject") -> bool:
 	"""
 	from IAccessibleHandler import SecureDesktopNVDAObject
 	from NVDAObjects.IAccessible import TaskListIcon
+	import config
+
+	if not config.isInstalledCopy():
+		# If NVDA is not installed, it cannot read below the lock screen
+		return False
 
 	foregroundWindow = winUser.getForegroundWindow()
 	foregroundProcessID, _foregroundThreadID = winUser.getWindowThreadProcessID(foregroundWindow)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None

### Summary of the issue:
NVDA can only detect the lock screen windows, and windows below the lock screen, if NVDA is installed.
When running a portable copy, or NVDA from source, locking NVDA causes an error every cache cycle due to the lock screen not being detected.

### Description of user facing changes

logging/error sounds are suppressed when locking Windows and using a portable or source copy of NVDA

### Description of development approach
Lock screen z-order is only checked if the current running version of NVDA is installed.

### Testing strategy:
Smoke test the lock screen with a portable, installed and source copy of NVDA.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
