### PR TITLE
Fix-up of #14557: remove unwanted backslashes appearing in replacement expression of dictionary

### DIFF
--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -44,7 +44,8 @@ class SpeechDictEntry:
 		if self.type == ENTRY_TYPE_REGEXP:
 			replacement = self.replacement
 		else:
-			replacement = re.escape(self.replacement)
+			# Escape the backslashes for non-regexp replacements
+			replacement = self.replacement.replace('\\', '\\\\')
 		return self.compiled.sub(replacement, text)
 
 class SpeechDict(list):


### PR DESCRIPTION
### Link to issue number:
Fixes #14663
Fix-up of #14557
### Summary of the issue:

When reading text containing a non-regexp dictionary entry, if the replacement field contains some special characters (such as space, +, etc.), these characters are escaped with a backslash. Thus this backslash is heard in the text spoken by NVDA.

### Description of user facing changes
No unappropriated backslash will be spoken by NVDA when the replacement field of a dictionary entry contains space or other special character.

### Description of development approach

Use `theString.replace('\\', '\\\\')` instead of `re.escape(theString)`.

Indeed, it was well documented in [the doc of `re.escape`](https://docs.python.org/3.7/library/re.html):

> This function must not be used for the replacement string in sub() and subn(), only backslashes should be escaped.

### Testing strategy:
Manual tests:
* STR in #14663
* Tests in #14557
* STR in #14556

### Known issues with pull request:
None
### Change log entries:
None: fixing unreleased bug.
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
