### PR TITLE
Fixup of #14704: Settings ring setting should have max value

### DIFF
--- a/source/synthSettingsRing.py
+++ b/source/synthSettingsRing.py
@@ -44,11 +44,18 @@ class StringSynthSetting(SynthSetting):
 		self._values = list(getattr(self.synth, f"available{self.setting.id.capitalize()}s").values())
 		return self._values
 
+	def _get_max(self):
+		return len(self._values) - 1
+
+	def _set_max(self, value):
+		# Max is set by L{SynthSetting} but should always be a calculated property.
+		pass
+
 	def _get_value(self):
 		curID=getattr(self.synth,self.setting.id)
 		for e,v in enumerate(self._values):
 			if curID==v.id:
-				return e 
+				return e
 
 	def _set_value(self,value):
 		"""Overridden to use code that supports updating speech dicts when changing voice"""
@@ -62,6 +69,7 @@ class StringSynthSetting(SynthSetting):
 
 	def _getReportValue(self, val):
 		return self._values[val].displayName
+
 
 class BooleanSynthSetting(SynthSetting):
 
@@ -100,7 +108,7 @@ class SynthSettingsRing(baseObject.AutoPropertyObject):
 		return self.settings[self._current].reportValue
 
 	def _set_currentSettingValue(self,value):
-		if self._current is not None: 
+		if self._current is not None:
 			self.settings[_current].value = val
 
 	def next(self):
@@ -118,7 +126,7 @@ class SynthSettingsRing(baseObject.AutoPropertyObject):
 
 	def increase(self):
 		""" increases the currentSetting and returns its new value """
-		if self._current is not None: 
+		if self._current is not None:
 			return self.settings[self._current].increase()
 		return None
 


### PR DESCRIPTION
### Link to issue number:
Fixes #14741 

### Summary of the issue:
In #14704, we introduced lazy loading of some settings ring settings. However, this resulted in error sounds being played when moving in the list of OneCore voices.

### Description of user facing changes
Fix of the regression.

### Description of development approach
The max value of a synth setting is based on the number of available settings. This is now dynamically fetched.

### Testing strategy:
Tested the steps to reproduce of #14741. It could no longer be reproduced.

### Known issues with pull request:
None

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
