### PR TITLE
Fixed a string that was not translatable.

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1821,7 +1821,7 @@ def getPropertiesSpeech(  # noqa: C901
 				textList.append(
 					# Translators: Speaks when there are further details/annotations that can be fetched manually.
 					# %s specifies the type of details (e.g. "comment, suggestion, details")
-					_("has %s" % roleString)
+					_("has %s") % roleString
 				)
 		else:
 			textList.append(


### PR DESCRIPTION
### Link to issue number:
[This thread](https://groups.io/g/nvda-translations/topic/problem_with_has_details/97336868?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,97336868,previd%3D1677758598895856486,nextid%3D1639270081052421299&previd=1677758598895856486&nextid=1639270081052421299) on the translators' mailing list.

### Summary of the issue:

The string "has %s" is not translatable whereas it should.

This is due to the fact that the formatting has been included in the gettext (underscore function)'s argument.

### Description of user facing changes
For translators: the translation of the string "has %s" should now be working.

### Description of development approach
First call gettext `_` (underscore) function, and then format the result.
### Testing strategy:
Manual test:
These strings have already been translated. Thus, test with the appveyor build or from source that translation is working:
- [x] in the example of the mailing list
- [x] in the [example](https://mdn.github.io/html-examples/aria-annotations/) of PR #14480 (paragraph "Comments")
- [x] in the [example](https://codepen.io/reefturner/pen/poKLQyj) of PR #14507.

### Known issues with pull request:
None
### Change log entries:
Not needed for this small fix.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
