### PR TITLE
Branch for 2023.2

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited
+# Copyright (C) 2006-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -66,7 +66,7 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2023
-version_major = 1
+version_major = 2
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -3,6 +3,23 @@ What's New in NVDA
 
 %!includeconf: ../changes.t2tconf
 
+= 2023.2 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
+
+=== Deprecations ===
+
+
 = 2023.1 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for the 2023.2 release.
This won't be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`

On merge:
- [x] Update auto milestone ID