### PR TITLE
Fix wts info class

### DIFF
--- a/source/winAPI/_wtsApi32.py
+++ b/source/winAPI/_wtsApi32.py
@@ -89,9 +89,8 @@ class WTS_INFO_CLASS(IntEnum):
 	WTSConfigInfo = 26
 	WTSValidationInfo = 27  # Info Class value used to fetch Validation Information
 	# through the WTSQuerySessionInformation
-	WTSQuerySessionInformation = 28
-	WTSSessionAddressV4 = 29
-	WTSIsRemoteSession = 30
+	WTSSessionAddressV4 = 28
+	WTSIsRemoteSession = 29
 
 
 WTS_CONNECTSTATE_CLASS = c_int

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -307,11 +307,11 @@ def _getCurrentSessionInfoEx() -> Optional[_WTS_INFO_POINTER_T]:
 		# (or the current session) specify WTS_CURRENT_SESSION
 		WTS_INFO_CLASS.WTSSessionInfoEx,  # Indicates the type of session information to retrieve
 		# Fetch a WTSINFOEXW containing a WTSINFOEX_LEVEL1 structure.
-		ctypes.pointer(ppBuffer),  # A pointer to a variable that receives a pointer to the requested information.
+		ctypes.byref(ppBuffer),  # A pointer to a variable that receives a pointer to the requested information.
 		# The format and contents of the data depend on the information class specified in the WTSInfoClass
 		# parameter.
 		# To free the returned buffer, call the WTSFreeMemory function.
-		ctypes.pointer(pBytesReturned),  # A pointer to a variable that receives the size, in bytes, of the data
+		ctypes.byref(pBytesReturned),  # A pointer to a variable that receives the size, in bytes, of the data
 		# returned in ppBuffer.
 	)
 	try:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The WTS_INFO_CLASS enum as defined in NVDA contained a WTSQuerySessionInformation value, which shouldn't be part of the actual enum according to [The docs](https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/ne-wtsapi32-wts_connectstate_class)
Also when calling WTSQuerySessionInformation, ctypes.pointer was used instead of ctypes.byref to pass values by reference.

### Description of user facing changes
None

### Description of development approach
Removed the entry and fixed the numbering. Use byref instead of pointer

### Testing strategy:
Tested something like this in a remote session:
`winAPI._wtsApi32.WTSQuerySessionInformation(winAPI._wtsApi32.WTS_CURRENT_SERVER_HANDLE, winAPI._wtsApi32.WTS_CURRENT_SESSION, 29, byref(ppBuffer), byref(pBytesReturned))`

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
