### PR TITLE
Add space between add-on list and External install button in the add-on store GUI

### DIFF
--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -132,6 +132,7 @@ class AddonStoreDialog(SettingsDialog):
 		self.externalInstallButton.Bind(wx.EVT_BUTTON, self.openExternalInstall, self.externalInstallButton)
 		self.bindHelpEvent("AddonStoreInstalling", self.externalInstallButton)
 
+		settingsSizer.AddSpacer(5)
 		settingsSizer.Add(generalActions.sizer)
 		self.onListTabPageChange(None)
 

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -132,7 +132,7 @@ class AddonStoreDialog(SettingsDialog):
 		self.externalInstallButton.Bind(wx.EVT_BUTTON, self.openExternalInstall, self.externalInstallButton)
 		self.bindHelpEvent("AddonStoreInstalling", self.externalInstallButton)
 
-		settingsSizer.AddSpacer(5)
+		settingsSizer.AddSpacer(guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 		settingsSizer.Add(generalActions.sizer)
 		self.onListTabPageChange(None)
 


### PR DESCRIPTION
### Link to issue number:

Fixes #15008

### Summary of the issue:
In the add-on store GUI, the add-on list and the "Install from external source" button are too close to each other.

### Description of user facing changes
There is now more space between the add-ons list and the button.

### Description of development approach
Added a spacer between the two controls in the sizer. I have use the hard-coded value 5 as done elsewhere in this dialog.
### Testing strategy:
* Checked visually that there is more space.
* Given my low vision, ask confirmation to someone else. Maybe @k-kolev1985 or @seanbudd can check once the appVeyor build is ready?
### Known issues with pull request:
None.
### Change log entries:
Not needed; fix on unrleased code.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
