### PR TITLE
Use UI automation for RICHEDIT60W in Microsoft Excel on Windows 10 and above

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -674,9 +674,13 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 
 	def _getTextAtRange(self,rangeObj):
 		embedRangeObj=None
-		bufText=rangeObj.text
+		try:
+			bufText=rangeObj.text
+		except COMError:
+			log.debugWarning("range.text failed", exc_info=True)
+			bufText = None
 		if not bufText:
-			return u""
+			return ""
 		if controlTypes.State.PROTECTED in self.obj.states:
 			return u'*'*len(bufText)
 		newTextList=[]

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -675,7 +675,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 	def _getTextAtRange(self,rangeObj):
 		embedRangeObj=None
 		try:
-			bufText=rangeObj.text
+			bufText = rangeObj.text
 		except COMError:
 			log.debugWarning("range.text failed", exc_info=True)
 			bufText = None

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -677,7 +677,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		try:
 			bufText = rangeObj.text
 		except COMError:
-			log.debugWarning("range.text failed", exc_info=True)
+			log.debugWarning("rangeObj.text failed", exc_info=True)
 			bufText = None
 		if not bufText:
 			return ""

--- a/source/appModules/excel.py
+++ b/source/appModules/excel.py
@@ -10,6 +10,8 @@ import eventHandler
 import api
 import UIAHandler
 from NVDAObjects.UIA import UIA
+import winUser
+import winVersion
 import controlTypes
 import appModuleHandler
 from NVDAObjects.window import DisplayModelEditableText
@@ -58,6 +60,21 @@ class Excel6_WhenUIAEnabled(IAccessible):
 
 
 class AppModule(appModuleHandler.AppModule):
+
+	def isGoodUIAWindow(self, hwnd: int) -> bool:
+		windowClass = winUser.getClassName(hwnd)
+		versionMajor = int(self.productVersion.split('.')[0])
+		if (
+			versionMajor >= 16
+			and windowClass == "RICHEDIT60W"
+			and winVersion.getWinVer() >= winVersion.WIN10
+		):
+			# RICHEDIT60W In Excel 2016+ on Windows 10+
+			# has a very good UI Automation implementation,
+			# Though oddly IsServerSideProvider returns false for these windows.
+			# Examples: Password field in the Protect sheet dialog.
+			return True
+		return False
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		windowClass = obj.windowClassName

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -61,6 +61,7 @@ Instead NVDA reports that the link has no destination. (#14723)
 - The destination of graphic links are now correctly reported in Chrome and Edge. (#14779)
 - In Windows 11, it is once again possible to open the Contributors and License items on the NVDA Help menu. (#14725)
 - When forcing UIA support with certain terminal and consoles, a bug is fixed which caused a freeze and the log file to be spammed. (#14689)
+- NVDA no longer fails to announce focusing password fields in Microsoft Excel and Outlook. (#14839)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Found when investigating #5221
Fixes #6871 
Fixes #11512
Though both of these issues had already been avoided in Outlook 2016+ by #14280 

### Summary of the issue:
When arrowing through a password in the password field in the Protect Sheet dialog in Microsoft Excel (alt h o p), NVDA produces an error and says nothing. Similarly, when tabbing to that control and the cursor is already on a password character, NVDA produces an error and the focus is not announced at all.
```
ERROR - scriptHandler.executeScript (18:54:08.558) - MainThread (5988):
error executing script: <bound method EditableText.script_caret_moveByCharacter of <NVDAObjects.Dynamic_IAccessibleRichEdit50WindowNVDAObject object at 0x0787CAF0>> with gesture 'home'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 289, in executeScript
  File "editableText.pyc", line 229, in script_caret_moveByCharacter
  File "editableText.pyc", line 164, in _caretMovementScriptHelper
  File "NVDAObjects\behaviors.pyc", line 220, in _caretScriptPostMovedHelper
  File "editableText.pyc", line 150, in _caretScriptPostMovedHelper
  File "speech\speech.pyc", line 1231, in speakTextInfo
  File "speech\types.pyc", line 42, in __iter__
  File "speech\speech.pyc", line 1273, in getTextInfoSpeech
  File "NVDAObjects\window\edit.pyc", line 735, in getTextWithFields
  File "NVDAObjects\window\edit.pyc", line 677, in _getTextAtRange
  File "comtypes\__init__.pyc", line 278, in __getattr__
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 32, in __call__
_ctypes.COMError: (-2147467259, 'Unspecified error', (None, None, None, 0, None))
```

### Description of user facing changes
NVDA no longer fails to announce the focus when tabbing to the password field in Excel's Protect sheet dialog.

### Description of development approach
1. In the ITextDocument TextInfo's text property: catch COMError when calling range.text. This can occur when the edit control is protected. Just log a debugWarning and return the empty string - there is nothing else we can do about this error. This allows NVDA to announce the focus without an error. And when arrowing through the characters, 'blank' will be spoken rather than an error, which is better than nothing.
2. In the appModule for Excel: treat RICHEDIT60W windows as having a good UI automation implementation if on Windows 10 or higher and Office 2016 or higher. Office 2016 on Win 10+ has a very good UI automation implementation for RICHEDIT60W, which includes being able to fetch 'circle' characters when arrowing through a password.
So in summary, on Office 2016 win10+ the error is gone and NvDA can announce 'circle' when arrowing through password characters in the Protect sheet dialog.
On older versions of Office / Windows, the error is gone, though NVDA will announce 'blank' when arrowing through password characters.

### Testing strategy:
Office 2016 on Windows 11:
* Open a new workbook in Excel. 
* Press alt h o p to pen the Protect sheet dialog. 
* Type a password into the password field.
* Arrow throuh the characters with left and right arrow, noticing that 'circle' is announced, and not an error.
* Tab past the control and back to it again. Notice that the password field is announced, rather than staying silent and producing an error.

### Known issues with pull request:
On older Office versions / older windows versions, 'blank' is announced when arrowing through the characters. Though previously nothing was announced an an error was produced.

### Change log entries:
New features
Changes
Bug fixes
NVDA no longer fails to announce focusing the password field in Excel's Protect Sheet dialog.
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
