### PR TITLE
Fix issue with saving config and FeatureFlags

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -39,6 +39,7 @@ from .configSpec import confspec
 from .featureFlag import (
 	_transformSpec_AddFeatureFlagDefault,
 	_validateConfig_featureFlag,
+	FeatureFlag,
 )
 from typing import (
 	Any,
@@ -1247,13 +1248,17 @@ class AggregatedSection:
 		except KeyError:
 			pass
 		else:
-			if self._isSection(val) or self._isSection(curVal):
-				# If value is a section, continue to update
-				pass
-			elif str(val) == str(curVal):
+			if (
+				# Feature flags override __eq__.
 				# Check str comparison as this is what is written to the config.
 				# If the value is unchanged, do not update
 				# or mark the profile as dirty.
+				(
+					isinstance(val, FeatureFlag)
+					or isinstance(curVal, FeatureFlag)
+				)
+				and str(val) == str(curVal)
+			):
 				return
 
 		# Set this value in the most recently activated profile.

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -428,8 +428,9 @@ def getSynth() -> Optional[SynthDriver]:
 
 
 def getSynthInstance(name, asDefault=False):
+	from synthDrivers.oneCore import OneCoreSynthDriver
 	newSynth: SynthDriver = _getSynthDriver(name)()
-	if asDefault and newSynth.name == 'oneCore':
+	if asDefault and isinstance(newSynth, OneCoreSynthDriver):
 		# Will raise an exception if oneCore does not support the system language
 		newSynth._getDefaultVoice(pickAny=False)
 	newSynth.initSettings()

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -428,9 +428,8 @@ def getSynth() -> Optional[SynthDriver]:
 
 
 def getSynthInstance(name, asDefault=False):
-	from synthDrivers.oneCore import OneCoreSynthDriver
 	newSynth: SynthDriver = _getSynthDriver(name)()
-	if asDefault and isinstance(newSynth, OneCoreSynthDriver):
+	if asDefault and newSynth.name == 'oneCore':
 		# Will raise an exception if oneCore does not support the system language
 		newSynth._getDefaultVoice(pickAny=False)
 	newSynth.initSettings()

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -422,10 +422,10 @@ class SynthDriver(SynthDriver):
 		val=self._percentToParam(val, _espeak.minPitch, _espeak.maxPitch)
 		_espeak.setParameter(_espeak.espeakRANGE,val,0)
 
-	def _get_volume(self):
+	def _get_volume(self) -> int:
 		return _espeak.getParameter(_espeak.espeakVOLUME,1)
 
-	def _set_volume(self,volume):
+	def _set_volume(self, volume: int):
 		_espeak.setParameter(_espeak.espeakVOLUME,volume,0)
 
 	def _getAvailableVoices(self):

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -222,9 +222,9 @@ class OneCoreSynthDriver(SynthDriver):
 		# Set initial values for parameters that can't be queried when prosody is not supported.
 		# This initialises our cache for the value.
 		# When prosody is supported, the values are used for cachign reasons.
-		self._rate = 50
-		self._pitch = 50
-		self._volume = 100
+		self._rate: int = 50
+		self._pitch: int = 50
+		self._volume: int = 100
 
 		if self.supportsProsodyOptions:
 			self._dll.ocSpeech_getPitch.restype = ctypes.c_double
@@ -339,13 +339,13 @@ class OneCoreSynthDriver(SynthDriver):
 		rawPitch = self._percentToParam(pitch, self.MIN_PITCH, self.MAX_PITCH)
 		self._queuedSpeech.append((self._dll.ocSpeech_setPitch, rawPitch))
 
-	def _get_volume(self):
+	def _get_volume(self) -> int:
 		if not self.supportsProsodyOptions:
 			return self._volume
 		rawVolume = self._dll.ocSpeech_getVolume(self._ocSpeechToken)
 		return int(rawVolume * 100)
 
-	def _set_volume(self, volume):
+	def _set_volume(self, volume: int):
 		self._volume = volume
 		if not self.supportsProsodyOptions:
 			return

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -163,7 +163,7 @@ class SynthDriver(SynthDriver):
 	def _get_pitch(self):
 		return self._pitch
 
-	def _get_volume(self):
+	def _get_volume(self) -> int:
 		return self.tts.volume
 
 	def _get_voice(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -110,6 +110,7 @@ Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively
 - When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)
 - NVDA now generally responds slightly faster to commands and focus changes. (#14928)
 - Displaying the OCR settings will not fail on some systems anymore. (#15017)
+- Fix bug related to saving and loading the NVDA configuration, including switching synthesizers. (#14760)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14760
Fixup of #14133

### Summary of the issue:
When saving a config spec, validation would be skipped if the string value of the data is unchanged.

This caused various issues including config values not being correctly converted to numbers from strings when validating.
This caused config profiles to fail to load or save correctly.

### Description of user facing changes
Fix up of various bugs related to user config

### Description of development approach
Perform special handling that was introduced in #14133 for feature flags only

### Testing strategy:
Test STR outlined in https://github.com/nvaccess/nvda/issues/14760#issuecomment-1491684838

### Known issues with pull request:
None

### Change log entries:
Bug fixes
```
- Fix bug related to saving and loading the NVDA config, including switching synthesizers. (#14760)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
