### PR TITLE
Add-on store: only make directories if should write to disk

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -76,10 +76,12 @@ class _DataManager:
 		self._cacheCompatibleFile = os.path.join(cacheDirLocation, _DataManager._cacheCompatibleFilename)
 		self._addonDownloadCacheDir = os.path.join(cacheDirLocation, "_dl")
 		self._installedAddonDataCacheDir = os.path.join(cacheDirLocation, "addons")
-		# ensure caching dirs exist
-		pathlib.Path(cacheDirLocation).mkdir(parents=True, exist_ok=True)
-		pathlib.Path(self._addonDownloadCacheDir).mkdir(parents=True, exist_ok=True)
-		pathlib.Path(self._installedAddonDataCacheDir).mkdir(parents=True, exist_ok=True)
+
+		if NVDAState.shouldWriteToDisk():
+			# ensure caching dirs exist
+			pathlib.Path(cacheDirLocation).mkdir(parents=True, exist_ok=True)
+			pathlib.Path(self._addonDownloadCacheDir).mkdir(parents=True, exist_ok=True)
+			pathlib.Path(self._installedAddonDataCacheDir).mkdir(parents=True, exist_ok=True)
 
 		self._latestAddonCache = self._getCachedAddonData(self._cacheLatestFile)
 		self._compatibleAddonCache = self._getCachedAddonData(self._cacheCompatibleFile)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fix up of https://github.com/nvaccess/nvda/pull/14955
Raised in https://github.com/nvaccess/nvda/discussions/14912#discussioncomment-6035346

### Summary of the issue:
Caching directories are still created when NVDA should not write to disk

### Description of user facing changes
Caching directories are no longer created when NVDA should not write to disk

### Description of development approach
Caching directories are no longer created when NVDA should not write to disk

### Testing strategy:
Refer to #14955

### Known issues with pull request:
N/a
### Change log entries:
N/a
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
