### PR TITLE
Add Braille and Tones extension points to avoid monkey patching by API consumers

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2118,7 +2118,8 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				self._enableDetection(bluetooth=False, keepCurrentDisplay=True, limitToDevices=[name])
 			# #14503: optimization, avoid notifications of unnecessary re-initialization
 			# of the noBraille display
-			# When setDisplayByName is refactored, ensure that braille display detection no longer triggers a reinit of noBraille.
+			# When setDisplayByName is refactored, ensure that braille display detection no longer triggers
+			# an unnecessary reinit of noBraille.
 			if not (sameDisplayReinit and newDisplay.name == "noBraille"):
 				self.displayChanged.notify(display=newDisplay, isFallback=isFallback, detected=detected)
 			return True

--- a/source/braille.py
+++ b/source/braille.py
@@ -1935,11 +1935,14 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def __init__(self):
 		louisHelper.initialize()
 		self.display: Optional[BrailleDisplayDriver] = None
-		#: Internal cache for the displaySize property.
-		#: This attribute is used to compare the displaySize output by l{filterDisplaySize}
-		#: with its previous output.
-		#: If the value differs, L{displaySizeChanged} is notified.
 		self._displaySize: int = 0
+		"""
+		Internal cache for the displaySize property.
+		This attribute is used to compare the displaySize output by l{filterDisplaySize}
+		with its previous output.
+		If the value differs, L{displaySizeChanged} is notified.
+		"""
+
 		self.mainBuffer = BrailleBuffer(self)
 		self.messageBuffer = BrailleBuffer(self)
 		self._messageCallLater = None

--- a/source/braille.py
+++ b/source/braille.py
@@ -2112,7 +2112,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				config.conf["braille"]["display"] = name
 			else: # detected:
 				self._disableDetection()
-			log.info("Loaded braille display driver %s, current display has %d cells." %(name, self.displaySize))
+			log.info(f"Loaded braille display driver {name!r}, current display has {newDisplay.numCells} cells.")
 			queueHandler.queueFunction(queueHandler.eventQueue, self.initialDisplay)
 			if detected and 'bluetoothName' in detected.deviceInfo:
 				self._enableDetection(bluetooth=False, keepCurrentDisplay=True, limitToDevices=[name])

--- a/source/braille.py
+++ b/source/braille.py
@@ -2092,8 +2092,8 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			oldDisplay = self.display
 			if detected and bdDetect._isDebug():
 				log.debug("Possibly detected display '%s'" % newDisplay.description)
-			sameDisplayReinit = newDisplay == oldDisplay.__class__
-			if sameDisplayReinit:
+			sameDisplayReInit = newDisplay == oldDisplay.__class__
+			if sameDisplayReInit:
 				# This is the same driver as was already set, so just re-initialise it.
 				log.debug("Reinitializing %s braille display"%name)
 				oldDisplay.terminate()

--- a/source/braille.py
+++ b/source/braille.py
@@ -304,10 +304,12 @@ CURSOR_SHAPES = (
 )
 SELECTION_SHAPE = 0xC0 #: Dots 7 and 8
 
-#: The braille shape shown on a braille display when
-#: the number of cells used by the braille handler is lower than the actual number of cells.
-#: The 0 based position of the shape is equal to the number of cells used by the braille handler.
 END_OF_BRAILLE_OUTPUT_SHAPE = 0xFF  # All dots
+"""
+The braille shape shown on a braille display when
+the number of cells used by the braille handler is lower than the actual number of cells.
+The 0 based position of the shape is equal to the number of cells used by the braille handler.
+"""
 
 #: Unicode braille indicator at the start of untranslated braille input.
 INPUT_START_IND = u"⣏"
@@ -1881,7 +1883,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	#: For example, when a system is controlled by a braille enabled remote system,
 	#: the remote system should know what cells to show on its display.
 	#: @param cells: The list of braille cells.
-	#: @type cells: [int]
+	#: @type cells: List[int]
 	#: @param rawText: The raw text that corresponds with the cells.
 	#: @type rawText: str
 	#: @param currentCellCount: The current number of cells

--- a/source/braille.py
+++ b/source/braille.py
@@ -1152,7 +1152,7 @@ class TextInfoRegion(Region):
 						if not inClickable and formatConfig['reportClickable']:
 							states=field.get('states')
 							if states and controlTypes.State.CLICKABLE in states:
-								# We have entered an outer most clickable or entered a new clickable after exiting a previous one 
+								# We have entered an outer most clickable or entered a new clickable after exiting a previous one
 								# Report it if there is nothing else interesting about the field
 								field._presCat=presCat=field.getPresentationCategory(ctrlFields,formatConfig)
 								if not presCat or presCat is field.PRESCAT_LAYOUT:
@@ -1558,7 +1558,7 @@ class BrailleBuffer(baseObject.AutoPropertyObject):
 		"""Sets the end position for the braille window and recalculates the window start position based on several variables.
 		1. Braille display size.
 		2. Whether one of the regions should be shown hard left on the braille display;
-			i.e. because of The configuration setting for focus context representation 
+			i.e. because of The configuration setting for focus context representation
 			or whether the braille region that corresponds with the focus represents a multi line edit box.
 		3. Whether word wrap is enabled."""
 		startPos = endPos - self.handler.displaySize
@@ -1878,45 +1878,59 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	queuedWriteLock: threading.Lock
 	ackTimerHandle: int
 
-	#: Notifies when cells are about to be written to a braille display.
-	#: This allows components and add-ons to perform an action.
-	#: For example, when a system is controlled by a braille enabled remote system,
-	#: the remote system should know what cells to show on its display.
-	#: @param cells: The list of braille cells.
-	#: @type cells: List[int]
-	#: @param rawText: The raw text that corresponds with the cells.
-	#: @type rawText: str
-	#: @param currentCellCount: The current number of cells
-	#: @type currentCellCount: bool
 	pre_writeCells: extensionPoints.Action
-	#: Filter that allows components or add-ons to change the display size used for braille output.
-	#: For example, when a system is controlled by a remote system while having a 80 cells display connected,
-	#: the display size should be lowered to 40 whenever the remote system has a 40 cells display connected.
-	#: @param value: the number of cells of the current display.
-	#: @type value: int
+	"""
+	Notifies when cells are about to be written to a braille display.
+	This allows components and add-ons to perform an action.
+	For example, when a system is controlled by a braille enabled remote system,
+	the remote system should know what cells to show on its display.
+	@param cells: The list of braille cells.
+	@type cells: List[int]
+	@param rawText: The raw text that corresponds with the cells.
+	@type rawText: str
+	@param currentCellCount: The current number of cells
+	@type currentCellCount: bool
+	"""
+
 	filter_displaySize: extensionPoints.Filter
-	#: Action that allows components or add-ons to be notified of display size changes.
-	#: For example, when a system is controlled by a remote system and the remote system swaps displays,
-	#: The local system should be notified about display size changes at the remote system.
-	#: @param displaySize: The current display size used by the braille handler.
-	#: @type displaySize: int
+	"""
+	Filter that allows components or add-ons to change the display size used for braille output.
+	For example, when a system is controlled by a remote system while having a 80 cells display connected,
+	the display size should be lowered to 40 whenever the remote system has a 40 cells display connected.
+	@param value: the number of cells of the current display.
+	@type value: int
+	"""
+
 	displaySizeChanged: extensionPoints.Action
