### PR TITLE
route review cursor and system caret

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -83,7 +83,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
 	interruptSpeechWhileScrolling = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	showSelection = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
-	routeReviewCursorAndSystemCaret = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="disabled")
+	routeSystemCaretAlongWithReviewCursor = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="disabled")
 	enableHidBrailleSupport = integer(0, 2, default=0)  # 0:Use default/recommended value (yes), 1:yes, 2:no
 
 	# Braille display driver settings

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -83,6 +83,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	focusContextPresentation = option("changedContext", "fill", "scroll", default="changedContext")
 	interruptSpeechWhileScrolling = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	showSelection = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
+	routeReviewCursorAndSystemCaret = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="disabled")
 	enableHidBrailleSupport = integer(0, 2, default=0)  # 0:Use default/recommended value (yes), 1:yes, 2:no
 
 	# Braille display driver settings

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3318,12 +3318,13 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Input help mode message for cycle through
-		# braille route review cursor and system caret command.
-		description=_("Cycle through the braille route review cursor and system caret states"),
+		# braille route system caret along with review cursor command.
+		description=_("Cycle through the braille route system caret along with review cursor states"),
 		category=SCRCAT_BRAILLE
 	)
-	def script_braille_cycleRouteReviewCursorAndSystemCaret(self, gesture: inputCore.InputGesture) -> None:
-		# If braille is not tethered to focus, set next state of braille route review cursor and system caret.
+	def script_braille_cycleRouteSystemCaretAlongWithReviewCursor(self, gesture: inputCore.InputGesture) -> None:
+		# If braille is not tethered to focus, set next state of
+		# braille route system caret along with review cursor.
 		# State is reported using ui.message.
 		# Unavailable if tether is to focus.
 		if TetherTo.FOCUS.value == config.conf["braille"]["tetherTo"]:
@@ -3334,24 +3335,24 @@ class GlobalCommands(ScriptableObject):
 				)
 			)
 			return
-		featureFlag: FeatureFlag = config.conf["braille"]["routeReviewCursorAndSystemCaret"]
+		featureFlag: FeatureFlag = config.conf["braille"]["routeSystemCaretAlongWithReviewCursor"]
 		boolFlag: BoolFlag = featureFlag.enumClassType
 		values = [x.value for x in boolFlag]
 		currentValue = featureFlag.value.value
 		nextValueIndex = (currentValue % len(values)) + 1
 		nextName: str = boolFlag(nextValueIndex).name
-		config.conf["braille"]["routeReviewCursorAndSystemCaret"] = nextName
-		featureFlag = config.conf["braille"]["routeReviewCursorAndSystemCaret"]
+		config.conf["braille"]["routeSystemCaretAlongWithReviewCursor"] = nextName
+		featureFlag = config.conf["braille"]["routeSystemCaretAlongWithReviewCursor"]
 		if featureFlag.isDefault():
 			msg = _(
-				# Translators: Used when reporting braille route review cursor and system caret
+				# Translators: Used when reporting braille route system caret along with review cursor
 				# state (default behavior).
-				"Braille route review cursor and system caret default (%s)"
+				"Braille route system caret along with review cursor default (%s)"
 			) % featureFlag.behaviorOfDefault.displayString
 		else:
-			# Translators: Reports which route review cursor and system caret state is used
+			# Translators: Reports which route system caret along with review cursor state is used
 			# (disabled or enabled).
