### PR TITLE
Create registry key to force secure mode

### DIFF
--- a/devDocs/deprecations.md
+++ b/devDocs/deprecations.md
@@ -17,7 +17,9 @@ def __getattr__(attrName: str) -> Any:
 		# Note: this should only log in situations where it will not be excessively noisy.
 		log.warning(
 			"Importing deprecatedSymbolName from here is deprecated. "
-			"Import X instead and do Y. "
+			"Import X instead and do Y. ",
+			# Include stack info so testers can report warning to add-on author.
+			stack_info=True,
 		)
 		# Ensure the API of deprecatedSymbolNameReplacement is the same as the deprecated symbol.
 		return deprecatedSymbolNameReplacement
@@ -69,4 +71,3 @@ Any API breaking changes such as deprecations marked for removal should be comme
 
 ## Announcements
 Deprecations should be announced via the [NVDA API mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-api/about).
-

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2019 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
+# Copyright (C) 2007-2023 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -41,7 +41,7 @@ import core
 import textUtils
 import NVDAHelper
 import config
-import globalVars
+from utils.security import isRunningOnSecureDesktop
 
 #: The path to the user's .accessibility.properties file, used
 #: to enable JAB.
@@ -844,7 +844,9 @@ def initialize():
 		raise NotImplementedError("dll not available")
 	_fixBridgeFuncs()
 	if (
-		not globalVars.appArgs.secure and config.isInstalledCopy()
+		# We should not attempt to write to disk from the secure desktop.
+		not isRunningOnSecureDesktop()
+		and config.isInstalledCopy()
 		and not isBridgeEnabled()
 	):
 		enableBridge()

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -30,7 +30,7 @@ import api
 import globalVars
 from logHandler import log
 import NVDAState
-from utils.security import _isLockScreenModeActive
+from utils.security import isLockScreenModeActive
 
 versionedLibPath = os.path.join(globalVars.appDir, 'lib')
 versionedLibARM64Path = os.path.join(globalVars.appDir, 'libArm64')
@@ -460,7 +460,7 @@ def nvdaControllerInternal_installAddonPackageFromPath(addonPath):
 	if globalVars.appArgs.secure:
 		log.debugWarning("Unable to install add-on into secure copy of NVDA.")
 		return
-	if _isLockScreenModeActive():
+	if isLockScreenModeActive():
 		log.debugWarning("Unable to install add-on while Windows is locked.")
 		return
 	import wx
@@ -475,7 +475,7 @@ def nvdaControllerInternal_openConfigDirectory():
 	if globalVars.appArgs.secure:
 		log.debugWarning("Unable to open user config directory for secure copy of NVDA.")
 		return
-	if _isLockScreenModeActive():
+	if isLockScreenModeActive():
 		log.debugWarning("Unable to open user config directory while Windows is locked.")
 		return
 	import systemUtils

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -42,7 +42,7 @@ import globalPluginHandler
 import brailleInput
 import locationHelper
 import aria
-from winAPI.sessionTracking import _isLockScreenModeActive
+from winAPI.sessionTracking import isLockScreenModeActive
 
 
 class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
@@ -188,7 +188,7 @@ class DynamicNVDAObjectType(baseObject.ScriptableObject.__class__):
 		Inserts LockScreenObject to the start of the clsList if Windows is locked.
 		"""
 		from .lockscreen import LockScreenObject
-		if _isLockScreenModeActive():
+		if isLockScreenModeActive():
 			# This must be resolved first to prevent object navigation outside of the lockscreen.
 			clsList.insert(0, LockScreenObject)
 
@@ -1529,6 +1529,6 @@ This code is executed if a gain focus event is received by this object.
 	isBelowLockScreen: bool
 
 	def _get_isBelowLockScreen(self) -> bool:
-		if not _isLockScreenModeActive():
+		if not isLockScreenModeActive():
 			return False
 		return _isObjectBelowLockScreen(self)

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -146,11 +146,11 @@ class _TrackNVDAInitialization:
 	regardless of lock state.
 	Security checks may cause the desktop object to not be set if NVDA starts on the lock screen.
 	As such, during initialization, NVDA should behave as if Windows is unlocked,
-	i.e. winAPI.sessionTracking._isLockScreenModeActive should return False.
+	i.e. winAPI.sessionTracking.isLockScreenModeActive should return False.
 	"""
 
 	_isNVDAInitialized = False
