### PR TITLE
Removed inappropriate pending install item when accessing NVDA menu through systray

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -208,7 +208,6 @@ class MainFrame(wx.Frame):
 			stack_info=True,
 		)
 		self.sysTrayIcon.evaluateUpdatePendingUpdateMenuItemCommand()
-		
 	
 	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onExitCommand(self, evt):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -519,7 +519,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		try:
 			self.menu.Remove(self.installPendingUpdateMenuItem)
 		except Exception:
-			log.debug("Error while removing  pending update menu item", exc_info=True)
+			log.debug("Error while removing pending update menu item", exc_info=True)
 		if not globalVars.appArgs.secure and updateCheck and updateCheck.isPendingUpdate():
 			self.menu.Insert(self.installPendingUpdateMenuItemPos, self.installPendingUpdateMenuItem)
 	

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
 # Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -136,7 +136,6 @@ class MainFrame(wx.Frame):
 		# Therefore, move the mouse to the center of the screen so that the menu will always pop up there.
 		location = api.getDesktopObject().location
 		winUser.setCursorPos(*location.center)
-		self.evaluateUpdatePendingUpdateMenuItemCommand()
 		self.sysTrayIcon.onActivate(None)
 
 	def onRevertToSavedConfigurationCommand(self,evt):
@@ -201,15 +200,6 @@ class MainFrame(wx.Frame):
 				gui.runScriptModalDialog(confirmUpdateDialog)
 			else:
 				updateCheck.executePendingUpdate()
-
-	def evaluateUpdatePendingUpdateMenuItemCommand(self):
-		try:
-			self.sysTrayIcon.menu.Remove(self.sysTrayIcon.installPendingUpdateMenuItem)
-		except:
-			log.debug("Error while removing  pending update menu item", exc_info=True)
-			pass
-		if not globalVars.appArgs.secure and updateCheck and updateCheck.isPendingUpdate():
-			self.sysTrayIcon.menu.Insert(self.sysTrayIcon.installPendingUpdateMenuItemPos,self.sysTrayIcon.installPendingUpdateMenuItem)
 
 	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onExitCommand(self, evt):
@@ -524,8 +514,17 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 
 		self.Bind(wx.adv.EVT_TASKBAR_LEFT_DOWN, self.onActivate)
 		self.Bind(wx.adv.EVT_TASKBAR_RIGHT_DOWN, self.onActivate)
-
+	
+	def evaluateUpdatePendingUpdateMenuItemCommand(self):
+		try:
+			self.menu.Remove(self.installPendingUpdateMenuItem)
+		except Exception:
+			log.debug("Error while removing  pending update menu item", exc_info=True)
+		if not globalVars.appArgs.secure and updateCheck and updateCheck.isPendingUpdate():
+			self.menu.Insert(self.installPendingUpdateMenuItemPos, self.installPendingUpdateMenuItem)
+	
 	def onActivate(self, evt):
+		self.evaluateUpdatePendingUpdateMenuItemCommand()
 		mainFrame.prePopup()
 		import appModules.nvda
 		if not appModules.nvda.nvdaMenuIaIdentity:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -201,6 +201,9 @@ class MainFrame(wx.Frame):
 			else:
 				updateCheck.executePendingUpdate()
 
+	def evaluateUpdatePendingUpdateMenuItemCommand(self):
+		self.sysTrayIcon.evaluateUpdatePendingUpdateMenuItemCommand()
+	
 	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onExitCommand(self, evt):
 		if config.conf["general"]["askToExit"]:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -202,7 +202,13 @@ class MainFrame(wx.Frame):
 				updateCheck.executePendingUpdate()
 
 	def evaluateUpdatePendingUpdateMenuItemCommand(self):
+		log.warning(
+			"MainFrame.evaluateUpdatePendingUpdateMenuItemCommand is deprecated. "
+			"Use SysTrayIcon.evaluateUpdatePendingUpdateMenuItemCommand instead.",
+			stack_info=True,
+		)
 		self.sysTrayIcon.evaluateUpdatePendingUpdateMenuItemCommand()
+		
 	
 	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onExitCommand(self, evt):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -69,6 +69,7 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 - Emojis should now be reported in more languages. (#14433)
 - The presence of an annotation is no longer missing in braille for some elements. (#13815)
 - Fixed an issue where config changes not save correctly when changing between a "Default" option and the value of the "Default" option. (#14133)
+- When accessing the NVDA menu via the notification area, NVDA will not suggest a pending update anymore when no update is available. (#14523)
 -
 
 
@@ -152,6 +153,8 @@ Use ``configFlags.TetherTo.*.value`` instead. (#14233)
 Use ``utils.security.post_sessionLockStateChanged`` instead. (#14486)
 - ``NVDAObject.hasDetails``, ``NVDAObject.detailsSummary``, ``NVDAObject.detailsRole`` has been deprecated.
 Use ``NVDAObject.annotations`` instead. (#14507)
+- ``gui.MainFrame.evaluateUpdatePendingUpdateMenuItemCommand`` has been deprecated.
+Use ``gui.MainFrame.SysTrayIcon.evaluateUpdatePendingUpdateMenuItemCommand`` instead. (#14523)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None.
Issue [reported](https://groups.io/g/nvda-fr/topics) on a French mailing list.
### Summary of the issue:

When accessing NVDA menu via the systray (enter or right click on the NVDA icon), the item "Install pending update" is present even if there is nothing to install.

In the code, it appears that the function to evaluate whether this item should be present or not is called only when accessing NVDA menu via NVDA+N shortcut, not when accessing it via the systray icon.

### Description of user facing changes

The item "Install pending update" will not be present anymore in NVDA menu when there is no pending update available.<

### Description of development approach
Moved the corresponding piece of code so that it is called in both scenarios.

Note: I have not written deprecation code since 2023.1 is an API breaking release and since this function is probably not used by so many add-ons (if any). I feel that in the case of functions/methods rarely used by add-on authors it's not worth making NVDA's core code heavier with deprecation functions when not necessary. If NVAccess wishes to maintain a deprecated method `evaluateUpdatePendingUpdateMenuItemCommand` in MainFrame

### Testing strategy:
Manual tests with a portable NVDA created from appVeyor build of this PR:
1. Launch NVDA
   * Open NVDA menu via NVDA+N and check that there is no pending install item in the menu
   * Open NVDA menu via systray icon and check that there is no pending install item in the menu
2. Check for update via NVDA menu, download the available (alpha) update but do not install it
   * Open NVDA menu via NVDA+N and check that there is a pending install item in the menu
   * Open NVDA menu via systray icon and check that there is a pending install item in the menu
3. In the `userConfig\updates` folder, delete the .exe file:
   * Open NVDA menu via NVDA+N and check that there is no pending install item in the menu
   * Open NVDA menu via systray icon and check that there is no pending install item in the menu

### Known issues with pull request:
None
### Change log entries:

Bug fixes
`When accessing NVDA menu via its icon in the notification area, NVDA will not suggest a pending update anymore when none is available.`

Changes for developers:
`gui.MainFrame.evaluateUpdatePendingUpdateMenuItemCommand` has been removed; use `gui.MainFrame.sysTrayIcon.evaluateUpdatePendingUpdateMenuItemCommand` instead.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
