### PR TITLE
Add-on store: make state pickling safer for downgrading

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -151,16 +151,16 @@ class AddonsState(collections.UserDict):
 
 	def load(self) -> None:
 		"""Populates state with the default content and then loads values from the config."""
-		self.update(self._generateDefaultStateContent())
+		state = self._generateDefaultStateContent()
+		self.update(state)
 		self._addonHandlerCache = AddonHandlerCache()
 		try:
 			# #9038: Python 3 requires binary format when working with pickles.
 			with open(self.statePath, "rb") as f:
 				pickledState: Dict[str, Set[str]] = pickle.load(f)
-				state = self._generateDefaultStateContent()
 				for category in pickledState:
 					# Make pickles case insensitive
-					state[category] = CaseInsensitiveSet(pickledState[category])
+					state[AddonStateCategory(category)] = CaseInsensitiveSet(pickledState[category])
 				self.update(state)
 		except FileNotFoundError:
 			pass  # Clean config - no point logging in this case

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -134,7 +134,8 @@ class AddonsState(collections.UserDict):
 	Therefore add-on IDs should be treated as case insensitive.
 	"""
 
-	def generateDefaultStateContent() -> Dict[AddonStateCategory, CaseInsensitiveSet[str]]:
+	@staticmethod
+	def _generateDefaultStateContent() -> Dict[AddonStateCategory, CaseInsensitiveSet[str]]:
 		return {
 			category: CaseInsensitiveSet() for category in AddonStateCategory
 		}
@@ -150,13 +151,13 @@ class AddonsState(collections.UserDict):
 
 	def load(self) -> None:
 		"""Populates state with the default content and then loads values from the config."""
-		self.update(self.generateDefaultStateContent())
+		self.update(self._generateDefaultStateContent())
 		self._addonHandlerCache = AddonHandlerCache()
 		try:
 			# #9038: Python 3 requires binary format when working with pickles.
 			with open(self.statePath, "rb") as f:
 				pickledState: Dict[str, Set[str]] = pickle.load(f)
-				state = self.generateDefaultStateContent()
+				state = self._generateDefaultStateContent()
 				for category in pickledState:
 					# Make pickles case insensitive
 					state[category] = CaseInsensitiveSet(pickledState[category])

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -246,7 +246,7 @@ def removeFailedDeletion(path: os.PathLike):
 
 def disableAddonsIfAny():
 	"""
-	Disables add-ons if told to do so by the user from add-ons manager.
+	Disables add-ons if told to do so by the user from add-on store.
 	This is usually executed before refreshing the list of available add-ons.
 	"""
 	# Pull in and enable add-ons that should be disabled and enabled, respectively.
@@ -499,7 +499,7 @@ class Addon(AddonBase):
 			state['pendingRemovesSet'].add(self.name)
 			# There's no point keeping a record of this add-on pending being disabled now.
 			# However, if the addon is disabled, then it needs to remain disabled so that
-			# the status in addonsManager continues to say "disabled"
+			# the status in add-on store continues to say "disabled"
 			state['pendingDisableSet'].discard(self.name)
 		state.save()
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -206,10 +206,11 @@ class AddonsState(collections.UserDict):
 		during uninstallation. As a result after reinstalling add-on with the same name it was disabled
 		by default confusing users. Fix this by removing all add-ons no longer present in the config
 		from the list of disabled add-ons in the state."""
-		installedAddonNames = set(self._addonHandlerCache.installedAddons.keys())
+		installedAddonNames = CaseInsensitiveSet(self._addonHandlerCache.installedAddons.keys())
 		for disabledAddonName in CaseInsensitiveSet(self[AddonStateCategory.DISABLED]):
 			# Iterate over copy of set to prevent updating the set while iterating over it.
 			if disabledAddonName not in installedAddonNames:
+				log.debug(f"Discarding {disabledAddonName} from disabled add-ons as it has been uninstalled.")
 				self[AddonStateCategory.DISABLED].discard(disabledAddonName)
 
 

--- a/source/addonStore/status.py
+++ b/source/addonStore/status.py
@@ -138,12 +138,13 @@ def _getStatus(model: AddonDetailsModel) -> Optional[AvailableAddonStatus]:
 
 
 _addonStoreStateToAddonHandlerState: Dict[AvailableAddonStatus, AddonStateCategory] = {
-	AvailableAddonStatus.INSTALLED: AddonStateCategory.PENDING_INSTALL,
-	AvailableAddonStatus.DISABLED: AddonStateCategory.DISABLED,
-	AvailableAddonStatus.INCOMPATIBLE_DISABLED: AddonStateCategory.BLOCKED,
-	AvailableAddonStatus.PENDING_DISABLE: AddonStateCategory.PENDING_DISABLE,
+	# Pending states must be first as the pending state may be altering another state. 
 	AvailableAddonStatus.PENDING_ENABLE: AddonStateCategory.PENDING_ENABLE,
+	AvailableAddonStatus.PENDING_DISABLE: AddonStateCategory.PENDING_DISABLE,
 	AvailableAddonStatus.PENDING_REMOVE: AddonStateCategory.PENDING_REMOVE,
+	AvailableAddonStatus.INCOMPATIBLE_DISABLED: AddonStateCategory.BLOCKED,
+	AvailableAddonStatus.DISABLED: AddonStateCategory.DISABLED,
+	AvailableAddonStatus.INSTALLED: AddonStateCategory.PENDING_INSTALL,
 }
 
 

