### PR TITLE
Plural forms support for translatable strings

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -460,6 +460,7 @@ def makePot(target, source, env):
 			"--foreign-user",
 			"--add-comments=Translators:",
 			"--keyword=pgettext:1c,2",
+			"--keyword=npgettext:1c,2,3",
 			"--from-code", "utf-8",
 			# Needed because xgettext doesn't recognise the .pyw extension.
 			"--language=python",

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -920,7 +920,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 					"%.1f line",
 					"%.1f lines",
 					multiLineSpacingVal,
-				) % (multiLineSpacingVal)
+				) % multiLineSpacingVal
 		revisionType=int(field.pop('wdRevisionType',0))
 		if revisionType==wdRevisionInsert:
 			field['revision-insertion']=True

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V.
+# Copyright (C) 2006-2023 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V., Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -912,8 +912,14 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 				# Translators: line spacing of at least x point
 				field['line-spacing']=pgettext('line spacing value',"at least %.1f pt")%float(lineSpacingVal)
 			elif lineSpacingRule==wdLineSpaceMultiple:
+				multiLineSpacingVal = float(lineSpacingVal) / 12.0
 				# Translators: line spacing of x lines
-				field['line-spacing']=pgettext('line spacing value',"%.1f lines")%(float(lineSpacingVal)/12.0)
+				field['line-spacing'] = npgettext(
+					'line spacing value',
+					"%.1f line",
+					"%.1f lines",
+					multiLineSpacingVal,
+				) % (multiLineSpacingVal)
 		revisionType=int(field.pop('wdRevisionType',0))
 		if revisionType==wdRevisionInsert:
 			field['revision-insertion']=True

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -913,9 +913,10 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 				field['line-spacing']=pgettext('line spacing value',"at least %.1f pt")%float(lineSpacingVal)
 			elif lineSpacingRule==wdLineSpaceMultiple:
 				multiLineSpacingVal = float(lineSpacingVal) / 12.0
-				# Translators: line spacing of x lines
+				
 				field['line-spacing'] = npgettext(
 					'line spacing value',
+					# Translators: line spacing of x lines
 					"%.1f line",
 					"%.1f lines",
 					multiLineSpacingVal,

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -44,7 +44,7 @@ from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA
 from NVDAObjects.UIA.wordDocument import WordDocument as UIAWordDocument
 import languageHandler
-
+from gettext import ngettext
 
 PR_LAST_VERB_EXECUTED=0x10810003
 VERB_REPLYTOSENDER=102
@@ -352,10 +352,12 @@ class CalendarView(IAccessible):
 			bufLength
 		) == 0:
 			raise ctypes.WinError()
+		categoriesCount = len(categories.split(f"{separatorBuf.value} "))
 
 		# Translators: Part of a message reported when on a calendar appointment with one or more categories
 		# in Microsoft Outlook.
-		return _("categories {categories}").format(categories=categories)
+		categoriesText = ngettext("category {categories}", "categories {categories}", categoriesCount)
+		return categoriesText.format(categories=categories)
 
 	def isDuplicateIAccessibleEvent(self,obj):
 		return False

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -44,7 +44,6 @@ from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA
 from NVDAObjects.UIA.wordDocument import WordDocument as UIAWordDocument
 import languageHandler
-from gettext import ngettext
 
 PR_LAST_VERB_EXECUTED=0x10810003
 VERB_REPLYTOSENDER=102

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -27,6 +27,7 @@ from typing import (
 	Optional,
 	Tuple,
 	Union,
+	Callable,
 )
 
 #a few Windows locale constants
@@ -309,14 +310,16 @@ def makePgettext(translations):
 	return pgettext
 
 
