### PR TITLE
Add-on Store: Add filter by channel

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -94,9 +94,9 @@ class AddonHandlerCache(AutoPropertyObject):
 		from addonStore.models import (
 			_createDetailsFromManifest,
 			Channel,
-			createAddonStoreCollection,
+			_createAddonDetailsCollection,
 		)
-		addons = createAddonStoreCollection()
+		addons = _createAddonDetailsCollection()
 		for addonId in self.installedAddons:
 			addonStoreData = self.installedAddons[addonId]._addonStoreData
 			if addonStoreData:

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -36,7 +36,7 @@ from .models import (
 	AddonStoreModel,
 	CachedAddonsModel,
 	Channel,
-	createAddonStoreCollection,
+	_createAddonDetailsCollection,
 	_createStoreModelFromData,
 	_createStoreCollectionFromJson,
 )
@@ -345,7 +345,7 @@ class _DataManager:
 				callLater(delay=0, callable=onDisplayableError.notify, displayableError=displayableError)
 
 		if self._compatibleAddonCache is None:
-			return createAddonStoreCollection()
+			return _createAddonDetailsCollection()
 		return self._compatibleAddonCache.cachedAddonData
 
 	def getLatestAddons(
@@ -381,7 +381,7 @@ class _DataManager:
 				callLater(delay=0, callable=onDisplayableError.notify, displayableError=displayableError)
 
 		if self._latestAddonCache is None:
-			return createAddonStoreCollection()
+			return _createAddonDetailsCollection()
 		return self._latestAddonCache.cachedAddonData
 
 	def _cacheInstalledAddon(self, addonData: AddonStoreModel):

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -12,7 +12,6 @@ from concurrent.futures import (
 	ThreadPoolExecutor,
 )
 from core import callLater
-import dataclasses
 from datetime import datetime, timedelta
 import json
 import os
@@ -27,19 +26,23 @@ from typing import (
 )
 
 import requests
-from requests.structures import CaseInsensitiveDict
 
 import addonAPIVersion
-from logHandler import log
 import globalVars
+from logHandler import log
 from utils.security import sha256_checksum
 
 from .models import (
+	AddonStoreModel,
+	CachedAddonsModel,
 	Channel,
+	createAddonStoreCollection,
 	_createStoreModelFromData,
 	_createStoreCollectionFromJson,
-	AddonStoreModel,
 )
+
+if TYPE_CHECKING:
+	from .models import AddonDetailsCollectionT
 
 addonDataManager: Optional["_DataManager"] = None
 
@@ -62,18 +65,6 @@ def _getCurrentApiVersionForURL() -> str:
 def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
 	_baseURL = "https://nvaccess.org/addonStore/"
 	return _baseURL + f"{lang}/{channel.value}/{nvdaApiVersion}.json"
-
-
-@dataclasses.dataclass
-class CachedAddonsModel:
-	availableAddons: CaseInsensitiveDict["AddonStoreModel"]
-	"""
-	Add-ons that have the same ID except differ in casing cause a path collision,
-	as add-on IDs are installed to a case insensitive path.
-	Therefore addon IDs should be treated as case insensitive.
-	"""
-	cachedAt: datetime
-	nvdaAPIVersion: addonAPIVersion.AddonApiVersionT
 
 
 class AddonFileDownloader:
@@ -315,7 +306,7 @@ class _DataManager:
 			return None
 		fetchTime = datetime.fromisoformat(cacheData["cacheDate"])
 		return CachedAddonsModel(
-			availableAddons=_createStoreCollectionFromJson(cacheData["data"]),
+			cachedAddonData=_createStoreCollectionFromJson(cacheData["data"]),
 			cachedAt=fetchTime,
 			nvdaAPIVersion=tuple(cacheData["nvdaAPIVersion"]),  # loads as list
 		)
@@ -323,7 +314,7 @@ class _DataManager:
 	def getLatestCompatibleAddons(
 			self,
 			onDisplayableError: DisplayableError.OnDisplayableErrorT
-	) -> CaseInsensitiveDict["AddonStoreModel"]:
+	) -> "AddonDetailsCollectionT":
 		shouldRefreshData = (
 			not self._compatibleAddonCache
 			or self._compatibleAddonCache.nvdaAPIVersion != addonAPIVersion.CURRENT
@@ -339,7 +330,7 @@ class _DataManager:
 					fetchTime=fetchTime,
 				)
 				self._compatibleAddonCache = CachedAddonsModel(
-					availableAddons=_createStoreCollectionFromJson(decodedApiData),
+					cachedAddonData=_createStoreCollectionFromJson(decodedApiData),
 					cachedAt=fetchTime,
 					nvdaAPIVersion=addonAPIVersion.CURRENT,
 				)
