### PR TITLE
Avoid circular reference on IOBase

### DIFF
--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -123,6 +123,7 @@ class IoBase(object):
 		if _isDebug():
 			log.debug("Closing")
 		self._onReceive = None
+		self._onReadError = None
 		if hasattr(self, "_file") and self._file is not INVALID_HANDLE_VALUE:
 			ctypes.windll.kernel32.CancelIoEx(self._file, byref(self._readOl))
 		if hasattr(self, "_writeFile") and self._writeFile not in (self._file, INVALID_HANDLE_VALUE):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
It is possible to register a callback on hwIo.IoBase to catch read errors. However, if this is a callback on a driver and the driver closes the device, the device keeps a reference to the callback on the driver. This causes a circular reference.

### Description of user facing changes
Possibly less unreachable object errors

### Description of development approach
Similar to _onReceive, ensure that onReadError is set to None when closing the device.

### Testing strategy:
Tested locally with a driver providing an onReadError callback, ensured that the garbage collector could correctly cleanup resources.

### Known issues with pull request:
None known

### Change log entries:
This was only noticeable in the log, it is not user visible.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
