### PR TITLE
Fix up speechDictVars deprecation

### DIFF
--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -157,6 +157,5 @@ It handles case when the synthesizer doesn't support voice setting.
 		baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
 	else:
 		baseName=r"{synth}.dic".format(synth=synth.name)
-	voiceDictsPath = dictFormatUpgrade.voiceDictsPath
-	fileName= os.path.join(voiceDictsPath, synth.name, baseName)
+	fileName = os.path.join(WritePaths.voiceDictsDir, synth.name, baseName)
 	dictionaries["voice"].load(fileName)

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -4,6 +4,7 @@
 # See the file COPYING for more details.
 
 import re
+from typing import Any
 import globalVars
 from logHandler import log
 import os
@@ -11,6 +12,21 @@ import codecs
 
 from NVDAState import WritePaths
 from . import dictFormatUpgrade
+
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility.
+	"""
+	import NVDAState
+	if attrName == "speechDictsPath" and NVDAState._allowDeprecatedAPI():
+		log.warning(
+			"speechDictHandler.speechDictsPath is deprecated, "
+			"instead use NVDAState.WritePaths.speechDictsDir",
+			stack_info=True
+		)
+		return WritePaths.speechDictsDir
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
 
 dictionaries = {}
 dictTypes = ("temp", "voice", "default", "builtin") # ordered by their priority E.G. voice specific speech dictionary is processed before the default

--- a/source/speechDictHandler/dictFormatUpgrade.py
+++ b/source/speechDictHandler/dictFormatUpgrade.py
@@ -1,12 +1,13 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017 NV Access Limited
+# Copyright (C) 2017-2023 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """Upgrade speech dict files
 """
 
+from typing import Any
 import globalVars
 import os
 import api
@@ -14,8 +15,38 @@ import glob
 from logHandler import log
 from NVDAState import WritePaths
 
-voiceDictsPath = WritePaths.voiceDictsDir
-voiceDictsBackupPath = WritePaths.voiceDictsBackupDir
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility.
+	"""
+	import NVDAState
+	if NVDAState._allowDeprecatedAPI():
+		if attrName == "speechDictsPath":
+			log.warning(
+				"speechDictHandler.dictFormatUpgrade.speechDictsPath is deprecated, "
+				"instead use NVDAState.WritePaths.speechDictsDir",
+				stack_info=True
+			)
+			return WritePaths.speechDictsDir
+
+		if attrName == "voiceDictsPath":
+			log.warning(
+				"speechDictHandler.dictFormatUpgrade.voiceDictsPath is deprecated, "
+				"instead use NVDAState.WritePaths.voiceDictsDir",
+				stack_info=True
+			)
+			return WritePaths.voiceDictsDir
+
+		if attrName == "voiceDictsBackupPath":
+			log.warning(
+				"speechDictHandler.dictFormatUpgrade.voiceDictsBackupPath is deprecated, "
+				"instead use NVDAState.WritePaths.voiceDictsBackupDir",
+				stack_info=True
+			)
+			return WritePaths.voiceDictsBackupDir
+
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
 
 def createVoiceDictFileName(synthName, voiceName):
 	""" Creates a filename used for the voice dictionary files.
@@ -56,12 +87,12 @@ def _doSynthVoiceDictBackupAndMove(synthName, oldFileNameToNewFileNameList=None)
 	"""
 	import shutil
 	
-	if not os.path.isdir(voiceDictsPath):
-		os.makedirs(voiceDictsPath)
-	if not os.path.isdir(voiceDictsBackupPath):
-		os.makedirs(voiceDictsBackupPath)
+	if not os.path.isdir(WritePaths.voiceDictsDir):
+		os.makedirs(WritePaths.voiceDictsDir)
+	if not os.path.isdir(WritePaths.voiceDictsBackupDir):
+		os.makedirs(WritePaths.voiceDictsBackupDir)
 	
-	newDictPath = os.path.join(voiceDictsPath,synthName)
+	newDictPath = os.path.join(WritePaths.voiceDictsDir, synthName)
 	needsUpgrade = not os.path.isdir(newDictPath)
 	if needsUpgrade:
 		log.info("Upgrading voice dictionaries for %s"%synthName)
@@ -82,7 +113,7 @@ def _doSynthVoiceDictBackupAndMove(synthName, oldFileNameToNewFileNameList=None)
 			log.debug("processing file: %s" % actualPath)
 			# files will be copied here before we modify them so as to avoid
 			# any data loss.
-			shutil.copy(actualPath, voiceDictsBackupPath)
+			shutil.copy(actualPath, WritePaths.voiceDictsBackupDir)
 			
 			actualBasename = os.path.basename(actualPath)
 			log.debug("basename: %s" % actualBasename)

--- a/source/speechDictHandler/speechDictVars.py
+++ b/source/speechDictHandler/speechDictVars.py
@@ -14,7 +14,7 @@ from NVDAState import WritePaths
 if NVDAState._allowDeprecatedAPI():
 	log.warning(
 		"speechDictHandler.speechDictVars.speechDictsPath is deprecated, "
-		"instead use WritePaths.speechDictsDir",
+		"instead use NVDAState.WritePaths.speechDictsDir",
 		stack_info=True
 	)
 	speechDictsPath = WritePaths.speechDictsDir

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -151,7 +151,7 @@ Instead import from ``hwIo.ioThread``. (#14627)
 It was introduced in NVDA 2023.1 and was never meant to be part of the public API.
 Until removal, it behaves as a no-op, i.e. a context manager yielding nothing. (#14924)
 - ``gui.MainFrame.onAddonsManagerCommand`` is deprecated, use ``gui.MainFrame.onAddonStoreCommand`` instead. (#13985)
-- ``speechDictHandler.speechDictVars.speechDictsPath`` is deprecated, use ``WritePaths.speechDictsDir`` instead. (#15021)
+- ``speechDictHandler.speechDictVars.speechDictsPath`` is deprecated, use ``NVDAState.WritePaths.speechDictsDir`` instead. (#15021)
 -
 
 = 2023.1 =

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -152,6 +152,8 @@ It was introduced in NVDA 2023.1 and was never meant to be part of the public AP
 Until removal, it behaves as a no-op, i.e. a context manager yielding nothing. (#14924)
 - ``gui.MainFrame.onAddonsManagerCommand`` is deprecated, use ``gui.MainFrame.onAddonStoreCommand`` instead. (#13985)
 - ``speechDictHandler.speechDictVars.speechDictsPath`` is deprecated, use ``NVDAState.WritePaths.speechDictsDir`` instead. (#15021)
+- Importing ``voiceDictsPath`` and ``voiceDictsBackupPath`` from ``speechDictHandler.dictFormatUpgrade`` is deprecated.
+Instead use ``WritePaths.voiceDictsDir`` and ``WritePaths.voiceDictsBackupDir`` from ``NVDAState``. (#15048)
 -
 
 = 2023.1 =


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Follow up of #15021 

### Summary of the issue:
The deprecation was incorrectly documented, missing the module name and referring to `NVDAState.WritePaths.speechDictsDir` instead of `WritePaths.speechDictsDir`.

The change also caused some issues for add-ons who were relying on the deprecated code being imported into a different module.

### Description of user facing changes
N/A

### Description of development approach
For ease of use, compatibility for the imported code has been retained, despite not being an API breaking change.

Documentation of the deprecation has been fixed.

### Testing strategy:

### Known issues with pull request:
None

### Change log entries:
Refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
