### PR TITLE
Revert "Improve responsiveness of input and focus by pumping immediately instead of after a delay. (#14701)"

### DIFF
--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -177,7 +177,7 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 				f"Adding winEvent to limiter: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
 			)
 		if winEventLimiter.addEvent(eventID, window, objectID, childID, threadID):
-			core.requestPump(immediate=eventID == winUser.EVENT_OBJECT_FOCUS)
+			core.requestPump()
 	except Exception:
 		log.error("winEventCallback", exc_info=True)
 

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -446,7 +446,7 @@ class LiveText(NVDAObject):
 						# so ignore it.
 						del outLines[0]
 					if outLines:
-						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewLines, outLines, _immediate=True)
+						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewLines, outLines)
 				oldText = newText
 			except:
 				log.exception("Error getting or calculating new text")

--- a/source/core.py
+++ b/source/core.py
@@ -20,7 +20,6 @@ import threading
 import os
 import time
 import ctypes
-from enum import Enum
 import logHandler
 import languageHandler
 import globalVars
@@ -53,16 +52,7 @@ PUMP_MAX_DELAY = 10
 mainThreadId = threading.get_ident()
 
 _pump = None
-
-
-class _PumpPending(Enum):
-	NONE = 0
-	DELAYED = 1
-	IMMEDIATE = 2
-
-	def __bool__(self):
-		return self is not self.NONE
-
+_isPumpPending = False
 
 _hasShutdownBeenTriggered = False
 _shuttingDownFlagLock = threading.Lock()
@@ -716,29 +706,11 @@ def main():
 	# Doing this here is a bit ugly, but we don't want these modules imported
 	# at module level, including wx.
 	log.debug("Initializing core pump")
-
-	class CorePump(wx.Timer):
+	class CorePump(gui.NonReEntrantTimer):
 		"Checks the queues and executes functions."
-		pending = _PumpPending.NONE
-		isPumping = False
-
-		def request(self):
-			if self.isPumping:
-				return  # Prevent re-entry.
-			if self.pending == _PumpPending.IMMEDIATE:
-				# A delayed pump might have been scheduled. If so, cancel it.
-				self.Stop()
-				self.Notify()
-			elif self.pending == _PumpPending.DELAYED:
-				self.Start(PUMP_MAX_DELAY, True)
-
-		def Notify(self):
-			if self.isPumping:
-				log.error("Pumping while already pumping", stack_info=True)
-			if not self.pending:
-				log.error("Pumping but pump wasn't pending", stack_info=True)
-			self.isPumping = True
-			self.pending = _PumpPending.NONE
+		def run(self):
+			global _isPumpPending
+			_isPumpPending = False
 			watchdog.alive()
 			try:
 				if touchHandler.handler:
@@ -754,11 +726,10 @@ def main():
 				log.exception("errors in this core pump cycle")
 			baseObject.AutoPropertyObject.invalidateCaches()
 			watchdog.asleep()
-			self.isPumping = False
-			if self.pending:
+			if _isPumpPending and not _pump.IsRunning():
 				# #3803: Another pump was requested during this pump execution.
 				# As our pump is not re-entrant, schedule another pump.
-				self.request()
+				_pump.Start(PUMP_MAX_DELAY, True)
 	global _pump
 	_pump = CorePump()
 	requestPump()
@@ -864,28 +835,23 @@ def _terminate(module, name=None):
 	except:
 		log.exception("Error terminating %s" % name)
 
-
-def requestPump(immediate: bool = False):
+def requestPump():
 	"""Request a core pump.
 	This will perform any queued activity.
-	@param immediate: If True, the pump will happen as soon as possible. This
-		should be used where response time is most important; e.g. user input or
-		focus events.
-		If False, it is delayed slightly so that queues can implement rate limiting,
-		filter extraneous events, etc.
+	It is delayed slightly so that queues can implement rate limiting,
+	filter extraneous events, etc.
 	"""
-	if not _pump:
+	global _isPumpPending
+	if not _pump or _isPumpPending:
 		return
