### PR TITLE
Add-on Store: prevent duplicate instances from opening

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -342,14 +342,11 @@ class MainFrame(wx.Frame):
 		from ._addonStoreGui import AddonStoreDialog
 		from ._addonStoreGui.viewModels.store import AddonStoreVM
 		_storeVM = AddonStoreVM()
+		_storeVM.refresh()
 		try:
-			d = AddonStoreDialog(mainFrame, _storeVM)
+			AddonStoreDialog(mainFrame, _storeVM).Show()
 		except SettingsDialog.MultiInstanceErrorWithDialog as errorWithDialog:
 			errorWithDialog.dialog.SetFocus()
-		else:
-			_storeVM.refresh()
-			d.Maximize()
-			d.Show()
 		self.postPopup()
 
 	def onReloadPluginsCommand(self, evt):

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -50,6 +50,7 @@ class AddonStoreDialog(SettingsDialog):
 		self._storeVM.onDisplayableError.register(self.handleDisplayableError)
 		self._actionsContextMenu = _ActionsContextMenu(self._storeVM)
 		super().__init__(parent, resizeable=True, buttons={wx.CLOSE})
+		self.Maximize()
 
 	def _enterActivatesOk_ctrlSActivatesApply(self, evt: wx.KeyEvent):
 		"""Disables parent behaviour which overrides behaviour for enter and ctrl+s"""
@@ -235,7 +236,13 @@ class AddonStoreDialog(SettingsDialog):
 				).format(len(addonDataManager._downloadsPendingInstall))
 			)
 			self._storeVM.installPending()
-			wx.CallAfter(installingDialog.done)
+
+			def postInstall():
+				installingDialog.done()
+				# let the dialog exit.
+				super().onClose(evt)
+
+			return wx.CallAfter(postInstall)
 
 		# let the dialog exit.
 		super().onClose(evt)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -143,7 +143,7 @@ class SettingsDialog(
 		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
 			# The dialog has been destroyed by wx, but the instance is still available.
 			# This indicates there is something keeping it alive.
-			log.debugWarning("Opening new settings dialog while instance still exists: {!r}".format(firstMatchingInstance))
+			log.debugWarning(f"Opening new settings dialog while instance still exists: {firstMatchingInstance!r}")
 			# Handle gracefully
 			SettingsDialog._instances[firstMatchingInstance] = cls.DialogState.CREATED
 			return firstMatchingInstance

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -141,9 +141,12 @@ class SettingsDialog(
 				"Only one instance of SettingsDialog can exist at a time",
 			)
 		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
-			# the dialog has been destroyed by wx, but the instance is still available. This indicates there is something
-			# keeping it alive.
-			log.error("Opening new settings dialog while instance still exists: {!r}".format(firstMatchingInstance))
+			# The dialog has been destroyed by wx, but the instance is still available.
+			# This indicates there is something keeping it alive.
+			log.debugWarning("Opening new settings dialog while instance still exists: {!r}".format(firstMatchingInstance))
+			# Handle gracefully
+			SettingsDialog._instances[firstMatchingInstance] = cls.DialogState.CREATED
+			return firstMatchingInstance
 		obj = super(SettingsDialog, cls).__new__(cls, *args, **kwargs)
 		SettingsDialog._instances[obj] = cls.DialogState.CREATED
 		return obj


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Closes #15041 

### Summary of the issue:
A reference to the add-on store is kept alive after being destroyed.
It is unclear what is causing this.
If a reference is kept alive, handling a new instance causes an error, allowing multiple instances of the add-on store dialog to be opened.

### Description of user facing changes
Prevent multiple instances of the add-on store dialog from opening.
Suppress the ERROR level log when an instance is kept alive to debugWarning, and instead handle the "dead" instance more gracefully.

### Description of development approach
Improve the initialisation and destruction of the add-on store with the goal of reducing references to the add-on store dialog from being held.
This is not effective at preventing the add-on store dialog reference from staying alive, but may help solve the problem in future.
It is unclear how the dialog instance is remaining alive, and where the reference is being held.

If an instance is being kept alive, instead of throwing an error when starting a new instance, mark the instance as alive and re-use the alive instance.

### Testing strategy:
Test opening and closing the add-on store through the close button, the "x" button for the window and escape.

### Known issues with pull request:
The add-on store dialog instance is still being kept alive, when it should die when the add-on store is closed.

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
