### PR TITLE
Remove previous add-on version before installing the next

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -548,12 +548,12 @@ def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901
 	try:
 		# Use context manager to ensure that `done` and `Destroy` are called on the progress dialog afterwards
 		with doneAndDestroy(progressDialog):
-			gui.ExecAndPump(addonHandler.installAddonBundle, bundle)
 			if prevAddon:
 				prevAddon.requestRemove()
+			gui.ExecAndPump(addonHandler.installAddonBundle, bundle)
 			return True
 	except:
-		log.error("Error installing  addon bundle from %s" % addonPath, exc_info=True)
+		log.error("Error installing addon bundle from %s" % addonPath, exc_info=True)
 		gui.messageBox(
 			# Translators: The message displayed when an error occurs when installing an add-on package.
 			_("Failed to install add-on from %s") % addonPath,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14991 

### Summary of the issue:
When installing an add-on from an external source, install tasks for the new add-on version are started before the previous add-on version is removed.
This causes the install to fail, as initialized DLLs as part of the install tasks may block the remove from occurring.
This is legacy behaviour (before #13985) so it is uncertain why this is a recent regression.

### Description of user facing changes
Should allow updating add-ons with DLL files from an external source.

### Description of development approach
Move install tasks to after removal

### Testing strategy:
- [ ] Confirm manual testing with @cary-rowen 

### Known issues with pull request:
none

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
