### PR TITLE
Follow up for decide_enabled extension point

### DIFF
--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -27,10 +27,12 @@ def actionTester(
 		such as a driver instance.
 	@param expectedKwargs: The kwargs that are expected to be passed to the action
 	"""
+	expectedKwargs["_called"] = True
 	actualKwargs = {}
 
 	def handler(**kwargs):
 		actualKwargs.update(kwargs)
+		actualKwargs["_called"] = True
 
 	action.register(handler)
 	try:
@@ -60,10 +62,12 @@ def deciderTester(
 		such as a driver instance.
 	@param expectedKwargs: The kwargs that are expected to be passed to the decider handler
 	"""
+	expectedKwargs["_called"] = True
 	actualKwargs = {}
 
 	def handler(**kwargs):
 		actualKwargs.update(kwargs)
+		actualKwargs["_called"] = True
 		return expectedDecision
 
 	decider.register(handler)
@@ -96,17 +100,14 @@ def filterTester(
 		such as a driver instance.
 	@param expectedKwargs: The kwargs that are expected to be passed to the filter handler.
 	"""
+	expectedKwargs["_called"] = True
+	expectedKwargs["_value"] = expectedInput
 	actualKwargs = {}
 
-	class InputValueContainer:
-		"""A class to propagate the input value entering the handler to the filterTester"""
-		value: Optional[FilterValueTypeT] = None
-
-	container = InputValueContainer()
-
-	def handler(inputVal: FilterValueTypeT, **kwargs):
-		container.value = inputVal
+	def handler(value: FilterValueTypeT, **kwargs):
 		actualKwargs.update(kwargs)
+		actualKwargs["_called"] = True
+		actualKwargs["_value"] = value
 		return expectedOutput
 
 	filter.register(handler)
@@ -114,6 +115,5 @@ def filterTester(
 		yield expectedOutput
 	finally:
 		filter.unregister(handler)
-		testCase.assertEqual(expectedInput, container.value)
 		testFunc = testCase.assertDictContainsSubset if useAssertDictContainsSubset else testCase.assertDictEqual
 		testFunc(expectedKwargs, actualKwargs)

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -179,4 +179,6 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			braille.handler.decide_enabled,
 			expectedDecision=False,
 		) as expectedDecision:
+			# Ensure that disabling braille by the decider doesn't try to call _handleEnabledDecisionFalse, as that relies on wx.
+			braille.handler._enabled = False
 			self.assertEqual(braille.handler.enabled, expectedDecision)

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -179,6 +179,7 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			braille.handler.decide_enabled,
 			expectedDecision=False,
 		) as expectedDecision:
-			# Ensure that disabling braille by the decider doesn't try to call _handleEnabledDecisionFalse, as that relies on wx.
+			# Ensure that disabling braille by the decider doesn't try to call _handleEnabledDecisionFalse,
+			# as that relies on wx.
 			braille.handler._enabled = False
 			self.assertEqual(braille.handler.enabled, expectedDecision)


### PR DESCRIPTION
### Link to issue number:
Fixup of #14503 

### Summary of the issue:
1. When a handler was registered to decide_enabled and a cursor was blinking or a message with timeout was shown on the braille display, the display would still be updated. Found when working on NVDA Remote to integrate the extension points.
2. The extensionPointTestHelpers wouldn't strictly test whether the handler was actually called. Also the handler argument for value was incorrect and using a class to store the filter value was overdone.

### Description of user facing changes
When a handler decides to disable the braille handler, cursor blinking is now stopped and a message is dismissed.

### Description of development approach
Pretty selfexplanatory.

### Testing strategy:
Manual testing in the python console with a blinking cursor enabled:

```
f=lambda: False
braille.handler.decide_enabled.register(f)
```

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