-	# We only need to do something if:
-	if (
-		# There is no pending pump.
-		_pump.pending == _PumpPending.NONE
-		# There is a pending delayed pump but an immediate pump was just requested.
-		or (immediate and _pump.pending == _PumpPending.DELAYED)
-	):
-		_pump.pending = _PumpPending.IMMEDIATE if immediate else _PumpPending.DELAYED
-		import wx
-		wx.CallAfter(_pump.request)
+	_isPumpPending = True
+	if threading.get_ident() == mainThreadId:
+		_pump.Start(PUMP_MAX_DELAY, True)
+		return
+	# This isn't the main thread. wx timers cannot be run outside the main thread.
+	# Therefore, Have wx start it in the main thread with a CallAfter.
+	import wx
+	wx.CallAfter(_pump.Start,PUMP_MAX_DELAY, True)
 
 
 class NVDANotInitializedError(Exception):

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -47,14 +47,7 @@ def queueEvent(eventName,obj,**kwargs):
 		_pendingEventCountsByName[eventName]=_pendingEventCountsByName.get(eventName,0)+1
 		_pendingEventCountsByObj[obj]=_pendingEventCountsByObj.get(obj,0)+1
 		_pendingEventCountsByNameAndObj[(eventName,obj)]=_pendingEventCountsByNameAndObj.get((eventName,obj),0)+1
-	queueHandler.queueFunction(
-		queueHandler.eventQueue,
-		_queueEventCallback,
-		eventName,
-		obj,
-		kwargs,
-		_immediate=eventName == "gainFocus"
-	)
+	queueHandler.queueFunction(queueHandler.eventQueue,_queueEventCallback,eventName,obj,kwargs)
 
 
 def _queueEventCallback(eventName,obj,kwargs):

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -524,7 +524,7 @@ class InputManager(baseObject.AutoPropertyObject):
 
 		speechEffect = gesture.speechEffectWhenExecuted
 		if speechEffect == gesture.SPEECHEFFECT_CANCEL:
-			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech, _immediate=True)
+			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech)
 		elif speechEffect in (gesture.SPEECHEFFECT_PAUSE, gesture.SPEECHEFFECT_RESUME):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
@@ -547,12 +547,7 @@ class InputManager(baseObject.AutoPropertyObject):
 			raise NoInputGestureAction
 
 		if config.conf["keyboard"]["speakCommandKeys"] and gesture.shouldReportAsCommand:
-			queueHandler.queueFunction(
-				queueHandler.eventQueue,
-				speech.speakMessage,
-				gesture.displayName,
-				_immediate=True
-			)
+			queueHandler.queueFunction(queueHandler.eventQueue, speech.speakMessage, gesture.displayName)
 
 		gesture.reportExtra()
 
@@ -585,13 +580,7 @@ class InputManager(baseObject.AutoPropertyObject):
 
 	def _inputHelpCaptor(self, gesture):
 		bypass = gesture.bypassInputHelp or getattr(gesture.script, "bypassInputHelp", False)
-		queueHandler.queueFunction(
-			queueHandler.eventQueue,
-			self._handleInputHelp,
-			gesture,
-			onlyLog=bypass or not gesture.reportInInputHelp,
-			_immediate=True
-		)
+		queueHandler.queueFunction(queueHandler.eventQueue, self._handleInputHelp, gesture, onlyLog=bypass or not gesture.reportInInputHelp)
 		return bypass
 
 	def _handleInputHelp(self, gesture, onlyLog=False):

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -38,18 +38,9 @@ def cancelGeneratorObject(generatorObjID):
 	except KeyError:
 		pass
 
-
-def queueFunction(queue, func, *args, _immediate: bool = False, **kwargs):
-	"""Queue a function to be executed in a specific queue.
-	@param queue: The queue to use. Currently, this can only be
-		L{queueHandler.eventQueue}.
-	@param func: The function to run.
-	@param _immediate: Whether to run this as soon as possible (e.g. input) or
-		to delay it slightly (e.g. events). See the immediate argument to
-		L{core.requestPump}.
-	"""
+def queueFunction(queue,func,*args,**kwargs):
 	queue.put_nowait((func,args,kwargs))
-	core.requestPump(immediate=_immediate)
+	core.requestPump()
 
 def isRunningGenerators():
 	res=len(generators)>0

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -249,13 +249,7 @@ def queueScript(script,gesture):
 	_numScriptsQueued+=1
 	if _isInterceptedCommandScript(script):
 		_numIncompleteInterceptedCommandScripts+=1
