### PR TITLE
Fix deprecation in `security.py`

### DIFF
--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,17 +26,16 @@ def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility.
 	"""
 	import NVDAState
-	if not NVDAState._allowDeprecatedAPI():
-		log.debug(f"Deprecated {attrName} imported while _allowDeprecatedAPI is False")
-	elif attrName == "isObjectAboveLockScreen":
-		log.warning(
-			"Importing isObjectAboveLockScreen(obj) is deprecated. "
-			"Instead use obj.isBelowLockScreen. "
-		)
-		return _isObjectAboveLockScreen
-	elif attrName == "postSessionLockStateChanged":
-		log.warning("postSessionLockStateChanged is deprecated, use post_sessionLockStateChanged instead.")
-		return post_sessionLockStateChanged
+	if NVDAState._allowDeprecatedAPI():
+		if attrName == "isObjectAboveLockScreen":
+			log.warning(
+				"Importing isObjectAboveLockScreen(obj) is deprecated. "
+				"Instead use obj.isBelowLockScreen. "
+			)
+			return _isObjectAboveLockScreen
+		if attrName == "postSessionLockStateChanged":
+			log.warning("postSessionLockStateChanged is deprecated, use post_sessionLockStateChanged instead.")
+			return post_sessionLockStateChanged
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -29,7 +29,7 @@ def __getattr__(attrName: str) -> Any:
 	if NVDAState._allowDeprecatedAPI():
 		if attrName == "isObjectAboveLockScreen":
 			log.warning(
-				"Importing isObjectAboveLockScreen(obj) is deprecated. "
+				"isObjectAboveLockScreen(obj) is deprecated. "
 				"Instead use obj.isBelowLockScreen. "
 			)
 			return _isObjectAboveLockScreen

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
 
 
 def __getattr__(attrName: str) -> Any:
-	import NVDAState
 	"""Module level `__getattr__` used to preserve backward compatibility.
 	"""
+	import NVDAState
 	if attrName == "SYSTEM_POWER_STATUS" and NVDAState._allowDeprecatedAPI():
 		from logHandler import log
 		from winAPI._powerTracking import SystemPowerStatus

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -45,6 +45,7 @@ WNDPROC=WINFUNCTYPE(LRESULT,HWND,c_uint,WPARAM,LPARAM)
 
 
 def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
 	from winAPI.winUser.constants import SystemMetrics
 	_deprecatedConstantsMap = {
 		"SM_CXSCREEN": SystemMetrics.CX_SCREEN,
@@ -55,7 +56,6 @@ def __getattr__(attrName: str) -> Any:
 		"SM_CXVIRTUALSCREEN": SystemMetrics.CX_VIRTUAL_SCREEN,
 		"SM_CYVIRTUALSCREEN": SystemMetrics.CY_VIRTUAL_SCREEN,
 	}
-	"""Module level `__getattr__` used to preserve backward compatibility."""
 	if attrName in _deprecatedConstantsMap and NVDAState._allowDeprecatedAPI():
 		replacementSymbol = _deprecatedConstantsMap[attrName]
 		log.warning(


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

When testing for deprecated code, the following message is found when importing something (even not deprecated) from `security.py`, e.g.:
from utils.security import post_sessionLockStateChanged

```
DEBUG - utils.security.__getattr__ (17:36:01.633) - MainThread (17584):
Deprecated __path__ imported while _allowDeprecatedAPI is False
```

### Description of user facing changes
No change for users.

For developers, when deprecated functions are not allowed, removed irrelevant log messages, e.g. indicating that `__path__` is deprecated.


### Description of development approach
* Fix made in the logic of `utils.security.__getattr__` in order not to log a debug message for any missing variable in utils.security (e.g. `__path__`)
* Removed the `log.debug` which did not seem useful in any case.
* While checking at other deprecation management functions, moved the docstrings which were found not at the top of the functions.

### Testing strategy:

Manual tests:
In the code, manually set `_allowDeprecatedAPI` to return False and run the following console commands:
```
# Check in the log that there is no related DEBUG message anymore when running the following command.
>>> from utils.security import post_sessionLockStateChanged

# Check that the following commands have an help message (docstring):
>>> help(winKernel.__getattr__)
>>> help(winUser.__getattr__)
```

### Known issues with pull request:
None

### Change log entries:
Not needed: fixing unreleased changes.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

