### PR TITLE
Fixed a bug causing wrong deprecation warnings or errors.

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
-# Babbage B.V., Mozilla Corporation, Julien Cochuyt, Leonard de Ruijter
+# Babbage B.V., Mozilla Corporation, Julien Cochuyt, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -48,7 +48,7 @@ from systemUtils import getCurrentProcessLogonSessionId, getProcessLogonSessionI
 
 # Dictionary of processID:appModule pairs used to hold the currently running modules
 runningTable: Dict[int, AppModule] = {}
-_CORE_APP_MODULES_PATH: os.PathLike = appModules.__path__[0]
+_CORE_APP_MODULES_PATH: os.PathLike = appModules.__path__[-1]
 _getAppModuleLock=threading.RLock()
 #: Notifies when another application is taking foreground.
 #: This allows components to react upon application switches.

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -48,7 +48,7 @@ from systemUtils import getCurrentProcessLogonSessionId, getProcessLogonSessionI
 
 # Dictionary of processID:appModule pairs used to hold the currently running modules
 runningTable: Dict[int, AppModule] = {}
-_CORE_APP_MODULES_PATH: os.PathLike = appModules.__path__[-1]
+_CORE_APP_MODULES_PATH: os.PathLike = os.path.dirname(appModules.__spec__.origin)
 _getAppModuleLock=threading.RLock()
 #: Notifies when another application is taking foreground.
 #: This allows components to react upon application switches.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -84,6 +84,7 @@ Similarly, the new ``getCompletionRoutine`` method allows you to convert a pytho
 - ``offsets.OffsetsTextInfo._get_boundingRects`` should now always return ``List[locationHelper.rectLTWH]`` as expected for a subclass of ``textInfos.TextInfo``. (#12424)
 - ``highlight-color`` is now a format field attribute. (#14610)
 - NVDA should more accurately determine if a logged message is coming from NVDA core. (#14812)
+- NVDA will no longer log inaccurate warnings or errors about deprecated appModules. (#14806)
 -
 
 === Deprecations ===


### PR DESCRIPTION
### Link to issue number:
None
Fix-up of #14350.
### Summary of the issue:

Running NVDA 2023.1 (and older), with add-ons and/or scratchpad enabled:

I get the following deprecation warnings:
* When opening start menu:
  ```
  WARNING - appModuleHandler._warnDeprecatedAliasAppModule (15:49:46.531) - MainThread (19688):
  Importing appModules.searchapp is deprecated, instead import appModules.searchui.
  ```
* When switching to Notepad++:
  ```
  WARNING - appModuleHandler._warnDeprecatedAliasAppModule (15:50:26.621) - MainThread (19688):
  Importing appModules.notepad++ is deprecated, instead import appModules.notepadPlusPlus.
  ```

And if I force errors on deprecated code by modifying `NVDAState._allowDeprecatedAPI` to return False, I get errors instead.

This is not expected since these warnings/errors come from NVDA's core code which should not (and actually does not) contain  deprecated code.

### Description of user facing changes
No more wrong deprecation warnings/errors due to NVDA's core appModules when opening start menu or switching to Notepad++

### Description of development approach
`appModules.__path__` contains the paths where NVDA has to search appModules. It contains first the folder in the scratchpad, then the folders in add-on containing appModules and finally the core appModule folder. Thus we need to look at the last element of `appModules.__path__`, not the first as it was done.

### Testing strategy:
* Test with add-ons and scratchpad that no deprecation warning nor error appear anymore.
* Tested that the following call in the console still causes the warning to be logged (upon first call):
`from appModules import searchapp`

Note: This was probably missed during #13366 test, maybe because it was tested without add-on nor scratchpad.

### Known issues with pull request:

### Change log entries:
Bug fixes (or Changes for developers? Where should bugfixes impacting only dev be listed?)

`NVDA will no longer log inaccurate warnings or errors about deprecated
appModules. (#14806)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
