### PR TITLE
Add support of getting link destination of graphic links

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3671,6 +3671,16 @@ class GlobalCommands(ScriptableObject):
 		obj: NVDAObject = ti.NVDAObjectAtStart
 		presses = scriptHandler.getLastScriptRepeatCount()
 		if (
+			obj.role == controlTypes.role.Role.GRAPHIC
+			and (
+				obj.parent
+				and obj.parent.role == controlTypes.role.Role.LINK
+			)
+		):
+			# In Firefox, graphics with a parent link also expose the parents link href value.
+			# In Chromium, the link href value must be fetched from the parent object. (#14779)
+			obj = obj.parent
+		if (
 			obj.role == controlTypes.role.Role.LINK  # If it's a link, or
 			or controlTypes.state.State.LINKED in obj.states  # if it isn't a link but contains one
 		):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -55,6 +55,7 @@ This only worked for Bluetooth Serial ports before. (#14524)
 Instead NVDA reports that the link has no destination. (#14723)
 - Several stability fixes to input/output for braille displays, resulting in less frequent errors and crashes of NVDA. (#14627)
 - NVDA again recovers from many more situations such as applications that stop responding which previously caused it to freeze completely. (#14759) 
+- The destination of graphic links are now correctly reported in Chrome and Edge. (#14779)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Closes #14779
### Summary of the issue:
destination of graphic links are not reported in chrome/edge
### Description of user facing changes
Destination of graphic links now should be reported in chrome/edge browsers
### Description of development approach
NVDA lands its focus to graphic elemeng "img" which does not have href value, but an element which is parent of that element is link.
So one more check was introduced to ensure han if we are focusing a graphic element and its parent is a link, we are now replacing an object by its parent object
### Testing strategy:
Opened a webpage with graphic links and ensured that their addresses are correctly reported
### Known issues with pull request:
None
### Change log entries:
New features
Changes
Bug fixes
Destination of graphic links are now corectly reported in chrome and edge browsers
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