-	"""When False, _isLockScreenModeActive is forced to return False.
+	"""When False, isLockScreenModeActive is forced to return False.
 	"""
 
 	@staticmethod

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import time
+import winreg
 
 import globalVars
 
@@ -160,3 +161,38 @@ class _TrackNVDAInitialization:
 	@staticmethod
 	def isInitializationComplete() -> bool:
 		return _TrackNVDAInitialization._isNVDAInitialized
+
+
+def _forceSecureModeEnabled() -> bool:
+	from config import RegistryKey
+	try:
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
+		return bool(winreg.QueryValueEx(k, RegistryKey.FORCE_SECURE_MODE_SUBKEY.value)[0])
+	except WindowsError:
+		# Expected state by default, forceSecureMode parameter not set
+		return False
+
+
+def _serviceDebugEnabled() -> bool:
+	from config import RegistryKey
+	try:
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
+		return bool(winreg.QueryValueEx(k, RegistryKey.SERVICE_DEBUG_SUBKEY.value)[0])
+	except WindowsError:
+		# Expected state by default, serviceDebug parameter not set
+		return False
+
+
+def	_configInLocalAppDataEnabled() -> bool:
+	from config import RegistryKey
+	from logHandler import log
+
+	try:
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
+		return bool(winreg.QueryValueEx(k, RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY.value)[0])
+	except FileNotFoundError:
+		log.debug("Installed user config is not in local app data")
+		return False
+	except WindowsError:
+		# Expected state by default, configInLocalAppData parameter not set
+		return False

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -183,7 +183,7 @@ def _serviceDebugEnabled() -> bool:
 		return False
 
 
-def	_configInLocalAppDataEnabled() -> bool:
+def _configInLocalAppDataEnabled() -> bool:
 	from config import RegistryKey
 	from logHandler import log
 

--- a/source/appModules/lockapp.py
+++ b/source/appModules/lockapp.py
@@ -21,13 +21,13 @@ from NVDAObjects.lockscreen import LockScreenObject
 from NVDAObjects.UIA import UIA
 import NVDAState
 from utils.security import getSafeScripts
-from winAPI.sessionTracking import _isLockScreenModeActive
+from winAPI.sessionTracking import isLockScreenModeActive
 
 """App module for the Windows 10 and 11 lock screen.
 
 The lock screen allows other windows to be opened, so security related functions
 are done at a higher level than the lockapp app module.
