### PR TITLE
Fix missing first SAPI5 utterance after silence

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.cpp
+++ b/nvdaHelper/local/nvdaHelperLocal.cpp
@@ -97,8 +97,11 @@ LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM
 		SetLastError(ERROR_CANCELLED);
 		return 0;
 	}
-
-	fuFlags |= SMTO_ABORTIFHUNG;
+	if (Msg < WM_APP || Msg > 0xBFFF) {
+		// Message in the range 0x8000 through 0xBFFF are available for applications to use as private messages.
+		// Setting the SMTO_ABORTIFHUNG for these messages is known to cause problems, for example with SAPI5 (#15082)
+		fuFlags |= SMTO_ABORTIFHUNG;
+	}
 	fuFlags &= ~SMTO_NOTIMEOUTIFNOTHUNG;
 
 	if (uTimeout > 10000) {


### PR DESCRIPTION
### Link to issue number:
Fixes #15082 

### Summary of the issue:
The first utterance after around 10 seconds of silence with a SAPI5 synth is not spoken.

### Description of user facing changes
Issue does no longer occur.

### Description of development approach
Since #14759 we are modifying some window messages in our process. This includes setting the SMTO_ABORTIFHUNG flag. I was able to pinpoint that setting this flag to a message of type WM_APP caused this particular issue with SAPI5. Therefore I excluded this range of messages (WM_APP through 0xBFFF).

### Testing strategy:
Tested that NVDA with SAPI5 no longer stays silent when pressing down arrow on the desktop after more than 10 seconds of silence.

### Known issues with pull request:
None known.

### Change log entries:
None needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
