### PR TITLE
Check existence of braille handler display before fetching gestureMap

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2631,7 +2631,8 @@ RENAMED_DRIVERS = {
 	"hid": "hidBrailleStandard",
 }
 
-handler: BrailleHandler
+handler: Optional[BrailleHandler] = None
+
 
 def initialize():
 	global handler

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -691,7 +691,7 @@ class _AllGestureMappingsRetriever(object):
 		self.addGlobalMap(manager.userGestureMap)
 		self.addGlobalMap(manager.localeGestureMap)
 		import braille
-		gmap = braille.handler.display.gestureMap
+		gmap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None
 		if gmap:
 			self.addGlobalMap(gmap)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14750

### Summary of the issue:
If a braille display is initialized, but then disconnected, the input gestures dialog cannot be opened.

### Description of user facing changes

### Description of development approach
As per handling in `scriptHandler`, we must check the existence of braille handler display before fetching gestureMap

https://github.com/nvaccess/nvda/blob/7a9b40a9afc54927f8d325028632cffa60e19df4/source/scriptHandler.py#L97

### Testing strategy:
- [ ] Confirm manual testing from @zstanecic 

### Known issues with pull request:
None

### Change log entries:
N/A fixes regression?

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
