### PR TITLE
More robust detection of language code with no description

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2634,8 +2634,8 @@ class UwpOcrPanel(SettingsPanel):
 			desc = languageHandler.getLanguageDescription(normLang)
 			if not desc:
 				# Raise an error in the hope that people be more likely to report the issue
-				log.error(f'No description for language: {normLang}. Using language code instead.')
-				desc = normLang
+				log.error(f'No description for language: {lang}. Using language code instead.')
+				desc = lang
 			languageChoices.append(desc)
 		# Translators: Label for an option in the Windows OCR dialog.
 		languageLabel = _("Recognition &language:")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2625,9 +2625,15 @@ class UwpOcrPanel(SettingsPanel):
 		# Lazily import this.
 		from contentRecog import uwpOcr
 		self.languageCodes = uwpOcr.getLanguages()
-		languageChoices = [
-			languageHandler.getLanguageDescription(languageHandler.normalizeLanguage(lang))
-			for lang in self.languageCodes]
+		languageChoices = []
+		for lang in self.languageCodes:
+			normLang = languageHandler.normalizeLanguage(lang)
+			desc = languageHandler.getLanguageDescription(normLang)
+			if not desc:
+				# Raise an error in the hope that people be more likely to report the issue
+				log.error(f'No description for language: {normLang}. Using language code instead.')
+				desc = normLang
+			languageChoices.append(desc)
 		# Translators: Label for an option in the Windows OCR dialog.
 		languageLabel = _("Recognition &language:")
 		self.languageChoice = sHelper.addLabeledControl(languageLabel, wx.Choice, choices=languageChoices)
@@ -4286,9 +4292,14 @@ class SpeechSymbolsDialog(SettingsDialog):
 		except LookupError:
 			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData("en")
 		self.symbolProcessor = symbolProcessor
+		desc = languageHandler.getLanguageDescription(self.symbolProcessor.locale)
+		if not desc:
+			desc = self.symbolProcessor.locale
+			# Raise an error in the hope that people be more likely to report the issue
+			log.error(f'No description for language: {desc}. Using language code instead.')
 		# Translators: This is the label for the symbol pronunciation dialog.
 		# %s is replaced by the language for which symbol pronunciation is being edited.
-		self.title = _("Symbol Pronunciation (%s)")%languageHandler.getLanguageDescription(self.symbolProcessor.locale)
+		self.title = _("Symbol Pronunciation (%s)") % desc
 		super(SpeechSymbolsDialog, self).__init__(
 			parent,
 			resizeable=True,

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -165,6 +165,8 @@ def getLanguageDescription(language: str) -> Optional[str]:
 		# and `languageHandler` is responsible for setting the translation.
 		import localesData
 		desc = localesData.LANG_NAMES_TO_LOCALIZED_DESCS.get(language, None)
+	if not desc:
+		log.debugWarning(f'Unable to provide a describption for the following language: {language}')
 	return desc
 
 

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -167,7 +167,7 @@ def getLanguageDescription(language: str) -> Optional[str]:
 		import localesData
 		desc = localesData.LANG_NAMES_TO_LOCALIZED_DESCS.get(language, None)
 	if not desc:
-		log.debugWarning(f'Unable to provide a describption for the following language: {language}')
+		log.debugWarning(f'Unable to provide a description for the following language: {language}')
 	return desc
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -109,6 +109,7 @@ Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively
 - Reporting of object shortcut keys has been improved. (#10807)
 - When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)
 - NVDA now generally responds slightly faster to commands and focus changes. (#14928)
+- Displaying the OCR settings will not fail on some systems anymore. (#15017)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Closes #15017 (work-around)

### Summary of the issue:
On a specific system (see #15017), Windows cannot get the language name from LCID. This cause an uncaught error preventing the OCR settings panel to be fully created (and the previous panel to be cleared).

### Description of user facing changes
Displaying the OCR settings will not fail anymore on some systems where it is not possible to derive the language name from LCID.
### Description of development approach
When listing OCR languages, we use `languageHandler.getLanguageDescription` to determine the name given the language code. However this function may return `None` in case it cannot find a language name.
This return value had not been taken into account when listing the OCR languages.

Thus this PR allows to add the language code instead of is name in the OCR list as a fallback if the name cannot be found.

A `debugWarning` is logged in the function `languageHandler.getLanguageDescription` if the language cannot be found; note that this function is used in some add-ons.

In the settings panel instead, I log an error so that the situations with unknown languages can be captured more easily.

### Testing strategy:

* Modified the code manually to add an unknown language code in the list of language codes and checked that it is listed as a language code in the combo box of the OCR settings panel; also checked the logged debugWarning and error messages.
* Ask to @cary-rowen or @hwf1324  to test this PR on the system where the error was found and check that GUI issues of #15017 do not occur anymore.

### Known issues with pull request:
This PR fixes the GUI issue but do not convert the language code to a valid language name.

The issue described in #15017 seems to occur only on a specific system running a Windows version that is not supported anymore (Windows 10 1809). Moreover the user will not have access to this system in the future. Thus I prefer not to modify our language normalization or conversion functions since I am not confident on how these modifications would impact other systems.

An error is logged for language codes that cannot be converted to full language names; so if other people face this issue we will have the information in the log (and in the GUI featuring language code instead of name). We may think to a fix if this impact many people on up-to-date systems.

### Change log entries:
Bug fixes
`Displaying the OCR settings will not fail on some systems anymore. (#15017)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
