### PR TITLE
Encapsulate NVDA state write paths

### DIFF
--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -1,12 +1,94 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
+import os
 import sys
 import time
 
 import globalVars
+
+
+class _WritePaths:
+	@property
+	def configDir(self) -> str:
+		return globalVars.appArgs.configPath
+	
+	@configDir.setter
+	def configDir(self, configPath: str):
+		globalVars.appArgs.configPath = configPath
+		return configPath
+
+	@property
+	def addonsDir(self) -> str:
+		return os.path.join(self.configDir, "addons")
+
+	@property
+	def addonStoreDir(self) -> str:
+		return os.path.join(self.configDir, "addonStore")
+
+	@property
+	def addonStoreDownloadDir(self) -> str:
+		return os.path.join(self.addonStoreDir, "_dl")
+
+	@property
+	def profilesDir(self) -> str:
+		return os.path.join(self.configDir, "profiles")
+
+	@property
+	def scratchpadDir(self) -> str:
+		return os.path.join(self.configDir, "scratchpad")
+
+	@property
+	def speechDictsDir(self) -> str:
+		return os.path.join(self.configDir, "speechDicts")
+
+	@property
+	def voiceDictsDir(self) -> str:
+		return os.path.join(self.speechDictsDir, "voiceDicts.v1")
+
+	@property
+	def voiceDictsBackupDir(self) -> str:
+		return os.path.join(self.speechDictsDir, "voiceDictsBackup.v0")
+
+	@property
+	def updatesDir(self) -> str:
+		return os.path.join(self.configDir, "updates")
+
+	@property
+	def nvdaConfigFile(self) -> str:
+		return os.path.join(self.configDir, "nvda.ini")
+
+	@property
+	def addonStateFile(self) -> str:
+		from addonHandler import stateFilename
+		return os.path.join(self.configDir, stateFilename)
+
+	@property
+	def profileTriggersFile(self) -> str:
+		return os.path.join(self.configDir, "profileTriggers.ini")
+
+	@property
+	def gesturesConfigFile(self) -> str:
+		return os.path.join(self.configDir, "gestures.ini")
+
+	@property
+	def speechDictDefaultFile(self) -> str:
+		return os.path.join(self.speechDictsDir, "default.dic")
+
+	@property
+	def updateCheckStateFile(self) -> str:
+		return os.path.join(self.configDir, "updateCheckState.pickle")
+
+	def getSymbolsConfigFile(self, locale: str) -> str:
+		return os.path.join(self.configDir, f"symbols-{locale}.dic")
+
+	def getProfileConfigFile(self, name: str) -> str:
+		return os.path.join(self.profilesDir, f"{name}.ini")
+
+
+WritePaths = _WritePaths()
 
 
 def isRunningAsSource() -> bool:

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -23,12 +23,12 @@ from six import string_types
 from typing import (
 	Callable,
 	Dict,
+	List,
 	Optional,
 	Set,
 	TYPE_CHECKING,
 	Tuple,
 )
-import globalVars
 import zipfile
 from configobj import ConfigObj
 from configobj.validate import Validator
@@ -39,6 +39,7 @@ import winKernel
 import addonAPIVersion
 import importlib
 import NVDAState
+from NVDAState import WritePaths
 from types import ModuleType
 
 from _addonStore.models.status import AddonStateCategory, SupportsAddonState
@@ -99,7 +100,7 @@ class AddonsState(collections.UserDict):
 	@property
 	def statePath(self) -> os.PathLike:
 		"""Returns path to the state file. """
-		return os.path.join(globalVars.appArgs.configPath, stateFilename)
+		return WritePaths.addonStateFile
 
 	def load(self) -> None:
 		"""Populates state with the default content and then loads values from the config."""
@@ -231,15 +232,14 @@ def terminate():
 	""" Terminates the add-ons subsystem. """
 	pass
 
-def _getDefaultAddonPaths():
-	r""" Returns paths where addons can be found.
+
+def _getDefaultAddonPaths() -> List[str]:
+	""" Returns paths where addons can be found.
 	For now, only <userConfig>\addons is supported.
