### PR TITLE
Stop WASAPI streams if they've been inactive for more than a minute.

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -73,6 +73,7 @@ EXPORTS
 	wasPlay_feed
 	wasPlay_stop
 	wasPlay_sync
+	wasPlay_idle
 	wasPlay_pause
 	wasPlay_resume
 	wasPlay_setChannelVolume

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -171,6 +171,7 @@ class WasapiPlayer {
 
 	HRESULT stop();
 	HRESULT sync();
+	HRESULT idle();
 	HRESULT pause();
 	HRESULT resume();
 	HRESULT setChannelVolume(unsigned int channel, float level);
@@ -470,6 +471,19 @@ HRESULT WasapiPlayer::sync() {
 	return S_OK;
 }
 
+HRESULT WasapiPlayer::idle() {
+	HRESULT hr = sync();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = stop();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	completeStop();
+	return S_OK;
+}
+
 HRESULT WasapiPlayer::pause() {
 	if (playState != PlayState::playing) {
 		return S_OK;
@@ -542,6 +556,10 @@ HRESULT wasPlay_stop(WasapiPlayer* player) {
 
 HRESULT wasPlay_sync(WasapiPlayer* player) {
 	return player->sync();
+}
+
+HRESULT wasPlay_idle(WasapiPlayer* player) {
+	return player->idle();
 }
 
 HRESULT wasPlay_pause(WasapiPlayer* player) {


### PR DESCRIPTION
### Link to issue number:
Fixes #14913.

### Summary of the issue:
On some systems, when WASAPI is enabled, the system won't automatically go to sleep, even though it goes to sleep fine when WASAPI is disabled.

### Description of user facing changes
When WASAPI audio is enabled, the computer now automatically goes to sleep if appropriate.

### Description of development approach
When a WASAPI stream isn't stopped, this unfortunately prevents some systems from going to sleep automatically. I think this is on Windows 10 and earlier, but the precise details aren't clear. According to a Microsoft engineer, [this is by design](https://stackoverflow.com/a/652796).

I originally thought this occurred when a WASAPI stream remained open. However, some testing revealed that stopping the stream seems to be enough to fix this. Previously, we didn't explicitly stop idle streams. Stopping is better than closing because opening a stream after it is closed can introduce delays or truncated audio.

Specific implementation details:

1. Add a method to stop a WASAPI stream when it is idle.
2. When feed() is called, track the current time as the last time the stream was definitely active. If there isn't a pending stream idle check, schedule one.
3. Every 5 seconds, check if there are any playing streams that haven't been active for 10 seconds. If there are any, stop them.
    We use a class-wide check to avoid continually resetting timers on every audio chunk. See the docstring for `WasapiWavePlayer._idleCheck` for details.

### Testing strategy:
Used beeps in the code to verify that streams get closed when they should.
I can't reproduce this sleep issue myself, so I asked users experiencing it to test with a try build. They reported that it fixed the issue for them.

### Known issues with pull request:
None.

### Change log entries:
No change log entry required because WASAPI hasn't been in a release yet.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