-	#: Action that allows components or add-ons to be notified of braille display changes.
-	#: For example, when a system is controlled by a remote system and the remote system swaps displays,
-	#: The local system should be notified about display parameters at the remote system,
-	#: e.g. name and cellcount.
-	#: @param display: The new braille display driver
-	#: @type display: L{BrailleDisplayDriver}
-	#: @param isFallback: Whether the display is set as fallback display due to another display's failure
-	#: @type isFallback: bool
-	#: @param detected: If the display was set by auto detection, the device match that matched the driver
-	#: @type detected: bdDetect.DeviceMatch or C{None}
+	"""
+	Action that allows components or add-ons to be notified of display size changes.
+	For example, when a system is controlled by a remote system and the remote system swaps displays,
+	The local system should be notified about display size changes at the remote system.
+	@param displaySize: The current display size used by the braille handler.
+	@type displaySize: int
+	"""
+
 	displayChanged: extensionPoints.Action
-	#: Allows components or add-ons to decide whether the braille handler should be forcefully disabled.
-	#: For example, when a system is controlling a remote system with braille,
-	#: the local braille handler should be disabled as long as the system is in control of the remote system.
-	#: Handlers are called without arguments.
+	"""
+	Action that allows components or add-ons to be notified of braille display changes.
+	For example, when a system is controlled by a remote system and the remote system swaps displays,
+	The local system should be notified about display parameters at the remote system,
+	e.g. name and cellcount.
+	@param display: The new braille display driver
+	@type display: L{BrailleDisplayDriver}
+	@param isFallback: Whether the display is set as fallback display due to another display's failure
+	@type isFallback: bool
+	@param detected: If the display was set by auto detection, the device match that matched the driver
+	@type detected: bdDetect.DeviceMatch or C{None}
+	"""
+
 	decide_enabled: extensionPoints.Decider
+	"""
+	Allows components or add-ons to decide whether the braille handler should be forcefully disabled.
+	For example, when a system is controlling a remote system with braille,
+	the local braille handler should be disabled as long as the system is in control of the remote system.
+	Handlers are called without arguments.
+	"""
 
 	def __init__(self):
 		louisHelper.initialize()

--- a/source/braille.py
+++ b/source/braille.py
@@ -2136,7 +2136,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			# of the noBraille display
 			# When setDisplayByName is refactored, ensure that braille display detection no longer triggers
 			# an unnecessary reinit of noBraille.
-			if not (sameDisplayReinit and newDisplay.name == "noBraille"):
+			if not (sameDisplayReInit and newDisplay.name == "noBraille"):
 				self.displayChanged.notify(display=newDisplay, isFallback=isFallback, detected=detected)
 			return True
 		except:

--- a/source/braille.py
+++ b/source/braille.py
@@ -1911,6 +1911,8 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		#: @type cells: [int]
 		#: @param rawText: The raw text that corresponds with the cells.
 		#: @type rawText: str
+		#: @param currentCellCount: The current number of cells
+		#: @type currentCellCount: bool
 		self.pre_writeCells = extensionPoints.Action()
 
 		#: Filter that allows components or add-ons to change the display size used for braille output.
@@ -1962,6 +1964,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		return self.enabled and config.conf["braille"]["tetherTo"] == TetherTo.AUTO.value
 
 	displaySize: int
+	_cache_displaySize = True
 
 	def _get_displaySize(self):
 		"""Returns the display size to use for braille output.
@@ -1982,6 +1985,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		)
 
 	enabled: bool
+	_cache_enabled = True
 
 	def _get_enabled(self):
 		"""Returns whether braille is enabled.
@@ -2113,9 +2117,9 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			wx.CallAfter(self._cursorBlinkTimer.Start,blinkRate)
 
 	def _writeCells(self, cells: List[int]):
-		self.pre_writeCells.notify(cells=cells, rawText=self._rawText)
-		displayCellCount = self.display.numCells
 		handlerCellCount = self.displaySize
+		self.pre_writeCells.notify(cells=cells, rawText=self._rawText, currentCellCount=handlerCellCount)
+		displayCellCount = self.display.numCells
 		if not displayCellCount:
 			# No physical display to write to
 			return

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -124,7 +124,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		return self.model
 
 	def _updateSettings(self):
-		oldNumCells = self.numCells
 		if self.isHid:
 			displaySettings = self._dev.getFeature(ALVA_DISPLAY_SETTINGS_REPORT)
 			if displaySettings[ALVA_DISPLAY_SETTINGS_STATUS_CELL_SIDE_POS] > 1:
@@ -152,9 +151,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			self._ser6SendMessage(b"H", b"?")
 			# Get HID keyboard input state
 			self._ser6SendMessage(b"r", b"?")
-		if oldNumCells not in (0, self.numCells):
-			# In case of splitpoint changes, we need to update the braille handler as well
-			braille.handler.displaySize = self.numCells
 
 	def __init__(self, port="auto"):
 		super(BrailleDisplayDriver,self).__init__()

--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2021 NV Access Limited, Joseph Lee, Łukasz Golonka
+# Copyright (C) 2017-2021 NV Access Limited, Joseph Lee, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -13,6 +13,7 @@ See the L{Action}, L{Filter}, L{Decider} and L{AccumulatingDecider} classes.
 from logHandler import log
 from .util import HandlerRegistrar, callWithSupportedKwargs, BoundMethodWeakref
 from typing import Set
+from typing import TypeVar, Generic
 
 
 class Action(HandlerRegistrar):
@@ -62,7 +63,10 @@ class Action(HandlerRegistrar):
 				log.exception(f"Error running handler {handler} for {self}. Exception {e}")
 
 
-class Filter(HandlerRegistrar):
+FilterValueTypeT = TypeVar("FilterOutputTypeT")
+
+
+class Filter(HandlerRegistrar, Generic[FilterValueTypeT]):
 	"""Allows interested parties to register to modify a specific kind of data.
 	For example, this might be used to allow modification of spoken messages before they are passed to the synthesizer.
 
@@ -86,7 +90,7 @@ class Filter(HandlerRegistrar):
 	'This is a message which has been filtered'
 	"""
 
-	def apply(self, value, **kwargs):
+	def apply(self, value: FilterValueTypeT, **kwargs) -> FilterValueTypeT:
 		"""Pass a value to be filtered through all registered handlers.
 		The value is passed to the first handler
 		and the return value from that handler is passed to the next handler.
@@ -102,6 +106,7 @@ class Filter(HandlerRegistrar):
 			except:
 				log.exception("Error running handler %r for %r" % (handler, self))
 		return value
+
 
 class Decider(HandlerRegistrar):
 	"""Allows interested parties to participate in deciding whether something
@@ -161,7 +166,7 @@ class AccumulatingDecider(HandlerRegistrar):
 	For example, normally user should be warned about all command line parameters
 	which are unknown to NVDA, but this extension point can be used to pass each unknown parameter
 	to all add-ons since one of them may want to process some command line arguments.
-	
+
 	First, a AccumulatingDecider is created with a default decision  :
 
 	>>> doSomething = AccumulatingDecider(defaultDecision=True)

