### PR TITLE
Output ARIA live regions in Braille

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -83,9 +83,10 @@ def nvdaController_brailleMessage(text):
 	focus=api.getFocusObject()
 	if focus.sleepMode==focus.SLEEP_FULL:
 		return -1
-	import queueHandler
-	import braille
-	queueHandler.queueFunction(queueHandler.eventQueue,braille.handler.message,text)
+	if config.conf["braille"]["reportLiveRegions"]:
+		import queueHandler
+		import braille
+		queueHandler.queueFunction(queueHandler.eventQueue, braille.handler.message, text)
 	return 0
 
 def _lookupKeyboardLayoutNameWithHexString(layoutString):

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -137,6 +137,7 @@ def nvdaControllerInternal_reportLiveRegion(text: str, politeness: str):
 		return -1
 	import queueHandler
 	import speech
+	import braille
 	from aria import AriaLivePoliteness
 	from speech.priorities import Spri
 	try:
@@ -155,6 +156,11 @@ def nvdaControllerInternal_reportLiveRegion(text: str, politeness: str):
 			if politenessValue == AriaLivePoliteness.ASSERTIVE
 			else Spri.NORMAL
 		)
+	)
+	queueHandler.queueFunction(
+		queueHandler.eventQueue,
+		braille.handler.message,
+		text
 	)
 	return 0
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -83,6 +83,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	interruptSpeechWhileScrolling = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	showSelection = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	enableHidBrailleSupport = integer(0, 2, default=0)  # 0:Use default/recommended value (yes), 1:yes, 2:no
+	reportLiveRegions = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 
 	# Braille display driver settings
 	[[__many__]]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2853,7 +2853,6 @@ class AdvancedPanelControls(
 		#  Advanced settings panel
 		label = _("Braille")
 		brailleSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
-		brailleBox = brailleSizer.GetStaticBox()
 		brailleGroup = guiHelper.BoxSizerHelper(self, sizer=brailleSizer)
 		sHelper.addItem(brailleGroup)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2851,12 +2851,11 @@ class AdvancedPanelControls(
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
-		label = _("HID Braille Standard")
-		hidBrailleSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
-		hidBrailleBox = hidBrailleSizer.GetStaticBox()
-		hidBrailleGroup = guiHelper.BoxSizerHelper(self, sizer=hidBrailleSizer)
-		self.bindHelpEvent("HIDBraille", hidBrailleBox)
-		sHelper.addItem(hidBrailleGroup)
+		label = _("Braille")
+		brailleSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		brailleBox = brailleSizer.GetStaticBox()
+		brailleGroup = guiHelper.BoxSizerHelper(self, sizer=brailleSizer)
+		sHelper.addItem(brailleGroup)
 
 		supportHidBrailleChoices = [
 			# Translators: Label for option in the 'Enable support for HID braille' combobox
@@ -2870,10 +2869,10 @@ class AdvancedPanelControls(
 			_("No"),
 		]
 
-		# Translators: This is the label for a checkbox in the
+		# Translators: This is the label for a combo box in the
 		#  Advanced settings panel.
 		label = _("Enable support for HID braille")
-		self.supportHidBrailleCombo: wx.Choice = hidBrailleGroup.addLabeledControl(
+		self.supportHidBrailleCombo: wx.Choice = brailleGroup.addLabeledControl(
 			labelText=label,
 			wxCtrlClass=wx.Choice,
 			choices=supportHidBrailleChoices,
@@ -2884,6 +2883,17 @@ class AdvancedPanelControls(
 		self.supportHidBrailleCombo.defaultValue = self._getDefaultValue(
 			["braille", "enableHidBrailleSupport"]
 		)
+		self.bindHelpEvent("HIDBraille", self.supportHidBrailleCombo)
+		self.brailleLiveRegionsCombo: nvdaControls.FeatureFlagCombo = brailleGroup.addLabeledControl(
+			labelText=_(
+				# Translators: This is the label for a combo-box in the Advanced settings panel.
+				"Report live regions:"
+			),
+			wxCtrlClass=nvdaControls.FeatureFlagCombo,
+			keyPath=["braille", "reportLiveRegions"],
+			conf=config.conf,
+		)
+		self.bindHelpEvent("BrailleLiveRegions", self.brailleLiveRegionsCombo)
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
@@ -3165,6 +3175,7 @@ class AdvancedPanelControls(
 			and self.annotationsDetailsCheckBox.IsChecked() == self.annotationsDetailsCheckBox.defaultValue
 			and self.ariaDescCheckBox.IsChecked() == self.ariaDescCheckBox.defaultValue
 			and self.supportHidBrailleCombo.GetSelection() == self.supportHidBrailleCombo.defaultValue
+			and self.brailleLiveRegionsCombo.isValueConfigSpecDefault()
 			and self.keyboardSupportInLegacyCheckBox.IsChecked() == self.keyboardSupportInLegacyCheckBox.defaultValue
 			and self.winConsoleSpeakPasswordsCheckBox.IsChecked() == self.winConsoleSpeakPasswordsCheckBox.defaultValue
 			and self.diffAlgoCombo.GetSelection() == self.diffAlgoCombo.defaultValue
@@ -3192,6 +3203,7 @@ class AdvancedPanelControls(
 		self.annotationsDetailsCheckBox.SetValue(self.annotationsDetailsCheckBox.defaultValue)
 		self.ariaDescCheckBox.SetValue(self.ariaDescCheckBox.defaultValue)
 		self.supportHidBrailleCombo.SetSelection(self.supportHidBrailleCombo.defaultValue)
+		self.brailleLiveRegionsCombo.resetToConfigSpecDefault()
 		self.winConsoleSpeakPasswordsCheckBox.SetValue(self.winConsoleSpeakPasswordsCheckBox.defaultValue)
 		self.keyboardSupportInLegacyCheckBox.SetValue(self.keyboardSupportInLegacyCheckBox.defaultValue)
 		self.diffAlgoCombo.SetSelection(self.diffAlgoCombo.defaultValue == 'auto')
@@ -3237,6 +3249,7 @@ class AdvancedPanelControls(
 		config.conf["annotations"]["reportDetails"] = self.annotationsDetailsCheckBox.IsChecked()
 		config.conf["annotations"]["reportAriaDescription"] = self.ariaDescCheckBox.IsChecked()
 		config.conf["braille"]["enableHidBrailleSupport"] = self.supportHidBrailleCombo.GetSelection()
+		self.brailleLiveRegionsCombo.saveCurrentValueToConf()
 		self.loadChromeVBufWhenBusyCombo.saveCurrentValueToConf()
 
 		for index,key in enumerate(self.logCategories):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2884,10 +2884,8 @@ class AdvancedPanelControls(
 		)
 		self.bindHelpEvent("HIDBraille", self.supportHidBrailleCombo)
 		self.brailleLiveRegionsCombo: nvdaControls.FeatureFlagCombo = brailleGroup.addLabeledControl(
-			labelText=_(
-				# Translators: This is the label for a combo-box in the Advanced settings panel.
-				"Report live regions:"
-			),
+			# Translators: This is the label for a combo-box in the Advanced settings panel.
+			labelText=_("Report live regions:"),
 			wxCtrlClass=nvdaControls.FeatureFlagCombo,
 			keyPath=["braille", "reportLiveRegions"],
 			conf=config.conf,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,7 +73,9 @@ Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively
 - Script for reporting the destination of a link now reports from the caret / focus position rather than the navigator object. (#14659)
 - Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (#14681)
 - If Windows is configured to display seconds in the system tray clock, using ``NVDA+f12`` to report the time now honors that setting. (#14742)
-- NVDA will now report unlabeled groupings that have useful position information, such as in recent versions of Microsoft Office 365 menus. (#14878) 
+- NVDA will now report unlabeled groupings that have useful position information, such as in recent versions of Microsoft Office 365 menus. (#14878)
+- Updates to dynamic web content (ARIA live regions) are now displayed in Braille.
+This can be disabled in the Advanced Settings panel. (#7756)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2259,6 +2259,16 @@ However, for basic spreadsheet navigating / editing, this option may provide a v
 We still do not recommend that  the majority of users turn this on by default, though we do welcome users of Microsoft Excel  build 16.0.13522.10000 or higher to test this feature and provide feedback.
 Microsoft Excel's UI automation implementation is ever changing, and  versions of Microsoft Office older than 16.0.13522.10000 may not expose enough information for this option to be of any use.
 
+==== Report live regions ====[BrailleLiveRegions]
+: Default
+  Enabled
+: Options
+  Disabled, Enabled
+:
+
+This option selects whether NVDA reports changes in some dynamic web content in Braille.
+Disabling this option is equivalent to NVDA's behaviour in versions 2023.1 and earlier, which only reported these content changes in speech.
+
 ==== Speak passwords in all enhanced terminals ====[AdvancedSettingsWinConsoleSpeakPasswords]
 This setting controls whether characters are spoken by [speak typed characters #KeyboardSettingsSpeakTypedCharacters] or [speak typed words #KeyboardSettingsSpeakTypedWords] in situations where the screen does not update (such as password entry) in some terminal programs, such as the Windows Console with UI automation support enabled and Mintty.
 For security purposes, this setting should be left disabled.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Closes #7756.

### Summary of the issue:
NVDA does not output ARIA live regions in Braille, making them completely inaccessible in Braille-only usage scenarios (for instance, @rperez030 would like to read incoming MS Teams messages in Braille during meetings).

### Description of user facing changes
ARIA live region updates are now displayed as Braille messages, similarly to UIA notification events.

### Description of development approach
Call `brailleHandler.message` on live region updates.

### Testing strategy:
Tested by @simon818 and @rperez030 for their use cases.

### Known issues with pull request:
None known

### Change log entries:
Something along the lines of:
== Changes ==
- Updates to dynamic web content (ARIA live regions) are now displayed in Braille. This can be disabled in NVDA's advanced settings panel. (#7756)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
