### PR TITLE
Add-on store: Add setting to view incompatible add-ons available to download and install

### DIFF
--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -35,6 +35,11 @@ EG: (x, y, z): Large changes to speech.py
 (2019, 3, 0): speech refactor, Python 3
 (0, 0, 0): API version zero, used to signify addons released prior to API version checks.
 """
+LATEST = "latest"
+"""
+A string value used in the add-on store to fetch the latest version of all add-ons,
+i.e include older incompatible versions.
+"""
 
 # Compiled regular expression to match an addon API version string.
 # Supports year.major.minor versions (e.g. 2018.1.1).

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -424,7 +424,7 @@ class AddonBase(SupportsVersionCheck, ABC):
 	@property
 	def _getAddonStoreData(self) -> Optional["AddonStoreModel"]:
 		from addonStore.dataManager import addonDataManager
-		return addonDataManager.getLatestAvailableAddons().get(self.name)
+		return addonDataManager.getLatestCompatibleAddons().get(self.name)
 
 
 class Addon(AddonBase):

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -193,8 +193,8 @@ class _DataManager:
 		pathlib.Path(self._addonDownloadCacheDir).mkdir(parents=True, exist_ok=True)
 		pathlib.Path(self._installedAddonDataCacheDir).mkdir(parents=True, exist_ok=True)
 
-		self._latestAddonCache: Optional[CachedAddonsModel] = self._getCachedAddonData(self._cacheLatestFile)
-		self._compatibleAddonCache: Optional[CachedAddonsModel] = self._getCachedAddonData(self._cacheCompatibleFile)
+		self._latestAddonCache = self._getCachedAddonData(self._cacheLatestFile)
+		self._compatibleAddonCache = self._getCachedAddonData(self._cacheCompatibleFile)
 
 	def getFileDownloader(self) -> AddonFileDownloader:
 		return AddonFileDownloader(self._addonDownloadCacheDir)

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -80,5 +80,3 @@ except ImportError:
 version_detailed = formatBuildVersionString()
 # A test version is anything other than a final or rc release.
 isTestVersion = not version[0].isdigit() or "alpha" in version or "beta" in version or "dev" in version
-# A pre-release version is a test version or rc release.
-isPreReleaseVersion = isTestVersion or "rc" in version

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -231,6 +231,9 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [documentNavigation]
 	paragraphStyle = featureFlag(optionsEnum="ParagraphNavigationFlag", behaviorOfDefault="application")
 
+[addonStore]
+	incompatibleAddons = boolean(default=false)
+
 [reviewCursor]
 	simpleReviewMode = boolean(default=True)
 	followFocus = boolean(default=True)

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -649,7 +649,10 @@ class AddonStoreVM:
 		if config.conf["addonStore"]["incompatibleAddons"]:
 			incompatibleAddons: CaseInsensitiveDict[AddonDetailsModel] = addonDataManager.getLatestAddons()
 			for addonId in incompatibleAddons:
-				# only include incompatible add-ons if no compatible or installed version available 
+				# only include incompatible add-ons if:
+				# - no compatible or installed versions are available
+				# - the user can override the compatibility of the add-on
+				# (it's too old and not too new)
 				if addonId not in addons and incompatibleAddons[addonId].canOverrideCompatibility:
 					addons[addonId] = incompatibleAddons[addonId]
 		log.debug("completed getting addons in the background")

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -37,6 +37,7 @@ from addonStore.status import (
 	_statusFilters,
 	AvailableAddonStatus,
 )
+import config
 import core
 import extensionPoints
 from logHandler import log
@@ -639,11 +640,18 @@ class AddonStoreVM:
 
 	def _getAddonsInBG(self):
 		log.debug("getting addons in the background")
-		addons: CaseInsensitiveDict[AddonDetailsModel] = addonDataManager.getLatestAvailableAddons()
+		addons: CaseInsensitiveDict[AddonDetailsModel] = addonDataManager.getLatestCompatibleAddons()
 		addonHandlerAddons = addonHandler.state._addonHandlerCache.availableAddonsAsDetails
 		for addonId in addonHandlerAddons:
+			# only use installed add-on data if no add-on store details available
 			if addonId not in addons:
 				addons[addonId] = addonHandlerAddons[addonId]
+		if config.conf["addonStore"]["incompatibleAddons"]:
+			incompatibleAddons: CaseInsensitiveDict[AddonDetailsModel] = addonDataManager.getLatestAddons()
+			for addonId in incompatibleAddons:
+				# only include incompatible add-ons if no compatible or installed version available 
+				if addonId not in addons and incompatibleAddons[addonId].canOverrideCompatibility:
+					addons[addonId] = incompatibleAddons[addonId]
 		log.debug("completed getting addons in the background")
 		self._addons = addons
 		self.listVM.resetListItems(self._createListItemVMs())

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -48,7 +48,7 @@ import brailleInput
 import vision
 import vision.providerInfo
 import vision.providerBase
-from typing import Callable, List, Optional, Any
+from typing import Callable, List, Optional, Any, cast
 import core
 import keyboardHandler
 import characterProcessing
@@ -2555,6 +2555,25 @@ class DocumentNavigationPanel(SettingsPanel):
 		self.paragraphStyleCombo.saveCurrentValueToConf()
 
 
+class AddonStorePanel(SettingsPanel):
+	# Translators: This is the label for the addon navigation settings panel.
+	title = _("Add-on Store")
+	helpId = "AddonStoreSettings"
+
+	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		# Translators: This is a label for the paragraph navigation style in the document navigation dialog
+		incompatibleAddonsLabel = _("List &incompatible add-ons as available")
+		self.incompatibleAddonsCheckBox = cast(wx.CheckBox, sHelper.addItem(
+			wx.CheckBox(self, label=incompatibleAddonsLabel)
+		))
+		self.incompatibleAddonsCheckBox.SetValue(config.conf["addonStore"]["incompatibleAddons"])
+		self.bindHelpEvent("IncompatibleAddonsSetting", self.incompatibleAddonsCheckBox)
+
+	def onSave(self):
+		config.conf["addonStore"]["incompatibleAddons"] = self.incompatibleAddonsCheckBox.IsChecked()
+
+
 class TouchInteractionPanel(SettingsPanel):
 	# Translators: This is the label for the touch interaction settings panel.
 	title = _("Touch Interaction")
@@ -4110,6 +4129,7 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		BrowseModePanel,
 		DocumentFormattingPanel,
 		DocumentNavigationPanel,
+		AddonStorePanel,
 	]
 	if touchHandler.touchSupported():
 		categoryClasses.append(TouchInteractionPanel)

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -7,11 +7,10 @@ Add-ons can be filtered by status.
 1. Open the add-on store
 1. Jump to the filter-by status field (`alt+f`)
 1. Filter by each status, ensure expected add-ons are displayed.
-    - all add-ons: should include all add-ons, installed and available for install
-    - installed
-    - updatable: should include installed add-ons which can be updated or replaced by an add-on store version
-    - disabled: should include manually disabled add-ons and add-ons disabled due to incompatibility
-    - available: should include add-ons available for install
+    - Installed: should include installed, disabled, and updatable add-ons.
+    - Updatable: should include installed add-ons which can be updated or replaced by an add-on store version
+    - Disabled: should include manually disabled add-ons and add-ons disabled due to incompatibility
+    - Available: should include add-ons available for install
 
 ### Filtering by add-on information
 Add-ons can be filtered by display name, publisher and description.
@@ -28,6 +27,15 @@ Add-ons can be filtered by display name, publisher and description.
 1. Jump to the search text field (`alt+s`)
 1. Search for a string which yields no add-ons.
 1. Ensure the add-on information dialog  states "no add-on selected".
+
+### Browsing incompatible add-ons available for download
+1. Open NVDA preferences
+1. Navigate to Add-on Store preferences
+1. Enable "List incompatible add-ons as available"
+1. Open the Add-on Store
+1. Jump to the filter-by status field (`alt+f`)
+1. Select "Available add-ons"
+1. Ensure add-ons with status "incompatible" are displayed in the list.
 
 
 ## Installing add-ons

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -35,7 +35,7 @@ Add-ons can be filtered by display name, publisher and description.
 1. Open the Add-on Store
 1. Jump to the filter-by status field (`alt+f`)
 1. Select "Available add-ons"
-1. Ensure add-ons with status "incompatible" are displayed in the list.
+1. Ensure add-ons with status "incompatible" are included in the list with the available add-ons.
 
 
 ## Installing add-ons

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -5,7 +5,7 @@
 Add-ons can be filtered by status.
 
 1. Open the add-on store
-1. Jump to the filter-by status field (`alt+s`)
+1. Jump to the filter-by status field (`alt+f`)
 1. Filter by each status, ensure expected add-ons are displayed.
     - all add-ons: should include all add-ons, installed and available for install
     - installed
@@ -17,7 +17,7 @@ Add-ons can be filtered by status.
 Add-ons can be filtered by display name, publisher and description.
 
 1. Open the add-on store
-1. Jump to the filter-by text field (`alt+f`)
+1. Jump to the search text field (`alt+s`)
 1. Search for a string, for example part of a publisher name, display name or description.
 1. Ensure expected add-ons appear after the filter view refreshes.
 1. Remove the filter-by string
@@ -25,7 +25,7 @@ Add-ons can be filtered by display name, publisher and description.
 
 ### Filtering where no add-ons are found
 1. Open the add-on store
-1. Jump to the filter-by text field (`alt+f`)
+1. Jump to the search text field (`alt+s`)
 1. Search for a string which yields no add-ons.
 1. Ensure the add-on information dialog  states "no add-on selected".
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2116,6 +2116,14 @@ Note that this paragraph style cannot be used in Microsoft Word or Microsoft Out
 
 You may toggle through the available paragraph styles from anywhere by assigning a key in the [Input Gestures dialog #InputGestures].
 
++++ Add-on Store Settings +++[AddonStoreSettings]
+The settings in this category allow you to configure the [Add-on Store #AddonsManager].
+This category contains the following options:
+
+==== List incompatible add-ons as available ====[IncompatibleAddonsSetting]
+When this checkbox is enabled, the add-on store will display add-ons that are incompatible due to being out of date.
+A user can install and enable [incompatible add-ons #incompatibleAddonsManager] at their own risk.
+
 +++ Windows OCR Settings +++[Win10OcrSettings]
 The settings in this category allow you to configure [Windows OCR #Win10Ocr].
 This category contains the following options:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2121,8 +2121,9 @@ The settings in this category allow you to configure the [Add-on Store #AddonsMa
 This category contains the following options:
 
 ==== List incompatible add-ons as available ====[IncompatibleAddonsSetting]
-When this checkbox is enabled, the add-on store will display add-ons that are incompatible due to being out of date.
-A user can install and enable [incompatible add-ons #incompatibleAddonsManager] at their own risk.
+The add-on store allows browsing add-ons available to install.
+When this checkbox is enabled, the add-on store will also display add-ons that are incompatible due to being out of date.
+This is so [incompatible add-ons #incompatibleAddonsManager] can be installed and enabled at your own risk.
 
 +++ Windows OCR Settings +++[Win10OcrSettings]
 The settings in this category allow you to configure [Windows OCR #Win10Ocr].


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
The add-on store displays add-ons compatible with the current version of NVDA by default.
It is expected that a user may wish to install an outdated version of an add-on, to test or manually override incompatibility.
As such, users need the option to view outdated add-ons in the add-on store.

### Description of user facing changes
Adds a new settings panel for the add-on store.
This gives users the option to view incompatible add-ons available to download and install in the add-on store.

### Description of development approach
Cache the latest version of compatible add-ons and the latest versions of all add-ons in separate files.
When including incompatible add-ons ensure:
- no compatible or installed versions are available
- the user can override the compatibility of the add-on (i.e. it's too old and not too new)

### Testing strategy:
Manual test plan:
1. Open NVDA preferences
1. Navigate to Add-on Store preferences
1. Enable "List incompatible add-ons as available"
1. Open the Add-on Store
1. Jump to the filter-by status field (`alt+f`)
1. Select "Available add-ons"
1. Ensure add-ons with status "incompatible" are displayed in the list.

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
