### PR TITLE
Handle Firefox annotation with unknown role, simplify datastructures

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -5,16 +5,18 @@
 
 """Base classes with common support for browsers exposing IAccessible2.
 """
-import typing
+
 from typing import (
 	Generator,
 	Optional,
+	Tuple,
 )
 from ctypes import c_short
 from comtypes import COMError, BSTR
 
 import oleacc
 from annotation import (
+	_AnnotationRolesT,
 	AnnotationTarget,
 	AnnotationOrigin,
 )
@@ -58,21 +60,24 @@ class IA2WebAnnotation(AnnotationOrigin):
 		)
 
 	@property
-	def targets(self) -> Generator[AnnotationTarget, None, None]:
+	def targets(self) -> Tuple[AnnotationTarget]:
 		if not bool(self):
 			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
 			if config.conf["debugLog"]["annotations"]:
 				log.debug("no annotations available")
 			return
 
-		ia2WebAnnotationTargetsGen = (
+		return (
 			IA2WebAnnotationTarget(rel)
 			for rel in self._originObj.detailsRelations
 		)
-		yield from ia2WebAnnotationTargetsGen
 
 	@property
-	def roles(self) -> Generator[Optional[controlTypes.Role], None, None]:
+	def roles(self) -> _AnnotationRolesT:
+		return tuple(self._rolesGenerator)
+
+	@property
+	def _rolesGenerator(self) -> Generator[Optional[controlTypes.Role], None, None]:
 		"""
 		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
 		to return them.
@@ -97,9 +102,8 @@ class IA2WebAnnotation(AnnotationOrigin):
 			yield detailsRole
 
 	@property
-	def summaries(self) -> Generator[str, None, None]:
-		for target in self.targets:
-			yield target.summary
+	def summaries(self) -> Tuple[str]:
+		return (target.summary for target in self.targets)
 
 
 class Ia2Web(IAccessible):
@@ -130,7 +134,7 @@ class Ia2Web(IAccessible):
 		return info
 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
-		ia2attrDescriptionFrom: typing.Optional[str] = self.IA2Attributes.get("description-from")
+		ia2attrDescriptionFrom: Optional[str] = self.IA2Attributes.get("description-from")
 		try:
 			return controlTypes.DescriptionFrom(ia2attrDescriptionFrom)
 		except ValueError:
@@ -145,7 +149,7 @@ class Ia2Web(IAccessible):
 		annotationOrigin = IA2WebAnnotation(self)
 		return annotationOrigin
 
-	def _get_detailsSummary(self) -> typing.Optional[str]:
+	def _get_detailsSummary(self) -> Optional[str]:
 		log.warning(
 			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
@@ -162,7 +166,7 @@ class Ia2Web(IAccessible):
 		)
 		return bool(self.annotations)
 
-	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
+	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
 		log.warning(
 			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -101,10 +101,6 @@ class IA2WebAnnotation(AnnotationOrigin):
 				log.debug(f"detailsRole: {repr(detailsRole)}")
 			yield detailsRole
 
-	@property
-	def summaries(self) -> Tuple[str]:
-		return (target.summary for target in self.targets)
-
 
 class Ia2Web(IAccessible):
 	IAccessibleTableUsesTableCellIndexAttrib=True
@@ -154,9 +150,8 @@ class Ia2Web(IAccessible):
 			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
 		)
-		for summary in self.annotations.summaries:
-			# just take the first for now.
-			return summary
+		# just take the first for now.
+		return self.annotations.targets[0].summary
 
 	@property
 	def hasDetails(self) -> bool:
@@ -171,9 +166,8 @@ class Ia2Web(IAccessible):
 			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
 		)
-		for role in self.annotations.roles:
-			# just take the first for now.
-			return role
+		# just take the first for now.
+		return self.annotations.roles[0]
 
 	def _get_isCurrent(self) -> controlTypes.IsCurrent:
 		ia2attrCurrent: str = self.IA2Attributes.get("current", "false")

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -7,7 +7,8 @@
 """
 import typing
 from typing import (
-	Iterable,
+	Generator,
+	Optional,
 )
 from ctypes import c_short
 from comtypes import COMError, BSTR
@@ -57,7 +58,7 @@ class IA2WebAnnotation(AnnotationOrigin):
 		)
 
 	@property
-	def targets(self) -> Iterable[AnnotationTarget]:
+	def targets(self) -> Generator[AnnotationTarget, None, None]:
 		if not bool(self):
 			# optimisation that avoids having to fetch details relations which may be a more costly procedure.
 			if config.conf["debugLog"]["annotations"]:
