### PR TITLE
    Update CLDR to version 43

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ There are now gestures for showing the braille settings dialog, accessing the st
 
 == Changes ==
 - Updated LibLouis braille translator to [3.25.0 https://github.com/liblouis/liblouis/releases/tag/v3.25.0]. (#14719)
+- CLDR has been updated to version 43.0. (#14918)
 - Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
 - Distance reported in Microsoft Word will now honour the unit defined in Word's advanced options even when using UIA to access Word documents. (#14542)
 - When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)


### PR DESCRIPTION
### Link to issue number:

Follow-up of https://github.com/nvaccess/nvda-cldr/pull/5

### Summary of the issue:
NVDA's CLDR data need to be updated regularly to follow CLDR releases. CLDR 43 was released on April 12th, 2023.

### Description of user facing changes
CLDR character names updated, especially in translations.

### Description of development approach
In nvda-cldr repo, checked out the commit e3af0878691391cc019d2e1e7965aa5756ac653a which is the one pointed by the branch main-out. This commit was created following the merge of https://github.com/nvaccess/nvda-cldr/pull/5

### Testing strategy:
Checked the symbol "₭" that has been corrected in French CLDR:
- in NVDA 2023.1: "kip loatien" ("a" and "o" switched)
- in this branch: "kip laotien"

### Known issues with pull request:
None

### Change log entries:
Changes
Update CLDR to version 43.

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
