### PR TITLE
Windows 11 Notepad: reposition status bar index to be the second to last item

### DIFF
--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -34,7 +34,8 @@ class AppModule(appModuleHandler.AppModule):
 			raise NotImplementedError()
 		# Look for a specific child as some children report the same UIA properties such as class name.
 		# Make sure to look for a foreground UIA element which hosts status bar content if visible.
-		notepadStatusBarIndex = 7
+		# #14573: status bar is the second to last item in Notepad UIA tree.
+		notepadStatusBarIndex = -2
 		statusBar = api.getForegroundObject().children[notepadStatusBarIndex].firstChild
 		# No location for a disabled status bar i.e. location is 0 (x, y, width, height).
 		if not any(statusBar.location):

--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -7,13 +7,15 @@
 While this app module also covers older Notepad releases,
 this module provides workarounds for Windows 11 Notepad."""
 
+from typing import Optional
 import appModuleHandler
 import api
+import NVDAObjects
 
 
 class AppModule(appModuleHandler.AppModule):
 
-	def _get_statusBar(self):
+	def _get_statusBar(self) -> Optional[NVDAObjects.NVDAObject]:
 		"""Retrieves Windows 11 Notepad status bar.
 		In Windows 10 and earlier, status bar can be obtained by looking at the bottom of the screen.
 		Windows 11 Notepad uses Windows 11 UI design (top-level window is labeled "DesktopWindowXamlSource",

--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited, Joseph Lee
+# Copyright (C) 2022-2023 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -78,6 +78,7 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 - In web browsers such as Chrome and Firefox, alerts such as file downloads are shown in braille in addition to being spoken. (#14562)
 - Bug fixed when navigating to the first and last column in a table in Firefox (#14554)
 - When NVDA is launched with --lang=Windows parameter, it is again possible to open NVDA's General settings dialog. (#14407)
+- In newer releases of Windows 11 Notepad, NVDA can once again announce status bar contents. (#14573)
 -
 
 


### PR DESCRIPTION

### Link to issue number:
Fixes #14573 

### Summary of the issue:
Status bar contents are not read in Notepad 11.2212.

### Description of user facing changes
Status bar will be read in newer Notepad 11 releases.

### Description of development approach
Reposition status bar index to become second to last item (-2) in the Notepad UI tree. This is applicable in stable (11.2210 as of time of this pull request) and upcoming dev (11.2212) release with tabbed Notepad interface. Unless the UI tree changes significantly, this change will support old and new Windows 11 Notepad releases.

### Testing strategy:
Manual testing:

1. Prepare two Windows 11 systems: one running build 22621 and another running an Insider Preview dev build (such as 25281).
2. Open Notepad on both versions, and for Insider Preview, make sure this is 11.2212 or later with tabbed Notepad interface.
3. With Notepad open on both systems, retrieve the status bar (NVDA+End in desktop layout, NVDA+Shift+End in laptop layout).
4. Verify that NVDA is announcing actual status bar content.

### Known issues with pull request:
None

### Change log entries:
Bug fixes (can be grouped under Windows 11 fixes or as a standalone entry):

In newer releases of Windows 11 Notepad, NVDA can once again announce status bar contents. (#14573)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