-	@rtype: list(string)
 	"""
 	addon_paths = []
-	user_addons = os.path.join(globalVars.appArgs.configPath, "addons")
-	if os.path.isdir(user_addons):
-		addon_paths.append(user_addons)
+	if os.path.isdir(WritePaths.addonsDir):
+		addon_paths.append(WritePaths.addonsDir)
 	return addon_paths
 
 

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2022 NV Access Limited, World Light Information Limited,
+# Copyright (C) 2010-2023 NV Access Limited, World Light Information Limited,
 # Hong Kong Blind Union, Babbage B.V., Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -22,6 +22,7 @@ from typing import (
 from logHandler import log
 import globalVars
 import config
+from NVDAState import WritePaths
 
 
 _LocaleDataT = TypeVar("_LocaleDataT")
@@ -406,11 +407,11 @@ def _getSpeechSymbolsForLocale(locale: str) -> Tuple[SpeechSymbols, SpeechSymbol
 	if not builtinDataImported:
 		raise LookupError("No symbol information for locale %s" % locale)
 	user = SpeechSymbols()
+	pathToSymbolsDic = WritePaths.getSymbolsConfigFile(locale)
 	try:
 		# Don't allow users to specify complex symbols
 		# because an error will cause the whole processor to fail.
-		user.load(os.path.join(globalVars.appArgs.configPath, "symbols-%s.dic" % locale),
-			allowComplexSymbols=False)
+		user.load(pathToSymbolsDic, allowComplexSymbols=False)
 	except IOError:
 		# An empty user SpeechSymbols is okay.
 		pass

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -49,6 +49,7 @@ from typing import (
 	Tuple,
 )
 import NVDAState
+from NVDAState import WritePaths
 
 
 #: True if NVDA is running as a Windows Store Desktop Bridge application
@@ -212,7 +213,7 @@ def getUserDefaultConfigPath(useInstalledPathIfExists=False):
 	"""Get the default path for the user configuration directory.
 	This is the default path and doesn't reflect overriding from the command line,
 	which includes temporary copies.
-	Most callers will want the C{globalVars.appArgs.configPath variable} instead.
+	Most callers will want the C{NVDAState.WritePaths.configDir variable} instead.
 	"""
 	installedUserConfigPath=getInstalledUserConfigPath()
 	if installedUserConfigPath and (isInstalledCopy() or isAppX or (useInstalledPathIfExists and os.path.isdir(installedUserConfigPath))):
@@ -236,9 +237,9 @@ SCRATCH_PAD_ONLY_DIRS = (
 )
 
 
-def getScratchpadDir(ensureExists=False):
+def getScratchpadDir(ensureExists: bool = False) -> str:
 	""" Returns the path where custom appModules, globalPlugins and drivers can be placed while being developed."""
-	path=os.path.join(globalVars.appArgs.configPath,'scratchpad')
+	path = WritePaths.scratchpadDir
 	if ensureExists:
 		if not os.path.isdir(path):
 			os.makedirs(path)
@@ -248,14 +249,14 @@ def getScratchpadDir(ensureExists=False):
 				os.makedirs(subpath)
 	return path
 
-def initConfigPath(configPath=None):
+
+def initConfigPath(configPath: Optional[str] = None) -> None:
 	"""
 	Creates the current configuration path if it doesn't exist. Also makes sure that various sub directories also exist.
 	@param configPath: an optional path which should be used instead (only useful when being called from outside of NVDA)
