### PR TITLE
Add setting to have the volume of NVDA sounds follow the voice volume.

### DIFF
--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -513,6 +513,16 @@ HRESULT WasapiPlayer::resume() {
 HRESULT WasapiPlayer::setSessionVolume(float level) {
 	CComPtr<ISimpleAudioVolume> volume;
 	HRESULT hr = client->GetService(IID_ISimpleAudioVolume, (void**)&volume);
+	if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
+		// If we're using a specific device, it's just been invalidated. Fall back
+		// to the default device.
+		deviceId.clear();
+		hr = open(true);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		hr = client->GetService(IID_ISimpleAudioVolume, (void**)&volume);
+	}
 	if (FAILED(hr)) {
 		return hr;
 	}

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -58,6 +58,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [audio]
 	audioDuckingMode = integer(default=0)
 	wasapi = boolean(default=true)
+	soundVolumeFollowsVoice = boolean(default=false)
 
 # Braille settings
 [braille]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3067,6 +3067,18 @@ class AdvancedPanelControls(
 		)
 		self.wasapiCheckBox.defaultValue = self._getDefaultValue(
 			["audio", "wasapi"])
+		# Translators: This is the label for a checkbox control in the
+		#  Advanced settings panel.
+		label = _("Volume of NVDA sounds follows voice volume (requires WASAPI)")
+		self.soundVolFollowCheckBox: wx.CheckBox = audioGroup.addItem(
+			wx.CheckBox(audioBox, label=label)
+		)
+		self.bindHelpEvent("SoundVolumeFollowsVoice", self.soundVolFollowCheckBox)
+		self.soundVolFollowCheckBox.SetValue(
+			config.conf["audio"]["soundVolumeFollowsVoice"]
+		)
+		self.soundVolFollowCheckBox.defaultValue = self._getDefaultValue(
+			["audio", "soundVolumeFollowsVoice"])
 
 		# Translators: This is the label for a group of advanced options in the
 		# Advanced settings panel
@@ -3156,6 +3168,7 @@ class AdvancedPanelControls(
 			and self.caretMoveTimeoutSpinControl.GetValue() == self.caretMoveTimeoutSpinControl.defaultValue
 			and self.reportTransparentColorCheckBox.GetValue() == self.reportTransparentColorCheckBox.defaultValue
 			and self.wasapiCheckBox.GetValue() == self.wasapiCheckBox.defaultValue
+			and self.soundVolFollowCheckBox.GetValue() == self.soundVolFollowCheckBox.defaultValue
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.playErrorSoundCombo.GetSelection() == self.playErrorSoundCombo.defaultValue
 			and True  # reduce noise in diff when the list is extended.
@@ -3182,6 +3195,7 @@ class AdvancedPanelControls(
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.wasapiCheckBox.SetValue(self.wasapiCheckBox.defaultValue)
+		self.soundVolFollowCheckBox.SetValue(self.soundVolFollowCheckBox.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self.playErrorSoundCombo.SetSelection(self.playErrorSoundCombo.defaultValue)
 		self._defaultsRestored = True
@@ -3213,6 +3227,7 @@ class AdvancedPanelControls(
 			self.reportTransparentColorCheckBox.IsChecked()
 		)
 		config.conf["audio"]["wasapi"] = self.wasapiCheckBox.IsChecked()
+		config.conf["audio"]["soundVolumeFollowsVoice"] = self.soundVolFollowCheckBox.IsChecked()
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
 		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCombo.GetSelection()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3144,7 +3144,7 @@ class AdvancedPanelControls(
 		path=config.getScratchpadDir(ensureExists=True)
 		os.startfile(path)
 
-	def onWasapiChange(self, evt):
+	def onWasapiChange(self, evt: wx.CommandEvent):
 		self.soundVolFollowCheckBox.Enable(evt.IsChecked())
 
 	def _getDefaultValue(self, configPath):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3062,6 +3062,7 @@ class AdvancedPanelControls(
 			wx.CheckBox(audioBox, label=label)
 		)
 		self.bindHelpEvent("WASAPI", self.wasapiCheckBox)
+		self.wasapiCheckBox.Bind(wx.EVT_CHECKBOX, self.onWasapiChange)
 		self.wasapiCheckBox.SetValue(
 			config.conf["audio"]["wasapi"]
 		)
@@ -3079,6 +3080,8 @@ class AdvancedPanelControls(
 		)
 		self.soundVolFollowCheckBox.defaultValue = self._getDefaultValue(
 			["audio", "soundVolumeFollowsVoice"])
+		if not self.wasapiCheckBox.GetValue():
+			self.soundVolFollowCheckBox.Disable()
 
 		# Translators: This is the label for a group of advanced options in the
 		# Advanced settings panel
@@ -3140,6 +3143,9 @@ class AdvancedPanelControls(
 	def onOpenScratchpadDir(self,evt):
 		path=config.getScratchpadDir(ensureExists=True)
 		os.startfile(path)
+
+	def onWasapiChange(self, evt):
+		self.soundVolFollowCheckBox.Enable(evt.IsChecked())
 
 	def _getDefaultValue(self, configPath):
 		return config.conf.getConfigValidation(configPath).default

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -31,10 +31,15 @@ There are now gestures for showing the braille settings dialog, accessing the st
 - When highlighted text is enabled Document Formatting, highlight colours are now reported in Microsoft Word. (#7396, #12101, #5866)
 - When colors are enabled Document Formatting, background colours are now reported in Microsoft Word. (#5866)
 - When pressing ``numpad2`` three times to report the numerical value of the character at the position of the review cursor, the information is now also provided in braille. (#14826)
-- NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. This can be disabled in Advanced settings if audio problems are encountered. (#14697)
+- NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds.
+This can be disabled in Advanced settings if audio problems are encountered. (#14697)
 - When using Excel shortcuts to toggle format such as bold, italic, underline and strike through of a cell in Excel, the result is now reported. (#14923)
 - Added support for the Help Tech Activator Braille display. (#14917)
-- In Windows 10 May 2019 Update and later, NVDA can announe virtual desktop names when opening, changing, and closing them. (#5641)
+- In Windows 10 May 2019 Update and later, NVDA can announce virtual desktop names when opening, changing, and closing them. (#5641)
+- It is now possible to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using.
+This option can be enabled in Advanced settings. (#1409)
+- You can now separately control the volume of NVDA sounds.
+This can be done using the Windows Volume Mixer. (#1409)
 - 
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2324,6 +2324,13 @@ WASAPI is a more modern audio framework which may improve the responsiveness, pe
 This option is enabled by default.
 After changing this option, you will need to restart NVDA for the change to take effect.
 
+==== Volume of NVDA sounds follows voice volume ====[SoundVolumeFollowsVoice]
+When this option is enabled, the volume of NVDA sounds and beeps will follow the volume setting of the voice you are using.
+If you decrease the volume of the voice, the volume of sounds will decrease.
+Similarly, if you increase the volume of the voice, the volume of sounds will increase.
+This option only takes effect when "Use WASAPI for audio output" is enabled.
+This option is disabled by default.
+
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.
 Logging these messages can result in decreased performance and large log files.


### PR DESCRIPTION
### Link to issue number:
Fixes #1409.

### Summary of the issue:
Users would like to be able to control the volume of NVDA sounds. With the WASAPI implementation in #14697, it is possible to separately control the volume of NVDA sounds using the Windows Volume Mixer. However, it is often useful to link the volume of NVDA sounds to the volume of the voice.

### Description of user facing changes
It is now possible to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. This option can be enabled in Advanced settings.

### Description of development approach
When this option is enabled and a WasapiWavePlayer is using soundsSession, the open() and stop() methods of WasapiWavePlayer set the session volume to the synth's voice volume. Note that we do this in stop() because some players keep the device open; e.g. tones.

### Testing strategy:
1. Enabled the new setting.
2. Decreased the voice volume.
3. Switched between browse and focus modes. Observed that the sound volume was lower.
4. Moved the mouse with mouse beeps enabled. Observed that the beep volume was lower.
5. Increased the voice volume to maximum.
6. Switched between browse and focus modes. Observed that the sound volume was maximum.
7. Moved the mouse with mouse beeps enabled. Observed that the beep volume was maximum.
8. Disabled the new setting.
9. Decreased the voice volume.
10. Switched between browse and focus modes. Observed that the sound volume was still maximum.
11. Moved the mouse with mouse beeps enabled. Observed that the beep volume was still maximum.
12. Enabled the new setting.
13. Switched between browse and focus modes. Observed that the sound volume was lower.
14. Disabled the new setting.
15. Switched between browse and focus modes. Observed that the sound volume was maximum.
16. Enabled the new setting.
17. Disconnected the default audio device (a headset).
18. Moved the mouse with mouse beeps enabled. Observed that the beep volume was lower.

### Known issues with pull request:
1. This is in Advanced settings because it depends on WASAPI and WASAPI is in Advanced settings. Once WASAPI is the only option, we can move this to Voice settings. Or should we just move it now?
2. The volume of a sound isn't adjusted while it is playing if the voice volume is changed. NVDA sounds usually aren't (and shouldn't be) very long, so I don't think this is a real issue, but I thought it worth noting anyway.

### Change log entries:
New features

> It is now possible to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. This option can be enabled in Advanced settings. (#1409)

Note that I forgot to mention that it's possible to separately control the volume of NVDA sounds in the What's New for #14697. We could add that too:

> You can now separately control the volume of NVDA sounds. This can be done using the Windows Volume Mixer. (#1409)

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
