### PR TITLE
Add-on store: fix support for starting NVDA with add-ons disabled

### DIFF
--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -8,6 +8,7 @@ from typing import (
 )
 
 import wx
+from wx.adv import BannerWindow
 
 from addonHandler import (
 	BUNDLE_EXTENSION,
@@ -19,6 +20,7 @@ from _addonStore.models.status import (
 	_StatusFilterKey,
 )
 from core import callLater
+import globalVars
 import gui
 from gui import (
 	guiHelper,
@@ -53,6 +55,17 @@ class AddonStoreDialog(SettingsDialog):
 		displayableError.displayError(gui.mainFrame)
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer):
+		if globalVars.appArgs.disableAddons:
+			self.banner = BannerWindow(self, dir=wx.TOP)
+			self.banner.SetText(
+				# Translators: Banner notice that is displayed in the Add-on Store.
+				pgettext("addonStore", "Note: NVDA was started with add-ons disabled"),
+				"",
+			)
+			normalBgColour = self.GetBackgroundColour()
+			self.banner.SetGradient(normalBgColour, normalBgColour)
+			settingsSizer.Add(self.banner, flag=wx.CENTER)
+
 		splitViewSizer = wx.BoxSizer(wx.HORIZONTAL)
 
 		self.addonListTabs = wx.Notebook(self)
@@ -179,7 +192,10 @@ class AddonStoreDialog(SettingsDialog):
 		filterCtrlsLine1.sizer.AddSpacer(FILTER_MARGIN_PADDING)
 
 	def postInit(self):
-		self.addonListView.SetFocus()
+		if globalVars.appArgs.disableAddons:
+			self.banner.SetFocus()
+		else:
+			self.addonListView.SetFocus()
 
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):
 		requiresRestart = self._requiresRestart


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:

Raised in https://github.com/nvaccess/nvda/discussions/14912#discussioncomment-6066474

### Summary of the issue:

When starting NVDA with add-ons disabled (e.g. through `--disable-addons`), enabled add-ons are not displayed in the add-on store.

### Description of user facing changes
When NVDA starts with add-ons disabled:
- Add-on store now displays enabled add-ons
- A banner is shown to warn the user that add-ons are disabled

### Description of development approach

Add a new state to differentiate between enabled and running, and enabled while not running.

### Testing strategy:

Manual testing
1. Start NVDA with add-ons disabled
1. Ensure enabled add-ons are shown in the list.

### Known issues with pull request:
None

### Change log entries:
N/A unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
