### PR TITLE
Add-on store - Clarify window title and list label

### DIFF
--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -274,11 +274,11 @@ class AddonStoreDialog(SettingsDialog):
 
 	@property
 	def _titleText(self) -> str:
-		return f"{self.title} - {self._listLabelText}"
+		return f"{self.title} - {self._statusFilterKey.displayString} ({self._channelFilterKey.displayString})"
 
 	@property
 	def _listLabelText(self) -> str:
-		return f"{self._channelFilterKey.displayString} {self._statusFilterKey.displayString}"
+		return f"{self._statusFilterKey.displayString}"
 
 	def _setListLabels(self):
 		self.listLabel.SetLabelText(self._listLabelText)


### PR DESCRIPTION
### Link to issue number:
Fixes #15042
### Summary of the issue:
The title of add-on store window is formatted such as "Add-on Store - All Installed add-ons"
After the dash, the string is a concatenation of the channel and the type of add-ons in the list.
* In English,it makes something almost grammatically correct to build a single expression (if we ignore case). But in other languages, this concatenation without any separator may produce stranger results that sound bad.
* Also, it has been noted that the type of add-on listed ("Available add-ons" in this example) is much more important than the channel; thus it should come first.

### Description of user facing changes
* Reworked the window title to create a title such as "Add-on Store - Installed add-ons (All)"
* While at it, also removed the channel in the list name as pointed in https://github.com/nvaccess/nvda/issues/15042#issuecomment-1603600419, that is, the list's name is now "Available add-ons" instead of "All Available add-ons" so that the list name is less verbose.

### Description of development approach
Implemented changes described below.

Note: I have used parenthesis for the channel, but I may have used a second dash as a separator instead, i.e. "Add-on store - Available add-ons - All". Let me know if you prefer this second version.
### Testing strategy:
Manually checked the window title and the list name.
### Known issues with pull request:

### Change log entries:
Not needed on unreleased code
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
