### PR TITLE
appModules/explorer: announce tab switches in Windows 11 2022 Update (22H2)

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -16,6 +16,7 @@ import winUser
 import winVersion
 import api
 import speech
+import braille
 import eventHandler
 import mouseHandler
 from NVDAObjects.IAccessible import IAccessible, List
@@ -551,4 +552,24 @@ class AppModule(appModuleHandler.AppModule):
 			if inputPanelWindow and inputPanelWindow.appModule.appName in inputPanelAppName:
 				eventHandler.executeEvent("UIA_window_windowOpen", inputPanelWindow)
 				return
+		nextHandler()
+
+	def event_UIA_elementSelected(self, obj: NVDAObject, nextHandler: Callable[[], None]):
+		# #14388: announce File Explorer tab switches (Windows 11 22H2 and later).
+		if (
+			obj.role == controlTypes.Role.TAB
+			and controlTypes.State.SELECTED in obj.states
+			and obj.parent.UIAAutomationId == "TabListView"
+			# this is done because 2 selection events are sent for the same object, so to prevent double speaking.
+			and not eventHandler.isPendingEvents(eventName="UIA_elementSelected")
+		):
+			speech.speakObject(obj, reason=controlTypes.OutputReason.FOCUS)
+			braille.handler.message(
+				braille.getPropertiesBraille(
+					name=obj.name,
+					role=obj.role,
+					states=obj.states,
+					positionInfo=obj.positionInfo
+				)
+			)
 		nextHandler()

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -10,6 +10,7 @@ Provides workarounds for controls such as identifying Start button, notification
 
 from comtypes import COMError
 import time
+from typing import Callable
 import appModuleHandler
 import controlTypes
 import winUser
@@ -19,6 +20,7 @@ import speech
 import braille
 import eventHandler
 import mouseHandler
+from NVDAObjects import NVDAObject
 from NVDAObjects.IAccessible import IAccessible, List
 from NVDAObjects.UIA import UIA
 from NVDAObjects.behaviors import ToolTip

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,9 +43,9 @@ This only worked for Bluetooth Serial ports before. (#14524)
 - In Mozilla Firefox and Google Chrome, typed characters are no longer reported in some text boxes even when speak typed characters is disabled. (#14666)
 - You can now use browse mode in Chromium Embedded Controls where it was not possible previously. (#13493, #8553)
 - For symbols which do not have a symbol description in the current locale, the default English symbol level will be used. (#14558, #14417)
-- Fixes for Windows 11 Notepad:
-  - NVDA can once again announce status bar contents. (#14573)
-  - Switching between tabs will announce the new tab name and position. (#14587)
+- Fixes for Windows 11:
+  - NVDA can once again announce Notepad status bar contents. (#14573)
+  - Switching between tabs will announce the new tab name and position for Notepad and File Explorer. (#14587, #14388)
   -
 - In Mozilla Firefox, moving the mouse over text after a link now reliably reports the text. (#9235)
 - In Windows 10 and 11 Calculator, a portable copy of NVDA will no longer do nothing or play error tones when entering expressions in standard calculator in compact overlay mode. (#14679)


### PR DESCRIPTION
### Link to issue number:
Closes #14388 

### Summary of the issue:
Later revisions of Windows 11 22H2 (2022 Update) introduced tabbed File Explorer. At the moment NVDA does not announce tab names when switching to different tabs.

### Description of user facing changes
NVDA will announce the name of the tab being switched to in Windows 11 2022 Update File Explorer.

### Description of development approach
Similar to tabbed Notepad (#14588), use UIA element selected event handler to announce tab names. Unlike Notepad, speech should not be cut off to let NVDA announce focused item when File Explorer opens.

### Testing strategy:
Manual testing (prerequisites: Windows 11 22H2 build 22621.675 and later): open File Explorer, press Control+T to open a new tab, press Control+Tab and Control+Shift+Tab to switch tabs, press Control+W to close tabs.

### Known issues with pull request:
None

### Change log entries:
Similar wording as Notepad 11 tab switching announcement but also adding File Explorer in Windows 11 2022 Update to it.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