-	queueHandler.queueFunction(
-		queueHandler.eventQueue,
-		_queueScriptCallback,
-		script,
-		gesture,
-		_immediate=True
-	)
+	queueHandler.queueFunction(queueHandler.eventQueue,_queueScriptCallback,script,gesture)
 
 def willSayAllResume(gesture):
 	return (

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -29,7 +29,6 @@ There are now gestures for showing the braille settings dialog, accessing the st
 - Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
 - Distance reported in Microsoft Word will now honour the unit defined in Word's advanced options even when using UIA to access Word documents. (#14542)
 - When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)
-- NVDA now responds slightly faster to commands and focus changes. (#14701)
 - NVDA responds faster when moving the cursor in edit controls. (#14708)
 - Baum Braille driver: addes several Braille chord gestures for performing common keyboard commands such as windows+d, alt+tab etc. Please refer to the NVDA user guide for a full list. (#14714)
 - When using a Braille Display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter. Also space+dot1 and space+dot4 now map to up and down arrow respectively. (#14713)


### PR DESCRIPTION
This reverts pr #14701, commit cc8b5ad

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14753
May fix #14803

### Summary of the issue:
After the merging of pr #14701, It was reported in #14753 that with input help mode on and moving your finger around the touch screen, many errors would be logged and eventually input help mode would be disabled.
An example rrror was:
```
ERROR - scriptHandler.executeScript (20:37:51.892) - MainThread (1032):
error executing script: <bound method GlobalCommands.script_touch_explore of <globalCommands.GlobalCommands object at 0x07873CF0>> with gesture 'hover'
Stack trace:
  File "nvda.pyw", line 406, in <module>
  File "core.pyc", line 794, in main
  File "wx\core.pyc", line 2237, in MainLoop
  File "core.pyc", line 761, in Notify
  File "core.pyc", line 731, in request
  File "core.pyc", line 761, in Notify
... another 100 times or so of request / notify calls... 
  File "queueHandler.pyc", line 97, in pumpAll
  File "queueHandler.pyc", line 64, in flushQueue
  File "scriptHandler.pyc", line 243, in _queueScriptCallback
  File "inputCore.pyc", line 221, in executeScript
  File "scriptHandler.pyc", line 297, in executeScript
Traceback (most recent call last):
  File "scriptHandler.pyc", line 295, in executeScript
  File "globalCommands.pyc", line 3849, in script_touch_explore
  File "screenExplorer.pyc", line 31, in moveTo
  File "NVDAObjects\__init__.pyc", line 322, in objectFromPoint
  File "NVDAObjects\__init__.pyc", line 99, in __call__
  File "NVDAObjects\IAccessible\__init__.pyc", line 482, in findOverlayClasses
  File "baseObject.pyc", line 41, in __get__
  File "NVDAObjects\IAccessible\__init__.pyc", line 908, in _get_role
  File "baseObject.pyc", line 62, in __get__
  File "baseObject.pyc", line 168, in _getPropertyViaCache
  File "NVDAObjects\IAccessible\__init__.pyc", line 920, in _get_IAccessibleStates
  File "comtypes\__init__.pyc", line 856, in __call__
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 32, in __call__
ctypes.ArgumentError: argument 1: <class 'RecursionError'>: maximum recursion depth exceeded while calling a Python object
```

The recursion itself was caused by the core pump's Notify method calling request directly, which itself calls Notify.
The obvious fix would be to wx.CallAfter the call to request. However, this then caused the WX event loop to fill up with responses to these call afters, and due to the way the wx event loop works (msgWaitForMultipleObjects waiting on a pending event win32 event), the event loop never ended up getting a chance to process OS and 3rd party messages. And because we monkeypatch CallAfter to PostMessage (in case we are in a win32 modal or menu and don't wake up) the win32 message queue was being filled completely thus not allowing future messages to be posted.
   
@jcsteh and I have considered several different ways of trying to work around this. Most of which have not been successful. There are probably more things we could try, but for now it is better to revert until we can get this right.
 
### Description of development approach
Fully reverts pr #14701 for now.
