### PR TITLE
Don't instal gettext and pgettext before initializing languageHandler

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -15,13 +15,11 @@ import os
 
 import typing
 
-import builtins
 import globalVars
 import ctypes
 from ctypes import wintypes
 import monkeyPatches
 import NVDAState
-from languageHandler import makePgettext
 
 
 monkeyPatches.applyMonkeyPatches()
@@ -61,26 +59,7 @@ globalVars.appDir = appDir
 globalVars.appPid = os.getpid()
 
 
-import locale
-import gettext
-
-try:
-	trans = gettext.translation(
-		'nvda',
-		localedir=os.path.join(globalVars.appDir, 'locale'),
-		languages=[locale.getdefaultlocale()[0]]
-	)
-	trans.install()
-	# Install our pgettext function.
-	builtins.pgettext = makePgettext(trans)
-except:
-	gettext.install('nvda')
-	# Install a no-translation pgettext function
-	builtins.pgettext = lambda context, message: message
-
-import time
 import argparse
-import globalVars
 import config
 import logHandler
 from logHandler import log

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -9,11 +9,10 @@ Performs miscellaneous tasks which need to be performed in a separate process.
 
 import sys
 import os
-import builtins
 import globalVars
+import logHandler
 import monkeyPatches.comtypesMonkeyPatches
 import NVDAState
-from languageHandler import makePgettext
 
 
 # Ensure that slave uses generated comInterfaces by adding our comInterfaces to `comtypes.gen` search path.
@@ -31,27 +30,6 @@ else:
 # #2391: some functions may still require the current directory to be set to NVDA's app dir
 os.chdir(globalVars.appDir)
 globalVars.appPid = os.getpid()
-
-
-import gettext
-import locale
-#Localization settings
-try:
-	trans = gettext.translation(
-		'nvda',
-		localedir=os.path.join(globalVars.appDir, 'locale'),
-		languages=[locale.getdefaultlocale()[0]]
-	)
-	trans.install()
-	# Install our pgettext function.
-	builtins.pgettext = makePgettext(trans)
-except:
-	gettext.install('nvda')
-	# Install a no-translation pgettext function
-	builtins.pgettext = lambda context, message: message
-
-
-import logHandler
 
 
 def getNvdaHelperRemote():


### PR DESCRIPTION
### Link to issue number:
Related to #14660

### Summary of the issue:
When starting NVDA installs a 'fake' `gettext` and `pgettext` functions which translates to the language set as the current Windows locale. Later in the startup process `languageHandler` overwrites these installed translation functions with a new one which translate strings to the language chosen by the user (either in the configuration or from the CLI). Unfortunately if there is a module with translatable strings at its top level and it is imported before `languageHandler` is initialized these strings are either translated to the default system language, or for locales for which Python's `locale.getdefaultlocale` fails they remain in English. Similar problems were reported in #7770 and in #14657. Both of these are fixed, but the main problem is that bugs like this are difficult to identify before the release, since most contributors either use both NVDA and Windows in English, or at least their NVDA is in the same language as their operating system.
### Description of user facing changes
This should not have any user visible impact.
### Description of development approach
When starting NVDA or `nvda_slave` `gettext` and `pgettext` are no longer installed before initializing `languageHandler`.
### Testing strategy:
Made sure NVDA starts - this require a longer period of testing in Alpha anyway.
### Known issues with pull request:
None known
### Change log entries:
None needed - this has no impact for add-ons developers since add-ons were initialized after `languageHandler`.
### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
