### PR TITLE
Add-on store: Use close button instead of OK/Cancel

### DIFF
--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -576,7 +576,11 @@ class AddonStoreDialog(SettingsDialog):
 	def __init__(self, parent: wx.Window, storeVM: AddonStoreVM):
 		self._storeVM = storeVM
 		self._storeVM.onDisplayableError.register(self.handleDisplayableError)
-		super().__init__(parent, resizeable=True)
+		super().__init__(parent, resizeable=True, buttons={wx.CLOSE})
+
+	def _enterActivatesOk_ctrlSActivatesApply(self, evt: wx.KeyEvent):
+		"""Disables parent behaviour which overrides behaviour for enter and ctrl+s"""
+		evt.Skip()
 
 	@staticmethod
 	def handleDisplayableError(displayableError: DisplayableError):
@@ -647,7 +651,7 @@ class AddonStoreDialog(SettingsDialog):
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):
 		super()._onWindowDestroy(evt)
 
-	def onOk(self, evt: wx.CommandEvent):
+	def onClose(self, evt: wx.CommandEvent):
 		# Translators: Title for message shown prior to installing add-ons when closing the add-on store dialog.
 		installationPromptTitle = _("Add-on installation")
 		numInProgress = len(self._storeVM._downloader.progress)
@@ -687,7 +691,7 @@ class AddonStoreDialog(SettingsDialog):
 			addonGui.promptUserForRestart()
 
 		# let the dialog exit.
-		super().onOk(evt)
+		super().onClose(evt)
 
 	def getStatusFilterLabel(self) -> str:
 		index = self.statusFilterCtrl.GetSelection()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
The add-on store makes more sense with a "Close" button instead of "OK/Cancel".
When exiting the dialog, users should be prompted to restart if they have changed the status of any add-ons.

### Description of user facing changes
The "OK/Cancel" buttons have been replaced by a single "Close" button.
Pressing enter no longer closes the dialog, but "escape" does.

### Description of development approach
The `SettingsDialog` now accepts "buttons" as a parameter. A developer can specify a set of buttons including OK, Cancel, Apply, Close.

### Testing strategy:
Manual testing:

**Closing the dialog prompts the user to restart when appropriate**
1. Open the add-on store
1. Disable an installed add-on
1. Try closing the dialog each of the following ways:
    - Pressing Escape
    - The dialog close button
    - The window close button - X at the top right of screen
1. Each time, the user should be prompted to restart NVDA.

**Enter keeps the dialog open**
1. Open the add-on store
1. Disable an installed add-on
1. Try closing the dialog by pressing Enter
1. Ensure the dialog remains open, as enter saves and exits the settings dialog by default

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