-	@type configPath: str
 	"""
 	if not configPath:
-		configPath=globalVars.appArgs.configPath
+		configPath = WritePaths.configDir
 	if not os.path.isdir(configPath):
 		os.makedirs(configPath)
 	else:
@@ -422,7 +423,7 @@ def _setStartOnLogonScreen(enable: bool) -> None:
 
 
 def setSystemConfigToCurrentConfig():
-	fromPath = globalVars.appArgs.configPath
+	fromPath = WritePaths.configDir
 	if ctypes.windll.shell32.IsUserAnAdmin():
 		_setSystemConfig(fromPath)
 	else:
@@ -560,7 +561,7 @@ class ConfigManager(object):
 			post_configProfileSwitch.notify(prevConf=currentRootSection.dict())
 
 	def _initBaseConf(self, factoryDefaults=False):
-		fn = os.path.join(globalVars.appArgs.configPath, "nvda.ini")
+		fn = WritePaths.nvdaConfigFile
 		if factoryDefaults:
 			profile = self._loadConfig(None)
 			profile.filename = fn
@@ -631,13 +632,13 @@ class ConfigManager(object):
 		return self.rootSection.dict()
 
 	def listProfiles(self):
-		for name in os.listdir(os.path.join(globalVars.appArgs.configPath, "profiles")):
+		for name in os.listdir(WritePaths.profilesDir):
 			name, ext = os.path.splitext(name)
 			if ext == ".ini":
 				yield name
 
-	def _getProfileFn(self, name):
-		return os.path.join(globalVars.appArgs.configPath, "profiles", name + ".ini")
+	def _getProfileFn(self, name: str) -> str:
+		return WritePaths.getProfileConfigFile(name)
 
 	def _getProfile(self, name, load=True):
 		try:
@@ -964,7 +965,7 @@ class ConfigManager(object):
 		self.profileTriggersEnabled = True
 
 	def _loadProfileTriggers(self):
-		fn = os.path.join(globalVars.appArgs.configPath, "profileTriggers.ini")
+		fn = WritePaths.profileTriggersFile
 		try:
 			cobj = ConfigObj(fn, indent_type="\t", encoding="UTF-8")
 		except:

--- a/source/core.py
+++ b/source/core.py
@@ -29,6 +29,7 @@ import addonHandler
 import extensionPoints
 import garbageHandler
 import NVDAState
+from NVDAState import WritePaths
 
 
 def __getattr__(attrName: str) -> Any:
@@ -493,11 +494,13 @@ def main():
 		setDPIAwareness()
 
 	import config
-	if not globalVars.appArgs.configPath:
-		globalVars.appArgs.configPath=config.getUserDefaultConfigPath(useInstalledPathIfExists=globalVars.appArgs.launcher)
+	if not WritePaths.configDir:
+		WritePaths.configDir = config.getUserDefaultConfigPath(
+			useInstalledPathIfExists=globalVars.appArgs.launcher
+		)
 	#Initialize the config path (make sure it exists)
 	config.initConfigPath()
-	log.info(f"Config dir: {globalVars.appArgs.configPath}")
+	log.info(f"Config dir: {WritePaths.configDir}")
 	log.debug("loading config")
 	import config
 	config.initialize()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -19,6 +19,7 @@ from gui import guiHelper
 import gui.contextHelp
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 import systemUtils
+from NVDAState import WritePaths
 
 
 def _canPortableConfigBeCopied() -> bool:
@@ -30,13 +31,13 @@ def _canPortableConfigBeCopied() -> bool:
 		# as we would  copy it into itself.
 		# However, if a user wants to run the launcher with a custom configPath,
 		# it is likely that he wants to copy that configuration when installing.
-		return globalVars.appArgs.configPath != config.getUserDefaultConfigPath(useInstalledPathIfExists=True)
+		return WritePaths.configDir != config.getUserDefaultConfigPath(useInstalledPathIfExists=True)
 	else:
 		# For portable copies we want to avoid copying the configuration to itself,
 		# so return True only if the configPath
 		# does not point to the config of the installed copy in appdata.
 		confPath = config.getInstalledUserConfigPath()
-		if confPath and confPath == globalVars.appArgs.configPath:
+		if confPath and confPath == WritePaths.configDir:
 			return False
 		return True
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -16,6 +16,7 @@ from enum import IntEnum
 
 import typing
 import wx
+from NVDAState import WritePaths
 
 from vision.providerBase import VisionEnhancementProviderSettings
 from wx.lib.expando import ExpandoTextCtrl
@@ -886,8 +887,10 @@ class GeneralSettingsPanel(SettingsPanel):
 			settingsSizerHelper.addItem(item)
 
 	def onCopySettings(self,evt):
-		addonsDirPath = os.path.join(globalVars.appArgs.configPath, 'addons')
-		if os.path.isdir(addonsDirPath) and 0 < len(os.listdir(addonsDirPath)):
+		if (
+			os.path.isdir(WritePaths.addonsDir)
+			and 0 < len(os.listdir(WritePaths.addonsDir))
+		):
 			message = _(
 				# Translators: A message to warn the user when attempting to copy current
 				# settings to system settings.

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -42,6 +42,7 @@ import languageHandler
 import controlTypes
 import winKernel
 import extensionPoints
+from NVDAState import WritePaths
 
 
 InputGestureBindingClassT = TypeVar("InputGestureBindingClassT")
@@ -635,7 +636,7 @@ class InputManager(baseObject.AutoPropertyObject):
 	def loadUserGestureMap(self):
 		self.userGestureMap.clear()
 		try:
-			self.userGestureMap.load(os.path.join(globalVars.appArgs.configPath, "gestures.ini"))
+			self.userGestureMap.load(WritePaths.gesturesConfigFile)
 		except IOError:
 			log.debugWarning("No user gesture map")
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2011-2019 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka
+# Copyright (C) 2011-2023 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka
 
 import ctypes
 import winreg
@@ -25,6 +25,7 @@ from typing import (
 	Dict,
 	Union,
 )
+from NVDAState import WritePaths
 
 _wsh=None
 def _getWSH():
@@ -142,7 +143,7 @@ def copyProgramFiles(destPath):
 			tryCopyFile(sourceFilePath,destFilePath)
 
 def copyUserConfig(destPath):
-	sourcePath = globalVars.appArgs.configPath
+	sourcePath = WritePaths.configDir
 	for curSourceDir,subDirs,files in os.walk(sourcePath):
 		curDestDir=os.path.join(destPath,os.path.relpath(curSourceDir,sourcePath))
 		if not os.path.isdir(curDestDir):

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2022 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
+# Copyright (C) 2007-2023 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
 # Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -22,6 +22,7 @@ from typing import Optional
 import exceptions
 import RPCConstants
 import NVDAState
+from NVDAState import WritePaths
 
 
 ERROR_INVALID_WINDOW_HANDLE = 1400
@@ -45,8 +46,9 @@ def isPathExternalToNVDA(path: str) -> bool:
 		and os.path.isabs(path)
 		and not os.path.normpath(path).startswith(_NVDA_CODE_PATH + "\\")
 		or (
-			globalVars.appArgs.configPath is not None  # Handle messages logged before config is initialized
-			and path.startswith(globalVars.appArgs.configPath)
+			# Handle messages logged before config is initialized
+			WritePaths.configDir is not None
+			and path.startswith(WritePaths.configDir)
 		)
 	):
 		# This module is external because:

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -8,10 +8,9 @@ import globalVars
 from logHandler import log
 import os
 import codecs
-import api
-import config
+
+from NVDAState import WritePaths
 from . import dictFormatUpgrade
-from .speechDictVars import speechDictsPath
 
 dictionaries = {}
 dictTypes = ("temp", "voice", "default", "builtin") # ordered by their priority E.G. voice specific speech dictionary is processed before the default
@@ -125,7 +124,7 @@ def processText(text):
 def initialize():
 	for type in dictTypes:
 		dictionaries[type]=SpeechDict()
-	dictionaries["default"].load(os.path.join(speechDictsPath, "default.dic"))
+	dictionaries["default"].load(WritePaths.speechDictDefaultFile)
 	dictionaries["builtin"].load(os.path.join(globalVars.appDir, "builtin.dic"))
 
 def loadVoiceDict(synth):

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -74,7 +74,7 @@ def _doSynthVoiceDictBackupAndMove(synthName, oldFileNameToNewFileNameList=None)
 		# dicts diectory
 		voiceDictGlob = os.path.join(
 			WritePaths.speechDictsDir,
-			r"{synthName}*".format(synthName=synthName)
+			"{synthName}*".format(synthName=synthName)
 		)
 		log.debug("voiceDictGlob: %s"%voiceDictGlob)
 

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -12,10 +12,10 @@ import os
 import api
 import glob
 from logHandler import log
-from .speechDictVars import speechDictsPath
+from NVDAState import WritePaths
 
-voiceDictsPath = os.path.join(speechDictsPath, r"voiceDicts.v1")
-voiceDictsBackupPath = os.path.join(speechDictsPath, r"voiceDictsBackup.v0")
+voiceDictsPath = WritePaths.voiceDictsDir
+voiceDictsBackupPath = WritePaths.voiceDictsBackupDir
 
 def createVoiceDictFileName(synthName, voiceName):
 	""" Creates a filename used for the voice dictionary files.
