### PR TITLE
Add-on store: Group by add-on status, install from external source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@ pyserial==3.5
 wxPython==4.1.1
 git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
 requests==2.28.2
+# Required to use a pinned old version for requests.
+# py2exe fails to compile properly without this.
+# This can be removed when upgrading py2exe to 0.13+ and python to 3.8+.
+# https://github.com/Ousret/charset_normalizer/issues/253
+charset-normalizer==2.1.1
 
 #NVDA_DMP requires diff-match-patch
 diff_match_patch_python==1.0.2

--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -3,12 +3,14 @@
 # Copyright (C) 2018-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 from typing_extensions import Protocol  # Python 3.8 adds native support
 import addonAPIVersion
 
 
 def getAddonCompatibilityMessage() -> str:
-	return _(
+	return pgettext(
+		"addonStore",
 		# Translators: A message indicating that some add-ons will be disabled
 		# unless reviewed before installation.
 		"Your NVDA configuration contains add-ons that are incompatible with this version of NVDA. "
@@ -18,10 +20,22 @@ def getAddonCompatibilityMessage() -> str:
 	)
 
 
+def getAddonCompatibilityConfirmationMessage() -> str:
+	return pgettext(
+		"addonStore",
+		# Translators: A message to confirm that the user understands that incompatible add-ons
+		# will be disabled after installation, and can be manually re-enabled.
+		"I understand that incompatible add-ons will be disabled "
+		"and can be manually re-enabled at my own risk after installation."
+	)
+
+
 class SupportsVersionCheck(Protocol):
 	""" Examples implementing this protocol include:
+	- addonHandler.Addon
 	- addonHandler.AddonBundle
 	- addonStore.models.AddonDetailsModel
+	- addonStore.models.AddonStoreModel
 	"""
 	minimumNVDAVersion: addonAPIVersion.AddonApiVersionT
 	lastTestedNVDAVersion: addonAPIVersion.AddonApiVersionT
@@ -44,6 +58,8 @@ class SupportsVersionCheck(Protocol):
 		overiddenAddons = state[AddonStateCategory.OVERRIDE_COMPATIBILITY]
 		assert self.name not in overiddenAddons and self.canOverrideCompatibility
 		overiddenAddons.add(self.name)
+		state[AddonStateCategory.BLOCKED].discard(self.name)
+		state[AddonStateCategory.DISABLED].discard(self.name)
 
 	@property
 	def canOverrideCompatibility(self) -> bool:

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -3,6 +3,10 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+# Needed for type hinting CaseInsensitiveDict
+# Can be removed in a future version of python (3.8+)
+from __future__ import annotations
+
 import dataclasses
 import globalVars
 import json
@@ -17,10 +21,11 @@ from datetime import datetime, timedelta
 import buildVersion
 from logHandler import log
 import requests
+from requests.structures import CaseInsensitiveDict
 
 import addonAPIVersion
-import typing
 from typing import (
+	cast,
 	Optional,
 	Dict,
 	Callable,
@@ -28,10 +33,9 @@ from typing import (
 )
 from .models import (
 	Channel,
-	_createAddonModelFromData,
-	_createModelFromData,
-	AddonDetailsModel,
-	_AddonDetailsCollectionT,
+	_createStoreModelFromData,
+	_createStoreCollectionFromJson,
+	AddonStoreModel,
 )
 
 addonDataManager: Optional["_DataManager"] = None
@@ -60,19 +64,24 @@ def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
 
 @dataclasses.dataclass
 class CachedAddonsModel:
-	availableAddons: _AddonDetailsCollectionT
+	availableAddons: CaseInsensitiveDict["AddonStoreModel"]
+	"""
+	Add-ons that have the same ID except differ in casing cause a path collision,
+	as add-on IDs are installed to a case insensitive path.
+	Therefore addon IDs should be treated as case insensitive.
+	"""
 	cachedAt: datetime
 	nvdaAPIVersion: addonAPIVersion.AddonApiVersionT
 
 
 class AddonFileDownloader:
-	OnCompleteT = Callable[[AddonDetailsModel, Optional[os.PathLike]], None]
+	OnCompleteT = Callable[[AddonStoreModel, Optional[os.PathLike]], None]
 
 	def __init__(self, cacheDir: os.PathLike):
 		self._cacheDir = cacheDir
-		self.progress: Dict[AddonDetailsModel, int] = {}  # Number of chunks received
-		self._pending: Dict[Future, Tuple[AddonDetailsModel, AddonFileDownloader.OnCompleteT]] = {}
-		self.complete: Dict[AddonDetailsModel, os.PathLike] = {}  # Path to downloaded file
+		self.progress: Dict[AddonStoreModel, int] = {}  # Number of chunks received
+		self._pending: Dict[Future, Tuple[AddonStoreModel, AddonFileDownloader.OnCompleteT]] = {}
+		self.complete: Dict[AddonStoreModel, os.PathLike] = {}  # Path to downloaded file
 		self._executor = ThreadPoolExecutor(
 			max_workers=1,
 			thread_name_prefix="AddonDownloader",
@@ -80,7 +89,7 @@ class AddonFileDownloader:
 
 	def download(
 			self,
-			addonData: AddonDetailsModel,
+			addonData: AddonStoreModel,
 			onComplete: OnCompleteT
 	):
 		self.progress[addonData] = 0
@@ -118,7 +127,7 @@ class AddonFileDownloader:
 		self.progress.clear()
 		self._pending.clear()
 
-	def _download(self, addonData: AddonDetailsModel) -> Optional[os.PathLike]:
+	def _download(self, addonData: AddonStoreModel) -> Optional[os.PathLike]:
 		log.debug(f"starting download: {addonData.addonId}")
 		cacheFilePath = os.path.join(
 			self._cacheDir,
@@ -160,10 +169,10 @@ class AddonFileDownloader:
 		os.rename(src=inProgressFilePath, dst=cacheFilePath)
 		log.debug(f"Cache file available: {cacheFilePath}")
 		# TODO: assert SHA256 sum
-		return typing.cast(os.PathLike, cacheFilePath)
+		return cast(os.PathLike, cacheFilePath)
 
 	@staticmethod
-	def _getCacheFilenameForAddon(addonData: AddonDetailsModel) -> str:
+	def _getCacheFilenameForAddon(addonData: AddonStoreModel) -> str:
 		return f"{addonData.addonId}-{addonData.addonVersionName}.nvda-addon"
 
 	def __del__(self):
@@ -228,12 +237,12 @@ class _DataManager:
 			return None
 		fetchTime = datetime.fromisoformat(cacheData["cacheDate"])
 		return CachedAddonsModel(
-			availableAddons=_createModelFromData(cacheData["data"]),
+			availableAddons=_createStoreCollectionFromJson(cacheData["data"]),
 			cachedAt=fetchTime,
 			nvdaAPIVersion=cacheData["nvdaAPIVersion"],
 		)
 
-	def getLatestAvailableAddons(self) -> _AddonDetailsCollectionT:
+	def getLatestAvailableAddons(self) -> CaseInsensitiveDict["AddonStoreModel"]:
 		shouldRefreshData = (
 			not self._availableAddonCache
 			or self._availableAddonCache.nvdaAPIVersion != addonAPIVersion.CURRENT
@@ -246,20 +255,20 @@ class _DataManager:
 				decodedApiData = apiData.decode()
 				self._cacheAddons(addonData=decodedApiData, fetchTime=fetchTime)
 				self._availableAddonCache = CachedAddonsModel(
-					availableAddons=_createModelFromData(decodedApiData),
+					availableAddons=_createStoreCollectionFromJson(decodedApiData),
 					cachedAt=fetchTime,
 					nvdaAPIVersion=addonAPIVersion.CURRENT,
 				)
 		return self._availableAddonCache.availableAddons
 
-	def _cacheInstalledAddon(self, addonData: AddonDetailsModel):
+	def _cacheInstalledAddon(self, addonData: AddonStoreModel):
 		if not addonData:
 			return
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonData.addonId}.json")
 		with open(addonCachePath, 'w') as cacheFile:
 			json.dump(addonData.asdict(), cacheFile, ensure_ascii=False)
 
-	def _getCachedInstalledAddonData(self, addonId: str) -> Optional[AddonDetailsModel]:
+	def _getCachedInstalledAddonData(self, addonId: str) -> Optional[AddonStoreModel]:
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonId}.json")
 		if not os.path.exists(addonCachePath):
 			return None
@@ -267,4 +276,4 @@ class _DataManager:
 			cacheData = json.load(cacheFile)
 		if not cacheData:
 			return None
-		return _createAddonModelFromData(cacheData)
+		return _createStoreModelFromData(cacheData)

--- a/source/gui/addonStoreGui/dialogs.py
+++ b/source/gui/addonStoreGui/dialogs.py
@@ -60,7 +60,7 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 	).ShowModal() == wx.OK
 
 
-def _shouldProceedAddonRemove(
+def _shouldProceedToRemoveAddonDialog(
 		addon: "SupportsVersionCheck"
 ) -> bool:
 	return messageBox(

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -157,7 +157,7 @@ class InstallerDialog(
 		))
 
 		mainSizer = self.mainSizer = wx.BoxSizer(wx.VERTICAL)
-		sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		# Translators: An informational message in the Install NVDA dialog.
 		msg=_("To install NVDA to your hard drive, please press the Continue button.")
@@ -168,18 +168,17 @@ class InstallerDialog(
 				# Translators: a message in the installer telling the user NVDA is now located in a different place.
 				msg+=" "+_("The installation path for NVDA has changed. it will now  be installed in {path}").format(path=installer.defaultInstallPath)
 		if shouldAskAboutAddons:
-			import updateCheck
-			msg += "\n\n" + updateCheck.getAddonCompatibilityMessage()
+			msg += "\n\n" + addonHandler.addonVersionCheck.getAddonCompatibilityMessage()
 
 		text = sHelper.addItem(wx.StaticText(self, label=msg))
 		text.Wrap(self.scaleSize(self.textWrapWidth))
 		if shouldAskAboutAddons:
-			self.confirmationCheckbox = sHelper.addItem(wx.CheckBox(
+			self.confirmationCheckbox = sHelper.addItem(
+				wx.CheckBox(
 					self,
-					# Translators: A message to confirm that the user understands that addons that have not been reviewed and made
-					# available, will be disabled after installation.
-					label=_("I understand that these incompatible add-ons will be disabled")
-				))
+					label=addonHandler.addonVersionCheck.getAddonCompatibilityConfirmationMessage()
+				)
+			)
 			self.bindHelpEvent("InstallWithIncompatibleAddons", self.confirmationCheckbox)
 			self.confirmationCheckbox.SetFocus()
 
@@ -347,7 +346,7 @@ class PortableCreaterDialog(
 		# Translators: The title of the Create Portable NVDA dialog.
 		super().__init__(parent, title=_("Create Portable NVDA"))
 		mainSizer = self.mainSizer = wx.BoxSizer(wx.VERTICAL)
-		sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		# Translators: An informational message displayed in the Create Portable NVDA dialog.
 		dialogCaption=_("To create a portable copy of NVDA, please select the path and other options and then press Continue")
@@ -357,14 +356,14 @@ class PortableCreaterDialog(
 		# in the Create Portable NVDA dialog.
 		directoryGroupText = _("Portable &directory:")
 		groupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=directoryGroupText)
-		groupHelper = sHelper.addItem(gui.guiHelper.BoxSizerHelper(self, sizer=groupSizer))
+		groupHelper = sHelper.addItem(guiHelper.BoxSizerHelper(self, sizer=groupSizer))
 		groupBox = groupSizer.GetStaticBox()
 		# Translators: The label of a button to browse for a directory.
 		browseText = _("Browse...")
 		# Translators: The title of the dialog presented when browsing for the
 		# destination directory when creating a portable copy of NVDA.
 		dirDialogTitle = _("Select portable  directory")
-		directoryPathHelper = gui.guiHelper.PathSelectionHelper(groupBox, browseText, dirDialogTitle)
+		directoryPathHelper = guiHelper.PathSelectionHelper(groupBox, browseText, dirDialogTitle)
 		directoryEntryControl = groupHelper.addItem(directoryPathHelper)
 		self.portableDirectoryEdit = directoryEntryControl.pathControl
 		if globalVars.appArgs.portablePath:
@@ -381,7 +380,7 @@ class PortableCreaterDialog(
 		self.startAfterCreateCheckbox = sHelper.addItem(wx.CheckBox(self, label=startAfterCreateText))
 		self.startAfterCreateCheckbox.Value = False
 
-		bHelper = sHelper.addDialogDismissButtons(gui.guiHelper.ButtonHelper(wx.HORIZONTAL), separated=True)
+		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL), separated=True)
 		
 		continueButton = bHelper.addButton(self, label=_("&Continue"), id=wx.ID_OK)
 		continueButton.SetDefault()
@@ -391,7 +390,7 @@ class PortableCreaterDialog(
 		# If we bind this using button.Bind, it fails to trigger when the dialog is closed.
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
 		
-		mainSizer.Add(sHelper.sizer, border=gui.guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
+		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.CentreOnScreen()

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -48,7 +48,10 @@ import braille
 import gui
 from gui import guiHelper
 from addonHandler import getCodeAddon, AddonError, getIncompatibleAddons
-from addonHandler.addonVersionCheck import getAddonCompatibilityMessage  # noqa: E402
+from addonHandler.addonVersionCheck import (  # noqa: E402
+	getAddonCompatibilityMessage,
+	getAddonCompatibilityConfirmationMessage,
+)
 from logHandler import log, isPathExternalToNVDA
 import config
 import shellapi
@@ -378,9 +381,7 @@ class UpdateResultDialog(
 				message += + "\n\n" + getAddonCompatibilityMessage()
 				confirmationCheckbox = sHelper.addItem(wx.CheckBox(
 					self,
-					# Translators: A message to confirm that the user understands that addons that have not been
-					# reviewed and made available, will be disabled after installation.
-					label=_("I understand that these incompatible add-ons will be disabled")
+					label=getAddonCompatibilityConfirmationMessage()
 				))
 				confirmationCheckbox.Bind(
 					wx.EVT_CHECKBOX,
@@ -498,9 +499,7 @@ class UpdateAskInstallDialog(
 		if showAddonCompat:
 			self.confirmationCheckbox = sHelper.addItem(wx.CheckBox(
 				self,
-				# Translators: A message to confirm that the user understands that addons that have not been reviewed and made
-				# available, will be disabled after installation.
-				label=_("I understand that these incompatible add-ons will be disabled")
+				label=getAddonCompatibilityConfirmationMessage()
 			))
 
 		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL))

--- a/source/utils/caseInsensitiveCollections.py
+++ b/source/utils/caseInsensitiveCollections.py
@@ -1,0 +1,37 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2023 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+from typing import (
+	Tuple,
+)
+
+
+class CaseInsensitiveSet(set):
+	def __init__(self, *args: Tuple[str]):
+		if len(args) > 1:
+			raise TypeError(
+				f"{type(self).__name__} expected at most 1 argument, "
+				f"got {len(args)}"
+			)
+		values = args[0] if args else ()
+		for v in values:
+			self.add(v)
+
+	def add(self, __element: str) -> None:
+		__element = __element.casefold()
+		return super().add(__element)
+	
+	def discard(self, __element: str) -> None:
+		__element = __element.casefold()
+		return super().discard(__element)
+
+	def remove(self, __element: str) -> None:
+		__element = __element.casefold()
+		return super().remove(__element)
+
+	def __contains__(self, __o: object) -> bool:
+		if isinstance(__o, str):
+			__o = __o.casefold()
+		return super().__contains__(__o)

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -1,30 +1,31 @@
 
 ## Browsing add-ons
 
-### Browse add-ons by category
-TODO:
+### Browse add-ons by status
+Add-ons can be filtered by status.
 
-- installed
-- incompatible
-- updatable/replace-able
-- available
-- all?
+1. Open the add-on store
+1. Jump to the filter-by status field (`alt+s`)
+1. Filter by each status, ensure expected add-ons are displayed.
+    - all add-ons: should include all add-ons, installed and available for install
+    - installed
+    - updatable: should include installed add-ons which can be updated or replaced by an add-on store version
+    - disabled: should include manually disabled add-ons and add-ons disabled due to incompatibility
+    - available: should include add-ons available for install
 
 ### Filtering by add-on information
-
 Add-ons can be filtered by display name, publisher and description.
 
 1. Open the add-on store
-1. Jump to the filter-by field (`alt+f`)
+1. Jump to the filter-by text field (`alt+f`)
 1. Search for a string, for example part of a publisher name, display name or description.
 1. Ensure expected add-ons appear after the filter view refreshes.
 1. Remove the filter-by string
 1. Ensure the list of add-ons refreshes to all add-ons, unfiltered.
 
 ### Filtering where no add-ons are found
-
 1. Open the add-on store
-1. Jump to the filter-by field (`alt+f`)
+1. Jump to the filter-by text field (`alt+f`)
 1. Search for a string which yields no add-ons.
 1. Ensure the add-on information dialog  states "no add-on selected".
 
@@ -40,7 +41,10 @@ Add-ons can be filtered by display name, publisher and description.
 1. Confirm the add-on is listed in the add-ons manager.
 
 ### Install add-on from external source in add-on store
-TODO
+1. Open the add-on store.
+1. Jump to the install from external source button (`alt+i`)
+1. Find an `*.nvda-addon` file, and open it
+1. Proceed with the installation
 
 ### Install and override incompatible add-on from add-on store
 1. Open the add-on store.
@@ -52,16 +56,14 @@ TODO
 ### Install and override incompatible add-on from external source
 1. Start the install of an incompatible add-on bundle.
 You can do this by:
-  - opening an `.nvda-addon` file while NVDA is running
-  - Using the "add-ons manager" dialog (TODO: this should be in the add-on store)
+    - opening an `.nvda-addon` file while NVDA is running
+    - using the "install from external source" button
 1. Confirm the warning message about add-on compatibility.
 1. Proceed with the installation.
 
 ### Enable and override compatibility for an installed add-on
-1. Attempt to enable a disabled add-on, which is incompatible.
-You can do this by:
-  - Using the add-on store, if an update is available
-  - Using the "add-ons manager" dialog (TODO: this should be in the add-on store)
+1. Browse incompatible disabled add-ons in the add-on store
+1. Press enable on a disabled add-on
 1. Confirm the warning message about add-on compatibility.
 1. Exit the add-on store dialog
 1. You should be prompted for restart, restart NVDA
@@ -74,17 +76,17 @@ You can do this by:
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-  - For source: `.\source\userConfig`
-  - For installed copies: `%APPDATA%\nvda`
+    - For source: `.\source\userConfig`
+    - For installed copies: `%APPDATA%\nvda`
 1. To spoof an old release, we need to edit 2 files:
-  1. Add-on store JSON metadata
-    - Located in: `.\addonStore\addons\`.
-    - Example: `source\userConfig\addonStore\addons\clock.json`
-    - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
-  1. Add-on manifest
-    - Located in: `.\addons\`.
-    - Example: `source\userConfig\addons\clock\manifest.ini`
-    - Edit "version": decrease the major release value number to match earlier edits.
+    - Add-on store JSON metadata
+        - Located in: `.\addonStore\addons\`.
+        - Example: `source\userConfig\addonStore\addons\clock.json`
+        - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
+    - Add-on manifest
+        - Located in: `.\addons\`.
+        - Example: `source\userConfig\addons\clock\manifest.ini`
+        - Edit "version": decrease the major release value number to match earlier edits.
 1. Open the add-on store
 1. Ensure the same add-on you edited is available on the add-on store with the status "update".
 1. Install the add-on again to test the "update" path.
@@ -93,17 +95,17 @@ For example: "Clock".
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-  - For source: `.\source\userConfig`
-  - For installed copies: `%APPDATA%\nvda`
+    - For source: `.\source\userConfig`
+    - For installed copies: `%APPDATA%\nvda`
 1. To spoof an externally loaded older release, we need to edit 2 files:
-  1. Add-on store JSON metadata
-    - Located in: `.\addonStore\addons\`.
-    - Example: `source\userConfig\addonStore\addons\clock.json`
-    - Delete this file.
-  1. Add-on manifest
-    - Located in: `.\addons\`.
-    - Example: `source\userConfig\addons\clock\manifest.ini`
-    - Edit "version": decrease the major release value number to match earlier edits.
+    - Add-on store JSON metadata
+        - Located in: `.\addonStore\addons\`.
+        - Example: `source\userConfig\addonStore\addons\clock.json`
+      - Delete this file.
+    - Add-on manifest
+        - Located in: `.\addons\`.
+        - Example: `source\userConfig\addons\clock\manifest.ini`
+        - Edit "version": decrease the major release value number to match earlier edits.
 1. Open the add-on store
 1. Ensure the same add-on you edited is available on the add-on store with the status "update".
 1. Install the add-on again to test the "update" path.
@@ -115,17 +117,17 @@ This means using the latest add-on store version might be a downgrade or sidegra
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-  - For source: `.\source\userConfig`
-  - For installed copies: `%APPDATA%\nvda`
+    - For source: `.\source\userConfig`
+    - For installed copies: `%APPDATA%\nvda`
 1. To spoof an externally loaded release, with an invalid version, we need to edit 2 files:
-  1. Add-on store JSON metadata
-    - Located in: `.\addonStore\addons\`.
-    - Example: `source\userConfig\addonStore\addons\clock.json`
-    - Delete this file.
-  1. Add-on manifest
-    - Located in: `.\addons\`.
-    - Example: `source\userConfig\addons\clock\manifest.ini`
-    - Edit "version": to something invalid e.g. "foo".
+    - Add-on store JSON metadata
+        - Located in: `.\addonStore\addons\`.
+        - Example: `source\userConfig\addonStore\addons\clock.json`
+        - Delete this file.
+    - Add-on manifest
+        - Located in: `.\addons\`.
+        - Example: `source\userConfig\addons\clock\manifest.ini`
+        - Edit "version": to something invalid e.g. "foo".
 1. Open the add-on store
 1. Ensure the same add-on you edited is available on the add-on store with the status "Migrate to add-on store".
 1. Install the add-on again to test the "migrate" path.

--- a/tests/unit/test_util/test_caseInsensitiveCollections.py
+++ b/tests/unit/test_util/test_caseInsensitiveCollections.py
@@ -1,0 +1,46 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited.
+
+"""Unit tests for the caseInsensitiveCollections submodule.
+"""
+
+import unittest
+
+from utils.caseInsensitiveCollections import CaseInsensitiveSet
+
+
+class Test_CaseInsensitiveSet(unittest.TestCase):
+	"""Tests should cover all expected uses of an instantiated CaseInsensitiveSet"""
+
+	def test_caseInsensitiveInit(self):
+		self.assertSetEqual(CaseInsensitiveSet({"foo", "FOO"}), CaseInsensitiveSet({"foo"}))
+
+	def test_caseInsensitiveAdd(self):
+		base = CaseInsensitiveSet({"foo"})
+		base.add("FOO")
+		self.assertSetEqual(base, CaseInsensitiveSet({"foo"}))
+
+	def test_caseInsensitiveDiscard(self):
+		base = CaseInsensitiveSet({"foo"})
+		base.discard("FOO")
+		self.assertSetEqual(base, CaseInsensitiveSet())
+
+	def test_caseInsensitiveRemove(self):
+		base = CaseInsensitiveSet({"foo"})
+		base.remove("FOO")
+		self.assertSetEqual(base, CaseInsensitiveSet())
+
+	def test_caseInsensitiveIn(self):
+		self.assertIn("FOO", CaseInsensitiveSet({"foo"}))
+
+	def test_caseInsensitiveSubtract(self):
+		base = CaseInsensitiveSet({"foo", "bar", "lorem"})
+		base -= CaseInsensitiveSet({"foo", "BAR"})
+		self.assertSetEqual(base, CaseInsensitiveSet({"lorem"}))
+
+	def test_caseInsensitiveAddSet(self):
+		base = CaseInsensitiveSet({"foo", "bar"})
+		base |= CaseInsensitiveSet({"lorem", "BAR"})
+		self.assertSetEqual(base, CaseInsensitiveSet({"foo", "bar", "lorem"}))


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
A user may wish to view installed add-ons in the add-on store.
A user may wish to group add-ons in the add-on by status (installed, available, updatable, etc).
A user may wish to install add-ons from an external source via the add-on store.

### Description of user facing changes
The add-on store now shows all add-ons, installed or available on the add-on store.
Users can group add-ons by status.
Users can also install add-ons from an external source via the add-on store.
This PR finishes duplicating functionality from the legacy add-ons manager, meaning that the add-ons manager can be removed.
Fixes various graphical bugs with the add-on store.

### Description of development approach
Ensure add-on IDs are tracked in a case insensitive manner.
This is because there may be collisions if add-on authors change the casing of their add-on ID, and case variations of add-on IDs should be treated as the same add-on.
Create a new model for displaying information in the add-on store, which can take data from an add-on manifest or from add-on store data.
Create a selection filter for grouping add-ons by status.
Add a button for installing add-ons from an external source, using the add-ons manager approach.

### Testing strategy:
Follow the manual test plan: https://github.com/nvaccess/nvda/blob/groupByStatus/tests/manual/addonStore.md

Unit tests have been added for the new case insensitive set data structure

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