-			msg = _("Braille route review cursor and system caret %s") % BoolFlag[nextName].displayString
+			msg = _("Braille route system caret along with review cursor %s") % BoolFlag[nextName].displayString
 		ui.message(msg)
 
 	@script(
@@ -3537,11 +3538,11 @@ class GlobalCommands(ScriptableObject):
 		# To proceed braille should be tethered to review cursor which means
 		# that tether is automatic (and review cursor is shown in braille)
 		# or tether is to review cursor.
-		# "Route review cursor and system caret" should be also enabled
+		# "Route system caret along with review cursor" should be also enabled
 		# in braille settings.
 		if (
 			braille.handler.getTether() != TetherTo.REVIEW.value
-			or not config.conf["braille"]["routeReviewCursorAndSystemCaret"]
+			or not config.conf["braille"]["routeSystemCaretAlongWithReviewCursor"]
 		):
 			return
 		navigatorObject: NVDAObject = api.getNavigatorObject()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3528,8 +3528,7 @@ class GlobalCommands(ScriptableObject):
 		if braille.handler.buffer is braille.handler.messageBuffer:
 			braille.handler.routeTo(gesture.routingIndex)
 			return
-		# Lookup error occured in Omnipage 19 when pressing routing button
-		# in "unknown" object.
+		# Lookup error occurs when pressing routing button in "unknown" object.
 		try:
 			braille.handler.routeTo(gesture.routingIndex)
 		except LookupError:
@@ -3573,6 +3572,11 @@ class GlobalCommands(ScriptableObject):
 			except COMError:
 				log.debug("Set focus failed.", exc_info=True)
 				return
+		# If not in browse mode, try to reduce "no caret" messages.
+		if not api.isObjectInActiveTreeInterceptor(navigatorObject):
+			if not navigatorObject._hasNavigableText:
+				log.debug(f"Navigator object {navigatorObject} is not navigable")
+				return
 		review: textInfos.TextInfo = api.getReviewPosition()
 		# This script is available on the lock screen via getSafeScripts, as such
 		# ensure the review object does not contain secure information
@@ -3580,11 +3584,6 @@ class GlobalCommands(ScriptableObject):
 		if objectBelowLockScreenAndWindowsIsLocked(review.obj):
 			ui.reviewMessage(gui.blockAction.Context.WINDOWS_LOCKED.translatedMessage)
 			return
-		# If not in browse mode, try to reduce "no caret" messages.
-		if not api.isObjectInActiveTreeInterceptor(navigatorObject):
-			if not navigatorObject._hasNavigableText:
-				log.debug(f"Navigator object {navigatorObject} is not navigable")
-				return
 		try:
 			review.updateCaret()
 		except NotImplementedError:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3524,10 +3524,11 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_braille_routeTo(self, gesture: inputCore.InputGesture) -> None:
 		# Routes cursor to or activates the object under this braille cell.
-		braille.handler.routeTo(gesture.routingIndex)
 		# Try to ensure that braille message can be dismissed.
 		if braille.handler.buffer is braille.handler.messageBuffer:
+			braille.handler.routeTo(gesture.routingIndex)
 			return
+		braille.handler.routeTo(gesture.routingIndex)
 		# To proceed braille should be tethered to review cursor which means
 		# that tether is automatic (and review cursor is shown in braille)
 		# or tether is to review cursor.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3323,7 +3323,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_BRAILLE
 	)
 	def script_braille_cycleRouteReviewCursorAndSystemCaret(self, gesture: inputCore.InputGesture) -> None:
-		If braille is not tethered to focus, set next state of braille route review cursor and system caret.
+		# If braille is not tethered to focus, set next state of braille route review cursor and system caret.
 		# State is reported using ui.message.
 		# Unavailable if tether is to focus.
 		if TetherTo.FOCUS.value == config.conf["braille"]["tetherTo"]:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3528,7 +3528,13 @@ class GlobalCommands(ScriptableObject):
 		if braille.handler.buffer is braille.handler.messageBuffer:
 			braille.handler.routeTo(gesture.routingIndex)
 			return
-		braille.handler.routeTo(gesture.routingIndex)
+		# Lookup error occured in Omnipage 19 when pressing routing button
+		# in "unknown" object.
+		try:
+			braille.handler.routeTo(gesture.routingIndex)
+		except LookupError:
+			log.debug(f"Routing failed.", exc_info=True)
+			return
 		# To proceed braille should be tethered to review cursor which means
 		# that tether is automatic (and review cursor is shown in braille)
 		# or tether is to review cursor.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3323,15 +3323,14 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_BRAILLE
 	)
 	def script_braille_cycleRouteReviewCursorAndSystemCaret(self, gesture: inputCore.InputGesture) -> None:
-		"""If braille is not tethered to focus, set next state of braille route review cursor and system caret.
-		State is reported using ui.message.
-		"""
+		If braille is not tethered to focus, set next state of braille route review cursor and system caret.
+		# State is reported using ui.message.
 		# Unavailable if tether is to focus.
 		if TetherTo.FOCUS.value == config.conf["braille"]["tetherTo"]:
 			ui.message(
 				_(
 					# Translators: Gesture is unavailable because braille tether is to focus.
-					"Gesture is unavailable because braille tether is to focus"
+					"Action unavailable. Braille is tethered to focus"
 				)
 			)
 			return