-Refer to usages of `winAPI.sessionTracking._isLockScreenModeActive`.
+Refer to usages of `winAPI.sessionTracking.isLockScreenModeActive`.
 """
 
 
@@ -60,7 +60,7 @@ class AppModule(appModuleHandler.AppModule):
 		if isinstance(obj,UIA) and obj.role==controlTypes.Role.PANE and obj.UIAElement.cachedClassName=="LockAppContainer":
 			clsList.insert(0,LockAppContainer)
 
-		if not _isLockScreenModeActive():
+		if not isLockScreenModeActive():
 			log.debugWarning(
 				"LockApp is being initialized but NVDA does not expect Windows to be locked. "
 				"DynamicNVDAObjectType may have failed to apply LockScreenObject. "

--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -17,7 +17,7 @@ from logHandler import log
 import fonts
 import inputCore
 import gui.contextHelp
-from utils.security import _isLockScreenModeActive, post_sessionLockStateChanged
+from utils.security import isLockScreenModeActive, post_sessionLockStateChanged
 
 BRAILLE_UNICODE_PATTERNS_START = 0x2800
 BRAILLE_SPACE_CHARACTER = chr(BRAILLE_UNICODE_PATTERNS_START)
@@ -398,7 +398,7 @@ class BrailleViewerFrame(
 		self._shouldShowOnStartupCheckBox.SetValue(config.conf["brailleViewer"]["showBrailleViewerAtStartup"])
 		self._shouldShowOnStartupCheckBox.Bind(wx.EVT_CHECKBOX, self._onShouldShowOnStartupChanged)
 		optionsSizer.Add(self._shouldShowOnStartupCheckBox)
-		if _isLockScreenModeActive():
+		if isLockScreenModeActive():
 			self._shouldShowOnStartupCheckBox.Disable()
 
 		# Translators: The label for a setting in the braille viewer that controls
@@ -415,11 +415,11 @@ class BrailleViewerFrame(
 		sizer.Add(optionsSizer, flag=wx.EXPAND | wx.TOP, border=5)
 
 	def _onShouldShowOnStartupChanged(self, evt: wx.CommandEvent):
-		if not _isLockScreenModeActive():
+		if not isLockScreenModeActive():
 			config.conf["brailleViewer"]["showBrailleViewerAtStartup"] = self._shouldShowOnStartupCheckBox.IsChecked()
 
 	def _onShouldHoverRouteToCellCheckBoxChanged(self, evt: wx.CommandEvent):
-		if not _isLockScreenModeActive():
+		if not isLockScreenModeActive():
 			config.conf["brailleViewer"]["shouldHoverRouteToCell"] = self._shouldHoverRouteToCellCheckBox.IsChecked()
 		self._updateMouseOverBinding(self._shouldHoverRouteToCellCheckBox.IsChecked())
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -91,6 +91,14 @@ def __getattr__(attrName: str) -> Any:
 		)
 		from addonHandler.packaging import addDirsToPythonPackagePath
 		return addDirsToPythonPackagePath
+	if attrName == "CONFIG_IN_LOCAL_APPDATA_SUBKEY" and NVDAState._allowDeprecatedAPI():
+		# Note: this should only log in situations where it will not be excessively noisy.
+		log.warning(
+			"CONFIG_IN_LOCAL_APPDATA_SUBKEY is deprecated. "
+			"Instead use RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY. ",
+			stack_info=True,
+		)
+		return RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY.value
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -27,7 +27,7 @@ from configobj.validate import Validator
 from logHandler import log
 import logging
 from logging import DEBUG
-import shlobj
+from shlobj import FolderId, SHGetKnownFolderPath
 import baseObject
 import easeOfAccess
 from fileUtils import FaultTolerantFile
@@ -187,9 +187,12 @@ def getInstalledUserConfigPath() -> Optional[str]:
 		log.error("Could not open nvda registry key", exc_info=True)
 		return None
 
-	appDataFolder = shlobj.FolderId.LOCAL_APP_DATA if NVDAState._configInLocalAppDataEnabled() else shlobj.FolderId.ROAMING_APP_DATA
+	if NVDAState._configInLocalAppDataEnabled():
+		configFolder = FolderId.LOCAL_APP_DATA
+	else:
+		configFolder = FolderId.ROAMING_APP_DATA
 
-	configParent = shlobj.SHGetKnownFolderPath(appDataFolder)
+	configParent = SHGetKnownFolderPath(configFolder)
 	try:
 		return os.path.join(configParent, "nvda")
 	except WindowsError:

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -50,10 +50,11 @@ class DefaultAppArgs(argparse.Namespace):
 	This is also set to True when NVDA is running on a secure screen
 	(systemUtils._isSecureDesktop() returns True)
 	and the serviceDebug parameter is not set.
+	This is forced to true if the forceSecureMode parameter is set.
 
 	For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
 	and the following userGuide sections:
-	 - SystemWideParameters (information on the serviceDebug parameter)
+	 - SystemWideParameters (information on the serviceDebug and forceSecureMode parameters)
 	 - SecureMode and SecureScreens
 	"""
 	disableAddons: bool = False

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -48,7 +48,7 @@ class DefaultAppArgs(argparse.Namespace):
 	When this is True, NVDA is running in secure mode.
 	This is set to True when NVDA starts with the --secure parameter.
 	This is also set to True when NVDA is running on a secure screen
