### PR TITLE
Settings Ring: Lazily load available setting values the first time they're needed

### DIFF
--- a/source/synthSettingsRing.py
+++ b/source/synthSettingsRing.py
@@ -37,10 +37,12 @@ class SynthSetting(baseObject.AutoPropertyObject):
 	def _get_reportValue(self):
 		return self._getReportValue(self.value)
 
+
 class StringSynthSetting(SynthSetting):
-	def __init__(self,synth,setting):
-		self._values=list(getattr(synth,"available%ss"%setting.id.capitalize()).values())
-		super(StringSynthSetting,self).__init__(synth,setting,0,len(self._values)-1)
+
+	def _get__values(self):
+		self._values = list(getattr(self.synth, f"available{self.setting.id.capitalize()}s").values())
+		return self._values
 
 	def _get_value(self):
 		curID=getattr(self.synth,self.setting.id)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -35,6 +35,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 - Added the ``bdDetect.scanForDevices`` extension point.
 Handlers can be registered that yield ``BrailleDisplayDriver/DeviceMatch`` pairs that don't fit in existing categories, like USB or Bluetooth. (#14531)
 - Added extension point: ``synthDriverHandler.synthChanged``. (#14618)
+- The NVDA Synth Settings Ring now caches available setting values the first time they're needed, rather than when loading the synthesizer. (#14704)
 -
 
 === Deprecations ===


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
A settings ring entry for a String setting caches its possible values when creating the StringSynthSetting object. This can be costly if it takes some time for the possible values to return, for example when they're coming from a remote system in [my remote desktop add-on](https://github.com/leonardder/nvdard).

### Description of user facing changes
None.

### Description of development approach
Load and cache the available settings values the first time they're fetched. This shouldn't have any noticeable impact for most synths.that 

### Testing strategy:
Tested with NVDA Remote Desktop add-on that initial setup of the remote synth is quicker, whereas the first selection of a settings ring entry is somewhat slower.

### Known issues with pull request:
None

### Change log entries:
For Developers
- The NVDA Synth Settings Ring now caches available setting values the first time they're needed, rather than when loading the synthesizer. 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
