### PR TITLE
Improve responsiveness of input and focus by pumping immediately instead of after a delay.

### DIFF
--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -177,7 +177,7 @@ def winEventCallback(handle, eventID, window, objectID, childID, threadID, times
 				f"Adding winEvent to limiter: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}"
 			)
 		if winEventLimiter.addEvent(eventID, window, objectID, childID, threadID):
-			core.requestPump()
+			core.requestPump(immediate=eventID == winUser.EVENT_OBJECT_FOCUS)
 	except Exception:
 		log.error("winEventCallback", exc_info=True)
 

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -446,7 +446,7 @@ class LiveText(NVDAObject):
 						# so ignore it.
 						del outLines[0]
 					if outLines:
-						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewLines, outLines)
+						queueHandler.queueFunction(queueHandler.eventQueue, self._reportNewLines, outLines, _immediate=True)
 				oldText = newText
 			except:
 				log.exception("Error getting or calculating new text")

--- a/source/core.py
+++ b/source/core.py
@@ -20,6 +20,7 @@ import threading
 import os
 import time
 import ctypes
+from enum import Enum
 import logHandler
 import languageHandler
 import globalVars
@@ -52,7 +53,16 @@ PUMP_MAX_DELAY = 10
 mainThreadId = threading.get_ident()
 
 _pump = None
-_isPumpPending = False
+
+
+class _PumpPending(Enum):
+	NONE = 0
+	DELAYED = 1
+	IMMEDIATE = 2
+
+	def __bool__(self):
+		return self is not self.NONE
+
 
 _hasShutdownBeenTriggered = False
 _shuttingDownFlagLock = threading.Lock()
@@ -710,11 +720,29 @@ def main():
 	# Doing this here is a bit ugly, but we don't want these modules imported
 	# at module level, including wx.
 	log.debug("Initializing core pump")
-	class CorePump(gui.NonReEntrantTimer):
+
+	class CorePump(wx.Timer):
 		"Checks the queues and executes functions."
-		def run(self):
-			global _isPumpPending
-			_isPumpPending = False
+		pending = _PumpPending.NONE
+		isPumping = False
+
+		def request(self):
+			if self.isPumping:
+				return  # Prevent re-entry.
+			if self.pending == _PumpPending.IMMEDIATE:
+				# A delayed pump might have been scheduled. If so, cancel it.
+				self.Stop()
+				self.Notify()
+			elif self.pending == _PumpPending.DELAYED:
+				self.Start(PUMP_MAX_DELAY, True)
+
+		def Notify(self):
+			if self.isPumping:
+				log.error("Pumping while already pumping", stack_info=True)
+			if not self.pending:
+				log.error("Pumping but pump wasn't pending", stack_info=True)
+			self.isPumping = True
+			self.pending = _PumpPending.NONE
 			watchdog.alive()
 			try:
 				if touchHandler.handler:
@@ -730,10 +758,11 @@ def main():
 				log.exception("errors in this core pump cycle")
 			baseObject.AutoPropertyObject.invalidateCaches()
 			watchdog.asleep()
-			if _isPumpPending and not _pump.IsRunning():
+			self.isPumping = False
+			if self.pending:
 				# #3803: Another pump was requested during this pump execution.
 				# As our pump is not re-entrant, schedule another pump.
-				_pump.Start(PUMP_MAX_DELAY, True)
+				self.request()
 	global _pump
 	_pump = CorePump()
 	requestPump()
@@ -844,23 +873,27 @@ def isMainThread() -> bool:
 	return threading.get_ident() == mainThreadId
 
 
-def requestPump():
+def requestPump(immediate: bool = False):
 	"""Request a core pump.
 	This will perform any queued activity.
-	It is delayed slightly so that queues can implement rate limiting,
-	filter extraneous events, etc.
+	@param immediate: If True, the pump will happen as soon as possible. This
+		should be used where response time is most important; e.g. user input or
+		focus events.
+		If False, it is delayed slightly so that queues can implement rate limiting,
+		filter extraneous events, etc.
 	"""
-	global _isPumpPending
-	if not _pump or _isPumpPending:
+	if not _pump:
 		return
