### PR TITLE
Support for audio output using WASAPI

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -67,3 +67,13 @@ EXPORTS
 	getOleClipboardText
 	_nvdaControllerInternal_reportLiveRegion
 	_nvdaControllerInternal_openConfigDirectory
+	wasPlay_create
+	wasPlay_destroy
+	wasPlay_open
+	wasPlay_feed
+	wasPlay_stop
+	wasPlay_sync
+	wasPlay_pause
+	wasPlay_resume
+	wasPlay_startup
+	wasPlay_getDevices

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -75,5 +75,6 @@ EXPORTS
 	wasPlay_sync
 	wasPlay_pause
 	wasPlay_resume
+	wasPlay_setSessionVolume
 	wasPlay_startup
 	wasPlay_getDevices

--- a/nvdaHelper/local/sconscript
+++ b/nvdaHelper/local/sconscript
@@ -91,6 +91,7 @@ localLib=env.SharedLibrary(
 		"UIAUtils.cpp",
 		"mixer.cpp",
 		"oleUtils.cpp",
+		"wasapi.cpp",
 	],
 	LIBS=[
 		"advapi32.lib",

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -1,0 +1,594 @@
+/*
+This file is a part of the NVDA project.
+URL: http://www.nvda-project.org/
+Copyright 2023 James Teh.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2.0, as published by
+    the Free Software Foundation.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+This license can be found at:
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
+#include <vector>
+#include <windows.h>
+#include <atlcomcli.h>
+#include <audioclient.h>
+#include <functiondiscoverykeys.h>
+#include <Functiondiscoverykeys_devpkey.h>
+#include <mmdeviceapi.h>
+#include <common/log.h>
+
+/**
+ * Support for audio playback using WASAPI.
+ * Most of the core work happens in the WasapiPlayer class. Because Python
+ * ctypes can't call C++ classes, NVDA interfaces with this using the wasPlay_*
+ * functions.
+ */
+
+constexpr REFERENCE_TIME REFTIMES_PER_MILLISEC = 10000;
+constexpr REFERENCE_TIME BUFFER_SIZE = 400 * REFTIMES_PER_MILLISEC;
+
+const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
+const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
+const IID IID_IAudioClient = __uuidof(IAudioClient);
+const IID IID_IAudioRenderClient = __uuidof(IAudioRenderClient);
+const IID IID_IAudioClock = __uuidof(IAudioClock);
+const IID IID_IMMNotificationClient = __uuidof(IMMNotificationClient);
+
+/**
+ * C++ RAII class to manage the lifecycle of a standard Windows HANDLE closed
+ * with CloseHandle.
+ */
+class AutoHandle {
+	public:
+	AutoHandle(): handle(nullptr) {}
+	AutoHandle(HANDLE handle): handle(handle) {}
+
+	~AutoHandle() {
+		if (handle) {
+			CloseHandle(handle);
+		}
+	}
+
+	AutoHandle& operator=(HANDLE newHandle) {
+		if (handle) {
+			CloseHandle(handle);
+		}
+		handle = newHandle;
+		return *this;
+	}
+
+	operator HANDLE() {
+		return handle;
+	}
+
+	private:
+	HANDLE handle;
+};
+
+/**
+ * Listens for default device changes. These are communicated to WasapiPlayer
+ * via the getDefaultDeviceChangeCount method.
+ */
+class NotificationClient: public IMMNotificationClient {
+	public:
+	ULONG STDMETHODCALLTYPE AddRef() override {
+		return InterlockedIncrement(&refCount);
+	}
+
+	ULONG STDMETHODCALLTYPE Release() override {
+		LONG result = InterlockedDecrement(&refCount);
+		if (result == 0) {
+			delete this;
+		}
+		return result;
+	}
+
+	STDMETHODIMP QueryInterface(REFIID riid, void** ppvObject) final {
+		if (riid == IID_IUnknown || riid == IID_IMMNotificationClient) {
+			AddRef();
+			*ppvObject = (void*)this;
+			return S_OK;
+		}
+		return E_NOINTERFACE;
+	}
+
+	STDMETHODIMP OnDefaultDeviceChanged(EDataFlow flow, ERole     role,
+		LPCWSTR   defaultDeviceId
+	) final {
+		if (flow == eRender && role == eConsole) {
+			++defaultDeviceChangeCount;
+		}
+		return S_OK;
+	}
+
+	STDMETHODIMP OnDeviceAdded(LPCWSTR deviceId) final {
+		return S_OK;
+	}
+
+	STDMETHODIMP OnDeviceRemoved(LPCWSTR deviceId) final {
+		return S_OK;
+	}
+
+	STDMETHODIMP OnDeviceStateChanged(LPCWSTR deviceId, DWORD   newState) final {
+		return S_OK;
+	}
+
+	STDMETHODIMP OnPropertyValueChanged(LPCWSTR           deviceId,
+		const PROPERTYKEY key
+	) final {
+		return S_OK;
+	}
+
+	/**
+	 * A counter which increases every time the default device changes. This is
+	 * used by WasapiPlayer instances to detect such changes while playing.
+	 */
+	unsigned int getDefaultDeviceChangeCount() {
+		return defaultDeviceChangeCount;
+	}
+
+	private:
+	LONG refCount = 0;
+	unsigned int defaultDeviceChangeCount = 0;
+};
+
+CComPtr<NotificationClient> notificationClient;
+
+/**
+ * Play a stream of audio using WASAPI.
+ */
+class WasapiPlayer {
+	public:
+	using ChunkCompletedCallback = void(*)(WasapiPlayer* player,
+		unsigned int id);
+
+	/**
+	 * Constructor.
+	 * Specify an empty (not null) deviceId to use the default device.
+	 */
+	WasapiPlayer(wchar_t* deviceId, WAVEFORMATEX format,
+		ChunkCompletedCallback callback);
+
+	/**
+	 * Open the audio device.
+	 * If force is true, the device will be reopened even if it is already open.
+	 */
+	HRESULT open(bool force=false);
+
+	/**
+	 * Feed a chunk of audio.
+	 * If not null, id will be set to a number used to identify the audio
+	 * associated with this call. The callback will be called with this number when
+	 * this audio finishes playing.
+	 */
+	HRESULT feed(unsigned char* data, unsigned int size, unsigned int* id);
+
+	HRESULT stop();
+	HRESULT sync();
+	HRESULT pause();
+	HRESULT resume();
+
+	private:
+	void maybeFireCallback();
+
+	// Reset our state due to being stopped. This runs on the feeder thread
+	// rather than on the thread which called stop() because writing to a vector
+	// isn't thread safe.
+	void completeStop();
+
+	// Convert frames into ms.
+	UINT64 framesToMs(UINT32 frames) {
+		return frames * 1000 / format.nSamplesPerSec;
+	}
+
+	// Get the current playback position in ms.
+	UINT64 getPlayPos();
+
+	// Wait until we need to wake up next. This includes needing to fire a
+	// callback.
+	void waitUntilNeeded(UINT64 maxWait=INFINITE);
+
+	enum class PlayState {
+		stopped,
+		playing,
+		stopping,
+	};
+
+	CComPtr<IAudioClient> client;
+	CComPtr<IAudioRenderClient> render;
+	CComPtr<IAudioClock> clock;
+	// The maximum number of frames that will fit in the buffer.
+	UINT32 bufferFrames;
+	std::wstring deviceId;
+	WAVEFORMATEX format;
+	ChunkCompletedCallback callback;
+	PlayState playState = PlayState::stopped;
+	// Maps feed ids to the end of their audio in ms since the start of the
+	// stream. This is used to call the callback.
+	std::vector<std::pair<unsigned int, UINT64>> feedEnds;
+	UINT64 clockFreq;
+	// The duration of audio sent (buffered) so far in ms.
+	UINT64 sentMs = 0;
+	unsigned int nextFeedId = 0;
+	AutoHandle wakeEvent;
+	unsigned int defaultDeviceChangeCount;
+};
+
+WasapiPlayer::WasapiPlayer(wchar_t* deviceId, WAVEFORMATEX format,
+	ChunkCompletedCallback callback)
+: deviceId(deviceId), format(format), callback(callback) {
+	wakeEvent = CreateEvent(nullptr, false, false, nullptr);
+}
+
+HRESULT WasapiPlayer::open(bool force) {
+	if (client && !force) {
+		// Device already open and we're not forcing reopen.
+		return S_OK;
+	}
+	defaultDeviceChangeCount = notificationClient->getDefaultDeviceChangeCount();
+	CComPtr<IMMDeviceEnumerator> enumerator;
+	HRESULT hr = enumerator.CoCreateInstance(CLSID_MMDeviceEnumerator);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	CComPtr<IMMDevice> device;
+	if (deviceId.empty()) {
+		hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
+	} else {
+		hr = enumerator->GetDevice(deviceId.c_str(), &device);
+	}
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = device->Activate(IID_IAudioClient, CLSCTX_ALL, nullptr, (void**)&client);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = client->Initialize(AUDCLNT_SHAREMODE_SHARED,
+		AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+		BUFFER_SIZE, 0, &format, nullptr);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = client->GetBufferSize(&bufferFrames);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = client->GetService(IID_IAudioRenderClient, (void**)&render);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = client->GetService(IID_IAudioClock, (void**)&clock);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = clock->GetFrequency(&clockFreq);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	playState = PlayState::stopped;
+	return S_OK;
+}
+
+HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
+	unsigned int* id
+) {
+	if (playState == PlayState::stopping) {
+		// stop() was called after feed() returned.
+		completeStop();
+	}
+	UINT32 remainingFrames = size / format.nBlockAlign;
+	HRESULT hr;
+
+	// Returns false if we should abort, in which case we should return hr.
+	auto reopenUsingNewDev = [&] {
+		HRESULT hr = open(true);
+		if (FAILED(hr)) {
+			return false;
+		}
+		// Call any pending callbacks. Otherwise, they'll never get called.
+		for (auto& [itemId, itemEnd]: feedEnds) {
+			callback(this, itemId);
+		}
+		feedEnds.clear();
+		// This is the start of a new stream as far as WASAPI is concerned.
+		sentMs = 0;
+		return true;
+	};
+
+	while (remainingFrames > 0) {
+		UINT32 paddingFrames;
+
+		// Returns false if we should abort, in which case we should return hr.
+		auto getPaddingHandlingStopOrDevChange = [&] {
+			if (playState == PlayState::stopping) {
+				// stop() was called in another thread. Don't send any more.
+				completeStop();
+				hr = S_OK;
+				return false;
+			}
+			if (deviceId.empty() && defaultDeviceChangeCount !=
+					notificationClient->getDefaultDeviceChangeCount()) {
+				// The default device changed.
+				if (!reopenUsingNewDev()) {
+					return false;
+				}
+			}
+			hr = client->GetCurrentPadding(&paddingFrames);
+			if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
+				// If we're using a specific device, it's just been invalidated. Fall back
+				// to the default device.
+				deviceId.clear();
+				if (!reopenUsingNewDev()) {
+					return false;
+				}
+				hr = client->GetCurrentPadding(&paddingFrames);
+			}
+			return SUCCEEDED(hr);
+		};
+
+		if (!getPaddingHandlingStopOrDevChange()) {
+			return hr;
+		}
+		if (paddingFrames > bufferFrames / 2) {
+			// Wait until the buffer is less than half full.
+			waitUntilNeeded(framesToMs(paddingFrames - bufferFrames / 2));
+			if (!getPaddingHandlingStopOrDevChange()) {
+				return hr;
+			}
+		}
+		// We might have more frames than will fit in the buffer. Send what we can.
+		const UINT32 sendFrames = std::min(remainingFrames,
+			bufferFrames - paddingFrames);
+		const UINT32 sendBytes = sendFrames * format.nBlockAlign;
+		BYTE* buffer;
+		hr = render->GetBuffer(sendFrames, &buffer);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		memcpy(buffer, data, sendBytes);
+		hr = render->ReleaseBuffer(sendFrames, 0);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		if (playState == PlayState::stopped) {
+			hr = client->Start();
+			if (FAILED(hr)) {
+				return hr;
+			}
+			if (playState == PlayState::stopping) {
+				// stop() was called while we were calling client->Start().
+				completeStop();
+				return S_OK;
+			}
+			playState = PlayState::playing;
+		}
+		maybeFireCallback();
+		data += sendBytes;
+		size -= sendBytes;
+		remainingFrames -= sendFrames;
+		sentMs += framesToMs(sendFrames);
+	}
+
+	if (playState == PlayState::playing) {
+		maybeFireCallback();
+	}
+	if (id) {
+		*id = nextFeedId++;
+		// Track that we want to call the callback with this id when playback
+		// reaches the end of the audio provided to this call.
+		// It is important that we add a new callback after we fire existing
+		// callbacks. Otherwise, we might fire a newly added callback before its
+		// feed() call returns, which will fail because the caller doesn't know about
+		// this new id yet.
+		feedEnds.push_back({*id, sentMs});
+	}
+	return S_OK;
+}
+
+void WasapiPlayer::maybeFireCallback() {
+	const UINT64 playPos = getPlayPos();
+	std::erase_if(feedEnds, [&](auto& val) {
+		auto [id, end] = val;
+		if (playPos >= end) {
+			callback(this, id);
+			return true;
+		}
+		return false;
+	});
+}
+
+UINT64 WasapiPlayer::getPlayPos() {
+	// Apparently IAudioClock::GetPosition can be expensive. If we hit performance
+	// problems here, consider using the performance counter it returns for
+	// subsequent calls.
+	UINT64 pos;
+	HRESULT hr = clock->GetPosition(&pos, nullptr);
+	if (FAILED(hr)) {
+		return 0;
+	}
+	return pos * 1000 / clockFreq;
+}
+
+void WasapiPlayer::waitUntilNeeded(UINT64 maxWait) {
+	if (!feedEnds.empty()) {
+		// There's at least one pending callback.
+		UINT64 feedEnd = feedEnds[0].second;
+		const UINT64 nextCallbackTime = feedEnd - getPlayPos();
+		if (nextCallbackTime < maxWait) {
+			// The callback needs to happen before maxWait supplied by the caller.
+			// Lower maxWait accordingly.
+			maxWait = nextCallbackTime;
+		}
+	}
+	WaitForSingleObject(wakeEvent, (DWORD)maxWait);
+}
+
+HRESULT WasapiPlayer::stop() {
+	playState = PlayState::stopping;
+	HRESULT hr = client->Stop();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = client->Reset();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	// If there is a feed/sync call waiting, wake it up so it can immediately
+	// return to the caller.
+	SetEvent(wakeEvent);
+	return S_OK;
+}
+
+void WasapiPlayer::completeStop() {
+	nextFeedId = 0;
+	sentMs = 0;
+	feedEnds.clear();
+	playState = PlayState::stopped;
+}
+
+HRESULT WasapiPlayer::sync() {
+	for (UINT64 playPos = getPlayPos(); playPos < sentMs;
+			playPos = getPlayPos()) {
+		if (playState != PlayState::playing) {
+			return S_OK;
+		}
+		maybeFireCallback();
+		waitUntilNeeded(sentMs - playPos);
+	}
+	// If there's a callback right at the end of the stream (sentMs), fire it.
+	if (playState == PlayState::playing) {
+		maybeFireCallback();
+	}
+	return S_OK;
+}
+
+HRESULT WasapiPlayer::pause() {
+	if (playState != PlayState::playing) {
+		return S_OK;
+	}
+	HRESULT hr = client->Stop();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	return S_OK;
+}
+
+HRESULT WasapiPlayer::resume() {
+	if (playState != PlayState::playing) {
+		return S_OK;
+	}
+	HRESULT hr = client->Start();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	return S_OK;
+}
+
+/*
+ * NVDA calls the functions below. Most of these just wrap calls to
+ * WasapiPlayer, with the exception of wasPlay_startup and wasPlay_getDevices.
+ */
+
+WasapiPlayer* wasPlay_create(wchar_t* deviceId, WAVEFORMATEX format,
+	WasapiPlayer::ChunkCompletedCallback callback
+) {
+	return new WasapiPlayer(deviceId, format, callback);
+}
+
+void wasPlay_destroy(WasapiPlayer* player) {
+	delete player;
+}
+
+HRESULT wasPlay_open(WasapiPlayer* player) {
+	return player->open();
+}
+
+HRESULT wasPlay_feed(WasapiPlayer* player, unsigned char* data,
+	unsigned int size, unsigned int* id
+) {
+	return player->feed(data, size, id);
+}
+
+HRESULT wasPlay_stop(WasapiPlayer* player) {
+	return player->stop();
+}
+
+HRESULT wasPlay_sync(WasapiPlayer* player) {
+	return player->sync();
+}
+
+HRESULT wasPlay_pause(WasapiPlayer* player) {
+	return player->pause();
+}
+
+HRESULT wasPlay_resume(WasapiPlayer* player) {
+	return player->resume();
+}
+
+/**
+ * This must be called once per session at startup before wasPlay_create is
+ * called.
+ */
+HRESULT wasPlay_startup() {
+	CComPtr<IMMDeviceEnumerator> enumerator;
+	HRESULT hr = enumerator.CoCreateInstance(CLSID_MMDeviceEnumerator);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	notificationClient = new NotificationClient();
+	return enumerator->RegisterEndpointNotificationCallback(notificationClient);
+}
+
+/**
+ * Get playback device ids and friendly names.
+ * devicesStr will be set to a BSTR of device ids and names separated by null
+ * characters; e.g. "id1\0name1\0id2\0name2\0"
+ */
+HRESULT wasPlay_getDevices(BSTR* devicesStr) {
+	CComPtr<IMMDeviceEnumerator> enumerator;
+	HRESULT hr = enumerator.CoCreateInstance(CLSID_MMDeviceEnumerator);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	CComPtr<IMMDeviceCollection> devices;
+	hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	UINT count = 0;
+	devices->GetCount(&count);
+	std::wostringstream s;
+	for (UINT d = 0; d < count; ++d) {
+		CComPtr<IMMDevice> device;
+		hr = devices->Item(d, &device);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		wchar_t* id;
+		hr = device->GetId(&id);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		s << id << L'\0';
+		CoTaskMemFree(id);
+		CComPtr<IPropertyStore> props;
+		hr = device->OpenPropertyStore(STGM_READ, &props);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		PROPVARIANT val;
+		hr = props->GetValue(PKEY_Device_FriendlyName, &val);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		s << val.pwszVal << L'\0';
+		PropVariantClear(&val);
+	}
+	*devicesStr = SysAllocStringLen(s.str().c_str(), (UINT)s.tellp());
+	return S_OK;
+}

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -56,6 +56,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 # Audio settings
 [audio]
 	audioDuckingMode = integer(default=0)
