### PR TITLE
Follow-up of #13045: Removed redundant \xfe\xfd from ESTABLISHED constant

### DIFF
--- a/source/brailleDisplayDrivers/albatross/constants.py
+++ b/source/brailleDisplayDrivers/albatross/constants.py
@@ -238,7 +238,7 @@ ROUTING_KEY_RANGES: FrozenSet[RoutingKeyRange] = frozenset(
 )
 """Defines routing key ranges. See L{RoutingKeyRange}."""
 
-ESTABLISHED = b"\xfe\xfd\xfe\xfd"
+ESTABLISHED = b"\xfe\xfd"
 """Send this to Albatross to confirm that connection is established."""
 
 INIT_START_BYTE = b"\xff"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Follow-up of #13045
### Summary of the issue:
Driver sent to Albatross display byte string `b"\xfe\xfd\xfe\xfd"` to tell device that there is active connection and it should not send init packets anymore. Byte string contained two establishment packets, and one should be enough. It should not cause harm to send two packets because display ignores latter one but it is redundant anyway.

In stead of `b"\xfe\xfd\xfe\xfd"` driver sends now `b"\xfe\xfd"` to display. 
### Description of user facing changes
None
### Description of development approach
None
### Testing strategy:
Starts/restarts, switching display off/on during connection, and using device's internal menu during connection.
### Known issues with pull request:
None
### Change log entries:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
