### PR TITLE
Avoid a situation where no NVDA modifier key is defined

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -12,14 +12,18 @@ the default value.
 """
 
 from enum import unique
-from utils.displayString import DisplayStringIntEnum, DisplayStringStrEnum
+from utils.displayString import (
+	DisplayStringIntEnum,
+	DisplayStringStrEnum,
+	DisplayStringIntFlag,
+)
 from keyLabels import localizedKeyLabels
 
 
 @unique
-class NVDAKey(DisplayStringIntEnum):
-	"""Enumeration containing the possible config values for "Select NVDA Modifier Keys" option in keyboard
-	settings.
+class NVDAKey(DisplayStringIntFlag):
+	"""IntFlag enumeration containing the possible config values for "Select NVDA Modifier Keys" option in
+	keyboard settings.
 	
 	Use NVDAKey.MEMBER.value to compare with the config;
 	the config stores a bitwise combination of one or more of these values.

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -13,6 +13,30 @@ the default value.
 
 from enum import unique
 from utils.displayString import DisplayStringIntEnum, DisplayStringStrEnum
+from keyLabels import localizedKeyLabels
+
+
+@unique
+class NVDAKey(DisplayStringIntEnum):
+	"""Enumeration containing the possible config values for "Select NVDA Modifier Keys" option in keyboard
+	settings.
+	
+	Use NVDAKey.MEMBER.value to compare with the config;
+	the config stores a bitwise combination of one or more of these values.
+	use NVDAKey.MEMBER.displayString in the UI for a translatable description of this member.
+	"""
+	
+	CAPS_LOCK = 1
+	NUMPAD_INSERT = 2
+	EXTENDED_INSERT = 4
+	
+	@property
+	def _displayStringLabels(self):
+		return {
+			NVDAKey.CAPS_LOCK: localizedKeyLabels['capslock'],
+			NVDAKey.NUMPAD_INSERT: localizedKeyLabels['numpadinsert'],
+			NVDAKey.EXTENDED_INSERT: localizedKeyLabels['insert'],
+		}
 
 
 @unique

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
+# Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
 # Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot, Rob Meredith
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -12,7 +12,7 @@ from configobj import ConfigObj
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config 
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 9
+latestSchemaVersion = 10
 
 #: The configuration specification string
 #: @type: String
@@ -151,9 +151,12 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 #Keyboard settings
 [keyboard]
-	useCapsLockAsNVDAModifierKey = boolean(default=false)
-	useNumpadInsertAsNVDAModifierKey = boolean(default=true)
-	useExtendedInsertAsNVDAModifierKey = boolean(default=true)
+	# NVDAModifierKeys: Integer value combining single-bit value:
+	# 1: CapsLock
+	# 2: NumpadInsert
+	# 4: ExtendedInsert
+	# Default = 6: NumpadInsert + ExtendedInsert
+	NVDAModifierKeys = integer(1, 7, default=6)
 	keyboardLayout = string(default="desktop")
 	speakTypedCharacters = boolean(default=true)
 	speakTypedWords = boolean(default=false)

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2022 NV Access Limited, Bill Dengler, Cyrille Bougot, Łukasz Golonka
+# Copyright (C) 2016-2023 NV Access Limited, Bill Dengler, Cyrille Bougot, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -16,6 +16,7 @@ that no information is lost, while updating the ConfigObj to meet the requiremen
 
 from logHandler import log
 from config.configFlags import (
+	NVDAKey,
 	ShowMessages,
 	TetherTo,
 	ReportLineIndentation,
@@ -300,3 +301,56 @@ def _upgradeConfigFrom_8_to_9_tetherTo(profile: ConfigObj) -> None:
 			profile["braille"]["tetherTo"] = TetherTo.AUTO.value
 		else:
 			profile["braille"]["tetherTo"] = tetherToVal
+
+
+def upgradeConfigFrom_9_to_10(profile: ConfigObj) -> None:
+	"""In NVDA config, use only one value to store NVDA keys rather than 3 distinct values.
+	"""
+	
+	anySettingInConfig = False
+	try:
+		capsLock: str = profile['keyboard']['useCapsLockAsNVDAModifierKey']
+		del profile['keyboard']['useCapsLockAsNVDAModifierKey']
+		anySettingInConfig = True
+	except KeyError:
+		capsLock = False
+	try:
+		numpadInsert: str = profile['keyboard']['useNumpadInsertAsNVDAModifierKey']
+		del profile['keyboard']['useNumpadInsertAsNVDAModifierKey']
+		anySettingInConfig = True
+	except KeyError:
+		numpadInsert = True
+	try:
+		extendedInsert: str = profile['keyboard']['useExtendedInsertAsNVDAModifierKey']
+		del profile['keyboard']['useExtendedInsertAsNVDAModifierKey']
+		anySettingInConfig = True
+	except KeyError:
+		extendedInsert = True
+	if anySettingInConfig:
+		val = 0
+		if configobj.validate.is_boolean(capsLock):
+			val |= NVDAKey.CAPS_LOCK.value
+		if configobj.validate.is_boolean(numpadInsert):
+			val |= NVDAKey.NUMPAD_INSERT.value
+		if configobj.validate.is_boolean(extendedInsert):
+			val |= NVDAKey.EXTENDED_INSERT.value
+		if val == 0:
+			# val may be 0 if:
+			# 1: The default profile has caps lock enabled and the currently upgraded profile has ext insert and
+			# numpad insert disabled. In the current profile's config this leads to:
+			# - useNumpadInsertAsNVDAModifierKey = False
+			# - useExtendedInsertAsNVDAModifierKey = False
+			# - useCapsLockAsNVDAModifierKey not present (True inherited from default config)
+			# (see issue #14527 for full description)
+			# or
+			# 2: Someone did disabled all 3 possible NVDA key in config manually, e.g. modifying nvda.ini or via the
+			# Python console.
+			# Thus we consider case 1 which is the only use case reachable by the user via NVDA's GUI.
+			log.debug(
+				"No True value for any of 'use*AsNVDAModifierKey',"
+				" restore caps lock (only possible case via NVDA's GUI)."
+			)
+			val = NVDAKey.CAPS_LOCK.value
+		profile['keyboard']['NVDAModifierKeys'] = val
+	else:
+		log.debug("['use*AsNVDAModifierKey'] values not present, no action taken.")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -353,4 +353,4 @@ def upgradeConfigFrom_9_to_10(profile: ConfigObj) -> None:
 			val = NVDAKey.CAPS_LOCK.value
 		profile['keyboard']['NVDAModifierKeys'] = val
 	else:
-		log.debug("['use*AsNVDAModifierKey'] values not present, no action taken.")
+		log.debug("use*AsNVDAModifierKey values not present, no action taken.")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
 # Rui Batista, Joseph Lee, Heiko Folkerts, Zahari Yurukov, Leonard de Ruijter,
 # Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Bill Dengler, Thomas Stivers,
 # Julien Cochuyt, Peter Vágner, Cyrille Bougot, Mesar Hameed, Łukasz Golonka, Aaron Cannon,
@@ -26,6 +26,7 @@ import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 from config.configFlags import (
+	NVDAKey,
 	ShowMessages,
 	TetherTo,
 	ReportLineIndentation,
@@ -1683,16 +1684,12 @@ class KeyboardSettingsPanel(SettingsPanel):
 		#Translators: This is the label for a list of checkboxes
 		# controlling which keys are NVDA modifier keys.
 		modifierBoxLabel = _("&Select NVDA Modifier Keys")
-		self.modifierChoices = [keyLabels.localizedKeyLabels[key] for key in keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS]
+		self.modifierChoices = [key.displayString for key in NVDAKey]
 		self.modifierList=sHelper.addLabeledControl(modifierBoxLabel, nvdaControls.CustomCheckListBox, choices=self.modifierChoices)
 		checkedItems = []
-		if config.conf["keyboard"]["useNumpadInsertAsNVDAModifierKey"]:
-			checkedItems.append(keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS.index("numpadinsert"))
-
-		if config.conf["keyboard"]["useExtendedInsertAsNVDAModifierKey"]:
-			checkedItems.append(keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS.index("insert"))
-		if config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"]:
-			checkedItems.append(keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS.index("capslock"))
+		for (n, key) in enumerate(NVDAKey):
+			if config.conf["keyboard"]["NVDAModifierKeys"] & key.value:
+				checkedItems.append(n)
 		self.modifierList.CheckedItems = checkedItems
 		self.modifierList.Select(0)
 
@@ -1781,9 +1778,9 @@ class KeyboardSettingsPanel(SettingsPanel):
 	def onSave(self):
 		layout=self.kbdNames[self.kbdList.GetSelection()]
 		config.conf['keyboard']['keyboardLayout']=layout
-		config.conf["keyboard"]["useNumpadInsertAsNVDAModifierKey"]= self.modifierList.IsChecked(keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS.index("numpadinsert"))
-		config.conf["keyboard"]["useExtendedInsertAsNVDAModifierKey"] = self.modifierList.IsChecked(keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS.index("insert"))
-		config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"] = self.modifierList.IsChecked(keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS.index("capslock"))
+		config.conf["keyboard"]["NVDAModifierKeys"] = sum([
+			key.value for (n, key) in enumerate(NVDAKey) if self.modifierList.IsChecked(n)
+		])
 		config.conf["keyboard"]["speakTypedCharacters"]=self.charsCheckBox.IsChecked()
 		config.conf["keyboard"]["speakTypedWords"]=self.wordsCheckBox.IsChecked()
 		config.conf["keyboard"]["speechInterruptForCharacters"]=self.speechInterruptForCharsCheckBox.IsChecked()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1778,9 +1778,9 @@ class KeyboardSettingsPanel(SettingsPanel):
 	def onSave(self):
 		layout=self.kbdNames[self.kbdList.GetSelection()]
 		config.conf['keyboard']['keyboardLayout']=layout
-		config.conf["keyboard"]["NVDAModifierKeys"] = sum([
+		config.conf["keyboard"]["NVDAModifierKeys"] = sum(
 			key.value for (n, key) in enumerate(NVDAKey) if self.modifierList.IsChecked(n)
-		])
+		)
 		config.conf["keyboard"]["speakTypedCharacters"]=self.charsCheckBox.IsChecked()
 		config.conf["keyboard"]["speakTypedWords"]=self.wordsCheckBox.IsChecked()
 		config.conf["keyboard"]["speechInterruptForCharacters"]=self.speechInterruptForCharsCheckBox.IsChecked()

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -115,8 +115,8 @@ class WelcomeDialog(
 			gui.messageBox(
 				_(
 					# Translators: The title of an error message box displayed when validating the startup dialog
-					"At least one NVDA modifier key should be selected. "
-					"As a consequence it has not been possible to disable the caps lock key."
+					"At least one NVDA modifier key must be set. "
+					"Caps lock will remain as an NVDA modifier key. "
 				),
 				# Translators: The title of an error message box displayed when validating the startup dialog
 				_("Error"),

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2021 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2006-2023 NV Access Limited, Łukasz Golonka, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -9,6 +9,7 @@ import weakref
 import wx
 
 import config
+from config.configFlags import NVDAKey
 import core
 from documentationUtils import getDocFilePath
 import globalVars
@@ -76,7 +77,7 @@ class WelcomeDialog(
 		# Translators: The label of a checkbox in the Welcome dialog.
 		capsAsNVDAModifierText = _("&Use CapsLock as an NVDA modifier key")
 		self.capsAsNVDAModifierCheckBox = sHelper.addItem(wx.CheckBox(optionsBox, label=capsAsNVDAModifierText))
-		self.capsAsNVDAModifierCheckBox.SetValue(config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"])
+		self.capsAsNVDAModifierCheckBox.SetValue(config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.CAPS_LOCK)
 		# Translators: The label of a checkbox in the Welcome dialog.
 		startAfterLogonText = _("St&art NVDA after I sign in")
 		self.startAfterLogonCheckBox = sHelper.addItem(wx.CheckBox(optionsBox, label=startAfterLogonText))
@@ -104,7 +105,11 @@ class WelcomeDialog(
 	def onOk(self, evt):
 		layout = self.kbdNames[self.kbdList.GetSelection()]
 		config.conf["keyboard"]["keyboardLayout"] = layout
-		config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"] = self.capsAsNVDAModifierCheckBox.IsChecked()
+		config.conf["keyboard"]["NVDAModifierKeys"] = (
+			(NVDAKey.CAPS_LOCK.value if self.capsAsNVDAModifierCheckBox.IsChecked() else 0)
+			| (config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.NUMPAD_INSERT.value)
+			| (config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.EXTENDED_INSERT.value)
+		)
 		if self.startAfterLogonCheckBox.Enabled:
 			config.setStartAfterLogon(self.startAfterLogonCheckBox.Value)
 		config.conf["general"]["showWelcomeDialogAtStartup"] = self.showWelcomeDialogAtStartupCheckBox.IsChecked()

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -105,11 +105,26 @@ class WelcomeDialog(
 	def onOk(self, evt):
 		layout = self.kbdNames[self.kbdList.GetSelection()]
 		config.conf["keyboard"]["keyboardLayout"] = layout
-		config.conf["keyboard"]["NVDAModifierKeys"] = (
+		NVDAKeysVal = (
 			(NVDAKey.CAPS_LOCK.value if self.capsAsNVDAModifierCheckBox.IsChecked() else 0)
 			| (config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.NUMPAD_INSERT.value)
 			| (config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.EXTENDED_INSERT.value)
 		)
+		if NVDAKeysVal == 0:
+			log.debugWarning("No NVDA key set")
+			gui.messageBox(
+				_(
+					# Translators: The title of an error message box displayed when validating the startup dialog
+					"Despite your choice, caps lock will remain used as NVDA modifier key"
+					" since no other possible key is currently configured as NVDA modifier key."
+				),
+				# Translators: The title of an error message box displayed when validating the startup dialog
+				_("Error"),
+				wx.OK | wx.ICON_ERROR,
+				self,
+			)
+		else:
+			config.conf["keyboard"]["NVDAModifierKeys"] = NVDAKeysVal
 		if self.startAfterLogonCheckBox.Enabled:
 			config.setStartAfterLogon(self.startAfterLogonCheckBox.Value)
 		config.conf["general"]["showWelcomeDialogAtStartup"] = self.showWelcomeDialogAtStartupCheckBox.IsChecked()

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -115,8 +115,8 @@ class WelcomeDialog(
 			gui.messageBox(
 				_(
 					# Translators: The title of an error message box displayed when validating the startup dialog
-					"Despite your choice, caps lock will remain used as NVDA modifier key"
-					" since no other possible key is currently configured as NVDA modifier key."
+					"At least one NVDA modifier key should be selected. "
+					"As a consequence it has not been possible to disable the caps lock key."
 				),
 				# Translators: The title of an error message box displayed when validating the startup dialog
 				_("Error"),

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -16,6 +16,7 @@ from typing import (
 	Tuple,
 	List,
 	Optional,
+	Any,
 )
 
 import wx
@@ -35,6 +36,7 @@ import winInputHook
 import inputCore
 import tones
 import core
+import NVDAState
 from contextlib import contextmanager
 import threading
 
@@ -111,7 +113,16 @@ def isNVDAModifierKey(vkCode: int, extended: bool) -> bool:
 	else:
 		return False
 
-SUPPORTED_NVDA_MODIFIER_KEYS = ("capslock", "numpadinsert", "insert")
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "SUPPORTED_NVDA_MODIFIER_KEYS" and NVDAState._allowDeprecatedAPI():
+		log.warning(
+			"keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS is deprecated with no direct replacement. "
+			"Consider using the class config.configFlags.NVDAKey instead."
+		)
+		return ("capslock", "numpadinsert", "insert")
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
 def getNVDAModifierKeys() -> List[Tuple[int, Optional[bool]]]:

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -12,7 +12,6 @@ import sys
 import time
 import re
 import typing
-from typing import Any
 
 import wx
 import winVersion
@@ -31,7 +30,6 @@ import winInputHook
 import inputCore
 import tones
 import core
-import NVDAState
 from contextlib import contextmanager
 import threading
 

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
-#keyboardHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2006-2017 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V.
+# keyboardHandler.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Cyrille Bougot
 
 """Keyboard support"""
 
@@ -12,6 +12,7 @@ import sys
 import time
 import re
 import typing
+from typing import Any
 
 import wx
 import winVersion
@@ -24,11 +25,13 @@ from keyLabels import localizedKeyLabels
 from logHandler import log
 import queueHandler
 import config
+from config.configFlags import NVDAKey
 import api
 import winInputHook
 import inputCore
 import tones
 import core
+import NVDAState
 from contextlib import contextmanager
 import threading
 
@@ -84,11 +87,22 @@ def passNextKeyThrough():
 		passKeyThroughCount=0
 
 def isNVDAModifierKey(vkCode,extended):
-	if config.conf["keyboard"]["useNumpadInsertAsNVDAModifierKey"] and vkCode==winUser.VK_INSERT and not extended:
+	if (
+		(config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.NUMPAD_INSERT)
+		and vkCode == winUser.VK_INSERT
+		and not extended
+	):
 		return True
-	elif config.conf["keyboard"]["useExtendedInsertAsNVDAModifierKey"] and vkCode==winUser.VK_INSERT and extended:
+	elif (
+		(config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.EXTENDED_INSERT)
+		and vkCode == winUser.VK_INSERT
+		and extended
+	):
 		return True
-	elif config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"] and vkCode==winUser.VK_CAPITAL:
+	elif (
+		(config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.CAPS_LOCK)
+		and vkCode == winUser.VK_CAPITAL
+	):
 		return True
 	else:
 		return False
@@ -97,11 +111,11 @@ SUPPORTED_NVDA_MODIFIER_KEYS = ("capslock", "numpadinsert", "insert")
 
 def getNVDAModifierKeys():
 	keys=[]
-	if config.conf["keyboard"]["useExtendedInsertAsNVDAModifierKey"]:
+	if config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.EXTENDED_INSERT:
 		keys.append(vkCodes.byName["insert"])
-	if config.conf["keyboard"]["useNumpadInsertAsNVDAModifierKey"]:
+	if config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.NUMPAD_INSERT:
 		keys.append(vkCodes.byName["numpadinsert"])
-	if config.conf["keyboard"]["useCapsLockAsNVDAModifierKey"]:
+	if config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.CAPS_LOCK:
 		keys.append(vkCodes.byName["capslock"])
 	return keys
 

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -12,6 +12,11 @@ import sys
 import time
 import re
 import typing
+from typing import (
+	Tuple,
+	List,
+	Optional,
+)
 
 import wx
 import winVersion
@@ -84,7 +89,8 @@ def passNextKeyThrough():
 	if passKeyThroughCount==-1:
 		passKeyThroughCount=0
 
-def isNVDAModifierKey(vkCode,extended):
+
+def isNVDAModifierKey(vkCode: int, extended: bool) -> bool:
 	if (
 		(config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.NUMPAD_INSERT)
 		and vkCode == winUser.VK_INSERT
@@ -107,7 +113,8 @@ def isNVDAModifierKey(vkCode,extended):
 
 SUPPORTED_NVDA_MODIFIER_KEYS = ("capslock", "numpadinsert", "insert")
 
-def getNVDAModifierKeys():
+
+def getNVDAModifierKeys() -> List[Tuple[int, Optional[bool]]]:
 	keys=[]
 	if config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.EXTENDED_INSERT:
 		keys.append(vkCodes.byName["insert"])

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka,
+# Copyright (C) 2006-2023 NV Access Limited, Aleksey Sadovoy, Babbage B.V., Joseph Lee, Łukasz Golonka,
 # Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -15,11 +15,13 @@ import os
 
 import typing
 
+import builtins
 import globalVars
 import ctypes
 from ctypes import wintypes
 import monkeyPatches
 import NVDAState
+from languageHandler import makePgettext
 
 
 monkeyPatches.applyMonkeyPatches()
@@ -63,13 +65,16 @@ import locale
 import gettext
 
 try:
-	gettext.translation(
+	trans = gettext.translation(
 		'nvda',
 		localedir=os.path.join(globalVars.appDir, 'locale'),
 		languages=[locale.getdefaultlocale()[0]]
-	).install(True)
+	)
+	trans.install(True)
 except:
 	gettext.install('nvda')
+# Install our pgettext function.
+builtins.pgettext = makePgettext(trans)
 
 import time
 import argparse

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -75,8 +75,8 @@ try:
 	builtins.pgettext = makePgettext(trans)
 except:
 	gettext.install('nvda')
-	# Install our pgettext function.
-	builtins.pgettext = lambda ctx, msg: msg
+	# Install a no-translation pgettext function
+	builtins.pgettext = lambda context, message: message
 
 import time
 import argparse

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -71,10 +71,12 @@ try:
 		languages=[locale.getdefaultlocale()[0]]
 	)
 	trans.install(True)
+	# Install our pgettext function.
+	builtins.pgettext = makePgettext(trans)
 except:
 	gettext.install('nvda')
-# Install our pgettext function.
-builtins.pgettext = makePgettext(trans)
+	# Install our pgettext function.
+	builtins.pgettext = lambda ctx, msg: msg
 
 import time
 import argparse

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -70,7 +70,7 @@ try:
 		localedir=os.path.join(globalVars.appDir, 'locale'),
 		languages=[locale.getdefaultlocale()[0]]
 	)
-	trans.install(True)
+	trans.install()
 	# Install our pgettext function.
 	builtins.pgettext = makePgettext(trans)
 except:

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2009-2022 NV Access Limited
+# Copyright (C) 2009-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -9,9 +9,11 @@ Performs miscellaneous tasks which need to be performed in a separate process.
 
 import sys
 import os
+import builtins
 import globalVars
 import monkeyPatches.comtypesMonkeyPatches
 import NVDAState
+from languageHandler import makePgettext
 
 
 # Ensure that slave uses generated comInterfaces by adding our comInterfaces to `comtypes.gen` search path.
@@ -35,13 +37,18 @@ import gettext
 import locale
 #Localization settings
 try:
-	gettext.translation(
+	trans = gettext.translation(
 		'nvda',
 		localedir=os.path.join(globalVars.appDir, 'locale'),
 		languages=[locale.getdefaultlocale()[0]]
-	).install()
+	)
+	trans.install()
+	# Install our pgettext function.
+	builtins.pgettext = makePgettext(trans)
 except:
 	gettext.install('nvda')
+	# Install a no-translation pgettext function
+	builtins.pgettext = lambda context, message: message
 
 
 import logHandler

--- a/source/utils/displayString.py
+++ b/source/utils/displayString.py
@@ -1,10 +1,15 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2021 NV Access Limited.
+# Copyright (C) 2021-2023 NV Access Limited, Cyrille Bougot
 
 from abc import ABC, ABCMeta, abstractproperty
-from enum import Enum, EnumMeta, IntEnum
+from enum import (
+	Enum,
+	EnumMeta,
+	IntEnum,
+	IntFlag,
+)
 from typing import Dict
 
 from logHandler import log
@@ -68,4 +73,9 @@ class DisplayStringStrEnum(_DisplayStringEnumMixin, str, Enum, metaclass=_Displa
 
 class DisplayStringIntEnum(_DisplayStringEnumMixin, IntEnum, metaclass=_DisplayStringEnumMixinMeta):
 	"""An IntEnum class that adds a displayString property defined by _displayStringLabels"""
+	pass
+
+
+class DisplayStringIntFlag(_DisplayStringEnumMixin, IntFlag, metaclass=_DisplayStringEnumMixinMeta):
+	"""An IntFlag class that adds a displayString property defined by _displayStringLabels"""
 	pass

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2017-2019 NV Access Limited, Babbage B.V.
+# Copyright (C) 2017-2023 NV Access Limited, Babbage B.V., Cyrille Bougot
 
 """NVDA unit testing.
 All unit tests should reside within this package and should be
