### PR TITLE
Add-on store: filter legacy add-ons

### DIFF
--- a/source/addonStore/models.py
+++ b/source/addonStore/models.py
@@ -105,6 +105,11 @@ class _AddonDetailsModel(SupportsVersionCheck, Protocol):
 	homepage: Optional[str]
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	legacy: bool
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
 
 	@property
 	def minimumNVDAVersion(self) -> addonAPIVersion.AddonApiVersionT:
@@ -158,6 +163,11 @@ class AddonDetailsModel(_AddonDetailsModel):
 	homepage: Optional[str]
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
 
 
 @dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
@@ -180,6 +190,11 @@ class AddonStoreModel(_AddonDetailsModel):
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
 
 
 def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
@@ -199,6 +214,7 @@ def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 		sha256=addon["sha256"],
 		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
 		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
+		legacy=addon.get("legacy", False),
 	)
 
 

--- a/source/gui/addonStoreGui/viewModels.py
+++ b/source/gui/addonStoreGui/viewModels.py
@@ -720,6 +720,9 @@ class AddonStoreVM:
 			for model, status in addonsWithStatus
 			if status in self._filteredStatuses
 			and model.channel in self._filteredChannels
+			# Legacy add-ons contain invalid metadata
+			# and should not be accessible through the add-on store.
+			and not model.legacy
 		]
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 

### Summary of the issue:
Legacy add-ons contain invalid metadata, e.g. addonId mismatch.
Invalid metadata can cause problems in NVDA.
For example, if the addonIds don't match, there is no way of tying a add-on store metadata to a running add-on and it's manifest.

### Description of user facing changes
Filters legacy add-ons from the add-on store, so that they are no longer accessible.

### Description of development approach
Add legacy field to addon details model and filter by it when generating views.

### Testing strategy:
Test browsing add-ons, ensure legacy add-ons are not viewed.

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
