### PR TITLE
Add-on store: support for optional homepage and licenseURL

### DIFF
--- a/source/addonStore/models.py
+++ b/source/addonStore/models.py
@@ -2,9 +2,15 @@
 # Copyright (C) 2022 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 import dataclasses
 import json
-import typing
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
 import addonAPIVersion
 
@@ -19,9 +25,9 @@ class AddonDetailsModel:
 	publisher: str
 	versionName: str
 	channel: str
-	homepage: str
+	homepage: Optional[str]
 	licenseName: str
-	licenseUrl: str
+	licenseUrl: Optional[str]
 	sourceUrl: str
 	addonURL: str
 	fileSHA: str
@@ -31,19 +37,19 @@ class AddonDetailsModel:
 	"""Deviates from name in JSON, in order to match name required for addonAPIVersion"""
 
 
-def _createAddonApiVersion(versionDict: typing.Dict[str, int]) -> addonAPIVersion.AddonApiVersionT:
+def _createAddonApiVersion(versionDict: Dict[str, int]) -> addonAPIVersion.AddonApiVersionT:
 	"""
 	@param versionDict: expected to contain a Dict like: {"major": 2019, "minor": 3, "patch": 0}
 	"""
 	return versionDict["major"], versionDict["minor"], versionDict["patch"]
 
 
-def _createModelFromData(jsonData: str) -> typing.List[AddonDetailsModel]:
+def _createModelFromData(jsonData: str) -> List[AddonDetailsModel]:
 	"""Use json string to construct a listing of available addons.
 	See https://github.com/nvaccess/addon-datastore#api-data-generation-details
 	for details of the data.
 	"""
-	data = json.loads(jsonData)
+	data: List[Dict[str, Any]] = json.loads(jsonData)
 	return [
 		AddonDetailsModel(
 			addonId=addon["addonId"],
@@ -52,9 +58,9 @@ def _createModelFromData(jsonData: str) -> typing.List[AddonDetailsModel]:
 			publisher=addon["publisher"],
 			channel=addon["channel"],
 			versionName=addon["addonVersionName"],
-			homepage=addon["homepage"],
+			homepage=addon.get("homepage"),
 			licenseName=addon["license"],
-			licenseUrl=addon["licenseURL"],
+			licenseUrl=addon.get("licenseURL"),
 			sourceUrl=addon["sourceURL"],
 			addonURL=addon["URL"],
 			fileSHA=addon["sha256"],

--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -424,11 +424,12 @@ class AddonDetails(
 					pgettext("addonStore", "Channel:"),
 					details.channel
 				)
-				self._appendDetailsLabelValue(
-					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
-					pgettext("addonStore", "Homepage:"),
-					details.homepage, URL=details.homepage
-				)
+				if details.homepage:
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+						pgettext("addonStore", "Homepage:"),
+						details.homepage, URL=details.homepage
+					)
 				self._appendDetailsLabelValue(
 					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 					pgettext("addonStore", "License:"),
@@ -447,13 +448,13 @@ class AddonDetails(
 		# Set caret/insertion point at the beginning so that NVDA users can more easily read from the start.
 		self.otherDetailsTextCtrl.SetInsertionPoint(0)
 
-	def _addDetailsLabel(self, label):
+	def _addDetailsLabel(self, label: str):
 		detailsTextCtrl = self.otherDetailsTextCtrl
 		detailsTextCtrl.SetDefaultStyle(self.labelStyle)
 		detailsTextCtrl.AppendText(label)
 		detailsTextCtrl.SetDefaultStyle(self.defaultStyle)
 
-	def _appendDetailsLabelValue(self, label, value, URL: Optional[str] = None):
+	def _appendDetailsLabelValue(self, label: str, value: str, URL: Optional[str] = None):
 		detailsTextCtrl = self.otherDetailsTextCtrl
 
 		if detailsTextCtrl.GetValue():


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
None, part of #13985 

### Summary of the issue:
The license URL and homepage url are optional parts of the addon schema.
This causes add-on data without these values to fail to render on the add-on store.

### Description of user facing changes
add-ons can be accessed on the add-on store, which do not have home page and license URLs.

### Description of development approach
Improve the typing and handling of these data items

### Testing strategy:
Ensure legacy add-ons can be tabbed through on the add-on store, which do not have home page and license URLS.

### Known issues with pull request:
None

### Change log entries:
None, part of #13985 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
