### PR TITLE
Report aria-haspopup dialog/grid/list/tree in Firefox and Chrome.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -203,6 +203,13 @@ class Ia2Web(IAccessible):
 		# Google has a custom ARIA attribute to force a node's editable state off (such as in Google Slides).
 		if self.IA2Attributes.get('goog-editable')=="false":
 			states.discard(controlTypes.State.EDITABLE)
+		if controlTypes.State.HASPOPUP in states:
+			popupState = aria.ariaHaspopupValuesToNVDAStates.get(
+				self.IA2Attributes.get("haspopup")
+			)
+			if popupState:
+				states.discard(controlTypes.State.HASPOPUP)
+				states.add(popupState)
 		return states
 
 	def _get_landmark(self):

--- a/source/aria.py
+++ b/source/aria.py
@@ -115,3 +115,13 @@ class AriaLivePoliteness(str, Enum):
 	OFF = "off"
 	POLITE = "polite"
 	ASSERTIVE = "assertive"
+
+
+ariaHaspopupValuesToNVDAStates: Dict[str, controlTypes.State] = {
+	"true": controlTypes.State.HASPOPUP,
+	"menu": controlTypes.State.HASPOPUP,
+	"dialog": controlTypes.State.HASPOPUP_DIALOG,
+	"grid": controlTypes.State.HASPOPUP_GRID,
+	"listbox": controlTypes.State.HASPOPUP_LIST,
+	"tree": controlTypes.State.HASPOPUP_TREE,
+}

--- a/source/controlTypes/state.py
+++ b/source/controlTypes/state.py
@@ -98,6 +98,10 @@ class State(DisplayStringIntEnum):
 	INDETERMINATE = setBit(44)
 	HALF_PRESSED = setBit(45)
 	ON = setBit(46)
+	HASPOPUP_DIALOG = setBit(47)
+	HASPOPUP_GRID = setBit(48)
+	HASPOPUP_LIST = setBit(49)
+	HASPOPUP_TREE = setBit(50)
 
 
 STATES_SORTED = frozenset([State.SORTED, State.SORTED_ASCENDING, State.SORTED_DESCENDING])
@@ -192,6 +196,14 @@ _stateLabels: Dict[State, str] = {
 	# Translators: a state that denotes a control is currently on
 	# E.g. a switch control.
 	State.ON: _("on"),
+	# Translators: Presented when a control has a pop-up dialog.
+	State.HASPOPUP_DIALOG: _("opens dialog"),
+	# Translators: Presented when a control has a pop-up grid.
+	State.HASPOPUP_GRID: _("opens grid"),
+	# Translators: Presented when a control has a pop-up list box.
+	State.HASPOPUP_LIST: _("opens list"),
+	# Translators: Presented when a control has a pop-up tree.
+	State.HASPOPUP_TREE: _("opens tree"),
 }
 
 

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -167,6 +167,12 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 			if controlTypes.State.CHECKED in states:
 				states.discard(controlTypes.State.CHECKED)
 				states.add(controlTypes.State.ON)
+		popupState = aria.ariaHaspopupValuesToNVDAStates.get(
+			attrs.get("IAccessible2::attribute_haspopup")
+		)
+		if popupState:
+			states.discard(controlTypes.State.HASPOPUP)
+			states.add(popupState)
 		attrs['role']=role
 		attrs['states']=states
 		if level != "" and level is not None:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,6 +7,7 @@ What's New in NVDA
 
 == New Features ==
 - Added pronunciation of Unicode braille symbols such as "⠐⠣⠃⠗⠇⠐⠜". (#14548)
+- In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup. (#14709)
 - 
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #8235.

### Summary of the issue:
NVDA reports "sub menu" for all values of aria-haspopup, which is misleading at best.

### Description of user facing changes
In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup.

### Description of development approach
1. Created new states for HASPOPUP_DIALOG, GRID, LIST and TREE. The general HASPOPUP state is still used for menus.
2. Mapped the ARIA string values to states.
3. Modified both the IA2Web NVDAObject and the Gecko_ia2 vbuf to expose these new states based on the haspopup object attribute.

### Testing strategy:
Tested with the [test case](https://codepen.io/stevef/pen/QaOXBY) in #8235. The correct message - "opens dialog", etc. - is reported when tabbing in focus mode, tabbing in browse mode, moving by line in browse mode and quick navigating in browse mode.

### Known issues with pull request:
None.

### Change log entries:
New features
In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
