### PR TITLE
PR template: indicate when PR state need to be set to 'Ready'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
 
-Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
+Please initially open PRs as a draft; When you would like a review, mark the PR as "ready for review". See https://github.com/nvaccess/nvda/wiki/Contributing
 -->
 
 ### Link to issue number:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,9 @@
 https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
 Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 
 
-Please initially open PRs as a draft; When you would like a review, mark the PR as "ready for review". See https://github.com/nvaccess/nvda/wiki/Contributing
+Please initially open PRs as a draft.
+When you would like a review, mark the PR as "ready for review". 
+See https://github.com/nvaccess/nvda/wiki/Contributing.
 -->
 
 ### Link to issue number:


### PR DESCRIPTION

### Link to issue number:
See https://github.com/nvaccess/nvda/pull/14610#issuecomment-1443874858, 
### Summary of the issue:
Sometimes, people open PRs as a draft as required but do not seem to know that they need to transition it to "Ready for review" so that someone at NVAccess look at it.

In the PR template we can read:
> Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing

But nothing on when it should be set "Ready for review".

### Description of user facing changes
See modified file.
### Description of development approach
Updated the PR template.
### Testing strategy:
* Copy the .md in GitHub's comment area and previsualize it to check that the md syntax is correct, i.e. the modified text does not appear since it is in a comment tag.
* Check when merged.
### Known issues with pull request:
None
### Change log entries:
None
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
