### PR TITLE
Replace os.environ["PROCESSOR_ARCHITEW6432"] with winVersion.getWinVer().processorArchitecture in most cases

### DIFF
--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -114,9 +114,9 @@ def fixCOMRegistrations():
 	"""Registers most common COM proxies, in case they have accidentally been unregistered or overwritten by
 	3rd party software installs or uninstalls.
 	"""
-	is64bit = os.environ.get("PROCESSOR_ARCHITEW6432", "").endswith("64")
 	winVer = winVersion.getWinVer()
 	OSMajorMinor = (winVer.major, winVer.minor)
+	is64bit = winVer.processorArchitecture.endswith("64")
 	log.debug(
 		f"Fixing COM registrations for Windows {OSMajorMinor[0]}.{OSMajorMinor[1]}, "
 		"{} bit.".format("64" if is64bit else "32")

--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -110,7 +110,7 @@ def apply64bitRegistryPatch(fileName: str) -> None:
 		log.debug(f"Applied 64-bit registry patch from {fileName}")
 
 
-def fixCOMRegistrations():
+def fixCOMRegistrations() -> None:
 	"""Registers most common COM proxies, in case they have accidentally been unregistered or overwritten by
 	3rd party software installs or uninstalls.
 	"""

--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2021 NV Access Limited, Luke Davis (Open Source Systems, Ltd.)
+# Copyright (C) 2018-2023 NV Access Limited, Luke Davis (Open Source Systems, Ltd.)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2022 NV Access Limited, Peter Vagner, Davy Kager, Mozilla Corporation, Google LLC,
+# Copyright (C) 2008-2023 NV Access Limited, Peter Vagner, Davy Kager, Mozilla Corporation, Google LLC,
 # Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -595,7 +595,7 @@ def initialize():
 	#Manually start the in-process manager thread for this NVDA main thread now, as a slow system can cause this action to confuse WX
 	_remoteLib.initInprocManagerThreadIfNeeded()
 	versionedLibARM64Path
-	arch = os.environ.get('PROCESSOR_ARCHITEW6432')
+	arch = winVersion.getWinVer().processorArchitecture
 	if arch == 'AMD64':
 		_remoteLoaderAMD64 = _RemoteLoader(versionedLibAMD64Path)
 	elif arch == 'ARM64':

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -528,7 +528,7 @@ class _RemoteLoader:
 		winKernel.closeHandle(self._process)
 
 
-def initialize():
+def initialize() -> None:
 	global _remoteLib, _remoteLoaderAMD64, _remoteLoaderARM64
 	global localLib, generateBeep, VBuf_getTextInRange, lastLanguageID, lastLayoutString
 	hkl=c_ulong(windll.User32.GetKeyboardLayout(0)).value

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -632,7 +632,7 @@ class AppModule(baseObject.ScriptableObject):
 		"""Whether the underlying process is a 64 bit process.
 		@rtype: bool
 		"""
-		if os.environ.get("PROCESSOR_ARCHITEW6432") not in ("AMD64","ARM64"):
+		if winVersion.getWinVer().processorArchitecture not in ("AMD64","ARM64"):
 			# This is 32 bit Windows.
 			self.is64BitProcess = False
 			return False
@@ -733,7 +733,7 @@ class AppModule(baseObject.ScriptableObject):
 				processMachine = ctypes.wintypes.USHORT()
 				ctypes.windll.kernel32.IsWow64Process2(self.processHandle, ctypes.byref(processMachine), None)
 				if not processMachine.value:
-					self.appArchitecture = os.environ.get("PROCESSOR_ARCHITEW6432")
+					self.appArchitecture = winVersion.getWinVer().processorArchitecture
 				else:
 					# On ARM64, two 32-bit architectures are supported: x86 (via emulation) and ARM (natively).
 					self.appArchitecture = archValues2ArchNames[processMachine.value]

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
 # Babbage B.V., Mozilla Corporation, Julien Cochuyt, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -632,7 +632,7 @@ class AppModule(baseObject.ScriptableObject):
 		"""Whether the underlying process is a 64 bit process.
 		@rtype: bool
 		"""
-		if winVersion.getWinVer().processorArchitecture not in ("AMD64","ARM64"):
+		if winVersion.getWinVer().processorArchitecture not in ("AMD64", "ARM64"):
 			# This is 32 bit Windows.
 			self.is64BitProcess = False
 			return False

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -628,7 +628,7 @@ class AppModule(baseObject.ScriptableObject):
 		self.appPath = path.value if path else None
 		return self.appPath
 
-	def _get_is64BitProcess(self):
+	def _get_is64BitProcess(self) -> bool:
 		"""Whether the underlying process is a 64 bit process.
 		@rtype: bool
 		"""


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes #14534 

### Summary of the issue:
Replace os.environ["PROCESSOR_ARCHITEW6432"] with winVersion.getWinVer().processorArchitecture in most cases (see below for exceptions).

### Description of user facing changes
None

### Description of development approach
Replace os.environ["PROCESSOR_ARCHITEW6432"] with winVersion.getWinVer().processArchitecture in the following cases:

* appModuleHandler.AppModule: is64bitProcess, appArchitecture
* NVDA helper: when starting appropriate helper suite for the right 64-bit architecture
* COM registration fixing tool: determining 32-bit or 64-bit Windows version

The only exception is update check, specifically since Windows 7 service pack 1 string must be recorded correctly; when NVDA moves to supporting Windows 8.1/10 or later, this can be dropped (no more service packs), allowing update check facility to switch to using winVersion.WinVersion class attributes, including processor architecture.

### Testing strategy:
In addition to existing unit test on processor architecture attribute, manu testing would involve testing COM registration fixing tool and comparing app module attributes to make sure they remain the same before and after the PR is merged.

### Known issues with pull request:
None

### Change log entries:
No changelog as #14439 changelog would suffice

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

### About add-on API
NO changes to the API as os.environ can be used by add-ons. winVErsion.WinVersion.processorArchitecture provides a one-stop shop for obtaining processor architecture in a more convenient way.
