### PR TITLE
Follow up of #14503: Move extension points to top level module and fix FilterValueT name

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1837,7 +1837,7 @@ def getFocusRegions(
 	from NVDAObjects import NVDAObject
 	if isinstance(obj, CursorManager):
 		region2 = (ReviewTextInfoRegion if review else CursorManagerRegion)(obj)
-	elif isinstance(obj, DocumentTreeInterceptor) or (isinstance(obj,NVDAObject) and NVDAObjectHasUsefulText(obj)): 
+	elif isinstance(obj, DocumentTreeInterceptor) or (isinstance(obj,NVDAObject) and NVDAObjectHasUsefulText(obj)):
 		region2 = (ReviewTextInfoRegion if review else TextInfoRegion)(obj)
 	else:
 		region2 = None
@@ -1976,7 +1976,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		brailleViewer.postBrailleViewerToolToggledAction.register(self._onBrailleViewerChangedState)
 
 		self.pre_writeCells = extensionPoints.Action()
-		self.filter_displaySize = extensionPoints.Filter()
+		self.filter_displaySize = extensionPoints.Filter[int]()
 		self.displaySizeChanged = extensionPoints.Action()
 		self.displayChanged = extensionPoints.Action()
 		self.decide_enabled = extensionPoints.Decider()

--- a/source/braille.py
+++ b/source/braille.py
@@ -1837,7 +1837,7 @@ def getFocusRegions(
 	from NVDAObjects import NVDAObject
 	if isinstance(obj, CursorManager):
 		region2 = (ReviewTextInfoRegion if review else CursorManagerRegion)(obj)
-	elif isinstance(obj, DocumentTreeInterceptor) or (isinstance(obj,NVDAObject) and NVDAObjectHasUsefulText(obj)):
+	elif isinstance(obj, DocumentTreeInterceptor) or (isinstance(obj,NVDAObject) and NVDAObjectHasUsefulText(obj)): 
 		region2 = (ReviewTextInfoRegion if review else TextInfoRegion)(obj)
 	else:
 		region2 = None

--- a/source/braille.py
+++ b/source/braille.py
@@ -1866,6 +1866,62 @@ def formatCellsForLog(cells: List[int]) -> str:
 		if cell else "-"
 		for cell in cells])
 
+
+pre_writeCells = extensionPoints.Action()
+"""
+Notifies when cells are about to be written to a braille display.
+This allows components and add-ons to perform an action.
+For example, when a system is controlled by a braille enabled remote system,
+the remote system should know what cells to show on its display.
+@param cells: The list of braille cells.
+@type cells: List[int]
+@param rawText: The raw text that corresponds with the cells.
+@type rawText: str
+@param currentCellCount: The current number of cells
+@type currentCellCount: bool
+"""
+
+filter_displaySize = extensionPoints.Filter()
+"""
+Filter that allows components or add-ons to change the display size used for braille output.
+For example, when a system is controlled by a remote system while having a 80 cells display connected,
+the display size should be lowered to 40 whenever the remote system has a 40 cells display connected.
+@param value: the number of cells of the current display.
+@type value: int
+"""
+
+displaySizeChanged = extensionPoints.Action()
+"""
+Action that allows components or add-ons to be notified of display size changes.
+For example, when a system is controlled by a remote system and the remote system swaps displays,
+The local system should be notified about display size changes at the remote system.
+@param displaySize: The current display size used by the braille handler.
+@type displaySize: int
+"""
+
+displayChanged = extensionPoints.Action()
+"""
+Action that allows components or add-ons to be notified of braille display changes.
+For example, when a system is controlled by a remote system and the remote system swaps displays,
+The local system should be notified about display parameters at the remote system,
+e.g. name and cellcount.
+@param display: The new braille display driver
+@type display: L{BrailleDisplayDriver}
+@param isFallback: Whether the display is set as fallback display due to another display's failure
+@type isFallback: bool
+@param detected: If the display was set by auto detection, the device match that matched the driver
+@type detected: bdDetect.DeviceMatch or C{None}
+"""
+
+decide_enabled = extensionPoints.Decider()
+"""
+Allows components or add-ons to decide whether the braille handler should be forcefully disabled.
+For example, when a system is controlling a remote system with braille,
+the local braille handler should be disabled as long as the system is in control of the remote system.
+Handlers are called without arguments.
+"""
+
+
 class BrailleHandler(baseObject.AutoPropertyObject):
 	# TETHER_AUTO, TETHER_FOCUS, TETHER_REVIEW and tetherValues
 	# are deprecated, but remain to retain API backwards compatibility
