### PR TITLE
Only show dev channel add-ons for pre-release NVDA

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -8,6 +8,7 @@ import enum
 from abc import abstractmethod, ABC
 import sys
 from typing import (
+	Optional,
 	TYPE_CHECKING,
 )
 
@@ -353,7 +354,7 @@ class AddonBase(ABC):
 		return self.manifest.get('lastTestedNVDAVersion')
 
 	@property
-	def channel(self) -> typing.Optional["Channel"]:
+	def channel(self) -> Optional["Channel"]:
 		"""
 		Channel is used in the new add-on data store.
 		The "None" case must be handled for side-loaded add-ons.

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -3,9 +3,14 @@
 # Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 import enum
 from abc import abstractmethod, ABC
 import sys
+from typing import (
+	TYPE_CHECKING,
+)
+
 import os.path
 import gettext
 import tempfile
@@ -33,6 +38,9 @@ from .packaging import isModuleName
 import importlib
 from types import ModuleType
 import extensionPoints
+
+if TYPE_CHECKING:
+	from addonStore.models import Channel  # noqa: F401 used for typing
 
 
 MANIFEST_FILENAME = "manifest.ini"
@@ -343,6 +351,14 @@ class AddonBase(ABC):
 	@property
 	def lastTestedNVDAVersion(self) -> addonAPIVersion.AddonApiVersionT:
 		return self.manifest.get('lastTestedNVDAVersion')
+
+	@property
+	def channel(self) -> typing.Optional["Channel"]:
+		"""
+		Channel is used in the new add-on data store.
+		The "None" case must be handled for side-loaded add-ons.
+		"""
+		return None
 
 	@property
 	@abstractmethod

--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -11,6 +11,7 @@ from typing_extensions import Protocol  # Python 3.8 adds native support
 
 import addonAPIVersion
 from addonStore.models import Channel
+from buildVersion import isPreReleaseVersion
 
 
 class SupportsVersionCheck(Protocol):
@@ -43,7 +44,6 @@ def isAddonTested(
 	"""
 	if addon.channel == Channel.DEV:
 		# Allow dev add-ons for pre-release versions
-		from buildVersion import isPreReleaseVersion
 		return isPreReleaseVersion
 	return addon.lastTestedNVDAVersion >= backwardsCompatToVersion
 

--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -1,10 +1,16 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018 NV Access Limited
+# Copyright (C) 2018-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
+from typing import (
+	Optional,
+)
 from typing_extensions import Protocol  # Python 3.8 adds native support
+
 import addonAPIVersion
+from addonStore.models import Channel
 
 
 class SupportsVersionCheck(Protocol):
@@ -14,30 +20,39 @@ class SupportsVersionCheck(Protocol):
 	"""
 	minimumNVDAVersion: addonAPIVersion.AddonApiVersionT
 	lastTestedNVDAVersion: addonAPIVersion.AddonApiVersionT
+	channel: Optional[Channel]
 
 
 def hasAddonGotRequiredSupport(
 		addon: SupportsVersionCheck,
-		currentAPIVersion=addonAPIVersion.CURRENT
-):
+		currentAPIVersion: addonAPIVersion.AddonApiVersionT = addonAPIVersion.CURRENT
+) -> bool:
 	"""True if NVDA provides the add-on with an API version high enough to meet the add-on's minimum requirements
 	"""
 	minVersion = addon.minimumNVDAVersion
 	return minVersion <= currentAPIVersion
 
 
-def isAddonTested(addon: SupportsVersionCheck, backwardsCompatToVersion=addonAPIVersion.BACK_COMPAT_TO):
+def isAddonTested(
+		addon: SupportsVersionCheck,
+		backwardsCompatToVersion: addonAPIVersion.AddonApiVersionT = addonAPIVersion.BACK_COMPAT_TO
+) -> bool:
 	"""True if this add-on is tested for the given API version.
 	By default, the current version of NVDA is evaluated.