@@ -71,7 +72,7 @@ class IA2WebAnnotation(AnnotationOrigin):
 		yield from ia2WebAnnotationTargetsGen
 
 	@property
-	def roles(self) -> Iterable[controlTypes.Role]:
+	def roles(self) -> Generator[Optional[controlTypes.Role], None, None]:
 		"""
 		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
 		to return them.
@@ -96,7 +97,7 @@ class IA2WebAnnotation(AnnotationOrigin):
 			yield detailsRole
 
 	@property
-	def summaries(self) -> Iterable[str]:
+	def summaries(self) -> Generator[str, None, None]:
 		for target in self.targets:
 			yield target.summary
 

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -67,7 +67,7 @@ class IA2WebAnnotation(AnnotationOrigin):
 				log.debug("no annotations available")
 			return
 
-		return (
+		return tuple(
 			IA2WebAnnotationTarget(rel)
 			for rel in self._originObj.detailsRelations
 		)

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -74,7 +74,7 @@ class MozAnnotation(AnnotationOrigin):
 
 	@property
 	def targets(self) -> Tuple[MozAnnotationTarget]:
-		return (MozAnnotationTarget(rel) for rel in self._originObj.detailsRelations)
+		return tuple(MozAnnotationTarget(rel) for rel in self._originObj.detailsRelations)
 
 
 	@property

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -76,7 +76,6 @@ class MozAnnotation(AnnotationOrigin):
 	def targets(self) -> Tuple[MozAnnotationTarget]:
 		return tuple(MozAnnotationTarget(rel) for rel in self._originObj.detailsRelations)
 
-
 	@property
 	def roles(self) -> _AnnotationRolesT:
 		return tuple(self._rolesGenerator)

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -7,9 +7,11 @@
 from typing import (
 	Generator,
 	Optional,
+	Tuple,
 )
 
 from annotation import (
+	_AnnotationRolesT,
 	AnnotationTarget,
 	AnnotationOrigin,
 )
@@ -71,13 +73,16 @@ class MozAnnotation(AnnotationOrigin):
 		)
 
 	@property
-	def targets(self) -> Generator[MozAnnotationTarget, None, None]:
-		detailsRelations = self._originObj.detailsRelations
-		for rel in detailsRelations:
-			yield MozAnnotationTarget(rel)
+	def targets(self) -> Tuple[MozAnnotationTarget]:
+		return (MozAnnotationTarget(rel) for rel in self._originObj.detailsRelations)
+
 
 	@property
-	def roles(self) -> Generator[Optional[controlTypes.Role], None, None]:
+	def roles(self) -> _AnnotationRolesT:
+		return tuple(self._rolesGenerator)
+
+	@property
+	def _rolesGenerator(self) -> Generator[Optional[controlTypes.Role], None, None]:
 		# Unlike base Ia2Web implementation, the details-roles
 		# IA2 attribute is not exposed in Firefox.
 		# Although slower, we have to fetch the details relations instead.
@@ -88,9 +93,8 @@ class MozAnnotation(AnnotationOrigin):
 				log.error("Error getting role.", exc_info=True)
 
 	@property
-	def summaries(self) -> Generator[str, None, None]:
-		for target in self.targets:
-			yield target.summary
+	def summaries(self) -> Tuple[str]:
+		return (target.summary for target in self.targets)
 
 
 class Mozilla(ia2Web.Ia2Web):

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -92,10 +92,6 @@ class MozAnnotation(AnnotationOrigin):
 			except ValueError:
 				log.error("Error getting role.", exc_info=True)
 
-	@property
-	def summaries(self) -> Tuple[str]:
-		return (target.summary for target in self.targets)
-
 
 class Mozilla(ia2Web.Ia2Web):
 
@@ -154,18 +150,16 @@ class Mozilla(ia2Web.Ia2Web):
 			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
 		)
-		for summary in self.annotations.summaries:
-			# just take the first for now.
-			return summary
+		# just take the first for now.
+		return self.annotations.targets[0].summary
 
 	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
 		log.warning(
 			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
 		)
-		for role in self.annotations.roles:
-			# just take the first target for now.
-			return role
+		# just take the first target for now.
+		return self.annotations.roles[0]
 
 	@property
 	def hasDetails(self) -> bool:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -528,7 +528,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	detailsSummary: typing.Optional[str]
 	"""
 	Typing information for auto property _get_detailsSummary
-	Deprecated, use self.annotations.summaries instead.
+	Deprecated, use self.annotations.targets instead.
 	"""
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -528,7 +528,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 	detailsSummary: typing.Optional[str]
 	"""
 	Typing information for auto property _get_detailsSummary
