### PR TITLE
fixup #14525 bug in Firefox table nav

### DIFF
--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -324,7 +324,7 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 			return self._getNearestTableCell(
 				startPos,
 				_TableCell(
-					cell.TableID,
+					cell.tableID,
 					destRow,
 					destCol,
 					rowSpan=1,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -74,6 +74,7 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 - When configuring NVDA there will always be at least one key is defined as a NVDA key. (#14527)
 - When accessing the NVDA menu via the notification area, NVDA will not suggest a pending update anymore when no update is available. (#14523)
 - In web browsers such as Chrome and Firefox, alerts such as file downloads are shown in braille in addition to being spoken. (#14562)
+- Bug fixed when navigating to the first and last column in a table in Firefox (#14554)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #14552

### Summary of the issue:
A typo in #14070  prevents navigated to the first column in a table in Firefox.

### Description of user facing changes
Use table navigation commands to move to the first column in firefox works again

### Description of development approach
Fix typo

### Testing strategy:
Test with STR in #14552

### Known issues with pull request:
None

### Change log entries:
Bug fixes
- Bug fixed when navigating to the first and last column in a table in Firefox

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
