### PR TITLE
No longer install fake gettext and pgettext in unit tests before initializing languageHandler

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,3 @@
-# tests/unit/__init__.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -16,15 +15,6 @@ Methods in test classes should have a C{test_} prefix.
 
 import os
 import sys
-
-import locale
-import gettext
-import builtins
-#Localization settings
-locale.setlocale(locale.LC_ALL,'')
-translations = gettext.NullTranslations()
-translations.install()
-builtins.pgettext = lambda context, message: message
 
 # The path to the unit tests.
 UNIT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -112,8 +112,11 @@ class Test_getSpellingCharAddCapNotification(unittest.TestCase):
 
 	@classmethod
 	def setUpClass(cls):
-		from . import translations as originalTranslationClass
-		cls.translationsFake = Translation_Fake(originalTranslationClass)
+		# Initialize fake translation,
+		# providing translation installed by `languageHandler` as an original one.
+		# To retrieve it we just get an gettext instance bound to the `_` function.
+		orig_translation = _.__self__
+		cls.translationsFake = Translation_Fake(orig_translation)
 		cls.translationsFake.install()
 
 	@classmethod


### PR DESCRIPTION

### Link to issue number:
Related to #14660

### Summary of the issue:
When executing unit tests we're installing fake gettext and pgettext functions. In normal usage this is not happening (`languageHandler` is responsible for setting localization support).
### Description of user facing changes
None - this touches only unit tests.
### Description of development approach
`_` and `pgettext` are no longer installed in unit tests. It was also necessary to modify unit tests which verifies announcements of capital letters, in which we are using a fake translation. It was changed so that the translation restored after tests is the one created by `languageHandler` not the fake one as it was done previously.
### Testing strategy:
Ensured that unit tests still pass.
### Known issues with pull request:
None known
### Change log entries:
None needed - test only change.
### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
