### PR TITLE
Report the presence of multiple annotations

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2007-2022 NV Access Limited, Mozilla Corporation
+Copyright 2007-2023 NV Access Limited, Mozilla Corporation
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -13,6 +13,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
 #include <memory>
+#include <numeric>
 #include <functional>
 #include <vector>
 #include <map>
@@ -47,43 +48,73 @@ bool hasXmlRoleAttribContainingValue(const map<wstring,wstring>& attribsMap, con
 	return attribsMapIt != attribsMap.end() && attribsMapIt->second.find(roleName) != wstring::npos;
 }
 
-CComPtr<IAccessible2> GeckoVBufBackend_t::getRelationElement(
+std::vector<CComQIPtr<IAccessible2>> GeckoVBufBackend_t::getRelationElementsOfType(
 	LPCOLESTR ia2TargetRelation,
-	IAccessible2_2* element
+	IAccessible2_2* element,
+	const std::optional<std::size_t> numRelations
 ) {
-	IUnknown** ppUnk=nullptr;
-	long nTargets=0;
-	// We only need to request one relation target
-	int numRelations=1;
-	// However, a bug in Chrome causes a buffer overrun if numRelations is less than the total number of targets the node has.
-	// Therefore, If this is Chrome, request all targets (by setting numRelations to 0) as this works around the bug.
-	// There is no major performance hit to fetch all targets in Chrome as Chrome is already fetching all targets either way.
-	// In Firefox there would be extra cross-proc calls.
-	if(this->toolkitName.compare(L"Chrome")==0) {
-		numRelations=0;
+	constexpr long FETCH_ALL = 0l;  // See docs of relationTargetsOfType.
+	long nTargets = static_cast<long>(
+		min<size_t>(
+			numRelations.value_or(FETCH_ALL),  // Default is to fetch all relations.
+			static_cast<size_t>((numeric_limits<long>::max)())
+		)
+	);
+
+	const bool isChrome = this->toolkitName.compare(L"Chrome") == 0;
+	if (isChrome) {
+		// A bug in Chrome causes a buffer overrun if numRelations is less than the total number of targets the node has.
+		// TODO: has this been reported?
+		// numRelations cannot be correctly determined due to another bug: https://crbug.com/1399184
+		// As a work around, request all targets (by setting numRelations to 0).
+		// There is no major performance hit to fetch all targets in Chrome as Chrome is already fetching all targets either way.
+		// In Firefox there would be extra cross-process calls.
+		nTargets = FETCH_ALL;
 	}
 	// the relation type string *must* be passed correctly as a BSTR otherwise we can see crashes in 32 bit Firefox.
 	CComBSTR relationAsBSTR(ia2TargetRelation);
+
+	IUnknown** targets = nullptr;
+	/*
+	relationTargetsOfType(
+		// type: use IA2_RELATION_* constants
+		// from 'include/ia2/api/AccessibleRelation.idl' becomes 'build/<arch>/ia2.h'
+		[in] BSTR type,
+		[in] long maxTargets, // 0 means all.
+		[out, size_is(,*nTargets)] IUnknown ***targets, // targets data.
+		[out, retval] long *nTargets // number targets fetched
+	)*/
 	HRESULT res = element->get_relationTargetsOfType(
 		relationAsBSTR,
-		numRelations,
-		&ppUnk,
+		nTargets,
+		&targets,
 		&nTargets
 	);
-	if(res!=S_OK) return nullptr;
-	// Grab all the returned IUnknowns and store them as smart pointers within a smart pointer array 
-	// so that any further returns will correctly release all the objects. 
-	auto ppUnk_smart=make_unique<CComPtr<IUnknown>[]>(nTargets);
-	for(int i=0;i<nTargets;++i) {
-		ppUnk_smart[i].Attach(ppUnk[i]);
+	if (res != S_OK) {
+		// Return early on failure. Due to failure, there is no need to CoTaskMemFree
+		// the targets parameter can be considered invalid.
+		return {};
+	}
+	// Grab all the returned IUnknowns and store them as a collection of smart pointers
+	// so that any further returns will correctly release all the objects.
+	const std::size_t numFetched = static_cast<std::size_t>(nTargets >= 0 ? nTargets : 0);  // handle negative numbers for signed conversion.
+	const std::size_t numToReturn = std::min<std::size_t>(  // Limit to numRelations, the amount expected by the caller.
+		numRelations.value_or(numFetched),
+		numFetched
+	);
+	std::vector< CComQIPtr<IAccessible2>> smartTargets;
+	for(std::size_t i = 0; i < numToReturn; ++i) {
+		CComPtr<IUnknown> punk;
+		punk.Attach(targets[i]);
+		smartTargets.emplace_back(punk);
 	}
 	// we can now free the memory that Gecko  allocated to give us  the IUnknowns
-	CoTaskMemFree(ppUnk);
+	CoTaskMemFree(targets);
 	if(nTargets==0) {
 		LOG_DEBUG(L"relationTargetsOfType for " << relationAsBSTR.m_str << L" found no targets");
-		return nullptr;
+		return {};
 	}
-	return CComQIPtr<IAccessible2>(ppUnk_smart[0]);
+	return smartTargets;
 }
 
 const wchar_t EMBEDDED_OBJ_CHAR = 0xFFFC;
@@ -220,11 +251,16 @@ void GeckoVBufBackend_t::versionSpecificInit(IAccessible2* pacc) {
 
 optional<int>
 getIAccessible2UniqueID(IAccessible2* targetAcc) {
-	int ID = 0;
+	if (targetAcc == nullptr) {
+		LOG_ERROR(L"targetAcc is null, can't getIAccessible2UniqueID");
+		return {};
+	}
+
 	//Get ID -- IAccessible2 uniqueID
-	if (targetAcc->get_uniqueID((long*)&ID) != S_OK) {
-		LOG_DEBUG(L"pacc->get_uniqueID failed");
-		return optional<int>();
+	long ID = 0l;
+	if (targetAcc->get_uniqueID(&ID) != S_OK) {
+		LOG_DEBUG(L"targetAcc->get_uniqueID failed");
+		return {};
 	}
 	return ID;
 }
@@ -239,25 +275,38 @@ using OptionalLabelInfo = optional< LabelInfo >;
 OptionalLabelInfo GeckoVBufBackend_t::getLabelInfo(IAccessible2* pacc2) {
 	CComQIPtr<IAccessible2_2> pacc2_2=pacc2;
 	if (!pacc2_2) return OptionalLabelInfo();
-	auto targetAcc = getRelationElement(IA2_RELATION_LABELLED_BY, pacc2_2);
-	if(!targetAcc) return OptionalLabelInfo();
+	constexpr std::size_t maxRelationsToFetch = 1;
+	auto accTargets = getRelationElementsOfType(IA2_RELATION_LABELLED_BY, pacc2_2, maxRelationsToFetch);
+
+	if (1 > accTargets.size()) {
+		return OptionalLabelInfo();
+	}
+	auto firstAccTarget = accTargets[0];
 	CComVariant child;
 	child.vt = VT_I4;
 	child.lVal = 0;
 	CComVariant state;
-	HRESULT res = targetAcc->get_accState(child, &state);
+	HRESULT res = firstAccTarget->get_accState(child, &state);
 	bool isVisible = res == S_OK && !(state.lVal & STATE_SYSTEM_INVISIBLE);
-	auto ID = getIAccessible2UniqueID(targetAcc);
+	auto ID = getIAccessible2UniqueID(firstAccTarget);
 	return LabelInfo { isVisible, ID } ;
 }
 
-std::optional<int> GeckoVBufBackend_t::getRelationId(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2) {
+std::vector<int> GeckoVBufBackend_t::getAllRelationIdsForRelationType(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2) {
 	CComQIPtr<IAccessible2_2> pacc2_2 = pacc2;
-	if (pacc2_2 == nullptr) return std::optional<int>();
-	auto targetAcc = getRelationElement(ia2TargetRelation, pacc2_2);
-	if (targetAcc == nullptr) return std::optional<int>();
-	auto ID = getIAccessible2UniqueID(targetAcc);
-	return ID;
+	if (pacc2_2 == nullptr) {
+		return {};
+	}
+	auto accTargets = getRelationElementsOfType(ia2TargetRelation, pacc2_2);
+	std::vector<int> ids;
+	for (auto& accTarget : accTargets) {
+		auto ID = getIAccessible2UniqueID(accTarget);
+		if (ID.has_value()) {
+			ids.push_back(ID.value());
+		}
+	}
+
+	return ids;
 }
 
 long getChildCount(const bool isAriaHidden, IAccessible2 * const pacc){
@@ -388,33 +437,66 @@ const vector<wstring>ATTRLIST_ROLES(1, L"IAccessible2::attribute_xml-roles");
 const wregex REGEX_PRESENTATION_ROLE(L"IAccessible2\\\\:\\\\:attribute_xml-roles:.*\\bpresentation\\b.*;");
 
 
+void _extendDetailsRolesAttribute(VBufStorage_controlFieldNode_t& node, const std::wstring& detailsRole)
+{
+	std::wstringstream ss;
+	auto roles = node.getAttribute(L"detailsRoles");
+	if (roles) {
+		ss << *roles << ',' << detailsRole;
+	}
+	else {
+		ss << detailsRole;
+	}
+	node.addAttribute(L"detailsRoles", ss.str());  // addAttribute will replace an attribute that already exists
+}
+
 void GeckoVBufBackend_t::fillVBufAriaDetails(
 	int docHandle,
 	CComPtr<IAccessible2> pacc,
 	VBufStorage_buffer_t& buffer,
-	VBufStorage_controlFieldNode_t& parentNode,
-	const std::wstring& roleAttr
+	VBufStorage_controlFieldNode_t& nodeBeingFilled,
+	const std::wstring& nodeBeingFilledRole
 ){
 	/* Set the details role by checking for both IA2_RELATION_DETAILS and IA2_RELATION_DETAILS_FOR as one
-	of the nodes in the relationship will not be in the buffer yet */
-	std::optional<int> detailsId = getRelationId(IA2_RELATION_DETAILS, pacc);
-	std::optional<int> detailsForId = getRelationId(IA2_RELATION_DETAILS_FOR, pacc);
-	VBufStorage_controlFieldNode_t* detailsParentNode = nullptr;
-	std::optional<std::wstring> detailsRole;
-	if (detailsId.has_value()) {
-		parentNode.addAttribute(L"hasDetails", L"true");
-		detailsParentNode = &parentNode;
-		auto detailsChildNode = buffer.getControlFieldNodeWithIdentifier(docHandle, detailsId.value());
-		if (detailsChildNode != nullptr) {
-			detailsRole = detailsChildNode->getAttribute(L"role");
+	of the nodes in the relationship will not be in the buffer yet.
+	It is possible that nodeBeingFilled is both the target and origin of multiple details relations.
+	*/
+	// handle case where nodeBeingFilled is the origin of a details relation.
+	auto idOfDetailsTargets = getAllRelationIdsForRelationType(IA2_RELATION_DETAILS, pacc);
+	if (0 < idOfDetailsTargets.size()) {
+		nodeBeingFilled.addAttribute(L"hasDetails", L"true");
+		for (const auto idOfDetailsTarget : idOfDetailsTargets) {
+			auto detailsTargetNode = buffer.getControlFieldNodeWithIdentifier(docHandle, idOfDetailsTarget);
+			if (detailsTargetNode != nullptr) {
+				const std::wstring roleName = L"role";
+				auto targetDetailsRole = detailsTargetNode->getAttribute(roleName);
+				if (targetDetailsRole.has_value()) {
+					_extendDetailsRolesAttribute(nodeBeingFilled, *targetDetailsRole);
+				}
+				else {
+					/*
+					This is not an error, the target may not have a role listed in its attributes.
+					Add "unknown" to the ariaDetailsRoles.
+					Explanation:
+					hasDetail=True is not enough to describe the scenario when there multiple details
+					relations but one has a generic role, EG. a comment and an 'unknown' role.
+					This would then produce attributes 'hasDetail=True detailsRoles="comment"',
+					reported as "has comment" since only one role is listed.
+					Instead prefer 'hasDetail=True detailsRoles="comment, unknown"',
+					reported as "has comment has details" since both roles are listed.
+					*/
+					_extendDetailsRolesAttribute(nodeBeingFilled, L"unknown");
+				}
+			}
 		}
 	}
-	if (detailsForId.has_value()) {
-		detailsParentNode = buffer.getControlFieldNodeWithIdentifier(docHandle, detailsForId.value());
-		detailsRole = roleAttr;
-	}
-	if (detailsParentNode != nullptr && detailsRole.has_value()) {
-		detailsParentNode->addAttribute(L"detailsRole", detailsRole.value());
+	// handle case where nodeBeingFilled is the target of a details relation.
+	auto idOfDetailsOrigins = getAllRelationIdsForRelationType(IA2_RELATION_DETAILS_FOR, pacc);
+	for(const auto idOfDetailsOrigin : idOfDetailsOrigins){
+		auto detailsOriginNode = buffer.getControlFieldNodeWithIdentifier(docHandle, idOfDetailsOrigin);
+		if (detailsOriginNode != nullptr) {
+			_extendDetailsRolesAttribute(*detailsOriginNode, nodeBeingFilledRole);
+		}
 	}
 }
 

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.h
@@ -1,7 +1,7 @@
 /*
 This file is a part of the NVDA project.
 URL: http://www.nvda-project.org/
-Copyright 2006-2022 NVDA contributors.
+Copyright 2006-2023 NVDA contributors.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2.0, as published by
     the Free Software Foundation.
@@ -33,12 +33,20 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 		bool ignoreInteractiveUnlabelledGraphics=false
 	);
 
+	/* Fill the virtual buffer with information required for aria details (annotations) information.
+	 * @note: Expected to be called by fillVBuf
+	 * @param docHandle: The handle of the current document, required to identify target/origin of an annotation relationship.
+	 * @param pacc: The IAccessible for the nodeBeingFilled
+	 * @param buffer: The virtual buffer that is being filled, used to get the other side of the relationship (target/origin)
+	 * @param nodeBeingFilled: The current node being filled. This maybe a target, origin, or neither.
+	 * @param nodeBeingFilledRole: The role of the parentNode, used to set the detailsRole in the origin of the annotation relationship.
+	 */
 	void fillVBufAriaDetails(
 		int docHandle,
 		CComPtr<IAccessible2> pacc,
 		VBufStorage_buffer_t& buffer,
-		VBufStorage_controlFieldNode_t& parentNode,
-		const std::wstring& roleAttr
+		VBufStorage_controlFieldNode_t& nodeBeingFilled,
+		const std::wstring& nodeBeingFilledRole
 	);
 
 	void versionSpecificInit(IAccessible2* pacc);
@@ -47,9 +55,28 @@ class GeckoVBufBackend_t: public VBufBackend_t {
 
 	std::wstring toolkitName;
 
-	std::optional<int> getRelationId(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2);
+	/* Get the IAccessible IDs for all relation targets of the specified relation type.
+	* @param ia2TargetRelation: The type of relation to fetch. Use IA2_RELATION_* constants
+			from 'include/ia2/api/AccessibleRelation.idl' becomes 'build/<arch>/ia2.h'
+	* @param pacc2: The element to fetch relations for.
+	*/
+	std::vector<int> getAllRelationIdsForRelationType(LPCOLESTR ia2TargetRelation, IAccessible2* pacc2);
+
+	/*
+	*/
 	std::optional< LabelInfo > getLabelInfo(IAccessible2* pacc2);
-	CComPtr<IAccessible2> getRelationElement(LPCOLESTR ia2TargetRelation, IAccessible2_2* element);
+
+	/* Get relation elements of the type.
+	 * @param ia2TargetRelation: The type of relation to fetch. Use IA2_RELATION_* constants
+			from 'include/ia2/api/AccessibleRelation.idl' becomes 'build/<arch>/ia2.h'
+	 * @param element: The element to fetch relations for.
+	 * @param numRelations: If supplied, only return up to numRelations. Note: Fetches all by default.
+	 */
+	std::vector<CComQIPtr<IAccessible2>> getRelationElementsOfType(
+		LPCOLESTR ia2TargetRelation,
+		IAccessible2_2* element,
+		const std::optional<std::size_t> numRelations = {}
+	);
 	CComPtr<IAccessible2> getSelectedItem(IAccessible2* container,
 		const std::map<std::wstring, std::wstring>& attribs);
 

--- a/nvdaHelper/vbufBase/storage.cpp
+++ b/nvdaHelper/vbufBase/storage.cpp
@@ -328,7 +328,6 @@ std::optional<std::wstring> VBufStorage_fieldNode_t::getAttribute(const std::wst
 	if (foundAttrib != attributes.end()) {
 		return foundAttrib->second;
 	}
-	LOG_ERROR(L"Couldn't find attribute " << name);
 	return std::nullopt;
 }
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -5,7 +5,9 @@
 
 import typing
 from typing import (
+	Generator,
 	Optional,
+	Tuple,
 	Union,
 	List,
 )
@@ -1523,7 +1525,7 @@ the NVDAObject for IAccessible
 			self,
 			relationType: "IAccessibleHandler.RelationType",
 			maxRelations: int = 1,
-	) -> typing.List[IUnknown]:
+	) -> Generator[IUnknown, None, None]:
 		"""Gets the target IAccessible (actually IUnknown; use QueryInterface or
 		normalizeIAccessible to resolve) for the relations with given type.
 		Allows escape of exception: COMError(-2147417836, 'Requested object does not exist.'),
@@ -1539,17 +1541,20 @@ the NVDAObject for IAccessible
 			raise ValueError
 		if not isinstance(acc, IA2.IAccessible2_2):
 			acc = acc.QueryInterface(IA2.IAccessible2_2)
+
 		targets, count = acc.relationTargetsOfType(
 			relationType.value,
+			# Bug in relationTargetsOfType, Chrome does not respect maxRelations param.
+			# https://crbug.com/1399184
 			maxRelations
 		)
+		log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
 		if count == 0:
-			return list()
-		relationsGen = (
+			return
+		yield from (
 			targets[i]
 			for i in range(min(maxRelations, count))
 		)
-		return list(relationsGen)
 
 	def _getIA2RelationFirstTarget(
 			self,
@@ -1568,9 +1573,10 @@ the NVDAObject for IAccessible
 
 		try:
 			# rather than fetch all the relations and querying the type, do that in process for performance reasons
-			targets = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
-			if targets:
-				ia2Object = IAccessibleHandler.normalizeIAccessible(targets[0])
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=1)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				# Just take the first.
 				return IAccessible(
 					IAccessibleObject=ia2Object,
 					IAccessibleChildID=0
@@ -1578,7 +1584,7 @@ the NVDAObject for IAccessible
 		except (NotImplementedError, COMError):
 			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
 
-		# eg IA2_2 is not available, fall back to old approach
+		# IA2_2 is not available, fall back to old approach
 		try:
 			for relation in self._IA2Relations:
 				if relation.relationType == relationType:
@@ -1594,20 +1600,73 @@ the NVDAObject for IAccessible
 			pass
 		return None
 
+	def _getIA2RelationTargetsOfType(
+			self,
+			relationType: Union[str, IAccessibleHandler.RelationType]
+	) -> typing.Iterable["IAccessible"]:
+		""" Get the targets for the relation of type.
+		Higher level function than _getIA2TargetsForRelationsOfType
+		@param relationType: The type of relation to fetch.
+		"""
+		if not isinstance(relationType, IAccessibleHandler.RelationType):
+			if isinstance(relationType, str):
+				relationType = IAccessibleHandler.RelationType(relationType)
+			else:
+				raise TypeError(f"Bad type for 'relationType' arg, got: {type(relationType)}")
+
+		relationType = typing.cast(IAccessibleHandler.RelationType, relationType)
+
+		try:
+			# rather than fetch all the relations and querying the type, do that in process for performance reasons
+			# Bug in Chrome, Chrome does not respect maxRelations param.
+			# https://crbug.com/1399184. In future, uncomment the next line.
+			# maxRelsToFetch = self.IAccessibleObject.nRelations  # they may or may not all match 'relationType'
+			maxRelsToFetch = 10
+			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=maxRelsToFetch)
+			for target in targetsGen:
+				ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+				ia = IAccessible(
+					IAccessibleObject=ia2Object,
+					IAccessibleChildID=0
+				)
+				yield ia
+			# NotImplementedError is expected to occur for all targets or none.
+			return  # Iterated all targets without error.
+		except (NotImplementedError, COMError):
+			log.debugWarning("Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.")
+
+		# IA2_2 is not available, fall back to old approach
+		log.debugWarning("IA2_2 is not available, fall back to old approach")
+		try:
+			for relation in self._IA2Relations:
+				if relation.relationType == relationType:
+					# Take the first of 'relation.nTargets' see IAccessibleRelation._methods_
+					for i in range(0, relation.nTargets):
+						target = relation.target(i)
+						ia2Object = IAccessibleHandler.normalizeIAccessible(target)
+						yield IAccessible(
+							IAccessibleObject=ia2Object,
+							IAccessibleChildID=0
+						)
+			return
+		except (NotImplementedError, COMError):
+			log.debug("Unable to fetch _IA2Relations", exc_info=True)
+			pass
+		return None
+
 	#: Type definition for auto prop '_get_detailsRelations'
-	detailsRelations: typing.Iterable["IAccessible"]
+	detailsRelations: Tuple["IAccessible"]
+
+	def _get_detailsRelations(self) -> Tuple["IAccessible"]:
+		detailsRelsGen = self._getIA2RelationTargetsOfType(IAccessibleHandler.RelationType.DETAILS)
+		# due to caching of baseObject.AutoPropertyObject, do not attempt to return a generator.
+		return tuple(detailsRelsGen)
 
 	def _get_controllerFor(self) -> List[NVDAObject]:
 		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
 		if control:
 			return [control]
 		return []
-
-	def _get_detailsRelations(self) -> typing.Iterable["IAccessible"]:
-		relationTarget = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.DETAILS)
-		if not relationTarget:
-			return ()
-		return (relationTarget, )
 
 	#: Type definition for auto prop '_get_flowsTo'
 	flowsTo: typing.Optional["IAccessible"]
@@ -1763,7 +1822,7 @@ the NVDAObject for IAccessible
 				ret = "exception: %s" % e
 			info.append("IAccessible2 attributes: %s" % ret)
 			try:
-				ret = ", ".join(r.RelationType for r in self._IA2Relations)
+				ret = ", ".join(f"{r.RelationType} * {r.nTargets}" for r in self._IA2Relations)
 			except Exception as e:
 				ret = f"exception: {e}"
 			info.append(f"IAccessible2 relations: {ret}")

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1548,7 +1548,8 @@ the NVDAObject for IAccessible
 			# https://crbug.com/1399184
 			maxRelations
 		)
-		log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
+		if config.conf["debugLog"]["annotations"]:
+			log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
 		if count == 0:
 			return
 		yield from (
@@ -1619,7 +1620,8 @@ the NVDAObject for IAccessible
 		try:
 			# rather than fetch all the relations and querying the type, do that in process for performance reasons
 			# Bug in Chrome, Chrome does not respect maxRelations param.
-			# https://crbug.com/1399184. In future, uncomment the next line.
+			# https://crbug.com/1399184.
+			# In future, uncomment the next line.
 			# maxRelsToFetch = self.IAccessibleObject.nRelations  # they may or may not all match 'relationType'
 			maxRelsToFetch = 10
 			targetsGen = self._getIA2TargetsForRelationsOfType(relationType, maxRelations=maxRelsToFetch)

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
 	from treeInterceptorHandler import TreeInterceptor  # noqa: F401
 
 supportedAriaDetailsRoles: Dict[str, Optional[controlTypes.Role]] = {
+	"unknown": None,  # no explicit role, should be reported as "details"
 	"comment": controlTypes.Role.COMMENT,
 	"doc-footnote": controlTypes.Role.FOOTNOTE,
 	# These roles are current unsupported by IAccessible2,

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -145,15 +145,27 @@ class Ia2Web(IAccessible):
 		return annotationOrigin
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
+		log.warning(
+			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True,
+		)
 		for summary in self.annotations.summaries:
 			# just take the first for now.
 			return summary
 
 	@property
 	def hasDetails(self) -> bool:
+		log.warning(
+			"NVDAObject.hasDetails is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True,
+		)
 		return bool(self.annotations)
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
+		log.warning(
+			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True,
+		)
 		for role in self.annotations.roles:
 			# just take the first for now.
 			return role

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -6,10 +6,17 @@
 """Base classes with common support for browsers exposing IAccessible2.
 """
 import typing
+from typing import (
+	Iterable,
+)
 from ctypes import c_short
 from comtypes import COMError, BSTR
 
 import oleacc
+from annotation import (
+	AnnotationTarget,
+	AnnotationOrigin,
+)
 from comInterfaces import IAccessible2Lib as IA2
 import controlTypes
 from logHandler import log
@@ -22,6 +29,76 @@ import api
 import speech
 import config
 import NVDAObjects
+
+
+class IA2WebAnnotationTarget(AnnotationTarget):
+	def __init__(self, target: IAccessible):
+		self._target: IAccessible = target
+
+	@property
+	def summary(self) -> str:
+		return self._target.summarizeInProcess()
+
+	@property
+	def role(self) -> controlTypes.Role:
+		return self._target.role
+
+	@property
+	def targetObject(self) -> IAccessible:
+		return self._target
+
+
+class IA2WebAnnotation(AnnotationOrigin):
+	_originObj: "Ia2Web"
+
+	def __bool__(self) -> bool:
+		return bool(
+			self._originObj.IA2Attributes.get("details-roles")
+		)
+
+	@property
+	def targets(self) -> Iterable[AnnotationTarget]:
+		if not bool(self):
+			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("no annotations available")
+			return
+
+		ia2WebAnnotationTargetsGen = (
+			IA2WebAnnotationTarget(rel)
+			for rel in self._originObj.detailsRelations
+		)
+		yield from ia2WebAnnotationTargetsGen
+
+	@property
+	def roles(self) -> Iterable[controlTypes.Role]:
+		"""
+		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
+		to return them.
+		@remarks: The order of "details-roles" IA2Attributes is expected to match the order of detailsRelations
+		objects.
+		"""
+		from .chromium import supportedAriaDetailsRoles
+		# Currently only defined in Chrome as of May 2022
+		# Refer to ComputeDetailsRoles
+		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
+		detailsRoles = self._originObj.IA2Attributes.get("details-roles")
+		if not detailsRoles:
+			if config.conf["debugLog"]["annotations"]:
+				log.debug("details-roles not found")
+			return None
+
+		for roleStr in detailsRoles.split(" "):
+			# Created supported details role
+			detailsRole = supportedAriaDetailsRoles.get(roleStr)
+			if config.conf["debugLog"]["annotations"]:
+				log.debug(f"detailsRole: {repr(detailsRole)}")
+			yield detailsRole
+
+	@property
+	def summaries(self) -> Iterable[str]:
+		for target in self.targets:
+			yield target.summary
 
 
 class Ia2Web(IAccessible):
@@ -60,42 +137,26 @@ class Ia2Web(IAccessible):
 				log.debugWarning(f"Unknown 'description-from' IA2Attribute value: {ia2attrDescriptionFrom}")
 			return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: "IA2WebAnnotation"
+	"""Typing information for auto property _get_annotations
+	"""
+	def _get_annotations(self) -> "AnnotationOrigin":
+		annotationOrigin = IA2WebAnnotation(self)
+		return annotationOrigin
+
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		if not self.hasDetails:
-			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("no details-roles")
-			return None
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			log.error("should be able to fetch detailsRelations")
-			return None
-		for target in detailsRelations:
+		for summary in self.annotations.summaries:
 			# just take the first for now.
-			return target.summarizeInProcess()
+			return summary
 
 	@property
 	def hasDetails(self) -> bool:
-		return bool(self.IA2Attributes.get("details-roles"))
+		return bool(self.annotations)
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
-		from .chromium import supportedAriaDetailsRoles
-		# Currently only defined in Chrome as of May 2022
-		# Refer to ComputeDetailsRoles
-		# https://chromium.googlesource.com/chromium/src/+/main/ui/accessibility/platform/ax_platform_node_base.cc#2419
-		detailsRoles = self.IA2Attributes.get("details-roles")
-		if not detailsRoles:
-			if config.conf["debugLog"]["annotations"]:
-				log.debug("details-roles not found")
-			return None
-		
-		firstDetailsRole = detailsRoles.split(" ")[0]
-		# return a supported details role
-		detailsRole = supportedAriaDetailsRoles.get(firstDetailsRole)
-		if config.conf["debugLog"]["annotations"]:
-			log.debug(f"detailsRole: {repr(detailsRole)}")
-		return detailsRole
-
+		for role in self.annotations.roles:
+			# just take the first for now.
+			return role
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
 		ia2attrCurrent: str = self.IA2Attributes.get("current", "false")

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -144,17 +144,29 @@ class Mozilla(ia2Web.Ia2Web):
 		return annotationOrigin
 
 	def _get_detailsSummary(self) -> Optional[str]:
+		log.warning(
+			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True,
+		)
 		for summary in self.annotations.summaries:
 			# just take the first for now.
 			return summary
 
 	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
+		log.warning(
+			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True,
+		)
 		for role in self.annotations.roles:
 			# just take the first target for now.
 			return role
 
 	@property
 	def hasDetails(self) -> bool:
+		log.warning(
+			"NVDAObject.hasDetails is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True,
+		)
 		return bool(self.annotations)
 
 

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -4,6 +4,15 @@
 # See the file COPYING for more details.
 # Copyright (C) 2006-2022 NV Access Limited, Peter Vágner
 
+from typing import (
+	Iterable,
+	Optional,
+)
+
+from annotation import (
+	AnnotationTarget,
+	AnnotationOrigin,
+)
 import IAccessibleHandler
 from comInterfaces import IAccessible2Lib as IA2
 import config
@@ -14,9 +23,72 @@ from . import IAccessible, WindowRoot
 from logHandler import log
 from NVDAObjects.behaviors import RowWithFakeNavigation
 from . import ia2Web
-from typing import (
-	Optional,
-)
+
+
+class MozAnnotationTarget(AnnotationTarget):
+	def __init__(self, target: IAccessible):
+		self._target: IAccessible = target
+
+	@property
+	def summary(self) -> str:
+		return self._target.summarizeInProcess()
+
+	@property
+	def role(self) -> controlTypes.Role:
+		# details-roles is currently only defined in Chromium
+		# this may diverge in Firefox in the future.
+		from .chromium import supportedAriaDetailsRoles
+		detailsRole = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(
+			self._target.IAccessibleRole
+		)
+		# return a supported details role
+		if config.conf["debugLog"]["annotations"]:
+			log.debug(f"detailsRole: {repr(detailsRole)}")
+		if detailsRole in supportedAriaDetailsRoles.values():
+			return detailsRole
+		raise ValueError(f"Unsupported aria details role: {detailsRole}")
+
+	@property
+	def targetObject(self) -> IAccessible:
+		return self._target
+
+
+class MozAnnotation(AnnotationOrigin):
+	"""
+	Unlike base Ia2Web implementation, the details-roles IA2 attribute is not exposed in Firefox.
+	"""
+	_originObj: "Mozilla"
+
+	def __bool__(self) -> bool:
+		# Unlike base Ia2Web implementation, the details-roles
+		# IA2 attribute is not exposed in Firefox.
+		# Although slower, we have to fetch the details relations instead.
+		return bool(
+			self._originObj.detailsRelations
+		)
+
+	@property
+	def targets(self) -> Iterable[MozAnnotationTarget]:
+		detailsRelations = self._originObj.detailsRelations
+		for rel in detailsRelations:
+			yield MozAnnotationTarget(rel)
+
+	@property
+	def roles(self) -> Iterable[controlTypes.Role]:
+		# Unlike base Ia2Web implementation, the details-roles
+		# IA2 attribute is not exposed in Firefox.
+		# Although slower, we have to fetch the details relations instead.
+		for target in self.targets:
+			# just take the first target for now.
+			try:
+				yield target.role
+			except ValueError:
+				log.error("Error getting role.", exc_info=True)
+
+	@property
+	def summaries(self) -> Iterable[str]:
+		for target in self.targets:
+			yield target.summary
 
 
 class Mozilla(ia2Web.Ia2Web):
@@ -63,43 +135,27 @@ class Mozilla(ia2Web.Ia2Web):
 				presType=self.presType_layout
 		return presType
 
+	annotations: MozAnnotation
+	"""Typing information for auto property _get_annotations
+	"""
+
+	def _get_annotations(self) -> MozAnnotation:
+		annotationOrigin = MozAnnotation(self)
+		return annotationOrigin
+
 	def _get_detailsSummary(self) -> Optional[str]:
-		# Unlike base Ia2Web implementation, the details-roles
-		# IA2 attribute is not exposed in Firefox.
-		# Although slower, we have to fetch the details relations instead.
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			return None
-		for target in detailsRelations:
+		for summary in self.annotations.summaries:
 			# just take the first for now.
-			return target.summarizeInProcess()
+			return summary
 
 	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
-		# Unlike base Ia2Web implementation, the details-roles
-		# IA2 attribute is not exposed in Firefox.
-		# Although slower, we have to fetch the details relations instead.
-		detailsRelations = self.detailsRelations
-		if not detailsRelations:
-			return None
-		for target in detailsRelations:
+		for role in self.annotations.roles:
 			# just take the first target for now.
-			# details-roles is currently only defined in Chromium
-			# this may diverge in Firefox in future.
-			from .chromium import supportedAriaDetailsRoles
-			detailsRole = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(target.IAccessibleRole)
-			# return a supported details role
-			if config.conf["debugLog"]["annotations"]:
-				log.debug(f"detailsRole: {repr(detailsRole)}")
-			if detailsRole in supportedAriaDetailsRoles.values():
-				return detailsRole
-			return None
+			return role
 
 	@property
 	def hasDetails(self) -> bool:
-		# Unlike base Ia2Web implementation, the details-roles
-		# IA2 attribute is not exposed in Firefox.
-		# Although slower, we have to fetch the details relations instead.
-		return bool(self.detailsRelations)
+		return bool(self.annotations)
 
 
 class Document(ia2Web.Document):

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
 # Davy Kager
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -525,12 +525,17 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 			)
 		return None
 
-	#: Typing information for auto property _get_detailsSummary
 	detailsSummary: typing.Optional[str]
+	"""
+	Typing information for auto property _get_detailsSummary
+	Deprecated, use self.annotations.roles instead.
+	"""
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:
-		if config.conf["debugLog"]["annotations"]:
-			log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
+		log.warning(
+			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True
+		)
 		return None
 
 	@property
@@ -538,12 +543,22 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""Default implementation is based on the result of _get_detailsSummary
 		In most instances this should be optimised.
 		"""
+		log.warning(
+			"NVDAObject.hasDetails is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True
+		)
 		return bool(self.annotations)
 
-	#: Typing information for auto property _get_detailsRole
 	detailsRole: typing.Optional[controlTypes.Role]
+	"""Typing information for auto property _get_detailsRole
+	Deprecated, use self.annotations.roles instead.
+	"""
 
 	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
+		log.warning(
+			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
+			stack_info=True
+		)
 		if config.conf["debugLog"]["annotations"]:
 			log.debugWarning(f"Fetching details summary not supported on: {self.__class__.__qualname__}")
 		return None

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -12,6 +12,9 @@ import time
 import typing
 import weakref
 import textUtils
+from annotation import (
+	AnnotationOrigin,
+)
 from logHandler import log
 import review
 import eventHandler
@@ -511,6 +514,17 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
 		return controlTypes.DescriptionFrom.UNKNOWN
 
+	annotations: AnnotationOrigin
+	"""Typing information for auto property _get_annotations
+	"""
+
+	def _get_annotations(self) -> typing.Optional[AnnotationOrigin]:
+		if config.conf["debugLog"]["annotations"]:
+			log.debugWarning(
+				f"Fetching annotations not supported on: {self.__class__.__qualname__}"
+			)
+		return None
+
 	#: Typing information for auto property _get_detailsSummary
 	detailsSummary: typing.Optional[str]
 
@@ -524,7 +538,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""Default implementation is based on the result of _get_detailsSummary
 		In most instances this should be optimised.
 		"""
-		return bool(self.detailsSummary)
+		return bool(self.annotations)
 
 	#: Typing information for auto property _get_detailsRole
 	detailsRole: typing.Optional[controlTypes.Role]

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -16,11 +16,16 @@ from typing import (
 	Iterable,
 	List,
 	Optional,
+	Set,
+	Union,
 )
 
 if TYPE_CHECKING:
 	import controlTypes
 	from NVDAObjects import NVDAObject
+
+
+_AnnotationRolesT = Set[Union[None, "controlTypes.Role"]]
 
 
 class AnnotationTarget:
@@ -45,7 +50,10 @@ class AnnotationTarget:
 class AnnotationOrigin:
 	"""
 	Structured information of an annotation origin.
+	Each origin may have many annotation targets.
+	Targets can have different roles.
 	For example, a phrase with a footnote and comments associated with it.
+	This class encapsulates the relation.
 	"""
 
 	def __init__(self, originObj: "NVDAObject"):

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -1,0 +1,86 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""
+Annotations are part of the ARIA spec, used to create relationships between nodes.
+For example: comment reply chains, terms with definitions, footnotes.
+
+https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Annotations
+"""
+
+from dataclasses import dataclass
+from typing import (
+	TYPE_CHECKING,
+	Iterable,
+	List,
+	Optional,
+)
+
+if TYPE_CHECKING:
+	import controlTypes
+	from NVDAObjects import NVDAObject
+
+
+class AnnotationTarget:
+	"""
+	Structured information of an annotation target.
+	For example, the definition of a term.
+	"""
+
+	@property
+	def role(self) -> "controlTypes.Role":
+		raise NotImplementedError
+
+	@property
+	def targetObject(self) -> "NVDAObject":
+		raise NotImplementedError
+
+	@property
+	def summary(self) -> str:
+		raise NotImplementedError
+
+
+class AnnotationOrigin:
+	"""
+	Structured information of an annotation origin.
+	For example, a phrase with a footnote and comments associated with it.
+	"""
+
+	def __init__(self, originObj: "NVDAObject"):
+		self._originObj: "NVDAObject" = originObj
+
+	def __bool__(self):
+		"""Performant implementation required to test for annotations
+		"""
+		raise NotImplementedError
+
+	@property
+	def targets(self) -> Iterable[AnnotationTarget]:
+		raise NotImplementedError
+
+	@property
+	def roles(self) -> Iterable["controlTypes.Role"]:
+		raise NotImplementedError
+
+	@property
+	def summaries(self) -> Iterable[str]:
+		raise NotImplementedError
+
+
+@dataclass
+class _AnnotationNavigationNode:
+	"""Node used in _AnnotationNavigation, for navigating between annotations."""
+	_TargetIndex = int  # Type for target index
+	origin: "NVDAObject"  # this is the last known location
+	indexOfLastReportedSummary: Optional[_TargetIndex] = None  # this would be the next destination
+
+
+class _AnnotationNavigation:
+	"""
+	Used to manage navigation of annotations.
+	For example, reporting a summary of each comment for an object with multiple comment annotation targets.
+	"""
+	lastReported: Optional[_AnnotationNavigationNode] = None
+	priorOrigins: List["NVDAObject"] = []

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -155,8 +155,8 @@ class CompoundTextInfo(textInfos.TextInfo):
 		field['roleText'] = obj.roleText
 		field['description'] = obj.description
 		field['_description-from'] = obj.descriptionFrom
-		field['hasDetails'] = obj.hasDetails
-		field["detailsRole"] = obj.detailsRole
+		field['hasDetails'] = bool(obj.annotations)
+		field["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.State.EDITABLE)
 		states.discard(controlTypes.State.MULTILINE)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2307,7 +2307,8 @@ class GlobalCommands(ScriptableObject):
 			log.debug(f"Trying with nvdaObject : {objAtStart}")
 
 		if objAtStart.detailsSummary:
-			log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
+			if _isDebugLogCatEnabled:
+				log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
 			return objAtStart
 		elif api.getFocusObject():
 			# If fetching from the caret position fails, try via the focus object
@@ -2347,7 +2348,8 @@ class GlobalCommands(ScriptableObject):
 			relation' in that range, and we don't yet have a way for the user to select which one to report.
 			For now, we minimise this risk by only reporting details at the current location.
 		"""
-		log.debug("Report annotation details summary at current location.")
+		_isDebugLogCatEnabled = config.conf["debugLog"]["annotations"]
+	
 		objWithAnnotation = self._getNvdaObjWithAnnotationUnderCaret()
 		if (
 			not objWithAnnotation
@@ -2358,10 +2360,14 @@ class GlobalCommands(ScriptableObject):
 			return
 
 		targets = list(objWithAnnotation.annotations.targets)
-		log.debug(f"Number of targets: {len(targets)}")
+		if _isDebugLogCatEnabled:
+			log.debug(f"Number of targets: {len(targets)}")
+
 		if 1 > len(targets):
-			log.debugWarning("Expected some annotation targets, none retrieved.")
+			if _isDebugLogCatEnabled:
+				log.debugWarning("Expected some annotation targets, none retrieved.")
 			return
+
 		if (
 			self._annotationNav.lastReported
 			and objWithAnnotation == self._annotationNav.lastReported.origin
@@ -2370,10 +2376,12 @@ class GlobalCommands(ScriptableObject):
 			last = self._annotationNav.lastReported.indexOfLastReportedSummary
 			indexOfNextTarget = (last + 1) % len(targets)
 		else:
-			log.debug(
-				f"No prior target summary reported:"
-				f" lastReported: {self._annotationNav.lastReported}")
-			if self._annotationNav.lastReported:
+			if _isDebugLogCatEnabled:
+				log.debug(
+					"No prior target summary reported:"
+					f" lastReported: {self._annotationNav.lastReported}"
+				)
+			if self._annotationNav.lastReported and _isDebugLogCatEnabled:
 				log.debug(
 					f" objWithAnnotation == self._annotationNav.lastReported.origin: "
 					f"{objWithAnnotation == self._annotationNav.lastReported.origin}"
@@ -2381,6 +2389,7 @@ class GlobalCommands(ScriptableObject):
 					f"{self._annotationNav.lastReported.indexOfLastReportedSummary}"
 				)
 			indexOfNextTarget = 0
+
 		targetToReport = targets[indexOfNextTarget]
 		ui.message(targetToReport.summary)
 		self._annotationNav.lastReported = _AnnotationNavigationNode(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2349,7 +2349,6 @@ class GlobalCommands(ScriptableObject):
 			For now, we minimise this risk by only reporting details at the current location.
 		"""
 		_isDebugLogCatEnabled = config.conf["debugLog"]["annotations"]
-	
 		objWithAnnotation = self._getNvdaObjWithAnnotationUnderCaret()
 		if (
 			not objWithAnnotation

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -14,6 +14,7 @@ import unicodedata
 import time
 import colors
 import api
+from annotation import _AnnotationRolesT
 import controlTypes
 from controlTypes import OutputReason, TextPosition
 import tones
@@ -494,9 +495,9 @@ def getObjectPropertiesSpeech(  # noqa: C901
 			newPropertyValues['current'] = obj.isCurrent
 
 		elif value and name == "hasDetails":
-			newPropertyValues['hasDetails'] = obj.hasDetails
-		elif value and name == "detailsRole":
-			newPropertyValues["detailsRole"] = obj.detailsRole
+			newPropertyValues['hasDetails'] = bool(obj.annotations)
+		elif value and name == "detailsRoles":
+			newPropertyValues["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
 		elif value and name == "descriptionFrom" and (
 			obj.descriptionFrom == controlTypes.DescriptionFrom.ARIA_DESCRIPTION
 		):
@@ -709,7 +710,7 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 		'value': True,
 		'description': True,
 		'hasDetails': config.conf["annotations"]["reportDetails"],
-		"detailsRole": config.conf["annotations"]["reportDetails"],
+		"detailsRoles": config.conf["annotations"]["reportDetails"],
 		'descriptionFrom': config.conf["annotations"]["reportAriaDescription"],
 		'keyboardShortcut': True,
 		'positionInfo_level': True,
@@ -1813,13 +1814,15 @@ def getPropertiesSpeech(  # noqa: C901
 	# are there further details
 	hasDetails = propertyValues.get('hasDetails', False)
 	if hasDetails:
-		detailsRole: Optional[controlTypes.Role] = propertyValues.get("detailsRole")
-		if detailsRole is not None:
-			textList.append(
-				# Translators: Speaks when there are further details/annotations that can be fetched manually.
-				# %s specifies the type of details (e.g. comment, suggestion)
-				_("has %s" % detailsRole.displayString)
-			)
+		detailsRoles: _AnnotationRolesT = propertyValues.get("detailsRoles", set())
+		if detailsRoles:
+			roleStrings = (role.displayString if role else _("details") for role in detailsRoles)
+			for roleString in roleStrings:
+				textList.append(
+					# Translators: Speaks when there are further details/annotations that can be fetched manually.
+					# %s specifies the type of details (e.g. "comment, suggestion, details")
+					_("has %s" % roleString)
+				)
 		else:
 			textList.append(
 				# Translators: Speaks when there are further details/annotations that can be fetched manually.
@@ -1926,7 +1929,7 @@ def getControlFieldSpeech(  # noqa: C901
 	keyboardShortcut=attrs.get('keyboardShortcut', "")
 	isCurrent = attrs.get('current', controlTypes.IsCurrent.NO)
 	hasDetails = attrs.get('hasDetails', False)
-	detailsRole: Optional[controlTypes.Role] = attrs.get("detailsRole")
+	detailsRoles: _AnnotationRolesT = set(attrs.get("detailsRoles", []))
 	placeholderValue=attrs.get('placeholder', None)
 	value=attrs.get('value',"")
 
@@ -1986,7 +1989,7 @@ def getControlFieldSpeech(  # noqa: C901
 			reason=reason, keyboardShortcut=keyboardShortcut
 		)
 	isCurrentSequence = getPropertiesSpeech(reason=reason, current=isCurrent)
-	hasDetailsSequence = getPropertiesSpeech(reason=reason, hasDetails=hasDetails, detailsRole=detailsRole)
+	hasDetailsSequence = getPropertiesSpeech(reason=reason, hasDetails=hasDetails, detailsRoles=detailsRoles)
 	placeholderSequence = getPropertiesSpeech(reason=reason, placeholder=placeholderValue)
 	nameSequence = getPropertiesSpeech(reason=reason, name=name)
 	valueSequence = getPropertiesSpeech(reason=reason, value=value, _role=role)

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -1,8 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2022 NV Access Limited, Babbage B.V., Mozilla Corporation, Accessolutions, Julien Cochuyt
+# Copyright (C) 2008-2023 NV Access Limited, Babbage B.V., Mozilla Corporation, Accessolutions, Julien Cochuyt
 
+from typing import (
+	Iterable,
+	Optional,
+)
 import typing
 import weakref
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
@@ -170,33 +174,44 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 		if landmark:
 			attrs["landmark"]=landmark
 
-		detailsRole = attrs.get('detailsRole')
-		if detailsRole is not None:
-			attrs['detailsRole'] = self._normalizeDetailsRole(detailsRole)
+		detailsRoles = attrs.get('detailsRoles')
+		if detailsRoles is not None:
+			attrs['detailsRoles'] = set(self._normalizeDetailsRole(detailsRoles))
+			if config.conf["debugLog"]["annotations"]:
+				log.debug(f"detailsRoles: {attrs['detailsRoles']}")
 		return super()._normalizeControlField(attrs)
 
-	def _normalizeDetailsRole(self, detailsRole: str) -> typing.Optional[controlTypes.Role]:
+	def _normalizeDetailsRole(self, detailsRoles: str) -> Iterable[Optional[controlTypes.Role]]:
 		"""
-		The attribute has been added directly to the buffer as a string, either as a role string or a role integer.
+		The attribute has been added directly to the buffer as a string, containing a comma separated list
+		of values, each value is either:
+		- role string
+		- role integer
 		Ensures the returned role is a fully supported by the details-roles attribute.
 		Braille and speech needs consistent normalization for translation and reporting.
 		"""
 		# Can't import at module level as chromium imports from this module
 		from NVDAObjects.IAccessible.chromium import supportedAriaDetailsRoles
 		if config.conf["debugLog"]["annotations"]:
-			log.debug(f"detailsRole: {repr(detailsRole)}")
-
-		if detailsRole.isdigit():
-			# get a role, but it may be unsupported
-			detailsRole = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(int(detailsRole))
-			# return a supported details role
-			if detailsRole not in supportedAriaDetailsRoles.values():
-				detailsRole = None
-		else:
-			# return a supported details role
-			detailsRole = supportedAriaDetailsRoles.get(detailsRole)
-
-		return detailsRole
+			log.debug(f"detailsRoles: {repr(detailsRoles)}")
+		detailsRolesValues = detailsRoles.split(',')
+		for detailsRole in detailsRolesValues:
+			if detailsRole.isdigit():
+				detailsRoleInt = int(detailsRole)
+				# get a role, but it may be unsupported
+				detailsRole = IAccessibleHandler.IAccessibleRolesToNVDARoles.get(detailsRoleInt)
+				# return a supported details role
+				if detailsRole in supportedAriaDetailsRoles.values():
+					yield detailsRole
+				else:
+					yield None
+			else:
+				# return a supported details role
+				# Note, "unknown" is used when the target has no role.
+				if detailsRole == "unknown" and config.conf["debugLog"]["annotations"]:
+					log.debug("Found unknown aria details role")
+				detailsRole = supportedAriaDetailsRoles.get(detailsRole)
+				yield detailsRole
 
 	def _normalizeFormatField(self, attrs):
 		normalizeIA2TextFormatField(attrs)

--- a/tests/system/libraries/AssertsLib.py
+++ b/tests/system/libraries/AssertsLib.py
@@ -5,6 +5,7 @@
 
 """This module provides custom asserts for system tests.
 """
+from typing import List
 from robot.libraries.BuiltIn import BuiltIn
 builtIn: BuiltIn = BuiltIn()
 
@@ -41,9 +42,63 @@ class AssertsLib:
 			raise
 
 	@staticmethod
+	def string_contains_strings(
+			actual: str,
+			expectedSubStrings: List[str],
+			ignore_case: bool = False,
+			comparison: str = "speech",
+			message: str = ""
+	):
+		message += '\n' if message else ''
+		# Include expected text in robot test report so that the actual behavior
+		# can be determined entirely from the report, even when the test passes.
+		builtIn.log(
+			f"{message}assert {comparison} string matches (ignore case: {ignore_case}):  '{expectedSubStrings}'",
+			level="INFO"
+		)
+		try:
+			for subString in expectedSubStrings:
+				builtIn.should_contain(
+					actual,
+					subString,
+					msg=f"{message}{comparison} Actual != Expected",
+					ignore_case=ignore_case
+				)
+		except AssertionError:
+			# Occasionally on assert failure the repr of the string makes it easier to determine the differences.
+			builtIn.log(
+				"repr of ({}) actual vs expected (ignore_case={}):\n{}\nvs\n{}".format(
+					comparison,
+					ignore_case,
+					repr(actual),
+					repr(subString)
+				),
+				level="DEBUG"
+			)
+			raise
+
+	@staticmethod
 	def speech_matches(actual, expected, ignore_case=False, message=""):
 		AssertsLib.strings_match(actual, expected, ignore_case, comparison="speech", message=message)
 
 	@staticmethod
+	def speech_contains(
+			actual: str,
+			expectedSpeechParts: List[str],
+			ignore_case: bool = False,
+			message: str = ""
+	):
+		AssertsLib.string_contains_strings(actual, expectedSpeechParts, ignore_case, comparison="speech", message=message)
+
+	@staticmethod
 	def braille_matches(actual, expected, ignore_case=False, message=""):
 		AssertsLib.strings_match(actual, expected, ignore_case, comparison="braille", message=message)
+
+	@staticmethod
+	def braille_contains(
+			actual: str,
+			expectedBrailleParts: List[str],
+			ignore_case: bool = False,
+			message: str = ""
+	):
+		AssertsLib.string_contains_strings(actual, expectedBrailleParts, ignore_case, comparison="braille", message=message)

--- a/tests/system/libraries/AssertsLib.py
+++ b/tests/system/libraries/AssertsLib.py
@@ -88,7 +88,13 @@ class AssertsLib:
 			ignore_case: bool = False,
 			message: str = ""
 	):
-		AssertsLib.string_contains_strings(actual, expectedSpeechParts, ignore_case, comparison="speech", message=message)
+		AssertsLib.string_contains_strings(
+			actual,
+			expectedSpeechParts,
+			ignore_case,
+			comparison="speech",
+			message=message
+		)
 
 	@staticmethod
 	def braille_matches(actual, expected, ignore_case=False, message=""):
@@ -101,4 +107,10 @@ class AssertsLib:
 			ignore_case: bool = False,
 			message: str = ""
 	):
-		AssertsLib.string_contains_strings(actual, expectedBrailleParts, ignore_case, comparison="braille", message=message)
+		AssertsLib.string_contains_strings(
+			actual,
+			expectedBrailleParts,
+			ignore_case,
+			comparison="braille",
+			message=message
+		)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -224,6 +224,8 @@ def test_mark_aria_details_role():
 		"has details",
 		"form",
 	])
+	_spy: NVDASpyLib = _NvdaLib.getSpyLib()
+	_spy.setBrailleCellCount(400)
 
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey('downArrow')
 
@@ -256,10 +258,10 @@ def test_mark_aria_details_role():
 			" ",  # space between spans
 			"details",
 			"definition,",
-			# The role "form" is deliberately unsupported
-			# "details",
-			# "form",
-			# "edt end",
+			" ",
+			"details",
+			"form",
+			"edt end",
 		])
 	)
 	
@@ -312,11 +314,9 @@ def test_mark_aria_details_role():
 			" ",  # space between spans
 			"details",
 			"definition,",
-			" ",  # space between spans
-			"d"  # Is this the start of the word 'details' with the rest cut-off?
-			# The role "form" is deliberately unsupported
-			# "details",
-			# "form",
+			" ",
+			"details",
+			"form",
 			# "edt end",
 		])
 	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -143,6 +143,9 @@ focus mode is turned on on focused read-only list item
 ARIA details role
 	[Documentation]	Test aria details roles being announced on discovery
 	test_mark_aria_details_role
+multiple ARIA details targets
+	[Documentation]	Test multiple aria details targets being announced
+	test_annotations_multi_target
 i10890
 	[Documentation]	Test sort state is announced on column header when changed with inner button
 	test_i10890

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,9 @@ What's New in NVDA
 - A new option has been added, "Paragraph Style" in "Document Navigation".
 This adds support for single line break (normal) and multi line break (block) paragraph navigation.
 This can be used with text editors that do not support paragraph navigation natively, such as Notepad and Notepad++. (#13797)
+- The presence of multiple annotations are now reported.
+``nvda+d`` now cycles through reporting the summary of each annotation target for origins with multiple annotation targets.
+For example, when text has a comment and a footnote associated with it. (#14507, #14480)
 -
 
 
@@ -118,9 +121,11 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
 - ``config.addConfigDirsToPythonPackagePath`` has been moved.
 Use ``addonHandler.packaging.addDirsToPythonPackagePath`` instead. (#14350)
 - ``braille.BrailleHandler.TETHER_*`` are deprecated.
-Please use ``configFlags.TetherTo.*.value`` instead. (#14233)
+Use ``configFlags.TetherTo.*.value`` instead. (#14233)
 - ``utils.security.postSessionLockStateChanged`` is deprecated.
-Please use ``utils.security.post_sessionLockStateChanged`` instead. (#14486)
+Use ``utils.security.post_sessionLockStateChanged`` instead. (#14486)
+- ``NVDAObject.hasDetails``, ``NVDAObject.detailsSummary``, ``NVDAObject.detailsRole`` has been deprecated.
+Use ``NVDAObject.annotations`` instead. (#14480)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -125,7 +125,7 @@ Use ``configFlags.TetherTo.*.value`` instead. (#14233)
 - ``utils.security.postSessionLockStateChanged`` is deprecated.
 Use ``utils.security.post_sessionLockStateChanged`` instead. (#14486)
 - ``NVDAObject.hasDetails``, ``NVDAObject.detailsSummary``, ``NVDAObject.detailsRole`` has been deprecated.
-Use ``NVDAObject.annotations`` instead. (#14480)
+Use ``NVDAObject.annotations`` instead. (#14507)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Stacked against #14480 
Supersedes #14426

### Summary of the issue:
Currently, NVDA only announces the first annotation target, and only announces the first annotation summary. 

#14480 introduces the ability to cycle through multiple annotations targets.
This PR introduces announcing the presence of multiple annotation targets.

When multiple annotation targets are present with different roles, NVDA should announce them.
Example:
- A footnote, a comment, and a no-role annotation are present
- NVDA should announce "has footnote, has comment, has details" to make it easier for the user to find the annotation they want to interact with.

### Description of user facing changes
When the annotation feature is enabled, NVDA will now report all the unique annotation target roles.

### Description of development approach
- From the virtual buffer, exposed comma separated values for the roles of annotation targets via the "detailsRoles" property.
- Converted all aria-details functions to plural form (handling a collection rather than a single optional value).
- Removed usages of, and deprecated `nvdaObject.hasDetails`, `nvdaObject.detailsSummary`, `nvdaObject.detailsRole`
   - These are replaced with new Annotations types

### Testing strategy:
- [x] Manual testing on Chrome and Firefox with: https://codepen.io/reefturner/pen/poKLQyj
- [x] System tests have been added for the presence and reporting of multiple annotations

### Known issues with pull request:
It appears that an internally documented chrome bug has not been reported to Chromium/Google yet.

### Change log entries:
New features
```
- The presence of multiple annotations are now reported.
For example, when text has a comment and a footnote associated with it.
```

For Developers
```
- ``NVDAObject.hasDetails``, ``NVDAObject.detailsSummary``, ``NVDAObject.detailsRole`` has been deprecated, instead use ``NVDAObject.annotations``.
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