@@ -72,10 +72,10 @@ def _doSynthVoiceDictBackupAndMove(synthName, oldFileNameToNewFileNameList=None)
 
 		# look for files that need to be upgraded  in the old voice 
 		# dicts diectory
-		voiceDictGlob=os.path.join(
-				speechDictsPath,
-				r"{synthName}*".format(synthName=synthName)
-				)
+		voiceDictGlob = os.path.join(
+			WritePaths.speechDictsDir,
+			r"{synthName}*".format(synthName=synthName)
+		)
 		log.debug("voiceDictGlob: %s"%voiceDictGlob)
 
 		for actualPath in glob.glob(voiceDictGlob):

--- a/source/speechDictHandler/speechDictVars.py
+++ b/source/speechDictHandler/speechDictVars.py
@@ -1,10 +1,18 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017 NV Access Limited
+# Copyright (C) 2017-2023 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-import os
-import globalVars
+from logHandler import log
+import NVDAState
+from NVDAState import WritePaths
 
-speechDictsPath=os.path.join(globalVars.appArgs.configPath, "speechDicts")
+
+if NVDAState._allowDeprecatedAPI():
+	log.warning(
+		"speechDictHandler.speechDictVars.speechDictsPath is deprecated, "
+		"instead use WritePaths.speechDictsDir",
+		stack_info=True
+	)
+	speechDictsPath = WritePaths.speechDictsDir

