### PR TITLE
Fixup #14531: Make Albatross again the last driver in detection order

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -545,11 +545,6 @@ def initialize():
 	scanForDevices.register(_Detector._bgScanBluetooth)
 
 	# Add devices
-	# albatross
-	addUsbDevices("albatross", KEY_SERIAL, {
-		"VID_0403&PID_6001",  # Caiku Albatross 46/80
-	})
-
 	# alva
 	addUsbDevices("alva", KEY_HID, {
 		"VID_0798&PID_0640",  # BC640
@@ -798,6 +793,11 @@ def initialize():
 		"seikantk",
 		isSeikaBluetoothDeviceMatch
 	)
+
+	# albatross
+	addUsbDevices("albatross", KEY_SERIAL, {
+		"VID_0403&PID_6001",  # Caiku Albatross 46/80
+	})
 
 
 def terminate():


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

## Link to issue number:
None

### Summary of the issue:
As part of #14531, I ordered display order in bdDetect alphabetically. However, it seems that querying Albatross first has a major negative impact on detecting other displays using the same Serial to USB converter (see #13045)

### Description of user facing changes
Handy Tech displays such as the Modular Evolution instantly auto detect again.

### Description of development approach
Restored the order, Albatross is last in the dictionary again. I'm pretty unhappy with how these displays work, but it looks like it's a design thing in the displays itself.

### Testing strategy:
Tested that Handy Tech displays are detected immediately.

### Known issues with pull request:
No changes to the albatross driver. @burmancomp  Would it be possible to provide a follow up for #13045 that decreases MAX_INIT_RETRIES or changes SLEEP_TIMEOUT to a lower value? This driver takes around 8 seconds to find out whether a display is connected or not if it doesn't receive the necessary packets. I assume as the display sends lots of these packets initially, it should be possible to find out whether initialisation worked after at most 5 attempts.

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
