### PR TITLE
add-on store: create support for latest endpoint and dev channel

### DIFF
--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -35,30 +35,17 @@ from .models import (
 class Channel(str, enum.Enum):
 	STABLE = "stable"
 	BETA = "beta"
+	DEV = "dev"
 	ALL = "all"
 
 
-def _workAroundForDevNVDAVersion() -> addonAPIVersion.AddonApiVersionT:
-	"""When a 'latest' endpoint is created, this workaround method can be removed.
-	"""
-	log.debugWarning(
-		"Workaround for Dev NVDA Version support with add-on store still in-place."
-		"This workaround should be removed before merging to master / beta / rc"
-	)
-	version = buildVersion.version
-	isNotPreMergeVersion = version[0].isdigit() or "alpha" in version or "beta" in version
-	if isNotPreMergeVersion:
-		# check if this gets merged accidentally.
-		log.error("Fix the addonStore version used for API endpoint")
-	return 2022, 2, 0  # hard-code for testing purposes.
-
-
 def _getCurrentApiVersionForURL() -> str:
-	# todo: replace with `currentVersion = addonAPIVersion.CURRENT`
-	# The version is manually overridden until a 'latest' endpoint can be used for 'pre-release' versions
-	# of NVDA
-	currentVersion = _workAroundForDevNVDAVersion()
-	year, major, minor = currentVersion
+	"""Returns 'latest' when on a test version of NVDA.
+	This allows add-on users to test add-ons with the alpha/beta of a breaking release.
+	"""
+	if buildVersion.isPreReleaseVersion:
+		return "latest"
+	year, major, minor = addonAPIVersion.CURRENT
 	return f"{year}.{major}.{minor}"
 
 

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -80,3 +80,5 @@ except ImportError:
 version_detailed = formatBuildVersionString()
 # A test version is anything other than a final or rc release.
 isTestVersion = not version[0].isdigit() or "alpha" in version or "beta" in version or "dev" in version
+# A pre-release version is a test version or rc release.
+isPreReleaseVersion = isTestVersion or "rc" in version


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes https://github.com/nvaccess/addon-datastore-transform/issues/15
part of https://github.com/nvaccess/nvda/pull/13985

### Summary of the issue:
When using a prerelease copy of NVDA (from source, alpha, beta, rc, or try builds) there is no available endpoint for add-on listings, resulting in an error.
Endpoints are available for each of the transforms based on the [set of available releases](https://github.com/nvaccess/addon-datastore-transform/blob/main/nvdaAPIVersions.json), however, by definition a pre-release version of NVDA is not going to be available in that list. Instead, a "latest" transform should be added.

### Description of user facing changes
A "latest" endpoint is used for any version of NVDA which is not a final release.

### Description of development approach
Follow suggested changes in comments

### Testing strategy:
Ensures the "latest" endpoint was used when browsing the add-on store with a dev version of NVDA

### Known issues with pull request:
None

### Change log entries:
None, part of https://github.com/nvaccess/nvda/pull/13985

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
