### PR TITLE
Braille show messages input gesture

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3268,11 +3268,11 @@ class GlobalCommands(ScriptableObject):
 		ui.message(_("Braille cursor %s") % shapeMsg)
 
 	@script(
-		# Translators: Input help mode message for toggle braille show messages command.
+		# Translators: Input help mode message for cycle through braille show messages command.
 		description=_("Cycle through the braille show messages modes"),
 		category=SCRCAT_BRAILLE
 	)
-	def script_braille_cycleShowMessages(self, gesture):
+	def script_braille_cycleShowMessages(self, gesture: inputCore.InputGesture) -> None:
 		"""Set next state of braille show messages and reports it with ui.message."""
 		values = [x.value for x in ShowMessages]
 		index = values.index(
@@ -3281,10 +3281,10 @@ class GlobalCommands(ScriptableObject):
 		newIndex = (index + 1) % len(values)
 		newValue = values[newIndex]
 		config.conf["braille"]["showMessages"] = newValue
-		# Translators: Reports which show braille message mode is used
-		# (disabled, timeout or indefinitely).
 		ui.message(
 			_(
+				# Translators: Reports which show braille message mode is used
+				# (disabled, timeout or indefinitely).
 				"Braille show messages %s"
 			)
 			% ShowMessages(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3275,22 +3275,14 @@ class GlobalCommands(ScriptableObject):
 	def script_braille_cycleShowMessages(self, gesture: inputCore.InputGesture) -> None:
 		"""Set next state of braille show messages and reports it with ui.message."""
 		values = [x.value for x in ShowMessages]
-		index = values.index(
-			config.conf["braille"]["showMessages"]
-		)
+		index = values.index(config.conf["braille"]["showMessages"])
 		newIndex = (index + 1) % len(values)
 		newValue = values[newIndex]
 		config.conf["braille"]["showMessages"] = newValue
-		ui.message(
-			_(
-				# Translators: Reports which show braille message mode is used
-				# (disabled, timeout or indefinitely).
-				"Braille show messages %s"
-			)
-			% ShowMessages(
-				newValue
-			).displayString
-		)
+		# Translators: Reports which show braille message mode is used
+		# (disabled, timeout or indefinitely).
+		msg = _("Braille show messages %s") % ShowMessages(newValue).displayString
+		ui.message(msg)
 
 	@script(
 		# Translators: Input help mode message for report clipboard text command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3265,11 +3265,11 @@ class GlobalCommands(ScriptableObject):
 		ui.message(_("Braille cursor %s") % shapeMsg)
 
 	@script(
-		# Translators: Input help mode message for toggle braille show messages command.
+		# Translators: Input help mode message for cycle through braille show messages command.
 		description=_("Cycle through the braille show messages modes"),
 		category=SCRCAT_BRAILLE
 	)
-	def script_braille_cycleShowMessages(self, gesture):
+	def script_braille_cycleShowMessages(self, gesture: inputCore.InputGesture) -> None:
 		"""Set next state of braille show messages and reports it with ui.message."""
 		values = [x.value for x in ShowMessages]
 		index = values.index(
@@ -3278,10 +3278,10 @@ class GlobalCommands(ScriptableObject):
 		newIndex = (index + 1) % len(values)
 		newValue = values[newIndex]
 		config.conf["braille"]["showMessages"] = newValue
-		# Translators: Reports which show braille message mode is used
-		# (disabled, timeout or indefinitely).
 		ui.message(
 			_(
+				# Translators: Reports which show braille message mode is used
+				# (disabled, timeout or indefinitely).
 				"Braille show messages %s"
 			)
 			% ShowMessages(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4,7 +4,8 @@
 # See the file COPYING for more details.
 # Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
-# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis
+# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis,
+# Burman's Computer and Education Ltd.
 
 import itertools
 from typing import (
@@ -36,7 +37,10 @@ import gui
 import systemUtils
 import wx
 import config
-from config.configFlags import TetherTo
+from config.configFlags import (
+	TetherTo,
+	ShowMessages,
+)
 import winUser
 import appModuleHandler
 import winKernel
@@ -3262,6 +3266,31 @@ class GlobalCommands(ScriptableObject):
 		shapeMsg = braille.CURSOR_SHAPES[index][1]
 		# Translators: Reports which braille cursor shape is activated.
 		ui.message(_("Braille cursor %s") % shapeMsg)
+
+	@script(
+		# Translators: Input help mode message for toggle braille show messages command.
+		description=_("Cycle through the braille show messages modes"),
+		category=SCRCAT_BRAILLE
+	)
+	def script_braille_cycleShowMessages(self, gesture):
+		"""Set next state of braille show messages and reports it with ui.message."""
+		values = [x.value for x in ShowMessages]
+		index = values.index(
+			config.conf["braille"]["showMessages"]
+		)
+		newIndex = (index + 1) % len(values)
+		newValue = values[newIndex]
+		config.conf["braille"]["showMessages"] = newValue
+		# Translators: Reports which show braille message mode is used
+		# (disabled, timeout or indefinitely).
+		ui.message(
+			_(
+				"Braille show messages %s"
+			)
+			% ShowMessages(
+				newValue
+			).displayString
+		)
 
 	@script(
 		# Translators: Input help mode message for report clipboard text command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4,7 +4,8 @@
 # See the file COPYING for more details.
 # Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
-# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis
+# Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis,
+# Burman's Computer and Education Ltd.
 
 import itertools
 from typing import (
@@ -35,7 +36,10 @@ from logHandler import log
 import gui
 import wx
 import config
-from config.configFlags import TetherTo
+from config.configFlags import (
+	TetherTo,
+	ShowMessages,
+)
 import winUser
 import appModuleHandler
 import winKernel
@@ -3259,6 +3263,31 @@ class GlobalCommands(ScriptableObject):
 		shapeMsg = braille.CURSOR_SHAPES[index][1]
 		# Translators: Reports which braille cursor shape is activated.
 		ui.message(_("Braille cursor %s") % shapeMsg)
+
+	@script(
+		# Translators: Input help mode message for toggle braille show messages command.
+		description=_("Cycle through the braille show messages modes"),
+		category=SCRCAT_BRAILLE
+	)
+	def script_braille_cycleShowMessages(self, gesture):
+		"""Set next state of braille show messages and reports it with ui.message."""
+		values = [x.value for x in ShowMessages]
+		index = values.index(
+			config.conf["braille"]["showMessages"]
+		)
+		newIndex = (index + 1) % len(values)
+		newValue = values[newIndex]
+		config.conf["braille"]["showMessages"] = newValue
+		# Translators: Reports which show braille message mode is used
+		# (disabled, timeout or indefinitely).
+		ui.message(
+			_(
+				"Braille show messages %s"
+			)
+			% ShowMessages(
+				newValue
+			).displayString
+		)
 
 	@script(
 		# Translators: Input help mode message for report clipboard text command.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,18 +11,21 @@ What's New in NVDA
   - braille symbols such as "⠐⠣⠃⠗⠇⠐⠜". (#14548)
   - Mac Option key symbol "⌥". (#14682)
   -
+- New input gestures:
+  - An unbound gesture to cycle through the available languages for Windows OCR. (#13036)
+  - An unbound gesture to cycle through the braille show messages modes. (#14864)
+  - Added gestures for Tivomatic Caiku Albatross Braille displays.
+There are now gestures for showing the braille settings dialog, accessing the status bar, cycling the braille cursor shape, and toggling the braille cursor on/off. (#14844)
+  -
 - In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup. (#14709)
 - It is now possible to use system variables (such as ``%temp%`` or ``%homepath%``) in the path specification while creating portable copies of NVDA. (#14680)
 - Added support for the ``aria-brailleroledescription`` ARIA 1.3 attribute, allowing web authors to override the type of an element shown on the Braille display. (#14748)
 - When highlighted text is enabled Document Formatting, highlight colours are now reported in Microsoft Word. (#7396, #12101, #5866)
 - When colors are enabled Document Formatting, background colours are now reported in Microsoft Word. (#5866)
-- Introduced a new command to cycle through the available languages for Windows OCR. (#13036)
 - When pressing ``numpad2`` three times to report the numerical value of the character at the position of the review cursor, the information is now also provided in braille. (#14826)
-- Added gestures for Tivomatic Caiku Albatross Braille displays.
-There are now gestures for showing the braille settings dialog, accessing the status bar, cycling the braille cursor shape, and toggling the braille cursor on/off. (#14844)
 - NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. This can be disabled in Advanced settings if audio problems are encountered. (#14697)
-- When using Excel shortcuts to toggle  format such as bold, italic, underline and strike through of a cell in Excel, the result is now reported. (#14923)
-- NVDA now supports the Help Tech Activator Braille display. (#14917)
+- When using Excel shortcuts to toggle format such as bold, italic, underline and strike through of a cell in Excel, the result is now reported. (#14923)
+- Added support for the Help Tech Activator Braille display. (#14917)
 - 
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1593,9 +1593,11 @@ The selection indicator is not affected by this option, it is always dots 7 and 
 ==== Show Messages ====[BrailleSettingsShowMessages]
 This is a combobox that allows you to select if NVDA should display braille messages and when they should disappear automatically.
 
+To toggle show messages from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
 ==== Message Timeout (sec) ====[BrailleSettingsMessageTimeout]
 This option is a numerical field that controls how long NVDA messages are displayed on the braille display.
-The NVDA message is imediately dismissed when pressing a routing key on the braille display, but appears again when pressing a corresponding key which triggers the message.
+The NVDA message is immediately dismissed when pressing a routing key on the braille display, but appears again when pressing a corresponding key which triggers the message.
 This option is shown only if "Show Messages" is set to "Use timeout".
 
 %kc:setting

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1585,9 +1585,11 @@ The selection indicator is not affected by this option, it is always dots 7 and 
 ==== Show Messages ====[BrailleSettingsShowMessages]
 This is a combobox that allows you to select if NVDA should display braille messages and when they should disappear automatically.
 
+To toggle show messages from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
 ==== Message Timeout (sec) ====[BrailleSettingsMessageTimeout]
 This option is a numerical field that controls how long NVDA messages are displayed on the braille display.
-The NVDA message is imediately dismissed when pressing a routing key on the braille display, but appears again when pressing a corresponding key which triggers the message.
+The NVDA message is immediately dismissed when pressing a routing key on the braille display, but appears again when pressing a corresponding key which triggers the message.
 This option is shown only if "Show Messages" is set to "Use timeout".
 
 %kc:setting


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14864
### Summary of the issue:
There are input gestures for example for cycle braille cursor shape, tether braille to and toggle show braille cursor but not for cycling braille show messages.
### Description of user facing changes
New input gesture "Cycle through the braille show messages modes" in braille category.
### Description of development approach
New script script_braille_cycleShowMessages in globalCommands.py.
### Testing strategy:
Added buttons and tested with Input help mode on/off.
### Known issues with pull request:

### Change log entries:
New features
New input gesture "Cycle through the braille show messages modes" in braille category.
Changes
Bug fixes
For Developers
New script script_braille_cycleShowMessages in globalCommands.py.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
