### PR TITLE
Bugfix: display ampersand character in the message of `nvdaControls.MessageDialog`

### DIFF
--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2021 NV Access Limited, Derek Riemer
+# Copyright (C) 2016-2022 NV Access Limited, Derek Riemer, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import collections
@@ -304,7 +304,9 @@ class MessageDialog(DPIScaledDialog):
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		contentsSizer = guiHelper.BoxSizerHelper(parent=self, orientation=wx.VERTICAL)
 
-		text = wx.StaticText(self, label=message)
+		# Double ampersand in the dialog's label to avoid this character to be interpreted as an accelerator.
+		label = message.replace('&', '&&')
+		text = wx.StaticText(self, label=label)
 		text.Wrap(self.scaleSize(self.GetSize().Width))
 		contentsSizer.addItem(text)
 		self._addContents(contentsSizer)


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:

When a message containing ampersand has to be displayed in `nvdaControls.MessageDialog`, the ampersand character is interpreted as an indication for accelerator key. Thus the ampersand character is not displayed and the following character is underlined.
Putting here an accelerator key does not make sense here since the `wx.StaticText` used in this dialog is not the label of a focusable element.

The real-life situation where this issue occurs is when installing [NVDA Dev & Test Toolbox](https://addons.nvda-project.org/addons/NVDA-Dev-Test-Toolbox.en.html). The dialog indicates "Extension : NVDA Dev  Test Toolbox 3.0" (without ampersand) instead of "Extension : NVDA Dev & Test Toolbox 3.0" (with ampersand).


### Description of user facing changes
Messages displayed in `nvdaControls.MessageDialog` will be displayed correctly when the message contains ampersand character. E.g. add-on install dialog and add-on install errror dialogs will display correctly the name of add-ons containing ampersand character in their name.

### Description of development approach

Doubled the ampersand character when present in the message.

### Testing strategy:
Manual test:
Check that the issue is fixed when installing NVDA Dev & Test Toolbox.
### Known issues with pull request:

I have made this PR minimalist, fixing only the situation where both these statements are true:
* string used in a `wx.StaticText` can contain ampersand character.
* the `wx.StaticText` is a standalone static text, i.e. not used as a label for another focusable element, e.g. edit field, combo-box or list following it

This PR is not waterproof to following hypothetical situations regarding standalone static text:
* in the future, the string of a standalone static text is changed with an ampersan in NVDA codebase.
* The string used in a standalone static text does not contain ampersand character but its translation does

For reviewer(s):
Maybe I should also handle these cases? In this PR? Or in another one? Or is it not worth it (assuming that translators do not use ampersand when it is not used in English)?
Let me know what you think.

### Change log entries:
Not needed for such a small change.

### Code Review Checklist:
- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