@@ -1877,60 +1933,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	queuedWrite: Optional[List[int]] = None
 	queuedWriteLock: threading.Lock
 	ackTimerHandle: int
-
-	pre_writeCells: extensionPoints.Action
-	"""
-	Notifies when cells are about to be written to a braille display.
-	This allows components and add-ons to perform an action.
-	For example, when a system is controlled by a braille enabled remote system,
-	the remote system should know what cells to show on its display.
-	@param cells: The list of braille cells.
-	@type cells: List[int]
-	@param rawText: The raw text that corresponds with the cells.
-	@type rawText: str
-	@param currentCellCount: The current number of cells
-	@type currentCellCount: bool
-	"""
-
-	filter_displaySize: extensionPoints.Filter
-	"""
-	Filter that allows components or add-ons to change the display size used for braille output.
-	For example, when a system is controlled by a remote system while having a 80 cells display connected,
-	the display size should be lowered to 40 whenever the remote system has a 40 cells display connected.
-	@param value: the number of cells of the current display.
-	@type value: int
-	"""
-
-	displaySizeChanged: extensionPoints.Action
-	"""
-	Action that allows components or add-ons to be notified of display size changes.
-	For example, when a system is controlled by a remote system and the remote system swaps displays,
-	The local system should be notified about display size changes at the remote system.
-	@param displaySize: The current display size used by the braille handler.
-	@type displaySize: int
-	"""
-
-	displayChanged: extensionPoints.Action
-	"""
-	Action that allows components or add-ons to be notified of braille display changes.
-	For example, when a system is controlled by a remote system and the remote system swaps displays,
-	The local system should be notified about display parameters at the remote system,
-	e.g. name and cellcount.
-	@param display: The new braille display driver
-	@type display: L{BrailleDisplayDriver}
-	@param isFallback: Whether the display is set as fallback display due to another display's failure
-	@type isFallback: bool
-	@param detected: If the display was set by auto detection, the device match that matched the driver
-	@type detected: bdDetect.DeviceMatch or C{None}
-	"""
-
-	decide_enabled: extensionPoints.Decider
-	"""
-	Allows components or add-ons to decide whether the braille handler should be forcefully disabled.
-	For example, when a system is controlling a remote system with braille,
-	the local braille handler should be disabled as long as the system is in control of the remote system.
-	Handlers are called without arguments.
-	"""
 
 	def __init__(self):
 		louisHelper.initialize()
@@ -1974,12 +1976,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self._ackTimeoutResetterApc = winKernel.PAPCFUNC(self._ackTimeoutResetter)
 
 		brailleViewer.postBrailleViewerToolToggledAction.register(self._onBrailleViewerChangedState)
-
-		self.pre_writeCells = extensionPoints.Action()
-		self.filter_displaySize = extensionPoints.Filter[int]()
-		self.displaySizeChanged = extensionPoints.Action()
-		self.displayChanged = extensionPoints.Action()
-		self.decide_enabled = extensionPoints.Decider()
 
 	def terminate(self):
 		self._disableDetection()
@@ -2025,9 +2021,9 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		Therefore, this is a read only property and can't be set.
 		"""
 		numCells = self.display.numCells if self.display else 0
-		currentDisplaySize = self.filter_displaySize.apply(numCells)
+		currentDisplaySize = filter_displaySize.apply(numCells)
 		if self._displaySize != currentDisplaySize:
-			self.displaySizeChanged.notify(displaySize=currentDisplaySize)
+			displaySizeChanged.notify(displaySize=currentDisplaySize)
 			self._displaySize = currentDisplaySize
 		return currentDisplaySize
 
@@ -2054,7 +2050,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		and thus is C{True} when the display size is greater than 0.
 		This is a read only property and can't be set.
 		"""
