### PR TITLE
Fix up dash pronunciation in system tests after #13857

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -409,7 +409,7 @@ def exercise_mark_aria_details(nvdaConfValues: "NVDASpyLib.NVDAConfMods"):
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey(READ_DETAILS_GESTURE)
 	_asserts.speech_matches(
 		actualSpeech,
-		"Cats go woof BTW  Jonathon Commentor No they don't  Zara",
+		"Cats go woof BTW  Jonathon Commentor No they don't —Zara",
 		message="Browse mode: Report details on word with details"
 	)
 	_asserts.braille_matches(
@@ -564,7 +564,7 @@ def exercise_mark_aria_details(nvdaConfValues: "NVDASpyLib.NVDAConfMods"):
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey(READ_DETAILS_GESTURE)
 	_asserts.speech_matches(
 		actualSpeech,
-		"Cats go woof BTW  Jonathon Commentor No they don't  Zara",
+		"Cats go woof BTW  Jonathon Commentor No they don't —Zara",
 		message="Focus mode:  Report details on word with details.",
 	)
 	_asserts.braille_matches(

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -103,7 +103,7 @@ def _doTestAriaDetails_NoVBufNoTextInterface(nvdaConfValues: "NVDASpyLib.NVDACon
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey(READ_DETAILS_GESTURE)
 	_asserts.speech_matches(
 		actualSpeech,
-		"Press to self destruct",
+		"Press to self-destruct",
 		message="Report details"
 	)
 	_asserts.braille_matches(
@@ -204,10 +204,10 @@ def test_mark_aria_details_role():
 		# the role doc-endnote is unsupported as an IA2 role
 		# The role "ROLE_LIST_ITEM" is used instead
 		"has details",
-		"doc endnote,",
+		"doc-endnote,",
 		"",  # space between spans
 		"has foot note",
-		"doc footnote,",
+		"doc-footnote,",
 		"",  # space between spans
 		"has comment",
 		"comment,",
@@ -409,7 +409,7 @@ def exercise_mark_aria_details(nvdaConfValues: "NVDASpyLib.NVDAConfMods"):
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey(READ_DETAILS_GESTURE)
 	_asserts.speech_matches(
 		actualSpeech,
-		"Cats go woof BTW  Jonathon Commentor No they don't —Zara",
+		"Cats go woof BTW —Jonathon Commentor No they don't —Zara",
 		message="Browse mode: Report details on word with details"
 	)
 	_asserts.braille_matches(
@@ -564,7 +564,7 @@ def exercise_mark_aria_details(nvdaConfValues: "NVDASpyLib.NVDAConfMods"):
 	actualSpeech, actualBraille = _NvdaLib.getSpeechAndBrailleAfterKey(READ_DETAILS_GESTURE)
 	_asserts.speech_matches(
 		actualSpeech,
-		"Cats go woof BTW  Jonathon Commentor No they don't —Zara",
+		"Cats go woof BTW —Jonathon Commentor No they don't —Zara",
 		message="Focus mode:  Report details on word with details.",
 	)
 	_asserts.braille_matches(

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -170,16 +170,16 @@ def test_moveByWord():
 			'left paren(quietly right paren)',  # Expect: parenthesis are named
 			'quote Hello comma,', 'Jim', 'quote  dot.',  # Expect: quote, comma and dot are named
 			'don tick t',  # Expect: mid-word symbol substituted
-			'right-pointing arrow', 't-shirt',
+			'right dash-pointing arrow', 't dash-shirt',
 			# Expect no empty words:
 			'1', 'bar', '2', 'bar  bar', '3', 'at  caret  star  line', '4',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right-pointing arrow',
-			't-shirt',
-			't-shirt',
+			'right dash-pointing arrow',
+			't dash-shirt',
+			't dash-shirt',
 			'blank'  # end of doc
 		]
 	)
@@ -266,7 +266,7 @@ def test_moveByChar():
 			'quote', 'tick',  # Expect quote and apostrophe named
 			'e', 'comma',  # Expect comma named
 			# todo: Expect no replacement with word 'dash' i.e. expect 'right-pointing arrow', 't-shirt'
-			'right dash pointing arrow', 't dash shirt',
+			'right dash-pointing arrow', 't dash-shirt',
 			'tab',  # Expect whitespace named.
 			'carriage return',  # on Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n
@@ -372,7 +372,7 @@ def test_selByWord():
 				'left paren(quietly right paren) ',  # Expect: parenthesis are named
 				'quote Hello comma, ', 'Jim ', 'quote  dot. ',  # Expect: quote, comma and dot are named
 				'don tick t ',  # Expect: mid-word symbol substituted
-				'right-pointing arrow  ', 't-shirt  ',  # Expect dash symbol not to be replaced with word.
+				'right dash-pointing arrow  ', 't dash-shirt  ',
 				# end of first line
 				'',  # newline  todo: There should not be any "empty" words.
 				# Expect no empty words:
@@ -382,11 +382,11 @@ def test_selByWord():
 				'tab ',  # newline and tab
 				'',  # newline and 4 spaces
 				'',  # newline
-				'right-pointing arrow',
+				'right dash-pointing arrow',
 				'',  # newline  todo: There should not be any "empty" words.
-				't-shirt',
+				't dash-shirt',
 				'',  # newline  todo: There should not be any "empty" words.
-				't-shirt',
+				't dash-shirt',
 				# end of doc
 			]
 		))
@@ -465,7 +465,7 @@ def test_selByChar():
 				'left paren', 'right paren',  # Expect parens named
 				'quote', 'tick',  # Expect quote and apostrophe named
 				'e', 'comma',  # Expect comma named
-				'right-pointing arrow', 't-shirt',
+				'right dash-pointing arrow', 't dash-shirt',
 				'tab',  # Expect tab named
 				'',  # Expect Windows/notepad newline is \r\n
 			]

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -145,16 +145,16 @@ def test_moveByWord():
 			'Say',
 			'(quietly)', 'Hello,', 'Jim', '.',  # Expected: no symbols named
 			"don't",  # Expected: mid-word symbol
