### PR TITLE
Add-on store: fix UX when using high contrast themes

### DIFF
--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -62,9 +62,6 @@ class AddonDetails(
 		selfSizer = wx.BoxSizer(wx.VERTICAL)
 		self.SetSizer(selfSizer)
 		parentSizer = wx.BoxSizer(wx.VERTICAL)
-		# To make the text fields less ugly.
-		# See Windows explorer file properties dialog for an example.
-		self.SetBackgroundColour(wx.Colour("white"))
 
 		self.addonNameCtrl = wx.StaticText(
 			self,
@@ -166,12 +163,16 @@ class AddonDetails(
 		# setting style1 as the default style will continue to result in blue text.
 		self.defaultStyle = wx.TextAttr()
 		self.defaultStyle.SetFontFaceName(_fontFaceName)
-		self.defaultStyle.SetTextColour("black")
 		self.defaultStyle.SetFontSize(10)
 
 		self.labelStyle = wx.TextAttr(self.defaultStyle)
 		# Note: setting font weight doesn't seem to work for RichText, instead specify via the font face name
 		self.labelStyle.SetFontFaceName(_fontFaceName_semiBold)
+
+		# Make the details panel background match the text fields.
+		# See Windows explorer file properties dialog for an example.
+		textBgColour = self.descriptionTextCtrl.GetBackgroundColour()
+		self.SetBackgroundColour(textBgColour)
 
 	def _setAddonNameCtrlStyle(self):
 		addonNameFont: wx.Font = self.addonNameCtrl.GetFont()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15007 

### Summary of the issue:
NVDA sets the background colour for the details panel explicitly as white, and the text of the details explicitly as black.
This causes text to be hard to read during high contrast mode.
When high contrast mode is activated the background of text controls are correctly set to black, but the text color is also black.
Additionally, the details background is set to white, instead of black, like the text controls.
Instead, we should infer the background colour to match contrast modes.

Example image:
![image](https://github.com/nvaccess/nvda/assets/7090342/6d617f02-d528-491b-9fa3-17f0aa6412a1)


### Description of user facing changes
High contrast themes works as expected for the add-on store dialog.
![image](https://github.com/nvaccess/nvda/assets/7090342/acfd4685-2a05-41e7-a525-b91faf46fa25)


### Description of development approach
Use the BG colour of text controls to set the background colour of the details panel.
Additionally, remove the code which makes the text explicitly black.

### Testing strategy:
View the add-on store dialog without any contrast themes - and ensure it hasn't visually changed.

View the add-on store dialog with each contrast theme - and ensure it is visually as expected.

### Known issues with pull request:
None 

### Change log entries:
N/a

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
