### PR TITLE
Addon store: Handle lost selection when filtering

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -864,6 +864,10 @@ def _terminate(module, name=None):
 		log.exception("Error terminating %s" % name)
 
 
+def isMainThread() -> bool:
+	return threading.get_ident() == mainThreadId
+
+
 def requestPump(immediate: bool = False):
 	"""Request a core pump.
 	This will perform any queued activity.

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -208,13 +208,17 @@ class AddonListVM:
 		# ensure calling on the main thread.
 		core.callLater(delay=0, callable=self.updated.notify)
 
-	def getAddonAttrText(self, index: int, attrName: str) -> str:
+	def getAddonAttrText(self, index: int, attrName: str) -> Optional[str]:
 		""" Get the text for an item's attribute.
 		@param index: The index of the item in _addonsFilteredOrdered
 		@param attrName: The exposed attribute for the addon. See L{AddonList.presentedAttributes}
 		@return: The text for the addon attribute
 		"""
-		addonId = self._addonsFilteredOrdered[index]
+		try:
+			addonId = self._addonsFilteredOrdered[index]
+		except IndexError:
+			# Failed to get addonId, index may have been lost in refresh.
+			return None
 		listItemVM = self._addons[addonId]
 		return self._getAddonAttrText(listItemVM, attrName)
 
@@ -234,7 +238,13 @@ class AddonListVM:
 
 	def setSelection(self, index: Optional[int]) -> Optional[AddonListItemVM]:
 		self._validate(selectionIndex=index)
-		self.selectedAddonId = self._addonsFilteredOrdered[index] if index is not None else None
+		self.selectedAddonId = None
+		if index is not None:
+			try:
+				self.selectedAddonId = self._addonsFilteredOrdered[index]
+			except IndexError:
+				# Failed to get addonId, index may have been lost in refresh.
+				pass
 		selectedItemVM: Optional[AddonListItemVM] = self.getSelection()
 		log.debug(f"selected Item: {selectedItemVM}")
 		# ensure calling on the main thread.

--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -152,6 +152,9 @@ class AddonVirtualList(
 			itemIndex,
 			AddonListVM.presentedAttributes[colIndex]
 		)
+		if dataItem is None:
+			# Failed to get dataItem, index may have been lost in refresh.
+			return ''
 		return str(dataItem)
 
 	def OnColClick(self, evt: wx.ListEvent):

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -1,0 +1,20 @@
+
+## Searching add-ons
+
+### Filtering by add-on information
+
+Add-ons can be filtered by display name, publisher and description.
+
+1. Open the add-on store
+1. Jump to the filter-by field (`alt+f`)
+1. Search for a string, for example part of a publisher name, display name or description.
+1. Ensure expected add-ons appear after the filter view refreshes.
+1. Remove the filter-by string
+1. Ensure the list of add-ons refreshes to all add-ons, unfiltered.
+
+### Filtering where no add-ons are found
+
+1. Open the add-on store
+1. Jump to the filter-by field (`alt+f`)
+1. Search for a string which yields no add-ons.
+1. Ensure the add-on information dialog  states "no add-on selected".


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
When an add-on is selected in the add-on store, information is displayed.
An index is kept to show the current selection, even when filtering add-ons.
When filtering add-ons, add-ons may disappear from the list, meaning an add-on at that index can no longer be selected.
This causes an error to be logged when the current selected index is no longer available after filtering add-ons

### Description of user facing changes

No errors being spammed to console, no lag when filtering add-ons while an add-on is currently selected.

### Description of development approach
Handle the case where the current selected index is lost

### Testing strategy:
Test filtering add-ons, refer to PR diff for steps

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
