### PR TITLE
Make add-on store accelerator keys label translatable and discoverable

### DIFF
--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -245,16 +245,37 @@ class _StatusFilterKey(DisplayStringEnum):
 
 	@property
 	def _displayStringLabels(self) -> Dict["_StatusFilterKey", str]:
+		return {k: v.replace('&', '') for (k, v) in self._displayStringLabelsWithAccelerators.items()}
+
+	@property
+	def _displayStringLabelsWithAccelerators(self) -> Dict["_StatusFilterKey", str]:
 		return {
-			# Translators: A selection option to display installed add-ons in the add-on store
-			self.INSTALLED: pgettext("addonStore", "Installed add-ons"),
-			# Translators: A selection option to display updatable add-ons in the add-on store
-			self.UPDATE: pgettext("addonStore", "Updatable add-ons"),
-			# Translators: A selection option to display available add-ons in the add-on store
-			self.AVAILABLE: pgettext("addonStore", "Available add-ons"),
-			# Translators: A selection option to display incompatible add-ons in the add-on store
-			self.INCOMPATIBLE: pgettext("addonStore", "Installed incompatible add-ons"),
+			# Translators: The label of a tab to display installed add-ons in the add-on store and the label of the
+			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			self.INSTALLED: pgettext("addonStore", "Installed &add-ons"),
+			# Translators: The label of a tab to display updatable add-ons in the add-on store and the label of the
+			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			self.UPDATE: pgettext("addonStore", "Updatable &add-ons"),
+			# Translators: The label of a tab to display available add-ons in the add-on store and the label of the
+			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			self.AVAILABLE: pgettext("addonStore", "Available &add-ons"),
+			# Translators: The label of a tab to display incompatible add-ons in the add-on store and the label of the
+			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			self.INCOMPATIBLE: pgettext("addonStore", "Installed incompatible &add-ons"),
 		}
