### PR TITLE
Allow the volume of NVDA sounds to be set within NVDA.

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -75,6 +75,6 @@ EXPORTS
 	wasPlay_sync
 	wasPlay_pause
 	wasPlay_resume
-	wasPlay_setSessionVolume
+	wasPlay_setChannelVolume
 	wasPlay_startup
 	wasPlay_getDevices

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -552,7 +552,9 @@ HRESULT wasPlay_resume(WasapiPlayer* player) {
 	return player->resume();
 }
 
-HRESULT wasPlay_setChannelVolume(WasapiPlayer* player, unsigned int channel,
+HRESULT wasPlay_setChannelVolume(
+	WasapiPlayer* player,
+	unsigned int channel,
 	float level
 ) {
 	return player->setChannelVolume(channel, level);

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -38,8 +38,7 @@ const IID IID_IAudioClient = __uuidof(IAudioClient);
 const IID IID_IAudioRenderClient = __uuidof(IAudioRenderClient);
 const IID IID_IAudioClock = __uuidof(IAudioClock);
 const IID IID_IMMNotificationClient = __uuidof(IMMNotificationClient);
-const IID IID_IAudioSessionControl = __uuidof(IAudioSessionControl);
-const IID IID_ISimpleAudioVolume = __uuidof(ISimpleAudioVolume);
+const IID IID_IAudioStreamVolume = __uuidof(IAudioStreamVolume);
 
 /**
  * C++ RAII class to manage the lifecycle of a standard Windows HANDLE closed
@@ -152,12 +151,9 @@ class WasapiPlayer {
 	/**
 	 * Constructor.
 	 * Specify an empty (not null) deviceId to use the default device.
-	 * Pass GUID_NULL for sessionGuid to use the default audio session.
-	 * Specify an empty (not null) sessionName if you do not wish to set the
-	 * session display name.
 	 */
 	WasapiPlayer(wchar_t* deviceId, WAVEFORMATEX format,
-		ChunkCompletedCallback callback, GUID sessionGuid, wchar_t* sessionName);
+		ChunkCompletedCallback callback);
 
 	/**
 	 * Open the audio device.
@@ -177,7 +173,7 @@ class WasapiPlayer {
 	HRESULT sync();
 	HRESULT pause();
 	HRESULT resume();
-	HRESULT setSessionVolume(float level);
+	HRESULT setChannelVolume(unsigned int channel, float level);
 
 	private:
 	void maybeFireCallback();
@@ -211,8 +207,6 @@ class WasapiPlayer {
 	// The maximum number of frames that will fit in the buffer.
 	UINT32 bufferFrames;
 	std::wstring deviceId;
-	GUID sessionGuid;
-	std::wstring sessionName;
 	WAVEFORMATEX format;
 	ChunkCompletedCallback callback;
 	PlayState playState = PlayState::stopped;
@@ -228,9 +222,8 @@ class WasapiPlayer {
 };
 
 WasapiPlayer::WasapiPlayer(wchar_t* deviceId, WAVEFORMATEX format,
-	ChunkCompletedCallback callback, GUID sessionGuid, wchar_t* sessionName)
-: deviceId(deviceId), format(format), callback(callback),
-sessionGuid(sessionGuid), sessionName(sessionName)  {
+	ChunkCompletedCallback callback)
+: deviceId(deviceId), format(format), callback(callback) {
 	wakeEvent = CreateEvent(nullptr, false, false, nullptr);
 }
 
@@ -260,20 +253,9 @@ HRESULT WasapiPlayer::open(bool force) {
 	}
 	hr = client->Initialize(AUDCLNT_SHAREMODE_SHARED,
 		AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
-		BUFFER_SIZE, 0, &format, &sessionGuid);
+		BUFFER_SIZE, 0, &format, nullptr);
 	if (FAILED(hr)) {
 		return hr;
-	}
-	if (!sessionName.empty()) {
-		CComPtr<IAudioSessionControl> control;
-		hr = client->GetService(IID_IAudioSessionControl, (void**)&control);
-		if (FAILED(hr)) {
-			return hr;
-		}
-		hr = control->SetDisplayName(sessionName.c_str(), nullptr);
-		if (FAILED(hr)) {
-			return hr;
-		}
 	}
 	hr = client->GetBufferSize(&bufferFrames);
 	if (FAILED(hr)) {
@@ -510,9 +492,9 @@ HRESULT WasapiPlayer::resume() {
 	return S_OK;
 }
 
-HRESULT WasapiPlayer::setSessionVolume(float level) {
-	CComPtr<ISimpleAudioVolume> volume;
-	HRESULT hr = client->GetService(IID_ISimpleAudioVolume, (void**)&volume);
+HRESULT WasapiPlayer::setChannelVolume(unsigned int channel, float level) {
+	CComPtr<IAudioStreamVolume> volume;
+	HRESULT hr = client->GetService(IID_IAudioStreamVolume, (void**)&volume);
 	if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
 		// If we're using a specific device, it's just been invalidated. Fall back
 		// to the default device.
@@ -521,12 +503,12 @@ HRESULT WasapiPlayer::setSessionVolume(float level) {
 		if (FAILED(hr)) {
 			return hr;
 		}
-		hr = client->GetService(IID_ISimpleAudioVolume, (void**)&volume);
+		hr = client->GetService(IID_IAudioStreamVolume, (void**)&volume);
 	}
 	if (FAILED(hr)) {
 		return hr;
 	}
-	return volume->SetMasterVolume(level, nullptr);
+	return volume->SetChannelVolume(channel, level);
 }
 
 /*
@@ -535,10 +517,9 @@ HRESULT WasapiPlayer::setSessionVolume(float level) {
  */
 
 WasapiPlayer* wasPlay_create(wchar_t* deviceId, WAVEFORMATEX format,
-	WasapiPlayer::ChunkCompletedCallback callback, GUID sessionGuid,
-	wchar_t* sessionName
+	WasapiPlayer::ChunkCompletedCallback callback
 ) {
-	return new WasapiPlayer(deviceId, format, callback, sessionGuid, sessionName);
+	return new WasapiPlayer(deviceId, format, callback);
 }
 
 void wasPlay_destroy(WasapiPlayer* player) {
@@ -571,8 +552,10 @@ HRESULT wasPlay_resume(WasapiPlayer* player) {
 	return player->resume();
 }
 
-HRESULT wasPlay_setSessionVolume(WasapiPlayer* player, float level) {
-	return player->setSessionVolume(level);
+HRESULT wasPlay_setChannelVolume(WasapiPlayer* player, unsigned int channel,
+	float level
+) {
+	return player->setChannelVolume(channel, level);
 }
 
 /**

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -59,6 +59,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	audioDuckingMode = integer(default=0)
 	wasapi = boolean(default=true)
 	soundVolumeFollowsVoice = boolean(default=false)
+	soundVolume = integer(default=100,min=0,max=100)
 
 # Braille settings
 [braille]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -59,7 +59,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	audioDuckingMode = integer(default=0)
 	wasapi = boolean(default=true)
 	soundVolumeFollowsVoice = boolean(default=false)
-	soundVolume = integer(default=100,min=0,max=100)
+	soundVolume = integer(default=100, min=0, max=100)
 
 # Braille settings
 [braille]

--- a/source/tones.py
+++ b/source/tones.py
@@ -27,7 +27,7 @@ def initialize():
 			bitsPerSample=16,
 			outputDevice=config.conf["speech"]["outputDevice"],
 			wantDucking=False,
-			session=nvwave.soundsSession
+			purpose=nvwave.AudioPurpose.SOUNDS
 		)
 	except Exception:
 		log.warning("Failed to initialize audio for tones", exc_info=True)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,7 +19,7 @@ What's New in NVDA
   - It is now possible to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using.
   This option can be enabled in Advanced settings. (#1409)
   - You can now separately control the volume of NVDA sounds.
-  This can be done using the Windows Volume Mixer. (#1409)
+  This can be done in Advanced settings. (#1409)
   -
 - New input gestures:
   - An unbound gesture to cycle through the available languages for Windows OCR. (#13036)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2331,6 +2331,10 @@ Similarly, if you increase the volume of the voice, the volume of sounds will in
 This option only takes effect when "Use WASAPI for audio output" is enabled.
 This option is disabled by default.
 
+==== Volume of NVDA sounds ====[SoundVolume]
+This slider allows you to set the volume of NVDA sounds and beeps.
+This setting only takes effect when "Use WASAPI for audio output" is enabled and "Volume of NVDA sounds follows voice volume" is disabled.
+
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.
 Logging these messages can result in decreased performance and large log files.


### PR DESCRIPTION
### Link to issue number:
Better solution for #1409. Addresses https://github.com/nvaccess/nvda/pull/14896#issuecomment-1594713278. Also addresses feedback I received on Mastodon regarding the NVDA sounds volume not appearing in the Windows Volume Mixer in some versions of Windows.

### Summary of the issue:
1. In #14697, I split NVDA speech and sounds into two separate Windows audio sessions to allow independent control of their levels. However, some users want these levels to be linked.
2. In #14896, I made it possible to have the sounds volume follow the voice volume. However, as per https://github.com/nvaccess/nvda/pull/14896#issuecomment-1594713278, some synths don't set the volume in a linear way, so the volumes don't match.
3. It was reported to me on Mastodon that in Windows 11 Insider builds, the "NVDA sounds" volume doesn't show up in the Windows Volume Mixer unless you actively play a sound while the Volume Mixer is running. This is not very intuitive, and if this is behaviour Microsoft intends to keep, it isn't going to work well for our users.
4. Having the volume of NVDA sounds controlled outside of NVDA is a little cumbersome.

### Description of user facing changes
1. There will now only be one entry for NVDA in the Windows Volume Mixer which will control all NVDA audio.
2. There will be a slider in NVDA Advanced Settings to control the volume of sounds.

### Description of development approach
1. Removed the ability to set a WASAPI session and volume.
2. Added a method to set the volume of a stream. This also allows you to set the volume of individual channels, though that's not used yet.
3. Added a slider in Advanced Settings to control the volume of NVDA sounds. This is disabled if the sound volume is following the voice volume.

### Testing strategy:
All the tests from #14896, plus:

1. Disabled "Volume of NVDA sounds follows voice volume".
2. Lowered the NVDA sounds volume to 10%.
3. Switched between focus and browse modes to verify that sounds played quieter.
4. Increased the NVDA sounds volume to 100%.
5. Switched between focus and browse modes to verify that sounds played louder.
6. Enabled "Volume of NVDA sounds follows voice volume".
7. Set the voice volume to 50%.
8. Switched between focus and browse modes to verify that sounds played quieter.

### Known issues with pull request:
No user facing issues. However:

1. I'm wondering whether I should make AudioPurpose, the purpose argument to WavePlayer and the setVolume method private (underscore prefixed) for now. I don't anticipate any further changes, but nor did I anticipate changes to the previous session API. Making it private would allow us to ensure this is stable internally before making it part of the public API. This might be overkill though.
2. This does change the WavePlayer API in beta (but not in release). I don't think that's considered API breaking if this gets merged to beta, but it's worth noting. It will be a problem if we don't merge this to beta.

### Change log entries:
In this entry in New features:
```
- You can now separately control the volume of NVDA sounds.
This can be done using the Windows Volume Mixer. (#1409)
```
The second line should be adjusted to say:
`This can be done in Advanced settings. (#1409)`

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
