### PR TITLE
Logging: Fix some edge cases when identifying if the logged messages comes from external code or not.

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -54,7 +54,7 @@ def isPathExternalToNVDA(path: str) -> bool:
 		# it has an absolute file path (code bundled in binary builds reports relative paths); and
 		# it is not part of NVDA's Python code
 		# (i.e. outside of NVDA directory or in NVDA's config,
-		# so belongs to an add-on or a plugin in the scratchpad).
+		# so it belongs to an add-on or a plugin in the scratchpad).
 		return True
 	return False
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -31,6 +31,11 @@ E_ACCESSDENIED = -2147024891
 CO_E_OBJNOTCONNECTED = -2147220995
 EVENT_E_ALL_SUBSCRIBERS_FAILED = -2147220991
 LOAD_WITH_ALTERED_SEARCH_PATH=0x8
+_NVDA_CODE_PATH = os.path.dirname(__file__)
+"""Store path in which NVDA code is placed.
+We cannot use `globalVars.appDir`, since for binary builds it points to the directory with NVDA binaries,
+whereas for compiled versions NVDA's code files are in `library.zip`.
+"""
 
 
 def isPathExternalToNVDA(path: str) -> bool:
@@ -38,14 +43,20 @@ def isPathExternalToNVDA(path: str) -> bool:
 	if(
 		path[0] != "<"
 		and os.path.isabs(path)
-		and not os.path.normpath(path).startswith(sys.path[0] + "\\")
+		and not os.path.normpath(path).startswith(_NVDA_CODE_PATH + "\\")
+		or(
+			globalVars.appArgs.configPath is not None  # Handle messages logged before config is initialized
+			and path.startswith(globalVars.appArgs.configPath)
+		)
 	):
 		# This module is external because:
 		# the code comes from a file (fn doesn't begin with "<");
-		# it has an absolute file path (code bundled in binary builds reports relative paths); and
-		# it is not part of NVDA's Python code (not beneath sys.path[0]).
+		# it has an absolute file path (code bundled in binary builds reports relative paths);
+		# it is not part of NVDA's Python code; and
+		# it is placed in NVDA's config, so belongs to an add-on or a plugin in the scratchpad.
 		return True
 	return False
+
 
 def getCodePath(f):
 	"""Using a frame object, gets its module path (relative to the current directory).[className.[funcName]]

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -44,16 +44,17 @@ def isPathExternalToNVDA(path: str) -> bool:
 		path[0] != "<"
 		and os.path.isabs(path)
 		and not os.path.normpath(path).startswith(_NVDA_CODE_PATH + "\\")
-		or(
+		or (
 			globalVars.appArgs.configPath is not None  # Handle messages logged before config is initialized
 			and path.startswith(globalVars.appArgs.configPath)
 		)
 	):
 		# This module is external because:
 		# the code comes from a file (fn doesn't begin with "<");
-		# it has an absolute file path (code bundled in binary builds reports relative paths);
-		# it is not part of NVDA's Python code; and
-		# it is placed in NVDA's config, so belongs to an add-on or a plugin in the scratchpad.
+		# it has an absolute file path (code bundled in binary builds reports relative paths); and
+		# it is not part of NVDA's Python code
+		# (i.e. outside of NVDA directory or in NVDA's config,
+		# so belongs to an add-on or a plugin in the scratchpad).
 		return True
 	return False
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -75,6 +75,7 @@ If not provided, the default thread is used. (#14627)
 Similarly, the new ``getCompletionRoutine`` method allows you to convert a python method into a completion routine safely. (#14627)
 - ``offsets.OffsetsTextInfo._get_boundingRects`` should now always return ``List[locationHelper.rectLTWH]`` as expected for a subclass of ``textInfos.TextInfo``. (#12424)
 - ``highlight-color`` is now a format field attribute. (#14610)
+- NVDA should more accurately determine if a logged message is coming from NVDA core. (#14812)
 -
 
 === Deprecations ===


### PR DESCRIPTION
### Link to issue number:
Discussion in #14806

### Summary of the issue:
When logging NVDA tries to determine if the logged message comes from its own code or from an add-on. In some cases it does so incorrectly.
### Case 1: Directory prepended to `sys.path` by an add-on
Some add-ons have to modify `sys.path` to import additional libraries. NVDA's `logHandler` relied on the fact that the first entry in path represents the location of NVDA's source code. While add-on developers should really clean-up after themselves i.e. modify path only for  as long as necessary to import additional libraries this is not something we can enforce. Initially observed by @CyrilleB79 for an add-on for ChatGPT.
### Case 2: Messages logged from add-ons installed in the default config for source copies
By default configuration folder for source copies is placed next to NVDA sources, i.e. in the `source` folder. When determining if the path belongs to NVDA or not we used to check if the given path starts with NVDA's source folder which was true for the plugins in  the user config even though the code was not a part of NVDA.
### Description of user facing changes
This should affect only developers who inspect the log.
### Description of development approach
When checking if the path is external or not we no longer rely on `sys.path` - rather the location of the `logHandler` is used to determine the true location of NVDA's source code. In addition if the path is beneath the current NVDA's config it is always marked as external.
### Testing strategy:
- With add-on for ChatGPT installed ensured that messages logged from NVDA core are not marked as external for both source and binary copies
- When running from sources ensured that messages logged from plugins installed in the default config folder are marked as coming from external code.
### Known issues with pull request:
None known
### Change log entries:
For Developers
- NVDA should more accurately determine if the logged message is coming from its own code

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
