### PR TITLE
Fix open of Contributors and License Help menu options on Windows 11 

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
-# Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot
+# Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot, Luke Davis
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -11,6 +11,7 @@ import threading
 import ctypes
 import wx
 import wx.adv
+
 import globalVars
 import tones
 import ui
@@ -21,6 +22,7 @@ import versionInfo
 import speech
 import queueHandler
 import core
+import systemUtils
 from .message import (
 	# messageBox is accessed through `gui.messageBox` as opposed to `gui.message.messageBox` throughout NVDA,
 	# be cautious when removing
@@ -87,7 +89,6 @@ class MainFrame(wx.Frame):
 		#: @type: list of L{NVDAObject}
 		self.prevFocusAncestors = None
 		# If NVDA has the uiAccess privilege, it can always set the foreground window.
-		import systemUtils
 		if not systemUtils.hasUiAccess():
 			# This makes Windows return to the previous foreground window and also seems to allow NVDA to be brought to the foreground.
 			self.Show()
@@ -371,7 +372,6 @@ class MainFrame(wx.Frame):
 			_("Please wait while NVDA tries to fix your system's COM registrations.")
 		)
 		try:
-			import systemUtils
 			systemUtils.execElevated(config.SLAVE_FILENAME, ["fixCOMRegistrations"])
 		except:
 			log.error("Could not execute fixCOMRegistrations command",exc_info=True) 
@@ -484,10 +484,18 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			self.Bind(wx.EVT_MENU, lambda evt: os.startfile("http://www.nvda-project.org/"), item)
 			# Translators: The label for the menu item to view NVDA License document.
 			item = menu_help.Append(wx.ID_ANY, _("L&icense"))
-			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(getDocFilePath("copying.txt", False)), item)
+			self.Bind(
+				wx.EVT_MENU,
+				lambda evt: systemUtils._displayTextFileWorkaround(getDocFilePath("copying.txt", False)),
+				item
+			)
 			# Translators: The label for the menu item to view NVDA Contributors list document.
 			item = menu_help.Append(wx.ID_ANY, _("C&ontributors"))
-			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(getDocFilePath("contributors.txt", False)), item)
+			self.Bind(
+				wx.EVT_MENU,
+				lambda evt: systemUtils._displayTextFileWorkaround(getDocFilePath("contributors.txt", False)),
+				item
+			)
 			# Translators: The label for the menu item to open NVDA Welcome Dialog.
 			item = menu_help.Append(wx.ID_ANY, _("We&lcome dialog..."))
 			self.Bind(wx.EVT_MENU, lambda evt: WelcomeDialog.run(), item)

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2022 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2020-2023 NV Access Limited, Łukasz Golonka, Luke Davis
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -17,6 +17,7 @@ import shellapi
 import winUser
 import functools
 import shlobj
+from os import startfile
 
 
 @functools.lru_cache(maxsize=1)
