### PR TITLE
Rewrote the paragraph describing ways to access the NVDA menu, in user guide section "The NVDA Menu"

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -486,7 +486,7 @@ To get to the NVDA menu from anywhere in Windows while NVDA is running, you may 
 - press ``NVDA+n`` on the keyboard.
 - Perform a 2-finger double-tap on the touch screen.
 - Access the system tray by pressing the Windows logo key+B, DownArrow to the NVDA icon, and press ``enter``.
-- Alternatively, access the system tray by pressing ``Windows+b``, DownArrow to the NVDA icon, and press the ``applications`` key located next to the right control key on most keyboards. On a keyboard without an ``applications`` key, press ``shift+F10``.
+- Alternatively, access the system tray by pressing ``Windows+b``, DownArrow to the NVDA icon, and open the Context menu by pressing the ``applications`` key located next to the right control key on most keyboards. On a keyboard without an ``applications`` key, press ``shift+F10`` instead.
 - Right-click on the NVDA icon located in the Windows system tray
 -
 When the menu comes up, You can use the arrow keys to navigate the menu, and the ``enter`` key to activate an item.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -485,8 +485,9 @@ The NVDA menu allows you to control NVDA's settings, access help, save/revert yo
 To get to the NVDA menu from anywhere in Windows while NVDA is running, you may do any of the following:
 - press ``NVDA+n`` on the keyboard.
 - Perform a 2-finger double-tap on the touch screen.
-- Access the system tray by pressing the Windows logo key+B, DownArrow to the NVDA icon, and press ``enter``.
-- Alternatively, access the system tray by pressing ``Windows+b``, DownArrow to the NVDA icon, and open the Context menu by pressing the ``applications`` key located next to the right control key on most keyboards. On a keyboard without an ``applications`` key, press ``shift+F10`` instead.
+- Access the system tray by pressing ``windows+b``, ``downArrow`` to the NVDA icon, and press ``enter``.
+- Alternatively, access the system tray by pressing ``windows+b``, ``downArrow`` to the NVDA icon, and open the Context menu by pressing the ``applications`` key located next to the right control key on most keyboards.
+On a keyboard without an ``applications`` key, press ``shift+F10`` instead.
 - Right-click on the NVDA icon located in the Windows system tray
 -
 When the menu comes up, You can use the arrow keys to navigate the menu, and the ``enter`` key to activate an item.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -485,8 +485,8 @@ The NVDA menu allows you to control NVDA's settings, access help, save/revert yo
 To get to the NVDA menu from anywhere in Windows while NVDA is running, you may do any of the following:
 - press ``NVDA+n`` on the keyboard.
 - Perform a 2-finger double-tap on the touch screen.
-- Access the system tray by pressing ``windows+b``, ``downArrow`` to the NVDA icon, and press ``enter``.
-- Alternatively, access the system tray by pressing ``windows+b``, ``downArrow`` to the NVDA icon, and open the Context menu by pressing the ``applications`` key located next to the right control key on most keyboards.
+- Access the system tray by pressing ``Windows+b``, ``downArrow`` to the NVDA icon, and press ``enter``.
+- Alternatively, access the system tray by pressing ``Windows+b``, ``downArrow`` to the NVDA icon, and open the context menu by pressing the ``applications`` key located next to the right control key on most keyboards.
 On a keyboard without an ``applications`` key, press ``shift+F10`` instead.
 - Right-click on the NVDA icon located in the Windows system tray
 -

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -482,10 +482,14 @@ The actual  commands will not execute while in input help mode.
 ++ The NVDA menu ++[TheNVDAMenu]
 The NVDA menu allows you to control NVDA's settings, access help, save/revert your configuration, Modify speech dictionaries, access additional tools and exit NVDA.
 
-To get to the NVDA menu from anywhere in Windows while NVDA is running, press NVDA+n on the keyboard or perform a 2-finger double-tap on the touch screen.
-You can also get to the NVDA menu via the Windows system tray.
-Either right-click on the NVDA icon located in the system tray, or access the system tray by pressing the Windows logo key+B, DownArrow to the NVDA icon and press the applications key located next to the right control key on most keyboards.
-When the menu comes up, You can use the arrow keys to navigate the menu, and the enter key to activate an item.
+To get to the NVDA menu from anywhere in Windows while NVDA is running, you may do any of the following:
+- press ``NVDA+n`` on the keyboard.
+- Perform a 2-finger double-tap on the touch screen.
+- Access the system tray by pressing the Windows logo key+B, DownArrow to the NVDA icon, and press ``enter``.
+- Alternatively, access the system tray by pressing ``Windows+b``, DownArrow to the NVDA icon, and press the ``applications`` key located next to the right control key on most keyboards. On a keyboard without an ``applications`` key, press ``shift+F10``.
+- Right-click on the NVDA icon located in the Windows system tray
+-
+When the menu comes up, You can use the arrow keys to navigate the menu, and the ``enter`` key to activate an item.
 
 ++ Basic NVDA commands ++[BasicNVDACommands]
 %kc:beginInclude


### PR DESCRIPTION
### Link to issue number:

Fixes #14929

### Summary of the issue:

Some users do not know that Shift+F10 is an alternative to the Applications key for accessing the Context menu.
As a good reason to provide this information in the user guide, make note of it in the first place which describes use of the Applications key: accessing the NVDA menu.

### Description of user facing changes

Altered the user guide section in question as follows:

* Since there were several ways listed to access the NVDA menu already, and #14929 asked to add another one: put all the methods in a list.
* Described the Shift+F10 alternative to the Applications key.
* Added code markers around all keys in that section, except "Windows logo key+B", which is written differently.
* Moved the right-click mouse option to last, since it is the least likely for a blind user.

### Description of development approach

Edited text. Saved text. Made commits. Did it some more.

### Testing strategy:

Have @Qchristensen read over the proposed changes. (Pending)

### Known issues with pull request:

None.

### Change log entries:
Changes
Listed all of the possible ways to reach the NVDA menu in the user guide, mentioning that Shift+F10 is an alternative to the Applications key for accessing the context menu.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
