### PR TITLE
Rewrote the user guide section about the settings dialog

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1296,16 +1296,19 @@ Some settings can also be changed using shortcut keys, which are listed where re
 
 ++ NVDA Settings ++[NVDASettings]
 %kc:settingsSection: || Name | Desktop key | Laptop key | Description |
-The NVDA Settings dialog contains many configuration parameters that can be changed.
-This dialog contains a list with several categories of settings to choose from.
-When you select a category, several settings related to this category will be shown in this dialog.
-These settings can be applied using the apply button, in which case the dialog will stay open.
+NVDA provides many configuration parameters that can be changed using the settings dialog.
+To make it easier to find the kind of settings you want to change, the dialog displays a list with several configuration categories to choose from.
+When you select a category, all of the settings related to it will be shown in the dialog.
+To move between categories, use ``tab`` or ``shift+tab`` to reach the list of categories, and then use the up and down arrow keys to navigate the list.
+From anywhere in the dialog., you may also move forward one category by pressing ``ctrl+tab``, or back one category by pressing ``shift+ctrl+tab``.
+
+Once you change one or more settings, the settings can be applied using the apply button, in which case the dialog will stay open, allowing you to change more settings or choose another category.
 If you want to save your settings and close the NVDA Settings dialog, you can use the OK button.
 
 Some settings categories have dedicated shortcut keys.
-If pressed, the shortcut key will open the NVDA Settings dialog in that particular category.
+If pressed, the shortcut key will open the NVDA Settings dialog directly to that particular category.
 By default, not all categories can be accessed with keyboard commands.
-If you wish to access categories which do not have dedicated shortcut keys, use the [Input Gestures dialog #InputGestures] to add a custom gesture such as a keyboard command or touch gesture for that category.
+If you frequently access categories that do not have dedicated shortcut keys, you may wish to use the [Input Gestures dialog #InputGestures] to add a custom gesture such as a keyboard command or touch gesture for that category.
 
 The settings categories found in the NVDA Settings dialog will be outlined below.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1297,10 +1297,10 @@ Some settings can also be changed using shortcut keys, which are listed where re
 ++ NVDA Settings ++[NVDASettings]
 %kc:settingsSection: || Name | Desktop key | Laptop key | Description |
 NVDA provides many configuration parameters that can be changed using the settings dialog.
-To make it easier to find the kind of settings you want to change, the dialog displays a list with several configuration categories to choose from.
+To make it easier to find the kind of settings you want to change, the dialog displays a list of configuration categories to choose from.
 When you select a category, all of the settings related to it will be shown in the dialog.
 To move between categories, use ``tab`` or ``shift+tab`` to reach the list of categories, and then use the up and down arrow keys to navigate the list.
-From anywhere in the dialog., you may also move forward one category by pressing ``ctrl+tab``, or back one category by pressing ``shift+ctrl+tab``.
+From anywhere in the dialog, you may also move forward one category by pressing ``ctrl+tab``, or back one category by pressing ``shift+ctrl+tab``.
 
 Once you change one or more settings, the settings can be applied using the apply button, in which case the dialog will stay open, allowing you to change more settings or choose another category.
 If you want to save your settings and close the NVDA Settings dialog, you can use the OK button.


### PR DESCRIPTION

### Link to issue number:

Fixes #14927 

### Summary of the issue:

The issue asked that Ctrl+Tab and Shift+Ctrl+Tab be listed in the user guide section regarding the settings dialog, since many users don't know they can use those to move between categories.

### Description of user facing changes

While editing the section, I found some awkward and seemingly redundant wording, and some unclear portions.

* Reworded the initial paragraph to be more clear about categories and settings.
* Added a note that Ctrl+Tab and Shift+Ctrl+Tab can move between settings categories.
* Clarified a sentence about what shortcut keys for categories do.
* Made the note about adding shortcut keys for categories more clear.  As it was written previously, it implied that adding shortcut keys might be the ONLY way to access those categories.

### Description of development approach

I tried to imagine myself in the position of a user who didn't know much about manipulating settings or their dialogs; and rewrote a bit from that prospective.

### Testing strategy:

The test will be whether @Qchristensen still talks to me after reading this.

### Known issues with pull request:

### Change log entries:

Changes
Clarified the user guide section describing the settings dialog.

### Code Review Checklist:

There is no code.