### PR TITLE
Some more gestures for Albatross

### DIFF
--- a/source/brailleDisplayDrivers/albatross/gestures.py
+++ b/source/brailleDisplayDrivers/albatross/gestures.py
@@ -57,6 +57,8 @@ _gestureMap = inputCore.GlobalGestureMap({
 		"reviewCursorToStatusLine": ("br(albatross):f1+end1", "br(albatross):f9+end2",),
 		"braille_cycleCursorShape": ("br(albatross):f1+eCursor1", "br(albatross):f9+eCursor2",),
 		"braille_toggleShowCursor": ("br(albatross):f1+cursor1", "br(albatross):f9+cursor2",),
+		"braille_cycleShowMessages": ("br(albatross):f1+f2", "br(albatross):f9+f10",),
+		"braille_cycleShowSelection": ("br(albatross):f1+f5", "br(albatross):f9+f14",),
 		"review_activate": ("br(albatross):f7+f8",),
 		"dateTime": ("br(albatross):f9",),
 		"say_battery_status": ("br(albatross):f10",),

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,8 +21,14 @@ What's New in NVDA
   - An unbound gesture to cycle through the available languages for Windows OCR. (#13036)
   - An unbound gesture to cycle through the braille show messages modes. (#14864)
   - An unbound gesture to toggle showing the selection indicator for braille. (#14948)
-  - Added gestures for Tivomatic Caiku Albatross Braille displays.
-There are now gestures for showing the braille settings dialog, accessing the status bar, cycling the braille cursor shape, and toggling the braille cursor on/off. (#14844)
+  -
+- Added gestures for Tivomatic Caiku Albatross Braille displays. (#14844, #15002)
+  - showing the braille settings dialog
+  - accessing the status bar
+  - cycling the braille cursor shape
+  - cycling the braille show messages mode
+  - toggling the braille cursor on/off
+  - toggling the braille show selection indicator state
   -
 - A new Braille option to toggle showing the selection indicator (dots 7 and 8). (#14948)
 - In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup. (#14709)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3842,6 +3842,8 @@ Please see the display's documentation for descriptions of where these keys can 
 | Reads status bar and moves navigator object into it | ``f1+end1``, ``f9+end2`` |
 | Cycle the braille cursor shape | ``f1+eCursor1``, ``f9+eCursor2`` |
 | Toggle the braille cursor | ``f1+cursor1``, ``f9+cursor2`` |
+| Cycle the braille show messages mode | ``f1+f2``, ``f9+f10`` |
+| Cycle the braille show selection state | ``f1+f5``, ``f9+f14`` |
 | Performs the default action on the current navigator object | ``f7+f8`` |
 | Reports date/time | ``f9`` |
 | Reports battery status and time remaining if AC is not plugged in | ``f10`` |


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
none
### Summary of the issue:
Added some gestures.
### Description of user facing changes
Added following gestures:

- | Cycle the braille show messages mode | ``f1+f2``, ``f9+f10`` |
- | Cycle the braille show selection state | ``f1+f5``, ``f9+f14`` |

### Description of development approach
none
### Testing strategy:
Tested with 80 cells model.
### Known issues with pull request:
none known
### Change log entries:
New features
Changes
Added gestures for cycling the braille show messages mode, and the braille show selection state.
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
