### PR TITLE
Add-on store: Improve refreshing the cache

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -39,6 +39,7 @@ from .models.addon import (
 )
 from .models.channel import Channel
 from .network import (
+	_getCurrentApiVersionForURL,
 	_getAddonStoreURL,
 	_getCacheHashURL,
 	_LATEST_API_VER,

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -119,7 +119,7 @@ class _DataManager:
 				f" response ({response.status_code}): {response.content}"
 			)
 			return None
-		cacheHash = response.content.decode().strip('"')
+		cacheHash = response.json()
 		return cacheHash
 
 	def _cacheCompatibleAddons(self, addonData: str, cacheHash: Optional[str]):

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -122,13 +122,13 @@ class _DataManager:
 		cacheHash = response.json()
 		return cacheHash
 
-	def _cacheCompatibleAddons(self, addonData: str):
+	def _cacheCompatibleAddons(self, addonData: str, cacheHash: str):
 		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData:
 			return
 		cacheData = {
-			"cacheHash": self._getCacheHash(),
+			"cacheHash": cacheHash,
 			"data": addonData,
 			"cachedLanguage": self._lang,
 			"nvdaAPIVersion": addonAPIVersion.CURRENT,
@@ -136,13 +136,13 @@ class _DataManager:
 		with open(self._cacheCompatibleFile, 'w') as cacheFile:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
-	def _cacheLatestAddons(self, addonData: str):
+	def _cacheLatestAddons(self, addonData: str, cacheHash: str):
 		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData:
 			return
 		cacheData = {
-			"cacheHash": self._getCacheHash(),
+			"cacheHash": cacheHash,
 			"data": addonData,
 			"cachedLanguage": self._lang,
 			"nvdaAPIVersion": _LATEST_API_VER,
@@ -190,6 +190,7 @@ class _DataManager:
 				decodedApiData = apiData.decode()
 				self._cacheCompatibleAddons(
 					addonData=decodedApiData,
+					cacheHash=cacheHash,
 				)
 				self._compatibleAddonCache = CachedAddonsModel(
 					cachedAddonData=_createStoreCollectionFromJson(decodedApiData),

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -183,7 +183,7 @@ class _DataManager:
 		shouldRefreshData = (
 			not self._compatibleAddonCache
 			or self._compatibleAddonCache.nvdaAPIVersion != addonAPIVersion.CURRENT
-			or self._compatibleAddonCache.cacheHash != cacheHash
+			or cacheHash and (self._compatibleAddonCache.cacheHash != cacheHash)
 			or self._compatibleAddonCache.cachedLanguage != self._lang
 		)
 		if shouldRefreshData:
@@ -220,7 +220,7 @@ class _DataManager:
 		cacheHash = self._getCacheHash()
 		shouldRefreshData = (
 			not self._latestAddonCache
-			or self._latestAddonCache.cacheHash != cacheHash
+			or cacheHash and (self._latestAddonCache.cacheHash != cacheHash)
 			or self._latestAddonCache.cachedLanguage != self._lang
 		)
 		if shouldRefreshData:

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -40,7 +40,6 @@ from .models.addon import (
 from .models.channel import Channel
 from .network import (
 	_getAddonStoreURL,
-	_getCurrentApiVersionForURL,
 	_getCacheHashURL,
 	_LATEST_API_VER,
 )

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -157,6 +157,7 @@ class _DataManager:
 			try:
 				cacheData = json.load(cacheFile)
 			except Exception:
+				log.exception(f"Invalid add-on store cache")
 				return None
 		try:
 			data = cacheData["data"]
@@ -164,6 +165,7 @@ class _DataManager:
 			cachedLanguage = cacheData["cachedLanguage"]
 			nvdaAPIVersion = cacheData["nvdaAPIVersion"]
 		except KeyError:
+			log.exception(f"Invalid add-on store cache:\n{cacheData}")
 			return None
 		return CachedAddonsModel(
 			cachedAddonData=_createStoreCollectionFromJson(data),

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -158,13 +158,14 @@ class _DataManager:
 		if not cacheData:
 			return None
 		try:
+			data = cacheData["data"]
 			cacheHash = cacheData["cacheHash"]
 			cachedLanguage = cacheData["cachedLanguage"]
 			nvdaAPIVersion = cacheData["nvdaAPIVersion"]
 		except KeyError:
 			return None
 		return CachedAddonsModel(
-			cachedAddonData=_createStoreCollectionFromJson(cacheData["data"]),
+			cachedAddonData=_createStoreCollectionFromJson(data),
 			cacheHash=cacheHash,
 			cachedLanguage=cachedLanguage,
 			nvdaAPIVersion=tuple(nvdaAPIVersion),  # loads as list,

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -154,9 +154,10 @@ class _DataManager:
 		if not os.path.exists(cacheFilePath):
 			return None
 		with open(cacheFilePath, 'r') as cacheFile:
-			cacheData = json.load(cacheFile)
-		if not cacheData:
-			return None
+			try:
+				cacheData = json.load(cacheFile)
+			except Exception:
+				return None
 		try:
 			data = cacheData["data"]
 			cacheHash = cacheData["cacheHash"]

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -125,7 +125,7 @@ class _DataManager:
 	def _cacheCompatibleAddons(self, addonData: str, cacheHash: str):
 		if not NVDAState.shouldWriteToDisk():
 			return
-		if not addonData:
+		if not addonData or not cacheHash:
 			return
 		cacheData = {
 			"cacheHash": cacheHash,
@@ -139,7 +139,7 @@ class _DataManager:
 	def _cacheLatestAddons(self, addonData: str, cacheHash: str):
 		if not NVDAState.shouldWriteToDisk():
 			return
-		if not addonData:
+		if not addonData or not cacheHash:
 			return
 		cacheData = {
 			"cacheHash": cacheHash,

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -185,7 +185,8 @@ class _DataManager:
 		shouldRefreshData = (
 			not self._compatibleAddonCache
 			or self._compatibleAddonCache.nvdaAPIVersion != addonAPIVersion.CURRENT
-			or cacheHash and (self._compatibleAddonCache.cacheHash != cacheHash)
+			or cacheHash is None
+			or self._compatibleAddonCache.cacheHash != cacheHash
 			or self._compatibleAddonCache.cachedLanguage != self._lang
 		)
 		if shouldRefreshData:
@@ -222,7 +223,8 @@ class _DataManager:
 		cacheHash = self._getCacheHash()
 		shouldRefreshData = (
 			not self._latestAddonCache
-			or cacheHash and (self._latestAddonCache.cacheHash != cacheHash)
+			or cacheHash is None
+			or self._latestAddonCache.cacheHash != cacheHash
 			or self._latestAddonCache.cachedLanguage != self._lang
 		)
 		if shouldRefreshData:

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -227,6 +227,7 @@ class _DataManager:
 				decodedApiData = apiData.decode()
 				self._cacheLatestAddons(
 					addonData=decodedApiData,
+					cacheHash=cacheHash,
 				)
 				self._latestAddonCache = CachedAddonsModel(
 					cachedAddonData=_createStoreCollectionFromJson(decodedApiData),

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -204,6 +204,7 @@ class AddonStoreModel(_AddonGUIModel):
 class CachedAddonsModel:
 	cachedAddonData: "AddonGUICollectionT"
 	cachedAt: datetime
+	cacheHash: Optional[str]
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER
 	nvdaAPIVersion: Union[addonAPIVersion.AddonApiVersionT, str]

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import dataclasses
-from datetime import datetime
 import json
 import os
 from typing import (
@@ -203,7 +202,6 @@ class AddonStoreModel(_AddonGUIModel):
 @dataclasses.dataclass
 class CachedAddonsModel:
 	cachedAddonData: "AddonGUICollectionT"
-	cachedAt: datetime
 	cacheHash: Optional[str]
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -202,7 +202,7 @@ class AddonStoreModel(_AddonGUIModel):
 @dataclasses.dataclass
 class CachedAddonsModel:
 	cachedAddonData: "AddonGUICollectionT"
-	cacheHash: Optional[str]
+	cacheHash: str
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER
 	nvdaAPIVersion: Union[addonAPIVersion.AddonApiVersionT, str]

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 	from gui.message import DisplayableError
 
 
-_CACHE_HASH_URL = "https://www.nvaccess.org/addonStore/cacheHash.json"
+_BASE_URL = "https://nvaccess.org/addonStore/"
 _LATEST_API_VER = "latest"
 """
 A string value used in the add-on store to fetch the latest version of all add-ons,
@@ -50,7 +50,11 @@ def _getCurrentApiVersionForURL() -> str:
 
 def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
 	_baseURL = "https://nvaccess.org/addonStore/"
-	return _baseURL + f"{lang}/{channel.value}/{nvdaApiVersion}.json"
+	return _BASE_URL + f"{lang}/{channel.value}/{nvdaApiVersion}.json"
+
+
+def _getCacheHashURL() -> str:
+	return _BASE_URL + "cacheHash.json"
 
 
 class AddonFileDownloader:

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 	from gui.message import DisplayableError
 
 
+_CACHE_HASH_URL = "https://www.nvaccess.org/addonStore/cacheHash.json"
 _LATEST_API_VER = "latest"
 """
 A string value used in the add-on store to fetch the latest version of all add-ons,

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -42,6 +42,10 @@ A string value used in the add-on store to fetch the latest version of all add-o
 i.e include older incompatible versions.
 """
 
+def _getCurrentApiVersionForURL() -> str:
+	year, major, minor = addonAPIVersion.CURRENT
+	return f"{year}.{major}.{minor}"
+
 
 def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
 	return f"{_BASE_URL}/{lang}/{channel.value}/{nvdaApiVersion}.json"

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -42,6 +42,7 @@ A string value used in the add-on store to fetch the latest version of all add-o
 i.e include older incompatible versions.
 """
 
+
 def _getCurrentApiVersionForURL() -> str:
 	year, major, minor = addonAPIVersion.CURRENT
 	return f"{year}.{major}.{minor}"

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 	from gui.message import DisplayableError
 
 
-_BASE_URL = "https://nvaccess.org/addonStore/"
+_BASE_URL = "https://nvaccess.org/addonStore"
 _LATEST_API_VER = "latest"
 """
 A string value used in the add-on store to fetch the latest version of all add-ons,
@@ -43,18 +43,12 @@ i.e include older incompatible versions.
 """
 
 
-def _getCurrentApiVersionForURL() -> str:
-	year, major, minor = addonAPIVersion.CURRENT
-	return f"{year}.{major}.{minor}"
-
-
 def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
-	_baseURL = "https://nvaccess.org/addonStore/"
-	return _BASE_URL + f"{lang}/{channel.value}/{nvdaApiVersion}.json"
+	return f"{_BASE_URL}/{lang}/{channel.value}/{nvdaApiVersion}.json"
 
 
 def _getCacheHashURL() -> str:
-	return _BASE_URL + "cacheHash.json"
+	return f"{_BASE_URL}/cacheHash.json"
 
 
 class AddonFileDownloader:


### PR DESCRIPTION
- Refresh cache based on cache Hash from NV Access server
- Don't use datetime to refresh cache

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15034
Fixes #15077 
### Summary of the issue:
The store data cache is refreshed every 6 hours. This may not be enough and it's desirable to add a mechanism to refresh it making a small request to the server, so we can request data just when a new commit has been done to the views branch of the nvaccess/addon-datastore repo.
### Description of user facing changes
When opening the add-on store, if there has been changes on the server, the cached data should be updated.

### Description of development approach
- In dataManager, a function has been added to get the cacheHash from NV Access server.
- References to date, including parameters of functions, have been replaced with variables which hold the value of the cache hash.
- try... except clauses have been used to ensure that .json files which store cache data are valid,though perhaps a jsonschema will be more robust and will allow to control data types.
- network.py has been tweaked.
### Testing strategy:
- Wifi has been deactivated and the store has been opened. When pressing tab to select available and updatable add-ons, and also when the checkbox to get incompatible add-ons has been checked, error messages have been displayed, since NVDA tried to get the hash.
Also, manual tests have confirmed that new add-ons sent to the store have been retrieved.

### Known issues with pull request:
When the checkbox to get incompatible add-ons is checked, the add-ons list is refreshed and this may take some seconds.
### Change log entries:
n/a
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
