### PR TITLE
soffice: Don't announce previous cell coordinates (as selection)

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -199,7 +199,11 @@ class SymphonyIATableCell(SymphonyTableCell):
 
 	def event_selectionAdd(self):
 		curFocus = api.getFocusObject()
-		if self.table and self.table == curFocus.table and self.table.IAccessibleTable2Object.nSelectedCells > 0:
+		if (
+			self.table
+			and self.table == curFocus.table
+			and self.table.IAccessibleTable2Object.nSelectedCells > 0
+		):
 			curFocus.announceSelectionChange()
 
 	def event_selectionRemove(self):

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -199,7 +199,7 @@ class SymphonyIATableCell(SymphonyTableCell):
 
 	def event_selectionAdd(self):
 		curFocus = api.getFocusObject()
-		if self.table and self.table == curFocus.table:
+		if self.table and self.table == curFocus.table and self.table.IAccessibleTable2Object.nSelectedCells > 0:
 			curFocus.announceSelectionChange()
 
 	def event_selectionRemove(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -76,6 +76,7 @@ Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively
 - NVDA will now report unlabeled groupings that have useful position information, such as in recent versions of Microsoft Office 365 menus. (#14878)
 - Updates to dynamic web content (ARIA live regions) are now displayed in Braille.
 This can be disabled in the Advanced Settings panel. (#7756)
+- When moving to a different cell in LibreOffice Calc, NVDA no longer incorrectly announces the coordinates of the previously focused cell when cell coordinate announcement is disabled in NVDA's settings. (#15098)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:

Fixes #15098

### Summary of the issue:

When announcement of cell coordinates is disabled in NVDA settings, moving focus in a Calc spreadsheet resulted in the coordinates of the previously focused cell to be announced.
This is caused by Libreoffice sending an EVENT_OBJECT_SELECTIONREMOVE event on the previously focused cell before sending an EVENT_OBJECT_FOCUS event for the newly focused cell
(s.  https://git.libreoffice.org/core/+/refs/heads/master/sc/source/ui/Accessibility/AccessibleSpreadsheet.cxx#588 ). This triggered announcement of the previously focused cell in the LibreOffice app module handling for cell selection changes.

### Description of user facing changes

No more announcement of the previosly focused cell when switching focus to another one in LibreOffice Calc and announcement of cell coordinates is disabled in NVDA settings.

### Description of development approach

In the LibreOffice app module specific code that handles EVENT_OBJECT_SELECTIONREMOVE and EVENT_OBJECT_SELECTIONADD for table cells, only trigger announcement of the selection (or currently focused cell) if a selection actually exists, i.e. the number of selected cells is positive. (Announcement of a focused cell when no selection exists still happens in response to the corresponding event indicating focus change.)

### Testing strategy:

1) Disable announcement of cell coordinates in NVDA's settings: under "Document Formatting" -> group "Table information", uncheck the "Cell coordinates" checkbox 
2) start LibreOffice Calc with a fresh document
3) press the arrow right key a few times and check that NVDA does not announce coordinates 
4) move arond a bit further using the arrow keys and check that NVDA does not announce coordinates 
5) select a few cells by pressing Shift + arrow keys and check that coordinates are still announced for the selection 
6) enable announcement of cell coordinates again in NVDA settings and repeat steps 2-5, now checking that cell coordinates are always announced

### Known issues with pull request:

none

### Change log entries:

Bug fixes
`When moving to a different cell in LibreOffice Calc, NVDA no longer incorrectly announces the coordinates of the previously focused cell when cell coordinate announcement is diabled in NVDA's settings. (#15098)`
New features

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
