### PR TITLE
Windows 10/11 Calculator: use UIA find descendants when fetching results while handling UIA notification event

### DIFF
--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2022 NV Access Limited, Joseph Lee
+# Copyright (C) 2020-2023 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/calculator.py
+++ b/source/appModules/calculator.py
@@ -86,7 +86,6 @@ class AppModule(appModuleHandler.AppModule):
 		# The event handler copy is used to handle the overall notification announcement later.
 		doNotAnnounceCalculatorResults = self._noCalculatorResultsGesturePressed
 		self._noCalculatorResultsGesturePressed = False
-		calculatorVersion = int(self.productVersion.split(".")[0])
 		# #12268: for "DisplayUpdated", announce display strings in braille  no matter what they are.
 		# There are other activity Id's such as "MemorySlotAdded" and "MemoryCleared"
 		# but they do not involve number entry.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,6 +40,7 @@ This only worked for Bluetooth Serial ports before. (#14524)
 - You can now use browse mode in Chromium Embedded Controls where it was not possible previously. (#13493, #8553)
 - For symbols which do not have a symbol description in the current locale, the default English symbol level will be used. (#14558, #14417)
 - In newer releases of Windows 11 Notepad, NVDA can once again announce status bar contents. (#14573)
+- In Windows 10 and 11 Calculator, a portable copy of NVDA will no longer do nothing or play error tones when entering expressions in standard calculator in compact overlay mode. (#14679)
 -
 
 


### PR DESCRIPTION

### Link to issue number:
Closes #14679 

### Summary of the issue:
Portable NVDA does not announce results when Windows 10/11 Calculator is in compact overlay mode.

### Description of user facing changes
Portable copy of NVDA will announce calculator expressions and results when Windows Calculator is in compact overlay mode (Alt+up arrow from standard calculator mode).

### Description of development approach
Instead of using tree traversal, use UIA find descendants approach (employed in File Explorer) to obtain results element when Calculator is in normal and compact overlay mode. This also removes the need to check Calculator version as Windows 11 Calculator has made its way to Windows 10.

### Testing strategy:
Manual testing:

1. After creating a portable copy of this PR or alpha builds with this PR applied, open Windows 10/11 Calculator.
2. Press Alt+H, then select standard calculator.
3. From standard calculator, enter some expressions. NVDA will announce expressions.
4. Press Alt+up arrow to switch to compact overlay mode, then type expressions.

Prior to this PR: portable NVDA would not announce anything or play error tones.

Expected: Portable NVDA will announce expressions and results when Calculator is in compact overlay mode.

The code was also tested with Windows App Essentials add-on.

### Known issues with pull request:
If COM error occurs, UIA notification event handler will simply exit, but no issues so far.

### Change log entries:
Bug fixes:

In Windows 10 and 11 Calculator, portable copy of NVDA will no longer do nothing or play error tones when entering expressions in standard calculator in compact overlay mode. (#14679)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
