### PR TITLE
Use a single APC and completion routine

### DIFF
--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -25,7 +25,7 @@ import braille
 from logHandler import log
 import config
 import time
-from .ioThread import IoThread, apcsWillBeStronglyReferenced
+from .ioThread import IoThread, _apcsWillBeStronglyReferenced
 import NVDAState
 
 
@@ -95,7 +95,7 @@ class IoBase(object):
 		ioThread = self._ioThreadRef()
 		if not ioThread:
 			raise RuntimeError("I/O thread is no longer available")
-		if apcsWillBeStronglyReferenced:
+		if _apcsWillBeStronglyReferenced:
 			ioThread.queueAsApc(self._asyncReadBackwardsCompat)
 		else:
 			ioThread.queueAsApc(self._asyncRead)
@@ -178,7 +178,7 @@ class IoBase(object):
 			ioThread.queueAsCompletionRoutine(self._ioDone, self._readOl)
 		)
 
-	if apcsWillBeStronglyReferenced:
+	if _apcsWillBeStronglyReferenced:
 		def _asyncReadBackwardsCompat(self, param: Optional[int] = None):
 			"""Backwards compatible wrapper around L{_asyncRead} that calls it without param.
 			"""

--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -175,7 +175,7 @@ class IoBase(object):
 			self._readBuf,
 			self._readSize,
 			byref(self._readOl),
-			ioThread.getCompletionRoutine(self._ioDone)
+			ioThread.queueAsCompletionRoutine(self._ioDone, self._readOl)
 		)
 
 	if apcsWillBeStronglyReferenced:

--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -35,7 +35,8 @@ ApcStoreT = typing.Dict[
 	]
 ]
 CompletionRoutineStoreTypeT = typing.Dict[
-	CompletionRoutineIdT,typing.Union[BoundMethodWeakref[CompletionRoutineT], AnnotatableWeakref[CompletionRoutineT]]
+	CompletionRoutineIdT,
+	typing.Union[BoundMethodWeakref[CompletionRoutineT], AnnotatableWeakref[CompletionRoutineT]]
 ]
 apcsWillBeStronglyReferenced = version_year < 2024 and NVDAState._allowDeprecatedAPI()
 """

--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -98,7 +98,7 @@ class IoThread(threading.Thread):
 		if self.exit:
 			return
 
-		ptr = ctypes.addressof(overlapped.contents)
+		ptr = ctypes.cast(overlapped, ctypes.c_void_p).value
 		reference = self._completionRoutineStore.pop(ptr, None)
 		if reference is None:
 			log.error(f"Internal completion routine called with pointer 0x{ptr:x}, but no such address in store")

--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -147,6 +147,17 @@ class IoThread(threading.Thread):
 		super().start()
 		self.handle = ctypes.windll.kernel32.OpenThread(winKernel.THREAD_SET_CONTEXT, False, self.ident)
 
+	if apcsWillBeStronglyReferenced:
+		@contextmanager
+		def autoDeleteApcReference(self, apcUuid):
+			log.warning(
+				"IoThread.autoDeleteApcReference is deprecated. "
+				"It was never meant to be part of the public API. "
+				"This method will be removed in NVDA 2024.1. "
+				"Up until that version, it behaves as a no-op, i.e. a context manager yielding nothing."
+			)
+			yield
+
 	def _registerToCallAsApc(
 			self,
 			func: ApcT,

--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -42,7 +42,7 @@ CompletionRoutineStoreTypeT = typing.Dict[
 		OVERLAPPED
 	]
 ]
-apcsWillBeStronglyReferenced = version_year < 2024 and NVDAState._allowDeprecatedAPI()
+_apcsWillBeStronglyReferenced = version_year < 2024 and NVDAState._allowDeprecatedAPI()
 """
 Starting from NVDA 2024.1, we will weakly reference functions that are executed as an APC.
 This will ensure that objects from which APCs have been queuedwon't be scattering around
@@ -147,7 +147,7 @@ class IoThread(threading.Thread):
 		super().start()
 		self.handle = ctypes.windll.kernel32.OpenThread(winKernel.THREAD_SET_CONTEXT, False, self.ident)
 
-	if apcsWillBeStronglyReferenced:
+	if _apcsWillBeStronglyReferenced:
 		@contextmanager
 		def autoDeleteApcReference(self, apcUuid):
 			log.warning(
@@ -179,7 +179,7 @@ class IoThread(threading.Thread):
 
 		# generate a number to identify the function in the store.
 		internalParam = next(self._apcParamCounter)
-		useWeak = _alwaysReferenceWeakly or not apcsWillBeStronglyReferenced
+		useWeak = _alwaysReferenceWeakly or not _apcsWillBeStronglyReferenced
 		reference = None
 		if useWeak:
 			# Generate a weak reference to the function

--- a/tests/unit/test_hwIo.py
+++ b/tests/unit/test_hwIo.py
@@ -26,13 +26,22 @@ class TestBgThreadApc(unittest.TestCase):
 
 	def test_apc(self):
 		"""Test queuing an APC that executes correctly.
+		As the param provided to the internal APC differs from the param passed to the Python function,
+		This test also ensures that the expected param is propagated correctly.
 		"""
 		# Initially, our event isn't set
 		self.assertFalse(self.event.is_set())
-		# Queue a function as APC that sets the event
 
+		class Container:
+			param: int
+
+		paramContainer = Container()
+
+		# Queue a function as APC that sets the event
 		def apc(param: int) -> None:
+			paramContainer.param = param
 			self.event.set()
-		hwIo.bgThread.queueAsApc(apc)
+		hwIo.bgThread.queueAsApc(apc, 42)
 		# Wait for atmost 2 seconds for the event to be set
 		self.assertTrue(self.event.wait(2))
+		self.assertEqual(paramContainer.param, 42)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -107,6 +107,9 @@ Similarly, the new ``getCompletionRoutine`` method allows you to convert a pytho
 Instead, functions should be weakly referenceable. (#14627)
 - Importing ``LPOVERLAPPED_COMPLETION_ROUTINE`` from ``hwIo.base`` is deprecated.
 Instead import from ``hwIo.ioThread``. (#14627)
+- ``IoThread.autoDeleteApcReference`` is deprecated.
+It was introduced in NVDA 2023.1 and was never meant to be part of the public API.
+Until removal, it behaves as a no-op, i.e. a context manager yielding nothing.
 -
 
 = 2023.1 =


### PR DESCRIPTION
### Link to issue number:
Related to #14899, #14312, #14627
Fixes #14895

### Summary of the issue:
Despite several attempts to fix this, NVDA's IoThread can crash without a clear cause.

### Description of user facing changes
Less crashes, most likely, as tests indicate that this is the case.

### Description of development approach
As proposed by @jcsteh , rather than creating a new function pointer for every APC or completion routine call, use a single internal APC and completion routine and use an internal cache to store the python functions, not the actual APC functions.

### Testing strategy:
Steps to reproduce from #14895.

### Known issues with pull request:
None known

### Change log entries:
Deprecations:
- IoThread.autoDeleteApcReference is deprecated. It was introduced in NVDA 2023.1 and was never meant to be part of the public API. Until deprecation, it behaves as a no-op, i.e. a context manager yielding nothing.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
