### PR TITLE
Fix dead "startupShutdown" link in technical docs

### DIFF
--- a/devDocs/technicalDesignOverview.md
+++ b/devDocs/technicalDesignOverview.md
@@ -82,7 +82,7 @@ It is divided into several distinct components.
 ### Launcher
 The launcher is the module which the user executes to start NVDA.
 It is contained in the file `nvda.pyw`.
-Refer to [startupShutdown documentation](./devDocs/startupShutdown.md).
+Refer to [startupShutdown documentation](./startupShutdown.md).
 
 ### Core
 The core (in the function `core.main`) loads the configuration, initialises all other components and then enters the main loop.


### PR DESCRIPTION
### Link to issue number:
N/A

### Summary of the issue:
Previously, in the "Technical Design Overview" document, the startupShutdown link under the [Launcher heading](https://github.com/nvaccess/nvda/blob/master/devDocs/technicalDesignOverview.md#launcher) didn't work.

### Description of user facing changes
Now, the startupShutdown link should correctly link to [NVDA Starting and Exiting outline page](https://github.com/nvaccess/nvda/blob/master/devDocs/startupShutdown.md).

### Description of development approach
N/A

### Testing strategy:
Used Github's "Preview" feature when editing `technicalDesignOverview.md` file to make sure the link opens up correctly.

### Known issues with pull request:
N/A

### Change log entries:
N/A - this is a small technical documentation fix.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