-		currentEnabled = bool(self.displaySize) and self.decide_enabled.decide()
+		currentEnabled = bool(self.displaySize) and decide_enabled.decide()
 		if self._enabled != currentEnabled:
 			self._enabled = currentEnabled
 			if currentEnabled is False:
@@ -2164,7 +2160,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			# When setDisplayByName is refactored, ensure that braille display detection no longer triggers
 			# an unnecessary reinit of noBraille.
 			if not (sameDisplayReInit and newDisplay.name == "noBraille"):
-				self.displayChanged.notify(display=newDisplay, isFallback=isFallback, detected=detected)
+				displayChanged.notify(display=newDisplay, isFallback=isFallback, detected=detected)
 			return True
 		except:
 			# For auto display detection, logging an error for every failure is too obnoxious.
@@ -2198,7 +2194,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 
 	def _writeCells(self, cells: List[int]):
 		handlerCellCount = self.displaySize
-		self.pre_writeCells.notify(cells=cells, rawText=self._rawText, currentCellCount=handlerCellCount)
+		pre_writeCells.notify(cells=cells, rawText=self._rawText, currentCellCount=handlerCellCount)
 		displayCellCount = self.display.numCells
 		if not displayCellCount:
 			# No physical display to write to

--- a/source/brailleViewer/__init__.py
+++ b/source/brailleViewer/__init__.py
@@ -68,9 +68,9 @@ def destroyBrailleViewer():
 	_brailleGui = None  # protect against re-entrance
 	if d and not d.isDestroyed:
 		import braille  # imported late to avoid a circular import.
-		updateBrailleDisplayedUnregistered = braille.handler.pre_writeCells.unregister(d.updateBrailleDisplayed)
+		updateBrailleDisplayedUnregistered = braille.pre_writeCells.unregister(d.updateBrailleDisplayed)
 		assert updateBrailleDisplayedUnregistered
-		getDisplaySizeUnregistered = braille.handler.filter_displaySize.unregister(_getDisplaySize)
+		getDisplaySizeUnregistered = braille.filter_displaySize.unregister(_getDisplaySize)
 		assert getDisplaySizeUnregistered
 		d.saveInfoAndDestroy()
 
@@ -98,7 +98,7 @@ def createBrailleViewerTool():
 	if not braille.handler:
 		raise RuntimeError("Can not initialise the BrailleViewerGui: braille.handler not yet initialised")
 
-	braille.handler.filter_displaySize.register(_getDisplaySize)
+	braille.filter_displaySize.register(_getDisplaySize)
 
 	global _brailleGui
 	if _brailleGui:
@@ -108,5 +108,5 @@ def createBrailleViewerTool():
 		braille.handler.displaySize,
 		_onGuiDestroyed
 	)
-	braille.handler.pre_writeCells.register(_brailleGui.updateBrailleDisplayed)
+	braille.pre_writeCells.register(_brailleGui.updateBrailleDisplayed)
 	postBrailleViewerToolToggledAction.notify(created=True)

--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -66,10 +66,10 @@ class Action(HandlerRegistrar):
 				log.exception(f"Error running handler {handler} for {self}. Exception {e}")
 
 
-FilterValueTypeT = TypeVar("FilterOutputTypeT")
+FilterValueT = TypeVar("FilterValueT")
 
 
-class Filter(HandlerRegistrar, Generic[FilterValueTypeT]):
+class Filter(HandlerRegistrar, Generic[FilterValueT]):
 	"""Allows interested parties to register to modify a specific kind of data.
 	For example, this might be used to allow modification of spoken messages before they are passed to the synthesizer.
 
@@ -93,7 +93,7 @@ class Filter(HandlerRegistrar, Generic[FilterValueTypeT]):
 	'This is a message which has been filtered'
 	"""
 
-	def apply(self, value: FilterValueTypeT, **kwargs) -> FilterValueTypeT:
+	def apply(self, value: FilterValueT, **kwargs) -> FilterValueT:
 		"""Pass a value to be filtered through all registered handlers.
 		The value is passed to the first handler
 		and the return value from that handler is passed to the next handler.

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -428,6 +428,19 @@ class GlobalGestureMap(object):
 		with FaultTolerantFile(out.filename) as f:
 			out.write(f)
 
+
+decide_executeGesture = extensionPoints.Decider()
+"""
+Notifies when a gesture is about to be executed,
+and allows components or add-ons to decide whether or not to execute a gesture.
+For example, when controlling a remote system with a connected local braille display,
+braille display gestures should not be executed locally.
+Handlers are called with one argument:
+@param gesture: The gesture that is about to be executed.
+@type gesture: L{InputGesture}
+"""
+
+
 class InputManager(baseObject.AutoPropertyObject):
 	"""Manages functionality related to input from the user.
 	Input includes key presses on the keyboard, as well as key presses on Braille displays, etc.