-	Deprecated, use self.annotations.roles instead.
+	Deprecated, use self.annotations.summaries instead.
 	"""
 
 	def _get_detailsSummary(self) -> typing.Optional[str]:

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -13,7 +13,7 @@ https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Annotations
 from dataclasses import dataclass
 from typing import (
 	TYPE_CHECKING,
-	Iterable,
+	Generator,
 	List,
 	Optional,
 	Set,
@@ -35,7 +35,7 @@ class AnnotationTarget:
 	"""
 
 	@property
-	def role(self) -> "controlTypes.Role":
+	def role(self) -> Optional["controlTypes.Role"]:
 		raise NotImplementedError
 
 	@property
@@ -65,15 +65,15 @@ class AnnotationOrigin:
 		raise NotImplementedError
 
 	@property
-	def targets(self) -> Iterable[AnnotationTarget]:
+	def targets(self) -> Generator[AnnotationTarget, None, None]:
 		raise NotImplementedError
 
 	@property
-	def roles(self) -> Iterable["controlTypes.Role"]:
+	def roles(self) -> Generator[Optional["controlTypes.Role"], None, None]:
 		raise NotImplementedError
 
 	@property
-	def summaries(self) -> Iterable[str]:
+	def summaries(self) -> Generator[str, None, None]:
 		raise NotImplementedError
 
 

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -70,10 +70,6 @@ class AnnotationOrigin:
 	def roles(self) -> _AnnotationRolesT:
 		raise NotImplementedError
 
-	@property
-	def summaries(self) -> Tuple[str]:
-		raise NotImplementedError
-
 
 @dataclass
 class _AnnotationNavigationNode:

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -13,11 +13,9 @@ https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Annotations
 from dataclasses import dataclass
 from typing import (
 	TYPE_CHECKING,
-	Generator,
 	List,
 	Optional,
-	Set,
-	Union,
+	Tuple,
 )
 
 if TYPE_CHECKING:
@@ -25,7 +23,7 @@ if TYPE_CHECKING:
 	from NVDAObjects import NVDAObject
 
 
-_AnnotationRolesT = Set[Union[None, "controlTypes.Role"]]
+_AnnotationRolesT = Tuple[Optional["controlTypes.Role"]]
 
 
 class AnnotationTarget:
@@ -65,15 +63,15 @@ class AnnotationOrigin:
 		raise NotImplementedError
 
 	@property
-	def targets(self) -> Generator[AnnotationTarget, None, None]:
+	def targets(self) -> Tuple[AnnotationTarget]:
 		raise NotImplementedError
 
 	@property
-	def roles(self) -> Generator[Optional["controlTypes.Role"], None, None]:
+	def roles(self) -> _AnnotationRolesT:
 		raise NotImplementedError
 
 	@property
-	def summaries(self) -> Generator[str, None, None]:
+	def summaries(self) -> Tuple[str]:
 		raise NotImplementedError
 
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -529,7 +529,7 @@ def _getAnnotationProperty(
 ) -> str:
 	# Translators: Braille when there are further details/annotations that can be fetched manually.
 	genericDetailsRole = _("details")