+	wasapi = boolean(default=false)
 
 # Braille settings
 [braille]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -56,7 +56,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 # Audio settings
 [audio]
 	audioDuckingMode = integer(default=0)
-	wasapi = boolean(default=false)
+	wasapi = boolean(default=true)
 
 # Braille settings
 [braille]

--- a/source/core.py
+++ b/source/core.py
@@ -17,7 +17,6 @@ import comtypes
 import sys
 import winVersion
 import threading
-import nvwave
 import os
 import time
 import ctypes
@@ -502,18 +501,24 @@ def main():
 	config.initialize()
 	if config.conf['development']['enableScratchpadDir']:
 		log.info("Developer Scratchpad mode enabled")
-	if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:
-		try:
-			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "start.wav"))
-		except:
-			pass
-	logHandler.setLogLevelFromConfig()
 	if languageHandler.isLanguageForced():
 		lang = globalVars.appArgs.language
 	else:
 		lang = config.conf["general"]["language"]
 	log.debug(f"setting language to {lang}")
 	languageHandler.setLanguage(lang)
+	import NVDAHelper
+	log.debug("Initializing NVDAHelper")
+	NVDAHelper.initialize()
+	import nvwave
+	log.debug("initializing nvwave")
+	nvwave.initialize()
+	if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:
+		try:
+			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "start.wav"))
+		except Exception:
+			pass
+	logHandler.setLogLevelFromConfig()
 	log.info(f"Windows version: {winVersion.getWinVer()}")
 	log.info("Using Python version %s"%sys.version)
 	log.info("Using comtypes version %s"%comtypes.__version__)
