### PR TITLE
sayAll: no longer prematurely stop sayAll after turning a page.

### DIFF
--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -267,7 +267,6 @@ class _TextReader(garbageHandler.TrackedObject, metaclass=ABCMeta):
 
 		if not self.initialIteration or not self.shouldReadInitialPosition():
 			if not self.nextLineImpl():
-				self.finish()
 				return
 		self.initialIteration = False
 		bookmark = self.reader.bookmark
@@ -408,6 +407,7 @@ class _TableTextReader(_CaretTextReader):
 			self.reader = self.nextLineFunc(self.reader)
 			return True
 		except StopIteration:
+			self.finish()
 			return False
 
 	def collapseLineImpl(self) -> bool:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -102,6 +102,7 @@ Same as pressing ``NVDA+k`` twice, but may be more useful for braille users. (#1
 - In web browsers such as Chrome and Firefox, alerts such as file downloads are shown in braille in addition to being spoken. (#14562)
 - Bug fixed when navigating to the first and last column in a table in Firefox (#14554)
 - When NVDA is launched with ``--lang=Windows`` parameter, it is again possible to open NVDA's General settings dialog. (#14407)
+- NVDA no longer fails to continue reading in Kindle for PC after turning the page. (#14390)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #14390

### Summary of the issue:
With the merging of pr #14070 which added sayall in tables, SayAll in Kindle for PC would fail to continue reading after turning the page.
Technical:
Some of the code in the nextLine method in sayAll was refacted into a nextLineImpl method. 
However, if nextLineImpl returned false, finish would be called and nextLIne would return. This would be correct for handling the case where there was no more text, or table cells, but not the case where the page has just been turned. In fact, text sayAll already called finish when there was no more text, so calling finish again was useless in the base case, but for page turns caused sayAll to abort prematurely after the page was turned.

### Description of user facing changes
NVDA no longer fails to keep reading with sayAll after crossing a page boundary.

### Description of development approach
In sayAll's nextLine method, removed the call to self.finish when nextLineImpl returns False, but ensured that  table sayAll's nextLineImpl does call finish itself if there is no more table cells.
In other words, the self.finish call has been moved into the specific nextLineImpl method where it is needed, rather than running more broadly.

### Testing strategy:
Opened a book in Kindle for PC. Started a sayAll and ensured that NVDA continued reading after the page was turned.
Using the table on the NvDA   snapshots page, ensured that NvDA read all the way across the first row using NVDA+control+alt+rightArrow, and that sayAll profile was handled correctly I.e. the synth was reset to the normal voice after sayAll completed.

### Known issues with pull request:
None.

### Change log entries:
New features
Changes
Bug fixes
- NVDA no longer fails to continue reading in Kindle for PC after turning the page. (#14390) 

For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
