### PR TITLE
Add-on Store: use Yes/No buttons with incompatibility question dialogs, instead of OK/Cancel buttons; improve related translator comments

### DIFF
--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -130,8 +130,8 @@ def _shouldEnableWhenAddonTooOldDialog(
 ) -> bool:
 	incompatibleMessage = pgettext(
 		"addonStore",
-		# Translators: The message displayed when enabling an incompatible add-on package,
-		# because it requires a new version than is currently installed.
+		# Translators: The message displayed when enabling an add-on package that is incompatible
+		# because the add-on is too old for the running version of NVDA.
 		"Warning: add-on is incompatible: {name} {version}. "
 		"Check for an updated version of this add-on if possible. "
 		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -60,7 +60,7 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 		"Warning: add-on installation may result in downgrade: {name}. "
 		"The installed add-on version cannot be compared with the add-on store version. "
 		"Installed version: {oldVersion}. "
-		"Available version: {version}. "
+		"Available version: {version}.\n"
 		"Proceed with installation anyway? "
 		).format(
 	name=addon.displayName,
@@ -107,7 +107,7 @@ def _shouldInstallWhenAddonTooOldDialog(
 		"Check for an updated version of this add-on if possible. "
 		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "
 		"your current NVDA version is {NVDAVersion}. "
-		"Installation may cause unstable behavior in NVDA. "
+		"Installation may cause unstable behavior in NVDA.\n"
 		"Proceed with installation anyway? "
 		).format(
 	name=addon.displayName,
@@ -136,7 +136,7 @@ def _shouldEnableWhenAddonTooOldDialog(
 		"Check for an updated version of this add-on if possible. "
 		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "
 		"your current NVDA version is {NVDAVersion}. "
-		"Enabling may cause unstable behavior in NVDA. "
+		"Enabling may cause unstable behavior in NVDA.\n"
 		"Proceed with enabling anyway? "
 		).format(
 	name=addon.displayName,

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -32,6 +32,34 @@ class ErrorAddonInstallDialogWithCancelButton(ErrorAddonInstallDialog):
 		cancelButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.CANCEL))
 
 
+class ErrorAddonInstallDialogWithYesNoButtons(ErrorAddonInstallDialog):
+	def _addButtons(self, buttonHelper: "ButtonHelper") -> None:
+		addonInfoButton = buttonHelper.addButton(
+			self,
+			# Translators: A button in the addon installation warning / blocked dialog which shows
+			# more information about the addon
+			label=pgettext("addonStore", "&About add-on...")
+		)
+		addonInfoButton.Bind(wx.EVT_BUTTON, lambda evt: self._showAddonInfoFunction())
+
+		yesButton = buttonHelper.addButton(
+			self,
+			id=wx.ID_YES,
+			# Translators: A button in the addon installation blocked dialog which will confirm the available action.
+			label=pgettext("addonStore", "&Yes")
+		)
+		yesButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.YES))
+
+		noButton = buttonHelper.addButton(
+			self,
+			id=wx.ID_NO,
+			# Translators: A button in the addon installation blocked dialog which will dismiss the dialog.
+			label=pgettext("addonStore", "&No")
+		)
+		noButton.SetDefault()
+		noButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.NO))
+
+
 def _shouldProceedWhenInstalledAddonVersionUnknown(
 		parent: wx.Window,
 		addon: AddonGUIModel

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -89,7 +89,7 @@ def _shouldProceedToRemoveAddonDialog(
 			"Are you sure you wish to remove the {addon} add-on from NVDA? "
 			"This cannot be undone."
 		).format(addon=addon.name),
-		# Translators: Title for message asking if the user really wishes to remove the selected Addon.
+		# Translators: Title for message asking if the user really wishes to remove the selected Add-on.
 		pgettext("addonStore", "Remove Add-on"),
 		wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
 	) == wx.YES

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -55,8 +55,8 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 	assert addon._addonHandlerModel
 	incompatibleMessage = pgettext(
 		"addonStore",
-		# Translators: The message displayed when installing an incompatible add-on package,
-		# because it requires a new version than is currently installed.
+		# Translators: The message displayed when updating an add-on, but the installed version
+		# identifier can not be compared with the version to be installed.
 		"Warning: add-on installation may result in downgrade: {name}. "
 		"The installed add-on version cannot be compared with the add-on store version. "
 		"Installed version: {oldVersion}. "

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -19,19 +19,6 @@ if TYPE_CHECKING:
 	from guiHelper import ButtonHelper
 
 
-class ErrorAddonInstallDialogWithCancelButton(ErrorAddonInstallDialog):
-	def _addButtons(self, buttonHelper: "ButtonHelper") -> None:
-		super()._addButtons(buttonHelper)
-		cancelButton = buttonHelper.addButton(
-			self,
-			id=wx.ID_CANCEL,
-			# Translators: A button in the addon installation blocked dialog which will dismiss the dialog.
-			label=pgettext("addonStore", "Cancel")
-		)
-		cancelButton.SetDefault()
-		cancelButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.CANCEL))
-
-
 class ErrorAddonInstallDialogWithYesNoButtons(ErrorAddonInstallDialog):
 	def _addButtons(self, buttonHelper: "ButtonHelper") -> None:
 		addonInfoButton = buttonHelper.addButton(

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -82,13 +82,13 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	return ErrorAddonInstallDialogWithCancelButton(
+	return ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
-	).ShowModal() == wx.OK
+	).ShowModal() == wx.YES
 
 
 def _shouldProceedToRemoveAddonDialog(
@@ -128,13 +128,13 @@ def _shouldInstallWhenAddonTooOldDialog(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	return ErrorAddonInstallDialogWithCancelButton(
+	return ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
-	).ShowModal() == wx.OK
+	).ShowModal() == wx.YES
 
 
 def _shouldEnableWhenAddonTooOldDialog(
@@ -157,13 +157,13 @@ def _shouldEnableWhenAddonTooOldDialog(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	return ErrorAddonInstallDialogWithCancelButton(
+	return ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
-	).ShowModal() == wx.OK
+	).ShowModal() == wx.YES
 
 
 def _showAddonInfo(addon: AddonGUIModel) -> None:

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -101,8 +101,8 @@ def _shouldInstallWhenAddonTooOldDialog(
 ) -> bool:
 	incompatibleMessage = pgettext(
 		"addonStore",
-		# Translators: The message displayed when installing an incompatible add-on package,
-		# because it requires a new version than is currently installed.
+		# Translators: The message displayed when installing an add-on package that is incompatible
+		# because the add-on is too old for the running version of NVDA.
 		"Warning: add-on is incompatible: {name} {version}. "
 		"Check for an updated version of this add-on if possible. "
 		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "


### PR DESCRIPTION
### Link to issue number:

Fixes #15000

### Summary of the issue:

Dialogs used when  installing, enabling, or upgrading to, incompatible add-ons, asked yes or no questions to the user.
However, such dialogs used OK and Cancel as their buttons, which didn't really make sense.

### Description of user facing changes

These three dialogs now have Yes and No buttons.

Incidentally, added a newline before the question in each dialog, as commented in the original issue. This can be reverted separately if undesirable.

### Description of development approach

* Replaced the `ErrorAddonInstallDialogWithCancelButton` class, with a new class called `ErrorAddonInstallDialogWithYesNoButtons`.
* Removed `ErrorAddonInstallDialogWithCancelButton`, since it wasn't used anywhere other than for these three dialogs in `gui/_addonStoreGui/controls/messageDialogs.py`.
* Added a newline to separate explanation from actual question in these dialogs.
* Enhanced (hopefully) some translator comments I noticed along the way, as follow:
    + Created a more accurate translator comment for the incomparable version during update message.
    + Made the translator comment less ambiguous, for the message used when an add-on is being installed but is too old to be compatible.
    + Made the translator comment more accurate, for the message used when enabling an add-on too old to be compatible.
    + Fixed a typo in another translator comment.

### Testing strategy:

* Manually tested installing an incompatible add-on.
* Manually tested enabling an incompatible add-on.

Haven't tested the case where an installed add-on version string is not able to be compared to a store version, but the dialog usage is the same as the other cases so it is likely to work as well as it did before this PR.

### Known issues with pull request:

Even though the default button is set to "no" in these dialogs, "About add-on" is the focused default when their used.
This was true before as well with the "Cancel" button.
I'm not quite sure why `SetDefault()` is being ignored.

### Change log entries:

The store is pre-release, none should be needed.

### Code Review Checklist:

- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
