### PR TITLE
Add-on store: bypass the compatibility checks for an add-on

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ comtypes==1.1.11
 pyserial==3.5
 wxPython==4.1.1
 git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
-requests==2.28.1
+requests==2.28.2
 
 #NVDA_DMP requires diff-match-patch
 diff_match_patch_python==1.0.2

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -525,7 +525,10 @@ class Addon(AddonBase):
 		log.debug("Addon %s added to %s package path", self.manifest['name'], package.__name__)
 
 	def enable(self, shouldEnable: bool) -> None:
-		"""Sets this add-on to be disabled or enabled when NVDA restarts."""
+		"""
+		Sets this add-on to be disabled or enabled when NVDA restarts.
+		@raises: AddonError on failure.
+		"""
 		if shouldEnable:
 			if not (
 				isAddonCompatible(self)

--- a/source/addonHandler/types.py
+++ b/source/addonHandler/types.py
@@ -1,0 +1,15 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2023 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from typing import (
+	Generator,
+	TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+	from . import Addon  # noqa: F401
+
+
+AddonGeneratorT = Generator["Addon", None, None]

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -22,7 +22,6 @@ import addonAPIVersion
 import typing
 from typing import (
 	Optional,
-	List,
 	Dict,
 	Callable,
 	Tuple,
@@ -32,6 +31,7 @@ from .models import (
 	_createAddonModelFromData,
 	_createModelFromData,
 	AddonDetailsModel,
+	_AddonDetailsCollectionT,
 )
 
 addonDataManager: Optional["_DataManager"] = None
@@ -60,7 +60,7 @@ def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
 
 @dataclasses.dataclass
 class CachedAddonsModel:
-	availableAddons: List[AddonDetailsModel]
+	availableAddons: _AddonDetailsCollectionT
 	cachedAt: datetime
 	nvdaAPIVersion: addonAPIVersion.AddonApiVersionT
 
@@ -233,7 +233,7 @@ class _DataManager:
 			nvdaAPIVersion=cacheData["nvdaAPIVersion"],
 		)
 
-	def getLatestAvailableAddons(self) -> List[AddonDetailsModel]:
+	def getLatestAvailableAddons(self) -> _AddonDetailsCollectionT:
 		shouldRefreshData = (
 			not self._availableAddonCache
 			or self._availableAddonCache.nvdaAPIVersion != addonAPIVersion.CURRENT

--- a/source/gui/addonStoreGui/dialogs.py
+++ b/source/gui/addonStoreGui/dialogs.py
@@ -1,0 +1,121 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2023 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from typing import (
+	TYPE_CHECKING,
+)
+
+import wx
+
+import addonAPIVersion
+from addonStore.models import AddonDetailsModel
+from gui.addonGui import ErrorAddonInstallDialog
+from gui.message import messageBox
+
+if TYPE_CHECKING:
+	from guiHelper import ButtonHelper
+
+
+class ErrorAddonInstallDialogWithCancelButton(ErrorAddonInstallDialog):
+	def _addButtons(self, buttonHelper: "ButtonHelper") -> None:
+		super()._addButtons(buttonHelper)
+		cancelButton = buttonHelper.addButton(
+			self,
+			id=wx.ID_CANCEL,
+			# Translators: A button in the addon installation blocked dialog which will dismiss the dialog.
+			label=_("Cancel")
+		)
+		cancelButton.SetDefault()
+		cancelButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.CANCEL))
+
+
+def _shouldProceedWhenInstalledAddonVersionUnknown(
+		parent: wx.Window,
+		addon: AddonDetailsModel
+) -> bool:
+	incompatibleMessage = _(
+		# Translators: The message displayed when installing an incompatible add-on package,
+		# because it requires a new version than is currently installed.
+		"Warning: add-on installation may result in downgrade: {name}. "
+		"The installed add-on version cannot be compared with the add-on store version. "
+		"Installed version: {oldVersion}. "
+		"Available version: {version}. "
+		"Proceed with installation anyway? "
+		).format(
+	name=addon.displayName,
+	version=addon.addonVersionName,
+	oldVersion=addon._addonHandlerModel.version,
+	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
+	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
+	)
+	return ErrorAddonInstallDialogWithCancelButton(
+		parent=parent,
+		# Translators: The title of a dialog presented when an error occurs.
+		title=_("Add-on not compatible"),
+		message=incompatibleMessage,
+		showAddonInfoFunction=lambda: _showAddonInfo(addon)
+	).ShowModal() == wx.OK
+
+
+def _shouldProceedWhenAddonTooOldDialog(
+		parent: wx.Window,
+		addon: AddonDetailsModel
+) -> bool:
+	incompatibleMessage = _(
+		# Translators: The message displayed when installing an incompatible add-on package,
+		# because it requires a new version than is currently installed.
+		"Warning: add-on is incompatible: {name} {version}. "
+		"Check for an updated version of this add-on if possible. "
+		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "
+		"your current NVDA version is {NVDAVersion}. "
+		"Installation may cause unstable behavior in NVDA. "
+		"Proceed with installation anyway? "
+		).format(
+	name=addon.displayName,
+	version=addon.addonVersionName,
+	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
+	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
+	)
+	return ErrorAddonInstallDialogWithCancelButton(
+		parent=parent,
+		# Translators: The title of a dialog presented when an error occurs.
+		title=_("Add-on not compatible"),
+		message=incompatibleMessage,
+		showAddonInfoFunction=lambda: _showAddonInfo(addon)
+	).ShowModal() == wx.OK
+
+
+def _showAddonInfo(addon: AddonDetailsModel) -> None:
+	message = [
+		_(
+			# Translators: message shown in the Addon Information dialog.
+			"{summary} ({name})\n"
+			"Version: {version}\n"
+			"Publisher: {publisher}\n"
+			"Description: {description}\n"
+			).format(
+		summary=addon.displayName,
+		name=addon.addonId,
+		version=addon.addonVersionName,
+		publisher=addon.publisher,
+		description=addon.description,
+		)
+	]
+	if addon.homepage:
+		# Translators: the url part of the About Add-on information
+		message.append(_("Homepage: {url}").format(url=addon.homepage))
+	minimumNVDAVersion = addonAPIVersion.formatForGUI(addon.minimumNVDAVersion)
+	message.append(
+		# Translators: the minimum NVDA version part of the About Add-on information
+		_("Minimum required NVDA version: {}").format(minimumNVDAVersion)
+	)
+	lastTestedNVDAVersion = addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion)
+	message.append(
+		# Translators: the last NVDA version tested part of the About Add-on information
+		_("Last NVDA version tested: {}").format(lastTestedNVDAVersion)
+	)
+	# Translators: title for the Addon Information dialog
+	title = _("Add-on Information")
+	messageBox("\n".join(message), title, wx.OK)

