### PR TITLE
Add-on store: Disable add-ons manager

### DIFF
--- a/devDocs/developerGuide.t2t
+++ b/devDocs/developerGuide.t2t
@@ -759,7 +759,7 @@ addonHandler.isCLIParamKnown.register(processArgs)
 ```
 
 + Packaging Code as NVDA Add-ons +[Addons]
-To make it easy for users to share and install plugins and drivers, they can be packaged in to a single NVDA add-on package which the user can then install into a copy of NVDA via the Add-ons Manager found under Tools in the NVDA menu.
+To make it easy for users to share and install plugins and drivers, they can be packaged in to a single NVDA add-on package which the user can then install into a copy of NVDA via the Add-on Store found under Tools in the NVDA menu.
 Add-on packages are only supported in NVDA 2012.2 and later.
 An add-on package is simply a standard zip archive with the file extension of "``nvda-addon``" which contains a manifest file, optional install/uninstall code and one or more directories containing plugins and/or drivers.
 
@@ -865,7 +865,7 @@ For more information about gettext and NVDA translation in general, please read 
 Documentation for an add-on should be placed in a doc directory in the archive.
 Similar to the locale directory, this directory should contain directories for each language in which documentation is available.
 
-Users can access documentation for a particular add-on by opening the Add-ons Manager, selecting the add-on and pressing the Add-on help button.
+Users can access documentation for a particular add-on by opening the Add-on Store, selecting the add-on and pressing the Add-on help button.
 This will open the file named in the docFileName parameter of the manifest.
 NVDA will search for this file in the appropriate language directories.
 For example, if docFileName is set to readme.html and the user is using English, NVDA will open doc\en\readme.html.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3123,12 +3123,12 @@ class GlobalCommands(ScriptableObject):
 		pythonConsole.activate()
 
 	@script(
-		# Translators: Input help mode message for activate manage add-ons command.
-		description=_("Activates the NVDA Add-ons Manager to install and uninstall add-on packages for NVDA"),
+		# Translators: Input help mode message to activate Add-on Store command.
+		description=_("Activates the Add-on Store to browse and manage add-on packages for NVDA"),
 		category=SCRCAT_TOOLS
 	)
-	def script_activateAddonsManager(self,gesture):
-		wx.CallAfter(gui.mainFrame.onAddonsManagerCommand, None)
+	def script_activateAddonsManager(self, gesture: inputCore.InputGesture):
+		wx.CallAfter(gui.mainFrame.onAddonStoreCommand, None)
 
 	@script(
 		description=_(

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -322,16 +322,10 @@ class MainFrame(wx.Frame):
 			pythonConsole.initialize()
 		pythonConsole.activate()
 
-	@blockAction.when(
-		blockAction.Context.SECURE_MODE,
-		blockAction.Context.MODAL_DIALOG_OPEN,
-	)
-	def onAddonsManagerCommand(self,evt):
-		self.prePopup()
-		from .addonGui import AddonsDialog
-		d=AddonsDialog(gui.mainFrame)
-		d.Show()
-		self.postPopup()
+	if NVDAState._allowDeprecatedAPI():
+		def onAddonsManagerCommand(self, evt: wx.MenuEvent):
+			log.warning("onAddonsManagerCommand is deprecated, use onAddonStoreCommand instead.")
+			self.onAddonStoreCommand(evt)
 
 	@blockAction.when(
 		blockAction.Context.SECURE_MODE,
@@ -470,9 +464,6 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			# Translators: The label for the menu item to open NVDA Python Console.
 			item = menu_tools.Append(wx.ID_ANY, _("Python console"))
 			self.Bind(wx.EVT_MENU, frame.onPythonConsoleCommand, item)
-			# Translators: The label of a menu item to open the Add-ons Manager.
-			item = menu_tools.Append(wx.ID_ANY, _("Manage &add-ons..."))
-			self.Bind(wx.EVT_MENU, frame.onAddonsManagerCommand, item)
 			# Translators: The label of a menu item to open the Add-on store
 			item = menu_tools.Append(wx.ID_ANY, _("Add-on &store..."))
 			self.Bind(wx.EVT_MENU, frame.onAddonStoreCommand, item)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
The add-ons manager is now redundant, and the add-on store replicates all features.
The add-ons manager should be disabled.

### Description of user facing changes
add-ons manager is disabled, commands to activate the add-ons manager are replaced with activating the add-on store.

### Description of development approach
Keeps script name the same so that key bindings for add-ons manager are kept for the add-on store

### Testing strategy:
Tested running `gui.mainFrame.onAddonsManagerCommand(None)` in the NVDA python console.

### Known issues with pull request:
None

### Change log entries:
**Add to add-on store changelog in PR description, perform mailing list announcement on merge to master**
- `gui.MainFrame.onAddonsManagerCommand` is deprecated, use `gui.MainFrame.onAddonStoreCommand` instead.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