@@ -352,14 +343,15 @@ class _DataManager:
 					pgettext("addonStore", "Add-on data update failure"),
 				)
 				callLater(delay=0, callable=onDisplayableError.notify, displayableError=displayableError)
+
 		if self._compatibleAddonCache is None:
-			return CaseInsensitiveDict()
-		return self._compatibleAddonCache.availableAddons
+			return createAddonStoreCollection()
+		return self._compatibleAddonCache.cachedAddonData
 
 	def getLatestAddons(
 			self,
 			onDisplayableError: DisplayableError.OnDisplayableErrorT
-	) -> CaseInsensitiveDict["AddonStoreModel"]:
+	) -> "AddonDetailsCollectionT":
 		shouldRefreshData = (
 			not self._latestAddonCache
 			or _DataManager._cachePeriod < (datetime.now() - self._latestAddonCache.cachedAt)
@@ -374,7 +366,7 @@ class _DataManager:
 					fetchTime=fetchTime,
 				)
 				self._latestAddonCache = CachedAddonsModel(
-					availableAddons=_createStoreCollectionFromJson(decodedApiData),
+					cachedAddonData=_createStoreCollectionFromJson(decodedApiData),
 					cachedAt=fetchTime,
 					nvdaAPIVersion=addonAPIVersion.LATEST,
 				)
@@ -387,9 +379,10 @@ class _DataManager:
 					pgettext("addonStore", "Add-on data update failure"),
 				)
 				callLater(delay=0, callable=onDisplayableError.notify, displayableError=displayableError)
+
 		if self._latestAddonCache is None:
-			return CaseInsensitiveDict()
-		return self._latestAddonCache.availableAddons
+			return createAddonStoreCollection()
+		return self._latestAddonCache.cachedAddonData
 
 	def _cacheInstalledAddon(self, addonData: AddonStoreModel):
 		if not addonData:

--- a/source/addonStore/models.py
+++ b/source/addonStore/models.py
@@ -225,7 +225,7 @@ if TYPE_CHECKING:
 	"""
 
 
-def createAddonStoreCollection() -> "AddonDetailsCollectionT":
+def _createAddonDetailsCollection() -> "AddonDetailsCollectionT":
 	"""
 	Add-ons that have the same ID except differ in casing cause a path collision,
 	as add-on IDs are installed to a case insensitive path.
