### PR TITLE
soffice: Report page-relative caret position when available

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,6 +14,7 @@ What's New in NVDA
 == Changes ==
 - Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
 - Distance reported in Microsoft Word will now honour the unit defined in Word's advanced options even when using UIA to access Word documents. (#14542)
+- When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)
 -
 
 


### PR DESCRIPTION
### Link to issue number:

Fixes #11696
Related LibreOffice bug report:
https://bugs.documentfoundation.org/show_bug.cgi?id=136760

### Summary of the issue:

When reporting the review cursor location in LibreOffice Writer, the announced position was not particularly useful to determine where in the document/page the cursor is currently located.

### Description of user facing changes

Similar to how it is done for Microsoft Word, report the current cursor/caret location relative to the current page when that information is available for LibreOffice Writer.

### Description of development approach

To retrieve the page-relative cursor/caret location, this introduces and makes use of a new `SymphonyDocumentTextInfo` class that retrieves the page-relative cursor position via accessible attributes from the document object.

These attributes are added to LibreOffice in this corresponding LibreOffice change:
https://gerrit.libreoffice.org/c/core/+/149051

The values returned by LibreOffice Writer are in twips, so convert that to inches or centimetres, depending on whether or not imperial measurement units are expected.

If the attributes are not available, fall back to the handling that was already used so far.

### Testing strategy:

Testing strategy:
* use a LibreOffice build that includes the changes from https://gerrit.libreoffice.org/c/core/+/149051
* start LibreOffice Writer
* trigger reporting the review cursor location by pressing NVDA+shift+numpadDelete
* verify that the current caret position is announced in centimetres or inches from the left and top edge of the page

### Known issues with pull request:

none

### Change log entries:

*Changes*
`When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)`


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.