### PR TITLE
Import keyLabels only after translation is  initialized to make the labels displayed in the  user's language

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -17,7 +17,6 @@ from utils.displayString import (
 	DisplayStringStrEnum,
 	DisplayStringIntFlag,
 )
-from keyLabels import localizedKeyLabels
 
 
 @unique
@@ -36,6 +35,8 @@ class NVDAKey(DisplayStringIntFlag):
 	
 	@property
 	def _displayStringLabels(self):
+		# Imported lazily since this module is imported before gettext translation is installed.
+		from keyLabels import localizedKeyLabels
 		return {
 			NVDAKey.CAPS_LOCK: localizedKeyLabels['capslock'],
 			NVDAKey.NUMPAD_INSERT: localizedKeyLabels['numpadinsert'],

--- a/source/keyLabels.py
+++ b/source/keyLabels.py
@@ -4,6 +4,13 @@
 #See the file COPYING for more details.
 #Copyright (C) 2008-2016 NV Access Limited, Aleksey Sadovoy, Babbage B.v.
 
+"""Contains mapping from the Windows key names to their localized labels.
+
+As there are localizable strings at module level,
+this can only be imported once localization is set up via `languageHandler.initialize`.
+"""
+
+
 localizedKeyLabels = {
 	# Translators: This is the name of the back key found on multimedia keyboards for controlling the web-browser.
 	'browserback': _("back"),


### PR DESCRIPTION
Opened against beta, since this pull request fixes regression which ideally should not get into the release.

### Link to issue number:
Fixes #14657
### Summary of the issue:
In pull request #14528 `keyLabels` were imported pretty early during NVDA's startup. Since this module contains localized strings at the module level these are translated before `languageHandler` is initialized. This means that they're translated either to the default language of the system, or for locales for which Python's `locale.getdefaultlocale` fails they remain in English, disregarding the language set in preferences.
### Description of user facing changes
Key labels are once again presented in the language set in preferences.
### Description of development approach
1. `keyLabels` are imported lazily in the `configFlags`
2. I've added docstring to the `keyLabels` module explaining when it can be safely imported.
### Testing strategy:
On a English Windows set NVDA's language to Polish, ensured that key labels in the keyboard help and in the preferences are displayed in Polish.
### Known issues with pull request:
While this pull request fixes this particular issue I'm of the opinion that we should not initialize a fake translation before parsing user's configured language. Since this would be bigger change, unsuitable for the beta branch at this stage, I'm going to open a separate issue to discuss and track this. Edit: I've created #14660
### Change log entries:
None needed - unreleased regression
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
