### PR TITLE
Toggle braille show selection indicator also with input gesture

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -497,7 +497,8 @@ class Region(object):
 			cursorPos=self.cursorPos
 		)
 		if (
-			self.selectionStart is not None and self.selectionEnd is not None
+			self.selectionStart is not None
+			and self.selectionEnd is not None
 			and config.conf["braille"]["showSelection"]
 		):
 			try:

--- a/source/braille.py
+++ b/source/braille.py
@@ -2,7 +2,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2008-2023 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau,
-# Leonard de Ruijter
+# Leonard de Ruijter, Burman's Computer and Education Ltd.
 
 import itertools
 import os
@@ -496,7 +496,10 @@ class Region(object):
 			mode=mode,
 			cursorPos=self.cursorPos
 		)
-		if self.selectionStart is not None and self.selectionEnd is not None:
+		if (
+			self.selectionStart is not None and self.selectionEnd is not None
+			and config.conf["braille"]["showSelection"]
+		):
 			try:
 				# Mark the selection.
 				self.brailleSelectionStart = self.rawToBraillePos[self.selectionStart]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,7 +1,8 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
-# Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot, Rob Meredith
+# Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot, Rob Meredith,
+# Burman's Computer and Education Ltd.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -79,6 +80,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	wordWrap = boolean(default=true)
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
 	interruptSpeechWhileScrolling = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
+	showSelection = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	enableHidBrailleSupport = integer(0, 2, default=0)  # 0:Use default/recommended value (yes), 1:yes, 2:no
 
 	# Braille display driver settings

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -44,6 +44,8 @@ from config.configFlags import (
 	TetherTo,
 	ShowMessages,
 )
+from config.featureFlag import FeatureFlag
+from config.featureFlagEnums import BoolFlag
 import winUser
 import appModuleHandler
 import winKernel
@@ -3287,6 +3289,40 @@ class GlobalCommands(ScriptableObject):
 		# (disabled, timeout or indefinitely).
 		msg = _("Braille show messages %s") % ShowMessages(newValue).displayString
 		ui.message(msg)