@@ -252,7 +252,7 @@ def _createStoreCollectionFromJson(jsonData: str) -> "AddonDetailsCollectionT":
 	for details of the data.
 	"""
 	data: List[Dict[str, Any]] = json.loads(jsonData)
-	addonCollection = createAddonStoreCollection()
+	addonCollection = _createAddonDetailsCollection()
 
 	for addon in data:
 		addonCollection[addon["channel"]][addon["addonId"]] = _createStoreModelFromData(addon)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -364,8 +364,9 @@ class AddonsDialog(
 		self.addonsList.DeleteAllItems()
 		self.curAddons: List[Addon] = []
 		anyAddonIncompatible = False
-		availableAddons = addonHandler.state._addonHandlerCache.availableAddons
-		for addon in sorted(availableAddons.values(), key=lambda a: strxfrm(a.manifest['summary'])):
+		assert addonHandler.state._addonHandlerCache
+		installedAddons = addonHandler.state._addonHandlerCache.installedAddons
+		for addon in sorted(installedAddons.values(), key=lambda a: strxfrm(a.manifest['summary'])):
 			self.addonsList.Append((
 				addon.manifest['summary'],
 				self.getAddonStatus(addon),

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -468,14 +468,14 @@ class AddonStoreVM:
 		return [
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Install"),
+				displayName=pgettext("addonStore", "&Install"),
 				actionHandler=self.getAddon,
 				validCheck=lambda aVM: aVM.status == AvailableAddonStatus.AVAILABLE,
 				listItemVM=selectedListItem
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Install (override incompatibility)"),
+				displayName=pgettext("addonStore", "&Install (override incompatibility)"),
 				actionHandler=self.installOverrideIncompatibilityForAddon,
 				validCheck=lambda aVM: (
 					aVM.status == AvailableAddonStatus.INCOMPATIBLE
@@ -485,21 +485,21 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Update"),
+				displayName=pgettext("addonStore", "&Update"),
 				actionHandler=self.getAddon,
 				validCheck=lambda aVM: aVM.status == AvailableAddonStatus.UPDATE,
 				listItemVM=selectedListItem
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Replace"),
+				displayName=pgettext("addonStore", "Re&place"),
 				actionHandler=self.replaceAddon,
 				validCheck=lambda aVM: aVM.status == AvailableAddonStatus.REPLACE_SIDE_LOAD,
 				listItemVM=selectedListItem
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Disable"),
+				displayName=pgettext("addonStore", "&Disable"),
 				actionHandler=self.disableAddon,
 				validCheck=lambda aVM: aVM.status not in (
 					AvailableAddonStatus.DISABLED,
@@ -512,7 +512,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Enable"),
+				displayName=pgettext("addonStore", "&Enable"),
 				actionHandler=self.enableAddon,
 				validCheck=lambda aVM: (
 					aVM.status == AvailableAddonStatus.DISABLED
@@ -522,7 +522,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("&Enable (override incompatibility)"),
+				displayName=pgettext("addonStore", "&Enable (override incompatibility)"),
 				actionHandler=self.enableOverrideIncompatibilityForAddon,
 				validCheck=lambda aVM: (
 					aVM.status == AvailableAddonStatus.INCOMPATIBLE_DISABLED
@@ -532,7 +532,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for a button that removes the selected addon
-				displayName=_("&Remove"),
+				displayName=pgettext("addonStore", "&Remove"),
 				actionHandler=self.removeAddon,
 				validCheck=lambda aVM: aVM.status not in (
 					AvailableAddonStatus.AVAILABLE,
@@ -543,7 +543,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for a button that installs the selected addon
-				displayName=_("Add-on &help"),
+				displayName=pgettext("addonStore", "Add-on &help"),
 				actionHandler=self.helpAddon,
 				validCheck=lambda aVM: aVM.status not in (
 					AvailableAddonStatus.AVAILABLE,

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -35,7 +35,7 @@ from addonStore.models import (
 	AddonDetailsModel,
 	AddonStoreModel,
 	Channel,
-	createAddonStoreCollection,
+	_createAddonDetailsCollection,
 )
 from addonStore.status import (
 	_getStatus,
@@ -419,7 +419,7 @@ class AddonActionVM:
 
 class AddonStoreVM:
 	def __init__(self):
-		self._addons = createAddonStoreCollection()
+		self._addons = _createAddonDetailsCollection()
 		self.hasError = extensionPoints.Action()
 		self.onDisplayableError = DisplayableError.OnDisplayableErrorT()
 		"""

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -11,8 +11,6 @@ from os import (
 	PathLike,
 	startfile,
 )