-	_isPumpPending = True
-	if threading.get_ident() == mainThreadId:
-		_pump.Start(PUMP_MAX_DELAY, True)
-		return
-	# This isn't the main thread. wx timers cannot be run outside the main thread.
-	# Therefore, Have wx start it in the main thread with a CallAfter.
-	import wx
-	wx.CallAfter(_pump.Start,PUMP_MAX_DELAY, True)
+	# We only need to do something if:
+	if (
+		# There is no pending pump.
+		_pump.pending == _PumpPending.NONE
+		# There is a pending delayed pump but an immediate pump was just requested.
+		or (immediate and _pump.pending == _PumpPending.DELAYED)
+	):
+		_pump.pending = _PumpPending.IMMEDIATE if immediate else _PumpPending.DELAYED
+		import wx
+		wx.CallAfter(_pump.request)
 
 
 class NVDANotInitializedError(Exception):

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -54,7 +54,14 @@ def queueEvent(eventName,obj,**kwargs):
 		_pendingEventCountsByName[eventName]=_pendingEventCountsByName.get(eventName,0)+1
 		_pendingEventCountsByObj[obj]=_pendingEventCountsByObj.get(obj,0)+1
 		_pendingEventCountsByNameAndObj[(eventName,obj)]=_pendingEventCountsByNameAndObj.get((eventName,obj),0)+1
-	queueHandler.queueFunction(queueHandler.eventQueue,_queueEventCallback,eventName,obj,kwargs)
+	queueHandler.queueFunction(
+		queueHandler.eventQueue,
+		_queueEventCallback,
+		eventName,
+		obj,
+		kwargs,
+		_immediate=eventName == "gainFocus"
+	)
 
 
 def _queueEventCallback(eventName,obj,kwargs):

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -524,7 +524,7 @@ class InputManager(baseObject.AutoPropertyObject):
 
 		speechEffect = gesture.speechEffectWhenExecuted
 		if speechEffect == gesture.SPEECHEFFECT_CANCEL:
-			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech)
+			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech, _immediate=True)
 		elif speechEffect in (gesture.SPEECHEFFECT_PAUSE, gesture.SPEECHEFFECT_RESUME):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
@@ -547,7 +547,12 @@ class InputManager(baseObject.AutoPropertyObject):
 			raise NoInputGestureAction
 
 		if config.conf["keyboard"]["speakCommandKeys"] and gesture.shouldReportAsCommand:
-			queueHandler.queueFunction(queueHandler.eventQueue, speech.speakMessage, gesture.displayName)
+			queueHandler.queueFunction(
+				queueHandler.eventQueue,
+				speech.speakMessage,
+				gesture.displayName,
+				_immediate=True
+			)
 
 		gesture.reportExtra()
 
@@ -580,7 +585,13 @@ class InputManager(baseObject.AutoPropertyObject):
 
 	def _inputHelpCaptor(self, gesture):
 		bypass = gesture.bypassInputHelp or getattr(gesture.script, "bypassInputHelp", False)
-		queueHandler.queueFunction(queueHandler.eventQueue, self._handleInputHelp, gesture, onlyLog=bypass or not gesture.reportInInputHelp)
+		queueHandler.queueFunction(
+			queueHandler.eventQueue,
+			self._handleInputHelp,
+			gesture,
+			onlyLog=bypass or not gesture.reportInInputHelp,
+			_immediate=True
+		)
 		return bypass
 
 	def _handleInputHelp(self, gesture, onlyLog=False):

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -522,9 +522,10 @@ class InputManager(baseObject.AutoPropertyObject):
 		if wasInSayAll:
 			gesture.wasInSayAll=True
 
+		immediate = getattr(gesture, "_immediate", True)
 		speechEffect = gesture.speechEffectWhenExecuted
 		if speechEffect == gesture.SPEECHEFFECT_CANCEL:
-			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech, _immediate=True)
+			queueHandler.queueFunction(queueHandler.eventQueue, speech.cancelSpeech, _immediate=immediate)
 		elif speechEffect in (gesture.SPEECHEFFECT_PAUSE, gesture.SPEECHEFFECT_RESUME):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
@@ -585,12 +586,13 @@ class InputManager(baseObject.AutoPropertyObject):
 
 	def _inputHelpCaptor(self, gesture):
 		bypass = gesture.bypassInputHelp or getattr(gesture.script, "bypassInputHelp", False)
+		immediate = getattr(gesture, "_immediate", True)
 		queueHandler.queueFunction(
 			queueHandler.eventQueue,
 			self._handleInputHelp,
 			gesture,
 			onlyLog=bypass or not gesture.reportInInputHelp,
-			_immediate=True
+			_immediate=immediate
 		)
 		return bypass
 

--- a/source/queueHandler.py
+++ b/source/queueHandler.py
@@ -38,9 +38,18 @@ def cancelGeneratorObject(generatorObjID):
 	except KeyError:
 		pass
 
