### PR TITLE
Display in braille the character number upon request

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1861,6 +1861,7 @@ class GlobalCommands(ScriptableObject):
 			if c is not None:
 				speech.speakMessage("%d," % c)
 				speech.speakSpelling(hex(c))
+				braille.handler.message(f"{c}, {hex(c)}")
 			else:
 				log.debugWarning("Couldn't calculate ordinal for character %r" % info.text)
 				speech.speakTextInfo(info, unit=textInfos.UNIT_CHARACTER, reason=controlTypes.OutputReason.CARET)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -17,6 +17,7 @@ What's New in NVDA
 - When highlighted text is enabled Document Formatting, highlight colours are now reported in Microsoft Word. (#7396, #12101, #5866)
 - When colors are enabled Document Formatting, background colours are now reported in Microsoft Word. (#5866)
 - Introduced a new command to cycle through the available languages for Windows OCR. (#13036)
+- When pressing ``numpad2`` three times to report the numerical value of the character at the position of the review cursor, the information is now also provided in braille. (#14826)
 - 
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #14826
### Summary of the issue:
When pressing 3 times numpad2, the character number is reported by speech (both in decimal form and hexadecimal form). However, for braille users it would be useful to have this information.
### Description of user facing changes
When pressing three times numpad2 to call the script "Report current character in review", the reported information (character number in decimal and hexadecimal) is also reported in braille, not only by speech.
First press and second press of this script remain unchanged since:
* First press only report the current character which is already available at the review cursor's position on the braille display, provided that the braille follows automatically (default settings) or review.
* Second press is a feature dedicated to speech users, when they cannot hear correctly the character name.

### Description of development approach
Added a braille update as done in `ui.message`. We do not use directly `ui.message` since the hex value has to be spelt.

### Testing strategy:
Manual testing:
Pressed once, twice and 3 times numpad2; and checked that:
* For each case, the speech is still reported the same way as it was before
* Upon first and second press, nothing happens at braille level
* At third press, the information reported vocally is also reported in braille
### Known issues with pull request:
None
### Change log entries:
New features
When pressing three times numpad2 to report the numerical value of the character at the position of the review cursor, the information is now also provided in braille. (#14826)

Note: better wording welcome if needed; cc @XLTechie 
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
