### PR TITLE
Revert "Windows 11 Notepad: reposition status bar index to be the second to last item"

### DIFF
--- a/source/appModules/notepad.py
+++ b/source/appModules/notepad.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Joseph Lee
+# Copyright (C) 2022 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -7,15 +7,13 @@
 While this app module also covers older Notepad releases,
 this module provides workarounds for Windows 11 Notepad."""
 
-from typing import Optional
 import appModuleHandler
 import api
-import NVDAObjects
 
 
 class AppModule(appModuleHandler.AppModule):
 
-	def _get_statusBar(self) -> Optional[NVDAObjects.NVDAObject]:
+	def _get_statusBar(self):
 		"""Retrieves Windows 11 Notepad status bar.
 		In Windows 10 and earlier, status bar can be obtained by looking at the bottom of the screen.
 		Windows 11 Notepad uses Windows 11 UI design (top-level window is labeled "DesktopWindowXamlSource",
@@ -36,8 +34,7 @@ class AppModule(appModuleHandler.AppModule):
 			raise NotImplementedError()
 		# Look for a specific child as some children report the same UIA properties such as class name.
 		# Make sure to look for a foreground UIA element which hosts status bar content if visible.
-		# #14573: status bar is the second to last item in Notepad UIA tree.
-		notepadStatusBarIndex = -2
+		notepadStatusBarIndex = 7
 		statusBar = api.getForegroundObject().children[notepadStatusBarIndex].firstChild
 		# No location for a disabled status bar i.e. location is 0 (x, y, width, height).
 		if not any(statusBar.location):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -78,7 +78,6 @@ For example, when text has a comment and a footnote associated with it. (#14507,
 - In web browsers such as Chrome and Firefox, alerts such as file downloads are shown in braille in addition to being spoken. (#14562)
 - Bug fixed when navigating to the first and last column in a table in Firefox (#14554)
 - When NVDA is launched with --lang=Windows parameter, it is again possible to open NVDA's General settings dialog. (#14407)
-- In newer releases of Windows 11 Notepad, NVDA can once again announce status bar contents. (#14573)
 -
 
 


### PR DESCRIPTION
Reverts nvaccess/nvda#14574 due to critical issue if Notepad settings is opened then closed. 