+
+	@script(
+		# Translators: Input help mode message for cycle through braille show selection command.
+		description=_("Cycle through the braille show selection states"),
+		category=SCRCAT_BRAILLE
+	)
+	def script_braille_cycleShowSelection(self, gesture: inputCore.InputGesture) -> None:
+		"""Set next state of braille show selection and reports it with ui.message."""
+		featureFlag: FeatureFlag = config.conf["braille"]["showSelection"]
+		boolFlag: BoolFlag = featureFlag.enumClassType
+		values = [x.value for x in boolFlag]
+		currentValue = featureFlag.value.value
+		nextName: str = boolFlag(
+			currentValue % len(values) + 1
+		).name
+		config.conf["braille"]["showSelection"] = nextName
+		featureFlag = config.conf["braille"]["showSelection"]
+		if featureFlag.isDefault():
+			displayString = featureFlag.behaviorOfDefault.displayString
+			# Translators: Used when reporting braille show selection feature flag
+			# default behavior.
+			msg = _("Braille show selection")
+			msg += f" {self._featureFlagDefaultBehaviorDisplayString(displayString)}"
+		else:
+			# Translators: Reports which show braille selection state is used
+			# (disabled or enabled).
+			msg = _("Braille show selection %s") % BoolFlag[nextName].displayString
+		ui.message(msg)
+
+	def _featureFlagDefaultBehaviorDisplayString(self, displayString: str) -> str:
+		"""Returns display string for feature flag default behavior."""
+		# Translators: Used when reporting feature flag default behavior.
+		msg = _("Default")
+		return msg + f" ({displayString})"
 
 	@script(
 		# Translators: Input help mode message for report clipboard text command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3301,17 +3301,15 @@ class GlobalCommands(ScriptableObject):
 		boolFlag: BoolFlag = featureFlag.enumClassType
 		values = [x.value for x in boolFlag]
 		currentValue = featureFlag.value.value
-		nextName: str = boolFlag(
-			currentValue % len(values) + 1
-		).name
+		nextValueIndex = (currentValue % len(values)) + 1
+		nextName: str = boolFlag(nextValueIndex).name
 		config.conf["braille"]["showSelection"] = nextName
 		featureFlag = config.conf["braille"]["showSelection"]
 		if featureFlag.isDefault():
-			displayString = featureFlag.behaviorOfDefault.displayString
-			# Translators: Used when reporting braille show selection feature flag
-			# default behavior.
-			msg = _("Braille show selection")
-			msg += f" {self._featureFlagDefaultBehaviorDisplayString(displayString)}"
+			displayString = self._featureFlagDefaultBehaviorDisplayString(featureFlag.behaviorOfDefault.displayString)
+			# Translators: Used when reporting braille show selection state
+			# (default behavior).
+			msg = _("Braille show selection %s") % displayString
 		else:
 			# Translators: Reports which show braille selection state is used
 			# (disabled or enabled).
@@ -3320,9 +3318,10 @@ class GlobalCommands(ScriptableObject):
 
 	def _featureFlagDefaultBehaviorDisplayString(self, displayString: str) -> str:
 		"""Returns display string for feature flag default behavior."""
-		# Translators: Used when reporting feature flag default behavior.
-		msg = _("Default")
-		return msg + f" ({displayString})"
+		# Translators: Used when reporting feature flag default behavior
+		# (default state/value).
+		msg = _("Default (%s)") % displayString
+		return msg
 
 	@script(
 		# Translators: Input help mode message for report clipboard text command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3306,22 +3306,14 @@ class GlobalCommands(ScriptableObject):
 		config.conf["braille"]["showSelection"] = nextName
 		featureFlag = config.conf["braille"]["showSelection"]
 		if featureFlag.isDefault():
-			displayString = self._featureFlagDefaultBehaviorDisplayString(featureFlag.behaviorOfDefault.displayString)
 			# Translators: Used when reporting braille show selection state
 			# (default behavior).
-			msg = _("Braille show selection %s") % displayString
+			msg = _("Braille show selection default (%s)") % featureFlag.behaviorOfDefault.displayString
 		else:
 			# Translators: Reports which show braille selection state is used
 			# (disabled or enabled).
 			msg = _("Braille show selection %s") % BoolFlag[nextName].displayString
 		ui.message(msg)
-
-	def _featureFlagDefaultBehaviorDisplayString(self, displayString: str) -> str:
-		"""Returns display string for feature flag default behavior."""
-		# Translators: Used when reporting feature flag default behavior
-		# (default state/value).
-		msg = _("Default (%s)") % displayString
-		return msg
 
 	@script(
 		# Translators: Input help mode message for report clipboard text command.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5,7 +5,7 @@
 # Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Bill Dengler, Thomas Stivers,
 # Julien Cochuyt, Peter Vágner, Cyrille Bougot, Mesar Hameed, Łukasz Golonka, Aaron Cannon,
 # Adriani90, André-Abush Clause, Dawid Pieper, Heiko Folkerts, Takuya Nishimoto, Thomas Stivers,
-# jakubl7545, mltony, Rob Meredith
+# jakubl7545, mltony, Rob Meredith, Burman's Computer and Education Ltd.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import logging
@@ -3700,6 +3700,17 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 		)
 		self.bindHelpEvent("BrailleSettingsInterruptSpeech", self.brailleInterruptSpeechCombo)
 
+		self.brailleShowSelectionCombo: nvdaControls.FeatureFlagCombo = sHelper.addLabeledControl(
+			labelText=_(
+				# Translators: This is a label for a combo-box in the Braille settings panel.
+				"Show se&lection"
+			),
+			wxCtrlClass=nvdaControls.FeatureFlagCombo,
+			keyPath=["braille", "showSelection"],
+			conf=config.conf,
+		)
+		self.bindHelpEvent("BrailleSettingsShowSelection", self.brailleShowSelectionCombo)
+
 		if gui._isDebug():
 			log.debug("Finished making settings, now at %.2f seconds from start"%(time.time() - startTime))
 
@@ -3724,6 +3735,7 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 		config.conf["braille"]["wordWrap"] = self.wordWrapCheckBox.Value
 		config.conf["braille"]["focusContextPresentation"] = self.focusContextPresentationValues[self.focusContextPresentationList.GetSelection()]
 		self.brailleInterruptSpeechCombo.saveCurrentValueToConf()
+		self.brailleShowSelectionCombo.saveCurrentValueToConf()
 
 	def onShowCursorChange(self, evt):
 		self.cursorBlinkCheckBox.Enable(evt.IsChecked())

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,9 +20,11 @@ What's New in NVDA
 - New input gestures:
   - An unbound gesture to cycle through the available languages for Windows OCR. (#13036)
   - An unbound gesture to cycle through the braille show messages modes. (#14864)
+  - An unbound gesture to toggle showing the selection indicator for braille. (#14948)
   - Added gestures for Tivomatic Caiku Albatross Braille displays.
 There are now gestures for showing the braille settings dialog, accessing the status bar, cycling the braille cursor shape, and toggling the braille cursor on/off. (#14844)
   -
+- A new Braille option to toggle showing the selection indicator (dots 7 and 8). (#14948)
 - In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup. (#14709)
 - It is now possible to use system variables (such as ``%temp%`` or ``%homepath%``) in the path specification while creating portable copies of NVDA. (#14680)
 - Added support for the ``aria-brailleroledescription`` ARIA 1.3 attribute, allowing web authors to override the type of an element shown on the Braille display. (#14748)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1673,6 +1673,21 @@ For this reason the option is enabled by default, interrupting speech when scrol
 
 Disabling this option allows speech to be heard while simultaneously reading Braille.
 
+==== Show selection ====[BrailleSettingsShowSelection]
+: Default
+  Enabled
+: Options
+  Default (Enabled), Enabled, Disabled
+:
+
+This setting determines if selection indicator (dots 7 and 8) is shown in braille display.
+
+The option is enabled by default so selection indicator is shown.
+
+Selection indicator might be a distraction while reading. Disabling this option may improve readability.
+
+To toggle show selection from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
 +++ Select Braille Display (NVDA+control+a) +++[SelectBrailleDisplay]
 The Select Braille Display dialog, which can be opened by activating the Change... button in the Braille category of the NVDA settings dialog, allows you to select which Braille display NVDA should use for braille output.
 Once you have selected your braille display of choice, you can press Ok and NVDA will load the selected display.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1681,10 +1681,9 @@ Disabling this option allows speech to be heard while simultaneously reading Bra
 :
 
 This setting determines if selection indicator (dots 7 and 8) is shown in braille display.
-
 The option is enabled by default so selection indicator is shown.
-
-Selection indicator might be a distraction while reading. Disabling this option may improve readability.
+Selection indicator might be a distraction while reading.
+Disabling this option may improve readability.
 
 To toggle show selection from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14948
### Summary of the issue:
Selection is indicated with dots 7 and 8 which may cause difficulties for reading.
### Description of user facing changes
There is feature flag setting "Show selection" in Braille category which default behavior is Enabled. There is also possibility to use input gesture to cycle setting.
### Description of development approach
Feature flag (BoolFlag) showSelection which default behavior is Enabled.
### Testing strategy:
Tested with input gesture and from settings dialog.
### Known issues with pull request:

### Change log entries:
New features
Possibility to toggle braille show selection indicator from braille settings and with input gesture.
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
