### PR TITLE
Add-on store: Improve disk management for launcher and secure copies

### DIFF
--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -46,6 +46,16 @@ def _setExitCode(exitCode: int) -> None:
 	globalVars.exitCode = exitCode
 
 
+def shouldWriteToDisk() -> bool:
+	"""
+	Never save config or state if running securely or if running from the launcher.
+	When running from the launcher we don't save settings because the user may decide not to
+	install this version, and these settings may not be compatible with the already
+	installed version. See #7688
+	"""
+	return not (globalVars.appArgs.secure or globalVars.appArgs.launcher)
+
+
 class _TrackNVDAInitialization:
 	"""
 	During NVDA initialization,

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -27,6 +27,7 @@ from core import callLater
 import globalVars
 import languageHandler
 from logHandler import log
+import NVDAState
 
 from .models.addon import (
 	AddonStoreModel,
@@ -68,7 +69,6 @@ class _DataManager:
 	_cachePeriod = timedelta(hours=6)
 
 	def __init__(self):
-		self._shouldCacheToDisk = not (globalVars.appArgs.secure or globalVars.appArgs.launcher)
 		cacheDirLocation = os.path.join(globalVars.appArgs.configPath, "addonStore")
 		self._lang = languageHandler.getLanguage()
 		self._preferredChannel = Channel.ALL
@@ -109,7 +109,7 @@ class _DataManager:
 		return response.content
 
 	def _cacheCompatibleAddons(self, addonData: str, fetchTime: datetime):
-		if not self._shouldCacheToDisk:
+		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData:
 			return
@@ -123,7 +123,7 @@ class _DataManager:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
 	def _cacheLatestAddons(self, addonData: str, fetchTime: datetime):
-		if not self._shouldCacheToDisk:
+		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData:
 			return
@@ -235,7 +235,7 @@ class _DataManager:
 			os.remove(addonCachePath)
 
 	def _cacheInstalledAddon(self, addonData: AddonStoreModel):
-		if not self._shouldCacheToDisk:
+		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData:
 			return

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -131,6 +131,10 @@ class AddonsState(collections.UserDict):
 
 	def save(self) -> None:
 		"""Saves content of the state to a file unless state is empty in which case this would be pointless."""
+		if globalVars.appArgs.secure or globalVars.appArgs.launcher:
+			log.error("NVDA should not write to disk from secure mode or launcher", stack_info=True)
+			return
+
 		if any(self.values()):
 			try:
 				# #9038: Python 3 requires binary format when working with pickles.
@@ -216,8 +220,9 @@ def initialize():
 	# #3090: Are there add-ons that are supposed to not run for this session?
 	disableAddonsIfAny()
 	getAvailableAddons(refresh=True, isFirstLoad=True)
-	state.cleanupRemovedDisabledAddons()
-	state.save()
+	if not (globalVars.appArgs.secure or globalVars.appArgs.launcher):
+		state.cleanupRemovedDisabledAddons()
+		state.save()
 	initializeModulePackagePaths()
 
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -38,6 +38,7 @@ from logHandler import log
 import winKernel
 import addonAPIVersion
 import importlib
+import NVDAState
 from types import ModuleType
 
 from _addonStore.models.status import AddonStateCategory, SupportsAddonState
@@ -131,7 +132,7 @@ class AddonsState(collections.UserDict):
 
 	def save(self) -> None:
 		"""Saves content of the state to a file unless state is empty in which case this would be pointless."""
-		if globalVars.appArgs.secure or globalVars.appArgs.launcher:
+		if not NVDAState.shouldWriteToDisk():
 			log.error("NVDA should not write to disk from secure mode or launcher", stack_info=True)
 			return
 
@@ -220,7 +221,7 @@ def initialize():
 	# #3090: Are there add-ons that are supposed to not run for this session?
 	disableAddonsIfAny()
 	getAvailableAddons(refresh=True, isFirstLoad=True)
-	if not (globalVars.appArgs.secure or globalVars.appArgs.launcher):
+	if NVDAState.shouldWriteToDisk():
 		state.cleanupRemovedDisabledAddons()
 		state.save()
 	initializeModulePackagePaths()

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -538,11 +538,6 @@ class ConfigManager(object):
 		self._shouldHandleProfileSwitch: bool = True
 		self._pendingHandleProfileSwitch: bool = False
 		self._suspendedTriggers: Optional[List[ProfileTrigger]] = None
-		# Never save the config if running securely or if running from the launcher.
-		# When running from the launcher we don't save settings because the user may decide not to
-		# install this version, and these settings may not be compatible with the already
-		# installed version. See #7688
-		self._shouldWriteProfile: bool = not (globalVars.appArgs.secure or globalVars.appArgs.launcher)
 		self._initBaseConf()
 		#: Maps triggers to profiles.
 		self.triggersToProfiles: Optional[Dict[ProfileTrigger, ConfigObj]] = None
@@ -600,7 +595,7 @@ class ConfigManager(object):
 		profile.newlines = "\r\n"
 		profileCopy = deepcopy(profile)
 		try:
-			writeProfileFunc = self._writeProfileToFile if self._shouldWriteProfile else None
+			writeProfileFunc = self._writeProfileToFile if NVDAState.shouldWriteToDisk() else None
 			profileUpgrader.upgrade(profile, self.validator, writeProfileFunc)
 		except Exception as e:
 			# Log at level info to ensure that the profile is logged.
@@ -704,7 +699,7 @@ class ConfigManager(object):
 		"""
 		# #7598: give others a chance to either save settings early or terminate tasks.
 		pre_configSave.notify()
