### PR TITLE
Add-on store: Display add-on incompatible reason

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -789,24 +789,6 @@ class IncompatibleAddonsDialog(
 		self.CentreOnScreen()
 		self.addonsList.SetFocus()
 
-	def _getIncompatReason(self, addon):
-		if not addonVersionCheck.hasAddonGotRequiredSupport(
-			addon,
-			currentAPIVersion=self._APIVersion
-		):
-			# Translators: The reason an add-on is not compatible. A more recent version of NVDA is
-			# required for the add-on to work. The placeholder will be replaced with Year.Major.Minor (EG 2019.1).
-			return _("An updated version of NVDA is required. NVDA version {} or later."
-			).format(addonAPIVersion.formatForGUI(addon.minimumNVDAVersion))
-		elif not addonVersionCheck.isAddonTested(
-			addon,
-			backwardsCompatToVersion=self._APIBackwardsCompatToVersion
-		):
-			# Translators: The reason an add-on is not compatible. The addon relies on older, removed features of NVDA,
-			# an updated add-on is required. The placeholder will be replaced with Year.Major.Minor (EG 2019.1).
-			return _("An updated version of this add-on is required. The minimum supported API version is now {}"
-			).format(addonAPIVersion.formatForGUI(self._APIBackwardsCompatToVersion))
-
 	def refreshAddonsList(self):
 		self.addonsList.DeleteAllItems()
 		self.curAddons=[]
@@ -814,7 +796,7 @@ class IncompatibleAddonsDialog(
 			self.addonsList.Append((
 				addon.manifest['summary'],
 				addon.version,
-				self._getIncompatReason(addon)
+				addon.getIncompatibleReason(self._APIBackwardsCompatToVersion, self._APIVersion),
 			))
 			self.curAddons.append(addon)  # onAbout depends on being able to recall the current addon based on selected index
 		activeIndex=0

--- a/source/gui/addonStoreGui/views.py
+++ b/source/gui/addonStoreGui/views.py
@@ -436,7 +436,8 @@ class AddonDetails(
 		self._refresh()
 
 	def _refresh(self):
-		details = None if not self._detailsVM.listItem else self._detailsVM.listItem.model
+		details = None if self._detailsVM.listItem is None else self._detailsVM.listItem.model
+		status = None if self._detailsVM.listItem is None else self._detailsVM.listItem.status
 
 		with guiHelper.autoThaw(self):
 			# AppendText is used to build up the details so that formatting can be set as text is added, via
@@ -459,8 +460,8 @@ class AddonDetails(
 					self.defaultStyle
 				)
 
-				if self._detailsVM.listItem:
-					self.statusTextCtrl.SetValue(self._detailsVM.listItem.status.displayString)
+				if status:
+					self.statusTextCtrl.SetValue(status.displayString)
 
 				self._appendDetailsLabelValue(
 					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
@@ -493,6 +494,14 @@ class AddonDetails(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "Source Code:"),
 						details.sourceURL, URL=details.sourceURL
+					)
+
+				incompatibleReason = details.getIncompatibleReason()
+				if incompatibleReason:
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+						pgettext("addonStore", "Incompatible Reason:"),
+						incompatibleReason
 					)
 				self.contentsPanel.Show()
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
The add-ons manager had a child dialog for viewing incompatible add-ons.
This child dialog included an incompatibility reason for each add-on.
This dialog also appears when upgrading NVDA, to display the add-ons that will become incompatible when upgrading.
The incompatibility reason was not accessible through the add-on store.

### Description of user facing changes
Incompatible add-ons now include the reason in the details panel.
This is a long message so it is placed at the end of the detail panel.
Updated the incompatibility reason to include that the add-on can be enabled at a users own risk.

### Description of development approach
Moved and refactored the current warning messages.

### Testing strategy:
Browse an incompatible add-on: ensure the message is displayed.

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