--- a/source/speechDictHandler/speechDictVars.py
+++ b/source/speechDictHandler/speechDictVars.py
@@ -4,6 +4,8 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
+"""This submodule is deprecated and new code should not be added."""
+
 from logHandler import log
 import NVDAState
 from NVDAState import WritePaths

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -19,6 +19,7 @@ import winUser
 import functools
 import shlobj
 from os import startfile
+from NVDAState import WritePaths
 
 
 @functools.lru_cache(maxsize=1)
@@ -31,8 +32,7 @@ def hasSyswow64Dir() -> bool:
 
 def openUserConfigurationDirectory():
 	"""Opens directory containing config files for the current user"""
-	import globalVars
-	shellapi.ShellExecute(0, None, globalVars.appArgs.configPath, None, None, winUser.SW_SHOWNORMAL)
+	shellapi.ShellExecute(0, None, WritePaths.configDir, None, None, winUser.SW_SHOWNORMAL)
 
 
 def openDefaultConfigurationDirectory():

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -16,6 +16,7 @@ import garbageHandler
 import globalVars
 import config
 import core
+from NVDAState import WritePaths
 if globalVars.appArgs.secure:
 	raise RuntimeError("updates disabled in secure mode")
 elif config.isAppX:
@@ -69,7 +70,7 @@ RETRY_INTERVAL = 600 # 10 min
 DOWNLOAD_BLOCK_SIZE = 8192 # 8 kb
 
 #: directory to store pending update files
-storeUpdatesDir=os.path.join(globalVars.appArgs.configPath, 'updates')
+storeUpdatesDir = WritePaths.updatesDir
 try:
 	os.makedirs(storeUpdatesDir)
 except OSError:
@@ -78,7 +79,7 @@ except OSError:
 
 #: Persistent state information.
 state: Optional[Dict[str, Any]] = None
-_stateFilename: Optional[str] = None
+
 #: The single instance of L{AutoUpdateChecker} if automatic update checking is enabled,
 #: C{None} if it is disabled.
 autoChecker: Optional["AutoUpdateChecker"] = None
@@ -229,7 +230,7 @@ def _executeUpdate(destPath):
 		if os.access(portablePath, os.W_OK):
 			executeParams = u'--create-portable --portable-path "{portablePath}" --config-path "{configPath}" -m'.format(
 				portablePath=portablePath,
-				configPath=globalVars.appArgs.configPath
+				configPath=WritePaths.configDir
 			)
 		else:
 			executeParams = u"--launcher"
@@ -776,17 +777,16 @@ class DonateRequestDialog(wx.Dialog):
 def saveState():
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
-		with open(_stateFilename, "wb") as f:
+		with open(WritePaths.updateCheckStateFile, "wb") as f:
 			pickle.dump(state, f, protocol=0)
 	except:
 		log.debugWarning("Error saving state", exc_info=True)
 
 def initialize():
-	global state, _stateFilename, autoChecker
-	_stateFilename = os.path.join(globalVars.appArgs.configPath, "updateCheckState.pickle")
+	global state, autoChecker
 	try:
 		# #9038: Python 3 requires binary format when working with pickles.
-		with open(_stateFilename, "rb") as f:
+		with open(WritePaths.updateCheckStateFile, "rb") as f:
 			state = pickle.load(f)
 	except:
 		log.debugWarning("Couldn't retrieve update state", exc_info=True)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -143,6 +143,7 @@ Instead import from ``hwIo.ioThread``. (#14627)
 It was introduced in NVDA 2023.1 and was never meant to be part of the public API.
 Until removal, it behaves as a no-op, i.e. a context manager yielding nothing. (#14924)
 - ``gui.MainFrame.onAddonsManagerCommand`` is deprecated, use ``gui.MainFrame.onAddonStoreCommand`` instead. (#13985)
+- ``speechDictHandler.speechDictVars.speechDictsPath`` is deprecated, use ``WritePaths.speechDictsDir`` instead. (#15021)
 -
 
 = 2023.1 =


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
None

### Summary of the issue:
NVDA uses a variety of paths to write to.
These can be hard to discover or track in the code, as write paths are not stored in globally available named symbols.
For example, if a developer wishes to find code instances where NVDA writes to the profile config directory, searching "profile" will yield additional results, e.g. code comments.

### Description of user facing changes
N/A

### Description of development approach
Created a centralised class to list all available write paths in NVDA.
This improves discoverability of write paths.

### Testing strategy:
Ran NVDA, tested saving some config options.

### Known issues with pull request:
None

### Change log entries:
For Developers

```
``speechDictHandler.speechDictVars.speechDictsPath`` is deprecated, instead use ``WritePaths.speechDictsDir``
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
