### PR TITLE
Make reporting MS Word UIA indent size consistent, use pt

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -389,24 +389,14 @@ class UIATextInfo(textInfos.TextInfo):
 		return formatField
 	
 	@staticmethod
-	def _getIndentValueDisplayString(val: float) -> str:
+	def _getIndentValueDisplayString(indentSizePt: float) -> str:
 		"""A function returning the string to display in formatting info.
 		@param val: an indent value measured in points, fetched via
 			an UIAHandler.UIA_Indentation*AttributeId attribute.
 		@return: The string used in formatting information to report the length of an indentation.
 		"""
-		
-		# convert points to inches (1pt = 1/72 in)
-		val /= 72.0
-		if languageHandler.useImperialMeasurements():
-			# Translators: a measurement in inches
-			valText = _("{val:.2f} in").format(val=val)
-		else:
-			# Convert from inches to centimetres
-			val *= 2.54
-			# Translators: a measurement in centimetres
-			valText = _("{val:.2f} cm").format(val=val)
-		return valText
+		# Translators: Abbreviation for points, a measurement of font size.
+		return pgettext("font size", "%s pt") % indentSizePt
 	
 	# C901 '__init__' is too complex
 	# Note: when working on getPropertiesBraille, look for opportunities to simplify

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -493,6 +493,8 @@ def normalizeLanguage(lang: str) -> Optional[str]:
 def useImperialMeasurements() -> bool:
 	"""
 	Whether or not measurements should be reported as imperial, rather than metric.
+
+	Note: this is currently unused by NVDA core but retained in case it is useful in future.
 	"""
 	bufLength = 2
 	buf = ctypes.create_unicode_buffer(bufLength)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixes #14542

### Summary of the issue:
#13575 aimed to make reporting font size consistent and translatable in NVDA, by reporting "pt" consistently.
Work introduced in #12924 was missed from this refactor, reporting indentation size in MS Word UIA using inches and cm.
Instead the reporting of NVDA should be consistent.

### Description of user facing changes
"pt" is reported correctly instead of "in/cm" when reporting indentation using UIA in MS Word

### Description of development approach
Use consistent display string for font size.

### Testing strategy:
Tested reporting indentation with UIA enabled (default) in MS Word.

### Known issues with pull request:
None

### Change log entries:
Bug fixes
- reporting indentation in MS Office now uses points rather than centimeters/inches to be consistent with the rest of NVDA

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
