### PR TITLE
Fix Excel cell reporting lagging behind

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -974,7 +974,7 @@ class ExcelWorksheet(ExcelBase):
 				break
 			elapsed = time.time() - start
 			if elapsed >= maxTimeout:
-				log.debug(f"Canceled detecting new selection after {elapsed} sec")	
+				log.debug(f"Canceled detecting new selection after {elapsed} sec")
 				break
 			# We spin the first few tries, as sleep is not accurate for tiny periods
 			# and we might end up sleeping longer than we need to. Spinning improves

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2023 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta, Accessolutions, Julien Cochuyt,
-# Cyrille Bougot
+# Cyrille Bougot, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -712,7 +712,6 @@ class ExcelWorksheet(ExcelBase):
 
 
 	treeInterceptorClass=ExcelBrowseModeTreeInterceptor
-
 	role=controlTypes.Role.TABLE
 
 	def _get_excelApplicationObject(self):
@@ -953,28 +952,43 @@ class ExcelWorksheet(ExcelBase):
 	), canPropagate=True)
 
 	def script_changeSelection(self,gesture):
-		oldSelection=api.getFocusObject()
+		oldSelection = self._getSelection()
 		gesture.send()
-		import eventHandler
-		import time
-		newSelection=None
-		curTime=startTime=time.time()
-		while (curTime-startTime)<=0.15:
+		newSelection = None
+		start = time.time()
+		retryInterval = 0.01
+		maxTimeout = 0.15
+		elapsed = 0
+		retries = 0
+		while True:
 			if scriptHandler.isScriptWaiting():
 				# Prevent lag if keys are pressed rapidly
 				return
-			if eventHandler.isPendingEvents('gainFocus'):
-				return
-			newSelection=self._getSelection()
-			if newSelection and newSelection!=oldSelection:
-				break
 			api.processPendingEvents(processEventQueue=False)
-			time.sleep(0.015)
-			curTime=time.time()
+			if eventHandler.isPendingEvents('gainFocus'):
+				# This object is no longer focused.
+				return
+			newSelection = self._getSelection()
+			if newSelection and newSelection != oldSelection:
+				log.debug(f"Detected new selection after {elapsed} sec")
+				break
+			elapsed = time.time() - start
+			if elapsed >= maxTimeout:
+				log.debug(f"Canceled detecting new selection after {elapsed} sec")	
+				break
+			# We spin the first few tries, as sleep is not accurate for tiny periods
+			# and we might end up sleeping longer than we need to. Spinning improves
+			# responsiveness in the case that the app responds fairly quickly.
+			if retries > 2:
+				# Don't spin too long, though. If we get to this point, the app is
+				# probably taking a while to respond, so super fast response is
+				# already lost.
+				time.sleep(retryInterval)
+			retries += 1
 		if newSelection:
 			if oldSelection.parent==newSelection.parent:
 				newSelection.parent=oldSelection.parent
-			eventHandler.executeEvent('gainFocus',newSelection)
+			eventHandler.executeEvent('gainFocus', newSelection)
 
 	def _WaitForValueChangeForAction(self, action, fetcher, timeout=0.15):
 		oldVal = fetcher()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -85,6 +85,7 @@ Instead NVDA reports that the link has no destination. (#14723)
 - NVDA will no longer refuse to save the configuration after a configuration reset. (#13187)
 - When running a temporary version from the launcher, NVDA will not mislead users into thinking they can save the configuration. (#14914)
 - Reporting of object shortcut keys has been improved. (#10807)
+- When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #14983 
Fixes #12200 
Fixes #12108?

### Summary of the issue:
Moving rapidly in Excel can result in lagging one cell behind when reporting focus.

### Description of user facing changes
Rapid movement in Excel will now always report the last cell.

### Description of development approach
First and foremost, NVDA was relying on the current focus object to cache the current selection in Excel rather than getting the current selection before executing the gesture. This resulted in the one behind behavior. There was logic to check for selection changes, but it detected a change based on the wrong old selection.

I also revamped the logic a bit based on #14708, i.e. perform three attempts before doing a time.sleep.

### Testing strategy:
Tested the str from #14983 

### Known issues with pull request:
None known

### Change log entries:
Bug fixes:
- When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