--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -12,8 +12,11 @@ See the L{Action}, L{Filter}, L{Decider} and L{AccumulatingDecider} classes.
 """
 from logHandler import log
 from .util import HandlerRegistrar, callWithSupportedKwargs, BoundMethodWeakref
-from typing import Set
-from typing import TypeVar, Generic
+from typing import (
+	Generic,
+	Set,
+	TypeVar,
+)
 
 
 class Action(HandlerRegistrar):

--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -80,7 +80,7 @@ class Filter(HandlerRegistrar):
 	>>> messageFilter.register(filterMessage)
 
 	When filtering is desired, all registered handlers are called to filter the data, see L{util.callWithSupportedKwargs}
-	for how args passed to notify are mapped to the handler:
+	for how args passed to apply are mapped to the handler:
 
 	>>> messageFilter.apply("This is a message", someArg=42)
 	'This is a message which has been filtered'
@@ -125,7 +125,7 @@ class Decider(HandlerRegistrar):
 
 	When the decision is to be made, registered handlers are called until
 	a handler returns False, see L{util.callWithSupportedKwargs}
-	for how args passed to notify are mapped to the handler:
+	for how args passed to decide are mapped to the handler:
 
 	>>> doSomething.decide(someArg=42)
 	False
@@ -175,9 +175,9 @@ class AccumulatingDecider(HandlerRegistrar):
 	...
 	>>> doSomething.register(shouldDoSomething)
 
-	When the decision is to be made registered handlers are called and they return values are collected,
+	When the decision is to be made registered handlers are called and their return values are collected,
 	see L{util.callWithSupportedKwargs}
-	for how args passed to notify are mapped to the handler:
+	for how args passed to decide are mapped to the handler:
 
 	>>> doSomething.decide(someArg=42)
 	False

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -478,7 +478,8 @@ class InputManager(baseObject.AutoPropertyObject):
 		if not self.decide_executeGesture.decide(gesture=gesture):
 			# A registered handler decided that this gesture shouldn't be executed.
 			# Purposely do not raise a NoInputGestureAction here, as that could
-			# lead to unexpected behavior for gesture emulation.
+			# lead to unexpected behavior for gesture emulation, i.e. the gesture will be send to the system
+			# when the decider decided not to execute it.
 			log.debug(
 				"Gesture execution canceled by handler registered to decide_executeGesture extension point"
 			)

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -437,6 +437,15 @@ class InputManager(baseObject.AutoPropertyObject):
 	#: @type: bool
 	lastModifierWasInSayAll=False
 
+	#: Notifies when a gesture is about to be executed,
+	#: and allows components or add-ons to decide whether or not to execute a gesture.
+	#: For example, when controlling a remote system with a connected local braille display,
+	#: braille display gestures should not be executed locally.
+	#: Handlers are called with one argument:
+	#: @param gesture: The gesture that is about to be executed.
+	#: @type gesture: L{InputGesture}
+	decide_executeGesture: extensionPoints.Decider
+
 	def __init__(self):
 		#: The function to call when capturing gestures.
 		#: If it returns C{False}, normal execution will be prevented.
@@ -452,13 +461,6 @@ class InputManager(baseObject.AutoPropertyObject):
 		self.loadUserGestureMap()
 		self._lastInputTime = None
 
-		#: Notifies when a gesture is about to be executed,
-		#: and allows components or add-ons to decide whether or not to execute a gesture.
-		#: For example, when controlling a remote system with a connected local braille display,
-		#: braille display gestures should not be executed locally.
-		#: Handlers are called with one argument:
-		#: @param gesture: The gesture that is about to be executed.
-		#: @type gesture: L{InputGesture}
 		self.decide_executeGesture = extensionPoints.Decider()
 
 	def executeGesture(self, gesture):

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -437,14 +437,16 @@ class InputManager(baseObject.AutoPropertyObject):
 	#: @type: bool
 	lastModifierWasInSayAll=False
 
-	#: Notifies when a gesture is about to be executed,
-	#: and allows components or add-ons to decide whether or not to execute a gesture.
-	#: For example, when controlling a remote system with a connected local braille display,
-	#: braille display gestures should not be executed locally.
-	#: Handlers are called with one argument:
-	#: @param gesture: The gesture that is about to be executed.
-	#: @type gesture: L{InputGesture}
 	decide_executeGesture: extensionPoints.Decider
+	"""
+	Notifies when a gesture is about to be executed,
+	and allows components or add-ons to decide whether or not to execute a gesture.
+	For example, when controlling a remote system with a connected local braille display,
+	braille display gestures should not be executed locally.
+	Handlers are called with one argument:
+	@param gesture: The gesture that is about to be executed.
+	@type gesture: L{InputGesture}
+	"""
 
 	def __init__(self):
 		#: The function to call when capturing gestures.
@@ -530,7 +532,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.speakMessage, gesture.displayName)
 
 		gesture.reportExtra()
-		
+
 		# #2953: if an intercepted command Script (script that sends a gesture) is queued
 		# then queue all following gestures (that don't have a script) with a fake script so that they remain in order.
 		if not script and scriptHandler._numIncompleteInterceptedCommandScripts:
@@ -797,7 +799,7 @@ class _AllGestureMappingsRetriever(object):
 
 class AllGesturesScriptInfo(object):
 	__slots__ = ("cls", "scriptName", "category", "displayName", "gestures")
-	
+
 	def __init__(self, cls, scriptName):
 		self.cls = cls
 		self.scriptName = scriptName

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -40,6 +40,7 @@ import globalVars
 import languageHandler
 import controlTypes
 import winKernel
+import extensionPoints
 
 
 InputGestureBindingClassT = TypeVar("InputGestureBindingClassT")
@@ -253,19 +254,21 @@ class GlobalGestureMap(object):
 		self._map.clear()
 		self.lastUpdateContainedError = False
 
-	def add(self, gesture, module, className, script,replace=False):
+	def add(
+			self,
+			gesture: str,
+			module: str,
+			className: str,
+			script: Optional[str],
+			replace: bool = False
+	):
 		"""Add a gesture mapping.
 		@param gesture: The gesture identifier.
-		@type gesture: str
 		@param module: The name of the Python module containing the target script.
-		@type module: str
 		@param className: The name of the class in L{module} containing the target script.
-		@type className: str
 		@param script: The name of the target script
 			or C{None} to unbind the gesture for this class.
-		@type script: str
 		@param replace: if true replaces all existing bindings for this gesture with the given script, otherwise only appends this binding.
-		@type replace: boolean
 		"""
 		gesture = normalizeGestureIdentifier(gesture)
 		try:
@@ -449,6 +452,15 @@ class InputManager(baseObject.AutoPropertyObject):
 		self.loadUserGestureMap()
 		self._lastInputTime = None
 
+		#: Notifies when a gesture is about to be executed,
+		#: and allows components or add-ons to decide whether or not to execute a gesture.
+		#: For example, when controlling a remote system with a connected local braille display,
+		#: braille display gestures should not be executed locally.
+		#: Handlers are called with one argument:
+		#: @param gesture: The gesture that is about to be executed.
+		#: @type gesture: L{InputGesture}
+		self.decide_executeGesture = extensionPoints.Decider()
+
 	def executeGesture(self, gesture):
 		"""Perform the action associated with a gesture.
 		@param gesture: The gesture to execute.
@@ -460,6 +472,15 @@ class InputManager(baseObject.AutoPropertyObject):
 			# This lets gestures pass through unhindered where possible,
 			# as well as stopping a flood of actions when the core revives.
 			raise NoInputGestureAction