-def makeNpgettext(translations):
-	"""Obtaina  npgettext function for use with a gettext translations instance.
+def makeNpgettext(
+		translations: Union[None, gettext.GNUTranslations, gettext.NullTranslations],
+) -> Callable[[str, str, str, Union[int, float]], str]:
+	"""Obtain a  npgettext function for use with a gettext translations instance.
 	npgettext is used to support message contexts with respect to ngettext,
 	but Python 3.7's gettext module doesn't support this,
 	so NVDA must provide its own implementation.
 	"""
 	if isinstance(translations, gettext.GNUTranslations):
-		def npgettext(context, msgSingular, msgPlural, n):
+		def npgettext(context: str, msgSingular: str, msgPlural: str, n: Union[int, float]) -> str:
 			try:
 				# Look up the message with its context.
 				return translations._catalog[(f"{context}\x04{msgSingular}", translations.plural(n))]
@@ -324,7 +327,7 @@ def makeNpgettext(translations):
 				return msgSingular if n == 1 else msgPlural
 	elif isinstance(translations, gettext.NullTranslations):
 		# A language without a translation catalog, such as English.
-		def npgettext(context, msgSingular, msgPlural, n):
+		def npgettext(context: str, msgSingular: str, msgPlural: str, n: Union[int, float]) -> str:
 			return msgSingular if n == 1 else msgPlural
 	else:
 		raise ValueError("%s is Not a GNUTranslations or NullTranslations object" % translations)

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2021 NV access Limited, Joseph Lee, Łukasz Golonka
+# Copyright (C) 2007-2023 NV access Limited, Joseph Lee, Łukasz Golonka, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -288,9 +288,9 @@ def getAvailableLanguages(presentational: bool = False) -> List[Tuple[str, str]]
 
 
 def makePgettext(translations):
-	"""Obtaina  pgettext function for use with a gettext translations instance.
+	"""Obtain a pgettext function for use with a gettext translations instance.
 	pgettext is used to support message contexts,
-	but Python's gettext module doesn't support this,
+	but Python 3.7's gettext module doesn't support this,
 	so NVDA must provide its own implementation.
 	"""
 	if isinstance(translations, gettext.GNUTranslations):
@@ -301,12 +301,34 @@ def makePgettext(translations):
 			except KeyError:
 				return message
 	elif isinstance(translations, gettext.NullTranslations):
-		# A language with out a translation catalog, such as English.
+		# A language without a translation catalog, such as English.
 		def pgettext(context, message):
 			return message
 	else:
 		raise ValueError("%s is Not a GNUTranslations or NullTranslations object" % translations)
 	return pgettext
+
+
+def makeNpgettext(translations):
+	"""Obtaina  npgettext function for use with a gettext translations instance.
+	npgettext is used to support message contexts with respect to ngettext,
+	but Python 3.7's gettext module doesn't support this,
+	so NVDA must provide its own implementation.
+	"""
+	if isinstance(translations, gettext.GNUTranslations):
+		def npgettext(context, msgSingular, msgPlural, n):
+			try:
+				# Look up the message with its context.
+				return translations._catalog[(f"{context}\x04{msgSingular}", translations.plural(n))]
+			except KeyError:
+				return msgSingular if n == 1 else msgPlural
+	elif isinstance(translations, gettext.NullTranslations):
+		# A language without a translation catalog, such as English.
+		def npgettext(context, msgSingular, msgPlural, n):
+			return msgSingular if n == 1 else msgPlural
+	else:
+		raise ValueError("%s is Not a GNUTranslations or NullTranslations object" % translations)
+	return npgettext
 
 
 def getLanguageCliArgs() -> Tuple[str, ...]:
@@ -381,10 +403,11 @@ def setLanguage(lang: str) -> None:
 	if trans is None:
 		trans = _createGettextTranslation("en")
 
-	trans.install()
+	trans.install(names=['ngettext'])
 	setLocale(getLanguage())
-	# Install our pgettext function.
+	# Install our pgettext and npgettext functions.
 	builtins.pgettext = makePgettext(trans)
