### PR TITLE
Move _TrackNVDAInitialization to NVDAState

### DIFF
--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -44,3 +44,27 @@ def _getExitCode() -> int:
 
 def _setExitCode(exitCode: int) -> None:
 	globalVars.exitCode = exitCode
+
+
+class _TrackNVDAInitialization:
+	"""
+	During NVDA initialization,
+	core._initializeObjectCaches needs to cache the desktop object,
+	regardless of lock state.
+	Security checks may cause the desktop object to not be set if NVDA starts on the lock screen.
+	As such, during initialization, NVDA should behave as if Windows is unlocked,
+	i.e. winAPI.sessionTracking._isLockScreenModeActive should return False.
+	"""
+
+	_isNVDAInitialized = False
+	"""When False, _isLockScreenModeActive is forced to return False.
+	"""
+
+	@staticmethod
+	def markInitializationComplete():
+		assert not _TrackNVDAInitialization._isNVDAInitialized
+		_TrackNVDAInitialization._isNVDAInitialized = True
+
+	@staticmethod
+	def isInitializationComplete() -> bool:
+		return _TrackNVDAInitialization._isNVDAInitialized

--- a/source/core.py
+++ b/source/core.py
@@ -453,32 +453,6 @@ def _initializeObjectCaches():
 	api.setMouseObject(desktopObject)
 
 
-class _TrackNVDAInitialization:
-	"""
-	During NVDA initialization,
-	core._initializeObjectCaches needs to cache the desktop object,
-	regardless of lock state.
-	Security checks may cause the desktop object to not be set if NVDA starts on the lock screen.
-	As such, during initialization, NVDA should behave as if Windows is unlocked,
-	i.e. winAPI.sessionTracking._isLockScreenModeActive should return False.
-
-	TODO: move to NVDAState module
-	"""
-
-	_isNVDAInitialized = False
-	"""When False, _isLockScreenModeActive is forced to return False.
-	"""
-
-	@staticmethod
-	def markInitializationComplete():
-		assert not _TrackNVDAInitialization._isNVDAInitialized
-		_TrackNVDAInitialization._isNVDAInitialized = True
-
-	@staticmethod
-	def isInitializationComplete() -> bool:
-		return _TrackNVDAInitialization._isNVDAInitialized
-
-
 def _doLoseFocus():
 	import api
 	focusObject = api.getFocusObject()
@@ -765,7 +739,7 @@ def main():
 	from winAPI import sessionTracking
 	sessionTracking.initialize()
 
-	_TrackNVDAInitialization.markInitializationComplete()
+	NVDAState._TrackNVDAInitialization.markInitializationComplete()
 
 	log.info("NVDA initialized")
 

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -30,6 +30,7 @@ from typing import (
 
 from baseObject import AutoPropertyObject
 from logHandler import log
+from NVDAState import _TrackNVDAInitialization
 
 from .types import HWNDValT
 from ._wtsApi32 import (
@@ -177,7 +178,6 @@ def isWindowsLocked() -> bool:
 
 
 def _isWindowsLocked() -> bool:
-	from core import _TrackNVDAInitialization
 	if not _TrackNVDAInitialization.isInitializationComplete():
 		# Wait until initialization is complete,
 		# so NVDA and other consumers can register the lock state


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:

### Summary of the issue:
`_TrackNVDAInitialization` was created on `rc` before `NVDAState` was created, while `NVDAState` had been implemented for `beta/alpha`. As such, it was flagged to be moved once 2022.3.3 was completed.

### Description of user facing changes
None

### Description of development approach
Code move

### Testing strategy:
None

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
