### PR TITLE
Fix on the panel's name in the multi-category settings dialog

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -589,7 +589,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 					 "MultiCategorySettingsDialog.MIN_SIZE"
 					).format(cls, panel.Size[0])
 				)
-			panel.SetLabel(panel.title)
+			panel.SetLabel(panel.title.replace('&', '&&'))
 			panel.SetAccessible(SettingsPanelAccessible(panel))
 		return panel
 


### PR DESCRIPTION
### Link to issue number:
Issue similar to #14607.
### Summary of the issue:
In the multi-category settings dialog, the panel takes the name of the corresponding category. This name is reported when tabbing from the category list to the panel. If the category name contains an ampersand, this character is not reported in the panel's name and it acts as an accelerator instead.

This is the case for NVDA Dev & Test Toolbox add-on where the add-on's name is used as category in the multi-category settings dialog and thus also as panel name.

### Description of user facing changes

The panel's name will match the category name, even in the case this name contains an ampersand (&) character.

### Description of development approach

Double the ampersand in the panel's name.

### Testing strategy:
* Tested that the issue is fixed for [NVDA Dev & Test toolbox](https://addons.nvda-project.org/addons/nvdaDevTestToolbox.fr.html) 4.0.n
* Also tested on another add-on (Clock add-on), renaming the panel's title to "Clock&Bells" and checked the change:
  * With NVDA 2023.1: the category in the list and the dialog's title reads "Clock&Bells" but the panel's name is "ClockBells" and when setting the nav object on this panel (property page), an alt+B shortcut is reported. This accelerator does not work however.
  * With this PR: the category in the list and the dialog's title reads "Clock&Bells" as well as the panel's name and when setting the nav object on this panel (property page), no shortcut is reported.
### Known issues with pull request:
None
### Change log entries:
Not needed for a such little fix.
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