+	builtins.npgettext = makeNpgettext(trans)
 
 	global installedTranslation
 	installedTranslation = weakref.ref(trans)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2041,7 +2041,7 @@ def getControlFieldSpeech(  # noqa: C901
 		# handled further down in the general cases section.
 		# This ensures that properties such as name, states and level etc still get reported appropriately.
 		# Translators: Number of items in a list (example output: list with 5 items).
-		containerContainsText=_("with %s items")%childControlCount
+		containerContainsText = ngettext("with %s item", "with %s items", childControlCount) % childControlCount
 	elif fieldType=="start_addedToControlFieldStack" and role==controlTypes.Role.TABLE and tableID:
 		# Table.
 		rowCount=(attrs.get("table-rowcount-presentational") or attrs.get("table-rowcount"))

--- a/tests/lint/flake8.ini
+++ b/tests/lint/flake8.ini
@@ -33,7 +33,9 @@ ignore =
 
 builtins = # inform flake8 about functions we consider built-in.
 	_, # translation lookup
+	ngettext, # translation lookup
 	pgettext, # translation lookup
+	npgettext, # translation lookup
 
 exclude = # don't bother looking in the following subdirectories / files.
 	.git,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -131,6 +131,7 @@ Similarly, the new ``getCompletionRoutine`` method allows you to convert a pytho
 - NVDA will no longer log inaccurate warnings or errors about deprecated appModules. (#14806)
 - All NVDA extension points are now briefly described in a new, dedicated chapter in the Developer Guide. (#14648)
 - ``scons checkpot`` will no longer check the ``userConfig`` subfolder anymore. (#14820)
+- Translatable strings can now be defined with a singular and a plural form using ``ngettext`` and ``npgettext``. (#12445)
 -
 
 === Deprecations ===


### PR DESCRIPTION
This PR is the first step to reintroduce the distinction of singulare/plural forms when formatting UI strings. The project is as follow:
1. This PR introduce three strings to be able to test the feature.
2. 2023.2 beta phase should be used to validate more widely the feature with translators
3. A second PR during 2023.3 dev cycle will implement the plural forms for all UI strings containing only one value to format them.
4. A third PR should implement more complex cases of string formatted by two or more values, e.g. such as "table with x rows and y columns".

This step-by-step approach should allow to lose less work in case an issue occurs and requires to revert changes.

### Link to issue number:
First step to implement #12445.
Restoring #11598, #12432 and #12435 that were reverted in #12448.
Unblocked by https://github.com/nvaccess/mrconfig/pull/97.
### Summary of the issue:
Some UI messages or strings are reported with plural form, no matter the number passed as parameter to format them, e.g. NVDA reports "list with 1 items" with "s" even if there is only one item.

### Description of user facing changes
The following strings will be reported using singular or plural form depending on the number used to format them:
* "with %s items" (used to describe the number of items in a list on the web)
* ".1f lines" (used when reporting multiple line spacing formatting in MS Word)
* ""categories {categories}" used to report categories of appointments in MS Outlook

Translators will be able to translate singular or plural forms.

### Description of development approach
* First revert #12448 to restore the first attempt that was made to introduce `ngettext`.
* Develop a custom `npgettext` function the same way as `pgettext` was introduced in NVDA since `npgettext` is not available in Python 3.7; `pgettext` and `npgettext` are available natively in Python 3.8.
* `ngettext` and `npgettext` are made accessible without importing them; `pgettext` was already added previously in builtins.
* Implement the plural form for two strings that are more commonly used than Outlook appointments category reporting:
  * "with %s items", using `ngettext`
  * "%.1f lines", using `npgettext`

### Testing strategy:
I have tested the 3 modified strings in the situation where they are reported:
* List of one or many items on the web
* Report formatting in MS Word with line spacing set to "multiple" with value of 0.8 or 3
* Outlook appointments with 1 or 2 assigned categories

Note: for MS Word, since reporting a line spacing of 1 line is not possible, I have tested in the console:
```
>>> npgettext("line spacing value", "with %s item", "with %s items", 1)
```

The checks were done for the following languages:
* English: no translation
* French: I have provided an updated .po with the 3 times 2 strings translated
* Italian: no updated translation provided; used to check the fallback to English strings

### Known issues with pull request:
Other strings with plural forms to be implemented in subsequent PRs.
### Change log entries:
New features
Changes
Bug fixes
For Developers
TBD
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

Cc @leonardder (author of 11598)
Cc @zstanecic (translator of various Slavic languages) Slavic languages are known to have complex forms of plural
