### PR TITLE
Updated the doc for the scratchpad option

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2137,8 +2137,8 @@ This may also be the case if you are unsure if the settings have been changed.
 
 ==== Enable loading custom code from Developer Scratchpad Directory ====[AdvancedSettingsEnableScratchpad]
 When developing add-ons for NVDA, it is useful to be able to test code as you are writing it.
-This option when enabled, allows NVDA to load custom appModules, globalPlugins, brailleDisplayDrivers and synthDrivers, from a special developer scratchpad directory in your NVDA user configuration directory.
-Previously NVDA would load custom code directly from the user configuration directory, with no way of disabling this.
+This option when enabled, allows NVDA to load custom appModules, globalPlugins, brailleDisplayDrivers, synthDrivers and vision enhancement providers, from a special developer scratchpad directory in your NVDA user configuration directory.
+As their equivalents in add-ons, these modules are loaded when starting NVDA or, in the case of appModules and globalPlugins, when [reloading plugins #ReloadPlugins].
 This option is off by default, ensuring that no untested code is ever run in NVDA with out the user's explicit knowledge.
 If you wish to distribute custom code to others, you should package it as an NVDA add-on.
 


### PR DESCRIPTION
### Link to issue number:
Closes #14773

### Summary of the issue:
In #14773, the user wanted to document when the code is loaded from the scratchpad directory.

### Description of user facing changes
As discussed in the issue, it is hard to add more details in the GUI. Thus, the User Guide's paragraph describing this option has been updated. Not that it is easily reachable from the GUI thanks to context help.

The following updates have been made:
* Added a sentence to indicate when all the modules from the scratchpad are loaded
* Added visual enhancement providers to the list of the modules that can be loaded from the scratchpad.
* Removed the sentence comparing the current situation with older versions of NVDA when the scratchpad did not exist and test modules were directly loaded from appModule, globalPlugins, etc. subfolders. Indeed, the scratchpad has been introduced in NVDA 2019.1, which is now quite old.

### Description of development approach
N/A

### Testing strategy:
Generated the documentation and checked it; also checked the link.
### Known issues with pull request:
None
### Change log entries:
Not needed.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