+	Dev add-ons are made available to any pre-release version of NVDA.
 	"""
+	if addon.channel == Channel.DEV:
+		# Allow dev add-ons for pre-release versions
+		from buildVersion import isPreReleaseVersion
+		return isPreReleaseVersion
 	return addon.lastTestedNVDAVersion >= backwardsCompatToVersion
 
 
 def isAddonCompatible(
 		addon: SupportsVersionCheck,
-		currentAPIVersion=addonAPIVersion.CURRENT,
-		backwardsCompatToVersion=addonAPIVersion.BACK_COMPAT_TO
-):
+		currentAPIVersion: addonAPIVersion.AddonApiVersionT = addonAPIVersion.CURRENT,
+		backwardsCompatToVersion: addonAPIVersion.AddonApiVersionT = addonAPIVersion.BACK_COMPAT_TO
+) -> bool:
 	"""Tests if the addon is compatible.
 	The compatibility is defined by having the required features in NVDA, and by having been tested / built against
 	an API version that is still supported by this version of NVDA.

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -1,9 +1,9 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 import dataclasses
-import enum
 import json
 import os
 import pathlib
@@ -27,16 +27,10 @@ from typing import (
 	Tuple,
 )
 from .models import (
+	Channel,
 	_createModelFromData,
 	AddonDetailsModel,
 )
-
-
-class Channel(str, enum.Enum):
-	STABLE = "stable"
-	BETA = "beta"
-	DEV = "dev"
-	ALL = "all"
 
 
 def _getCurrentApiVersionForURL() -> str:

--- a/source/addonStore/models.py
+++ b/source/addonStore/models.py
@@ -1,18 +1,26 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 import dataclasses
+from enum import Enum
 import json
 from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
+	Any,
+	Dict,
+	List,
+	Optional,
 )
 
 import addonAPIVersion
+
+
+class Channel(str, Enum):
+	STABLE = "stable"
+	BETA = "beta"
+	DEV = "dev"
+	ALL = "all"
 
 
 @dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
@@ -24,7 +32,7 @@ class AddonDetailsModel:
 	description: str
 	publisher: str
 	versionName: str
-	channel: str
+	channel: Channel
 	homepage: Optional[str]
 	licenseName: str
 	licenseUrl: Optional[str]
@@ -56,7 +64,7 @@ def _createModelFromData(jsonData: str) -> List[AddonDetailsModel]:
 			displayName=addon["displayName"],
 			description=addon["description"],
 			publisher=addon["publisher"],
-			channel=addon["channel"],
+			channel=Channel(addon["channel"]),
 			versionName=addon["addonVersionName"],
 			homepage=addon.get("homepage"),
 			licenseName=addon["license"],

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -558,7 +558,7 @@ class AddonStoreVM:
 
 	def _getAddonsInBG(self):
 		log.debug("getting addons in the background")
-		addons = self._dataManager.getLatestAvailableAddons()
+		addons = [a for a in self._dataManager.getLatestAvailableAddons() if addonVersionCheck.isAddonCompatible(a)]
 		log.debug("completed getting addons in the background")
 		if self._addons == addons:  # no change
 			log.debug("no change in addons")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Closes https://github.com/nvaccess/addon-datastore-transform/issues/15

### Summary of the issue:
The "dev" channel is designed to be used for pre-release versions of NVDA only, and allow installation to incompatible API versions.

### Description of user facing changes
Makes "dev" channel add-ons always compatible with pre-release versions of NVDA
Filters incompatible add-ons from the add-on store.
For stable NVDA releases:
 - this removes dev versions
For NVDA pre-releases:
 - this removes unsupported stable and beta versions, and shows dev versions.

### Description of development approach
Check the channel when checking addon compatibility.

filter compatible add-on versions in the main view of the store.

### Testing strategy:
Test add-on store views for stable and pre-release NVDA, by changing `buildVersion`

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
