### PR TITLE
Inform the user that the configuration cannot be saved from a temporary version of NVDA (launcher)

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -149,7 +149,10 @@ class MainFrame(wx.Frame):
 		# Translators: Reported when configuration has been restored to defaults by using restore configuration to factory defaults item in NVDA menu.
 		queueHandler.queueFunction(queueHandler.eventQueue,ui.message,_("Configuration restored to factory defaults"))
 
-	@blockAction.when(blockAction.Context.SECURE_MODE)
+	@blockAction.when(
+		blockAction.Context.SECURE_MODE,
+		blockAction.Context.RUNNING_LAUNCHER,
+	)
 	def onSaveConfigurationCommand(self,evt):
 		try:
 			config.conf.save()
@@ -608,7 +611,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			_("Reset all settings to default state")
 		)
 		self.Bind(wx.EVT_MENU, frame.onRevertToDefaultConfigurationCommand, item)
-		if not globalVars.appArgs.secure:
+		if not (globalVars.appArgs.secure or globalVars.appArgs.launcher):
 			item = self.menu.Append(
 				wx.ID_SAVE,
 				# Translators: The label for the menu item to save current settings.

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -42,6 +42,12 @@ class Context(_Context, Enum):
 		lambda: globalVars.appArgs.secure,
 		# Translators: Reported when an action cannot be performed because Windows is locked.
 		_("Action unavailable while Windows is locked"),
+	)
+	RUNNING_LAUNCHER = (
+		lambda: globalVars.appArgs.launcher,
+		# Translators: Reported when an action cannot be performed because NVDA is running the launcher temporary
+		# version
+		_("Action unavailable in a temporary version of NVDA"),
 	)
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -66,6 +66,7 @@ Instead NVDA reports that the link has no destination. (#14723)
 - When forcing UIA support with certain terminal and consoles, a bug is fixed which caused a freeze and the log file to be spammed. (#14689)
 - NVDA no longer fails to announce focusing password fields in Microsoft Excel and Outlook. (#14839)
 - NVDA will no longer refuse to save the configuration after a configuration reset. (#13187)
+- When running a temporary version from the launcher, NVDA will not mislead users into thinking they can save the configuration. (#14914)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When running NVDA temp version (from launcher), the configuration cannot be save due to possible compatibility of version scheme. When pressing NVDA+control+C, the configuration is not saved and a message is logged in the log. However, NVDA reports "Configuration saved".

### Description of user facing changes
When running the temporary version of the launcher:
* NVDA will not report erroneously that the config was saved when trying to save it with NVDA+control+C command.
* NVDA will also not offer anymore the possibility to save the configuration in the NVDA menu.

### Description of development approach
As when running in secure mode:
- When trying to save the config, use the decorator to block action and report that the config cannot be saved in this version of NVDA.
- Also removed the "Save configuration" item in the NVDA menu when running the temp version (launcher)

### Testing strategy:
Manual tests:
Launched NVDA with and without the `--launcher` parameter and checked NVDA+control+C and the NVDA menu.

### Known issues with pull request:
None

### Change log entries:
Bug fixes
`When running a temporary version from the launcher, NVDA will not let the users think that they can save the configuration. (#14914)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