-	(systemUtils.isRunningOnSecureDesktop() returns True)
+	(utils.security.isRunningOnSecureDesktop() returns True)
 	and the serviceDebug parameter is not set.
 	This is forced to true if the forceSecureMode parameter is set.
 

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -48,7 +48,7 @@ class DefaultAppArgs(argparse.Namespace):
 	When this is True, NVDA is running in secure mode.
 	This is set to True when NVDA starts with the --secure parameter.
 	This is also set to True when NVDA is running on a secure screen
-	(systemUtils._isSecureDesktop() returns True)
+	(systemUtils.isRunningOnSecureDesktop() returns True)
 	and the serviceDebug parameter is not set.
 	This is forced to true if the forceSecureMode parameter is set.
 

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -10,6 +10,7 @@ from functools import wraps
 import globalVars
 from typing import Callable
 import ui
+from utils.security import isLockScreenModeActive, isRunningOnSecureDesktop
 from gui.message import isModalMessageBoxActive
 import queueHandler
 
@@ -39,7 +40,7 @@ class Context(_Context, Enum):
 		_("Action unavailable while a dialog requires a response"),
 	)
 	WINDOWS_LOCKED = (
-		lambda: globalVars.appArgs.secure,
+		lambda: isLockScreenModeActive() or isRunningOnSecureDesktop(),
 		# Translators: Reported when an action cannot be performed because Windows is locked.
 		_("Action unavailable while Windows is locked"),
 	)

