### PR TITLE
Handy tech driver updates

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -734,6 +734,7 @@ def initialize():
 		"VID_1FE4&PID_008C",  # Basic Braille 84
 		"VID_1FE4&PID_0093",  # Basic Braille Plus 32
 		"VID_1FE4&PID_0094",  # Basic Braille Plus 40
+		"VID_1FE4&PID_00A4",  # Activator
 	})
 
 	# Some older HT displays use a HID converter and an internal serial interface
@@ -753,6 +754,7 @@ def initialize():
 		"Braillino BL",
 		"Braille Wave BW",
 		"Easy Braille EBR",
+		"Activator AC",
 	)))
 
 	# hims

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -531,7 +531,7 @@ class Activator(TimeSyncFirmnessMixin, AtcMixin, JoystickMixin, TripleActionKeys
 	genericName = name = 'Activator'
 
 	def _get_keys(self):
-		keys = super(Activator, self).keys
+		keys = super().keys
 		keys.update({
 			0x7A: "escape",
 			0x7B: "return",

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -530,7 +530,7 @@ class Activator(TimeSyncFirmnessMixin, AtcMixin, JoystickMixin, TripleActionKeys
 	numCells = 40
 	genericName = name = 'Activator'
 
-	def _get_keys(self):
+	def _get_keys(self) -> Dict[int, str]:
 		keys = super().keys
 		keys.update({
 			0x7A: "escape",

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2021 NV Access Limited, Bram Duvigneau, Babbage B.V.,
+# Copyright (C) 2008-2023 NV Access Limited, Bram Duvigneau, Babbage B.V.,
 # Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter
 
 """
@@ -9,6 +9,13 @@ Braille display driver for Handy Tech braille displays.
 """
 
 from collections import OrderedDict
+from typing import (
+	Dict,
+	List,
+	Optional,
+	Union,
+)
+
 from io import BytesIO
 import serial
 import weakref
@@ -28,7 +35,6 @@ from ctypes import windll
 import windowUtils
 
 import wx
-from typing import List, Any, Union, Optional
 
 
 class InvisibleDriverWindow(windowUtils.CustomWindow):
@@ -530,7 +536,7 @@ class Activator(TimeSyncFirmnessMixin, AtcMixin, JoystickMixin, TripleActionKeys
 	numCells = 40
 	genericName = name = 'Activator'
 
-	def _get_keys(self) -> dict[int, str]:
+	def _get_keys(self) -> Dict[int, str]:
 		keys = super().keys
 		keys.update({
 			0x7A: "escape",

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -2,7 +2,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2008-2021 NV Access Limited, Bram Duvigneau, Babbage B.V.,
-# Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter
+ # Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter
 
 """
 Braille display driver for Handy Tech braille displays.
@@ -103,6 +103,7 @@ MODEL_BRAILLE_STAR_80 = b"\x78"
 MODEL_MODULAR_20 = b"\x80"
 MODEL_MODULAR_80 = b"\x88"
 MODEL_MODULAR_40 = b"\x89"
+MODEL_ACTIVATOR = b"\xA4"
 
 # Key constants
 KEY_B1 = 0x03
@@ -522,6 +523,20 @@ class Modular40(Modular):
 class Modular80(Modular):
 	deviceId = MODEL_MODULAR_80
 	numCells = 80
+
+
+class Activator(TimeSyncFirmnessMixin, AtcMixin, JoystickMixin, TripleActionKeysMixin, Model):
+	deviceId = MODEL_ACTIVATOR
+	numCells = 40
+	genericName = name = 'Activator'
+
+	def _get_keys(self):
+		keys = super(Activator, self).keys
+		keys.update({
+			0x7A: "escape",
+			0x7B: "return",
+		})
+		return keys
 
 
 def _allSubclasses(cls):
@@ -1039,3 +1054,12 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			if key in KEY_DOTS:
 				dots |= 1 << (KEY_DOTS[key] - 1)
 		return dots
+
+# Temporary: Add Activator to USB port enumeration
+bdDetect.addUsbDevices("handyTech", bdDetect.KEY_HID, {
+	"VID_1FE4&PID_00A4"
+	})
+bdDetect.addBluetoothDevices("handyTech", lambda m: any(m.id.startswith(prefix) for prefix in (
+		"Activator"
+	)))
+

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -2,7 +2,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2008-2021 NV Access Limited, Bram Duvigneau, Babbage B.V.,
- # Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter
+# Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter
 
 """
 Braille display driver for Handy Tech braille displays.
@@ -1054,12 +1054,3 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 			if key in KEY_DOTS:
 				dots |= 1 << (KEY_DOTS[key] - 1)
 		return dots
-
-# Temporary: Add Activator to USB port enumeration
-bdDetect.addUsbDevices("handyTech", bdDetect.KEY_HID, {
-	"VID_1FE4&PID_00A4"
-	})
-bdDetect.addBluetoothDevices("handyTech", lambda m: any(m.id.startswith(prefix) for prefix in (
-		"Activator"
-	)))
-

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -530,7 +530,7 @@ class Activator(TimeSyncFirmnessMixin, AtcMixin, JoystickMixin, TripleActionKeys
 	numCells = 40
 	genericName = name = 'Activator'
 
-	def _get_keys(self) -> Dict[int, str]:
+	def _get_keys(self) -> dict[int, str]:
 		keys = super().keys
 		keys.update({
 			0x7A: "escape",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,6 +22,7 @@ What's New in NVDA
 There are now gestures for showing the braille settings dialog, accessing the status bar, cycling the braille cursor shape, and toggling the braille cursor on/off. (#14844)
 - NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. This can be disabled in Advanced settings if audio problems are encountered. (#14697)
 - When using Excel shortcuts to toggle  format such as bold, italic, underline and strike through of a cell in Excel, the result is now reported. (#14923)
+- NVDA now supports the Help Tech Activator Braille display. (#14917)
 - 
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Summary of the issue:
Help Tech Activator Braille display was not supported.
### Description of user facing changes
Activator is now detected and can be used.
### Description of development approach
Modified driver and detection logic.
### Testing strategy:
Tested Braille with updated driver in developer scratchpad.
### Change log entries:
Help Tech Activator now supported.
