### PR TITLE
Add-on store: fix various upgrading bugs

### DIFF
--- a/source/_addonStore/install.py
+++ b/source/_addonStore/install.py
@@ -85,9 +85,9 @@ def installAddon(addonPath: PathLike) -> None:
 	prevAddon = _getPreviouslyInstalledAddonById(bundle)
 
 	try:
+		installAddonBundle(bundle)
 		if prevAddon:
 			prevAddon.requestRemove()
-		installAddonBundle(bundle)
 	except AddonError:  # Handle other exceptions as they are known
 		log.error("Error installing addon bundle from %s" % addonPath, exc_info=True)
 		raise DisplayableError(

--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -149,9 +149,13 @@ def getStatus(model: "AddonGUIModel") -> Optional[AvailableAddonStatus]:
 		state as addonHandlerState,
 	)
 	from ..dataManager import addonDataManager
+	assert addonDataManager is not None
 	from .addon import AddonStoreModel
 	from .version import MajorMinorPatch
 	addonHandlerModel = model._addonHandlerModel
+
+	if model.name in (d.model.name for d, _ in addonDataManager._downloadsPendingInstall):
+		return AvailableAddonStatus.DOWNLOAD_SUCCESS
 
 	if addonHandlerModel is None:
 		if model.isPendingInstall:
@@ -226,6 +230,12 @@ _addonStoreStateToAddonHandlerState: OrderedDict[
 		AddonStateCategory.OVERRIDE_COMPATIBILITY,
 		AddonStateCategory.PENDING_ENABLE,
 	},
+	# If an add-on is being updated,
+	# it will be in both pending remove and pending install
+	AvailableAddonStatus.INSTALLED: {
+		AddonStateCategory.PENDING_INSTALL,
+		AddonStateCategory.PENDING_REMOVE,
+	},
 	AvailableAddonStatus.PENDING_REMOVE: {AddonStateCategory.PENDING_REMOVE},
 	AvailableAddonStatus.PENDING_ENABLE: {AddonStateCategory.PENDING_ENABLE},
 	AvailableAddonStatus.PENDING_DISABLE: {AddonStateCategory.PENDING_DISABLE},
@@ -276,8 +286,6 @@ class _StatusFilterKey(DisplayStringEnum):
 			raise e
 
 
-
-
 _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = OrderedDict({
 	_StatusFilterKey.INSTALLED: {
 		AvailableAddonStatus.UPDATE,
@@ -293,6 +301,7 @@ _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = Order
 		AvailableAddonStatus.PENDING_REMOVE,
 		AvailableAddonStatus.RUNNING,
 		AvailableAddonStatus.ENABLED,
+		AvailableAddonStatus.DOWNLOAD_SUCCESS,
 	},
 	_StatusFilterKey.UPDATE: {
 		AvailableAddonStatus.UPDATE,
@@ -330,9 +339,8 @@ class SupportsAddonState(SupportsVersionCheck, Protocol):
 
 	@property
 	def isEnabled(self) -> bool:
-		return not (
-			self.isPendingInstall
-			or self.isDisabled
+		return self.isInstalled and not (
+			self.isDisabled
 			or self.isBlocked
 		)
 

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -240,7 +240,7 @@ class AddonStoreDialog(SettingsDialog):
 			def postInstall():
 				installingDialog.done()
 				# let the dialog exit.
-				super().onClose(evt)
+				super(AddonStoreDialog, self).onClose(evt)
 
 			return wx.CallAfter(postInstall)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14991 

### Summary of the issue:
There are various bugs with updating add-ons
- An externally sourced add-on replacing an add-on store add-on does not correctly flush the add-on store version JSON cache. This causes the outdated add-on version information to be used by the externally installed add-on.
- Updating an add-on through via the store does not correctly reflect the state: this allows an add-on to be updated multiple times. Instead the "download, pending install" state must be tracked better.
- Updating an add-on externally does not correctly reflect the state: instead "pending removal" is shown, instead of pending install.
- Updating an add-on externally is not handled correctly, causing the updated add-on to never be installed correctly
- Updating an add-on through the store is not handled correctly, the new bundle should be installed before the previous bundle is marked for removal. This allows the add-on to run install/uninstall tasks in an expected way

### Description of user facing changes
Fix various bugs with updating an add-on

### Description of development approach
- match the addonHandler installation / removal order when updating an add-on through the add-on store
- check download status when determining state
- Reflect "pending install" rather than "pending removal" for add-ons being updated.
- include downloaded, pending installs in the installed add-ons tab
- ensure add-ons are detected correctly when removing pending installs

### Testing strategy:
Manual testing. Completed the steps for installing and updating add-ons:
- https://github.com/nvaccess/nvda/blob/master/tests/manual/addonStore.md#installing-add-ons

### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
