### PR TITLE
Fixup #14531: TypeError: 'property' object is not iterable

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -359,7 +359,7 @@ class _Detector:
 		"""
 		if not bluetooth:
 			return
-		btDevs: Optional[Iterable[Tuple[str, DeviceMatch]]] = _DeviceInfoFetcher.btDevsCache
+		btDevs: Optional[Iterable[Tuple[str, DeviceMatch]]] = deviceInfoFetcher.btDevsCache
 		if btDevs is None:
 			btDevs = getDriversForPossibleBluetoothDevices()
 			# Cache Bluetooth devices for next time.
@@ -373,7 +373,7 @@ class _Detector:
 				btDevsCache.append((driver, match))
 			yield (driver, match)
 		if btDevsCache is not btDevs:
-			_DeviceInfoFetcher.btDevsCache = btDevsCache
+			deviceInfoFetcher.btDevsCache = btDevsCache
 
 	def _bgScan(
 			self,
@@ -420,7 +420,7 @@ class _Detector:
 		"""
 		self._stopBgScan()
 		# Clear the cache of bluetooth devices so new devices can be picked up.
-		_DeviceInfoFetcher.btDevsCache = None
+		deviceInfoFetcher.btDevsCache = None
 		self._queueBgScan(usb=usb, bluetooth=bluetooth, limitToDevices=limitToDevices)
 
 	def handleWindowMessage(self, msg=None, wParam=None):
@@ -433,7 +433,7 @@ class _Detector:
 		if not self._detectBluetooth:
 			# Do not poll bluetooth devices at all when bluetooth is disabled.
 			return
-		if not _DeviceInfoFetcher.btDevsCache:
+		if not deviceInfoFetcher.btDevsCache:
 			return
 		self._queueBgScan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
 
@@ -442,7 +442,7 @@ class _Detector:
 		messageWindow.pre_handleWindowMessage.unregister(self.handleWindowMessage)
 		self._stopBgScan()
 		# Clear the cache of bluetooth devices so new devices can be picked up with a new instance.
-		_DeviceInfoFetcher.btDevsCache = None
+		deviceInfoFetcher.btDevsCache = None
 		self._executor.shutdown(wait=False)
 
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -103,6 +103,11 @@ def getFakeCellCount(numCells: int) -> int:
 
 braille.filter_displaySize.register(getFakeCellCount)
 
+# Changing braille displays might call braille.handler.disableDetection(),
+# which requires the bdDetect.deviceInfoFetcher to be set.
+import bdDetect  # noqa: E402
+bdDetect.deviceInfoFetcher = bdDetect._DeviceInfoFetcher()
+
 # The focus and navigator objects need to be initialized to something.
 from .objectProvider import PlaceholderNVDAObject,NVDAObjectWithRole
 phObj = PlaceholderNVDAObject()


### PR DESCRIPTION
### Link to issue number:
Fix for #14531

### Summary of the issue:
Error 'property' object is not iterable when enabling autodetect for the first time with Bluetooth on.

### Description of user facing changes
None

### Description of development approach
The detector was trying to save the bdDefsCache on the _DeviceInfoFfetcher class (not the instance).

### Testing strategy:
Tested that NVDA no longer produces errors after a clean start with automatic detection on.

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
