### PR TITLE
Add-on Store: replace old user guide "AddonsManager" anchor with "AddonStore". Embed hidden HTML to enable the former to still work

### DIFF
--- a/devDocs/userGuideStandards.md
+++ b/devDocs/userGuideStandards.md
@@ -29,3 +29,29 @@ Once the anchor is set it cannot be updated, while settings may move categories.
 This setting allows the feature of using functionality in a certain situation to be controlled in some way.
 If necessary, a description of a common use case that is supported by each option.
 ```
+
+## Raw HTML inclusion
+
+Including raw HTML may be done by placing it in a "raw area mark", or on a "raw line mark"..
+Then, replace each `<` character with `{{`, and each `>` character with `}}`.
+More information can be found [in this Txt2Tags tip](https://txt2tags.org/tips.html#html-custom-tags).
+
+Example 1:
+
+```text2tags
+""" {{div id="my_div"}}
+Something to appear in the div.
+
+""" {{/div}}
+```
+
+Example 2:
+
+```text2tags
+"""
+{{div id="my_other_div"}}
+{{p}}something to appear{{br}}
+on two lines{{/p}}
+{{/div}}
+"""
+```

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2539,7 +2539,7 @@ Settings for NVDA when running during sign-in or on UAC screens are stored in th
 Usually, this configuration should not be touched.
 To change NVDA's configuration during sign-in or on UAC screens, configure NVDA as you wish while signed into Windows, save the configuration, and then press the "use currently saved settings during sign-in and on secure screens" button in the General category of the [NVDA Settings #NVDASettings] dialog.
 
-+ Add-ons and the Add-on Store +[AddonsManager]
++ Add-ons and the Add-on Store +[AddonStore]
 Add-ons are software packages which provide new or altered functionality for NVDA.
 They are developed by the NVDA community, and external organisations such as commercial vendors.
 Add-ons may do any of the following:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -311,7 +311,7 @@ If you have add-ons already installed there may also be a warning that incompati
 Before you're able to press the Continue button you will have to use the checkbox to confirm that you understand that these add-ons will be disabled.
 There will also be a button present to review the add-ons that will be disabled.
 Refer to the [incompatible add-ons dialog section #incompatibleAddonsManager] for more help on this button.
-After installation, you are able to re-enable incompatible add-ons at your own risk from within the [Add-on Store #AddonsManager].
+After installation, you are able to re-enable incompatible add-ons at your own risk from within the [Add-on Store #AddonStore].
 
 +++ Use NVDA during sign-in +++[StartAtWindowsLogon]
 This option allows you to choose whether or not NVDA should automatically start while at the Windows sign-in screen, before you have entered a password.
@@ -1036,7 +1036,7 @@ While NVDA is primarily aimed at blind or vision impaired people who primarily u
 Within NVDA, such a visual aid is called a vision enhancement provider.
 
 NVDA offers several built-in vision enhancement providers which are described below.
-Additional vision enhancement providers can be provided in [NVDA add-ons #AddonsManager].
+Additional vision enhancement providers can be provided in [NVDA add-ons #AddonStore].
 
 NVDA's vision settings can be changed in the [vision category #VisionSettings] of the [NVDA Settings #NVDASettings] dialog.
 
@@ -1708,7 +1708,7 @@ Therefore it is recommended to only connect one Braille Display of a given type 
 +++ Vision +++[VisionSettings]
 The Vision category in the NVDA Settings dialog allows you to enable, disable and configure [visual aids #Vision].
 
-Note that the available options in this category could be extended by [NVDA add-ons #AddonsManager].
+Note that the available options in this category could be extended by [NVDA add-ons #AddonStore].
 By default, this settings category contains the following options:
 
 ==== Visual Highlight ====[VisionSettingsFocusHighlight]
@@ -1739,7 +1739,7 @@ By default, sounds are played when the Screen Curtain is toggled.
 When you want to change this behaviour, you can uncheck the "Play sound when toggling Screen Curtain" check box.
 
 ==== Settings for third party visual aids ====[VisionSettingsThirdPartyVisualAids]
-Additional vision enhancement providers can be provided in [NVDA add-ons #AddonsManager].
+Additional vision enhancement providers can be provided in [NVDA add-ons #AddonStore].
 When these providers have adjustable settings, they will be shown in this settings category in separate groupings.
 For the supported settings per provider, please refer to the documentation for that provider.
 
@@ -2711,8 +2711,8 @@ The NVDA Python console, found under Tools in the NVDA menu, is a development to
 For more information, please see the [NVDA Developer Guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html].
 
 ++ Add-on Store ++
-This will open the [NVDA Add-on Store #AddonsManager].
-For more information, read the in-depth chapter: [Add-ons and the Add-on Store #AddonsManager].
+This will open the [NVDA Add-on Store #AddonStore].
+For more information, read the in-depth chapter: [Add-ons and the Add-on Store #AddonStore].
 
 ++ Create portable copy ++[CreatePortableCopy]
 This will open a dialog which allows you to create a portable copy of NVDA out of the installed version.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2541,8 +2541,9 @@ To change NVDA's configuration during sign-in or on UAC screens, configure NVDA 
 
 """
 {{!-- Preserve functionality of external links to the old Add-ons Manager used in NVDA 2023.1 and earlier. --}}
-{{a style="visibility: hidden;" name="AddonsManager"}}&nbsp;{{/a}}
+{{a name="AddonsManager"}}{{/a}}
 """
+
 + Add-ons and the Add-on Store +[AddonStore]
 Add-ons are software packages which provide new or altered functionality for NVDA.
 They are developed by the NVDA community, and external organisations such as commercial vendors.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2539,6 +2539,10 @@ Settings for NVDA when running during sign-in or on UAC screens are stored in th
 Usually, this configuration should not be touched.
 To change NVDA's configuration during sign-in or on UAC screens, configure NVDA as you wish while signed into Windows, save the configuration, and then press the "use currently saved settings during sign-in and on secure screens" button in the General category of the [NVDA Settings #NVDASettings] dialog.
 
+"""
+{{!-- Preserve functionality of external links to the old Add-ons Manager used in NVDA 2023.1 and earlier. --}}
+{{a style="visibility: hidden;" name="AddonsManager"}}&nbsp;{{/a}}
+"""
 + Add-ons and the Add-on Store +[AddonStore]
 Add-ons are software packages which provide new or altered functionality for NVDA.
 They are developed by the NVDA community, and external organisations such as commercial vendors.

--- a/user_docs/userGuide.t2tconf
+++ b/user_docs/userGuide.t2tconf
@@ -1,3 +1,8 @@
 %!includeconf: global.t2tconf
 
 %!Options: --toc
+
+% Enable the inclusion of raw HTML in the User Guide, provided that
+% < and > are replaced with {{ and }}, respectively.
+% This implements the method described here: https://txt2tags.org/tips.html#html-custom-tags
+%!postproc(html):  {{(.*?)}}  <\1>


### PR DESCRIPTION
### Link to issue number:

Implements https://github.com/nvaccess/nvda/pull/14961#issuecomment-1576424082

### Summary of the issue:

Even though the Add-ons Manager has been replaced by the Add-on Store, the anchor used for jumping to the appropriate section of the User Guide was still "`AddonsManager`".
The original intent was to leave it that way, because of links to this section which might exist outside of NV Access's control.

The comment proposed a solution that both changes the anchor to be appropriate to the store, and provides a mechanism for the older anchor to continue to bring readers to the new store chapter.

### Description of user facing changes

Readers will be able to reach the Add-on Store chapter of the User Guide via either `#AddonStore` or `#AddonsManager`, in the HTML version of the User Guide.

