### PR TITLE
Bugfix when resetting configuration

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -714,7 +714,7 @@ class ConfigManager(object):
 				self._writeProfileToFile(self._profileCache[name].filename, self._profileCache[name])
 				log.info("Saved configuration profile %s" % name)
 			self._dirtyProfiles.clear()
-		except Exception as e:
+		except PermissionError as e:
 			log.warning("Error saving configuration; probably read only file system")
 			log.debugWarning("", exc_info=True)
 			raise e

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
-# Joseph Lee, Babbage B.V., Łukasz Golonka, Julien Cochuyt
+# Copyright (C) 2006-2023 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
+# Joseph Lee, Babbage B.V., Łukasz Golonka, Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -728,6 +728,7 @@ class ConfigManager(object):
 		pre_configReset.notify(factoryDefaults=factoryDefaults)
 		self.profiles = []
 		self._profileCache.clear()
+		self._dirtyProfiles.clear()
 		# Signal that we're initialising.
 		self.rootSection = None
 		self._initBaseConf(factoryDefaults=factoryDefaults)

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -155,7 +155,7 @@ class MainFrame(wx.Frame):
 			config.conf.save()
 			# Translators: Reported when current configuration has been saved.
 			queueHandler.queueFunction(queueHandler.eventQueue,ui.message,_("Configuration saved"))
-		except:
+		except PermissionError:
 			# Translators: Message shown when current configuration cannot be saved such as when running NVDA from a CD.
 			messageBox(_("Could not save configuration - probably read only file system"),_("Error"),wx.OK | wx.ICON_ERROR)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -65,6 +65,7 @@ Instead NVDA reports that the link has no destination. (#14723)
 - In Windows 11, it is once again possible to open the Contributors and License items on the NVDA Help menu. (#14725)
 - When forcing UIA support with certain terminal and consoles, a bug is fixed which caused a freeze and the log file to be spammed. (#14689)
 - NVDA no longer fails to announce focusing password fields in Microsoft Excel and Outlook. (#14839)
+- NVDA will no longer refuse to save the configuration after a configuration reset. (#13187)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13187
### Summary of the issue:

After having modified a parameter in a profile and then reset it to its original value with NVDA+control+C,  it was not possible to save the configuration with NVDA+control+R; NVDA was complaining that the file system was probably read-only.

### Description of user facing changes
NVDA will no longer refuse to save the configuration after a configuration reset.

### Description of development approach
Bugfix: when resetting the config, `config.conf._dirtyProfiles` is cleared

I have also narrowed the exception filtering when saving the config since in #13187, we get a message related to file write error, whereas the real error had nothing to do with it: it was a `KeyError` when trying to find "notepad" in `config.conf._profileCache`. I have filtered on `PermissionError` which is the error that I get when I set `nvda.ini` (or the whole NVDA setting folder) as read-only and try to save the config.


### Testing strategy:
Manual tests:

#### Test 1
Check that NVDA+control+R can still save the configuration in normal case

#### Test 2
Reproduce the steps in #13187 and check that we get expected result as described there.

#### Test 3
Set file `nvda.ini` or whole NVDA settings folder as read only and try to save the config with NVDA+shift+C. Check that we still get the error message.

#### Test 4
* Add  an unknown variable in the try clause of `ConfigManager.save` in `config.__init__.py`.
* Try to save the config
* Check that we do not get the Error dialog box but an error in the log.

### Known issues with pull request:
None
### Change log entries:

Bug fixes

`NVDA will no longer refuse to save the configuration after a configuration reset. (#13187)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
