### PR TITLE
No longer use a single semicolon as separator between title and message with ui.browseableMessage

### DIFF
--- a/source/message.html
+++ b/source/message.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <HTML style="width : 350; height: 300">
 <HEAD>
@@ -15,7 +14,7 @@ function escapeKeyPress(e) {
 function windowOnLoad() {
 	// #5875: string.prototype.split strips the tail when a limit is supplied,
 	// so use a regexp instead.
-	var args = window.dialogArguments.match(/^(.*?);([\s\S]*)$/);
+	var args = window.dialogArguments.match(/^(.*?)__NVDA:split-here__([\s\S]*)$/);
 	// args[0] is the whole string.
 	if (args && args.length == 3){
 		document.title= args[1];

--- a/source/ui.py
+++ b/source/ui.py
@@ -88,6 +88,7 @@ def browseableMessage(message: str, title: Optional[str] = None, isHtml: bool = 
 	@param title: The title for the message.
 	@param isHtml: Whether the message is html
 	"""
+	splitWith: str = "__NVDA:split-here__"  # Unambiguous regex splitter for javascript in message.html, #14667
 	if _isSecureDesktop():
 		import wx  # Late import to prevent circular dependency.
 		wx.CallAfter(_warnBrowsableMessageNotAvailableOnSecureScreens, title)
@@ -103,7 +104,7 @@ def browseableMessage(message: str, title: Optional[str] = None, isHtml: bool = 
 		title = _("NVDA Message")
 	if not isHtml:
 		message = f"<pre>{escape(message)}</pre>"
-	dialogString = f"{title};{message}"
+	dialogString = f"{title}{splitWith}{message}"
 	dialogArguements = automation.VARIANT( dialogString )
 	gui.mainFrame.prePopup() 
 	windll.mshtml.ShowHTMLDialogEx( 


### PR DESCRIPTION
### Link to issue number:

Fixes #14667 

### Summary of the issue:

If `ui.browseableMessage` was given a title containing a semicolon (;), the title would be broken at the semicolon, and the rest of the title would be rendered before (as part of) the message in the HTML portion of the window.
This had the potential to result in unexpected outcomes, if the message content was HTML; not to mention being confusing for the user.

While this was noticed in relation to the Report link destination feature introduced by #14583, it did not result from that feature, and could have occurred prior to its introduction. It does however effect it significantly, as the title of the link the destination of which is being identified, is presented in the title of a ui.browseableMessage, if the command is called twice, or the alternate version of the command is mapped to a key.

### Description of user facing changes

If a link name contains a semicolon, portions of that name will no longer appear along with the link address, when reporting link destination in its window version.

### Description of development approach

Changed the regex separator string in `ui.browseableMessage`, and in the `message.html` file, to one which should hopefully be much less likely to appear in the wild. Instead of a single semicolon ("`;`"), the string is now "`__NVDA:split-here__`".

Also removed the blank line from the top of `message.html`. I know of no purpose for having a blank line there.

### Testing strategy:

* Performed the STR in #14667, and confirmed that the title no longer breaks.
* Tested some other cases of `ui.browseableMessage`, such as NVDA+f, to make sure they act as expected.

### Known issues with pull request:

### Change log entries:

This was introduced in beta. If fixed in beta, no user level change should need to be listed.

For Developers
Titles in `ui.browseableMessage` calls, can now include semicolons without side effects.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
