### PR TITLE
Fixes some links in the dev guide

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -17,7 +17,7 @@ The NVDA Add-on API includes all NVDA internals, except symbols that are prefixe
 
 The NVDA Add-on API changes over time, such as removals, deprecations and new features.
 Important changes to the API are announced on the [NVDA API mailing list https://groups.google.com/a/nvaccess.org/g/nvda-api/about].
-Changes relevant to developers are also announced via the [NVDA changes file](https://www.nvaccess.org/files/nvda/documentation/changes.html).
+Changes relevant to developers are also announced via the [NVDA changes file https://www.nvaccess.org/files/nvda/documentation/changes.html].
 Any changes to the API policy outlined in this section will be conveyed via these two channels.
 
 API breaking releases happen at most once per year, these are ``.1`` releases, e.g. ``2022.1``.

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -38,7 +38,7 @@ Documentation and other resources related to the Python language can be found at
 ++ C++ ++
 Some of NVDA is written in C++, EG nvdaHelper.
 For an overview of nvdaHelper, including how to configure Visual Studio to enable intellisense see the
-[nvdaHelper readme nvdaHelper_readme.md]
+[nvdaHelper readme https://github.com/nvaccess/nvda/blob/master/nvdaHelper/readme.md]
 
 
 + Translation +

--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -45,7 +45,7 @@ For an overview of nvdaHelper, including how to configure Visual Studio to enabl
 In order to support multiple languages/locales, NVDA must be translated and data specific to the locale must be provided.
 This section only includes information on custom NVDA file formats required for translation.
 Other items need to be translated, such as the NVDA user interface and documentation, but these use standard file formats.
-For complete documentation about translating NVDA, please see https://github.com/nvaccess/nvda/wiki/Translating
+For complete documentation about translating NVDA, please see the [Translating wiki page https://github.com/nvaccess/nvda/wiki/Translating]
 
 ++ Character Descriptions ++
 Sometimes, it can be very difficult or even impossible to distinguish one character from another.
@@ -859,8 +859,7 @@ All other fields will be ignored.
 Each language directory can also contain gettext information, which is the system used to translate the rest of NVDA's user interface and reported messages.
 As with the rest of NVDA, an nvda.mo compiled gettext database file should be placed in the LC_MESSAGES directory within this directory.
 To allow plugins in your add-on to access gettext message information via calls to _(), you must initialize translations at the top of each Python module by calling addonHandler.initTranslation().
-For more information about gettext and NVDA translation in general, please read
-https://github.com/nvaccess/nvda/wiki/Translating
+For more information about gettext and NVDA translation in general, please read the [Translating NVDA wiki page https://github.com/nvaccess/nvda/wiki/Translating]
 
 ++ Add-on Documentation ++[AddonDoc]
 Documentation for an add-on should be placed in a doc directory in the archive.


### PR DESCRIPTION
### Link to issue number:

Corrects the exact problem mentioned in #14632, but may not solve it ultimately in the desired way. See the known issues section below. This is both a stop-gap while the ultimate solution is decided, and fixes some moderate errors found while working on it.

### Summary of the issue:

The link to the NVDA Helper README in the Development Guide did not work.

### Description of user facing changes

Fixed that link per suggested alternative given by @michaelDCurran  in [#14632 (comment)](https://github.com/nvaccess/nvda/issues/14632#issuecomment-1427456883).

While doing that, I noticed and fixed:
* A couple links to the Translating NVDA wiki page, which had no link markup at all.
* One case of a link which was written in markdown style instead of T2T style.

### Description of development approach

* Searched file for the helper readme reference, and replaced the broken file reference with the link given by @michaelDCurran .
* Searched for other occurrences of "http", and verified that they were all in validly formatted link markup, and fixed them where found not to be.

### Testing strategy:

Checked links generated in PR build. All changed links are clickable, and go to the expected destinations.

### Known issues with pull request:

This PR does not address @michaelDCurran's suggestion in [this comment](https://github.com/nvaccess/nvda/issues/14632#issuecomment-1427451718).

### Change log entries:

None needed.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
