### PR TITLE
Event handler: introduce virtual desktop announcement switch handling

### DIFF
--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -308,8 +308,8 @@ def executeEvent(
 			return
 		elif not sleepMode:
 			_EventExecuter(eventName, obj, kwargs)
-	except:
-		log.exception("error executing event: %s on %s with extra args of %s" % (eventName, obj, kwargs))
+	except Exception:
+		log.exception(f"error executing event: {eventName} on {obj} with extra args of {kwargs}")
 
 
 virtualDesktopName = None

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -291,8 +291,8 @@ def executeEvent(
 		isGainFocus = eventName == "gainFocus"
 		# Allow NVDAObjects to redirect focus events to another object of their choosing.
 		if isGainFocus and obj.focusRedirect:
-			obj=obj.focusRedirect
-		sleepMode=obj.sleepMode
+			obj = obj.focusRedirect
+		sleepMode = obj.sleepMode
 		# Handle possible virtual desktop name change event.
 		if eventName == "nameChange" and obj.windowClassName == "#32769":
 			import core
@@ -304,12 +304,12 @@ def executeEvent(
 			core.callLater(250, handlePossibleDesktopNameChange)
 		if isGainFocus and not doPreGainFocus(obj, sleepMode=sleepMode):
 			return
-		elif not sleepMode and eventName=="documentLoadComplete" and not doPreDocumentLoadComplete(obj):
+		elif not sleepMode and eventName == "documentLoadComplete" and not doPreDocumentLoadComplete(obj):
 			return
 		elif not sleepMode:
-			_EventExecuter(eventName,obj,kwargs)
+			_EventExecuter(eventName, obj, kwargs)
 	except:
-		log.exception("error executing event: %s on %s with extra args of %s"%(eventName,obj,kwargs))
+		log.exception("error executing event: %s on %s with extra args of %s" % (eventName, obj, kwargs))
 
 
 virtualDesktopName = None
@@ -339,8 +339,8 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 		shouldLog=config.conf["debugLog"]["events"],
 	):
 		return False
-	oldFocus=api.getFocusObject()
-	oldTreeInterceptor=oldFocus.treeInterceptor if oldFocus else None
+	oldFocus = api.getFocusObject()
+	oldTreeInterceptor = oldFocus.treeInterceptor if oldFocus else None
 	if not api.setFocusObject(obj):
 		return False
 	if speech.manager._shouldCancelExpiredFocusEvents():
@@ -367,26 +367,31 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 		# not the secure desktop.
 		and not isinstance(obj, SecureDesktopNVDAObject)
 	):
-		newForeground=api.getDesktopObject().objectInForeground()
+		newForeground = api.getDesktopObject().objectInForeground()
 		if not newForeground:
 			log.debugWarning("Can not get real foreground, resorting to focus ancestors")
-			ancestors=api.getFocusAncestors()
-			if len(ancestors)>1:
-				newForeground=ancestors[1]
+			ancestors = api.getFocusAncestors()
+			if len(ancestors) > 1:
+				newForeground = ancestors[1]
 			else:
-				newForeground=obj
+				newForeground = obj
 		if not api.setForegroundObject(newForeground):
 			return False
 		executeEvent('foreground', newForeground)
 	handlePossibleDesktopNameChange()
-	if sleepMode: return True
-	#Fire focus entered events for all new ancestors of the focus if this is a gainFocus event
+	if sleepMode:
+		return True
+	# Fire focus entered events for all new ancestors of the focus if this is a gainFocus event
 	for parent in api.getFocusAncestors()[api.getFocusDifferenceLevel():]:
-		executeEvent("focusEntered",parent)
+		executeEvent("focusEntered", parent)
 	if obj.treeInterceptor is not oldTreeInterceptor:
-		if hasattr(oldTreeInterceptor,"event_treeInterceptor_loseFocus"):
+		if hasattr(oldTreeInterceptor, "event_treeInterceptor_loseFocus"):
 			oldTreeInterceptor.event_treeInterceptor_loseFocus()
-		if obj.treeInterceptor and obj.treeInterceptor.isReady and hasattr(obj.treeInterceptor,"event_treeInterceptor_gainFocus"):
+		if (
+			obj.treeInterceptor
+			and obj.treeInterceptor.isReady
+			and hasattr(obj.treeInterceptor, "event_treeInterceptor_gainFocus")
+		):
 			obj.treeInterceptor.event_treeInterceptor_gainFocus()
 	return True
 

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -373,6 +373,7 @@ def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bo
 		if not api.setForegroundObject(newForeground):
 			return False
 		executeEvent('foreground', newForeground)
+	handlePossibleDesktopNameChange()
 	if sleepMode: return True
 	#Fire focus entered events for all new ancestors of the focus if this is a gainFocus event
 	for parent in api.getFocusAncestors()[api.getFocusDifferenceLevel():]:

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2007-2022 NV Access Limited, Babbage B.V.
+# Copyright (C) 2007-2023 NV Access Limited, Babbage B.V., Joseph Lee
 
 import threading
 import typing

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -296,6 +296,10 @@ def executeEvent(
 		# Handle possible virtual desktop name change event.
 		if eventName == "nameChange" and obj.windowClassName == "#32769":
 			import core
+			import winVersion
+			# More effective in Windows 10 Version 1903 and later.
+			if winVersion.getWinVer() < winVersion.WIN10_1903:
+				return
 			virtualDesktopName = obj.name
 			core.callLater(250, handlePossibleDesktopNameChange)
 		if isGainFocus and not doPreGainFocus(obj, sleepMode=sleepMode):
@@ -318,7 +322,8 @@ def handlePossibleDesktopNameChange():
 	"""
 	global virtualDesktopName
 	import winVersion
-	if winVersion.getWinVer() < winVersion.WIN10:
+	# Virtual desktop switch announcement works more effectively in Version 1903 and later.
+	if winVersion.getWinVer() < winVersion.WIN10_1903:
 		return
 	if virtualDesktopName:
 		import ui

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -287,11 +287,17 @@ def executeEvent(
 	):
 		return
 	try:
+		global virtualDesktopName
 		isGainFocus = eventName == "gainFocus"
 		# Allow NVDAObjects to redirect focus events to another object of their choosing.
 		if isGainFocus and obj.focusRedirect:
 			obj=obj.focusRedirect
 		sleepMode=obj.sleepMode
+		# Handle possible virtual desktop name change event.
+		if eventName == "nameChange" and obj.windowClassName == "#32769":
+			import core
+			virtualDesktopName = obj.name
+			core.callLater(250, handlePossibleDesktopNameChange)
 		if isGainFocus and not doPreGainFocus(obj, sleepMode=sleepMode):
 			return
 		elif not sleepMode and eventName=="documentLoadComplete" and not doPreDocumentLoadComplete(obj):

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -40,8 +40,8 @@ lastQueuedFocusObject=None
 
 
 # Handle virtual desktop switch announcements in Windows 10 and later
-virtualDesktopName: Optional[str] = None
-canAnnounceVirtualDesktopNames: bool = winVersion.getWinVer() >= winVersion.WIN10_1903
+_virtualDesktopName: Optional[str] = None
+_canAnnounceVirtualDesktopNames: bool = winVersion.getWinVer() >= winVersion.WIN10_1903
 
 
 def queueEvent(eventName,obj,**kwargs):
@@ -294,7 +294,7 @@ def executeEvent(
 	):
 		return
 	try:
-		global virtualDesktopName
+		global _virtualDesktopName
 		isGainFocus = eventName == "gainFocus"
 		# Allow NVDAObjects to redirect focus events to another object of their choosing.
 		if isGainFocus and obj.focusRedirect:
@@ -305,10 +305,10 @@ def executeEvent(
 		if (
 			eventName == "nameChange"
 			and obj.windowClassName == "#32769"
-			and canAnnounceVirtualDesktopNames
+			and _canAnnounceVirtualDesktopNames
 		):
 			import core
-			virtualDesktopName = obj.name
+			_virtualDesktopName = obj.name
 			core.callLater(250, handlePossibleDesktopNameChange)
 		if isGainFocus and not doPreGainFocus(obj, sleepMode=sleepMode):
 			return
@@ -325,14 +325,14 @@ def handlePossibleDesktopNameChange() -> None:
 	Reports the new virtual desktop name if changed.
 	On Windows versions lower than Windows 10, this function does nothing.
 	"""
-	global virtualDesktopName
+	global _virtualDesktopName
 	# Virtual desktop switch announcement works more effectively in Version 1903 and later.
-	if not canAnnounceVirtualDesktopNames:
+	if not _canAnnounceVirtualDesktopNames:
 		return
-	if virtualDesktopName:
+	if _virtualDesktopName:
 		import ui
-		ui.message(virtualDesktopName)
-		virtualDesktopName = None
+		ui.message(_virtualDesktopName)
+		_virtualDesktopName = None
 
 
 def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bool:

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -302,6 +302,24 @@ def executeEvent(
 		log.exception("error executing event: %s on %s with extra args of %s"%(eventName,obj,kwargs))
 
 
+virtualDesktopName = None
+
+
+def handlePossibleDesktopNameChange():
+	"""
+	Reports the new virtual desktop name if changed.
+	On Windows versions lower than Windows 10, this function does nothing.
+	"""
+	global virtualDesktopName
+	import winVersion
+	if winVersion.getWinVer() < winVersion.WIN10:
+		return
+	if virtualDesktopName:
+		import ui
+		ui.message(virtualDesktopName)
+		virtualDesktopName = None
+
+
 def doPreGainFocus(obj: "NVDAObjects.NVDAObject", sleepMode: bool = False) -> bool:
 	from IAccessibleHandler import SecureDesktopNVDAObject
 

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -38,6 +38,12 @@ _pendingEventCountsLock=threading.RLock()
 #: the last object queued for a gainFocus event. Useful for code running outside NVDA's core queue 
 lastQueuedFocusObject=None
 
+
+# Handle virtual desktop switch announcements in Windows 10 and later
+virtualDesktopName: Optional[str] = None
+canAnnounceVirtualDesktopNames: bool = winVersion.getWinVer() >= winVersion.WIN10_1903
+
+
 def queueEvent(eventName,obj,**kwargs):
 	"""Queues an NVDA event to be executed.
 	@param eventName: the name of the event type (e.g. 'gainFocus', 'nameChange')
@@ -312,10 +318,6 @@ def executeEvent(
 			_EventExecuter(eventName, obj, kwargs)
 	except Exception:
 		log.exception(f"error executing event: {eventName} on {obj} with extra args of {kwargs}")
-
-
-virtualDesktopName: Optional[str] = None
-canAnnounceVirtualDesktopNames: bool = winVersion.getWinVer() >= winVersion.WIN10_1903
 
 
 def handlePossibleDesktopNameChange() -> None:

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -312,10 +312,10 @@ def executeEvent(
 		log.exception(f"error executing event: {eventName} on {obj} with extra args of {kwargs}")
 
 
-virtualDesktopName = None
+virtualDesktopName: Optional[str] = None
 
 
-def handlePossibleDesktopNameChange():
+def handlePossibleDesktopNameChange() -> None:
 	"""
 	Reports the new virtual desktop name if changed.
 	On Windows versions lower than Windows 10, this function does nothing.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -303,9 +303,9 @@ def executeEvent(
 		# Handle possible virtual desktop name change event.
 		# More effective in Windows 10 Version 1903 and later.
 		if (
-				eventName == "nameChange"
-				and obj.windowClassName == "#32769"
-				and canAnnounceVirtualDesktopNames
+			eventName == "nameChange"
+			and obj.windowClassName == "#32769"
+			and canAnnounceVirtualDesktopNames
 		):
 			import core
 			virtualDesktopName = obj.name

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ There are now gestures for showing the braille settings dialog, accessing the st
 - NVDA now outputs audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. This can be disabled in Advanced settings if audio problems are encountered. (#14697)
 - When using Excel shortcuts to toggle format such as bold, italic, underline and strike through of a cell in Excel, the result is now reported. (#14923)
 - Added support for the Help Tech Activator Braille display. (#14917)
+- In Windows 10 May 2019 Update and later, NVDA can announe virtual desktop names when opening, changing, and closing them. (#5641)
 - 
 
 
@@ -39,7 +40,8 @@ There are now gestures for showing the braille settings dialog, accessing the st
   -
 - Distance reported in Microsoft Word will now honour the unit defined in Word's advanced options even when using UIA to access Word documents. (#14542)
 - NVDA responds faster when moving the cursor in edit controls. (#14708)
-- Baum Braille driver: addes several Braille chord gestures for performing common keyboard commands such as windows+d, alt+tab etc. Please refer to the NVDA user guide for a full list. (#14714)
+- Baum Braille driver: addes several Braille chord gestures for performing common keyboard commands such as ``windows+d``, ``alt+tab`` etc.
+Please refer to the NVDA user guide for a full list. (#14714)
 - When using a Braille Display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter. Also space+dot1 and space+dot4 now map to up and down arrow respectively. (#14713)
 - Script for reporting the destination of a link now reports from the caret / focus position rather than the navigator object. (#14659)
 - Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (#14681)


### PR DESCRIPTION
Note: this is take 3.1 of #5641 to see if a PR build can be built:

### Link to issue number:
Fixes #5641 

### Summary of the issue:
In Windows 10 and later, NVDA does not announce virtual desktop names wen they are opened, switched, and closed.

### Description of user facing changes
NVDA will announce names of virtual desktops when opening, switching, and closing them.

### Description of development approach
Event handler is extended to include a virtual desktop switch handler and an extension to execute event to catch a name change event coming from CSRSS.

### Testing strategy:
Manual testing (prerequisites: Windows 10 or later):

1. Press Control+Windows+D to open virtual desktops
2. Switch between virtual desktops.
3. Close a virtual desktop.

### Known issues with pull request:
In some cases, closing a virtual desktop wil announce the focused control first and then announce virtual desktop name, but this is due to focus event firing before name change event.

### Change log entries:
New features:

In Windows 10 May 2019 Update and later, NVDA can announe virtual desktop names when opening, changing, and closing them. (#5641)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