### Description of development approach

Because we use Txt2Tags 2.5 instead of 2.6, it is not possible to use the `'''` method of including raw HTML, as suggested in the original comment. An alternative method has been used.

1. Renamed the anchor for the chapter "Add-ons and the Add-on Store", from "`AddonsManager`" to "`AddonStore`".
2. Changed all links in the User Guide that referenced "`#AddonsManager`" to "`#AddonStore`".
3. Added some escaped raw HTML before the "Add-ons and the Add-ons Store" chapter, to enable use of the old anchor. It results in two `<a name...>` elements--one for the new anchor, and one for the old.
4. Included an HTML comment so future editors will understand what's going on.
5. Modified `userGuide.t2tconf` to enable inclusion of HTML by converting `<` to `{{`, and `>` to `}}`. This is done using the T2T procedure outlined [here](https://txt2tags.org/tips.html#html-custom-tags).
6. Added a "Raw HTML inclusion" section to the `userGuideStandards.md` file.

### Testing strategy:

Manual testing that the anchors both work.

### Known issues with pull request:

1. The new anchor is currently "`AddonStore`". Should we switch this to "`Addons`"? The chapter could reasonably be either, and "`#Addons`" is shorter.
2. Should we use a T2T comment instead of an HTML comment, on line 2543 of the User Guide (relating to number 4 above)? An HTML comment will show up in the source HTML of the output; a T2T comment won't.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