-			'right pointing arrow', 't shirt',  # todo: Expect dash
+			'right-pointing arrow', 't-shirt',
 			# todo: There should not be any "empty" words. Expect 'bar bar', and 'at  caret  star  line'
 			'1', 'bar', '2', '', '3', '', '4',
 			# end of first line
 			'blank',  # single space and newline
 			'',  # tab and newline  todo: There should not be any "empty" words.
 			'blank',  # 4 spaces and newline
-			'right pointing arrow',
-			't shirt',  # todo: Expect dash
-			't shirt',  # todo: Expect dash
+			'right-pointing arrow',
+			't-shirt',
+			't-shirt',
 			'blank',  # end of doc
 		],
 	)
@@ -170,16 +170,16 @@ def test_moveByWord():
 			'left paren(quietly right paren)',  # Expect: parenthesis are named
 			'quote Hello comma,', 'Jim', 'quote  dot.',  # Expect: quote, comma and dot are named
 			'don tick t',  # Expect: mid-word symbol substituted
-			'right dash pointing arrow', 't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
+			'right-pointing arrow', 't-shirt',
 			# Expect no empty words:
 			'1', 'bar', '2', 'bar  bar', '3', 'at  caret  star  line', '4',
 			# end of first line
 			'blank',  # single space and newline
 			'tab',  # tab and newline
 			'blank',  # 4 spaces and newline
-			'right dash pointing arrow',  # todo: Expect dash symbol not to be replaced with word.
-			't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
-			't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
+			'right-pointing arrow',
+			't-shirt',
+			't-shirt',
 			'blank'  # end of doc
 		]
 	)
@@ -247,7 +247,7 @@ def test_moveByChar():
 			'left paren', 'right paren',  # Expect parens named
 			'quote', 'tick',  # Expect quote and apostrophe named
 			'e', 'comma',  # Expect comma named
-			'right pointing arrow', 't shirt',   # todo: Expect dash i.e. 'right-pointing arrow', 't-shirt'
+			'right-pointing arrow', 't-shirt',
 			'tab',  # Expect tab named
 			'carriage return',  # Expect Windows/notepad newline is \r\n
 			'line feed',  # on Windows/notepad newline is \r\n
@@ -256,8 +256,6 @@ def test_moveByChar():
 
 	_NvdaLib.getSpeechAfterKey(Move.REVIEW_HOME.value)  # reset to start position.
 
-	# todo: Bug, with symbol level ALL text due to a symbol substitution has further substitutions applied:
-	#       IE: "t-shirt" either becomes "t shirt" or "t dash shirt" dependent on symbol level.
 	_doTest(
 		navKey=Move.REVIEW_CHAR,
 		reportedAfterLast=EndSpeech.RIGHT,
@@ -351,11 +349,11 @@ def test_selByWord():
 				'',  # newline and tab  todo: There should not be any "empty" words.
 				'',  # newline and 4 spaces todo: There should not be any "empty" words.
 				'',  # newline  todo: There should not be any "empty" words.
-				'right pointing arrow',  # todo: Expect dash
+				'right-pointing arrow',
 				'',  # newline  todo: There should not be any "empty" words.
-				't shirt',  # todo: Expect dash
+				't-shirt',
 				'',  # newline  todo: There should not be any "empty" words.
-				't shirt',  # todo: Expect dash
+				't-shirt',
 				# end of doc
 			]
 		)),