@@ -529,9 +534,6 @@ def main():
 	import appModuleHandler
 	log.debug("Initializing appModule Handler")
 	appModuleHandler.initialize()
-	import NVDAHelper
-	log.debug("Initializing NVDAHelper")
-	NVDAHelper.initialize()
 	log.debug("initializing background i/o")
 	import hwIo
 	hwIo.initialize()
@@ -818,7 +820,6 @@ def main():
 	_terminate(JABHandler, name="Java Access Bridge support")
 	_terminate(appModuleHandler, name="app module handler")
 	_terminate(tones)
-	_terminate(NVDAHelper)
 	_terminate(touchHandler)
 	_terminate(keyboardHandler, name="keyboard handler")
 	_terminate(mouseHandler)
@@ -851,6 +852,7 @@ def main():
 	# #5189: Destroy the message window as late as possible
 	# so new instances of NVDA can find this one even if it freezes during exit.
 	messageWindow.destroy()
+	_terminate(NVDAHelper)
 	log.debug("core done")
 
 def _terminate(module, name=None):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3014,6 +3014,27 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a group of advanced options in the
 		# Advanced settings panel
+		label = _("Audio")
+		audio = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		audioBox = audio.GetStaticBox()
+		audioGroup = guiHelper.BoxSizerHelper(self, sizer=audio)
+		sHelper.addItem(audioGroup)
+
+		# Translators: This is the label for a checkbox control in the
+		#  Advanced settings panel.
+		label = _("Use WASAPI for audio output (requires restart)")
+		self.wasapiCheckBox: wx.CheckBox = audioGroup.addItem(
+			wx.CheckBox(audioBox, label=label)
+		)
+		self.bindHelpEvent("WASAPI", self.wasapiCheckBox)
+		self.wasapiCheckBox.SetValue(
+			config.conf["audio"]["wasapi"]
+		)
+		self.wasapiCheckBox.defaultValue = self._getDefaultValue(
+			["audio", "wasapi"])
+
+		# Translators: This is the label for a group of advanced options in the
+		# Advanced settings panel
 		label = _("Debug logging")
 		debugLogSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
 		debugLogGroup = guiHelper.BoxSizerHelper(self, sizer=debugLogSizer)