@@ -179,3 +180,12 @@ def _isSecureDesktop() -> bool:
 	 - SecureMode and SecureScreens
 	"""
 	return _getDesktopName() == "Winlogon"
+
+
+def _displayTextFileWorkaround(file: str) -> None:
+	# os.startfile does not currently (NVDA 2023.1, Python 3.7) work reliably to open .txt files in Notepadunder
+	# Windows 11, if relying on the default behavior (i.e. `operation="open"`). (#14725)
+	# Using `operation="edit"`, however, has the desired effect--opening the text file in Notepad. (#14816)
+	# Since this may be a bug in Python 3.7's os.startfile, or the underlying Win32 function, it may be
+	# possible to deprecate this workaround after a Python upgrade.
+	startfile(file, operation="edit")

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -183,7 +183,7 @@ def _isSecureDesktop() -> bool:
 
 
 def _displayTextFileWorkaround(file: str) -> None:
-	# os.startfile does not currently (NVDA 2023.1, Python 3.7) work reliably to open .txt files in Notepadunder
+	# os.startfile does not currently (NVDA 2023.1, Python 3.7) work reliably to open .txt files in Notepad under
 	# Windows 11, if relying on the default behavior (i.e. `operation="open"`). (#14725)
 	# Using `operation="edit"`, however, has the desired effect--opening the text file in Notepad. (#14816)
 	# Since this may be a bug in Python 3.7's os.startfile, or the underlying Win32 function, it may be

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,6 +57,7 @@ Instead NVDA reports that the link has no destination. (#14723)
 - Several stability fixes to input/output for braille displays, resulting in less frequent errors and crashes of NVDA. (#14627)
 - NVDA again recovers from many more situations such as applications that stop responding which previously caused it to freeze completely. (#14759) 
 - The destination of graphic links are now correctly reported in Chrome and Edge. (#14779)
+- In Windows 11, it is once again possible to open the Contributors and License items on the NVDA Help menu. (#14725)
 -
 
 


### PR DESCRIPTION
### Link to issue number:

Fixes #14725 

### Summary of the issue:

Under Windows 11, attempting to open the NVDA Help menu items "Contributors" or "License", results in Notepad trying to open nonsense filenames while using installed, normal user level, copies of NVDA

Through testing, this has been narrowed to a bug in `os.startfile` in Python 3.7 as invoked on Windows 11, though the actual bug may be in a lower level library. The bug does not seem to occur when using the commandline "`start`" command.
It also does not occur in portable or admin level copies of NVDA.

### Description of user facing changes

Restores the ability to open the Contributors List or License file from the NVDA Help menu.

### Description of development approach

Through testing, I and @britechguy were able to narrow the source of the errors, and determine that attempting to open the file for editing, rather than by trusting the Windows open file association for .txt files, would open these files in Notepad correctly.

Taken from the text of the commit:
* Added the `_displayTextFileWorkaround` function to the `systemUtils` module.
    - Called it wherever `os.startfile` was opening a .txt file in `gui/__init__.py`.
    - The function uses `os.startfile`'s "`edit`" operation to open the text file, which still uses Notepad, at least on most systems.

Additionally:
* gui.MainFrame was importing systemUtils late, in __init__, and onRunCOMRegistrationFixesCommand.
    - Moved to a single import in top section.

### Testing strategy:

* Manual testing with 2023.1's Python console, that calling `os.startfile` as described, opens these files correctly under Windows 11. While calling it the standard way from the Python console, results in nonsense filenames being delivered to Notepad, and the subsequent failure of the task.
* Using a try build of this PR, tested opening these help menu items on Windows 10, with expected success.
* Tested that installing a try build of this PR on Windows 11, could open the files from the menu, and could open a copy of `copying.txt` at the root of the system drive, using the Python console.
* A portable copy generated from this PR, placed in the root directory of a USB stick, could open its included text files from the Help menu, and could open a copy of `copying.txt` placed at the root of the USB drive.

Additionally, to confirm that consolidating and moving the imports of `systemUtils` didn't break anything, I tested that NVDA launched, and the COM Registration Fixing Tool still works, under Windows 10, which is sufficient.

Tested on:
* Windows 11: 22H2, build 22621.1555
* Windows 10: 22H2, build 19045.2846

### Known issues with pull request:

* It is not necessary to use `operation="edit"` under Windows 10. Since this seemed (1) rather harmless, and (2) a low impact bug, I didn't think it was necessary to test for Windows version before deciding which call structure to use for the new function.
* It is conceivable, that opening for editing will have side effects on some systems. However, since it seems reasonable to presume that a user who has made editing text files open in some other program than Notepad is quite experienced, I thought the negative potential here was rather low to non-existent.
* When we migrate to a newer Python version, the necessity of this workaround should be reevaluated, as hopefully this will be fixed by a newer library.

### Change log entries:
Bug fixes
In Windows 11, it is (once again) possible to open the Contributors and License items on the NVDA Help menu.

### Code Review Checklist:
- [X] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