-
-from requests.structures import CaseInsensitiveDict
 from typing import (
 	Callable,
 	Set,
@@ -25,12 +23,19 @@ from typing import (
 )
 import threading
 
+from requests.structures import CaseInsensitiveDict
+
 import addonHandler
 from addonHandler import addonVersionCheck
-from addonStore.dataManager import addonDataManager
+from addonStore.dataManager import (
+	addonDataManager,
+)
 from addonStore.models import (
+	_channelFilters,
 	AddonDetailsModel,
 	AddonStoreModel,
+	Channel,
+	createAddonStoreCollection,
 )
 from addonStore.status import (
 	_getStatus,
@@ -53,6 +58,7 @@ from .dialogs import (
 if TYPE_CHECKING:
 	# Remove when https://github.com/python/typing/issues/760 is resolved
 	from _typeshed import SupportsLessThan
+	from addonStore.models import AddonDetailsCollectionT
 
 
 class AddonListItemVM:
@@ -82,8 +88,8 @@ class AddonListItemVM:
 			core.callLater(delay=0, callable=self.updated.notify, addonListItemVM=self)
 
 	@property
-	def Id(self) -> Optional[str]:
-		return self._model.addonId
+	def Id(self) -> str:
+		return self._model.listItemVMId
 
 	def __repr__(self) -> str:
 		return f"{self.__class__.__name__}: {self.Id}, {self.status}"
@@ -114,10 +120,23 @@ class AddonDetailsVM:
 		core.callLater(delay=0, callable=self.updated.notify, addonDetailsVM=self)
 
 
+if TYPE_CHECKING:
+	AddonListItemVMCollectionT = Dict[Channel, CaseInsensitiveDict["AddonListItemVM"]]
+
+
+def createAddonListItemVMCollection() -> "AddonListItemVMCollectionT":
+	return {
+		channel: CaseInsensitiveDict()
+		for channel in Channel
+		if channel != Channel.ALL
+	}
+
+
 class AddonListVM:
 	presentedAttributes = (
 		"displayName",
 		"addonVersionName",
+		"channel",
 		"publisher",
 		"status",  # NVDA state for this addon, see L{AvailableAddonStatus}
 	)
@@ -126,7 +145,7 @@ class AddonListVM:
 			self,
 			addons: List[AddonListItemVM],
 	):
-		self._addons: Dict[str, AddonListItemVM] = {}
+		self._addons: CaseInsensitiveDict[AddonListItemVM] = CaseInsensitiveDict()
 		self.itemUpdated = extensionPoints.Action()
 		self.updated = extensionPoints.Action()
 		self.selectionChanged = extensionPoints.Action()
@@ -163,10 +182,10 @@ class AddonListVM:
 			_addonListItemVM.updated.unregister(self._itemDataUpdated)
 
 		# set new ID:listItemVM mapping.
-		self._addons: Dict[str, AddonListItemVM] = {
+		self._addons = CaseInsensitiveDict({
 			vm.Id: vm
 			for vm in listVMs
-		}
+		})
 		self._updateAddonListing()
 
 		# allow new listItemVMs to notify of updates.
@@ -199,6 +218,8 @@ class AddonListVM:
 		assert attrName in AddonListVM.presentedAttributes
 		if attrName == "status":  # special handling, not on the model.
 			return listItemVM.status.displayString
+		if attrName == "channel":
+			return listItemVM.model.channel.displayString
 		return getattr(listItemVM.model, attrName)
 
 	def getCount(self) -> int:
@@ -225,7 +246,9 @@ class AddonListVM:
 		return selectedItemVM
 
 	def getSelection(self) -> Optional[AddonListItemVM]:
-		return self._addons.get(self.selectedAddonId, None)
+		if self.selectedAddonId is None:
+			return None
+		return self._addons.get(self.selectedAddonId)
 
 	def _validate(
 			self,
@@ -396,6 +419,8 @@ class AddonActionVM:
 
 class AddonStoreVM:
 	def __init__(self):
+		self._addons = createAddonStoreCollection()
+		self.hasError = extensionPoints.Action()
 		self.onDisplayableError = DisplayableError.OnDisplayableErrorT()
 		"""
 		An extension point used to notify the add-on store VM when an error
@@ -406,17 +431,17 @@ class AddonStoreVM:
 		@param displayableError: Error that can be displayed to the user.
 		@type displayableError: gui.message.DisplayableError
 		"""
-		self._addons: CaseInsensitiveDict[AddonDetailsModel] = CaseInsensitiveDict()
-		"""
-		Add-ons that have the same ID except differ in casing cause a path collision,
-		as add-on IDs are installed to a case insensitive path.
-		Therefore addon IDs should be treated as case insensitive.
-		"""
 		self._filteredStatuses: Set[AvailableAddonStatus] = next(iter(_statusFilters.values()))
 		"""
 		Filters the add-on list view model by add-on status.
 		Add-ons with a status in _filteredStatuses should be displayed in the list.
 		Uses first filter in _statusFilters as default.
+		"""
+		self._filteredChannels: Set[Channel] = next(iter(_channelFilters.values()))
+		"""
+		Filters the add-on list view model by add-on channel.
+		Add-ons with a channel in _filteredChannels should be displayed in the list.
+		Uses first filter in _channelFilters as default.
 		"""
 
 		self._downloader = addonDataManager.getFileDownloader()
@@ -599,7 +624,7 @@ class AddonStoreVM:
 		self._downloader.download(listItemVM.model, self._downloadComplete, self.onDisplayableError)
 
 	def _downloadComplete(self, addonDetails: AddonStoreModel, fileDownloaded: Optional[PathLike]):
-		listItemVM: Optional[AddonListItemVM] = self.listVM._addons[addonDetails.addonId]
+		listItemVM: Optional[AddonListItemVM] = self.listVM._addons[addonDetails.listItemVMId]
 		if listItemVM is None:
 			log.error(f"No list item VM for addon with id: {addonDetails.addonId}")
 			return
@@ -650,22 +675,28 @@ class AddonStoreVM:
 
 	def _getAddonsInBG(self):
 		log.debug("getting addons in the background")
-		addons: CaseInsensitiveDict[AddonDetailsModel]
-		addons = addonDataManager.getLatestCompatibleAddons(self.onDisplayableError)
-		addonHandlerAddons = addonHandler.state._addonHandlerCache.availableAddonsAsDetails
-		for addonId in addonHandlerAddons:
-			# only use installed add-on data if no add-on store details available
-			if addonId not in addons:
-				addons[addonId] = addonHandlerAddons[addonId]
-		if config.conf["addonStore"]["incompatibleAddons"]:
+		assert addonDataManager
+		assert addonHandler.state._addonHandlerCache
+		addons: AddonDetailsCollectionT = addonDataManager.getLatestCompatibleAddons(self.onDisplayableError)
+		addonHandlerAddons = addonHandler.state._addonHandlerCache.installedAddonsAsDetails
+		for channel in addonHandlerAddons:
+			for addonId in addonHandlerAddons[channel]:
+				# only use installed add-on data if no add-on store details available
+				if addonId not in addons[channel]:
+					addons[channel][addonId] = addonHandlerAddons[channel][addonId]
+		if bool(config.conf["addonStore"]["incompatibleAddons"]):
 			incompatibleAddons = addonDataManager.getLatestAddons(self.onDisplayableError)
-			for addonId in incompatibleAddons:
-				# only include incompatible add-ons if:
-				# - no compatible or installed versions are available
-				# - the user can override the compatibility of the add-on
-				# (it's too old and not too new)
-				if addonId not in addons and incompatibleAddons[addonId].canOverrideCompatibility:
-					addons[addonId] = incompatibleAddons[addonId]
+			for channel in incompatibleAddons:
+				for addonId in incompatibleAddons[channel]:
+					# only include incompatible add-ons if:
+					# - no compatible or installed versions are available
+					# - the user can override the compatibility of the add-on
+					# (it's too old and not too new)
+					if (
+						addonId not in addons[channel]
+						and incompatibleAddons[channel][addonId].canOverrideCompatibility
+					):
+						addons[channel][addonId] = incompatibleAddons[channel][addonId]
 		log.debug("completed getting addons in the background")
 		self._addons = addons
 		self.listVM.resetListItems(self._createListItemVMs())
@@ -674,18 +705,21 @@ class AddonStoreVM:
 
 	def cancelDownloads(self):
 		for a in self._downloader.progress.keys():
-			self.listVM._addons[a.addonId].status = AvailableAddonStatus.AVAILABLE
+			self.listVM._addons[a.listItemVMId].status = AvailableAddonStatus.AVAILABLE
 		self._downloader.cancelAll()
 
 	def _createListItemVMs(self) -> List[AddonListItemVM]:
 		addonsWithStatus = (
 			(model, _getStatus(model))
-			for model in self._addons.values()
+			for channel in self._addons
+			for model in self._addons[channel].values()
 		)
+
 		return [
 			AddonListItemVM(model=model, status=status)
 			for model, status in addonsWithStatus
 			if status in self._filteredStatuses
+			and model.channel in self._filteredChannels
 		]
 
 
@@ -726,7 +760,8 @@ def getAddonBundleToInstallIfValid(addonPath: str) -> addonHandler.AddonBundle:
 
 
 def getPreviouslyInstalledAddonById(addon: addonHandler.AddonBundle) -> Optional[addonHandler.Addon]:
-	installedAddon = addonHandler.state._addonHandlerCache.availableAddons.get(addon.name)
+	assert addonHandler.state._addonHandlerCache
+	installedAddon = addonHandler.state._addonHandlerCache.installedAddons.get(addon.name)
 	if installedAddon is None or installedAddon.isPendingRemove:
 		return None
 	return installedAddon

--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -600,7 +600,7 @@ class AddonStoreDialog(SettingsDialog):
 
 		self.channelFilterCtrl = cast(wx.Choice, browseCtrlHelper.addLabeledControl(
 			# Translators: The label of a selection field to filter the list of add-ons in the add-on store dialog.
-			labelText=pgettext("addonStore", "&Channel:"),
+			labelText=pgettext("addonStore", "Cha&nnel:"),
 			wxCtrlClass=wx.Choice,
 			choices=list(_channelFilters.keys()),
 		))
@@ -652,7 +652,7 @@ class AddonStoreDialog(SettingsDialog):
 
 		generalActions = guiHelper.ButtonHelper(wx.HORIZONTAL)
 		# Translators: The label for a button in add-ons Store dialog to install an external add-on.
-		self.externalInstallButton = generalActions.addButton(self, label=_("&Install from external source"))
+		self.externalInstallButton = generalActions.addButton(self, label=_("Install from e&xternal source"))
 		self.externalInstallButton.Bind(wx.EVT_BUTTON, self.openExternalInstall, self.externalInstallButton)
 		self.bindHelpEvent("AddonStoreInstalling", self.externalInstallButton)
 

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -16,7 +16,7 @@ Add-ons can be filtered by status.
 Add-ons can be filtered by channel: e.g. stable, beta, dev.
 
 1. Open the add-on store
-1. Jump to the filter-by channel field (`alt+c`)
+1. Jump to the filter-by channel field (`alt+n`)
 1. Filter by each channel grouping, ensure expected add-ons are displayed.
 
 ### Filtering by add-on information

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -1,7 +1,7 @@
 
 ## Browsing add-ons
 
-### Browse add-ons by status
+### Filter add-ons by status
 Add-ons can be filtered by status.
 
 1. Open the add-on store
@@ -11,6 +11,13 @@ Add-ons can be filtered by status.
     - Updatable: should include installed add-ons which can be updated or replaced by an add-on store version
     - Disabled: should include manually disabled add-ons and add-ons disabled due to incompatibility
     - Available: should include add-ons available for install
+
+### Filter add-ons by channel
+Add-ons can be filtered by channel: e.g. stable, beta, dev.
+
+1. Open the add-on store
+1. Jump to the filter-by channel field (`alt+c`)
+1. Filter by each channel grouping, ensure expected add-ons are displayed.
 
 ### Filtering by add-on information
 Add-ons can be filtered by display name, publisher and description.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
A user may want to browse add-ons by different channels.

A bug was introduced to the add-on store which caused only one channel version per add-on to be available in the listing.
A user may wish to browse add-ons by channel, as well as view all channels for an add-on.

### Description of user facing changes
Added "channel" to the listing columns.
Added a filter by channel.
A bug was fixed where only one channel version per add-on was listed when listing all available add-ons for all channels.

### Description of development approach
Add-ons are now collected by channel and add-on ID.
A channel filter was added similar to the status filter.

### Testing strategy:

1. Open the add-on store
1. Jump to the filter-by channel field (`alt+n`)
1. Filter by each channel grouping, ensure expected add-ons are displayed.

### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