-		if not self._shouldWriteProfile:
+		if not NVDAState.shouldWriteToDisk():
 			log.info("Not writing profile, either --secure or --launcher args present")
 			return
 		try:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -335,6 +335,7 @@ class MainFrame(wx.Frame):
 		blockAction.Context.MODAL_DIALOG_OPEN,
 		blockAction.Context.WINDOWS_LOCKED,
 		blockAction.Context.WINDOWS_STORE_VERSION,
+		blockAction.Context.RUNNING_LAUNCHER,
 	)
 	def onAddonStoreCommand(self, evt: wx.MenuEvent):
 		self.prePopup()

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -469,13 +469,16 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		self.menu_tools_toggleBrailleViewer.Check(brailleViewer.isBrailleViewerActive())
 		brailleViewer.postBrailleViewerToolToggledAction.register(frame.onBrailleViewerChangedState)
 
+		if not config.isAppX and NVDAState.shouldWriteToDisk():
+			# Translators: The label of a menu item to open the Add-on store
+			item = menu_tools.Append(wx.ID_ANY, _("Add-on &store..."))
+			self.Bind(wx.EVT_MENU, frame.onAddonStoreCommand, item)
+
 		if not globalVars.appArgs.secure and not config.isAppX:
 			# Translators: The label for the menu item to open NVDA Python Console.
 			item = menu_tools.Append(wx.ID_ANY, _("Python console"))
 			self.Bind(wx.EVT_MENU, frame.onPythonConsoleCommand, item)
-			# Translators: The label of a menu item to open the Add-on store
-			item = menu_tools.Append(wx.ID_ANY, _("Add-on &store..."))
-			self.Bind(wx.EVT_MENU, frame.onAddonStoreCommand, item)
+
 		if not globalVars.appArgs.secure and not config.isAppX and not NVDAState.isRunningAsSource():
 			# Translators: The label for the menu item to create a portable copy of NVDA from an installed or another portable version.
 			item = menu_tools.Append(wx.ID_ANY, _("Create portable copy..."))
@@ -633,7 +636,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			_("Reset all settings to default state")
 		)
 		self.Bind(wx.EVT_MENU, frame.onRevertToDefaultConfigurationCommand, item)
-		if not (globalVars.appArgs.secure or globalVars.appArgs.launcher):
+		if NVDAState.shouldWriteToDisk():
 			item = self.menu.Append(
 				wx.ID_SAVE,
 				# Translators: The label for the menu item to save current settings.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #13985 
_Originally raised by @XLTechie in https://github.com/nvaccess/nvda/discussions/14912#discussioncomment-6036854_


### Summary of the issue:

>The installer for add-on store versions of NVDA, is creating the `addonStore` folder in `%appdata%\nvda`, even before the license agreement is accepted!
E.g. If starting the installer, and selecting "exit" instead of agreeing to the license agreement, the `addonStore` directory is created and populated with some files and directories under `%appdata%\nvda`.
It won't create `%appdata%\nvda`, but if that already exists, it will create the store directory.

>This is absolutely not expected behavior. NVDA should never be doing any directory and file creation on the local system before "install" is selected.
I have not looked at the code, so do not know what this would do to an existing installed store copy, but really no user would expect that the installed NVDA's configuration could be altered by an installer that was not told to "install".

### Description of user facing changes
Ensure the caching behaviour of add-ons matches that of NVDA's config.
Files should only be written to disk when not running as launcher nor in a secure context.

### Description of development approach
Adds relevant checks to prevent saving the add-on handler state and add-on store caches to disk.

### Testing strategy:
- [x] Manual testing to be confirmed

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
