### PR TITLE
Made portable creation through the installer or tools menu more flexible, by allowing system variables in paths

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -404,34 +404,48 @@ class PortableCreaterDialog(
 
 	def onCreatePortable(self, evt):
 		if not self.portableDirectoryEdit.Value:
-			# Translators: The message displayed when the user has not specified a destination directory
-			# in the Create Portable NVDA dialog.
-			gui.messageBox(_("Please specify a directory in which to create the portable copy."),
-				_("Error"),
-				wx.OK | wx.ICON_ERROR)
-			return
-		if not os.path.isabs(self.portableDirectoryEdit.Value):
 			gui.messageBox(
-				# Translators: The message displayed when the user has not specified an absolute destination directory
+				# Translators: The message displayed when the user has not specified a destination directory
 				# in the Create Portable NVDA dialog.
-				_("Please specify an absolute path (including drive letter)  in which to create the portable copy."),
-				# Translators: The message title displayed
-				# when the user has not specified an absolute destination directory
-				# in the Create Portable NVDA dialog.
+				_("Please specify a directory in which to create the portable copy."),
+				# Translators: the title of an error dialog.
 				_("Error"),
 				wx.OK | wx.ICON_ERROR
 			)
 			return
-		drv=os.path.splitdrive(self.portableDirectoryEdit.Value)[0]
-		if drv and not os.path.isdir(drv):
-			# Translators: The message displayed when the user specifies an invalid destination drive
-			# in the Create Portable NVDA dialog.
-			gui.messageBox(_("Invalid drive %s")%drv,
+		expandedPortableDirectory = os.path.expandvars(self.portableDirectoryEdit.Value)
+		if not os.path.isabs(expandedPortableDirectory):
+			gui.messageBox(
+				_(
+					# Translators: The message displayed when the user has not specified an absolute destination directory
+					# in the Create Portable NVDA dialog.
+					"Please specify the absolute path where the portable copy should be created. "
+					"It may include system variables (%temp%, %homepath%, etc.)."
+				),
+				# Translators: The message title displayed when the user has not specified an absolute
+				# destination directory in the Create Portable NVDA dialog.
 				_("Error"),
-				wx.OK | wx.ICON_ERROR)
+				wx.OK | wx.ICON_ERROR
+			)
+			return
+		drv = os.path.splitdrive(expandedPortableDirectory)[0]
+		if drv and not os.path.isdir(drv):
+			gui.messageBox(
+				# Translators: The message displayed when the user specifies an invalid destination drive
+				# in the Create Portable NVDA dialog.
+				_("Invalid drive ({drive}).").format(drive=drv),
+				# Translators: the title of an error dialog.
+				_("Error"),
+				wx.OK | wx.ICON_ERROR
+			)
 			return
 		self.Hide()
-		doCreatePortable(self.portableDirectoryEdit.Value,self.copyUserConfigCheckbox.Value,False,self.startAfterCreateCheckbox.Value)
+		doCreatePortable(
+			expandedPortableDirectory,
+			self.copyUserConfigCheckbox.Value,
+			False,
+			self.startAfterCreateCheckbox.Value
+		)
 		self.Destroy()
 
 	def onCancel(self, evt):

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -428,8 +428,9 @@ class PortableCreaterDialog(
 				wx.OK | wx.ICON_ERROR
 			)
 			return
-		# isabs determines if the path is absolute, with or without a drive letter.
-		# abspath resolves an absolute path, adding a drive letter (which?) if necessary. (#14681)
+		# isabs determines if the path is absolute, with or without a drive letter. abspath adds any missing initial
+		# components to that path to make it absolute from other contexts, by adding a drive letter/share path if
+		# needed. The OS's idea of the current drive is used, as in os.getcwd(). (#14681)
 		expandedPortableDirectory = os.path.abspath(expandedPortableDirectory)
 		self.Hide()
 		doCreatePortable(

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -428,17 +428,10 @@ class PortableCreaterDialog(
 				wx.OK | wx.ICON_ERROR
 			)
 			return
-		drv = os.path.splitdrive(expandedPortableDirectory)[0]
-		if drv and not os.path.isdir(drv):
-			gui.messageBox(
-				# Translators: The message displayed when the user specifies an invalid destination drive
-				# in the Create Portable NVDA dialog.
-				_("Invalid drive ({drive}).").format(drive=drv),
-				# Translators: the title of an error dialog.
-				_("Error"),
-				wx.OK | wx.ICON_ERROR
-			)
-			return
+		# We used to separate out the drive letter, check it, and present an error if it was not
+		# its own directory, as a secondary check of path absoluteness.
+		# But if os.path.isabs is convinced, we should just add the drive letter if missing, and carry on. (#14681)
+		expandedPortableDirectory = os.path.abspath(expandedPortableDirectory)
 		self.Hide()
 		doCreatePortable(
 			expandedPortableDirectory,

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -444,6 +444,7 @@ class PortableCreaterDialog(
 	def onCancel(self, evt):
 		self.Destroy()
 
+
 def doCreatePortable(
 		portableDirectory: str,
 		copyUserConfig: bool = False,

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -451,36 +451,49 @@ class PortableCreaterDialog(
 	def onCancel(self, evt):
 		self.Destroy()
 
-def doCreatePortable(portableDirectory,copyUserConfig=False,silent=False,startAfterCreate=False):
-	d = gui.IndeterminateProgressDialog(gui.mainFrame,
-		# Translators: The title of the dialog presented while a portable copy of NVDA is bieng created.
+def doCreatePortable(
+		portableDirectory: str,
+		copyUserConfig: bool = False,
+		silent: bool = False,
+		startAfterCreate: bool = False
+) -> None:
+	d = gui.IndeterminateProgressDialog(
+		gui.mainFrame,
+		# Translators: The title of the dialog presented while a portable copy of NVDA is being created.
 		_("Creating Portable Copy"),
-		# Translators: The message displayed while a portable copy of NVDA is bieng created.
-		_("Please wait while a portable copy of NVDA is created."))
+		# Translators: The message displayed while a portable copy of NVDA is being created.
+		_("Please wait while a portable copy of NVDA is created.")
+	)
 	try:
-		gui.ExecAndPump(installer.createPortableCopy,portableDirectory,copyUserConfig)
+		gui.ExecAndPump(installer.createPortableCopy, portableDirectory, copyUserConfig)
 	except Exception as e:
-		log.error("Failed to create portable copy",exc_info=True)
+		log.error("Failed to create portable copy", exc_info=True)
 		d.done()
-		if isinstance(e,installer.RetriableFailure):
+		if isinstance(e, installer.RetriableFailure):
 			# Translators: a message dialog asking to retry or cancel when NVDA portable copy creation fails
-			message=_("NVDA is unable to remove or overwrite a file.")
+			message = _("NVDA is unable to remove or overwrite a file.")
 			# Translators: the title of a retry cancel dialog when NVDA portable copy creation  fails
-			title=_("File in Use")
-			if winUser.MessageBox(None,message,title,winUser.MB_RETRYCANCEL)==winUser.IDRETRY:
-				return doCreatePortable(portableDirectory,copyUserConfig,silent,startAfterCreate)
-		# Translators: The message displayed when an error occurs while creating a portable copy of NVDA.
-		# %s will be replaced with the specific error message.
-		gui.messageBox(_("Failed to create portable copy: %s")%e,
+			title = _("File in Use")
+			if winUser.MessageBox(None, message, title, winUser.MB_RETRYCANCEL) == winUser.IDRETRY:
+				return doCreatePortable(portableDirectory, copyUserConfig, silent, startAfterCreate)
+		gui.messageBox(
+			# Translators: The message displayed when an error occurs while creating a portable copy of NVDA.
+			# {error} will be replaced with the specific error message.
+			_("Failed to create portable copy: {error}.").format(error=e),
+			# Translators: Title of an error dialog shown when an error occurs while creating a portable copy of NVDA.
 			_("Error"),
-			wx.OK | wx.ICON_ERROR)
+			wx.OK | wx.ICON_ERROR
+		)
 		return
 	d.done()
 	if not silent:
-		# Translators: The message displayed when a portable copy of NVDA has been successfully created.
-		# %s will be replaced with the destination directory.
-		gui.messageBox(_("Successfully created a portable copy of NVDA at %s")%portableDirectory,
-			_("Success"))
+		gui.messageBox(
+			# Translators: The message displayed when a portable copy of NVDA has been successfully created.
+			# {dir} will be replaced with the destination directory.
+			_("Successfully created a portable copy of NVDA at {dir}").format(dir=portableDirectory),
+			# Translators: Title of a dialog shown when a portable copy of NVDA is created.
+			_("Success")
+		)
 	if silent or startAfterCreate:
 		newNVDA = None
 		if startAfterCreate:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -428,9 +428,8 @@ class PortableCreaterDialog(
 				wx.OK | wx.ICON_ERROR
 			)
 			return
-		# We used to separate out the drive letter, check it, and present an error if it was not
-		# its own directory, as a secondary check of path absoluteness.
-		# But if os.path.isabs is convinced, we should just add the drive letter if missing, and carry on. (#14681)
+		# isabs determines if the path is absolute, with or without a drive letter.
+		# abspath resolves an absolute path, adding a drive letter (which?) if necessary. (#14681)
 		expandedPortableDirectory = os.path.abspath(expandedPortableDirectory)
 		self.Hide()
 		doCreatePortable(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,6 +12,7 @@ What's New in NVDA
   - Mac Option key symbol "⌥". (#14682)
   -
 - In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup. (#14709)
+- It is now possible to use system variables (such as ``%temp%`` or ``%homepath%``) in the path specification while creating portable copies of NVDA. (#14680)
 - 
 
 
@@ -25,6 +26,7 @@ What's New in NVDA
 - Baum Braille driver: addes several Braille chord gestures for performing common keyboard commands such as windows+d, alt+tab etc. Please refer to the NVDA user guide for a full list. (#14714)
 - When using a Braille Display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter. Also space+dot1 and space+dot4 now map to up and down arrow respectively. (#14713)
 - Script for reporting the destination of a link now reports from the caret / focus position rather than the navigator object. (#14659)
+- Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (14681)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,7 +26,7 @@ What's New in NVDA
 - Baum Braille driver: addes several Braille chord gestures for performing common keyboard commands such as windows+d, alt+tab etc. Please refer to the NVDA user guide for a full list. (#14714)
 - When using a Braille Display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter. Also space+dot1 and space+dot4 now map to up and down arrow respectively. (#14713)
 - Script for reporting the destination of a link now reports from the caret / focus position rather than the navigator object. (#14659)
-- Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (14681)
+- Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (#14681)
 -
 
 


### PR DESCRIPTION
### Link to issue number:

Fixes #14680 

### Summary of the issue:

While it is possible to use system variables (%appdata%, %userprofile%, %temp%, etc.) in the create portable dialog's "browse" sub-dialog, it was not possible to use them in the Create Portable dialog itself. Therefore, when using the installer or the tools menu portable option, one either had to enter full paths, or use the browse dialog to utilize system variables to minimize typing.
For people who create many portables, that can be unnecessary overhead.

### Description of user facing changes

It is now possible to use system variables (such as %tmp% or %homepath%) in the path specification while creating portable copies of NVDA.
Additionally, it is no longer necessary to include a drive letter when entering the absolute path to a portable target.

### Description of development approach

In `gui.installerGUI`, there is a method of `PortableCreaterDialog` class, called `onCreatePortable`: The path, as entered in the dialog (`self.portableDirectoryEdit.Value`), was used in this method three times.

- Created a local variable, `expandedPortableDirectory`, containing that value, processed through `os.path.expandvars()`.
- Used that local value throughout the remainder of the method.
- Added a note to the error which appears if the user doesn't specify an absolute path, stating that system variables may be used.
- Rephrased the messages asking for the path, and removed the mention of the required drive letter, per NV Access review comments.
- Replaced a % substitution with a .format() string formatter, in an error dialog.
- Edited, reformatted, and added missing translator comments.
- Miscellaneous linting.
Additional:
- In gui.installerGUI.doCreatePortable(): Linting, spelling, added translation comments, replaced substitutions with calls to format

#### A note regarding no longer checking for drive letter in entered absolute path:

While creating a portable copy, we ask the user for an absolute path. In the os.path module's opinion, a path can be absolute without having a drive letter. Therefore, we previously checked and threw an error if the drive letter was missing.
When @seanbudd suggested removing the drive letter notation from absolute path messages, testing without entering one revealed errors that occurred if there was no drive letter, even though it shouldn't technically matter.

Instead, since os.path.isabs has already determined that the path is absolute, we can just add the drive letter if it's missing.
We can do that by calling os.path.abspath, which absolutizes the (probably mostly) already absolute path, by adding a drive letter if it was missing, and any other path components necessary to have a fully qualified path.

### Testing strategy:

* Created portables using variables in their paths, from both the installer and the tools menu.
* Tested that badly-named variables cause the same error as invalid paths.
* Absolute paths with no drive letter work as a user would expect.

### Known issues with pull request:
None
### Change log entries:
New features
It is now possible to use system variables (such as %temp% or %homepath%) in the path specification while creating portable copies of NVDA.

Bug fixes
`gui.installerGUI.PortableCreaterDialog.onCreatePortable` now properly checks for system variables used in the entered paths of potential portable copies, instead of automatically showing an invalid path error when system variables are used.

Changes
Portable copy creation no longer requires that a drive letter be entered as part of the absolute path.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