--- a/source/gui/addonStoreGui/dialogs.py
+++ b/source/gui/addonStoreGui/dialogs.py
@@ -15,6 +15,7 @@ from gui.addonGui import ErrorAddonInstallDialog
 from gui.message import messageBox
 
 if TYPE_CHECKING:
+	from addonHandler import SupportsVersionCheck
 	from guiHelper import ButtonHelper
 
 
@@ -57,6 +58,22 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
 	).ShowModal() == wx.OK
+
+
+def _shouldProceedAddonRemove(
+		addon: "SupportsVersionCheck"
+) -> bool:
+	return messageBox(
+		(_(
+			# Translators: Presented when attempting to remove the selected add-on.
+			# {addon} is replaced with the add-on name.
+			"Are you sure you wish to remove the {addon} add-on from NVDA? "
+			"This cannot be undone."
+		)).format(addon=addon.name),
+		# Translators: Title for message asking if the user really wishes to remove the selected Addon.
+		_("Remove Add-on"),
+		wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
+	) == wx.YES
 
 
 def _shouldProceedWhenAddonTooOldDialog(

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -798,15 +798,11 @@ def getAddonBundleToInstallIfValid(addonPath: str) -> addonHandler.AddonBundle:
 	return bundle
 
 
-def getPreviouslyInstalledAddonById(addonId: str) -> Optional[addonHandler.Addon]:
-	for addon in addonHandler.getAvailableAddons():
-		if (
-			not addon.isPendingRemove
-			# name is the primary identifier within add-on manifests.
-			and addonId.lower() == addon.manifest['name'].lower()
-		):
-			return addon
-	return None
+def getPreviouslyInstalledAddonById(addon: addonHandler.AddonBundle) -> Optional[addonHandler.Addon]:
+	installedAddon = addonHandler.AddonsState._addonHandlerCache.availableAddons.get(addon.name)
+	if installedAddon is None or installedAddon.isPendingRemove:
+		return None
+	return installedAddon
 
 
 def installAddon(addonPath: PathLike) -> None:
@@ -818,7 +814,7 @@ def installAddon(addonPath: PathLike) -> None:
 	"""
 	addonPath = typing.cast(str, addonPath)
 	bundle = getAddonBundleToInstallIfValid(addonPath)
-	prevAddon = getPreviouslyInstalledAddonById(addonId=bundle.name)
+	prevAddon = getPreviouslyInstalledAddonById(bundle)
 
 	try:
 		if prevAddon:

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -799,7 +799,7 @@ def getAddonBundleToInstallIfValid(addonPath: str) -> addonHandler.AddonBundle:
 
 
 def getPreviouslyInstalledAddonById(addon: addonHandler.AddonBundle) -> Optional[addonHandler.Addon]:
-	installedAddon = addonHandler.AddonsState._addonHandlerCache.availableAddons.get(addon.name)
+	installedAddon = addonHandler.state._addonHandlerCache.availableAddons.get(addon.name)
 	if installedAddon is None or installedAddon.isPendingRemove:
 		return None
 	return installedAddon

--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -15,6 +15,10 @@ import wx
 import wx.lib.newevent
 from wx.lib.expando import ExpandoTextCtrl
 
+from addonHandler import (
+	state as addonHandlerState,
+	AddonStateCategory,
+)
 import gui
 import winVersion
 from gui import (
@@ -641,6 +645,13 @@ class AddonStoreDialog(SettingsDialog):
 				installationPromptTitle
 			)
 			self._storeVM.installPending()
+			addonGui.promptUserForRestart()
+		
+		if (
+			addonHandlerState[AddonStateCategory.PENDING_DISABLE]
+			or addonHandlerState[AddonStateCategory.PENDING_ENABLE]
+			or addonHandlerState[AddonStateCategory.PENDING_REMOVE]
+		):
 			addonGui.promptUserForRestart()
 
 		# let the dialog exit.

--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -1,7 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 import functools
 from typing import (
 	List,
@@ -82,7 +83,7 @@ class AddonVirtualList(
 		self._addonsListVM = addonsListVM
 		self._actionVMList = actionVMList
 		self._contextMenu = wx.Menu()
-		self._actionMenuItemMap = {}
+		self._actionMenuItemMap: Dict[AddonActionVM, wx.MenuItem] = {}
 		self.Bind(event=wx.EVT_CONTEXT_MENU, handler=self._popupContextMenu)
 		for action in self._actionVMList:
 			menuItem: wx.MenuItem = self._contextMenu.Append(id=-1, item=action.displayName)
@@ -250,6 +251,14 @@ class AddonDetails(
 	# In the add-on store dialog.
 	_descriptionLabelText: str = pgettext("addonStore", "Description:")
 
+	# Translators: Label for the text control containing a description of the selected add-on.
+	# In the add-on store dialog.
+	_statusLabelText: str = pgettext("addonStore", "Status:")
+
+	# Translators: Label for the text control containing a description of the selected add-on.
+	# In the add-on store dialog.
+	_actionsLabelText: str = pgettext("addonStore", "Actions:")
+
 	def __init__(self, parent, actionVMList: List[AddonActionVM], detailsVM: AddonDetailsVM):
 		self._detailsVM: AddonDetailsVM = detailsVM
 		self._actionVMList = actionVMList
@@ -308,6 +317,18 @@ class AddonDetails(
 			)
 		)
 		self.contents.Add(self.descriptionTextCtrl, flag=wx.EXPAND)
+		self.contents.Add(wx.StaticLine(self), flag=wx.EXPAND)
+
+		self.statusLabel = wx.StaticText(
+			self,
+			label=AddonDetails._statusLabelText
+		)
+		self.contents.Add(self.statusLabel, flag=wx.EXPAND)
+		self.statusTextCtrl = ExpandoTextCtrl(
+			self,
+			style=wx.TE_READONLY | wx.BORDER_NONE
+		)
+		self.contents.Add(self.statusTextCtrl, flag=wx.EXPAND)
 		self.contents.Add(wx.StaticLine(self), flag=wx.EXPAND)
 
 		self._actionButtonMap: Dict[AddonActionVM, wx.Button] = {}
@@ -401,6 +422,7 @@ class AddonDetails(
 				log.debugWarning(f"URL queue len {len(self._urlQueue)}")
 				self.updateAddonName(details.displayName)
 				self.descriptionLabel.SetLabelText(AddonDetails._descriptionLabelText)
+				self.statusTextCtrl.SetValue(self._detailsVM.listItem.status.displayString)
 
 				# For a ExpandoTextCtr, SetDefaultStyle can not be used to set the style (along with the use
 				# of AppendText) because AppendText has been overridden to use SetValue(GetValue()+newStr)
@@ -492,8 +514,12 @@ class AddonDetails(
 			"""Get around python binding to the latest value in a for loop, create a new lambda
 			for each value with an explicit binding to the addon details.
 			"""
-			# evt: wx.CommandEvent
-			return lambda evt: _action.actionHandler(self._detailsVM.listItem)
+			def handleButtonClickEvent(event: wx.CommandEvent) -> None:
+				_action.actionHandler(self._detailsVM.listItem)
+				# set focus on status so that is easily read after firing an action
+				self.statusTextCtrl.SetFocus()
+
+			return handleButtonClickEvent
 
 		for action in self._actionVMList:
 			button = wx.Button(parent=self, label=action.displayName)
@@ -503,13 +529,14 @@ class AddonDetails(
 				event=wx.EVT_BUTTON,
 				handler=_makeButtonClickedEventHandler(action)
 			)
-			button.Enable(enable=action.isValid)
+			button.Show(show=action.isValid)
 			action.updated.register(self._actionVmChanged)
 			self._actionButtonMap[action] = button
 		return _actionsSizer
 
 	def _actionVmChanged(self, addonActionVM: AddonActionVM):
-		self._actionButtonMap[addonActionVM].Enable(enable=addonActionVM.isValid)
+		self._actionButtonMap[addonActionVM].Show(show=addonActionVM.isValid)
+		self.statusTextCtrl.SetValue(self._detailsVM.listItem.status.displayString)
 
 
 def displayError(error: TranslatedError):

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2011-2021 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
+# Copyright (C) 2011-2023 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
 # Bill Dengler, Joseph Lee, Takuya Nishimoto
 
 import os
@@ -168,14 +168,8 @@ class InstallerDialog(
 				# Translators: a message in the installer telling the user NVDA is now located in a different place.
 				msg+=" "+_("The installation path for NVDA has changed. it will now  be installed in {path}").format(path=installer.defaultInstallPath)
 		if shouldAskAboutAddons:
-			msg+=_(
-				# Translators: A message in the installer to let the user know that
-				# some addons are not compatible.
-				"\n\n"
-				"However, your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
-				"These add-ons will be disabled after installation. If you rely on these add-ons, "
-				"please review the list to decide whether to continue with the installation"
-			)
+			import updateCheck
+			msg += "\n\n" + updateCheck.getAddonCompatibilityMessage()
 
 		text = sHelper.addItem(wx.StaticText(self, label=msg))
 		text.Wrap(self.scaleSize(self.textWrapWidth))

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -48,6 +48,7 @@ import braille
 import gui
 from gui import guiHelper
 from addonHandler import getCodeAddon, AddonError, getIncompatibleAddons
+from addonHandler.addonVersionCheck import getAddonCompatibilityMessage  # noqa: E402
 from logHandler import log, isPathExternalToNVDA
 import config
 import shellapi
@@ -374,14 +375,7 @@ class UpdateResultDialog(
 				backCompatToAPIVersion=self.backCompatTo
 			))
 			if showAddonCompat:
-				message = message + _(
-					# Translators: A message indicating that some add-ons will be disabled
-					# unless reviewed before installation.
-					"\n\n"
-					"However, your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
-					"These add-ons will be disabled after installation. If you rely on these add-ons, "
-					"please review the list to decide whether to continue with the installation"
-				)
+				message += + "\n\n" + getAddonCompatibilityMessage()
 				confirmationCheckbox = sHelper.addItem(wx.CheckBox(
 					self,
 					# Translators: A message to confirm that the user understands that addons that have not been
@@ -497,14 +491,7 @@ class UpdateAskInstallDialog(
 			backCompatToAPIVersion=self.backCompatTo
 		))
 		if showAddonCompat:
-			message = message + _(
-				# Translators: A message indicating that some add-ons will be disabled
-				# unless reviewed before installation.
-				"\n"
-				"However, your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
-				"These add-ons will be disabled after installation. If you rely on these add-ons, "
-				"please review the list to decide whether to continue with the installation"
-			)
+			message += "\n" + getAddonCompatibilityMessage()
 		text = sHelper.addItem(wx.StaticText(self, label=message))
 		text.Wrap(self.scaleSize(500))
 

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -1,6 +1,14 @@
 
 ## Browsing add-ons
-TODO
+
+### Browse add-ons by category
+TODO:
+
+- installed
+- incompatible
+- updatable/replace-able
+- available
+- all?
 
 ### Filtering by add-on information
 
@@ -23,13 +31,16 @@ Add-ons can be filtered by display name, publisher and description.
 
 ## Installing add-ons
 
-### Install add-on
+### Install add-on from add-on store
 1. Open the add-on store.
 1. Select an add-on.
 1. Navigate to and press the install button for the add-on.
 1. Exit the dialog
 1. Restart NVDA as prompted.
 1. Confirm the add-on is listed in the add-ons manager.
+
+### Install add-on from external source in add-on store
+TODO
 
 ### Install and override incompatible add-on from add-on store
 1. Open the add-on store.
@@ -52,7 +63,9 @@ You can do this by:
   - Using the add-on store, if an update is available
   - Using the "add-ons manager" dialog (TODO: this should be in the add-on store)
 1. Confirm the warning message about add-on compatibility.
-1. Proceed with the installation.
+1. Exit the add-on store dialog
+1. You should be prompted for restart, restart NVDA
+1. Confirm the add-on is enabled in the add-ons manager
 
 
 ## Updating add-ons
@@ -123,3 +136,32 @@ For example: "Clock".
 
 ### Automatic updating
 TODO
+
+
+## Other add-on actions
+
+### Disabling an add-on
+1. Find a running add-on in the add-on store
+1. Press the disable button
+1. Exit the add-on store dialog
+1. You should be prompted for restart, restart NVDA
+1. Confirm the add-on is disabled in the add-ons manager
+
+### Enabling an add-on
+1. Find a disabled add-on in the add-on store
+1. Press the enable button
+1. Exit the add-on store dialog
+1. You should be prompted for restart, restart NVDA
+1. Confirm the add-on is disabled in the add-ons manager
+
+### Removing an add-on
+1. Find an installed add-on in the add-on store
+1. Press the remove button
+1. Exit the add-on store dialog
+1. You should be prompted for restart, restart NVDA
+1. Confirm the add-on is removed in the add-ons manager
+
+### Browse an add-ons help
+1. Find an installed add-on in the add-on store
+1. Press the "add-on help" button
+1. A window should open with the help documentation

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -31,11 +31,28 @@ Add-ons can be filtered by display name, publisher and description.
 1. Restart NVDA as prompted.
 1. Confirm the add-on is listed in the add-ons manager.
 
-### Overriding incompatible add-on from add-on store
-TODO
+### Install and override incompatible add-on from add-on store
+1. Open the add-on store.
+1. Find an add-on listed as "incompatible" for download.
+1. Navigate to and press the "install (override compatibility)" button for the add-on.
+1. Confirm the warning message about add-on compatibility.
+1. Proceed with the installation.
 
-### Overriding incompatible add-on from external install
-TODO
+### Install and override incompatible add-on from external source
+1. Start the install of an incompatible add-on bundle.
+You can do this by:
+  - opening an `.nvda-addon` file while NVDA is running
+  - Using the "add-ons manager" dialog (TODO: this should be in the add-on store)
+1. Confirm the warning message about add-on compatibility.
+1. Proceed with the installation.
+
+### Enable and override compatibility for an installed add-on
+1. Attempt to enable a disabled add-on, which is incompatible.
+You can do this by:
+  - Using the add-on store, if an update is available
+  - Using the "add-ons manager" dialog (TODO: this should be in the add-on store)
+1. Confirm the warning message about add-on compatibility.
+1. Proceed with the installation.
 
 
 ## Updating add-ons


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
A user may wish to over-ride compatibility issues with an add-on at their own risk.
This should only be possible when an add-on is incompatible due to API breaking changes, i.e when the last tested version of NVDA is not recent enough.

Compatibility overrides should be reset when:
 - updating to an API breaking version of NVDA
 - updating an add-on
 - disabling an add-on
 - removing an add-on

### Description of user facing changes

Users are warned rather than blocked when attempting to enable or install an incompatible add-on.
Warning has been updated when updating to an API breaking version of NVDA.

Incidentally to this PR:
- adds several actions to the add-on store: enable, disable, remove, add-on help
- focus is moved to the add-on status after performing an action on an add-on

### Description of development approach
Added a state tracker in addonHandler to track add-ons which have been disabled for compatibility reasons.

### Testing strategy:
Manual testing - [test plan in changes](https://github.com/nvaccess/nvda/blob/overrideCompat/tests/manual/addonStore.md)

### Known issues with pull request:
None

### Change log entries:
N/A, part of add-on store

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