-	detailsRoles: _AnnotationRolesT = set(propertyValues.get("detailsRoles", []))
+	detailsRoles: _AnnotationRolesT = propertyValues.get("detailsRoles", tuple())
 	if not detailsRoles:
 		log.debugWarning(
 			"There should always be detailsRoles (at least a single None value) when hasDetails is true."

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -156,7 +156,7 @@ class CompoundTextInfo(textInfos.TextInfo):
 		field['description'] = obj.description
 		field['_description-from'] = obj.descriptionFrom
 		field['hasDetails'] = bool(obj.annotations)
-		field["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
+		field["detailsRoles"] = obj.annotations.roles if obj.annotations else tuple()
 		# The user doesn't care about certain states, as they are obvious.
 		states.discard(controlTypes.State.EDITABLE)
 		states.discard(controlTypes.State.MULTILINE)

--- a/source/controlTypes/state.py
+++ b/source/controlTypes/state.py
@@ -89,7 +89,7 @@ class State(DisplayStringIntEnum):
 	OVERFLOWING = setBit(40)
 	UNLOCKED = setBit(41)
 	# HAS_ARIA_DETAILS is not used internally.
-	# See instead NVDAObject.annotations introduced with commit aa351c55ada5254e061957097a9e0e638091b13d
+	# See instead refer to NVDAObject.annotations
 	# This enum value was initially added to controlTypes.py in commit d6787b8f47861f5e76aba68da7a13a217404196f
 	HAS_ARIA_DETAILS = setBit(42)  # Restored for backwards compat only.
 	HASNOTE = setBit(43)

--- a/source/controlTypes/state.py
+++ b/source/controlTypes/state.py
@@ -89,7 +89,7 @@ class State(DisplayStringIntEnum):
 	OVERFLOWING = setBit(40)
 	UNLOCKED = setBit(41)
 	# HAS_ARIA_DETAILS is not used internally.
-	# See instead NVDAObject.hasDetails introduced with commit aa351c55ada5254e061957097a9e0e638091b13d
+	# See instead NVDAObject.annotations introduced with commit aa351c55ada5254e061957097a9e0e638091b13d
 	# This enum value was initially added to controlTypes.py in commit d6787b8f47861f5e76aba68da7a13a217404196f
 	HAS_ARIA_DETAILS = setBit(42)  # Restored for backwards compat only.
 	HASNOTE = setBit(43)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2306,9 +2306,9 @@ class GlobalCommands(ScriptableObject):
 		if _isDebugLogCatEnabled:
 			log.debug(f"Trying with nvdaObject : {objAtStart}")
 
-		if objAtStart.detailsSummary:
+		if objAtStart.annotations:
 			if _isDebugLogCatEnabled:
-				log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
+				log.debug(f"NVDAObjectAtStart of caret has details")
 			return objAtStart
 		elif api.getFocusObject():
 			# If fetching from the caret position fails, try via the focus object
@@ -2320,7 +2320,7 @@ class GlobalCommands(ScriptableObject):
 			if _isDebugLogCatEnabled:
 				log.debug(f"Trying focus object: {focus}")
 
-			if focus.detailsSummary:
+			if objAtStart.annotations:
 				if _isDebugLogCatEnabled:
 					log.debug("focus object has details, able to proceed")
 				return focus

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2358,7 +2358,7 @@ class GlobalCommands(ScriptableObject):
 			ui.message(_("No additional details"))
 			return
 
-		targets = list(objWithAnnotation.annotations.targets)
+		targets = objWithAnnotation.annotations.targets
 		if _isDebugLogCatEnabled:
 			log.debug(f"Number of targets: {len(targets)}")
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -497,7 +497,7 @@ def getObjectPropertiesSpeech(  # noqa: C901
 		elif value and name == "hasDetails":
 			newPropertyValues['hasDetails'] = bool(obj.annotations)
 		elif value and name == "detailsRoles":
-			newPropertyValues["detailsRoles"] = set(obj.annotations.roles if obj.annotations else [])
+			newPropertyValues["detailsRoles"] = obj.annotations.roles if obj.annotations else tuple()
 		elif value and name == "descriptionFrom" and (
 			obj.descriptionFrom == controlTypes.DescriptionFrom.ARIA_DESCRIPTION
 		):
@@ -1814,7 +1814,7 @@ def getPropertiesSpeech(  # noqa: C901
 	# are there further details
 	hasDetails = propertyValues.get('hasDetails', False)
 	if hasDetails:
-		detailsRoles: _AnnotationRolesT = propertyValues.get("detailsRoles", set())
+		detailsRoles: _AnnotationRolesT = propertyValues.get("detailsRoles", tuple())
 		if detailsRoles:
 			roleStrings = (role.displayString if role else _("details") for role in detailsRoles)
 			for roleString in roleStrings:
@@ -1929,7 +1929,7 @@ def getControlFieldSpeech(  # noqa: C901
 	keyboardShortcut=attrs.get('keyboardShortcut', "")
 	isCurrent = attrs.get('current', controlTypes.IsCurrent.NO)
 	hasDetails = attrs.get('hasDetails', False)
-	detailsRoles: _AnnotationRolesT = set(attrs.get("detailsRoles", []))
+	detailsRoles: _AnnotationRolesT = attrs.get("detailsRoles", tuple())
 	placeholderValue=attrs.get('placeholder', None)
 	value=attrs.get('value',"")
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Follow up of #14507, #14480

### Summary of the issue:
Firefox incorrectly throws an error when browsing annotated content with an unsupported role.
Instead an unknown role should be reported: i.e. "has details".

The typing for annotation data structures were incorrect.

### Description of user facing changes
When browsing content in Firefox with an annotation with unsupported role, "has details" is reported instead of throwing an error.

### Description of development approach
Update typing to be more accurate for annotation data structures, log and return None in the Firefox case to match Chromium behaviour.
Use Tuples rather than generators for `annotations.targets` and `annotations.roles`.
Drops the superfluous/unused `annotations.summaries`


### Testing strategy:
- [x] Manual testing on Chrome and Firefox with: https://codepen.io/reefturner/pen/poKLQyj

### Known issues with pull request:

### Change log entries:
N/A unreleased bug

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
