### PR TITLE
Allow translators to specify row/column when reporting the end coordinate of a merged cell

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt, Derek Riemer, Cyrille Bougot
 
 """High-level functions to speak information.
@@ -1755,7 +1755,7 @@ def getPropertiesSpeech(  # noqa: C901
 				textList.append(rowNumberTranslation)
 				if rowSpan>1 and columnSpan<=1:
 					# Translators: Speaks the row span added to the current row number (example output: through 5).
-					rowSpanAddedTranslation: str = _("through %s") % (rowNumber + rowSpan - 1)
+					rowSpanAddedTranslation: str = _("through {endRow}").format(endRow=rowNumber + rowSpan - 1)
 					textList.append(rowSpanAddedTranslation)
 			_speechState.oldRowNumber = rowNumber
 			_speechState.oldRowSpan = rowSpan
@@ -1773,7 +1773,7 @@ def getPropertiesSpeech(  # noqa: C901
 				textList.append(colNumberTranslation)
 				if columnSpan>1 and rowSpan<=1:
 					# Translators: Speaks the column span added to the current column number (example output: through 5).
-					colSpanAddedTranslation: str = _("through %s") % (columnNumber + columnSpan - 1)
+					colSpanAddedTranslation: str = _("through {endCol}").format(endCol=columnNumber + columnSpan - 1)
 					textList.append(colSpanAddedTranslation)
 			_speechState.oldColumnNumber = columnNumber
 			_speechState.oldColumnSpan = columnSpan


### PR DESCRIPTION
### Link to issue number:
Fixes #14581 
### Summary of the issue:
For some translators (Chinese ones at least), in the case of merged cell it would be better to report "column 2 to column 3" instead of "column 2 to 3" as we do today.

Today, NVDA uses 2 translatable strings to report the coordinates of a merged cell:
* for rows: "row %s" and "through %s"
* for columns: "column %s" and  and "through %s"


### Description of user facing changes
Translators will now have two strings indicating the end coordinate of a merged cell, one for rows and one for columns.

### Description of development approach
I just have used `.format(...)` with named parameters. Defining strings with two parameters named differently allows to create 2 translatable strings instead of only one. As a side effect, it's also better for translators to have named parameters rather than just `%s` which is not explicit.

Note: using `pgettext` was another option, but with named parameters, it didn't turn out to be necessary.

### Testing strategy:

Manual test: Create po/pot file and check that we can translate separately the two strings indicating "row" or "column"
### Known issues with pull request:
None
### Change log entries:
Not deserving an entry.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