-def queueFunction(queue,func,*args,**kwargs):
+
+def queueFunction(queue, func, *args, _immediate: bool = False, **kwargs):
+	"""Queue a function to be executed in a specific queue.
+	@param queue: The queue to use. Currently, this can only be
+		L{queueHandler.eventQueue}.
+	@param func: The function to run.
+	@param _immediate: Whether to run this as soon as possible (e.g. input) or
+		to delay it slightly (e.g. events). See the immediate argument to
+		L{core.requestPump}.
+	"""
 	queue.put_nowait((func,args,kwargs))
-	core.requestPump()
+	core.requestPump(immediate=_immediate)
 
 def isRunningGenerators():
 	res=len(generators)>0

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -249,7 +249,13 @@ def queueScript(script,gesture):
 	_numScriptsQueued+=1
 	if _isInterceptedCommandScript(script):
 		_numIncompleteInterceptedCommandScripts+=1
-	queueHandler.queueFunction(queueHandler.eventQueue,_queueScriptCallback,script,gesture)
+	queueHandler.queueFunction(
+		queueHandler.eventQueue,
+		_queueScriptCallback,
+		script,
+		gesture,
+		_immediate=True
+	)
 
 def willSayAllResume(gesture):
 	return (

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -254,7 +254,7 @@ def queueScript(script,gesture):
 		_queueScriptCallback,
 		script,
 		gesture,
-		_immediate=True
+		_immediate=getattr(gesture, "_immediate", True)
 	)
 
 def willSayAllResume(gesture):

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -199,6 +199,13 @@ class TouchInputGesture(inputCore.InputGesture):
 			source=u"{source}, {mode}".format(source=source,mode=touchModeLabels[mode])
 		return source,u" + ".join(actions)
 
+	def _get__immediate(self):
+		# Because touch may produce a hover gesture for every pump, an immediate pump
+		# can result in exhaustion of the window message queue. Thus, don't do
+		# immediate pumps for hover gestures.
+		return not self.tracker.action == touchTracker.action_hover
+
+
 inputCore.registerGestureSource("ts", TouchInputGesture)
 
 class TouchHandler(threading.Thread):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -86,6 +86,7 @@ Instead NVDA reports that the link has no destination. (#14723)
 - When running a temporary version from the launcher, NVDA will not mislead users into thinking they can save the configuration. (#14914)
 - Reporting of object shortcut keys has been improved. (#10807)
 - When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)
+- NVDA now generally responds slightly faster to commands and focus changes. (#14928)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Currently, everything in NVDA, including responding to keyboard input and focus changes, goes through the core pump. The core pump is always run with a slight delay. Assuming nothing else is already queued, any input or focus change will not be processed for a minimum of 10 ms. In reality, it's potentially longer due to the system timer resolution and the fact that timers are low priority messages. We should be aiming for the fastest possible response to user input and focus changes.

### Description of user facing changes
NVDA will respond slightly faster to commands and focus changes.

### Description of development approach
1. The core pump has been refactored.
    - Rather than using NonReEntrantTimer, it now uses wx.Timer directly and guards re-entry itself for better control.
    - There is a method (queueRequest) which uses wx.CallAfter to execute the request on the main thread if necessary, avoiding recursion. However, if a delayed pump is requested on the main thread, starting the timer will happen there, rather than being queued via the window message.
    - A main thread method triggered by wx.CallAfter (processRequest) manages scheduling/executing the pump to make state management easier.
    - The pump always queues a subsequent request using wx.CallAfter rather than executing it directly to avoid recursion and to ensure that other window messages have a chance to execute.
2. requestPump has a new immediate argument which specifies whether the pump should happen as soon as possible or after the delay. Delayed pumps are still useful in most cases for rate limiting and filtering, so this defaults to False.
3. queueHandler.queueFunction has an `_immediate` argument which is passed to requestPump. It is `_` prefixed to mitigate conflicts with keyword arguments intended for queued functions.
4. inputCore, scriptHandler, focus changes and live text output all request an immediate core pump.
5. As an exception, a gesture can set the private `_immediate` attribute to False to prevent immediate pumps. This is set on all touch hover gestures to avoid exhausting the window message queue, since hover gestures are queued every pump if there is an active hover.

### Testing strategy:
I used "time since input" logging to measure the differences in times before and after the change in various situations:

- Report time (NVDA+f12) and input help took ~10 ms before the patch, ~0 ms after.
- Navigating in the NVDA menu took > 20 ms before the change, ~10 ms after.
- Moving the caret in Firefox took ~35 ms before the change, ~20 ms after.

This can be quite variable, so it's only a rough guide, but the results are pretty suggestive.

I also verified that touch hovering works as expected even when my finger remains in contact with the screen for 30 seconds. I tested that turning on input help and holding down two fingers for 10 seconds doesn't break input help.

### Known issues with pull request:
None.

### Change log entries:
Bug fixes
NVDA now responds slightly faster to commands and focus changes.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
