### PR TITLE
Windows 11/input experience window: recognize IME interface

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -308,7 +308,11 @@ class AppModule(appModuleHandler.AppModule):
 					)
 					and obj.parent.parent.UIAAutomationId == "IME_Candidate_Window"
 				)
-				or obj.parent.UIAAutomationId in ("IME_Candidate_Window", "IME_Prediction_Window")
+				or obj.parent.UIAAutomationId in (
+					"IME_Candidate_Window",
+					"IME_Prediction_Window",
+					"TEMPLATE_PART_CandidatePanel",
+				)
 			):
 				clsList.insert(0, ImeCandidateItem)
 			elif obj.role == controlTypes.Role.PANE and obj.UIAAutomationId in (

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -88,6 +88,10 @@ class ImeCandidateItem(CandidateItemBehavior, UIA):
 		return super(ImeCandidateItem, self).name
 
 	def event_UIA_elementSelected(self):
+		# In Windows 11, focus event is fired when a candidate item receives focus,
+		# therefore ignore this event for now.
+		if winVersion.getWinVer() >= winVersion.WIN11:
+			return
 		oldNav = api.getNavigatorObject()
 		if isinstance(oldNav, ImeCandidateItem) and self.name == oldNav.name:
 			# Duplicate selection event fired on the candidate item. Ignore it.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -315,9 +315,13 @@ class AppModule(appModuleHandler.AppModule):
 				)
 			):
 				clsList.insert(0, ImeCandidateItem)
-			elif obj.role == controlTypes.Role.PANE and obj.UIAAutomationId in (
-				"IME_Candidate_Window",
-				"IME_Prediction_Window"
+			elif (
+				obj.role in (controlTypes.Role.PANE, controlTypes.Role.LIST, controlTypes.Role.POPUPMENU)
+				and obj.UIAAutomationId in (
+					"IME_Candidate_Window",
+					"IME_Prediction_Window",
+					"TEMPLATE_PART_CandidatePanel",
+				)
 			):
 				clsList.insert(0, ImeCandidateUI)
 			# #13104: newer revisions of Windows 11 build 22000 moves focus to emoji search field.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -121,6 +121,9 @@ class AppModule(appModuleHandler.AppModule):
 	disableBrowseModeByDefault: bool = True
 
 	def event_UIA_elementSelected(self, obj, nextHandler):
+		# In Windows 11, candidate panel houses candidate items, not the prediction window.
+		if obj.UIAAutomationId == "TEMPLATE_PART_CandidatePanel":
+			obj = obj.firstChild
 		# Logic for IME candidate items is handled all within its own object
 		# Therefore pass these events straight on.
 		if isinstance(obj, ImeCandidateItem):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -49,6 +49,7 @@ This only worked for Bluetooth Serial ports before. (#14524)
 - Fixes for Windows 11:
   - NVDA can once again announce Notepad status bar contents. (#14573)
   - Switching between tabs will announce the new tab name and position for Notepad and File Explorer. (#14587, #14388)
+  - NVDA will once again announce candidate items when entering text in languages such as Chinese and Japanese. (#14509)
   -
 - In Mozilla Firefox, moving the mouse over text after a link now reliably reports the text. (#9235)
 - In Windows 10 and 11 Calculator, a portable copy of NVDA will no longer do nothing or play error tones when entering expressions in standard calculator in compact overlay mode. (#14679)


### PR DESCRIPTION

### Link to issue number:
Closes #14509 

### Summary of the issue:
NVDA does not recognize Windows 11 IME interface, or if it does, announces candidate items multiple times.

### Description of user facing changes
NVDA will recognize and announce Windows 11 IME candidate items used when entering text in languages such as Chinese, Japanese, Korean, and other languages through use of input method editors (IME).

### Description of development approach
Three changes to modern keyboard app module:

1. Recognize IME candidate UI and candidate items found in Windows 11.
2. Unlike Windows 10, Windows 11 adds an extra element to IME candidate window, therefore descend one more level when locating IME candidate items in app module version of UIA element selected event handler.
3. Veto UIA element selected event for IME candidate item in Windows 11 until a solution that allows focus and element selected events to cooperate when announcing IME candidate items.

For the third change, feedback from people speaking and typing Chinese, Japanese, and Korean would be helpful (this PR was based on Korean nput but could be expanded to cover Chinese, Japanese, and perhaps other languages in the future, either part of this pull request (unlikely) or in future PR's).

### Testing strategy:
Manual testing (prerequisite: CJK input method editors must be instaled):

On Windows 11, install IME for languages such as Chinse, Japanese, or Korean. Then open a text field such as Notepad document, switch input language to one of these languages (Windows+Space), then:

1. Without the PR installed, type something in one of the new languages. Notice that NVDA may not recognize IME candidates, or if it does, only focus event is fired.
2. Repeat item 1 but with the PR applied.

### Known issues with pull request:
Feedback from speakers of various languages and users of IME's would be helpful in refining this PR as this implementation is limited to CJK IME at this time.

### Change log entries:
If adopted and tested after receiving feedback:

Bug fixes:

Under Windows 11 fixes section:
NVDA will once again announce candidate items when entering text in languages such as Chinese and Japanese. (#14509)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

### Additional context:
This PR comes from code found in Windows App Essentials add-on, with the fixed described included in the add-on since late 2021.