+
+	@property
+	def displayStringWithAccelerator(self) -> str:
+		"""
+		@return: The translated UI display string with accelerator that should be used for this value of the enum.
+		"""
+		try:
+			return self._displayStringLabelsWithAccelerators[self]
+		except KeyError as e:
+			log.error(f"No translation mapping for: {self}")
+			raise e
+
+
 
 
 _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = OrderedDict({

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -42,7 +42,7 @@ class AddonDetails(
 
 	# Translators: Label for the text control containing a description of the selected add-on.
 	# In the add-on store dialog.
-	_actionsLabelText: str = pgettext("addonStore", "&Actions")
+	_actionsLabelText: str = pgettext("addonStore", "A&ctions")
 
 	def __init__(
 			self,
@@ -126,9 +126,6 @@ class AddonDetails(
 		self.contents.Add(wx.StaticLine(self.contentsPanel), flag=wx.EXPAND)
 		self.contents.AddSpacer(guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
-		# It would be nice to override the name using wx.Accessible,
-		# but using it on a TextCtrl breaks the accessibility of the control entirely (all state/role is reset)
-		# Instead, add a hidden label for the textBox, Windows exposes this as the accessible name.
 		self.otherDetailsLabel = wx.StaticText(
 			self.contentsPanel,
 			# Translators: Label for the text control containing extra details about the selected add-on.
@@ -136,7 +133,6 @@ class AddonDetails(
 			label=pgettext("addonStore", "&Other Details:")
 		)
 		self.contents.Add(self.otherDetailsLabel, flag=wx.EXPAND)
-		self.otherDetailsLabel.Hide()
 		self.otherDetailsTextCtrl = wx.TextCtrl(
 			self.contentsPanel,
 			size=self.scaleSize((panelWidth, 400)),

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -97,13 +97,11 @@ class AddonStoreDialog(SettingsDialog):
 
 		settingsSizer.Add(splitViewSizer, flag=wx.EXPAND, proportion=1)
 
-		# add a label for the AddonListVM so that it is announced with a name in NVDA
 		self.listLabel = wx.StaticText(self)
 		tabPageHelper.addItem(
 			self.listLabel,
 			flag=wx.EXPAND
 		)
-		self.listLabel.Hide()
 		self._setListLabels()
 
 		self.addonListView = AddonVirtualList(
@@ -112,12 +110,6 @@ class AddonStoreDialog(SettingsDialog):
 			actionsContextMenu=self._actionsContextMenu,
 		)
 		self.bindHelpEvent("AddonStoreBrowsing", self.addonListView)
-		# Add alt+l accelerator key
-		_setFocusToAddonListView_eventId = wx.NewIdRef(count=1)
-		self.Bind(wx.EVT_MENU, lambda e: self.addonListView.SetFocus(), _setFocusToAddonListView_eventId)
-		self.SetAcceleratorTable(wx.AcceleratorTable([
-			wx.AcceleratorEntry(wx.ACCEL_ALT, ord("l"), _setFocusToAddonListView_eventId)
-		]))
 		tabPageHelper.addItem(self.addonListView, flag=wx.EXPAND, proportion=1)
 		splitViewSizer.AddSpacer(5)
 
@@ -281,10 +273,15 @@ class AddonStoreDialog(SettingsDialog):
 
 	@property
 	def _listLabelText(self) -> str:
-		return f"{self._statusFilterKey.displayString}"
+		return pgettext(
+			"addonStore",
+			# Translators: The label of the add-on list in the add-on store; {category} is replaced by the selected
+			# tab's name.
+			"{category}:",
+		).format(category=self._statusFilterKey.displayStringWithAccelerator)
 
 	def _setListLabels(self):
-		self.listLabel.SetLabelText(self._listLabelText)
+		self.listLabel.SetLabel(self._listLabelText)
 		self.SetTitle(self._titleText)
 
 	def _toggleFilterControls(self):

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -183,3 +183,23 @@ Automatic updating of add-ons is currently unsupported.
 1. Find an installed add-on in the add-on store
 1. Press the "add-on help" button
 1. A window should open with the help documentation
+
+## Using accelerator keys in the GUI
+
+### Add-on list accelerator
+
+1. Select installed add-ons tab
+1. Check visually that "a" is underlined in the add-ons list label.
+1. Tab to another control and check that `alt+a` allows to move the focus back to the add-ons list.
+1. From the "Search" field, tab to the add-ons list and check that "alt+a" is reported
+1. When an add-on is focused in the add-on list, check that moving up the navigator object reports the list's name and its shortcut key `alt+a`.
+1. Write a non-matching string in "Search" field to empty the list, tab to the list and check that `shift+numpad2` reports the shortcut key.
+1. Perform the same tests selecting successively the three other possible tabs (Updatable add-ons, Available add-ons and Incompatible installed add-ons)
+
+### Accelerators for other GUI items
+
+For "Action" button and "Other details" text field controls:
+1. Check visually that the letter indicating an accelerator key is underlined on the control's label.
+1. Tab to another control and check that `alt+<letter>` allows to move the focus back to the control.
+1. From another control tab to the control and check that `alt+<letter>` is reported.
+1. In the control, check that `shift+numpad2` reports the shortcut key.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2637,8 +2637,8 @@ Add-ons will be listed if the search text can be found in the display name, publ
 
 ++ Add-on actions ++[AddonStoreActions]
 Add-ons have associated actions, such as install, help, disable, and remove.
-The actions menu can be accessed for an add-on in the add-on list by pressing the ``applications`` key, ``enter``, right clicking or double clicking the add-on.
-There is also an Actions button in the selected add-on's details allowing to access it.
+For an add-on in the add-on list , these actions can be launched through a menu opened by pressing the ``applications`` key, ``enter``, right clicking or double clicking the add-on.
+This menu can also be accessed through an Actions button in the selected add-on's details.
 
 +++ Installing add-ons +++[AddonStoreInstalling]
 Just because an add-on is available in the NVDA Add-ons Store, does not mean that it has been approved or vetted by NV Access or anyone else.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2637,7 +2637,7 @@ Add-ons will be listed if the search text can be found in the display name, publ
 
 ++ Add-on actions ++[AddonStoreActions]
 Add-ons have associated actions, such as install, help, disable, and remove.
-For an add-on in the add-on list , these actions can be launched through a menu opened by pressing the ``applications`` key, ``enter``, right clicking or double clicking the add-on.
+For an add-on in the add-on list, these actions can be accessed through a menu opened by pressing the ``applications`` key, ``enter``, right clicking or double clicking the add-on.
 This menu can also be accessed through an Actions button in the selected add-on's details.
 
 +++ Installing add-ons +++[AddonStoreInstalling]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2591,7 +2591,6 @@ To access the Add-on Store from anywhere, assign a custom gesture using the [Inp
 
 ++ Browsing add-ons ++[AddonStoreBrowsing]
 When opened, the Add-on Store displays a list of add-ons.
-You can jump back to the add-ons list with ``alt+a`` from anywhere else within the store.
 If you have not installed an add-on before, the add-on store will open to a list of add-ons available to install.
 If you have installed add-ons, the list will display currently installed add-ons.
 
@@ -2639,7 +2638,7 @@ Add-ons will be listed if the search text can be found in the display name, publ
 ++ Add-on actions ++[AddonStoreActions]
 Add-ons have associated actions, such as install, help, disable, and remove.
 The actions menu can be accessed for an add-on in the add-on list by pressing the ``applications`` key, ``enter``, right clicking or double clicking the add-on.
-There is also an Actions button in the selected add-on's details, which can be activated normally or by pressing ``alt+a``.
+There is also an Actions button in the selected add-on's details, which can be activated normally or by pressing ``alt+c``.
 
 +++ Installing add-ons +++[AddonStoreInstalling]
 Just because an add-on is available in the NVDA Add-ons Store, does not mean that it has been approved or vetted by NV Access or anyone else.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2638,7 +2638,7 @@ Add-ons will be listed if the search text can be found in the display name, publ
 ++ Add-on actions ++[AddonStoreActions]
 Add-ons have associated actions, such as install, help, disable, and remove.
 The actions menu can be accessed for an add-on in the add-on list by pressing the ``applications`` key, ``enter``, right clicking or double clicking the add-on.
-There is also an Actions button in the selected add-on's details, which can be activated normally or by pressing ``alt+c``.
+There is also an Actions button in the selected add-on's details allowing to access it.
 
 +++ Installing add-ons +++[AddonStoreInstalling]
 Just because an add-on is available in the NVDA Add-ons Store, does not mean that it has been approved or vetted by NV Access or anyone else.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2591,7 +2591,7 @@ To access the Add-on Store from anywhere, assign a custom gesture using the [Inp
 
 ++ Browsing add-ons ++[AddonStoreBrowsing]
 When opened, the Add-on Store displays a list of add-ons.
-You can jump back to the list with ``alt+l`` from anywhere else within the store.
+You can jump back to the add-ons list with ``alt+a`` from anywhere else within the store.
 If you have not installed an add-on before, the add-on store will open to a list of add-ons available to install.
 If you have installed add-ons, the list will display currently installed add-ons.
 


### PR DESCRIPTION
### Link to issue number:
Closes #15010
Closes #15011
### Summary of the issue:
In add-on store, some accelerator keys are not discoverable nor translatable:
* alt+L for the add-on list is hard-coded (thus not modifiable by translators) and is not discoverable, neither visually (no visible label), nor via object navigation on the whole list
* alt+O for "Other details" field is not discoverable visually nor with shift+numpad2.

### Description of user facing changes
* The labels for the list and for "other details" field are made visible and the accelerator key is underlined.
* shift+numpad2 allows to report the accelerator key of the field.

### Description of development approach
* Do not hide anymore the labels of the list and "other details" field
* used the same strings for the label of the list and of the tabs; the only difference is that the "&" making a letter an accelerator key is removed when the string is used for the tabs (and for the title).
* Used "alt+c" for the "Actions" button to free up "alt+a" for the add-on list label.

### Testing strategy:
For "Other details" and for the 4 possible labels of the add-on list:
* Visual check
* Check that alt+a/alt+o are working, i.e. moving the focus
* When tabbing to "Other details" or to empty add-on list, checked that alt+O/alt+A is reported
* When in "Other details" or in empty add-on list, shift+numpad2 reports the shortcut key
* When moving nav object to the add-on list (not specifically empty), the shortcut key is reported.

### Known issues with pull request:
The shortcut key is not reported for non-empty list with shift+numpad2 or when it gains focus. This is expected and like in other lists since a child item is focused, not the whole list.

### Still to be discussed

* I have updated the shortcut key of the list in the user doc; but I wonder if it is still worth mentioning it at all since it is now discoverable. The user doc usually does not mention standard shortcut keys.
* Maybe showing these labels make the add-on store visually less nice; feel free to suggest a better visual experience if you have a better idea.
* On the opposite, I have kept the "Description" label hidden since there is no shortcut key. Do you think that this label should be shown as well to follow the convention used for the other controls? Does this description field deserve a shortcut key as well?

### Change log entries:
Not needed; add-on store not yet released.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
