### PR TITLE
Added global commands which allow a user to easily learn the destination of a link

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2,9 +2,9 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
-# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith
+# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis
 
 import itertools
 from typing import (
@@ -3627,6 +3627,57 @@ class GlobalCommands(ScriptableObject):
 		NVDAObject.clearDynamicClassCache()
 		# Translators: Presented when plugins (app modules and global plugins) are reloaded.
 		ui.message(_("Plugins reloaded"))
+
+	@script(
+		description=_(
+			# Translators: input help mode message for Report destination URL of navigator link command
+			"Report the destination URL of the link in the navigator object. "
+			"If pressed twice, shows the URL in a window for easier review."
+		),
+		gesture="kb:NVDA+k",
+		category=SCRCAT_TOOLS
+	)
+	def script_reportLinkDestination(
+			self, gesture: inputCore.InputGesture, forceBrowseable: bool = False
+	) -> None:
+		"""Generates a ui.message or ui.browseableMessage of a link's destination, if the navigator
+		object is a link, or an element with an included link such as a graphic.
+		@param forceBrowseable: skips the press once check, and displays the browseableMessage version.
+		"""
+		obj = api.getNavigatorObject()
+		presses = scriptHandler.getLastScriptRepeatCount()
+		if (
+			obj.role == controlTypes.role.Role.LINK  # If it's a link, or
+			or controlTypes.state.State.LINKED in obj.states  # if it isn't a link but contains one
+		):
+			if (
+				presses == 1  # If pressed twice, or
+				or forceBrowseable  # if a browseable message is preferred unconditionally
+			):
+				# Translators: Informs the user that the window contains the destination of the
+				# link with given title
+				ui.browseableMessage(obj.value, title=_("Destination of: {name}").format(name=obj.name))
+			elif presses == 0:  # One press
+				ui.message(obj.value)  # Speak the link
+			else:  # Some other number of presses
+				return  # Do nothing
+		else:
+			# Translators: Tell user that the command has been run on something that is not a link
+			ui.message(_("Not a link."))
+
+	@script(
+		description=_(
+			# Translators: input help mode message for Report URL of navigator link in a window command
+			"Reports the destination URL of the link in the navigator object in a window, "
+			"instead of just speaking it. May be preferred by braille users."
+		),
+		category=SCRCAT_TOOLS
+	)
+	def script_reportLinkDestinationInWindow(self, gesture: inputCore.InputGesture) -> None:
+		"""Uses the forceBrowseable flag of script_reportLinkDestination, to generate a
+		ui.browseableMessage of a link's destination.
+		"""
+		self.script_reportLinkDestination(gesture, True)
 
 	@script(
 		# Translators: Input help mode message for a touchscreen gesture.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,6 +23,8 @@ This can be used with text editors that do not support paragraph navigation nati
 ``nvda+d`` now cycles through reporting the summary of each annotation target for origins with multiple annotation targets.
 For example, when text has a comment and a footnote associated with it. (#14507, #14480)
 - Added support for Tivomatic Caiku Albatross 46/80 braille displays. (#13045)
+- New global command: Report link destination (NVDA+k). Pressed once will speak/braille the destination of the link that is in the navigator object. Pressing twice will show it in a window, for more detailed review. (#14583)
+- New unmapped global command (Tools category): Report link destination in a window. Same as pressing NVDA+k twice, but may be more useful for braille users. (#14583)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -222,6 +222,7 @@ The actual commands will not execute while in input help mode.
 | Read status bar | ``NVDA+end`` | ``NVDA+shift+end`` | Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
 | Read time | ``NVDA+f12`` | ``NVDA+f12`` | Pressing once reports the current time, pressing twice reports the date |
 | Report text formatting | ``NVDA+f`` | ``NVDA+f`` | Reports text formatting. Pressing twice shows the information in a window |
+| Report link destination | ``NVDA+k`` | ``NVDA+k`` | Pressing once speaks the destination URL of the link in the [navigator object #ObjectNavigation]. Pressing twice shows it in a window for more careful review |
 
 +++ Toggle which information NVDA reads +++[ToggleWhichInformationNVDAReads]
 || Name | Desktop key | Laptop key | Description |


### PR DESCRIPTION

### Link to issue number:

Closes #14535

### Summary of the issue:

@Qchristensen pointed out, that in this age of phishing and other daily digital security threats effecting average users across the globe, the ability to determine where a link on the web, in an email, or anywhere else, is actually going to take you, is of increasing importance.

NVDA has no current way to do that in most/all circumstances.

### Description of user facing changes

Added the following global commands:
* NVDA+k (all layouts): Report the destination URL of the link in the navigator object. Pressed once, will speak/braille the link, or other element containing a link, represented by the navigator object. Pressed twice, will show the link text in a window with the link name as its title, which can be reviewed more carefully.
* Unassigned by default: Report the destination URL of the link in the navigator object in a window. Will skip directly to showing the browseable message, as above. This second option is imagined as an alternative to which braille users might prefer to remap NVDA+k.

The NVDA+k key was chosen because of its relatability to the browse mode K command.

I also added the `NVDA+k` key and description, to the "**Reporting location and other information**" section of the user guide. I did not add information about the unmapped command, or a broader description of the feature in general, because I was not sure of an appropriate section for it, though it may be worth adding a "Miscellaneous Features" section at some point.

### Description of development approach

* Added two new scripts to `globalCommands.py`. The first will output the link, if the navigator object is or contains a link (such as a graphic with a link), as a `ui.message` if called once, or as a `ui.browseableMessage` if called twice.
* If the role is not LINK, or the states do not contain the LINKED state, it speaks/brailles "Not a link".
* The second script just calls the first script, with a flag directing it to ignore whether the key was pressed twice, and proceed directly to displaying in a `ui.browseableMessage`.

### Testing strategy:

* Manually tested links, and things that aren't links, in Firefox and Chromium web browsers.
* Tested that links are correctly spoken in MS Outlook browse mode, in either the reader or composer.
* Tested that links are correctly spoken when reading a message in MS Outlook focus mode.

### Known issues with pull request:

I can only make this work in MS Word browse mode, if I set UIA to always.
In focus mode, neither UIA or DOM indicate links properly.

While I consider this an issue to be solved, I think the fact that the current implementation works in most other places, warrants submitting the PR now.

I am not equipped to test this with braille or for low vision.

### Change log entries:
New features
* New global command: Report link destination (NVDA+k). Pressed once will speak/braille the destination of the link that is in the navigator object. Pressing twice will show it in a window, for more detailed review.
* New unmapped global command (Tools category): Report link destination in a window. Same as pressing NVDA+k twice, but may be more useful for braille users.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