@@ -436,17 +449,6 @@ class InputManager(baseObject.AutoPropertyObject):
 	#: a modifier gesture was just executed while sayAll was running
 	#: @type: bool
 	lastModifierWasInSayAll=False
-
-	decide_executeGesture: extensionPoints.Decider
-	"""
-	Notifies when a gesture is about to be executed,
-	and allows components or add-ons to decide whether or not to execute a gesture.
-	For example, when controlling a remote system with a connected local braille display,
-	braille display gestures should not be executed locally.
-	Handlers are called with one argument:
-	@param gesture: The gesture that is about to be executed.
-	@type gesture: L{InputGesture}
-	"""
 
 	def __init__(self):
 		#: The function to call when capturing gestures.
@@ -463,8 +465,6 @@ class InputManager(baseObject.AutoPropertyObject):
 		self.loadUserGestureMap()
 		self._lastInputTime = None
 
-		self.decide_executeGesture = extensionPoints.Decider()
-
 	def executeGesture(self, gesture):
 		"""Perform the action associated with a gesture.
 		@param gesture: The gesture to execute.
@@ -477,7 +477,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			# as well as stopping a flood of actions when the core revives.
 			raise NoInputGestureAction
 
-		if not self.decide_executeGesture.decide(gesture=gesture):
+		if not decide_executeGesture.decide(gesture=gesture):
 			# A registered handler decided that this gesture shouldn't be executed.
 			# Purposely do not raise a NoInputGestureAction here, as that could
 			# lead to unexpected behavior for gesture emulation, i.e. the gesture will be send to the system

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -157,8 +157,8 @@ class NVDASpyLib:
 	def _onNvdaStartupComplete(self):
 		self._isNvdaStartupComplete = True
 		import braille
-		braille.handler.filter_displaySize.register(self.getBrailleCellCount)
-		braille.handler.pre_writeCells.register(self._onNvdaBraille)
+		braille.filter_displaySize.register(self.getBrailleCellCount)
+		braille.pre_writeCells.register(self._onNvdaBraille)
 
 	def _onNvdaBraille(self, rawText: str):
 		if not rawText:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -99,7 +99,7 @@ def getFakeCellCount(numCells: int) -> int:
 	return 40
 
 
-braille.handler.filter_displaySize.register(getFakeCellCount)
+braille.filter_displaySize.register(getFakeCellCount)
 
 # The focus and navigator objects need to be initialized to something.
 from .objectProvider import PlaceholderNVDAObject,NVDAObjectWithRole

--- a/tests/unit/extensionPointTestHelpers.py
+++ b/tests/unit/extensionPointTestHelpers.py
@@ -5,7 +5,7 @@
 
 """Helper functions to test extension points."""
 
-from extensionPoints import Action, Decider, Filter, FilterValueTypeT
+from extensionPoints import Action, Decider, Filter, FilterValueT
 import unittest
 from contextlib import contextmanager
 from typing import Optional
@@ -83,8 +83,8 @@ def deciderTester(
 def filterTester(
 		testCase: unittest.TestCase,
 		filter: Filter,
-		expectedInput: FilterValueTypeT,
-		expectedOutput: FilterValueTypeT,
+		expectedInput: FilterValueT,
+		expectedOutput: FilterValueT,
 		useAssertDictContainsSubset: bool = False,
 		**expectedKwargs
 ):
@@ -104,7 +104,7 @@ def filterTester(
 	expectedKwargs["_value"] = expectedInput
 	actualKwargs = {}
 
-	def handler(value: FilterValueTypeT, **kwargs):
+	def handler(value: FilterValueT, **kwargs):
 		actualKwargs.update(kwargs)
 		actualKwargs["_called"] = True
 		actualKwargs["_value"] = value

--- a/tests/unit/test_braille.py
+++ b/tests/unit/test_braille.py
@@ -138,7 +138,7 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			currentCellCount=braille.handler.displaySize
 		)
 
-		with actionTester(self, braille.handler.pre_writeCells, **expectedKwargs):
+		with actionTester(self, braille.pre_writeCells, **expectedKwargs):
 			braille.handler._writeCells(cells)
 
 	def test_displaySizeChanged(self):
@@ -146,7 +146,7 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			displaySize=braille.handler.displaySize
 		)
 
-		with actionTester(self, braille.handler.displaySizeChanged, **expectedKwargs):
+		with actionTester(self, braille.displaySizeChanged, **expectedKwargs):
 			# Change the attribute that is compared with the value coming from filter_displaySize
 			braille.handler._displaySize = 0
 			# The getter should now trigger the action.
@@ -158,7 +158,7 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 			detected=None
 		)
 
-		with actionTester(self, braille.handler.displayChanged, useAssertDictContainsSubset=True, **expectedKwargs):
+		with actionTester(self, braille.displayChanged, useAssertDictContainsSubset=True, **expectedKwargs):
 			# Terminate the current noBraille instance to ensure that the action is triggered when choosing it again.
 			braille.handler.display.terminate()
 			braille.handler.display = None
@@ -167,7 +167,7 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 	def test_filter_displaySize(self):
 		with filterTester(
 			self,
-			braille.handler.filter_displaySize,
+			braille.filter_displaySize,
 			braille.handler._displaySize,  # The currently cached display size
 			20,   # The filter handler should change the display size to 40
 		) as expectedOutput:
@@ -176,7 +176,7 @@ class TestHandlerExtensionPoints(unittest.TestCase):
 	def test_decide_enabled(self):
 		with deciderTester(
 			self,
-			braille.handler.decide_enabled,
+			braille.decide_enabled,
 			expectedDecision=False,
 		) as expectedDecision:
 			# Ensure that disabling braille by the decider doesn't try to call _handleEnabledDecisionFalse,

--- a/tests/unit/test_inputCore.py
+++ b/tests/unit/test_inputCore.py
@@ -25,7 +25,7 @@ class TestInputManagerExtensionPoints(unittest.TestCase):
 		gesture = keyboardHandler.KeyboardInputGesture.fromName("NVDA+T")
 		with deciderTester(
 			self,
-			inputCore.manager.decide_executeGesture,
+			inputCore.decide_executeGesture,
 			expectedDecision=False,
 			gesture=gesture
 		):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -96,15 +96,15 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - This new class is not a singleton by design, add-on authors are encouraged to use their own instance when doing hardware i/o.
   -
 - The processor architecture for the computer can be queried from ``winVersion.WinVersion.processorArchitecture attribute.`` (#14439)
-- New extension points have be added. (#14503)
-  - ``inputCore.manager.decide_executeGesture``
+- New extension points have been added. (#14503)
+  - ``inputCore.decide_executeGesture``
   - ``tones.decide_beep``
   - ``nvwave.decide_playWaveFile``
-  - ``braille.handler.pre_writeCells``
-  - ``braille.handler.filter_displaySize``
-  - ``braille.handler.decide_enabled``
-  - ``braille.handler.displayChanged``
-  - ``braille.handler.displaySizeChanged``
+  - ``braille.pre_writeCells``
+  - ``braille.filter_displaySize``
+  - ``braille.decide_enabled``
+  - ``braille.displayChanged``
+  - ``braille.displaySizeChanged``
   - 
 -
 


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/pull/14531#discussion_r1070737107

### Summary of the issue:
1. FilterValueTypeT nneeded renaming to FilterValueT and had a wrong string in its TypeVar declaration.
2. When experimenting with the extensionPoints, particularlyy with registering a handler to decide_executeGesture in a braille display driver, I discovered that inputCore was not yet initialized when initializing the driver and therefore extension point registration failed.

### Description of user facing changes
Moved extension points, changes file is changed as part of this pr to reflect this.

### Description of development approach
Just moving and renaming code

### Testing strategy:
Unit tests should cover this, I manually tested the braille viewer.

### Known issues with pull request:
None known

### Change log entries:
In PR diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
