### PR TITLE
Try to log exceptions in IoThread

### DIFF
--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -17,6 +17,7 @@ from extensionPoints.util import AnnotatableWeakref, BoundMethodWeakref
 from inspect import ismethod
 from buildVersion import version_year
 import NVDAState
+from watchdog import getFormattedStacksForAllThreads
 
 LPOVERLAPPED_COMPLETION_ROUTINE = ctypes.WINFUNCTYPE(
 	None,
@@ -203,4 +204,6 @@ class IoThread(threading.Thread):
 				if self.exit:
 					break
 		except Exception:
-			log.critical("Exception in IoThread function", exc_info=True, stack_info=True)
+			log.critical("Exception in IoThread function", exc_info=True)
+			stacks = getFormattedStacksForAllThreads()
+			log.info(f"Listing stacks for Python threads after IoThread crash:\n{stacks}")

--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -197,7 +197,10 @@ class IoThread(threading.Thread):
 		self.handle = None
 
 	def run(self):
-		while True:
-			ctypes.windll.kernel32.SleepEx(winKernel.INFINITE, True)
-			if self.exit:
-				break
+		try:
+			while True:
+				ctypes.windll.kernel32.SleepEx(winKernel.INFINITE, True)
+				if self.exit:
+					break
+		except Exception:
+			log.critical("Exception in IoThread function", exc_info=True, stack_info=True)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
I'm still seeing access violations in the IoThread here and there, same for @bramd. I really want to track these down! We need to handle those more gracefully anyway.

### Description of user facing changes
Better logging

### Description of development approach
De run block of the IOThread is now wrapped in a try/except that logs the stack. I hope the stack will give us more info about what's going wrong here.

### Testing strategy:
No longer stuff like this in the logThere should no longer be stuff like this in the log:
```
ERROR - stderr (14:44:14.406) - hwIo.ioThread.IoThread (24944):
Exception in thread hwIo.ioThread.IoThread:
Traceback (most recent call last):
  File "threading.pyc", line 926, in _bootstrap_inner
  File "hwIo\ioThread.pyc", line 201, in run
OSError: exception: access violation reading 0x05B50058
```
Rather, it should be a critical error that logs the stack. This pr needs a follow up to handle the underlying issue.

### Known issues with pull request:
I can only test this with a signed try build, though I'm pretty sure this can go to Alpha pretty safely.

### Change log entries:
None needed as this isn't a fix, it only improves logging to track down the underlying issue.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
