### PR TITLE
Add-on store: minor addonHandler fixup

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -197,9 +197,10 @@ class AddonsState(collections.UserDict):
 		by default confusing users. Fix this by removing all add-ons no longer present in the config
 		from the list of disabled add-ons in the state."""
 		installedAddonNames = set(self._addonHandlerCache.availableAddons.keys())
-		for disabledAddonName in self["disabledAddons"]:
+		for disabledAddonName in CaseInsensitiveSet(self[AddonStateCategory.DISABLED]):
+			# Iterate over copy of set to prevent updating the set while iterating over it.
 			if disabledAddonName not in installedAddonNames:
-				self["disabledAddons"].discard(disabledAddonName)
+				self[AddonStateCategory.DISABLED].discard(disabledAddonName)
 
 
 state: AddonsState[AddonStateCategory, CaseInsensitiveSet[str]] = AddonsState()
@@ -424,6 +425,9 @@ class AddonBase(SupportsVersionCheck, ABC):
 	@property
 	def _getAddonStoreData(self) -> Optional["AddonStoreModel"]:
 		from addonStore.dataManager import addonDataManager
+		installedData = addonDataManager._getCachedInstalledAddonData(self.name)
+		if installedData is not None:
+			return installedData
 		return addonDataManager.getLatestCompatibleAddons().get(self.name)
 
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -425,9 +425,6 @@ class AddonBase(SupportsVersionCheck, ABC):
 	@property
 	def _getAddonStoreData(self) -> Optional["AddonStoreModel"]:
 		from addonStore.dataManager import addonDataManager
-		installedData = addonDataManager._getCachedInstalledAddonData(self.name)
-		if installedData is not None:
-			return installedData
 		return addonDataManager.getLatestCompatibleAddons().get(self.name)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
Add-on handler was mistakenly modified to modify a set while iterating over it.
This is fixed now.

### Description of user facing changes
Fixes bug/crash when cleaning up removed add-ons

### Description of development approach
Create another case insensitive set copy to iterate over.

### Testing strategy:
Tested cleaning up removed add-ons

### Known issues with pull request:
None

### Change log entries:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
