### PR TITLE
IA2TextTextInfo: Fix handling of embedded objects when expanding to mouse chunk.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,6 +40,7 @@ This only worked for Bluetooth Serial ports before. (#14524)
 - You can now use browse mode in Chromium Embedded Controls where it was not possible previously. (#13493, #8553)
 - For symbols which do not have a symbol description in the current locale, the default English symbol level will be used. (#14558, #14417)
 - In newer releases of Windows 11 Notepad, NVDA can once again announce status bar contents. (#14573)
+- In Mozilla Firefox, moving the mouse over text after a link now reliably reports the text. (#9235)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #9235.

### Summary of the issue:
In Firefox, when there is text before and after a link, mousing over the text after the link often doesn't read the text. This applies to other types of inline elements as well; e.g. buttons.

### Description of user facing changes
In Mozilla Firefox, moving the mouse over text after a link, etc. now reliably reports the text.

### Description of development approach
When handling unit_mouseChunk, the code in IA2TextTextInfo.expand first expands to the user configured resolution (line, paragraph, etc.). It then attempts to shrink the range so that it only covers the text between embedded objects before and after the origin, if any.

The code previously calculated the final end offset incorrectly. It used `oldEnd - self._startOffset` as the offset from which to search for an embedded object after the origin. However, self._startOffset had already been moved to the embedded object before the origin, so it was no longer related to the text string. This meant that the search offset was completely bogus and could even result in `_endOffset` being smaller than `_startOffset`.

Now, we use the same offset for both embedded object searches: our origin relative to the start of the expanded range of text. I've also added comments.

### Testing strategy:
Opened this test case in Firefox:
`data:text/html,a b c <button>d</button> e f g<br>h`
Moused over a, d and h.
Before this change, NVDA reported "a b c", "d" and "h", but would not report "e f g".
Now, it does.

Opened this page in Firefox: https://github.blog/2023-03-09-how-github-accelerates-development-for-embedded-systems/
1. NVDA+control+f, enter: We know that DevOps
2. Route the mouse to the text. NVDA reports correctly both before and after this change.
3. Press k to move to the "ISO 26262" link.
4. Use the cursor keys to move right out of the link.
5. Route the mouse. NVDA reports nothing before this change, but correctly reports "for automotive," with this change.
6. Press k to move to the "IEC 62304" link.
7. Use the cursor keys to move right out of the link.
8. Route the mouse. NVDA reports nothing before this change, but correctly reports "for medical devices," etc. with this change.

### Known issues with pull request:
None.

### Change log entries:
Bug fixes
In Mozilla Firefox, moving the mouse over text after a link, etc. now reliably reports the text.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
