### PR TITLE
Fixup 14303: Respect config reportLandmarks

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2068,12 +2068,18 @@ def getControlFieldSpeech(  # noqa: C901
 			controlTypes.Role.LANDMARK,
 			controlTypes.Role.REGION,
 		)
-		and config.conf["documentFormatting"]["reportLandmarks"]
 	):
 		# #10095, #3321, #709: Report the name and description of groupings (such as fieldsets) and tab pages
 		# #13307: report the label for landmarks and regions
 		nameAndRole = nameSequence[:]
-		nameAndRole.extend(roleTextSequence)
+		if (
+			role in (
+				controlTypes.Role.LANDMARK,
+				controlTypes.Role.REGION,
+			)
+			and config.conf["documentFormatting"]["reportLandmarks"]
+		):
+			nameAndRole.extend(roleTextSequence)
 		types.logBadSequenceTypes(nameAndRole)
 		return nameAndRole
 	elif (

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2073,11 +2073,11 @@ def getControlFieldSpeech(  # noqa: C901
 		# #13307: report the label for landmarks and regions
 		nameAndRole = nameSequence[:]
 		if (
-			role in (
+			role not in (
 				controlTypes.Role.LANDMARK,
 				controlTypes.Role.REGION,
 			)
-			and config.conf["documentFormatting"]["reportLandmarks"]
+			or config.conf["documentFormatting"]["reportLandmarks"]
 		):
 			nameAndRole.extend(roleTextSequence)
 		types.logBadSequenceTypes(nameAndRole)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2068,6 +2068,7 @@ def getControlFieldSpeech(  # noqa: C901
 			controlTypes.Role.LANDMARK,
 			controlTypes.Role.REGION,
 		)
+		and config.conf["documentFormatting"]["reportLandmarks"]
 	):
 		# #10095, #3321, #709: Report the name and description of groupings (such as fieldsets) and tab pages
 		# #13307: report the label for landmarks and regions


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14519
Fixup of #14303 

### Summary of the issue:
#14303 fixed a bug where landmarks and regions were not correctly reported in some cases.
However, #14303 failed to check/respect the config setting for `reportLandmarks`

### Description of user facing changes
Landmarks are no longer reported incorrectly

### Description of development approach
Check the config setting when reporting landmarks/regions in the case introduced by #14303

### Testing strategy:
Manually tested the STR outlined in #14519

1. open preferences, Document formatting, and disable landmarks reporting;
2. go i.e. to issues page;
3. press 3 to find h3 Footer navigation.
4. Check whether or not "landmark" is reported

### Known issues with pull request:
None

### Change log entries:
None, fixes unreleased bug
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
