### PR TITLE
Add-on store: Notify user when download/fetch fails

### DIFF
--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -195,7 +195,7 @@ class AddonFileDownloader:
 				pgettext(
 					"addonStore",
 					# Translators: A message to the user if an add-on download fails
-					"Unable to download add-on file: {name}"
+					"Unable to download add-on: {name}"
 				).format(name=addonData.displayName),
 				_addonDownloadFailureMessageTitle,
 			)
@@ -205,7 +205,7 @@ class AddonFileDownloader:
 				pgettext(
 					"addonStore",
 					# Translators: A message to the user if an add-on download fails
-					"Unable to save add-on file: {name}"
+					"Unable to save add-on as a file: {name}"
 				).format(name=addonData.displayName),
 				_addonDownloadFailureMessageTitle,
 			)

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -300,7 +300,7 @@ class _DataManager:
 		return CachedAddonsModel(
 			availableAddons=_createStoreCollectionFromJson(cacheData["data"]),
 			cachedAt=fetchTime,
-			nvdaAPIVersion=cacheData["nvdaAPIVersion"],
+			nvdaAPIVersion=tuple(cacheData["nvdaAPIVersion"]),  # loads as list
 		)
 
 	def getLatestCompatibleAddons(

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -7,29 +7,32 @@
 # Can be removed in a future version of python (3.8+)
 from __future__ import annotations
 
+from concurrent.futures import (
+	Future,
+	ThreadPoolExecutor,
+)
+from core import callLater
 import dataclasses
-import globalVars
+from datetime import datetime, timedelta
 import json
 import os
 import pathlib
-from concurrent.futures import (
-	Future,
-	ThreadPoolExecutor
+from typing import (
+	TYPE_CHECKING,
+	cast,
+	Callable,
+	Dict,
+	Optional,
+	Tuple,
 )
-from datetime import datetime, timedelta
 
-from logHandler import log
 import requests
 from requests.structures import CaseInsensitiveDict
 
 import addonAPIVersion
-from typing import (
-	cast,
-	Optional,
-	Dict,
-	Callable,
-	Tuple,
-)
+from logHandler import log
+import globalVars
+
 from .models import (
 	Channel,
 	_createStoreModelFromData,
@@ -38,6 +41,10 @@ from .models import (
 )
 
 addonDataManager: Optional["_DataManager"] = None
+
+
+if TYPE_CHECKING:
+	from gui.message import DisplayableError
 
 
 def initialize():
@@ -74,7 +81,14 @@ class AddonFileDownloader:
 	def __init__(self, cacheDir: os.PathLike):
 		self._cacheDir = cacheDir
 		self.progress: Dict[AddonStoreModel, int] = {}  # Number of chunks received
-		self._pending: Dict[Future, Tuple[AddonStoreModel, AddonFileDownloader.OnCompleteT]] = {}
+		self._pending: Dict[
+			Future,
+			Tuple[
+				AddonStoreModel,
+				AddonFileDownloader.OnCompleteT,
+				"DisplayableError.OnDisplayableErrorT"
+			]
+		] = {}
 		self.complete: Dict[AddonStoreModel, os.PathLike] = {}  # Path to downloaded file
 		self._executor = ThreadPoolExecutor(
 			max_workers=1,
@@ -84,13 +98,14 @@ class AddonFileDownloader:
 	def download(
 			self,
 			addonData: AddonStoreModel,
-			onComplete: OnCompleteT
+			onComplete: OnCompleteT,
+			onDisplayableError: "DisplayableError.OnDisplayableErrorT",
 	):
 		self.progress[addonData] = 0
 		f: Future = self._executor.submit(
 			self._download, addonData,
 		)
-		self._pending[f] = addonData, onComplete
+		self._pending[f] = addonData, onComplete, onDisplayableError
 		f.add_done_callback(self._done)
 
 	def _done(self, downloadAddonFuture: Future):
@@ -103,10 +118,21 @@ class AddonFileDownloader:
 		if not downloadAddonFuture.done() or downloadAddonFuture.cancelled():
 			log.error("Logic error with download in BG thread.")
 			return
-		if downloadAddonFuture.exception():
-			log.error(f"Unhandled exception in _download", exc_info=downloadAddonFuture.exception())
-			return
-		addonData, onComplete = self._pending.pop(downloadAddonFuture)
+		addonData, onComplete, onDisplayableError = self._pending[downloadAddonFuture]
+		downloadAddonFutureException = downloadAddonFuture.exception()
+		if downloadAddonFutureException:
+			from gui.message import DisplayableError
+			if not isinstance(downloadAddonFutureException, DisplayableError):
+				log.error(f"Unhandled exception in _download", exc_info=downloadAddonFuture.exception())
+				return
+			else:
+				callLater(
+					delay=0,
+					callable=onDisplayableError.notify,
+					displayableError=downloadAddonFutureException
+				)
+
+		del self._pending[downloadAddonFuture]
 		del self.progress[addonData]
 		cacheFilePath: Optional[os.PathLike] = downloadAddonFuture.result()
 		self.complete[addonData] = cacheFilePath
@@ -121,7 +147,36 @@ class AddonFileDownloader:
 		self.progress.clear()
 		self._pending.clear()
 
+	def _downloadAddonToPath(self, addonData: AddonStoreModel, downloadFilePath: str) -> bool:
+		"""
+		@return: True if the add-on is downloaded successfully,
+		False if the download is cancelled
+		"""
+		with requests.get(addonData.URL, stream=True) as r:
+			with open(downloadFilePath, 'wb') as fd:
+				# Most add-ons are small. This value was chosen quite arbitrarily, but with the intention to allow
+				# interrupting the download. This is particularly important on a slow connection, to provide
+				# a responsive UI when cancelling.
+				# A size has been selected attempting to balance the maximum throughput, with responsiveness for
+				# users with a slow connection.
+				# This could be improved by dynamically adjusting the chunk size based on the time elapsed between
+				# chunk, starting with small chunks and increasing up until a maximum wait time is reached.
+				chunkSize = 128000
+				for chunk in r.iter_content(chunk_size=chunkSize):
+					log.debug(f"Chunk download: {addonData.addonId}")
+					fd.write(chunk)
+					if addonData in self.progress:  # Removed when the download should be cancelled.
+						self.progress[addonData] += 1
+					else:
+						log.debug(f"Cancelled download: {addonData.addonId}")
+						return False  # The download was cancelled
+		return True
+
 	def _download(self, addonData: AddonStoreModel) -> Optional[os.PathLike]:
+		from gui.message import DisplayableError
+		# Translators: A title for a dialog notifying a user of an add-on download failure.
+		_addonDownloadFailureMessageTitle = pgettext("addonStore", "Add-on download failure")
+
 		log.debug(f"starting download: {addonData.addonId}")
 		cacheFilePath = os.path.join(
 			self._cacheDir,
@@ -132,30 +187,28 @@ class AddonFileDownloader:
 			log.debug("the download was cancelled before it started.")
 			return None  # The download was cancelled
 		try:
-			with requests.get(addonData.URL, stream=True) as r:
-				with open(inProgressFilePath, 'wb') as fd:
-					# Most add-ons are small. This value was chosen quite arbitrarily, but with the intention to allow
-					# interrupting the download. This is particularly important on a slow connection, to provide
-					# a responsive UI when cancelling.
-					# A size has been selected attempting to balance the maximum throughput, with responsiveness for
-					# users with a slow connection.
-					# This could be improved by dynamically adjusting the chunk size based on the time elapsed between
-					# chunk, starting with small chunks and increasing up until a maximum wait time is reached.
-					chunkSize = 128000
-					for chunk in r.iter_content(chunk_size=chunkSize):
-						log.debug(f"Chunk download: {addonData.addonId}")
-						fd.write(chunk)
-						if addonData in self.progress:  # Removed when the download should be cancelled.
-							self.progress[addonData] += 1
-						else:
-							log.debug(f"Cancelled download: {addonData.addonId}")
-							return None  # The download was cancelled
+			if not self._downloadAddonToPath(addonData, inProgressFilePath):
+				return None  # The download was cancelled
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to download addon file: {e}")
-			return None
+			raise DisplayableError(
+				pgettext(
+					"addonStore",
+					# Translators: A message to the user if an add-on download fails
+					"Unable to download add-on file: {name}"
+				).format(name=addonData.displayName),
+				_addonDownloadFailureMessageTitle,
+			)
 		except OSError as e:
 			log.debugWarning(f"Unable to save addon file ({inProgressFilePath}): {e}")
-			return None
+			raise DisplayableError(
+				pgettext(
+					"addonStore",
+					# Translators: A message to the user if an add-on download fails
+					"Unable to save add-on file: {name}"
+				).format(name=addonData.displayName),
+				_addonDownloadFailureMessageTitle,
+			)
 		log.debug(f"Download complete: {inProgressFilePath}")
 		if os.path.exists(cacheFilePath):
 			log.debug(f"Cache file already exists, deleting prior to rename: {cacheFilePath}")
@@ -203,7 +256,7 @@ class _DataManager:
 		url = _getAddonStoreURL(self._preferredChannel, self._lang, apiVersion)
 		try:
 			response = requests.get(url)
-		except requests.exceptions.ConnectionError as e:
+		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to fetch addon data: {e}")
 			return None
 		if response.status_code != requests.codes.OK:
@@ -250,7 +303,10 @@ class _DataManager:
 			nvdaAPIVersion=cacheData["nvdaAPIVersion"],
 		)
 
-	def getLatestCompatibleAddons(self) -> CaseInsensitiveDict["AddonStoreModel"]:
+	def getLatestCompatibleAddons(
+			self,
+			onDisplayableError: DisplayableError.OnDisplayableErrorT
+	) -> CaseInsensitiveDict["AddonStoreModel"]:
 		shouldRefreshData = (
 			not self._compatibleAddonCache
 			or self._compatibleAddonCache.nvdaAPIVersion != addonAPIVersion.CURRENT
@@ -270,16 +326,30 @@ class _DataManager:
 					cachedAt=fetchTime,
 					nvdaAPIVersion=addonAPIVersion.CURRENT,
 				)
+			else:
+				from gui.message import DisplayableError
+				displayableError = DisplayableError(
+					# Translators: A message shown when fetching add-on data from the store fails
+					pgettext("addonStore", "Unable to fetch latest add-on data for compatible add-ons."),
+					# Translators: A title of the dialog shown when fetching add-on data from the store fails
+					pgettext("addonStore", "Add-on data update failure"),
+				)
+				callLater(delay=0, callable=onDisplayableError.notify, displayableError=displayableError)
+		if self._compatibleAddonCache is None:
+			return CaseInsensitiveDict()
 		return self._compatibleAddonCache.availableAddons
 
-	def getLatestAddons(self) -> CaseInsensitiveDict["AddonStoreModel"]:
+	def getLatestAddons(
+			self,
+			onDisplayableError: DisplayableError.OnDisplayableErrorT
+	) -> CaseInsensitiveDict["AddonStoreModel"]:
 		shouldRefreshData = (
 			not self._latestAddonCache
 			or _DataManager._cachePeriod < (datetime.now() - self._latestAddonCache.cachedAt)
 		)
 		if shouldRefreshData:
 			fetchTime = datetime.now()
-			apiData = self._getLatestAddonsDataForVersion(addonAPIVersion.LATEST)
+			apiData = self._getLatestAddonsDataForVersion(addonAPIVersion.LATEST, onDisplayableError)
 			if apiData:
 				decodedApiData = apiData.decode()
 				self._cacheLatestAddons(
@@ -291,6 +361,17 @@ class _DataManager:
 					cachedAt=fetchTime,
 					nvdaAPIVersion=addonAPIVersion.LATEST,
 				)
+			else:
+				from gui.message import DisplayableError
+				displayableError = DisplayableError(
+					# Translators: A message shown when fetching add-on data from the store fails
+					pgettext("addonStore", "Unable to fetch latest add-on data for incompatible add-ons."),
+					# Translators: A title of the dialog shown when fetching add-on data from the store fails
+					pgettext("addonStore", "Add-on data update failure"),
+				)
+				callLater(delay=0, callable=onDisplayableError.notify, displayableError=displayableError)
+		if self._latestAddonCache is None:
+			return CaseInsensitiveDict()
 		return self._latestAddonCache.availableAddons
 
 	def _cacheInstalledAddon(self, addonData: AddonStoreModel):

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -9,6 +9,8 @@ import threading
 from typing import Optional
 import wx
 
+import extensionPoints
+
 _messageBoxCounterLock = threading.Lock()
 _messageBoxCounter = 0
 
@@ -76,3 +78,34 @@ def messageBox(
 			_messageBoxCounter -= 1
 
 	return res
+
+
+class DisplayableError(Exception):
+	OnDisplayableErrorT = extensionPoints.Action
+	"""
+	A type of extension point used to notify a handler when an error occurs.
+	This allows a handler to handle displaying an error.
+
+	@param displayableError: Error that can be displayed to the user.
+	@type displayableError: DisplayableError
+	"""
+
+	def __init__(self, displayMessage: str, titleMessage: Optional[str] = None):
+		"""
+		@param displayMessage: A translated message, to be displayed to the user.
+		@param titleMessage: A translated message, to be used as a title for the display message.
+		If left None, "Error" is presented as the title by default.
+		"""
+		self.displayMessage = displayMessage
+		if titleMessage is None:
+			# Translators: A message indicating that an error occurred.
+			self.titleMessage = _("Error")
+		else:
+			self.titleMessage = titleMessage
+
+	def displayError(self):
+		messageBox(
+			message=self.displayMessage,
+			caption=self.titleMessage,
+			style=wx.OK | wx.ICON_ERROR
+		)

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -37,6 +37,16 @@ Add-ons can be filtered by display name, publisher and description.
 1. Select "Available add-ons"
 1. Ensure add-ons with status "incompatible" are included in the list with the available add-ons.
 
+### Failure to fetch add-ons available for download
+1. Disable your internet connection
+1. Go to your NVDA user configuration folder:
+    - For source: `.\source\userConfig`
+    - For installed copies: `%APPDATA%\nvda`
+1. To delete the current cache of available add-on store add-ons, delete the file: `addonStore\_cachedCompatibleAddons.json`
+1. Open the Add-on Store
+1. Ensure a warning is displayed: "Unable to fetch latest compatible add-ons"
+1. Ensure installed add-ons are still available in the add-on store.
+
 
 ## Installing add-ons
 
@@ -76,6 +86,13 @@ You can do this by:
 1. Exit the add-on store dialog
 1. You should be prompted for restart, restart NVDA
 1. Confirm the add-on is enabled in the add-ons manager
+
+### Failure to download add-on
+1. Open the Add-on Store
+1. Filter by available add-ons.
+1. Disable your internet connection
+1. Press install on a cached add-on
+1. Ensure a warning is displayed: "Unable download add-on"
 
 
 ## Updating add-ons


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
The add-on store may fail to fetch the latest data.
The add-on store may also have a problem downloading an add-on.
Currently, users are not notified of these failures.

### Description of user facing changes
Users are now notified when an add-on fails to download, or when the add-on store data fails to be fetched.

### Description of development approach
A "DisplayError" exception class was created based on the "TranslatedError" used previously.
When raising this exception, translatable strings for an error message are required.
When handling this exception, a message modal is created displaying the warning.

This allows injecting a error display handler for the add-on data-manager.
This is important if external components use the add-on data-manager, other than the add-on store GUI.
For example, when there is an automatic add-on updater.

### Testing strategy:
Manual test plans:

**Failure to fetch add-ons available for download**
1. Disable your internet connection
1. Go to your NVDA user configuration folder:
    - For source: `.\source\userConfig`
    - For installed copies: `%APPDATA%\nvda`
1. To delete the current cache of available add-on store add-ons, delete the file: `addonStore\_cachedCompatibleAddons.json`
1. Open the Add-on Store
1. Ensure a warning is displayed: "Unable to fetch latest compatible add-ons"
1. Ensure installed add-ons are still available in the add-on store.

**Failure to download add-on**
1. Open the Add-on Store
1. Filter by available add-ons.
1. Disable your internet connection
1. Press install on a cached add-on
1. Ensure a warning is displayed: "Unable download add-on"

### Known issues with pull request:
N/A

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
