### PR TITLE
Fix context help in Add-on Store

### DIFF
--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -40,7 +40,10 @@ from .details import AddonDetails
 class AddonStoreDialog(SettingsDialog):
 	# Translators: The title of the addonStore dialog where the user can find and download add-ons
 	title = pgettext("addonStore", "Add-on Store")
-	helpId = "addonStore"
+	# For the Add-on Store paragraph in the User Guide, we have kept "AddonsManager" anchor instead of something
+	# more adapted like "AddonStore" so that old external links pointing to the add-ons manager paragraph now
+	# point to the Add-on Store one.
+	helpId = "AddonsManager"
 
 	def __init__(self, parent: wx.Window, storeVM: AddonStoreVM):
 		self._storeVM = storeVM


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
* Calling context help in the add-on store while the focus is in "Other details" or on the tabs does not jump to the add-on store paragraph.
* Context help on other GUI controls (add-ons list, action button) is not impacted by this issue since they have dedicated help targets.
### Description of user facing changes
Context help works correctly in add-on store, i.e. jumps to the correct paragraph.
### Description of development approach
Fix the anchor's name according to what is in the user guide.
### Testing strategy:
Tested F1 with a portable version created from the snapshot generated by appVeyor (nvda_snapshot_pr15080-28549,7e72e668.exe) when the focus is in tabs, description field or other details.

### Known issues with pull request:
None
### Change log entries:
None (patching unreleased feature)
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