+
+		if not self.decide_executeGesture.decide(gesture=gesture):
+			# A registered handler decided that this gesture shouldn't be executed.
+			# Purposely do not raise a NoInputGestureAction here, as that could
+			# lead to unexpected behavior for gesture emulation.
+			log.debug(
+				"Gesture execution canceled by handler registered to decide_executeGesture extension point"
+			)
+			return
 
 		script = gesture.script
 		focus = api.getFocusObject()

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1,5 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2021 NV Access Limited, Aleksey Sadovoy, Cyrille Bougot, Peter Vágner
+# Copyright (C) 2007-2021 NV Access Limited, Aleksey Sadovoy, Cyrille Bougot, Peter Vágner, Babbage B.V.,
+# Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -37,15 +38,29 @@ import wave
 import config
 from logHandler import log
 import os.path
+import extensionPoints
+
 
 __all__ = (
-	"WavePlayer", "getOutputDeviceNames", "outputDeviceIDToName", "outputDeviceNameToID",
+	"WavePlayer",
+	"getOutputDeviceNames",
+	"outputDeviceIDToName",
+	"outputDeviceNameToID",
+	"decide_playWaveFile",
 )
 
 winmm = windll.winmm
 
 HWAVEOUT = HANDLE
 LPHWAVEOUT = POINTER(HWAVEOUT)
