### PR TITLE
Added reportHighlight to _reportFormattingHelper

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2145,6 +2145,7 @@ class GlobalCommands(ScriptableObject):
 			"reportFontSize",
 			"reportFontAttributes",
 			"reportSuperscriptsAndSubscripts",
+			"reportHighlight",
 			"reportColor",
 			"reportStyle",
 			"reportAlignment",


### PR DESCRIPTION
### Link to issue number:

Fixes #15075

### Summary of the issue:

Highlight has not been reported when querying formatting manually via script in globalCommands, particularly useful after pr #14610.

### Description of user facing changes

If a text is highlighted in Word, now it's reported with NVDA+f, even if highlight reporting is disabled in document formatting settings.

### Description of development approach

Simply added "reportHighlight" as config key to query in _reportFormattingHelper, inside globalCommans.py.

### Testing strategy:

Manual, for example with #5866 attachment.

### Known issues with pull request:

It not covers highlight in web browsers via mark HTML tag, that seems exposed in another way/not in FormatField values.

### Change log entries:
New features
- in Word without UIA, highlighting is now reported when user asks for formatting information.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
