### PR TITLE
Improve typing and handling of updateCheck state

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -1,12 +1,17 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2021 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
+# Copyright (C) 2012-2023 NV Access Limited, Zahari Yurukov, Babbage B.V., Joseph Lee
 
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.
 """
-from typing import Dict, Optional, Tuple
+from typing import (
+	Any,
+	Dict,
+	Optional,
+	Tuple,
+)
 import garbageHandler
 import globalVars
 import config
@@ -68,12 +73,12 @@ except OSError:
 		log.debugWarning("Default download path for updates %s could not be created."%storeUpdatesDir)
 
 #: Persistent state information.
-#: @type: dict
-state = None
-_stateFileName = None
+state: Optional[Dict[str, Any]] = None
+_stateFilename: Optional[str] = None
 #: The single instance of L{AutoUpdateChecker} if automatic update checking is enabled,
 #: C{None} if it is disabled.
-autoChecker = None
+autoChecker: Optional["AutoUpdateChecker"] = None
+
 
 def getQualifiedDriverClassNameForStats(cls):
 	""" fetches the name from a given synthDriver or brailleDisplay class, and appends core for in-built code, the add-on name for code from an add-on, or external for code in the NVDA user profile.
@@ -250,6 +255,7 @@ class UpdateChecker(garbageHandler.TrackedObject):
 
 	def _bg(self):
 		try:
+			assert state is not None
 			info = checkForUpdate(self.AUTO)
 		except:
 			log.debugWarning("Error checking for update", exc_info=True)
@@ -805,9 +811,18 @@ def initialize():
 		}
 		_setStateToNone(state)
 
+	if state is None:
+		state = {
+			"lastCheck": 0,
+			"dontRemindVersion": None,
+		}
+
 	# check the pending version against the current version
 	# and make sure that pendingUpdateFile and pendingUpdateVersion are part of the state dictionary.
-	if "pendingUpdateVersion" not in state or state["pendingUpdateVersion"] == versionInfo.version:
+	if (
+		"pendingUpdateVersion" not in state
+		or state["pendingUpdateVersion"] == versionInfo.version
+	):
 		_setStateToNone(state)
 	# remove all update files except the one that is currently pending (if any)
 	try:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -804,18 +804,15 @@ def initialize():
 			state = pickle.load(f)
 	except:
 		log.debugWarning("Couldn't retrieve update state", exc_info=True)
+		state = None
+
+	if state is None:
 		# Defaults.
 		state = {
 			"lastCheck": 0,
 			"dontRemindVersion": None,
 		}
 		_setStateToNone(state)
-
-	if state is None:
-		state = {
-			"lastCheck": 0,
-			"dontRemindVersion": None,
-		}
 
 	# check the pending version against the current version
 	# and make sure that pendingUpdateFile and pendingUpdateVersion are part of the state dictionary.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
Reported privately

### Summary of the issue:

If the updateCheckState pickle is set to "None", the state fails to load correctly.
This can cause a crash.
It is uncertain as to the cause of the pickle being set to None, but it is assumed to do with exiting NVDA during initialization.

```py
initializing updateCheck
CRITICAL - __main__ (08:40:58.427) - MainThread (8816):
core failure
Traceback (most recent call last):
  File "nvda.pyw", line 427, in <module>
  File "core.pyc", line 737, in main
  File "updateCheck.pyc", line 810, in initialize
TypeError: argument of type 'NoneType' is not iterable
```

https://github.com/nvaccess/nvda/blob/af0e9987234f078575c1583364b217e9d3510c0d/source/updateCheck.py#L792-L813

### Description of user facing changes
Should fix rare crash where updateCheck.pickle is written to with invalid state information (unknown cause).

### Description of development approach
Add typing, handle the case where `pickle.load` loads None for the state.

### Testing strategy:

1. Set `%appdata%/nvda/updateCheckState.pickle` to "N." which loads as "None"
1. Test if NVDA crashes on start up

### Known issues with pull request:
None

### Change log entries:
Not needed, rare bug

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
