### PR TITLE
Add-on Store: Revision of User Guide language for better explanation of free add-ons with paid components

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2549,8 +2549,8 @@ Add-ons may do any of the following:
 -
 
 NVDA's Add-on Store allows you to browse and manage add-on packages.
-All add-ons that are available in the Add-on Store are free.
-However, some free add-ons do require users to pay for a license or additional software before they can be used.
+All add-ons that are available in the Add-on Store can be downloaded for free.
+However, some of them may require users to pay for a license or additional software before they can be used.
 Commercial speech synthesizers are an example of this type of add-on.
 If you install an add-on with paid components and change your mind about using it, the add-on can be easily removed.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2549,8 +2549,10 @@ Add-ons may do any of the following:
 -
 
 NVDA's Add-on Store allows you to browse and manage add-on packages.
-Add-ons that are available in the Add-on Store are free.
-Other add-ons which require payment do exist, such as those which add support for commercial speech synthesizers; but these must be installed from external sources.
+All add-ons that are available in the Add-on Store are free.
+However, some free add-ons do require users to pay for a license or additional software before they can be used.
+Commercial speech synthesizers are an example of this type of add-on.
+If you install an add-on with paid components and change your mind about using it, the add-on can be easily removed.
 
 The Add-on Store is accessed from the Tools submenu of the NVDA menu.
 To access the Add-on Store from anywhere, assign a custom gesture using the [Input Gestures dialog #InputGestures].


### PR DESCRIPTION

### Link to issue number:

Pursuant to https://github.com/nvaccess/nvda/pull/14966#issuecomment-1579717421, https://github.com/nvaccess/nvda/pull/14966#issuecomment-1579720998, and https://github.com/nvaccess/nvda/pull/14966#issuecomment-1579730601

### Summary of the issue:

Consideration of the language to use in the User Guide, when describing all add-ons as free in the store, while certain add-ons require the purchase of components or licenses in order to do anything.

### Description of user facing changes

Revised language.

### Description of development approach

Edited the language to be more in line with the comments in #14966. It may still not be as desired, but this provides a context to revise it in.

### Testing strategy:

N/A

### Known issues with pull request:

WIP.
