### PR TITLE
Respect non-config settings on synth drivers

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
 # Joseph Lee, Arnold Loubriat, Leonard de Ruijter
 
 import pkgutil
@@ -53,7 +53,7 @@ class SynthDriver(driverHandler.Driver):
 	Each synthesizer driver should be a separate Python module in the root synthDrivers directory
 	containing a SynthDriver class
 	which inherits from this base class.
-	
+
 	At a minimum, synth drivers must set L{name} and L{description} and override the L{check} method.
 	The methods L{speak}, L{cancel} and L{pause} should be overridden as appropriate.
 	L{supportedSettings} should be set as appropriate for the settings supported by the synthesiser.
@@ -343,7 +343,7 @@ class SynthDriver(driverHandler.Driver):
 		elif not onlyChanged:
 			changeVoice(self, None)
 		for s in self.supportedSettings:
-			if s.id == "voice" or c[s.id] is None:
+			if not s.useConfig or s.id == "voice" or c[s.id] is None:
 				continue
 			val = c[s.id]
 			if onlyChanged and getattr(self, s.id) == val:
@@ -466,7 +466,7 @@ def setSynth(name: Optional[str], isFallback: bool = False):
 		_curSynth = getSynthInstance(name, asDefault)
 	except:  # noqa: E722 # Legacy bare except
 		log.error(f"setSynth failed for {name}", exc_info=True)
-	
+
 	if _curSynth is not None:
 		_audioOutputDevice = config.conf["speech"]["outputDevice"]
 		if not isFallback:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -111,6 +111,7 @@ This functionality is now available generically via ``behaviours.EditableText`` 
   - ``braille.displayChanged``
   - ``braille.displaySizeChanged``
   - 
+- It is possible to set useConfig to False on supported settings for a synthesizer driver. (#14601)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
A synth driver inherrits from `autoSettingsUtils.autoSettings.AutoSettings` but overrides its loadSettings method to work around changing the voice. However, that override doesn't respect settings that aren't saved in config, like the parent class does.

### Description of user facing changes
None

### Description of development approach
Ensure that a synth doesn't try to get a setting from config that's not a setting stored in config.

### Testing strategy:
Tested with an add-on that had synth settings with useConfig set to False. The synth was able to load again.

### Known issues with pull request:
None

### Change log entries:
For Developers
- It is possible to set `useConfig` to False on supported settings for a synthesizer driver.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
