### PR TITLE
Bug fix when opening General settings dialog while command line --lan…

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -729,9 +729,16 @@ class GeneralSettingsPanel(SettingsPanel):
 		self.languageNames = languageHandler.getAvailableLanguages(presentational=True)
 		languageChoices = [x[1] for x in self.languageNames]
 		if languageHandler.isLanguageForced():
-			cmdLangDescription = [
-				ld[1] for ld in self.languageNames if ld[0] == globalVars.appArgs.language
-			][0]
+			try:
+				cmdLangDescription = next(
+					ld for code, ld in self.languageNames if code == globalVars.appArgs.language
+				)
+			except StopIteration:
+				# In case --lang=Windows is passed to the command line, globalVars.appArgs.language is the current
+				# Windows language,, which may not be in the list of NVDA supported languages, e.g. Windows language may
+				# be 'fr_FR' but NVDA only supports 'fr'.
+				# In this situation, only use language code as a description.
+				cmdLangDescription = globalVars.appArgs.language
 			languageChoices.append(
 				# Translators: Shown for a language which has been provided from the command line
 				# 'langDesc' would be replaced with description of the given locale.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -75,6 +75,7 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 - When accessing the NVDA menu via the notification area, NVDA will not suggest a pending update anymore when no update is available. (#14523)
 - In web browsers such as Chrome and Firefox, alerts such as file downloads are shown in braille in addition to being spoken. (#14562)
 - Bug fixed when navigating to the first and last column in a table in Firefox (#14554)
+- When NVDA is launched with --lang=Windows parameter, it is again possible to open NVDA's General settings dialog. (#14407)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #14407
### Summary of the issue:
When launching NVDA with parameter `--lang=windows`, an error occurs when openeing the General settings dialog.
This error probably occurs when Windows language is not in the list of languages supported by NVDA (even if I have not been able to test such Windows localization). This error also occurs when Windows provides language+region code ('fr_FR') whereas NVDA supports 'fr' more generally.

### Description of user facing changes
For Windows language not directly supported by NVDA, use the language code as a description instead of a full  text description.

### Description of development approach

I have choosen to replace full text description by the language code when NVDA does not support windows language+region. This is the simplest approach.

For fr_FR, I may have implemented a fallback to 'fr', but this would just throw other corner cases for Windows languages completely unknown to NVDA. I believe that displaying full text language names in a few more cases do not deserve a much more complex implementation. The first goal is to be able to open the settings dialog.

### Testing strategy:
Manual tests:
Launch NVDA with various arguments and open the General settings dialogs:
* `--lang=Windows`
* `--lang=fr`
* `--lang=it`
* `--lang=pt_BR`
* no `--lang` parameter

### Known issues with pull request:
Language description of command line argument is not always a full description.
### Change log entries:

Bug fixes
`When NVDA is launched with --lang=Windows parameter, it is again to open General settings dialog. (#14407)`

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