@@ -3524,19 +3523,18 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_BRAILLE
 	)
 	def script_braille_routeTo(self, gesture: inputCore.InputGesture) -> None:
-		"""Routes cursor to or activates the object under this braille cell."""
+		# Routes cursor to or activates the object under this braille cell.
+		braille.handler.routeTo(gesture.routingIndex)
 		# Try to ensure that braille message can be dismissed.
 		if braille.handler.buffer is braille.handler.messageBuffer:
-			braille.handler.routeTo(gesture.routingIndex)
 			return
-		braille.handler.routeTo(gesture.routingIndex)
 		# To proceed braille should be tethered to review cursor which means
 		# that tether is automatic (and review cursor is shown in braille)
 		# or tether is to review cursor.
 		# "Route review cursor and system caret" should be also enabled
 		# in braille settings.
 		if (
-			TetherTo.REVIEW.value != config.conf["braille"]["tetherTo"]
+			braille.handler.getTether() != TetherTo.REVIEW.value
 			or not config.conf["braille"]["routeReviewCursorAndSystemCaret"]
 		):
 			return

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3759,23 +3759,24 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 		)
 		self.bindHelpEvent("BrailleSettingsShowSelection", self.brailleShowSelectionCombo)
 
-		self.brailleRouteReviewCursorAndSystemCaretCombo: nvdaControls.FeatureFlagCombo = sHelper.addLabeledControl(
+		self.brailleRouteSystemCaretAlongWithReviewCursorCombo: nvdaControls.FeatureFlagCombo = \
+		sHelper.addLabeledControl(
 			labelText=_(
 				# Translators: This is a label for a combo-box in the Braille settings panel.
-				"Ro&ute review cursor and system caret"
+				"Ro&ute system caret along with review cursor"
 			),
 			wxCtrlClass=nvdaControls.FeatureFlagCombo,
-			keyPath=["braille", "routeReviewCursorAndSystemCaret"],
+			keyPath=["braille", "routeSystemCaretAlongWithReviewCursor"],
 			conf=config.conf,
 		)
 		self.bindHelpEvent(
-			"BrailleSettingsRouteReviewCursorAndSystemCaret",
-			self.brailleRouteReviewCursorAndSystemCaretCombo
+			"BrailleSettingsRouteSystemCaretAlongWithReviewCursor",
+			self.brailleRouteSystemCaretAlongWithReviewCursorCombo
 		)
 		tetherChoice = [x.value for x in TetherTo][self.tetherList.GetSelection()]
 		# Setting has no effect when braille is tethered to focus.
 		if tetherChoice == TetherTo.FOCUS.value:
-			self.brailleRouteReviewCursorAndSystemCaretCombo.Disable()
+			self.brailleRouteSystemCaretAlongWithReviewCursorCombo.Disable()
 
 		if gui._isDebug():
 			log.debug("Finished making settings, now at %.2f seconds from start"%(time.time() - startTime))
@@ -3802,7 +3803,7 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 		config.conf["braille"]["focusContextPresentation"] = self.focusContextPresentationValues[self.focusContextPresentationList.GetSelection()]
 		self.brailleInterruptSpeechCombo.saveCurrentValueToConf()
 		self.brailleShowSelectionCombo.saveCurrentValueToConf()
-		self.brailleRouteReviewCursorAndSystemCaretCombo.saveCurrentValueToConf()
+		self.brailleRouteSystemCaretAlongWithReviewCursorCombo.saveCurrentValueToConf()
 
 	def onShowCursorChange(self, evt):
 		self.cursorBlinkCheckBox.Enable(evt.IsChecked())
@@ -3817,9 +3818,9 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 		self.messageTimeoutEdit.Enable(evt.GetSelection() == 1)
 
 	def onTetherToChange(self, evt: wx.CommandEvent) -> None:
-		"""Showss or hides "Route review cursor and system caret" braille setting."""
+		"""Shows or hides "Route system caret along with review cursor" braille setting."""
 		tetherChoice = [x.value for x in TetherTo][evt.GetSelection()]
-		self.brailleRouteReviewCursorAndSystemCaretCombo.Enable(tetherChoice != TetherTo.FOCUS.value)
+		self.brailleRouteSystemCaretAlongWithReviewCursorCombo.Enable(tetherChoice != TetherTo.FOCUS.value)
 
 def showStartErrorForProviders(
 		parent: wx.Window,

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -1,5 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot,
+# Burman's Computer and Education Ltd.
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -99,7 +100,6 @@ def getSafeScripts() -> Set["scriptHandler._ScriptFunctionT"]:
 		# on the lock screen using braille.
 		commands.script_braille_scrollBack,
 		commands.script_braille_scrollForward,
-		commands.script_braille_routeTo,
 		commands.script_braille_previousLine,
 		commands.script_braille_nextLine,
 		
@@ -107,6 +107,8 @@ def getSafeScripts() -> Set["scriptHandler._ScriptFunctionT"]:
 		# on the lock screen are accessible.
 		# Preventing object navigation outside the lock screen
 		# is handled in `api.setNavigatorObject` and by applying `LockScreenObject`.
+		# Routing is here because it may change focus.
+		commands.script_braille_routeTo,
 		commands.script_navigatorObject_current,
 		commands.script_navigatorObject_currentDimensions,
 		commands.script_navigatorObject_toFocus,

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1687,7 +1687,7 @@ Disabling this option may improve readability.
 
 To toggle show selection from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
 
-==== Route review cursor and system caret ====[BrailleSettingsRouteReviewCursorAndSystemCaret]
+==== Route system caret along with review cursor ====[BrailleSettingsRouteSystemCaretAlongWithReviewCursor]
 : Default
   Disabled
 : Options
@@ -1707,7 +1707,7 @@ It may be especially handy to review text without affecting system caret in edit
 Please note: The option is hidden, and it has no effect unless
 the braille is tethered automatically or to review cursor.
 
-To toggle route review cursor and system caret from anywhere,
+To toggle route system caret along with review cursor from anywhere,
 please assign a custom gesture using the [Input Gestures dialog #InputGestures].
 
 +++ Select Braille Display (NVDA+control+a) +++[SelectBrailleDisplay]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1687,6 +1687,29 @@ Disabling this option may improve readability.
 
 To toggle show selection from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
 
+==== Route review cursor and system caret ====[BrailleSettingsRouteReviewCursorAndSystemCaret]
+: Default
+  Disabled
+: Options
+  Default (Disabled), Enabled, Disabled
+:
+
+This setting determines if system focus/caret should be also tried to be moved
+with a routing button press when [braille tether #BrailleTether] is automatic
+and braille is temporarily tethered to review, or tether is to review cursor.
+Option is disabled by default.
+
+When this option is enabled and braille is tethered to review,
+it is often but not always possible to move both review cursor
+and system focus/caret to the desired position by pressing a routing button.
+It may be especially handy to review text without affecting system caret in edit areas, and move system caret only when needed.
+
+Please note: The option is hidden, and it has no effect unless
+the braille is tethered automatically or to review cursor.
+
+To toggle route review cursor and system caret from anywhere,
+please assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
 +++ Select Braille Display (NVDA+control+a) +++[SelectBrailleDisplay]
 The Select Braille Display dialog, which can be opened by activating the Change... button in the Braille category of the NVDA settings dialog, allows you to select which Braille display NVDA should use for braille output.
 Once you have selected your braille display of choice, you can press Ok and NVDA will load the selected display.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
14885
### Summary of the issue:
It has not been possible to move system focus/caret with single routing button press when braille is tethered to review, or when braille is tethered to automatically and follows temporarily review cursor. When user wants to review editable text without affecting system caret position (braille tethered to review continuously or temporarily), it maybe useful if he/she can route caret when needed for example to correct typos. Although thiskinds of routing has been possible, it has required at least one extra routing button press.
### Description of user facing changes
There is new setting "Route review cursor and system caret" in braille category. Setting is disabled by default. User can also add input gesture. If braille is tethered to focus, setting is hidden and gesture reports itself as unavailable.

If setting is enabled, and braille is tethered to review, or to automatically and braille follows temporarily review, routing buttons try to move system focus/caret.
### Description of development approach
This is modification from navigatorObject_moveFocus script so results should be similar.
### Testing strategy:
Tested using Albatross 80 model.
### Known issues with pull request:
none
### Change log entries:
New features
It is possible to move system caret with routing buttons especially in edit areas when braille is tethered to review.
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
