### PR TITLE
Comment clarification/typo fixes about extensionPoints, across six files

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -52,7 +52,7 @@ _CORE_APP_MODULES_PATH: os.PathLike = appModules.__path__[0]
 _getAppModuleLock=threading.RLock()
 #: Notifies when another application is taking foreground.
 #: This allows components to react upon application switches.
-#: For example, braille triggers bluetooth polling for braille displaysf necessary.
+#: For example, braille triggers bluetooth polling for braille displays if necessary.
 #: Handlers are called with no arguments.
 post_appSwitch = extensionPoints.Action()
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -1895,8 +1895,8 @@ the remote system should know what cells to show on its display.
 filter_displaySize = extensionPoints.Filter()
 """
 Filter that allows components or add-ons to change the display size used for braille output.
-For example, when a system is controlled by a remote system while having a 80 cells display connected,
-the display size should be lowered to 40 whenever the remote system has a 40 cells display connected.
+For example, when a system has an 80 cell display, but is being controlled by a remote system with a 40 cell
+display, the display size should be lowered to 40 .
 @param value: the number of cells of the current display.
 @type value: int
 """

--- a/source/brailleViewer/__init__.py
+++ b/source/brailleViewer/__init__.py
@@ -53,7 +53,7 @@ _brailleGui: Optional[BrailleViewerFrame] = None
 # Extension points action:
 # Triggered every time the Braille Viewer is created / shown or hidden / destroyed.
 # Callback definition: Callable(created: bool) -> None
-#   created - True for created/shown, False for hidden/destructed.
+#   created - True for created/shown, False for hidden/destroyed.
 postBrailleViewerToolToggledAction = extensionPoints.Action()
 DEFAULT_NUM_CELLS = config.conf['brailleViewer']['defaultCellCount']
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -58,7 +58,7 @@ isAppX=False
 #: @type: ConfigManager
 conf = None
 
-#: Notifies when the configuration profile is switched.
+#: Notifies after the configuration profile has been switched.
 #: This allows components and add-ons to apply changes required by the new configuration.
 #: For example, braille switches braille displays if necessary.
 #: Handlers are called with no arguments.

--- a/source/core.py
+++ b/source/core.py
@@ -46,7 +46,7 @@ def __getattr__(attrName: str) -> Any:
 
 
 
-# inform those who want to know that NVDA has finished starting up.
+# Inform those who want to know that NVDA has finished starting up.
 postNvdaStartup = extensionPoints.Action()
 
 PUMP_MAX_DELAY = 10

--- a/source/core.py
+++ b/source/core.py
@@ -45,7 +45,6 @@ def __getattr__(attrName: str) -> Any:
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
-
 # Inform those who want to know that NVDA has finished starting up.
 postNvdaStartup = extensionPoints.Action()
 

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -27,7 +27,7 @@ import windowUtils
 pre_handleWindowMessage = extensionPoints.Action()
 """
 Notifies when a window message has been received by NVDA.
-This allows components to perform an action when several system events occur,
+This allows components to perform an action when certain system events occur,
 such as power, screen orientation and hardware changes.
 
 Handlers are called with three arguments.


### PR DESCRIPTION

### Link to issue number:

None.

### Summary of the issue:

While working on #14810, I found several places where comments about the core extensionPoints could be made clearer, or had typos/capitalization errors/questionable grammar.

### Description of user facing changes

None.

### Description of development approach

I fixed them as I went along, and scooped them all into their own branch. Here is the result.

I changed no code in this, and nothing structural has been altered. That is, where `#:` style comments were used in some places, and docstring style comments in others, I left them that way. I'm not actually sure what we prefer now. I wasn't trying to lint anything, just fix language.

### Testing strategy:

Letting Appveyor build this branch in the PR, and see if any lint errors pop out. That's about all I would expect to find.

### Known issues with pull request:

None, unless the mixed comment style is an issue. But I didn't do that.

### Change log entries:

None needed.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
