### PR TITLE
Update eSpeak for 2023.2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `f520fecb`
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `ed9a7bcf`
 * [Sonic](https://github.com/waywardgeek/sonic), commit 1d705135
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit cbc1f29631780
 * [liblouis](http://www.liblouis.io/), version 3.26.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,6 +50,7 @@ This can be done using the Windows Volume Mixer. (#1409)
 
 
 == Changes ==
+- eSpeak NG has been updated to 1.52-dev commit ``ed9a7bcf``. (#15036)
 - Updated LibLouis braille translator to [3.26.0 https://github.com/liblouis/liblouis/releases/tag/v3.26.0]. (#14970)
 - CLDR has been updated to version 43.0. (#14918)
 - Dash and em-dash symbols will always be sent to the synthesizer. (#13830)


### PR DESCRIPTION
Janitorial update for eSpeak.

No noted new languages or major changes.