--- a/source/installer.py
+++ b/source/installer.py
@@ -29,20 +29,6 @@ from typing import (
 import NVDAState
 from NVDAState import WritePaths
 
-
-def __getattr__(attrName: str) -> Any:
-	"""Module level `__getattr__` used to preserve backward compatibility."""
-	if attrName == "CONFIG_IN_LOCAL_APPDATA_SUBKEY" and NVDAState._allowDeprecatedAPI():
-		# Note: this should only log in situations where it will not be excessively noisy.
-		log.warning(
-			"Importing CONFIG_IN_LOCAL_APPDATA_SUBKEY from here is deprecated. "
-			"Instead use config.RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY. ",
-			stack_info=True,
-		)
-		return config.RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY.value
-	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
-
-
 _wsh=None
 def _getWSH():
 	global _wsh

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -355,6 +355,18 @@ if mutex is None:
 	sys.exit(1)
 
 
+def _forceSecureModeEnabled() -> bool:
+	import winreg
+	try:
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NVDA")
+		if winreg.QueryValueEx(k, "forceSecureMode")[0]:
+			return True
+	except WindowsError:
+		# Expected state by default, forceSecureMode parameter not set
+		pass
+	return False
+
+
 def _serviceDebugEnabled() -> bool:
 	import winreg
 	try:
@@ -365,6 +377,10 @@ def _serviceDebugEnabled() -> bool:
 		# Expected state by default, serviceDebug parameter not set
 		pass
 	return False
+
+
+if _forceSecureModeEnabled():
+	globalVars.appArgs.secure = True
 
 
 if _isSecureDesktop():

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -276,7 +276,8 @@ elif globalVars.appArgs.check_running:
 
 
 # Suppress E402 (module level import not at top of file)
-from systemUtils import _getDesktopName, _isSecureDesktop  # noqa: E402
+from utils.security import isRunningOnSecureDesktop  # noqa: E402
+from systemUtils import _getDesktopName  # noqa: E402
 # Ensure multiple instances are not fully started by using a mutex
 desktopName = _getDesktopName()
 _log.info(f"DesktopName: {desktopName}")
@@ -359,7 +360,7 @@ if NVDAState._forceSecureModeEnabled():
 	globalVars.appArgs.secure = True
 
 
-if _isSecureDesktop():
+if isRunningOnSecureDesktop():
 	if not NVDAState._serviceDebugEnabled():
 		globalVars.appArgs.secure = True
 	globalVars.appArgs.changeScreenReaderFlag = False
@@ -390,7 +391,7 @@ if not ctypes.windll.user32.ChangeWindowMessageFilter(winUser.WM_QUIT, winUser.M
 	raise winUser.WinError()
 # Make this the last application to be shut down and don't display a retry dialog box.
 winKernel.SetProcessShutdownParameters(0x100, winKernel.SHUTDOWN_NORETRY)
-if not _isSecureDesktop() and not config.isAppX:
+if not isRunningOnSecureDesktop() and not config.isAppX:
 	import easeOfAccess
 	easeOfAccess.notify(3)
 try:
@@ -400,7 +401,7 @@ except:
 	log.critical("core failure",exc_info=True)
 	sys.exit(1)
 finally:
-	if not _isSecureDesktop() and not config.isAppX:
+	if not isRunningOnSecureDesktop() and not config.isAppX:
 		easeOfAccess.notify(2)
 	if globalVars.appArgs.changeScreenReaderFlag:
 		winUser.setSystemScreenReaderFlag(False)

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -355,36 +355,12 @@ if mutex is None:
 	sys.exit(1)
 
 
-def _forceSecureModeEnabled() -> bool:
-	import winreg
-	try:
-		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NVDA")
-		if winreg.QueryValueEx(k, "forceSecureMode")[0]:
-			return True
-	except WindowsError:
-		# Expected state by default, forceSecureMode parameter not set
-		pass
-	return False
-
-
-def _serviceDebugEnabled() -> bool:
-	import winreg
-	try:
-		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NVDA")
-		if winreg.QueryValueEx(k, "serviceDebug")[0]:
-			return True
-	except WindowsError:
-		# Expected state by default, serviceDebug parameter not set
-		pass
-	return False
-
-
-if _forceSecureModeEnabled():
+if NVDAState._forceSecureModeEnabled():
 	globalVars.appArgs.secure = True
 
 
 if _isSecureDesktop():
-	if not _serviceDebugEnabled():
+	if not NVDAState._serviceDebugEnabled():
 		globalVars.appArgs.secure = True
 	globalVars.appArgs.changeScreenReaderFlag = False
 	globalVars.appArgs.minimal = True

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -105,11 +105,11 @@ def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List["inputCore.In
 
 def findScript(gesture: "inputCore.InputGesture") -> Optional[_ScriptFunctionT]:
 	from utils.security import getSafeScripts
-	from winAPI.sessionTracking import _isLockScreenModeActive
+	from winAPI.sessionTracking import isLockScreenModeActive
 	foundScript = _findScript(gesture)
 	if (
 		foundScript is not None
-		and _isLockScreenModeActive()
+		and isLockScreenModeActive()
 		and foundScript not in getSafeScripts()
 	):
 		return None

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -13,7 +13,7 @@ import config
 from logHandler import log
 from speech import SpeechSequence
 import gui.contextHelp
-from utils.security import _isLockScreenModeActive, post_sessionLockStateChanged
+from utils.security import isLockScreenModeActive, post_sessionLockStateChanged
 
 
 # Inherit from wx.Frame because these windows show in the alt+tab menu (where miniFrame does not)
@@ -102,7 +102,7 @@ class SpeechViewerFrame(
 			wx.EVT_CHECKBOX,
 			self.onShouldShowOnStartupChanged
 		)
-		if _isLockScreenModeActive():
+		if isLockScreenModeActive():
 			self.shouldShowOnStartupCheckBox.Disable()
 
 	def _onDialogActivated(self, evt):
@@ -119,7 +119,7 @@ class SpeechViewerFrame(
 		deactivate()
 
 	def onShouldShowOnStartupChanged(self, evt: wx.CommandEvent):
-		if not _isLockScreenModeActive():
+		if not isLockScreenModeActive():
 			config.conf["speechViewer"]["showSpeechViewerAtStartup"] = self.shouldShowOnStartupCheckBox.IsChecked()
 
 	_isDestroyed: bool

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -348,6 +348,7 @@ class SynthDriver(driverHandler.Driver):
 			val = c[s.id]
 			if onlyChanged and getattr(self, s.id) == val:
 				continue
+			# log.debug() ? what is being set here and why?
 			setattr(self, s.id, val)
 		log.debug(
 			(

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -348,7 +348,6 @@ class SynthDriver(driverHandler.Driver):
 			val = c[s.id]
 			if onlyChanged and getattr(self, s.id) == val:
 				continue
-			# log.debug() ? what is being set here and why?
 			setattr(self, s.id, val)
 		log.debug(
 			(

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -167,22 +167,6 @@ def _getDesktopName() -> str:
 	return name.value
 
 
-def _isSecureDesktop() -> bool:
-	"""
-	When NVDA is running on a secure screen,
-	it is running on the secure desktop.
-	When the serviceDebug parameter is not set,
-	NVDA should run in secure mode when on the secure desktop.
-	globalVars.appArgs.secure being set to True means NVDA is running in secure mode.
-
-	For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
-	and the following userGuide sections:
-	 - SystemWideParameters (information on the serviceDebug parameter)
-	 - SecureMode and SecureScreens
-	"""
-	return _getDesktopName() == "Winlogon"
-
-
 def _displayTextFileWorkaround(file: str) -> None:
 	# os.startfile does not currently (NVDA 2023.1, Python 3.7) work reliably to open .txt files in Notepad under
 	# Windows 11, if relying on the default behavior (i.e. `operation="open"`). (#14725)

--- a/source/ui.py
+++ b/source/ui.py
@@ -24,7 +24,7 @@ from config.configFlags import TetherTo
 import globalVars
 from typing import Optional
 
-from systemUtils import _isSecureDesktop
+from utils.security import isRunningOnSecureDesktop
 
 # From urlmon.h
 URL_MK_UNIFORM = 1
@@ -89,7 +89,7 @@ def browseableMessage(message: str, title: Optional[str] = None, isHtml: bool = 
 	@param isHtml: Whether the message is html
 	"""
 	splitWith: str = "__NVDA:split-here__"  # Unambiguous regex splitter for javascript in message.html, #14667
-	if _isSecureDesktop():
+	if isRunningOnSecureDesktop():
 		import wx  # Late import to prevent circular dependency.
 		wx.CallAfter(_warnBrowsableMessageNotAvailableOnSecureScreens, title)
 		return

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -17,7 +17,7 @@ from typing import (
 import extensionPoints
 from logHandler import log
 import systemUtils
-from winAPI.sessionTracking import _isLockScreenModeActive
+from winAPI.sessionTracking import isLockScreenModeActive
 import winUser
 
 if TYPE_CHECKING:
@@ -170,7 +170,7 @@ def objectBelowLockScreenAndWindowsIsLocked(
 	@return: C{True} if the Windows 10/11 lockscreen is active and C{obj} is below the lock screen.
 	"""
 	try:
-		isObjectBelowLockScreen = _isLockScreenModeActive() and obj.isBelowLockScreen
+		isObjectBelowLockScreen = isLockScreenModeActive() and obj.isBelowLockScreen
 	except Exception:
 		log.exception()
 		return False

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -16,6 +16,7 @@ from typing import (
 
 import extensionPoints
 from logHandler import log
+import systemUtils
 from winAPI.sessionTracking import _isLockScreenModeActive
 import winUser
 
@@ -403,3 +404,19 @@ def sha256_checksum(binaryReadModeFile: BinaryIO, blockSize: int = SHA_BLOCK_SIZ
 	for block in iter(lambda: f.read(blockSize), b''):
 		sha256sum.update(block)
 	return sha256sum.hexdigest()
+
+
+def isRunningOnSecureDesktop() -> bool:
+	"""
+	When NVDA is running on a secure screen,
+	it is running on the secure desktop.
+	When the serviceDebug parameter is not set,
+	NVDA should run in secure mode when on the secure desktop.
+	globalVars.appArgs.secure being set to True means NVDA is running in secure mode.
+
+	For more information, refer to devDocs/technicalDesignOverview.md 'Logging in secure mode'
+	and the following userGuide sections:
+	 - SystemWideParameters (information on the serviceDebug parameter)
+	 - SecureMode and SecureScreens
+	"""
+	return systemUtils._getDesktopName() == "Winlogon"

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -154,8 +154,8 @@ def _isLockScreenModeActive() -> bool:
 	Includes temporary locked desktops,
 	such as the PIN workflow reset and the Out Of Box Experience.
 	"""
-	from systemUtils import _isSecureDesktop
-	if _isSecureDesktop():
+	from utils.security import isRunningOnSecureDesktop
+	if isRunningOnSecureDesktop():
 		# Use secure mode instead if on the secure desktop
 		return False
 

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -147,7 +147,7 @@ def _isWindowsLocked() -> bool:
 	return _lockStateTracker.isWindowsLocked
 
 
-def _isLockScreenModeActive() -> bool:
+def isLockScreenModeActive() -> bool:
 	"""
 	Checks if the Window lock screen is active.
 	Not to be confused with the Windows sign-in screen, a secure screen.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -52,6 +52,7 @@ What's New in NVDA
 - When using Excel shortcuts to toggle format such as bold, italic, underline and strike through of a cell in Excel, the result is now reported. (#14923)
 - Added support for the Help Tech Activator Braille display. (#14917)
 - In Windows 10 May 2019 Update and later, NVDA can announce virtual desktop names when opening, changing, and closing them. (#5641)
+- A system wide parameter has been added to allow users and system administrators to force NVDA to start in secure mode. (#10018)
 - 
 
 
@@ -163,6 +164,8 @@ Until removal, it behaves as a no-op, i.e. a context manager yielding nothing. (
 - ``speechDictHandler.speechDictVars.speechDictsPath`` is deprecated, use ``NVDAState.WritePaths.speechDictsDir`` instead. (#15021)
 - Importing ``voiceDictsPath`` and ``voiceDictsBackupPath`` from ``speechDictHandler.dictFormatUpgrade`` is deprecated.
 Instead use ``WritePaths.voiceDictsDir`` and ``WritePaths.voiceDictsBackupDir`` from ``NVDAState``. (#15048)
+- ``config.CONFIG_IN_LOCAL_APPDATA_SUBKEY`` is deprecated.
+Instead use ``config.RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY``. (#15049)
 -
 
 = 2023.1 =

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3923,6 +3923,7 @@ Secure mode disables:
 - The [Add-on Store #AddonsManager]
 - The [NVDA Python console #PythonConsole]
 - The [Log Viewer #LogViewer] and logging
+- Opening external documents from the NVDA menu, such as the user guide or contributors file.
 -
 
 Installed copies of NVDA store their configuration including add-ons in ``%APPDATA%\nvda``.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3905,18 +3905,32 @@ Following are the current key assignments for these displays.
 + Advanced Topics +[AdvancedTopics]
 
 ++ Secure Mode ++[SecureMode]
-NVDA can be started in secure mode with the ``-s`` [command line option #CommandLineOptions].
+System administrators may wish to configure NVDA to restrict unauthorized system access.
+NVDA allows the installation of custom add-ons, which can execute arbitrary code, including when NVDA is elevated to administrator privileges.
+NVDA also allows users to execute arbitrary code through the NVDA Python Console.
+NVDA secure mode prevents users from modifying their NVDA configuration, and otherwise limits unauthorized system access.
+
 NVDA runs in secure mode when executed on [secure screens #SecureScreens], unless the ``serviceDebug`` [system wide parameter #SystemWideParameters] is enabled.
+To force NVDA to always start in secure mode, set the ``forceSecureMode`` [system wide parameter #SystemWideParameters].
+NVDA can also be started in secure mode with the ``-s`` [command line option #CommandLineOptions].
 
 Secure mode disables:
 
 - Saving configuration and other settings to disk
 - Saving the gesture map to disk
-- [Configuration Profile #ConfigurationProfiles] features such as creation, deletion, renaming profiles e.t.c.
+- [Configuration Profile #ConfigurationProfiles] features such as creation, deletion, renaming profiles etc.
 - Updating NVDA and creating portable copies
-- The [Python console #PythonConsole]
+- The [Add-on Store #AddonsManager]
+- The [NVDA Python console #PythonConsole]
 - The [Log Viewer #LogViewer] and logging
 -
+
+Installed copies of NVDA store their configuration including add-ons in ``%APPDATA%\nvda``.
+To prevent NVDA users from modifying their configuration or add-ons directly, user access to this folder must also be restricted.
+
+NVDA users often rely on configurating their NVDA profile to suit their needs.
+This may include installing and configuring custom add-ons, which should be vetted independently to NVDA.
+Secure mode freezes changes to NVDA configuration, so please ensure that NVDA is configured appropriately before forcing secure mode.
 
 ++ Secure Screens ++[SecureScreens]
 NVDA runs in [secure mode #SecureMode] when executed on secure screens unless the ``serviceDebug`` [system wide parameter #SystemWideParameters] is enabled.
@@ -3987,8 +4001,9 @@ These values are stored in the registry under one of the following keys:
 
 The following values can be set under this registry key:
 || Name | Type | Possible values | Description |
-| configInLocalAppData | DWORD | 0 (default) to disable, 1 to enable | If enabled, stores the NVDA user configuration in the local application data instead of the roaming application data |
-| serviceDebug | DWORD | 0 (default) to disable, 1 to enable | If enabled, disables [Secure Mode #SecureMode] on [secure screens #SecureScreens]. Due to several major security implications, the use of this option is strongly discouraged |
+| ``configInLocalAppData`` | DWORD | 0 (default) to disable, 1 to enable | If enabled, stores the NVDA user configuration in the local application data instead of the roaming application data |
+| ``serviceDebug`` | DWORD | 0 (default) to disable, 1 to enable | If enabled, disables [Secure Mode #SecureMode] on [secure screens #SecureScreens]. Due to several major security implications, the use of this option is strongly discouraged |
+| ``forceSecureMode`` | DWORD | 0 (default) to disable, 1 to enable | If enabled, forces [Secure Mode #SecureMode] to be enabled when running NVDA. |
 
 + Further Information +[FurtherInformation]
 If you require further information or assistance regarding NVDA, please visit the NVDA web site at NVDA_URL.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3929,7 +3929,7 @@ Secure mode disables:
 Installed copies of NVDA store their configuration including add-ons in ``%APPDATA%\nvda``.
 To prevent NVDA users from modifying their configuration or add-ons directly, user access to this folder must also be restricted.
 
-NVDA users often rely on configurating their NVDA profile to suit their needs.
+NVDA users often rely on configuring their NVDA profile to suit their needs.
 This may include installing and configuring custom add-ons, which should be vetted independently to NVDA.
 Secure mode freezes changes to NVDA configuration, so please ensure that NVDA is configured appropriately before forcing secure mode.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #10018

### Summary of the issue:
System administrators may wish to configure NVDA to restrict unauthorized system access.
Secure mode can be forced through the `--secure` CLI parameter, however, forcing this parameter is not easily done for system administrators.

In a corporate environment where application usage is restricted, NVDA should be forced into secure mode via a registry key parameter, rather than a CLI parameter

### Description of user facing changes
Added a registry key parameter to force secure mode of NVDA.

Improved documentation for system administrators on secure mode.

### Description of development approach
Added a registry key parameter to force secure mode of NVDA.

make isRunningOnSecureDesktop and isLockScreenModeActive  part of public API

### Testing strategy:
Tested setting the reg key parameter.

### Known issues with pull request:
None

### Change log entries:
**After 2023.2 release, relevant info should be added to the [NV Access corporate page](https://www.nvaccess.org/corporate-government/)**

**New features**

A system wide parameter has been added to allow users and system administrators to force NVDA to start in secure mode.

**Deprecations**
config.CONFIG_IN_LOCAL_APPDATA_SUBKEY is deprecated. Instead use config.RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY. 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
