### PR TITLE
Made two messages translatable.

### DIFF
--- a/source/documentNavigation/paragraphHelper.py
+++ b/source/documentNavigation/paragraphHelper.py
@@ -129,10 +129,10 @@ def speakSingleLineBreakParagraph(ti: textInfos.TextInfo) -> None:
 def _notFoundMessage(nextParagraph: bool):
 	if nextParagraph:
 		# Translators: this message is given when there is no next paragraph when navigating by paragraph
-		ui.message("No next paragraph")
+		ui.message(_("No next paragraph"))
 	else:
 		# Translators: this message is given when there is no previous paragraph when navigating by paragraph
-		ui.message("No previous paragraph")
+		ui.message(_("No previous paragraph"))
 
 
 def _moveTextInfoToSingleLineBreakParagraph(nextParagraph: bool, ti: textInfos.TextInfo) -> bool:


### PR DESCRIPTION

### Link to issue number:
Reported on the translator's mailing list in [this thread](https://groups.io/g/nvda-translations/topic/next_and_previous_paragraph/97877959?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,97877959,previd%3D1679908281732285910,nextid%3D1640151634246428332&previd=1679908281732285910&nextid=1640151634246428332).
### Summary of the issue:
PR #13798 introduced paragraph navigation in documents. Unfortunately two message added by this PR are not translatable: "No next/previous paragraph" since the gettext (_) function call has been forgotten; the translators comments are already there though.

### Description of user facing changes
The message will be translatable
### Description of development approach
Just added the call  to the gettext function (_).

### Testing strategy:
Manual:
Generate a .pot, merge to .po in French, translate it and use it with the feature.
### Known issues with pull request:
While at it, I have searched for other occurrences of `ui.message` called with untranslated content. In `NVDAObjects/IAccessible/winword.py`, in the script `script_reportCurrentHeaders`, I have found:
`ui.message("Row %s, column %s"%(rowText or "empty",columnText or "empty"))`

I have not fixed this as this script is a half buggy, half debug and undocumented  script (see #11465 for details).

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

Cc @rob-aph