### PR TITLE
User guide: clarify the usage of character level in the Punctuation/symbol pronunciation dialog

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2350,6 +2350,7 @@ You can filter the symbols by entering the symbol or a part of the symbol's repl
 
 - The Replacement field allows you to change the text that should be spoken in place of this symbol.
 - Using the Level field, you can adjust the lowest symbol level at which this symbol should be spoken.
+If you set the level on "character", the symbol will not be spoken regardless of the symbol level you are using, except when you navigate by character or when the character is spelt.
 - The Send actual symbol to synthesizer field specifies when the symbol itself (in contrast to its replacement) should be sent to the synthesizer.
 This is useful if the symbol causes the synthesizer to pause or change the inflection of the voice.
 For example, a comma causes the synthesizer to pause.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2350,7 +2350,7 @@ You can filter the symbols by entering the symbol or a part of the symbol's repl
 
 - The Replacement field allows you to change the text that should be spoken in place of this symbol.
 - Using the Level field, you can adjust the lowest symbol level at which this symbol should be spoken.
-If you set the level on "character", the symbol will not be spoken regardless of the symbol level you are using, except when you navigate by character or when the character is spelt.
+If you set the level on "character", the symbol will not be spoken regardless of the symbol level you are using, except when you navigate by character or when some text is spelt.
 - The Send actual symbol to synthesizer field specifies when the symbol itself (in contrast to its replacement) should be sent to the synthesizer.
 This is useful if the symbol causes the synthesizer to pause or change the inflection of the voice.
 For example, a comma causes the synthesizer to pause.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2349,8 +2349,11 @@ To change a symbol, first select it in the Symbols list.
 You can filter the symbols by entering the symbol or a part of the symbol's replacement into the Filter by edit box.
 
 - The Replacement field allows you to change the text that should be spoken in place of this symbol.
-- Using the Level field, you can adjust the lowest symbol level at which this symbol should be spoken.
-If you set the level on "character", the symbol will not be spoken regardless of the symbol level you are using, except when you navigate by character or when some text is spelt.
+- Using the Level field, you can adjust the lowest symbol level at which this symbol should be spoken (none, some, most or all).
+You can also set the level to character; in this case the symbol will not be spoken regardless of the symbol level in use, with the following two exceptions:
+ - When navigating character by character.
+ - When NVDA is spelling any text containing that symbol.
+ -
 - The Send actual symbol to synthesizer field specifies when the symbol itself (in contrast to its replacement) should be sent to the synthesizer.
 This is useful if the symbol causes the synthesizer to pause or change the inflection of the voice.
 For example, a comma causes the synthesizer to pause.


### PR DESCRIPTION
### Link to issue number:
Reported on NVDA mailing list in [this thread](https://nvda.groups.io/g/nvda/topic/a_question_regarding/97792914?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,97792914,previd%3D1679584239357744480,nextid%3D1677473392587535303&previd=1679584239357744480&nextid=1677473392587535303).

### Summary of the issue:
People are 
In Punctuation/symbol pronunciation dialogue, in the level field, there is an options named "character". People are wondering what this option does since it is not documented in the user guide.

### Description of user facing changes
Added a sentence in the doc to describe it.

### Description of development approach
N/A

### Testing strategy:
* Manual test: check the doc generated by appVeyor.
* Also inform on the mailing list so that people can confirm if the new sentence is understood.

### Known issues with pull request:
None
### Change log entries:
Doc only; not needed.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
