### PR TITLE
Remove deprecated functions from sessionTracking

### DIFF
--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -23,7 +23,6 @@ from ctypes.wintypes import (
 )
 import enum
 from typing import (
-	Any,
 	Generator,
 	Optional,
 )
@@ -31,7 +30,6 @@ from typing import (
 from baseObject import AutoPropertyObject
 from logHandler import log
 
-from .types import HWNDValT
 from ._wtsApi32 import (
 	WTSINFOEXW,
 	WTSQuerySessionInformation,
@@ -133,49 +131,6 @@ def pumpAll():
 		postSessionLockStateChanged.notify(isNowLocked=windowsIsNowLocked)
 
 
-def __getattr__(attrName: str) -> Any:
-	"""Module level `__getattr__` used to preserve backward compatibility."""
-	from buildVersion import version_year
-	import NVDAState
-	if not NVDAState._allowDeprecatedAPI():
-		return
-	if version_year < 2023:
-		if attrName == "isWindowsLocked":
-			log.warning(
-				"isWindowsLocked is deprecated for removal in 2023.1"
-			)
-			return _isWindowsLocked
-		elif attrName == "isLockStateSuccessfullyTracked":
-			log.warning(
-				"isLockStateSuccessfullyTracked is deprecated for removal in 2023.1"
-			)
-			return _isLockStateSuccessfullyTracked
-		elif attrName == "register":
-			log.warning(
-				"sessionTracking.register is deprecated for removal in 2023.1"
-			)
-			return _register
-		elif attrName == "unregister":
-			log.warning(
-				"sessionTracking.register is deprecated for removal in 2023.1"
-			)
-			return _unregister
-		elif attrName == "handleSessionChange":
-			log.warning(
-				"sessionTracking.handleSessionChange is deprecated for removal in 2023.1"
-			)
-			return _handleSessionChange
-	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
-
-
-def isWindowsLocked() -> bool:
-	log.error(
-		"This function is deprecated, for removal in 2023.1. "
-		"It was never expected that add-on authors would use this function"
-	)
-	return _isWindowsLocked()
-
-
 def _isWindowsLocked() -> bool:
 	from core import _TrackNVDAInitialization
 	if not _TrackNVDAInitialization.isInitializationComplete():
@@ -231,40 +186,6 @@ def _isWindowsLocked_checkViaSessionQuery() -> bool:
 		)
 		return False
 	return sessionQueryLockState == WTS_LockState.WTS_SESSIONSTATE_LOCK
-
-
-def _isLockStateSuccessfullyTracked() -> bool:
-	log.error(
-		"NVDA no longer registers to receive session tracking notifications. "
-		"This function is deprecated, for removal in 2023.1. "
-		"It was never expected that add-on authors would use this function"
-	)
-	return True
-
-
-def _register(handle: HWNDValT) -> bool:
-	log.error(
-		"NVDA no longer registers to receive session tracking notifications. "
-		"This function is deprecated, for removal in 2023.1. "
-		"It was never expected that add-on authors would use this function"
-	)
-	return True
-
-
-def _unregister(handle: HWNDValT) -> None:
-	log.error(
-		"NVDA no longer registers to receive session tracking notifications. "
-		"This function is deprecated, for removal in 2023.1. "
-		"It was never expected that add-on authors would use this function"
-	)
-
-
-def _handleSessionChange(newState: WindowsTrackedSession, sessionId: int) -> None:
-	log.error(
-		"NVDA no longer registers to receive session tracking notifications. "
-		"This function is deprecated, for removal in 2023.1. "
-		"It was never expected that add-on authors would use this function"
-	)
 
 
 _WTS_INFO_POINTER_T = ctypes.POINTER(WTSINFOEXW)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -95,6 +95,13 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
     -
   -
 - The ``NVDAHelper.RemoteLoader64`` class has been removed with no replacement. (#14449)
+- The following functions in ``winAPI.sessionTracking`` are removed with no replacement. (#14416, #14490)
+  - ``isWindowsLocked``
+  - ``handleSessionChange``
+  - ``unregister``
+  - ``register``
+  - ``isLockStateSuccessfullyTracked``
+  - 
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
#14416 deprecated several functions for removal from `winAPI.sessionTracking`.
This was released in 2022.3.3, and scheduled for removal in 2023.1

### Summary of the issue:
Code needed to be removed

### Description of user facing changes
None

### Description of development approach
Removed code scheduled for removal

### Testing strategy:
none
### Known issues with pull request:
none
### Change log entries:
refer to diff
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
   - [ ] After merging, announce on the addon-api list
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
