### PR TITLE
Fix Excel cell formatting reporting

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -992,7 +992,7 @@ class ExcelWorksheet(ExcelBase):
 				# they are in fact not the same python object, i.e.
 				# `newSelection.parent is self` would return False.
 				# Therefore we set newSelection.parent to self in order for the format field speech cache
-				# to persist across selection changes.
+				# to persist across selection changes. (#15091)
 				newSelection.parent = self
 			eventHandler.executeEvent('gainFocus', newSelection)
 

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -953,8 +953,6 @@ class ExcelWorksheet(ExcelBase):
 
 	def script_changeSelection(self,gesture):
 		oldSelection = self._getSelection()
-		if oldSelection.parent == self:
-			oldSelection.parent = self
 		gesture.send()
 		newSelection = None
 		start = time.time()
@@ -988,8 +986,14 @@ class ExcelWorksheet(ExcelBase):
 				time.sleep(retryInterval)
 			retries += 1
 		if newSelection:
-			if oldSelection.parent==newSelection.parent:
-				newSelection.parent=oldSelection.parent
+			if newSelection.parent == self:
+				# The new selection has this work sheet as its parent.
+				# While newSelection.parent and self compare equal,
+				# they are in fact not the same python object, i.e.
+				# `newSelection.parent is self` would return False.
+				# Therefore we set newSelection.parent to self in order for the format field speech cache
+				# to persist across selection changes.
+				newSelection.parent = self
 			eventHandler.executeEvent('gainFocus', newSelection)
 
 	def _WaitForValueChangeForAction(self, action, fetcher, timeout=0.15):

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -953,6 +953,8 @@ class ExcelWorksheet(ExcelBase):
 
 	def script_changeSelection(self,gesture):
 		oldSelection = self._getSelection()
+		if oldSelection.parent == self:
+			oldSelection.parent = self
 		gesture.send()
 		newSelection = None
 		start = time.time()


### PR DESCRIPTION
### Link to issue number:
Fixes #15091

### Summary of the issue:
Pr #14984 broke Excel cell formatting reporting in such a way that it would always report all formatting, regardless of whether the formatting changed between cells.

### Description of user facing changes
Ensure that cell formatting isn't repeated needlessly.

### Description of development approach
When getting the selection in script_changeSelection, override the parent of the selection with self. This ensures that the format field cache on the work sheet will persist when moving through cells.

### Testing strategy:
Test the str from #15091

### Known issues with pull request:
None known

### Change log entries:
None needed, issue regressed after 2023.1.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
