### PR TITLE
soffice: Implement methods for status bar announcement

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -33,8 +33,11 @@ There are now gestures for showing the braille settings dialog, accessing the st
 - Updated LibLouis braille translator to [3.25.0 https://github.com/liblouis/liblouis/releases/tag/v3.25.0]. (#14719)
 - CLDR has been updated to version 43.0. (#14918)
 - Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
+- LibreOffice changes:
+  - When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)
+  - Announcement of the status bar (e.g. triggered by ``NVDA+end``) works for LibreOffice. (#11698)
+  -
 - Distance reported in Microsoft Word will now honour the unit defined in Word's advanced options even when using UIA to access Word documents. (#14542)
-- When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)
 - NVDA responds faster when moving the cursor in edit controls. (#14708)
 - Baum Braille driver: addes several Braille chord gestures for performing common keyboard commands such as windows+d, alt+tab etc. Please refer to the NVDA user guide for a full list. (#14714)
 - When using a Braille Display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter. Also space+dot1 and space+dot4 now map to up and down arrow respectively. (#14713)
@@ -112,7 +115,7 @@ Instead, functions should be weakly referenceable. (#14627)
 Instead import from ``hwIo.ioThread``. (#14627)
 - ``IoThread.autoDeleteApcReference`` is deprecated.
 It was introduced in NVDA 2023.1 and was never meant to be part of the public API.
-Until removal, it behaves as a no-op, i.e. a context manager yielding nothing.
+Until removal, it behaves as a no-op, i.e. a context manager yielding nothing. (#14924)
 -
 
 = 2023.1 =


### PR DESCRIPTION
 <!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:

Fixes #11698

### Summary of the issue:

Announcement of the status bar in LibreOffice (e.g. triggered by NVDA+End) didn't work because the default implementations do not work for the LibreOffice case.

### Description of user facing changes

Announcement of the status bar (e.g. triggered
by NVDA+End) works for LibreOffice.

### Description of development approach

Override the default app module implementation to retrieve the status bar and announce its text in the LibreOffice app module, since the default implementations are not sufficient for the LibreOffice case:

* To retrieve the status bar object, locate the descendant with the corresponding role, but only descend into children of role `ROOTPANE` and `WINDOW` for performance reasons.

* To generate text from the status bar object, retrieve the text of each status bar child using the IAccessibleText interface. (The default implementation in api.py only uses the object names and values, which are both empty.)

### Testing strategy:

1) start NVDA
2) start LibreOffice Writer
3) Press NVDA+End key to trigger announcement of status line 4) check that the visible content of the status bar is announced
   (e.g. something like "Page 1 of 1 5 words, 20 characters  Default
   Page Style English (United States) {en-US}       80%")
5) repeat the above steps, but use LibreOffice Calc, Draw and Impress
   instead of Writer (in step 2)

### Known issues with pull request:

none

### Change log entries:

Changes
`Announcement of the status bar (e.g. triggered
by NVDA+End) works for LibreOffice. (#11698)`

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