+
+#: Notifies when a wave file is about to be played,
+#: and allows components or add-ons to decide whether the wave file should be played.
+#: For example, when controlling a remote system,
+#: the remote system must be notified of sounds played on the local system.
+#: Also, registrars should be able to suppress playing sounds if desired.
+#: Handlers are called with the same arguments as L{playWaveFile} as keyword arguments.
+decide_playWaveFile = extensionPoints.Decider()
 
 class WAVEFORMATEX(Structure):
 	_fields_ = [
@@ -627,16 +642,31 @@ fileWavePlayer: Optional[WavePlayer] = None
 fileWavePlayerThread = None
 
 
-def playWaveFile(fileName, asynchronous=True):
+def playWaveFile(
+		fileName: str,
+		asynchronous: bool = True,
+		isSPeechWaveFileCommand: bool = False
+):
 	"""plays a specified wave file.
+	@param fileName: the path to the wave file, usually absolute.
 	@param asynchronous: whether the wave file should be played asynchronously
-	@type asynchronous: bool
+		If C{False}, the calling thread is blocked until the wave has finished playing.
+	@param isSPeechWaveFileCommand: whether this wave is played as part of a speech sequence.
 	"""
 	global fileWavePlayer, fileWavePlayerThread
 	f = wave.open(fileName,"r")
 	if f is None: raise RuntimeError("can not open file %s"%fileName)
 	if fileWavePlayer is not None:
 		fileWavePlayer.stop()
+	if not decide_playWaveFile.decide(
+		fileName=fileName,
+		asynchronous=asynchronous,
+		isSPeechWaveFileCommand=isSPeechWaveFileCommand
+	):
+		log.debug(
+			"Playing wave file canceled by handler registered to decide_playWaveFile extension point"
+		)
+		return
 	fileWavePlayer = WavePlayer(
 		channels=f.getnchannels(),
 		samplesPerSec=f.getframerate(),

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -54,13 +54,16 @@ winmm = windll.winmm
 HWAVEOUT = HANDLE
 LPHWAVEOUT = POINTER(HWAVEOUT)
 
-#: Notifies when a wave file is about to be played,
-#: and allows components or add-ons to decide whether the wave file should be played.
-#: For example, when controlling a remote system,
-#: the remote system must be notified of sounds played on the local system.
-#: Also, registrars should be able to suppress playing sounds if desired.
-#: Handlers are called with the same arguments as L{playWaveFile} as keyword arguments.
 decide_playWaveFile = extensionPoints.Decider()
+"""
+Notifies when a wave file is about to be played,
+and allows components or add-ons to decide whether the wave file should be played.
+For example, when controlling a remote system,
+the remote system must be notified of sounds played on the local system.
+Also, registrars should be able to suppress playing sounds if desired.
+Handlers are called with the same arguments as L{playWaveFile} as keyword arguments.
+"""
+
 
 class WAVEFORMATEX(Structure):
 	_fields_ = [

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -651,7 +651,7 @@ def playWaveFile(
 	@param fileName: the path to the wave file, usually absolute.
 	@param asynchronous: whether the wave file should be played asynchronously
 		If C{False}, the calling thread is blocked until the wave has finished playing.
-	@param isSPeechWaveFileCommand: whether this wave is played as part of a speech sequence.
+	@param isSpeechWaveFileCommand: whether this wave is played as part of a speech sequence.
 	"""
 	global fileWavePlayer, fileWavePlayerThread
 	f = wave.open(fileName,"r")
@@ -661,7 +661,7 @@ def playWaveFile(
 	if not decide_playWaveFile.decide(
 		fileName=fileName,
 		asynchronous=asynchronous,
-		isSPeechWaveFileCommand=isSPeechWaveFileCommand
+		isSpeechWaveFileCommand=isSpeechWaveFileCommand
 	):
 		log.debug(
 			"Playing wave file canceled by handler registered to decide_playWaveFile extension point"

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -645,7 +645,7 @@ fileWavePlayerThread = None
 def playWaveFile(
 		fileName: str,
 		asynchronous: bool = True,
-		isSPeechWaveFileCommand: bool = False
+		isSpeechWaveFileCommand: bool = False
 ):
 	"""plays a specified wave file.
 	@param fileName: the path to the wave file, usually absolute.

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -357,7 +357,7 @@ class BeepCommand(BaseCallbackCommand):
 			self.length,
 			left=self.left,
 			right=self.right,
-			isSPeechBeepCommand=True
+			isSpeechBeepCommand=True
 		)
 
 	def __repr__(self):
@@ -373,7 +373,7 @@ class WaveFileCommand(BaseCallbackCommand):
 
 	def run(self):
 		import nvwave
-		nvwave.playWaveFile(self.fileName, asynchronous=True, isSPeechWaveFileCommand=True)
+		nvwave.playWaveFile(self.fileName, asynchronous=True, isSpeechWaveFileCommand=True)
 
 	def __repr__(self):
 		return "WaveFileCommand(%r)" % self.fileName

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -352,7 +352,13 @@ class BeepCommand(BaseCallbackCommand):
 
 	def run(self):
 		import tones
-		tones.beep(self.hz, self.length, left=self.left, right=self.right)
+		tones.beep(
+			self.hz,
+			self.length,
+			left=self.left,
+			right=self.right,
+			isSPeechBeepCommand=True
+		)
 
 	def __repr__(self):
 		return "BeepCommand({hz}, {length}, left={left}, right={right})".format(
@@ -367,7 +373,7 @@ class WaveFileCommand(BaseCallbackCommand):
 
 	def run(self):
 		import nvwave
-		nvwave.playWaveFile(self.fileName, asynchronous=True)
+		nvwave.playWaveFile(self.fileName, asynchronous=True, isSPeechWaveFileCommand=True)
 
 	def __repr__(self):
 		return "WaveFileCommand(%r)" % self.fileName

--- a/source/tones.py
+++ b/source/tones.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2017 NV Access Limited, Aleksey Sadovoy, Leonard de Ruijter
+# Copyright (C) 2007-2023 NV Access Limited, Aleksey Sadovoy, Leonard de Ruijter, Babbage B.V.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -11,6 +11,7 @@ import config
 import globalVars
 from logHandler import log
 from ctypes import create_string_buffer, byref
+import extensionPoints
 
 SAMPLE_RATE = 44100
 
@@ -38,18 +39,42 @@ def terminate():
 	global player
 	player = None
 
-def beep(hz,length,left=50,right=50):
+
+#: Notifies when a beep is about to be generated and played,
+#: and allows components or add-ons to decide whether the beep should actually be played.
+#: For example, when controlling a remote system,
+#: the remote system must be notified of beeps played on the local system.
+#: Also, registrars should be able to suppress playing beeps if desired.
+#: Handlers are called with the same arguments as L{beep} as keyword arguments.
+decide_beep = extensionPoints.Decider()
+
+
+def beep(
+		hz: float,
+		length: int,
+		left: int = 50,
+		right: int = 50,
+		isSPeechBeepCommand: bool = False
+):
 	"""Plays a tone at the given hz, length, and stereo balance.
 	@param hz: pitch in hz of the tone
-	@type hz: float
 	@param length: length of the tone in ms
-	@type length: integer
 	@param left: volume of the left channel (0 to 100)
-	@type left: integer
 	@param right: volume of the right channel (0 to 100)
-	@type right: integer
+	@param isSPeechBeepCommand: whether this beep is created as part of a speech sequence
 	"""
 	log.io("Beep at pitch %s, for %s ms, left volume %s, right volume %s"%(hz,length,left,right))
+	if not decide_beep.decide(
+		hz=hz,
+		length=length,
+		left=left,
+		right=right,
+		isSPeechBeepCommand=isSPeechBeepCommand
+	):
+		log.debug(
+			"Beep canceled by handler registered to decide_beep extension point"
+		)
+		return
 	if not player:
 		return
 	from NVDAHelper import generateBeep

--- a/source/tones.py
+++ b/source/tones.py
@@ -40,13 +40,15 @@ def terminate():
 	player = None
 
 
-#: Notifies when a beep is about to be generated and played,
-#: and allows components or add-ons to decide whether the beep should actually be played.
-#: For example, when controlling a remote system,
-#: the remote system must be notified of beeps played on the local system.
-#: Also, registrars should be able to suppress playing beeps if desired.
-#: Handlers are called with the same arguments as L{beep} as keyword arguments.
 decide_beep = extensionPoints.Decider()
+"""
+Notifies when a beep is about to be generated and played,
+and allows components or add-ons to decide whether the beep should actually be played.
+For example, when controlling a remote system,
+the remote system must be notified of beeps played on the local system.
+Also, registrars should be able to suppress playing beeps if desired.
+Handlers are called with the same arguments as L{beep} as keyword arguments.
+"""
 
 
 def beep(

--- a/source/tones.py
+++ b/source/tones.py
@@ -54,7 +54,7 @@ def beep(
 		length: int,
 		left: int = 50,
 		right: int = 50,
-		isSPeechBeepCommand: bool = False
+		isSpeechBeepCommand: bool = False
 ):
 	"""Plays a tone at the given hz, length, and stereo balance.
 	@param hz: pitch in hz of the tone

--- a/source/tones.py
+++ b/source/tones.py
@@ -61,7 +61,7 @@ def beep(
 	@param length: length of the tone in ms
 	@param left: volume of the left channel (0 to 100)
 	@param right: volume of the right channel (0 to 100)
-	@param isSPeechBeepCommand: whether this beep is created as part of a speech sequence
+	@param isSpeechBeepCommand: whether this beep is created as part of a speech sequence
 	"""
 	log.io("Beep at pitch %s, for %s ms, left volume %s, right volume %s"%(hz,length,left,right))
 	if not decide_beep.decide(
@@ -69,7 +69,7 @@ def beep(
 		length=length,
 		left=left,
 		right=right,
-		isSPeechBeepCommand=isSPeechBeepCommand
+		isSpeechBeepCommand=isSpeechBeepCommand
 	):
 		log.debug(
 			"Beep canceled by handler registered to decide_beep extension point"

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -47,32 +47,6 @@ def _importRobotRemoteServer() -> typing.Type:
 	return RobotRemoteServer
 
 
-class BrailleViewerSpy:
-	postBrailleUpdate = extensionPoints.Action()
-
-	def __init__(self):
-		self._last = ""
-
-	def updateBrailleDisplayed(
-			self,
-			cells,  # ignored
-			rawText,
-			currentCellCount,  # ignored
-	):
-		rawText = rawText.strip()
-		if rawText and rawText != self._last:
-			self._last = rawText
-			self.postBrailleUpdate.notify(rawText=rawText)
-
-	isDestroyed: bool = False
-
-	def saveInfoAndDestroy(self):
-		if not self.isDestroyed:
-			self.isDestroyed = True
-			import brailleViewer
-			brailleViewer._onGuiDestroyed()
-
-
 class NVDASpyLib:
 	""" Robot Framework Library to spy on NVDA during system tests.
 	Used to determine if NVDA has finished starting, and various ways of getting speech output.
@@ -89,7 +63,7 @@ class NVDASpyLib:
 		self._lastSpeechTime_requiresLock = _timer()
 		#: Lock to protect members that are written to in _onNvdaSpeech.
 		self._speechLock = threading.RLock()
-
+		self._lastRawText = ""
 		# braille raw text (not dots) cache is ordered temporally,
 		# oldest at low indexes, most recent at highest index.
 		self._nvdaBraille_requiresLock = [  # requires thread locking before read/write
@@ -113,9 +87,6 @@ class NVDASpyLib:
 		# Import path must be valid after `speechSpySynthDriver.py` is moved to "scratchpad/synthDrivers/"
 		from synthDrivers.speechSpySynthDriver import post_speech
 		post_speech.register(self._onNvdaSpeech)
-
-		self._brailleSpy = BrailleViewerSpy()
-		self._brailleSpy.postBrailleUpdate.register(self._onNvdaBraille)
 
 	ConfKeyPath = typing.List[str]
 	ConfKeyVal = typing.Union[str, bool, int]
@@ -185,17 +156,19 @@ class NVDASpyLib:
 	# callbacks for extension points
 	def _onNvdaStartupComplete(self):
 		self._isNvdaStartupComplete = True
-		import brailleViewer
-		brailleViewer._brailleGui = self._brailleSpy
 		import braille
 		braille.handler.filter_displaySize.register(self.getBrailleCellCount)
-		brailleViewer.postBrailleViewerToolToggledAction.notify(created=True)
+		braille.handler.pre_writeCells.register(self._onNvdaBraille)
 
 	def _onNvdaBraille(self, rawText: str):
 		if not rawText:
 			return
 		if not isinstance(rawText, str):
 			raise TypeError(f"rawText expected as str, got: {type(rawText)}, {rawText!r}")
+		rawText = rawText.strip()
+		if rawText == self._lastRawText:
+			return
+		self._lastRawText = rawText
 		with self._brailleLock:
 			log.debug(f"Appending to braille spy at index {len(self._nvdaBraille_requiresLock)}")
 			self._nvdaBraille_requiresLock.append(rawText)
@@ -261,7 +234,7 @@ class NVDASpyLib:
 	def setBrailleCellCount(self, brailleCellCount: int):
 		self._brailleCellCount = brailleCellCount
 
-	def getBrailleCellCount(self, currentCellCount: int):
+	def getBrailleCellCount(self, value: int):
 		return self._brailleCellCount
 
 	def _getBrailleAtIndex(self, brailleIndex: int) -> str:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -79,6 +79,7 @@ class NVDASpyLib:
 	All public methods are part of the Robot Library
 	"""
 	SPEECH_HAS_FINISHED_SECONDS: float = 1.0
+	_brailleCellCount: int = 120
 
 	def __init__(self):
 		# speech cache is ordered temporally, oldest at low indexes, most recent at highest index.
@@ -257,8 +258,11 @@ class NVDASpyLib:
 			finished = self.SPEECH_HAS_FINISHED_SECONDS < elapsed
 			return started and finished
 
+	def setBrailleCellCount(self, brailleCellCount: int):
+		self._brailleCellCount = brailleCellCount
+
 	def getBrailleCellCount(self, currentCellCount: int):
-		return 120
+		return self._brailleCellCount
 
 	def _getBrailleAtIndex(self, brailleIndex: int) -> str:
 		with self._brailleLock:

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -186,7 +186,8 @@ class NVDASpyLib:
 		self._isNvdaStartupComplete = True
 		import brailleViewer
 		brailleViewer._brailleGui = self._brailleSpy
-		self.setBrailleCellCount(120)
+		import braille
+		braille.handler.filter_displaySize.register(self.getBrailleCellCount)
 		brailleViewer.postBrailleViewerToolToggledAction.notify(created=True)
 
 	def _onNvdaBraille(self, rawText: str):
@@ -256,9 +257,8 @@ class NVDASpyLib:
 			finished = self.SPEECH_HAS_FINISHED_SECONDS < elapsed
 			return started and finished
 
-	def setBrailleCellCount(self, brailleCellCount: int):
-		import brailleViewer
-		brailleViewer.DEFAULT_NUM_CELLS = brailleCellCount
+	def getBrailleCellCount(self, currentCellCount: int):
+		return 120
 
 	def _getBrailleAtIndex(self, brailleIndex: int) -> str:
 		with self._brailleLock:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -92,9 +92,10 @@ import braille
 config.conf['braille']['display'] = "noBraille"
 braille.initialize()
 
+
 # For braille unit tests, we need to enable the braille handler by providing it a  cell count
 # Give the display 40 cells
-def getFakeCellCount(numCells: int) ->int:
+def getFakeCellCount(numCells: int) -> int:
 	return 40
 
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -91,10 +91,15 @@ import braille
 # Disable auto detection of braille displays when unit testing.
 config.conf['braille']['display'] = "noBraille"
 braille.initialize()
-# For braille unit tests, we need to construct a fake braille display as well as enable the braille handler
+
+# For braille unit tests, we need to enable the braille handler by providing it a  cell count
 # Give the display 40 cells
-braille.handler.displaySize=40
-braille.handler.enabled = True
+def getFakeCellCount(numCells: int) ->int:
+	return 40
+
+
+braille.handler.filter_displaySize.register(getFakeCellCount)
+
 # The focus and navigator objects need to be initialized to something.
 from .objectProvider import PlaceholderNVDAObject,NVDAObjectWithRole
 phObj = PlaceholderNVDAObject()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -93,7 +93,7 @@ config.conf['braille']['display'] = "noBraille"
 braille.initialize()
 
 
-# For braille unit tests, we need to enable the braille handler by providing it a  cell count
+# For braille unit tests, we need to enable the braille handler by providing it a cell count
 # Give the display 40 cells
 def getFakeCellCount(numCells: int) -> int:
 	return 40

--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -41,19 +41,19 @@ def actionTester(
 		testFunc(expectedKwargs, actualKwargs)
 
 
+@contextmanager
 def deciderTester(
 		testCase: unittest.TestCase,
 		decider: Decider,
 		expectedDecision: bool,
-		actualDecisionGetter: Callable[[], bool],
 		useAssertDictContainsSubset: bool = False,
 		**expectedKwargs
 ):
-	"""A function that allows testing a Decider.
+	"""A context manager that allows testing a Decider.
 	@param testCase: The test case to apply the assertion on.
 	@param decider: The Decider that will be consulted by the test case.
 	@param expectedDecision: The expected decision as returned by L{Decider.decide}
-	@param actualDecisionGetter: A callable that returns the actual decision
+		it will also be yielded by the context manager.
 	@param useAssertDictContainsSubset: Whether to use L{unittest.TestCase.assertDictContainsSubset} instead of
 		L{unittest.TestCase.assertDictEqual}
 		This can be used if a decider is consulted with dictionary values that can't be predicted at test time,
@@ -68,19 +68,19 @@ def deciderTester(
 
 	decider.register(handler)
 	try:
-		testCase.assertEqual(expectedDecision, actualDecisionGetter())
+		yield expectedDecision
 	finally:
 		decider.unregister(handler)
 		testFunc = testCase.assertDictContainsSubset if useAssertDictContainsSubset else testCase.assertDictEqual
 		testFunc(expectedKwargs, actualKwargs)
 
 
+@contextmanager
 def filterTester(
 		testCase: unittest.TestCase,
 		filter: Filter,
 		expectedInput: FilterValueTypeT,
 		expectedOutput: FilterValueTypeT,
-		actualOutputGetter: Callable[[], FilterValueTypeT],
 		useAssertDictContainsSubset: bool = False,
 		**expectedKwargs
 ):
@@ -89,7 +89,7 @@ def filterTester(
 	@param filter: The filter that will be applied by the test case.
 	@param expectedInput: The expected input as entering the filter handler.
 	@param expectedOutput: The expected output as returned by L{Filter.apply}
-	@param actualOutputGetter: A callable that returns the actual output
+		it will also be yielded by the context manager
 	@param useAssertDictContainsSubset: Whether to use L{unittest.TestCase.assertDictContainsSubset} instead of
 		L{unittest.TestCase.assertDictEqual}
 		This can be used if a filter is applied with dictionary values that can't be predicted at test time,
@@ -111,9 +111,9 @@ def filterTester(
 
 	filter.register(handler)
 	try:
-		testCase.assertEqual(expectedOutput, actualOutputGetter())
-		testCase.assertEqual(expectedInput, container.value)
+		yield expectedOutput
 	finally:
 		filter.unregister(handler)
+		testCase.assertEqual(expectedInput, container.value)
 		testFunc = testCase.assertDictContainsSubset if useAssertDictContainsSubset else testCase.assertDictEqual
 		testFunc(expectedKwargs, actualKwargs)

--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -8,7 +8,7 @@
 from extensionPoints import Action, Decider, Filter, FilterValueTypeT
 import unittest
 from contextlib import contextmanager
-from typing import Callable, Optional
+from typing import Optional
 
 
 @contextmanager

--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -1,0 +1,88 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023NV Access Limited, Babbage B.V., Leonard de Ruijter
+
+"""Helper functions to test extension points."""
+
+from extensionPoints import Action, Decider, Filter, FilterValueTypeT
+import unittest
+from contextlib import contextmanager
+from typing import Callable, Optional
+
+
+@contextmanager
+def actionTester(
+	testCase: unittest.TestCase,
+	action: Action,
+	**expectedKwargs
+):
+	"""A context manager that allows testing an Action.
+	@param testCase: The test case to apply assertions on.
+	@param action: The action that will be triggered by the test case.
+	@param expectedKwargs: The kwargs that are expected to be passed to the action
+	"""
+	actualKwargs = {}
+
+	def handler(**kwargs):
+		actualKwargs.update(kwargs)
+
+	action.register(handler)
+	try:
+		yield
+	finally:
+		action.unregister(handler)
+		testCase.assertDictEqual(expectedKwargs, actualKwargs)
+
+
+def deciderTester(
+	testCase: unittest.TestCase,
+	decider: Decider,
+	expectedDecision: bool,
+	actualDecisionGetter: Callable[[], bool],
+):
+	"""A function that allows testing a Decider.
+	@param testCase: The test case to apply the assertion on.
+	@param decider: The Decider that will be consulted by the test case.
+	@param expectedDecision: The expected decision as returned by L{Decider.decide}
+	@param actualDecisionGetter: A callable that returns the actual decision
+	"""
+	def handler(**kwargs):
+		return expectedDecision
+
+	decider.register(handler)
+	try:
+		testCase.assertEqual(expectedDecision, actualDecisionGetter())
+	finally:
+		decider.unregister(handler)
+
+
+def filterTester(
+	testCase: unittest.TestCase,
+	filter: Filter,
+	expectedInput: FilterValueTypeT,
+	expectedOutput: FilterValueTypeT,
+	actualOutputGetter: Callable[[], FilterValueTypeT],
+):
+	"""A function that allows testing a Filter.
+	@param testCase: The test case to apply the assertion on.
+	@param filter: The filter that will be applied by the test case.
+	@param expectedInput: The expected input as entering the filter handler.
+	@param expectedOutput: The expected output as returned by L{Filter.apply}
+	@param actualOutputGetter: A callable that returns the actual output
+	"""
+
+	class InputValueContainer:
+		"""A class to propagate the input value entering the handler to the filterTester"""
+		value: Optional[FilterValueTypeT] = None
+
+	container = InputValueContainer()
+
+	def handler(inputVal: FilterValueTypeT):
+		container.value = inputVal
+		return expectedOutput
+
+	filter.register(handler)
+	testCase.assertEqual(expectedOutput, actualOutputGetter())
+	testCase.assertEqual(expectedInput, container.value)
+	filter.unregister(handler)

--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2023NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 """Helper functions to test extension points."""
 

--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -13,13 +13,18 @@ from typing import Callable, Optional
 
 @contextmanager
 def actionTester(
-	testCase: unittest.TestCase,
-	action: Action,
-	**expectedKwargs
+		testCase: unittest.TestCase,
+		action: Action,
+		useAssertDictContainsSubset: bool = False,
+		**expectedKwargs
 ):
 	"""A context manager that allows testing an Action.
 	@param testCase: The test case to apply assertions on.
 	@param action: The action that will be triggered by the test case.
+	@param useAssertDictContainsSubset: Whether to use L{unittest.TestCase.assertDictContainsSubset} instead of
+		L{unittest.TestCase.assertDictEqual}
+		This can be used if an action is notified with dictionary values that can't be predicted at test time,
+		such as a driver instance.
 	@param expectedKwargs: The kwargs that are expected to be passed to the action
 	"""
 	actualKwargs = {}
@@ -32,14 +37,15 @@ def actionTester(
 		yield
 	finally:
 		action.unregister(handler)
-		testCase.assertDictEqual(expectedKwargs, actualKwargs)
+		testFunc = testCase.assertDictContainsSubset if useAssertDictContainsSubset else testCase.assertDictEqual
+		testFunc(expectedKwargs, actualKwargs)
 
 
 def deciderTester(
-	testCase: unittest.TestCase,
-	decider: Decider,
-	expectedDecision: bool,
-	actualDecisionGetter: Callable[[], bool],
+		testCase: unittest.TestCase,
+		decider: Decider,
+		expectedDecision: bool,
+		actualDecisionGetter: Callable[[], bool],
 ):
 	"""A function that allows testing a Decider.
 	@param testCase: The test case to apply the assertion on.
@@ -58,11 +64,11 @@ def deciderTester(
 
 
 def filterTester(
-	testCase: unittest.TestCase,
-	filter: Filter,
-	expectedInput: FilterValueTypeT,
-	expectedOutput: FilterValueTypeT,
-	actualOutputGetter: Callable[[], FilterValueTypeT],
+		testCase: unittest.TestCase,
+		filter: Filter,
+		expectedInput: FilterValueTypeT,
+		expectedOutput: FilterValueTypeT,
+		actualOutputGetter: Callable[[], FilterValueTypeT],
 ):
 	"""A function that allows testing a Filter.
 	@param testCase: The test case to apply the assertion on.

--- a/tests/unit/objectProvider.py
+++ b/tests/unit/objectProvider.py
@@ -11,7 +11,9 @@ from NVDAObjects import NVDAObject
 import controlTypes
 
 class PlaceholderNVDAObject(NVDAObject):
-	processID = None # Must be implemented to instantiate.
+	processID = None  # Must be implemented to instantiate.
+	windowThreadID = None  # Must be implemented for inputCore tests
+
 
 class NVDAObjectWithRole(PlaceholderNVDAObject):
 	"""An object that accepts a role as one of its construction parameters.

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -13,7 +13,6 @@ import controlTypes
 from config import conf
 import api
 import globalVars
-from typing import List
 from .extensionPointTestHelpers import actionTester, filterTester, deciderTester
 
 
@@ -152,6 +151,18 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			braille.handler._displaySize = 0
 			# The getter should now trigger the action.
 			braille.handler._get_displaySize()
+
+	def test_displayChanged(self):
+		expectedKwargs = dict(
+			isFallback=False,
+			detected=None
+		)
+
+		with actionTester(self, braille.handler.displayChanged, useAssertDictContainsSubset=True, **expectedKwargs):
+			# Terminate the current noBraille instance to ensure that the action is triggered when choosing it again.
+			braille.handler.display.terminate()
+			braille.handler.display = None
+			braille.handler.setDisplayByName("noBraille")
 
 	def test_filter_displaySize(self):
 		filterTester(

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -177,6 +177,6 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 		with deciderTester(
 			self,
 			braille.handler.decide_enabled,
-			False,
+			expectedDecision=False,
 		) as expectedDecision:
 			self.assertEqual(braille.handler.enabled, expectedDecision)

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -165,18 +165,18 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			braille.handler.setDisplayByName("noBraille")
 
 	def test_filter_displaySize(self):
-		filterTester(
+		with filterTester(
 			self,
 			braille.handler.filter_displaySize,
 			braille.handler._displaySize,  # The currently cached display size
 			20,   # The filter handler should change the display size to 40
-			braille.handler._get_displaySize
-		)
+		) as expectedOutput:
+			self.assertEqual(braille.handler.displaySize, expectedOutput)
 
 	def test_decide_enabled(self):
-		deciderTester(
+		with deciderTester(
 			self,
 			braille.handler.decide_enabled,
 			False,
-			braille.handler._get_enabled
-		)
+		) as expectedDecision:
+			self.assertEqual(braille.handler.enabled, expectedDecision)

--- a/tests/unit/test_inputCore.py
+++ b/tests/unit/test_inputCore.py
@@ -1,0 +1,32 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
+
+"""Unit tests for the inputCore module.
+"""
+
+import unittest
+import inputCore
+import keyboardHandler
+from .extensionPointTestHelpers import deciderTester
+
+
+class TestHandlerExtensionPoints(unittest.TestCase):
+	"""A test for the extension points on the input manager."""
+
+	def setUp(self) -> None:
+		inputCore.initialize()
+
+	def tearDown(self) -> None:
+		inputCore.terminate()
+
+	def test_decide_executeGesture(self):
+		gesture = keyboardHandler.KeyboardInputGesture.fromName("NVDA+T")
+		deciderTester(
+			self,
+			inputCore.manager.decide_executeGesture,
+			None,
+			lambda: inputCore.manager.executeGesture(gesture),
+			gesture=gesture
+		)

--- a/tests/unit/test_inputCore.py
+++ b/tests/unit/test_inputCore.py
@@ -26,7 +26,7 @@ class TestInputManagerExtensionPoints(unittest.TestCase):
 		with deciderTester(
 			self,
 			inputCore.manager.decide_executeGesture,
-			False,
+			expectedDecision=False,
 			gesture=gesture
 		):
 			inputCore.manager.executeGesture(gesture)

--- a/tests/unit/test_inputCore.py
+++ b/tests/unit/test_inputCore.py
@@ -12,7 +12,7 @@ import keyboardHandler
 from .extensionPointTestHelpers import deciderTester
 
 
-class TestHandlerExtensionPoints(unittest.TestCase):
+class TestInputManagerExtensionPoints(unittest.TestCase):
 	"""A test for the extension points on the input manager."""
 
 	def setUp(self) -> None:
@@ -23,10 +23,10 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 
 	def test_decide_executeGesture(self):
 		gesture = keyboardHandler.KeyboardInputGesture.fromName("NVDA+T")
-		deciderTester(
+		with deciderTester(
 			self,
 			inputCore.manager.decide_executeGesture,
-			None,
-			lambda: inputCore.manager.executeGesture(gesture),
+			False,
 			gesture=gesture
-		)
+		):
+			inputCore.manager.executeGesture(gesture)

--- a/tests/unit/test_nvwave.py
+++ b/tests/unit/test_nvwave.py
@@ -25,7 +25,7 @@ class TestNVWaveExtensionPoints(unittest.TestCase):
 		with deciderTester(
 			self,
 			nvwave.decide_playWaveFile,
-			False,
+			expectedDecision=False,
 			**kwargs
 		):
 			nvwave.playWaveFile(**kwargs)

--- a/tests/unit/test_nvwave.py
+++ b/tests/unit/test_nvwave.py
@@ -1,0 +1,31 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
+
+"""Unit tests for the nvwave module.
+"""
+
+import unittest
+import nvwave
+from .extensionPointTestHelpers import deciderTester
+import os.path
+import globalVars
+
+
+class TestNVWaveExtensionPoints(unittest.TestCase):
+	"""A test for the extension points on the nvwave module."""
+
+	def test_decide_playWaveFile(self):
+		kwargs = {
+			"fileName": os.path.join(globalVars.appDir, "waves", "start.wav"),
+			"asynchronous": False,
+			"isSpeechWaveFileCommand": False
+		}
+		with deciderTester(
+			self,
+			nvwave.decide_playWaveFile,
+			False,
+			**kwargs
+		):
+			nvwave.playWaveFile(**kwargs)

--- a/tests/unit/test_tones.py
+++ b/tests/unit/test_tones.py
@@ -31,7 +31,7 @@ class TestTonesExtensionPoints(unittest.TestCase):
 		with deciderTester(
 			self,
 			tones.decide_beep,
-			False,
+			expectedDecision=False,
 			**kwargs
 		):
 			tones.beep(**kwargs)

--- a/tests/unit/test_tones.py
+++ b/tests/unit/test_tones.py
@@ -1,0 +1,37 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
+
+"""Unit tests for the tones module.
+"""
+
+import unittest
+import tones
+from .extensionPointTestHelpers import deciderTester
+
+
+class TestTonesExtensionPoints(unittest.TestCase):
+	"""A test for the extension points on the tones module."""
+
+	def setUp(self) -> None:
+		tones.initialize()
+
+	def tearDown(self) -> None:
+		tones.terminate()
+
+	def test_decide_beep(self):
+		kwargs = {
+			"hz": 440.0,
+			"length": 500,
+			"left": 50,
+			"right": 50,
+			"isSpeechBeepCommand": False,
+		}
+		with deciderTester(
+			self,
+			tones.decide_beep,
+			False,
+			**kwargs
+		):
+			tones.beep(**kwargs)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -93,6 +93,16 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - This new class is not a singleton by design, add-on authors are encouraged to use their own instance when doing hardware i/o.
   -
 - The processor architecture for the computer can be queried from ``winVersion.WinVersion.processorArchitecture attribute.`` (#14439)
+- New extension points have be added. (#14503)
+  - ``inputCore.manager.decide_executeGesture``
+  - ``tones.decide_beep``
+  - ``nvwave.decide_playWaveFile``
+  - ``braille.handler.pre_writeCells``
+  - ``braille.handler.filter_displaySize``
+  - ``braille.handler.decide_enabled``
+  - ``braille.handler.displayChanged``
+  - ``braille.handler.displaySizeChanged``
+  - 
 -
 
 === API Breaking Changes ===
@@ -118,6 +128,11 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
   - ``register``
   - ``isLockStateSuccessfullyTracked``
   - 
+- It is no longer possible to enable/disable the braille handler by setting ``braille.handler.enabled``.
+To disable the braille handler programatically, register a handler to ``braille.handler.decide_enabled``. (#14503)
+- It is no longer possible to update the display size of the handler by setting ``braille.handler.displaySize``.
+To update the displaySize programatically, register a handler to ``braille.handler.filter_displaySize``.
+Refer to ``brailleViewer`` for an example on how to do this. (#14503)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Replaces #9917 

### Summary of the issue:
Tools like NVDA remote that need to intercept speech and braille output currently rely on monkeypatching to do this.

### Description of user facing changes
It is no longer possible to override the display size of the braille handler by setting braille.handler.displaySize. It is also no longer possible to enable/disable the handler by setting braille.handler.enabled.

### Description of development approach
Added the following extension points:

* inputCore.manager.decide_executeGesture: Decider for filtering gestures
* tones.decide_beep
* nvwave.decide_playWaveFile
* braille.handler.pre_writeCells
* braille.handler.filter_displaySize
* braille.handler.decide_enabled
* braille.handler.displayChange
* braille.handler.displaySizeChanged

This means that NVDA Remote and similar tools can at least drop all monkeypatching related to braille, playing tones and waves. Speech is a separate subject and will be handled in a follow up.

### Testing strategy:
* Tested that NVDA will still work as normal.
* Tested that lowering the display size programatically adds a full cell to the end of the text to indicate that there's a hard stop because of a lower cell count used.
* New unit tests

### Known issues with pull request:
None known

### Change log entries:
For Developers
- Added the following extension points: (Check them in source documentation for details).
 - inputCore.manager.decide_executeGesture
 - tones.decide_beep
 - nvwave.decide_playWaveFile
 - braille.handler.pre_writeCells
 - braille.handler.filter_displaySize
 - braille.handler.decide_enabled
 - braille.handler.displayChanged
 - braille.handler.displaySizeChanged

API breaking changes
- it is no longer possible to enable/disable the braille handler by setting braille.handler.enabled or update the display size of the handler by setting braille.handler.displaySize.
 - To update the displaySize programatically, register a handler to braille.handler.filter_displaySize. See the brailleViewer code for an example on how to do this.
 - To disable the braille handler programatically, register a handler to braille.handler.decide_enabled.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