--- a/source/addonStore/status.py
+++ b/source/addonStore/status.py
@@ -93,8 +93,8 @@ class AvailableAddonStatus(DisplayStringEnum):
 
 def _getStatus(model: AddonDetailsModel) -> Optional[AvailableAddonStatus]:
 	from addonStore.dataManager import addonDataManager
-	addonData = model._addonHandlerModel
-	if addonData is None:
+	addonHandlerModel = model._addonHandlerModel
+	if addonHandlerModel is None:
 		if not isAddonCompatible(model):
 			# Installed incompatible add-ons have a status of disabled or running
 			return AvailableAddonStatus.INCOMPATIBLE
@@ -118,7 +118,7 @@ def _getStatus(model: AddonDetailsModel) -> Optional[AvailableAddonStatus]:
 		else:
 			# Parsing from a side-loaded add-on
 			try:
-				manifestAddonVersion = MajorMinorPatch._parseVersionFromVersionStr(addonData.version)
+				manifestAddonVersion = MajorMinorPatch._parseVersionFromVersionStr(addonHandlerModel.version)
 			except ValueError:
 				# Parsing failed to get a numeric version.
 				# Ideally a numeric version would be compared,
@@ -130,7 +130,7 @@ def _getStatus(model: AddonDetailsModel) -> Optional[AvailableAddonStatus]:
 			if model.addonVersionNumber > manifestAddonVersion:
 				return AvailableAddonStatus.UPDATE
 
-	if addonData.isRunning:
+	if addonHandlerModel.isRunning:
 		return AvailableAddonStatus.RUNNING
 
 	log.debugWarning(f"Add-on in unknown state: {model.addonId}")

--- a/source/addonStore/status.py
+++ b/source/addonStore/status.py
@@ -137,15 +137,15 @@ def _getStatus(model: AddonDetailsModel) -> Optional[AvailableAddonStatus]:
 	return None
 
 
-_addonStoreStateToAddonHandlerState: Dict[AvailableAddonStatus, AddonStateCategory] = {
-	# Pending states must be first as the pending state may be altering another state. 
+_addonStoreStateToAddonHandlerState: OrderedDict[AvailableAddonStatus, AddonStateCategory] = OrderedDict({
+	# Pending states must be first as the pending state may be altering another state.
 	AvailableAddonStatus.PENDING_ENABLE: AddonStateCategory.PENDING_ENABLE,
 	AvailableAddonStatus.PENDING_DISABLE: AddonStateCategory.PENDING_DISABLE,
 	AvailableAddonStatus.PENDING_REMOVE: AddonStateCategory.PENDING_REMOVE,
 	AvailableAddonStatus.INCOMPATIBLE_DISABLED: AddonStateCategory.BLOCKED,
 	AvailableAddonStatus.DISABLED: AddonStateCategory.DISABLED,
 	AvailableAddonStatus.INSTALLED: AddonStateCategory.PENDING_INSTALL,
-}
+})
 
 
 _statusFilters: OrderedDict[str, Set[AvailableAddonStatus]] = OrderedDict({

--- a/source/utils/caseInsensitiveCollections.py
+++ b/source/utils/caseInsensitiveCollections.py
@@ -4,12 +4,12 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 from typing import (
-	Tuple,
+	Iterable,
 )
 
 
 class CaseInsensitiveSet(set):
-	def __init__(self, *args: Tuple[str]):
+	def __init__(self, *args: Iterable[str]):
 		if len(args) > 1:
 			raise TypeError(
 				f"{type(self).__name__} expected at most 1 argument, "


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 
Identified in https://github.com/nvaccess/nvda/pull/13985#issuecomment-1518010912

### Summary of the issue:

The state of add-on needs to be pickled using in built data-types. Otherwise, when downgrading, the unpickling fails. 
This is because the old version of NVDA is unaware of the pickled data types.

If a user disables one or more add-ons, installs add-on store build, then moves back to a previous build, the following traceback may result:

```py
CRITICAL - main (08:33:07.417) - MainThread (19836):
core failure
Traceback (most recent call last):
File "nvda.pyw", line 406, in
File "core.pyc", line 526, in main
File "addonHandler_init_.pyc", line 167, in initialize
File "addonHandler_init_.pyc", line 78, in load
AttributeError: Can't get attribute 'AddonStateCategory' on <module 'addonHandler' from 'C:\Program Files (x86)\NVDA\library.zip\addonHandler\init.pyc'>
```

### Description of user facing changes
Fixes described bug

### Description of development approach
Convert data types when pickling and unpickling.

### Testing strategy:
Manually tested STR described in the issue

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
