### PR TITLE
Windows 11 clipboard history: disable browse mode by default

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2022 NV Access Limited, Joseph Lee
+# Copyright (C) 2017-2023 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -111,6 +111,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	# Cache the most recently selected item.
 	_recentlySelected = None
+
 	# In Windows 11, clipboard history is seen as a web document.
 	# Turn off browse mode by default so clipboard history entry menu items can be announced when tabbed to.
 	disableBrowseModeByDefault: bool = True

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -111,6 +111,9 @@ class AppModule(appModuleHandler.AppModule):
 
 	# Cache the most recently selected item.
 	_recentlySelected = None
+	# In Windows 11, clipboard history is seen as a web document.
+	# Turn off browse mode by default so clipboard history entry menu items can be announced when tabbed to.
+	disableBrowseModeByDefault: bool = True
 
 	def event_UIA_elementSelected(self, obj, nextHandler):
 		# Logic for IME candidate items is handled all within its own object

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,7 +33,11 @@ This can be used with text editors that do not support paragraph navigation nati
 
 
 == Bug Fixes ==
-- In Windows 11, NVDA will announce search highlights when opening Start menu. (#13841)
+- Windows 11 fixes:
+  - NVDA will announce search highlights when opening Start menu. (#13841)
+  - On ARM, x64 apps are no longer identified as ARM64 applications. (#14403)
+  - Clipboard history menu items such as "pin item" can be accessed. (#14508)
+  -
 - Suggestions are reported when typing an @mention in in Microsoft Excel comments. (#13764)
 - In the Google Chrome location bar, suggestion controls (switch to tab, remove suggestion etc) are now reported when selected. (#13522)
 - When requesting formatting information, colors are now explicitly reported in Wordpad or log viewer, rather than only "Default color". (#13959)
@@ -56,7 +60,6 @@ This can be used with text editors that do not support paragraph navigation nati
   -
 - Emojis should now be reported in more languages. (#14433)
 - The presence of an annotation is no longer missing in braille for some elements. (#13815)
-- In Windows 11 on ARM, x64 apps are no longer identified as ARM64 applications. (#14403)
 -
 
 


### PR DESCRIPTION

### Link to issue number:
Closes #14508 

### Summary of the issue:
Browse mode is enabled in Windows 11 clipboard history when it should not be.

### Description of user facing changes
Users will be able to tab through various parts of Windows 11 lipboard history, specificlaly to access menu items such as pinning and unpinning items.

### Description of development approach
"Disable browse mode" flag is set to True in emoji panel app module.

### Testing strategy:
Manual testing:

1. In Windows 11, copy text to the clipboard.
2. Open an app such as Notepad and press Windows+V.
3. When clipboard history opens, press Tab to move through the interface. Make sure NVDA can announce menu items such as pin.

### Known issues with pull request:
None

### Change log entries:
Bug fixes:

In Windows 11, clipboard history menu items such as "pin item" can be accessed. (Re #14508)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
