### PR TITLE
Speech dictionaries: stop intra-dictionary and inter-dictionary cascading of replacements

### DIFF
--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -115,7 +115,8 @@ class SpeechDict(list):
 def processText(text: str) -> str:
 	"""Calls dictionaries.sub on a text string for each defined dictionary, if dictionary processing is enabled.
 	"""
-	if not globalVars.speechDictionaryProcessing:
+	# If dictionary processing is turned off, or we have no dictionaries to process, return the text
+	if not globalVars.speechDictionaryProcessing or len(dictTypes) == 0:
 		return text
 	for type in dictTypes:
 		newText = dictionaries[type].sub(text)

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -1,8 +1,8 @@
-#speechDictHandler.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2023 NVDA Contributors <http://www.nvda-project.org/>
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# speechDictHandler.py
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2023 NVDA Contributors <http://www.nvda-project.org/>
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import re
 import globalVars
@@ -112,6 +112,7 @@ class SpeechDict(list):
 				del self[index]
 		return text
 
+
 def processText(text: str) -> str:
 	"""Calls dictionaries.sub on a text string for each defined dictionary, if dictionary processing is enabled.
 	"""
@@ -124,6 +125,7 @@ def processText(text: str) -> str:
 		if newText != text:
 			break
 	return newText
+
 
 def initialize():
 	for type in dictTypes:

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -1,6 +1,6 @@
 #speechDictHandler.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2017 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2023 NVDA Contributors <http://www.nvda-project.org/>
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -112,7 +112,9 @@ class SpeechDict(list):
 				del self[index]
 		return text
 
-def processText(text):
+def processText(text: str) -> str:
+	"""Calls dictionaries.sub on a text string for each defined dictionary, if dictionary processing is enabled.
+	"""
 	if not globalVars.speechDictionaryProcessing:
 		return text
 	for type in dictTypes:

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -116,8 +116,11 @@ def processText(text):
 	if not globalVars.speechDictionaryProcessing:
 		return text
 	for type in dictTypes:
-		text=dictionaries[type].sub(text)
-	return text
+		newText = dictionaries[type].sub(text)
+		# To stop intra-dictionary and inter-dictionary cascade replacements, break on successful replacement
+		if newText != text:
+			break
+	return newText
 
 def initialize():
 	for type in dictTypes:


### PR DESCRIPTION
### Link to issue number:

Fixes #11823 

### Summary of the issue:

If an entry in a speech dictionary causes some text to be replaced, that replacement text was continuing to be processed, in effect as if it was new text, through the same and other dictionaries.
This could lead to all sorts of confusion and unexpected behavior for users, particularly the intra-dictionary reprocessing.

Examples can be found in the original issue, and an extensive discussion of the confusion and possible outcomes, along with arguments fore and against various fixes, can be found in [this mailing list discussion](https://nvda.groups.io/g/nvda/topic/96240115).

### Description of user facing changes

When an entry is found in a speech dictionary, a replacement will be made, and no further speech dictionary processing will be done for that entry or its replacement.

It will no longer be possible to replace text in one dictionary, and then have the replacement replaced by the same or another dictionary.

### Description of development approach

Inserted a conditional break statement in the processText function of speechDictHandler, causing it to leave the loop which continues looking for further matches.
To do this, and still return correctly, it was necessary to add a second variable to hold the result of replacements against which to compare.

I also added a comment and a docstring while I was at it.

This solution was proposed in an earlier form, by @tsiegel in a [post on the nvda-devel mailing list](https://groups.io/g/nvda-devel/message/46652), so I have listed him as a co-author.

### Testing strategy:

* Tested that normal entries in the default and temp dictionaries work.
* Tested that an identical entry in the default, voice, and temp dictionaries, still prefers the entry in temp in all cases.
* Tested that an entry in the temp dictionary, does not have its replacement text processed through the default dictionary.
* Tested that an entry in the default dictionary, does not have its replacement text processed through the temp dictionary.
* Tested that a replacement in the default dictionary, is properly overridden by an entry in the voice dictionary, whenever the voice dictionary is activated by use of its associated voice (per @josephsl's request below).
* Tested that the Default and temp dictionaries, do not further act on  the replacement output of a voice dictionary.

### Known issues with pull request:

While intra-dictionary cascading has apparently been considered a bug for a long time, I can not tell whether inter-dictionary cascading has been.
In other words: if the temp dictionary generates some replacement text, was it a design choice that the replacement text would then be subject to replacement by, for example, a pattern in the voice dictionary?

I can see arguments either way, and the module has no documentation stating the original intention.

This PR, as it stands, disables all kinds of cascading, as the majority of users in the list discussion above appeared to prefer.

**That will be a breaking change for add-ons which rely on it, if any do.**

### Change log entries:

Changes, Bug fixes, For Developers

Speech dictionary processing no longer reprocesses replacement text through the same or other dictionaries, but stops after the first replacement is made, except that higher priority dictionaries still take precedence over lower (the current priority order is temporary, voice, default, built-in).

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