@@ -19,10 +19,12 @@ import sys
 
 import locale
 import gettext
+import builtins
 #Localization settings
 locale.setlocale(locale.LC_ALL,'')
 translations = gettext.NullTranslations()
 translations.install()
+builtins.pgettext = lambda context, message: message
 
 # The path to the unit tests.
 UNIT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 import enum
 import typing
 import unittest

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2022 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
 import enum
 import typing
 import unittest
@@ -28,8 +28,10 @@ from config.profileUpgradeSteps import (
 	_upgradeConfigFrom_8_to_9_cellBorders,
 	_upgradeConfigFrom_8_to_9_showMessages,
 	_upgradeConfigFrom_8_to_9_tetherTo,
+	upgradeConfigFrom_9_to_10,
 )
 from config.configFlags import (
+	NVDAKey,
 	ShowMessages,
 	ReportLineIndentation,
 	ReportCellBorders,
@@ -695,6 +697,90 @@ class Config_profileUpgradeSteps_upgradeConfigFrom_8_to_9_tetherTo(unittest.Test
 		_upgradeConfigFrom_8_to_9_tetherTo(profile)
 		self._checkOldKeyRemoved(profile)
 		self.assertEqual(profile['braille']['tetherTo'], TetherTo.REVIEW.value)
+
+
+class Config_profileUpgradeSteps_upgradeConfigFrom_9_to_10(unittest.TestCase):
+
+	def _checkOldKeyRemoved(self, profile: configobj.ConfigObj) -> None:
+		with self.assertRaises(KeyError):
+			profile['keyboard']['useCapsLockAsNVDAModifierKey']
+		with self.assertRaises(KeyError):
+			profile['keyboard']['useNumpadInsertAsNVDAModifierKey']
+		with self.assertRaises(KeyError):
+			profile['keyboard']['useExtendedInsertAsNVDAModifierKey']
+
+	def test_DefaultProfile_Unmodified(self):
+		"""Keyboard settings, NVDA Modifiers Keys option not modified in default profile."""
+		
+		configString = "[keyboard]"
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_9_to_10(profile)
+		self._checkOldKeyRemoved(profile)
+		with self.assertRaises(KeyError):
+			profile['keyboard']['NVDAModifierKeys']
+
+	def test_DefaultProfile_setCapsLockTrue(self):
+		"""Keyboard settings, Caps Lock enabled as NVDA Modifier key in default profile; other keys remain enabled
+		(default).
+		"""
+		
+		configString = """
+[keyboard]
+	useCapsLockAsNVDAModifierKey = True
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_9_to_10(profile)
+		self._checkOldKeyRemoved(profile)
+		self.assertEqual(
+			profile['keyboard']['NVDAModifierKeys'],
+			NVDAKey.CAPS_LOCK.value | NVDAKey.NUMPAD_INSERT.value | NVDAKey.EXTENDED_INSERT.value,
+		)
+
+	def test_DefaultProfile_setCapsLockTrueOtherFalse(self):
+		"""Keyboard settings, Caps Lock enabled as NVDA Modifier key in default profile; other keys disabled.
+		"""
+		
+		configString = """
+[keyboard]
+	useCapsLockAsNVDAModifierKey = True
+	useNumpadInsertAsNVDAModifierKey = False
+	useExtendedInsertAsNVDAModifierKey = False
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_9_to_10(profile)
+		self._checkOldKeyRemoved(profile)
+		self.assertEqual(
+			profile['keyboard']['NVDAModifierKeys'],
+			NVDAKey.CAPS_LOCK.value,
+		)
+	
+	def test_ManualProfile_setNumpadInsertFalseExtendedInsertFalse(self):
+		"""Keyboard settings, NVDA Modifier keys option set on:
+		- numpad insert and extended insert explicitely disabled in the manual profile, while caps lock was still
+		enabled in default profile
+		- caps lock explicitely disabled in the default profile afterwards
+		
+		Thus the configuration for manually activated profile only explicitely disables numpad insert and
+		extended insert since caps lock enabled was inherited from default profile.
+		
+		See issue #14527 for full description.
+		"""
+		
+		# Note that this config is not possible in default profile using only NVDA GUI options, i.e. not using
+		# Python console or manually editing nvda.ini.
+		configString = """
+[keyboard]
+	useNumpadInsertAsNVDAModifierKey = False
+	useExtendedInsertAsNVDAModifierKey = False
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_9_to_10(profile)
+		self._checkOldKeyRemoved(profile)
+		# Check that Caps Lock is restored to avoid having no NVDA modifier key at all.
+		self.assertEqual(
+			profile['keyboard']['NVDAModifierKeys'],
+			NVDAKey.CAPS_LOCK.value,
+		)
 
 
 class Config_AggregatedSection_getitem(unittest.TestCase):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -69,6 +69,7 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 - Emojis should now be reported in more languages. (#14433)
 - The presence of an annotation is no longer missing in braille for some elements. (#13815)
 - Fixed an issue where config changes not save correctly when changing between a "Default" option and the value of the "Default" option. (#14133)
+- When configuring NVDA there will always be at least one key is defined as a NVDA key. (#14527)
 -
 
 
@@ -99,16 +100,20 @@ This functionality is now available generically via ``behaviours.EditableText`` 
 === API Breaking Changes ===
 These are breaking API changes.
 Please open a GitHub issue if your Add-on has an issue with updating to the new API.
-- The configuration specification has been altered, keys have been removed or modified (#14233).
-  - In ``[documentFormatting]`` section:
+- The configuration specification has been altered, keys have been removed or modified:
+  - In ``[documentFormatting]`` section (#14233):
     - ``reportLineIndentation`` stores an int value (0 to 3) instead of a boolean
     - ``reportLineIndentationWithTones`` has been removed.
     - ``reportBorderStyle`` and ``reportBorderColor`` have been removed and are replaced by ``reportCellBorders``.
     -
-  - In ``[braille]`` section:
+  - In ``[braille]`` section (#14233):
     - ``noMessageTimeout`` has been removed, replaced by a value for ``showMessages``.
     - ``messageTimeout`` cannot take the value 0 anymore, replaced by a value for ``showMessages``.
     - ``autoTether`` has been removed; ``tetherTo`` can now take the value "auto" instead.
+    -
+  - In ``[keyboard]`` section  (#14528):
+    - ``useCapsLockAsNVDAModifierKey``, ``useNumpadInsertAsNVDAModifierKey``, ``useExtendedInsertAsNVDAModifierKey`` has been removed.
+    They are replaced by ``NVDAModifierKeys``.
     -
   -
 - The ``NVDAHelper.RemoteLoader64`` class has been removed with no replacement. (#14449)
@@ -132,6 +137,8 @@ Use ``configFlags.TetherTo.*.value`` instead. (#14233)
 Use ``utils.security.post_sessionLockStateChanged`` instead. (#14486)
 - ``NVDAObject.hasDetails``, ``NVDAObject.detailsSummary``, ``NVDAObject.detailsRole`` has been deprecated.
 Use ``NVDAObject.annotations`` instead. (#14507)
+- ``keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS`` is deprecated with no direct replacement.
+Consider using the class ``config.configFlags.NVDAKey`` instead. (#14528)
 -
 
 


### PR DESCRIPTION
### Link to issue number:

Fixes #14527

May be considered a follow-up of #14233.

### Summary of the issue:
When configuring NVDA Modifier Key for a non-default profile and for the default profile, we can end-up with no NVDA key defined at all in the non-default profile (see #14527 for detailed steps).

This is due to the fact that the config stores one item per NVDA key but that there is a dependency between these values to honor the requirement that at least one key should be defined as NVDA key. These values are checked when changing NVDA keys via the GUI. But the requirement may be missed when switching profiles and stacking their configurations.

There is also a second scenario allowing to have no NVDA key defined using only default profile:
* In keyboard settings enable only caps lock and disable both insert, then validate
* Open the NVDA startup dialog via Help menu, uncheck caps lock and validate.
This scenario is quite unlikely but there is no check in NVDA startup dialog to prevent such situation.
* 

### Description of user facing changes
Situations where no NVDA key is defined will not be possible anymore.

### Description of development approach
* Use only one config item to store the used NVDA modifier keys.
* Define a config flag for NVDA key; each value corresponds to one bit so that all the values can be bitwise or-ed and the reesulting value can be stored in the config as an integer.

During the dev, I have had to import key labels (via the config flag) early during NVDA startup. This has caused issues since `pgettext` was not yet defined at this moment. I have tried to fix this; but please double-check it because I do not know very well this part of the code and why gettext translations need to be initialized two times during NVDA startup.

Note: with this PR, `keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEY` is not used anymore in NVDA's code. Should I deprecate it?

### Testing strategy:

Manual tests:
* Check config upgrade in `nvda.ini`
* Modify NVDA modifier keys in keyboard parameters
* Enable or not caps lock as NVDA modifier in NVDA startup dialog
* Test scenario of #14527
* Test 2nd scenario with startup dialog described in this PR.

Unit tests:
* New unit tests created to check various config upgrade situations

### Known issues with pull request:
None

### Change log entries:

Bug fixes
When configuring NVDA it will be ensured that at least one key is defined as NVDA key in any situation. (#14527)

Deprecation:
keyboardHandler.SUPPORTED_NVDA_MODIFIER_KEYS is deprecated with no direct replacement. Consider using the class config.configFlags.NVDAKey instead. (#14528)

API breaking changes:
- In the configuration, the following keys have been removed from the ``[keyboard]`` section: useCapsLockAsNVDAModifierKey, useNumpadInsertAsNVDAModifierKey, useExtendedInsertAsNVDAModifierKey. They are replaced by NVDAModifierKeys. (#14528)
  - 
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
