### PR TITLE
Fix for the left and right double angle bracket readout, when the symbol level is set to none

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -124,8 +124,8 @@ _	line	most
 ◆	black diamond	some
 §	section	all
 °	degrees	some
-«	double left pointing angle bracket	none
-»	double right pointing angle bracket	none
+«	double left pointing angle bracket	most	always
+»	double right pointing angle bracket	most	always
 µ	micro	some
 ⁰	superscript 0	some
 ¹	superscript 1	some


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14939 
### Summary of the issue:
When the symbol level is set to none, left double angle bracket and right double angle bracket are read, which should not be the case.
### Description of user facing changes
The left double angle bracket and right double angle bracket symbols are no longer read, when the symbol level is set to none and speech synthesizers will properly react on these symbols.
### Description of development approach
This needed just the change of the english symbols.dic file. It should propagate all locales and languages. It overwrites erroneous definition in dldr.dic for all locales.
### Testing strategy:
Tested on the latest alpha with my local modified symbol files.
tried the following sentence with the ukrainian tts:
Процвітання. Слово «процвітати» дуже позитивне, оскільки уособлює собою зростання, розвиток та рух на краще.
### Known issues with pull request:
None known.
### Change log entries:
New features
Changes
Bug fixes
For Developers
Bug fixes
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
