### PR TITLE
Revert "Update eSpeak to a51235aa commit"

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -101,8 +101,8 @@ env.Append(
 		# errors when winsock2 is included by espeak\src\include\compat\endian.h
 		'/DWIN32_LEAN_AND_MEAN',
 		# Preprocessor definitions. Espeak Features
-		'/DUSE_SPEECHPLAYER=1',
-		'/DUSE_KLATT=1',
+		'/DINCLUDE_SPEECHPLAYER=1',
+		'/DINCLUDE_KLATT=1',
 		'/DHAVE_SONIC_H=1',
 	])
 
@@ -395,7 +395,6 @@ espeakLib=env.SharedLibrary(
 		"espeak_api.c",
 		"ieee80.c",
 		"intonation.c",
-		"langopts.c",
 		"klatt.c", # we do use KLATT, this is a compile option in espeak
 #		"mbrowrap.c", # we don't use MBROLA, this is a compile option in espeak
 		"mnemonics.c",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `a51235aa`
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `b17ed2d6`
 * [Sonic](https://github.com/waywardgeek/sonic), commit 1d705135
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.org/), version 3.23.0

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -334,7 +334,9 @@ class SynthDriver(SynthDriver):
 				textList.append(langChangeXML)
 				langChanged = True
 			elif isinstance(item, BreakCommand):
-				textList.append(f'<break time="{item.time}ms" />')
+				# Break commands are ignored at the start of speech unless strength is specified.
+				# Refer to eSpeak issue: https://github.com/espeak-ng/espeak-ng/issues/1232
+				textList.append(f'<break time="{item.time}ms" strength="1" />')
 			elif type(item) in self.PROSODY_ATTRS:
 				if prosody:
 					# Close previous prosody tag.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -28,9 +28,6 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 == Changes ==
 - Updated Sonic rate boost library to commit ``1d70513``. (#14180)
 - CLDR has been updated to version 42.0. (#14273)
-- eSpeak NG has been updated to 1.52-dev commit ``a51235aa``. (#14281)
-  - Fixed reporting of large numbers. (#14241)
-  -
 - Java applications with controls using the selectable state will now announce when an item is not selected rather than when the item is selected. (#14336)
 -
 


### PR DESCRIPTION
Reverts nvaccess/nvda#14483 due to a bug with eSpeak rate boost