@@ -3099,6 +3120,7 @@ class AdvancedPanelControls(
 			and self.loadChromeVBufWhenBusyCombo.isValueConfigSpecDefault()
 			and self.caretMoveTimeoutSpinControl.GetValue() == self.caretMoveTimeoutSpinControl.defaultValue
 			and self.reportTransparentColorCheckBox.GetValue() == self.reportTransparentColorCheckBox.defaultValue
+			and self.wasapiCheckBox.GetValue() == self.wasapiCheckBox.defaultValue
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.playErrorSoundCombo.GetSelection() == self.playErrorSoundCombo.defaultValue
 			and True  # reduce noise in diff when the list is extended.
@@ -3124,6 +3146,7 @@ class AdvancedPanelControls(
 		self.loadChromeVBufWhenBusyCombo.resetToConfigSpecDefault()
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
+		self.wasapiCheckBox.SetValue(self.wasapiCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self.playErrorSoundCombo.SetSelection(self.playErrorSoundCombo.defaultValue)
 		self._defaultsRestored = True
@@ -3154,6 +3177,7 @@ class AdvancedPanelControls(
 		config.conf["documentFormatting"]["reportTransparentColor"] = (
 			self.reportTransparentColorCheckBox.IsChecked()
 		)
+		config.conf["audio"]["wasapi"] = self.wasapiCheckBox.IsChecked()
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
 		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCombo.GetSelection()

--- a/source/tones.py
+++ b/source/tones.py
@@ -26,7 +26,8 @@ def initialize():
 			samplesPerSec=int(SAMPLE_RATE),
 			bitsPerSample=16,
 			outputDevice=config.conf["speech"]["outputDevice"],
-			wantDucking=False
+			wantDucking=False,
+			session=nvwave.soundsSession
 		)
 	except Exception:
 		log.warning("Failed to initialize audio for tones", exc_info=True)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,7 @@ What's New in NVDA
 - When pressing ``numpad2`` three times to report the numerical value of the character at the position of the review cursor, the information is now also provided in braille. (#14826)
 - Added gestures for Tivomatic Caiku Albatross Braille displays.
 There are now gestures for showing the braille settings dialog, accessing the status bar, cycling the braille cursor shape, and toggling the braille cursor on/off. (#14844)
+- NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. This can be disabled in Advanced settings if audio problems are encountered. (#14697)
 - 
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2293,6 +2293,12 @@ Some GDI applications will highlight text with a background color, NVDA (via dis
 In some situations, the text background may be entirely transparent, with the text layered on some other GUI element.
 With several historically popular GUI APIs, the text may be rendered with a transparent background, but visually the background color is accurate.
 
+==== Use WASAPI for audio output ====[WASAPI]
+This option enables audio output via the Windows Audio Session API (WASAPI).
+WASAPI is a more modern audio framework which may improve the responsiveness, performance and stability of NVDA audio output, including both speech and sounds.
+This option is currently experimental and is disabled by default.
+After changing this option, you will need to restart NVDA for the change to take effect.
+
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.
 Logging these messages can result in decreased performance and large log files.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2296,7 +2296,7 @@ With several historically popular GUI APIs, the text may be rendered with a tran
 ==== Use WASAPI for audio output ====[WASAPI]
 This option enables audio output via the Windows Audio Session API (WASAPI).
 WASAPI is a more modern audio framework which may improve the responsiveness, performance and stability of NVDA audio output, including both speech and sounds.
-This option is currently experimental and is disabled by default.
+This option is enabled by default.
 After changing this option, you will need to restart NVDA for the change to take effect.
 
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]


### PR DESCRIPTION
### Link to issue number:
Fixes #11615. Fixes #5096. Fixes #10185. Fixes #11061. Partially addresses #10413 and #1409. May address #11169.

### Summary of the issue:
NVDA's existing audio output code (nvwave) is largely very old and uses WinMM, a very old legacy Windows audio API. It is also written in pure Python, contains quite a few threading locks necessitated by WinMM, and parts of it have become rather difficult to reason about. There are several known stability and audio glitching issues that are difficult to solve with the existing code.

### Description of user facing changes
At the very least, this fixes audio glitches at the end of some utterances as described in #10185 and #11061.

I haven't noticed a significant improvement in responsiveness on my system, but my system is also very powerful. It's hard to know whether the stability issues (e.g. #11169) are fixed or not. Time will tell as I run with this more.

### Description of development approach
1. The bulk of the WASAPI implementation is written in C++. The WASAPI interfaces are easy to access in C++ and difficult to access in Python. In addition, this allows for the best possible performance, given that we regularly and continually stream audio data.
2. The WinMM code fired callbacks by waiting for the previous chunk to finish playing before sending the next chunk, which could result in buffer underruns (glitches) if callbacks were close together (#10185 and #11061). In contrast, the WASAPI code uses the audio playback clock to fire callbacks independent of data buffering, eliminating glitches caused by callbacks.
3. The WinMM WavePlayer class is renamed to WinmmWavePlayer. The WASAPI version is called WasapiWavePlayer. Rather than having a common base class, this relies on duck-typing. I figured it didn't make sense to have a base class given that WasapiWavePlayer will likely replace WinmmWavePlayer altogether at some point.
4. WavePlayer is set to one of these two classes during initialisation based on a new advanced configuration setting. WASAPI defaults to disabled.
5. WasapiWavePlayer.feed can take a ctypes pointer and size instead of a Python bytes object. This avoids the overhead of additional memory copying and Python objects in cases where we are given a direct pointer to memory anyway, which is true for most (if not all) speech synthesisers.
6. For compatibility, WinmmWavePlayer.feed supports a ctypes pointer as well, but it just converts it to a Python bytes object.
7. eSpeak and oneCore have been updated to pass a ctypes pointer to WavePlayer.feed.
8. When playWaveFile is used asynchronously, it now feeds audio on the background thread, rather than calling feed on the current thread. This is necessary because the WASAPI code blocks once the buffer (400 ms) is full, rather than having variable sized buffers. Even with the WinMM code, playWaveFile code could block for a short time (#10413). This should improve that also.
9. WasapiWavePlayer supports associating a stream with a specific audio session, which allows that session to be separately configurable in the system Volume Mixer. NVDA tones and wave files have been split into a separate "NVDA sounds" session. WinmmWavePlayer has a new setSessionVolume method that can be used to set the volume of a session. This at least partially addresses #1409.

### Testing strategy:
- Given that this deals with realtime audio output, there isn't a way to unit test or system test this.
- I've been running with this code for several weeks as my main screen reader.
- I've tested with both eSpeak and OneCore.
- I've tested various situations requiring indexing with both eSpeak and OneCore, including say all, indentation tones and focusing dialogs (which relies on indexing due to multiple utterances).
- I've tested switching default devices, disconnecting the default device and disconnecting a preferred device.
- I've tested configuring NVDA to use a specific (non-default) device, exiting NVDA, disconnecting that device and starting NVDA. NVDA falls back to the default device as it should.
- I've tested independently setting the volume of NVDA speech and sounds in the system Volume Mixer.
- I have not tested with operating systems other than Windows 11 21h2, as I don't have any other versions of Windows set up to test with.
- I also haven't tested with any other speech synthesisers, as I don't have any.

### Known issues with pull request:
- This needs a lot more testing across various computers, Windows versions, audio devices, speech synthesisers and configurations. It is enabled by default to gather maximum feedback, but can be easily disabled if it causes problems.
- Calling tones.beep with a length longer than 399 ms will block, again due to the different buffering strategy. I don't think this will matter in practice, as I doubt beeps that long are used in practice.
- If a synthesiser sends very small chunks of audio, playback might glitch. I'm not sure if any synths actually do this, so I'm not sure if this needs to be addressed or not. I do have some thoughts on how we could handle it though.
- If a preferred device is specified and it is disconnected, playback falls back to the default device. The WinMM code had some logic to switch back to the preferred device if it is reconnected. I haven't implemented this for WASAPI; it will remain on the default device. I think it's possible to implement this, but it increases complexity and I'm not sure how useful it is, especially since the WinMM code only did this on idle anyway.

### Change log entries:
New features
NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. This can be disabled in Advanced settings if audio problems are encountered.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