@@ -384,11 +382,11 @@ def test_selByWord():
 				'tab ',  # newline and tab
 				'',  # newline and 4 spaces
 				'',  # newline
-				'right dash pointing arrow',  # todo: Expect dash symbol not to be replaced with word.
+				'right-pointing arrow',
 				'',  # newline  todo: There should not be any "empty" words.
-				't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
+				't-shirt',
 				'',  # newline  todo: There should not be any "empty" words.
-				't dash shirt',  # todo: Expect dash symbol not to be replaced with word.
+				't-shirt',
 				# end of doc
 			]
 		))
@@ -467,7 +465,7 @@ def test_selByChar():
 				'left paren', 'right paren',  # Expect parens named
 				'quote', 'tick',  # Expect quote and apostrophe named
 				'e', 'comma',  # Expect comma named
-				'right pointing arrow', 't shirt',   # todo: Expect dash i.e. 'right-pointing arrow', 't-shirt'
+				'right-pointing arrow', 't-shirt',
 				'tab',  # Expect tab named
 				'',  # Expect Windows/notepad newline is \r\n
 			]
@@ -476,8 +474,6 @@ def test_selByChar():
 
 	_NvdaLib.getSpeechAfterKey(Move.CARET_HOME.value)  # reset to start position.
 
-	# todo: Bug, with symbol level ALL text due to a symbol substitution has further substitutions applied:
-	#       IE: "t-shirt" either becomes "t shirt" or "t dash shirt" dependent on symbol level.
 	_doTest(
 		navKey=Move.SEL_CARET_CHAR,
 		reportedAfterLast=EndSpeech.NONE,
@@ -615,7 +611,7 @@ def test_tableHeaders():
 			"with 2 rows and 3 columns",  # details of the table context
 			"row 1",  # enter row 1 context
 			"column 1",  # enter column 1 context
-			"First dash name",  # the contents of the cell
+			"First dash-name",  # the contents of the cell
 		])
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
@@ -643,7 +639,7 @@ def test_tableHeaders():
 		# describe third column header
 		'  '.join([
 			"row 2",   # enter row 2 context, still in table
-			"First dash name",  # reminder of the column name
+			"First dash-name",  # reminder of the column name
 			"column 1",  # explicit column 2 context,
 			"a",  # the contents of the cell
 		])

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -372,7 +372,7 @@ def test_selByWord():
 				'left paren(quietly right paren) ',  # Expect: parenthesis are named
 				'quote Hello comma, ', 'Jim ', 'quote  dot. ',  # Expect: quote, comma and dot are named
 				'don tick t ',  # Expect: mid-word symbol substituted
-				'right dash-pointing arrow  ', 't dash-shirt  ',
+				'right-pointing arrow  ', 't-shirt  ',
 				# end of first line
 				'',  # newline  todo: There should not be any "empty" words.
 				# Expect no empty words:

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -372,7 +372,7 @@ def test_selByWord():
 				'left paren(quietly right paren) ',  # Expect: parenthesis are named
 				'quote Hello comma, ', 'Jim ', 'quote  dot. ',  # Expect: quote, comma and dot are named
 				'don tick t ',  # Expect: mid-word symbol substituted
-				'right-pointing arrow  ', 't-shirt  ',
+				'right-pointing arrow  ', 't-shirt  ',  # Expect dash symbol not to be replaced with word.
 				# end of first line
 				'',  # newline  todo: There should not be any "empty" words.
 				# Expect no empty words:

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -465,7 +465,7 @@ def test_selByChar():
 				'left paren', 'right paren',  # Expect parens named
 				'quote', 'tick',  # Expect quote and apostrophe named
 				'e', 'comma',  # Expect comma named
-				'right dash-pointing arrow', 't dash-shirt',
+				'right-pointing arrow', 't-shirt',
 				'tab',  # Expect tab named
 				'',  # Expect Windows/notepad newline is \r\n
 			]
@@ -485,7 +485,7 @@ def test_selByChar():
 				'quote', 'tick',  # Expect quote and apostrophe named
 				'e', 'comma',  # Expect comma named
 				# todo: Expect no replacement with word 'dash' i.e. expect 'right-pointing arrow', 't-shirt'
-				'right dash pointing arrow', 't dash shirt',
+				'right dash-pointing arrow', 't dash-shirt',
 				'tab',  # Expect whitespace named.
 				'',  # on Windows/notepad newline is \r\n
 			]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Fixup of #13857 

### Summary of the issue:
 #13857 was merged assuming the system test failures were random false positives.
 #13857 changed symbol pronunciation of the dash symbol, and as such, relevant system tests had to be updated.

### Description of user facing changes
None

### Description of development approach
N/A

### Testing strategy:
N/A
### Known issues with pull request:
None
### Change log entries:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
