### PR TITLE
Revert "Settings Ring: Lazily load available setting values the first time they're needed"

### DIFF
--- a/source/synthSettingsRing.py
+++ b/source/synthSettingsRing.py
@@ -37,12 +37,10 @@ class SynthSetting(baseObject.AutoPropertyObject):
 	def _get_reportValue(self):
 		return self._getReportValue(self.value)
 
-
 class StringSynthSetting(SynthSetting):
-
-	def _get__values(self):
-		self._values = list(getattr(self.synth, f"available{self.setting.id.capitalize()}s").values())
-		return self._values
+	def __init__(self,synth,setting):
+		self._values=list(getattr(synth,"available%ss"%setting.id.capitalize()).values())
+		super(StringSynthSetting,self).__init__(synth,setting,0,len(self._values)-1)
 
 	def _get_value(self):
 		curID=getattr(self.synth,self.setting.id)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -47,7 +47,6 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 - Added the ``bdDetect.scanForDevices`` extension point.
 Handlers can be registered that yield ``BrailleDisplayDriver/DeviceMatch`` pairs that don't fit in existing categories, like USB or Bluetooth. (#14531)
 - Added extension point: ``synthDriverHandler.synthChanged``. (#14618)
-- The NVDA Synth Settings Ring now caches available setting values the first time they're needed, rather than when loading the synthesizer. (#14704)
 -
 
 === Deprecations ===


### PR DESCRIPTION
When implementing #14704, I overlooked that initialising a StringSynthSetting actually requires the values to be known at initialisation time because the number of values is saved on the instance. So, a lazy init this way is simply not possible or we have to change things dramatically. Let's revert this to how it was before.

Reverts nvaccess/nvda#14704
fixes #14741 